### PR TITLE
feat(xlsx): external workbook references — read & roundtrip

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,37 @@ workbook.sheets[0].rows[0][0] = "Updated!";
 const output = await saveXlsx(workbook); // Charts, VBA, themes preserved
 ```
 
+### External Workbook References
+
+`[N]Sheet!Ref` references to other workbooks are read into a typed
+`workbook.externalLinks` model and re-declared on roundtrip — without
+this the `<externalReferences>` block and the matching relationship
+disappear from `xl/workbook.xml.rels`, leaving Excel with orphan
+`externalLinkN.xml` parts that it ignores.
+
+```ts
+import { readXlsx, parseExternalLink } from "hucre";
+
+const wb = await readXlsx(buf);
+for (const link of wb.externalLinks ?? []) {
+  console.log(link.target, link.targetMode, link.sheetNames);
+  for (const sheet of link.sheetData) {
+    for (const cell of sheet.cells) {
+      // cell.type ∈ "n" | "s" | "b" | "e" | "str"
+      console.log(cell.ref, cell.type, cell.value);
+    }
+  }
+}
+
+// Standalone parser when you already have the XML strings
+const link = parseExternalLink(externalLinkXml, externalLinkRelsXml);
+```
+
+The 1-based index in `workbook.externalLinks` matches the `[N]` prefix
+used by formulas like `[1]Sheet1!A1`. Cached `t="s"` values stay as
+shared-string indices into the _external_ workbook (which hucre cannot
+dereference); resolved strings live in the linked file.
+
 ### Unified API
 
 Auto-detect format and work with simple helpers:
@@ -776,6 +807,7 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 | `streamXlsxRows(input, options?)`  | AsyncGenerator yielding rows one at a time                              |
 | `XlsxStreamWriter`                 | Incremental row-by-row XLSX writing; auto-splits past `maxRowsPerSheet` |
 | `XLSX_MAX_ROWS_PER_SHEET`          | Excel hard row limit (1,048,576) — exported constant                    |
+| `parseExternalLink(xml, relsXml?)` | Parse `xl/externalLinks/externalLinkN.xml` → `ExternalLink`             |
 
 ### ODS
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -678,6 +678,51 @@ export interface WorkbookProperties {
   custom?: Record<string, string | number | boolean | Date>;
 }
 
+// ── External Workbook Links ────────────────────────────────────────
+
+/** Cached cell type as encoded in `cell/@t`. Mirrors OOXML cell type codes. */
+export type ExternalCellType = "n" | "s" | "b" | "e" | "str";
+
+export interface ExternalCachedCell {
+  /** A1-style reference within the external sheet. */
+  ref: string;
+  type: ExternalCellType;
+  /** Cached value. Strings include error text for `t="e"`. */
+  value: string | number | boolean;
+}
+
+export interface ExternalSheetData {
+  /** 0-based index into the external workbook's sheet list. */
+  sheetId: number;
+  cells: ExternalCachedCell[];
+}
+
+export interface ExternalDefinedName {
+  name: string;
+  refersTo?: string;
+  /** Sheet-local index when present; omitted for workbook-level names. */
+  sheetId?: number;
+}
+
+/**
+ * A reference to another workbook resolved via
+ * `xl/externalLinks/externalLinkN.xml`. Cached values follow Excel's
+ * formula syntax `[N]Sheet!Ref`, where `N` is this entry's 1-based
+ * position in `Workbook.externalLinks`.
+ */
+export interface ExternalLink {
+  /** Target path of the linked workbook (URL, file path, or local entry). */
+  target: string;
+  /** Almost always `"External"`. Mirrors the `TargetMode` attribute. */
+  targetMode?: "External" | "Internal";
+  /** External workbook's sheets in declaration order. */
+  sheetNames: string[];
+  /** Cached cell values, keyed by external sheet id. */
+  sheetData: ExternalSheetData[];
+  /** Defined names declared in the external workbook. */
+  definedNames?: ExternalDefinedName[];
+}
+
 // ── Workbook ───────────────────────────────────────────────────────
 
 export interface Workbook {
@@ -697,6 +742,12 @@ export interface Workbook {
     lockStructure?: boolean;
     lockWindows?: boolean;
   };
+  /**
+   * External workbook references, resolved from
+   * `xl/externalLinks/externalLinkN.xml`. The 1-based position in this
+   * array matches the `[N]` prefix used in formulas like `[1]Sheet1!A1`.
+   */
+  externalLinks?: ExternalLink[];
 }
 
 // ── Read Options ───────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,16 @@ export { validateWithSchema } from "./_schema";
 export * as a11y from "./a11y";
 export type { A11yIssue, A11ySeverity, A11yCode, A11yLocation, SheetA11y } from "./_types";
 
+// ── External Workbook Links ────────────────────────────────────────
+export { parseExternalLink } from "./xlsx/external-link-reader";
+export type {
+  ExternalLink,
+  ExternalCellType,
+  ExternalCachedCell,
+  ExternalSheetData,
+  ExternalDefinedName,
+} from "./_types";
+
 // ── Date Utilities ─────────────────────────────────────────────────
 export {
   serialToDate,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -92,6 +92,7 @@ export interface SerializedWorkbook {
   dateSystem?: Workbook["dateSystem"];
   defaultFont?: Workbook["defaultFont"];
   activeSheet?: Workbook["activeSheet"];
+  externalLinks?: Workbook["externalLinks"];
 }
 
 // ── Serialize ───────────────────────────────────────────────────────
@@ -243,6 +244,7 @@ export function serializeWorkbook(wb: Workbook): SerializedWorkbook {
   if (wb.dateSystem) out.dateSystem = wb.dateSystem;
   if (wb.defaultFont) out.defaultFont = wb.defaultFont;
   if (wb.activeSheet !== undefined) out.activeSheet = wb.activeSheet;
+  if (wb.externalLinks) out.externalLinks = wb.externalLinks;
 
   return out;
 }
@@ -395,6 +397,7 @@ export function deserializeWorkbook(data: SerializedWorkbook): Workbook {
   if (data.dateSystem) wb.dateSystem = data.dateSystem;
   if (data.defaultFont) wb.defaultFont = data.defaultFont;
   if (data.activeSheet !== undefined) wb.activeSheet = data.activeSheet;
+  if (data.externalLinks) wb.externalLinks = data.externalLinks;
 
   return wb;
 }

--- a/src/xlsx/content-types-writer.ts
+++ b/src/xlsx/content-types-writer.ts
@@ -19,6 +19,8 @@ const CT_COMMENTS = "application/vnd.openxmlformats-officedocument.spreadsheetml
 const CT_VML = "application/vnd.openxmlformats-officedocument.vmlDrawing";
 const CT_TABLE = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml";
 const CT_THEME = "application/vnd.openxmlformats-officedocument.theme+xml";
+const CT_EXTERNAL_LINK =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml";
 
 /** Image extension → content type mapping */
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
@@ -40,6 +42,11 @@ export interface ContentTypesOptions {
   commentIndices?: number[];
   /** 1-based indices of tables (e.g. [1, 2, 3] means table1.xml, table2.xml, table3.xml exist) */
   tableIndices?: number[];
+  /**
+   * 1-based indices of external link parts. Each entry adds an
+   * `Override` for `/xl/externalLinks/externalLinkN.xml`.
+   */
+  externalLinkIndices?: number[];
   /** Whether docProps/core.xml is present */
   hasCoreProps?: boolean;
   /** Whether docProps/app.xml is present */
@@ -169,6 +176,18 @@ export function writeContentTypes(
         xmlSelfClose("Override", {
           PartName: `/xl/tables/table${idx}.xml`,
           ContentType: CT_TABLE,
+        }),
+      );
+    }
+  }
+
+  // Override for each external link
+  if (opts.externalLinkIndices) {
+    for (const idx of opts.externalLinkIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/externalLinks/externalLink${idx}.xml`,
+          ContentType: CT_EXTERNAL_LINK,
         }),
       );
     }

--- a/src/xlsx/external-link-reader.ts
+++ b/src/xlsx/external-link-reader.ts
@@ -1,0 +1,181 @@
+// ── External Link Reader ──────────────────────────────────────────
+// Parses xl/externalLinks/externalLinkN.xml plus its sibling
+// `_rels/externalLinkN.xml.rels` into a structured ExternalLink so
+// callers can inspect linked workbooks and their cached cell values.
+//
+// OOXML reference: ECMA-376 Part 1, §18.14 (External Workbook References).
+
+import type {
+  ExternalCachedCell,
+  ExternalCellType,
+  ExternalDefinedName,
+  ExternalLink,
+  ExternalSheetData,
+} from "../_types";
+import { parseXml } from "../xml/parser";
+import type { XmlElement, XmlNode } from "../xml/parser";
+import { parseRelationships } from "./relationships";
+
+const VALID_TYPES: ReadonlySet<ExternalCellType> = new Set(["n", "s", "b", "e", "str"]);
+
+const REL_EXTERNAL_LINK_PATH =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath";
+const REL_EXTERNAL_LINK_PATH_STRICT =
+  "http://purl.oclc.org/ooxml/officeDocument/relationships/externalLinkPath";
+
+/**
+ * Parse a single external link.
+ *
+ * @param xml      Raw XML of `xl/externalLinks/externalLinkN.xml`.
+ * @param relsXml  Optional XML of `xl/externalLinks/_rels/externalLinkN.xml.rels`,
+ *                 used to resolve the external workbook's target path. When
+ *                 omitted the returned `target` is the empty string.
+ */
+export function parseExternalLink(xml: string, relsXml?: string): ExternalLink {
+  const root = parseXml(xml);
+  const externalBook = findChild(root, "externalBook");
+
+  let target = "";
+  let targetMode: "External" | "Internal" | undefined;
+  if (externalBook && relsXml) {
+    const rels = parseRelationships(relsXml);
+    const rId = externalBook.attrs["r:id"] ?? externalBook.attrs.id;
+    const rel = rId ? rels.find((r) => r.id === rId) : undefined;
+    if (rel) {
+      target = rel.target;
+      // parseRelationships only surfaces id/type/target today, so we re-read
+      // TargetMode straight from the XML to avoid losing it.
+      // `[^>]*?` keeps the match scoped to a single Relationship element —
+      // relationship elements are always self-closed with `/>`, so we can
+      // safely anchor on `>` even when Target contains `/` (e.g. `../foo`).
+      const modeMatch = relsXml.match(
+        new RegExp(`Id="${escapeRegex(rId ?? "")}"[^>]*?TargetMode="([^"]+)"`),
+      );
+      if (modeMatch) targetMode = modeMatch[1] as "External" | "Internal";
+    }
+  }
+
+  const sheetNames = parseSheetNames(externalBook);
+  const sheetData = parseSheetDataSet(externalBook);
+  const definedNames = parseDefinedNames(externalBook);
+
+  const link: ExternalLink = { target, sheetNames, sheetData };
+  if (targetMode) link.targetMode = targetMode;
+  if (definedNames && definedNames.length > 0) link.definedNames = definedNames;
+  return link;
+}
+
+// ── Internals ─────────────────────────────────────────────────────
+
+function parseSheetNames(externalBook: XmlElement | undefined): string[] {
+  const sheetNames = externalBook ? findChild(externalBook, "sheetNames") : undefined;
+  if (!sheetNames) return [];
+  const names: string[] = [];
+  for (const child of childElements(sheetNames)) {
+    if (child.local === "sheetName") names.push(child.attrs.val ?? "");
+  }
+  return names;
+}
+
+function parseSheetDataSet(externalBook: XmlElement | undefined): ExternalSheetData[] {
+  const dataSet = externalBook ? findChild(externalBook, "sheetDataSet") : undefined;
+  if (!dataSet) return [];
+  const result: ExternalSheetData[] = [];
+  for (const sheetData of childElements(dataSet)) {
+    if (sheetData.local !== "sheetData") continue;
+    const sheetId = parseIntSafe(sheetData.attrs.sheetId, 0);
+    const cells: ExternalCachedCell[] = [];
+    for (const row of childElements(sheetData)) {
+      if (row.local !== "row") continue;
+      for (const cell of childElements(row)) {
+        if (cell.local !== "cell") continue;
+        const ref = cell.attrs.r ?? "";
+        if (!ref) continue;
+        const rawType = (cell.attrs.t ?? "n") as ExternalCellType;
+        const type: ExternalCellType = VALID_TYPES.has(rawType) ? rawType : "n";
+        const valueText = readChildText(cell, "v");
+        cells.push({ ref, type, value: coerceValue(type, valueText) });
+      }
+    }
+    result.push({ sheetId, cells });
+  }
+  return result;
+}
+
+function parseDefinedNames(externalBook: XmlElement | undefined): ExternalDefinedName[] {
+  const dn = externalBook ? findChild(externalBook, "definedNames") : undefined;
+  if (!dn) return [];
+  const result: ExternalDefinedName[] = [];
+  for (const child of childElements(dn)) {
+    if (child.local !== "definedName") continue;
+    const entry: ExternalDefinedName = { name: child.attrs.name ?? "" };
+    if (child.attrs.refersTo) entry.refersTo = child.attrs.refersTo;
+    if (child.attrs.sheetId !== undefined) {
+      const id = parseIntSafe(child.attrs.sheetId, NaN);
+      if (!Number.isNaN(id)) entry.sheetId = id;
+    }
+    if (entry.name) result.push(entry);
+  }
+  return result;
+}
+
+function coerceValue(type: ExternalCellType, text: string): string | number | boolean {
+  switch (type) {
+    case "n":
+    case "s": {
+      // `s` here is the shared-string index of the *external* workbook;
+      // the index is meaningless without that workbook so we keep it as
+      // a number for fidelity. Callers wanting the resolved string need
+      // the linked workbook itself.
+      const n = Number(text);
+      return Number.isFinite(n) ? n : 0;
+    }
+    case "b":
+      return text === "1" || text === "true";
+    case "e":
+    case "str":
+      return text;
+  }
+}
+
+function findChild(el: XmlElement, localName: string): XmlElement | undefined {
+  for (const c of el.children) {
+    if (typeof c !== "string" && c.local === localName) return c;
+  }
+  return undefined;
+}
+
+function childElements(el: XmlElement): XmlElement[] {
+  const out: XmlElement[] = [];
+  for (const c of el.children) {
+    if (typeof c !== "string") out.push(c);
+  }
+  return out;
+}
+
+function readChildText(el: XmlElement, localName: string): string {
+  const child = findChild(el, localName);
+  if (!child) return "";
+  let text = "";
+  for (const c of child.children as XmlNode[]) {
+    if (typeof c === "string") text += c;
+  }
+  return text;
+}
+
+function parseIntSafe(s: string | undefined, fallback: number): number {
+  if (s === undefined) return fallback;
+  const n = parseInt(s, 10);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Deliberately exported but not used internally — exposed for callers
+// that already extracted the relationship list and just want the body.
+export const REL_EXTERNAL_LINK_PATH_TYPES = [
+  REL_EXTERNAL_LINK_PATH,
+  REL_EXTERNAL_LINK_PATH_STRICT,
+] as const;

--- a/src/xlsx/external-link-reader.ts
+++ b/src/xlsx/external-link-reader.ts
@@ -43,15 +43,9 @@ export function parseExternalLink(xml: string, relsXml?: string): ExternalLink {
     const rel = rId ? rels.find((r) => r.id === rId) : undefined;
     if (rel) {
       target = rel.target;
-      // parseRelationships only surfaces id/type/target today, so we re-read
-      // TargetMode straight from the XML to avoid losing it.
-      // `[^>]*?` keeps the match scoped to a single Relationship element —
-      // relationship elements are always self-closed with `/>`, so we can
-      // safely anchor on `>` even when Target contains `/` (e.g. `../foo`).
-      const modeMatch = relsXml.match(
-        new RegExp(`Id="${escapeRegex(rId ?? "")}"[^>]*?TargetMode="([^"]+)"`),
-      );
-      if (modeMatch) targetMode = modeMatch[1] as "External" | "Internal";
+      if (rel.targetMode === "External" || rel.targetMode === "Internal") {
+        targetMode = rel.targetMode;
+      }
     }
   }
 
@@ -167,10 +161,6 @@ function parseIntSafe(s: string | undefined, fallback: number): number {
   if (s === undefined) return fallback;
   const n = parseInt(s, 10);
   return Number.isNaN(n) ? fallback : n;
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // Deliberately exported but not used internally — exposed for callers

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -10,7 +10,9 @@ import type {
   NamedRange,
   TableDefinition,
   TableColumn,
+  ExternalLink,
 } from "../_types";
+import { parseExternalLink } from "./external-link-reader";
 import { ParseError, ZipError } from "../errors";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
@@ -183,6 +185,25 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (zip.has(themePath)) {
     const themeXml = decodeUtf8(await zip.extract(themePath));
     themeColors = parseThemeColors(themeXml);
+  }
+
+  // 7c. Parse external workbook links (xl/externalLinks/externalLinkN.xml).
+  // The workbook.xml.rels file declares them with Type=".../externalLink";
+  // resolve each one in declaration order so the index lines up with
+  // the `[N]` prefix used in formulas.
+  const externalLinkRels = workbookRels
+    .filter((r) => matchesRelType(r.type, "externalLink"))
+    .sort((a, b) => relIdNum(a.id) - relIdNum(b.id));
+  const externalLinks: ExternalLink[] = [];
+  for (const rel of externalLinkRels) {
+    const linkPath = resolvePath(workbookDir, rel.target);
+    if (!zip.has(linkPath)) continue;
+    const linkXml = decodeUtf8(await zip.extract(linkPath));
+    const linkRelsPath = relsPathFor(linkPath);
+    const linkRelsXml = zip.has(linkRelsPath)
+      ? decodeUtf8(await zip.extract(linkRelsPath))
+      : undefined;
+    externalLinks.push(parseExternalLink(linkXml, linkRelsXml));
   }
 
   // 8. Build a map of rId → sheet relationship for worksheet paths
@@ -363,7 +384,33 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     workbook.workbookProtection = workbookProtection;
   }
 
+  if (externalLinks.length > 0) {
+    workbook.externalLinks = externalLinks;
+  }
+
   return workbook;
+}
+
+/**
+ * Numeric value for the trailing digits of an `rIdNN` identifier so we
+ * can sort external link relationships in declaration order. Falls
+ * back to `Infinity` when the id has no digits — keeps malformed
+ * entries last instead of throwing.
+ */
+function relIdNum(rId: string): number {
+  const m = rId.match(/(\d+)$/);
+  return m ? parseInt(m[1], 10) : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Path of the `_rels` file belonging to `partPath`. Returns
+ * `xl/externalLinks/_rels/externalLink1.xml.rels` for input
+ * `xl/externalLinks/externalLink1.xml`.
+ */
+function relsPathFor(partPath: string): string {
+  const slash = partPath.lastIndexOf("/");
+  if (slash === -1) return `_rels/${partPath}.rels`;
+  return `${partPath.slice(0, slash)}/_rels/${partPath.slice(slash + 1)}.rels`;
 }
 
 // ── Drawing / Image Extraction ────────────────────────────────────────

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -280,6 +280,29 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     }
   }
 
+  // Collect external link parts that survived in the raw entries.
+  // Roundtrip preserves the externalLinkN.xml bodies and their _rels;
+  // the workbook.xml + workbook.xml.rels are regenerated and need to
+  // re-declare each link so Excel keeps the references.
+  const externalLinkIndices: number[] = [];
+  for (const path of workbook._rawEntries.keys()) {
+    const m = path.match(/^xl\/externalLinks\/externalLink(\d+)\.xml$/i);
+    if (m) externalLinkIndices.push(parseInt(m[1], 10));
+  }
+  externalLinkIndices.sort((a, b) => a - b);
+  // rIds for external link relationships: assigned after all
+  // sheet/styles/sharedStrings/theme/macros/featurePropertyBag rIds.
+  const externalLinkRelStart = computeExternalLinkRelStart(
+    writeSheets.length,
+    hasSharedStrings,
+    !!workbook.hasMacros,
+    false, // featurePropertyBag — not yet roundtripped
+  );
+  const externalLinkRels = externalLinkIndices.map((idx, i) => ({
+    rId: `rId${externalLinkRelStart + i}`,
+    target: `externalLinks/externalLink${idx}.xml`,
+  }));
+
   // Build ZIP archive
   const zip = new ZipWriter();
 
@@ -324,6 +347,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     imageExtensions: imageExtensions.size > 0 ? imageExtensions : undefined,
     commentIndices: commentIndices.length > 0 ? commentIndices : undefined,
     tableIndices: allTableIndices.length > 0 ? allTableIndices : undefined,
+    externalLinkIndices: externalLinkIndices.length > 0 ? externalLinkIndices : undefined,
     hasCoreProps: true,
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
@@ -347,6 +371,8 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         allNamedRanges.length > 0 ? allNamedRanges : undefined,
         dateSystem,
         activeSheet,
+        undefined,
+        externalLinkRels.length > 0 ? externalLinkRels : undefined,
       ),
     ),
   );
@@ -354,7 +380,15 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
   // xl/_rels/workbook.xml.rels
   zip.add(
     "xl/_rels/workbook.xml.rels",
-    encoder.encode(writeWorkbookRels(writeSheets.length, hasSharedStrings, workbook.hasMacros)),
+    encoder.encode(
+      writeWorkbookRels(
+        writeSheets.length,
+        hasSharedStrings,
+        workbook.hasMacros,
+        false,
+        externalLinkRels.length > 0 ? externalLinkRels : undefined,
+      ),
+    ),
   );
 
   // xl/styles.xml
@@ -473,6 +507,28 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Mirror the `nextRid` counter inside `writeWorkbookRels` to determine
+ * the starting rId for external link relationships. Keep this in sync
+ * with `writeWorkbookRels` — order is: worksheets, styles, optional
+ * sharedStrings, theme, optional vbaProject, optional FeaturePropertyBag,
+ * then externalLinks.
+ */
+function computeExternalLinkRelStart(
+  sheetCount: number,
+  hasSharedStrings: boolean,
+  hasMacros: boolean,
+  hasFeaturePropertyBag: boolean,
+): number {
+  let next = sheetCount + 1; // worksheets occupy rId1..rId{sheetCount}
+  next++; // styles
+  if (hasSharedStrings) next++;
+  next++; // theme
+  if (hasMacros) next++;
+  if (hasFeaturePropertyBag) next++;
+  return next;
+}
 
 /**
  * Build the full list of named ranges, merging user-defined ranges with

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -26,6 +26,7 @@ export function writeWorkbookXml(
   dateSystem?: "1900" | "1904",
   activeSheet?: number,
   workbookProtection?: { lockStructure?: boolean; lockWindows?: boolean; password?: string },
+  externalLinkRels?: ReadonlyArray<{ rId: string }>,
 ): string {
   const sheetElements: string[] = [];
 
@@ -114,6 +115,19 @@ export function writeWorkbookXml(
   // ── calcPr — tells Excel to recalculate all formulas on open ──
   parts.push(xmlSelfClose("calcPr", { calcId: 0, fullCalcOnLoad: 1 }));
 
+  // ── externalReferences — must come AFTER calcPr per OOXML schema order
+  // is incorrect; the schema actually places it before. Excel however
+  // accepts both orders, and ECMA-376 §18.2.2 lists externalReferences
+  // before calcPr in the workbook content model, so emit it earlier.
+  // Move logic: rebuild parts with the block injected at the right spot.
+  if (externalLinkRels && externalLinkRels.length > 0) {
+    const refChildren = externalLinkRels.map((r) =>
+      xmlSelfClose("externalReference", { "r:id": r.rId }),
+    );
+    // Insert just before the trailing calcPr we already pushed.
+    parts.splice(parts.length - 1, 0, xmlElement("externalReferences", undefined, refChildren));
+  }
+
   return xmlDocument("workbook", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts);
 }
 
@@ -121,12 +135,23 @@ const REL_VBA_PROJECT = "http://schemas.microsoft.com/office/2006/relationships/
 const REL_FEATURE_PROPERTY_BAG =
   "http://schemas.microsoft.com/office/2022/11/relationships/FeaturePropertyBag";
 
+const REL_EXTERNAL_LINK =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink";
+
+/** A relationship description for an externalLink emitted in workbook.xml.rels. */
+export interface ExternalLinkRel {
+  rId: string;
+  /** Path relative to the workbook directory, e.g. "externalLinks/externalLink1.xml". */
+  target: string;
+}
+
 /** Generate xl/_rels/workbook.xml.rels */
 export function writeWorkbookRels(
   sheetCount: number,
   hasSharedStrings: boolean,
   hasMacros?: boolean,
   hasFeaturePropertyBag?: boolean,
+  externalLinkRels?: ReadonlyArray<ExternalLinkRel>,
 ): string {
   const children: string[] = [];
 
@@ -195,6 +220,20 @@ export function writeWorkbookRels(
         Target: "featurePropertyBag/featurePropertyBag.xml",
       }),
     );
+    nextRid++;
+  }
+
+  // External link relationships (caller supplies pre-assigned rIds)
+  if (externalLinkRels) {
+    for (const link of externalLinkRels) {
+      children.push(
+        xmlSelfClose("Relationship", {
+          Id: link.rId,
+          Type: REL_EXTERNAL_LINK,
+          Target: link.target,
+        }),
+      );
+    }
   }
 
   return xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, children);

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -112,21 +112,18 @@ export function writeWorkbookXml(
     parts.push(xmlElement("definedNames", undefined, dnElements));
   }
 
-  // ── calcPr — tells Excel to recalculate all formulas on open ──
-  parts.push(xmlSelfClose("calcPr", { calcId: 0, fullCalcOnLoad: 1 }));
-
-  // ── externalReferences — must come AFTER calcPr per OOXML schema order
-  // is incorrect; the schema actually places it before. Excel however
-  // accepts both orders, and ECMA-376 §18.2.2 lists externalReferences
-  // before calcPr in the workbook content model, so emit it earlier.
-  // Move logic: rebuild parts with the block injected at the right spot.
+  // ── externalReferences — ECMA-376 §18.2.2 places the block after
+  // definedNames and before calcPr. Excel tolerates other orders, but
+  // the spec order is what we emit so generated files validate clean.
   if (externalLinkRels && externalLinkRels.length > 0) {
     const refChildren = externalLinkRels.map((r) =>
       xmlSelfClose("externalReference", { "r:id": r.rId }),
     );
-    // Insert just before the trailing calcPr we already pushed.
-    parts.splice(parts.length - 1, 0, xmlElement("externalReferences", undefined, refChildren));
+    parts.push(xmlElement("externalReferences", undefined, refChildren));
   }
+
+  // ── calcPr — tells Excel to recalculate all formulas on open ──
+  parts.push(xmlSelfClose("calcPr", { calcId: 0, fullCalcOnLoad: 1 }));
 
   return xmlDocument("workbook", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts);
 }

--- a/test/external-links.test.ts
+++ b/test/external-links.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from "vitest";
+import { parseExternalLink } from "../src/xlsx/external-link-reader";
+import { ZipWriter } from "../src/zip/writer";
+import { ZipReader } from "../src/zip/reader";
+import { readXlsx } from "../src/xlsx/reader";
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip";
+
+const encoder = new TextEncoder();
+
+// ── parseExternalLink: standalone ──────────────────────────────────
+
+describe("parseExternalLink", () => {
+  it("returns an empty link when given a nearly-empty externalLink XML", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <externalBook r:id="rId1"/>
+</externalLink>`;
+    const link = parseExternalLink(xml);
+    expect(link.target).toBe("");
+    expect(link.sheetNames).toEqual([]);
+    expect(link.sheetData).toEqual([]);
+    expect(link.definedNames).toBeUndefined();
+  });
+
+  it("resolves the target path and TargetMode from the rels XML", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <externalBook r:id="rId1"/>
+</externalLink>`;
+    const relsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath"
+    Target="External.xlsx" TargetMode="External"/>
+</Relationships>`;
+    const link = parseExternalLink(xml, relsXml);
+    expect(link.target).toBe("External.xlsx");
+    expect(link.targetMode).toBe("External");
+  });
+
+  it("parses sheetNames in declaration order", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <externalBook r:id="rId1">
+    <sheetNames>
+      <sheetName val="Summary"/>
+      <sheetName val="Data"/>
+      <sheetName val="Hidden &amp; Notes"/>
+    </sheetNames>
+  </externalBook>
+</externalLink>`;
+    const link = parseExternalLink(xml);
+    expect(link.sheetNames).toEqual(["Summary", "Data", "Hidden & Notes"]);
+  });
+
+  it("parses cached numeric, string, boolean, error, and inline-string cells", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <externalBook r:id="rId1">
+    <sheetNames><sheetName val="Sheet1"/></sheetNames>
+    <sheetDataSet>
+      <sheetData sheetId="0">
+        <row r="1">
+          <cell r="A1" t="n"><v>42.5</v></cell>
+          <cell r="B1" t="b"><v>1</v></cell>
+          <cell r="C1" t="e"><v>#REF!</v></cell>
+          <cell r="D1" t="str"><v>Hello</v></cell>
+          <cell r="E1" t="s"><v>3</v></cell>
+        </row>
+      </sheetData>
+    </sheetDataSet>
+  </externalBook>
+</externalLink>`;
+    const link = parseExternalLink(xml);
+    expect(link.sheetData).toHaveLength(1);
+    expect(link.sheetData[0].sheetId).toBe(0);
+    const cells = link.sheetData[0].cells;
+    expect(cells).toHaveLength(5);
+    expect(cells[0]).toEqual({ ref: "A1", type: "n", value: 42.5 });
+    expect(cells[1]).toEqual({ ref: "B1", type: "b", value: true });
+    expect(cells[2]).toEqual({ ref: "C1", type: "e", value: "#REF!" });
+    expect(cells[3]).toEqual({ ref: "D1", type: "str", value: "Hello" });
+    // shared-string indices stay numeric — the resolved string lives in
+    // the external workbook, which the reader cannot dereference here.
+    expect(cells[4]).toEqual({ ref: "E1", type: "s", value: 3 });
+  });
+
+  it("parses defined names with sheetId scoping", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <externalBook r:id="rId1">
+    <sheetNames><sheetName val="S"/></sheetNames>
+    <definedNames>
+      <definedName name="Total" refersTo="[1]S!$B$10"/>
+      <definedName name="LocalTotal" refersTo="[1]S!$B$11" sheetId="0"/>
+    </definedNames>
+  </externalBook>
+</externalLink>`;
+    const link = parseExternalLink(xml);
+    expect(link.definedNames).toHaveLength(2);
+    expect(link.definedNames?.[0]).toEqual({ name: "Total", refersTo: "[1]S!$B$10" });
+    expect(link.definedNames?.[1]).toEqual({
+      name: "LocalTotal",
+      refersTo: "[1]S!$B$11",
+      sheetId: 0,
+    });
+  });
+
+  it("skips cells without an `r=` reference rather than throwing", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <externalBook>
+    <sheetNames><sheetName val="S"/></sheetNames>
+    <sheetDataSet>
+      <sheetData sheetId="0">
+        <row r="1">
+          <cell t="n"><v>1</v></cell>
+          <cell r="A1" t="n"><v>2</v></cell>
+        </row>
+      </sheetData>
+    </sheetDataSet>
+  </externalBook>
+</externalLink>`;
+    const link = parseExternalLink(xml);
+    expect(link.sheetData[0].cells).toHaveLength(1);
+    expect(link.sheetData[0].cells[0].ref).toBe("A1");
+  });
+
+  it("falls back to type=n when an unknown cell type is encountered", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <externalBook>
+    <sheetNames><sheetName val="S"/></sheetNames>
+    <sheetDataSet>
+      <sheetData sheetId="0">
+        <row r="1">
+          <cell r="A1" t="bogus"><v>9</v></cell>
+        </row>
+      </sheetData>
+    </sheetDataSet>
+  </externalBook>
+</externalLink>`;
+    const link = parseExternalLink(xml);
+    expect(link.sheetData[0].cells[0].type).toBe("n");
+    expect(link.sheetData[0].cells[0].value).toBe(9);
+  });
+});
+
+// ── End-to-end: full XLSX with external links ──────────────────────
+
+/**
+ * Build a minimal but valid XLSX containing one worksheet and one
+ * external workbook reference. Anything not strictly required is
+ * stripped down to the bare bones the reader actually inspects.
+ */
+async function buildXlsxWithExternalLink(): Promise<Uint8Array> {
+  const z = new ZipWriter();
+
+  z.add(
+    "[Content_Types].xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/externalLinks/externalLink1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml"/>
+</Types>`),
+  );
+
+  z.add(
+    "_rels/.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/workbook.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Main" sheetId="1" r:id="rId1"/>
+  </sheets>
+  <externalReferences>
+    <externalReference r:id="rId2"/>
+  </externalReferences>
+</workbook>`),
+  );
+
+  z.add(
+    "xl/_rels/workbook.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink" Target="externalLinks/externalLink1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/worksheets/sheet1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="n"><v>10</v></c></row>
+  </sheetData>
+</worksheet>`),
+  );
+
+  z.add(
+    "xl/externalLinks/externalLink1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <externalBook r:id="rId1">
+    <sheetNames>
+      <sheetName val="Lookup"/>
+    </sheetNames>
+    <sheetDataSet>
+      <sheetData sheetId="0">
+        <row r="1">
+          <cell r="A1" t="n"><v>123</v></cell>
+          <cell r="B1" t="str"><v>label</v></cell>
+        </row>
+      </sheetData>
+    </sheetDataSet>
+  </externalBook>
+</externalLink>`),
+  );
+
+  z.add(
+    "xl/externalLinks/_rels/externalLink1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath"
+    Target="../External.xlsx" TargetMode="External"/>
+</Relationships>`),
+  );
+
+  return await z.build();
+}
+
+describe("readXlsx — external link integration", () => {
+  it("attaches workbook.externalLinks with parsed target and cached values", async () => {
+    const buf = await buildXlsxWithExternalLink();
+    const wb = await readXlsx(buf);
+    expect(wb.externalLinks).toBeDefined();
+    expect(wb.externalLinks).toHaveLength(1);
+    const link = wb.externalLinks![0];
+    expect(link.target).toBe("../External.xlsx");
+    expect(link.targetMode).toBe("External");
+    expect(link.sheetNames).toEqual(["Lookup"]);
+    expect(link.sheetData[0].cells).toEqual([
+      { ref: "A1", type: "n", value: 123 },
+      { ref: "B1", type: "str", value: "label" },
+    ]);
+  });
+
+  it("preserves the externalLink files and re-emits the references on roundtrip", async () => {
+    const buf = await buildXlsxWithExternalLink();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+
+    // The externalLink body and its rels file must survive byte-for-byte.
+    const zip = new ZipReader(out);
+    expect(zip.has("xl/externalLinks/externalLink1.xml")).toBe(true);
+    expect(zip.has("xl/externalLinks/_rels/externalLink1.xml.rels")).toBe(true);
+
+    // The regenerated workbook.xml must declare the externalReference and
+    // workbook.xml.rels must carry the externalLink relationship — without
+    // these Excel silently drops the link on next open.
+    const wbXml = new TextDecoder("utf-8").decode(await zip.extract("xl/workbook.xml"));
+    expect(wbXml).toContain("<externalReferences>");
+    expect(wbXml).toMatch(/<externalReference [^>]*r:id="rId\d+"/);
+
+    const wbRels = new TextDecoder("utf-8").decode(await zip.extract("xl/_rels/workbook.xml.rels"));
+    expect(wbRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink"',
+    );
+    expect(wbRels).toContain('Target="externalLinks/externalLink1.xml"');
+
+    // [Content_Types].xml must declare the externalLink override or
+    // Excel will refuse to load the part.
+    const ct = new TextDecoder("utf-8").decode(await zip.extract("[Content_Types].xml"));
+    expect(ct).toContain("/xl/externalLinks/externalLink1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml",
+    );
+  });
+
+  it("re-reading the saved workbook returns the same external link", async () => {
+    const buf = await buildXlsxWithExternalLink();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const reread = await readXlsx(out);
+    expect(reread.externalLinks).toHaveLength(1);
+    expect(reread.externalLinks?.[0].target).toBe("../External.xlsx");
+    expect(reread.externalLinks?.[0].sheetData[0].cells[0]).toEqual({
+      ref: "A1",
+      type: "n",
+      value: 123,
+    });
+  });
+
+  it("does not set externalLinks when the workbook has none", async () => {
+    const z = new ZipWriter();
+    z.add(
+      "[Content_Types].xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>`),
+    );
+    z.add(
+      "_rels/.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/workbook.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Main" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+    );
+    z.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/worksheets/sheet1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>`),
+    );
+
+    const wb = await readXlsx(await z.build());
+    expect(wb.externalLinks).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

External workbook references (`[N]Sheet!Ref`) were previously silently dropped on roundtrip — the `xl/externalLinks/externalLinkN.xml` files survived in the ZIP, but the `<externalReferences>` block in `xl/workbook.xml` and the `Type=\".../externalLink\"` relationships in `xl/_rels/workbook.xml.rels` were both regenerated without them, leaving orphan parts that Excel ignores.

This PR makes external links first-class: read into a typed model, preserved on roundtrip, and re-declared in all three places that point to them.

## API

```ts
import { readXlsx } from \"hucre\";

const wb = await readXlsx(buf);
for (const link of wb.externalLinks ?? []) {
  console.log(link.target, link.targetMode, link.sheetNames);
  for (const sheet of link.sheetData) {
    for (const cell of sheet.cells) {
      console.log(cell.ref, cell.type, cell.value);
    }
  }
}

// Standalone parser, useful when you already have the XML strings
import { parseExternalLink } from \"hucre\";
const link = parseExternalLink(externalLinkXml, externalLinkRelsXml);
```

## Model

```ts
interface ExternalLink {
  target: string;                    // e.g. \"../External.xlsx\"
  targetMode?: \"External\" | \"Internal\";
  sheetNames: string[];              // declaration order
  sheetData: ExternalSheetData[];    // cached cell values per external sheet
  definedNames?: ExternalDefinedName[];
}

interface ExternalCachedCell {
  ref: string;                       // A1-style
  type: \"n\" | \"s\" | \"b\" | \"e\" | \"str\";
  value: string | number | boolean;
}
```

The 1-based index in `workbook.externalLinks` matches the `[N]` prefix in formulas like `[1]Sheet1!A1`.

## What changed in the writer side

| Hook | Change |
| --- | --- |
| `writeContentTypes` | new `externalLinkIndices?: number[]` → emits `Override` per link |
| `writeWorkbookXml` | new `externalLinkRels` arg → emits `<externalReferences>` block |
| `writeWorkbookRels` | new `externalLinkRels` arg → emits `Type=\".../externalLink\"` relationships with rIds that follow worksheets / styles / sharedStrings / theme / vbaProject / FeaturePropertyBag |
| `roundtrip` | scans `_rawEntries` for `xl/externalLinks/externalLinkN.xml` and threads the indices through |

## Test plan

- [x] 2211 tests pass (11 new); `pnpm test` green (lint + typecheck + vitest)
- [x] `parseExternalLink` covers all five OOXML cell types, `TargetMode`, defined-name scoping, missing `r=`, unknown `t=`
- [x] End-to-end: a full XLSX with an external link round-trips through `openXlsx → saveXlsx` and a re-read recovers the same target, sheet names, and cached values
- [x] Output declares `Override` for `/xl/externalLinks/externalLink1.xml`, `<externalReference r:id=\"rId...\"/>`, and the `Type=\".../externalLink\"` relationship
- [x] No-externalLinks workbooks still emit byte-identical workbook rels

## Out of scope

Generating an external link from a parsed `ExternalLink` model on a fresh `writeXlsx` call (i.e. without an existing source file) needs an XML serializer for the `externalLinkN.xml` body. The infrastructure to wire that in is now in place — adding it is a follow-up.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)