### PR TITLE
feat(xlsx): threaded comments — read & roundtrip (Excel 365+)

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -463,6 +463,57 @@ export interface SheetTextBox {
   };
 }
 
+// ── Threaded Comments (Excel 365+) ─────────────────────────────────
+
+/**
+ * A person who can author or be mentioned in threaded comments.
+ * Stored in the workbook-wide `xl/persons/person.xml` part.
+ */
+export interface ThreadedCommentPerson {
+  /** Stable GUID identifying this person within the workbook. */
+  id: string;
+  /** Display name shown in Excel's comment pane (required by the schema). */
+  displayName: string;
+  /** Identity-system user id, e.g. the Azure AD object id. */
+  userId?: string;
+  /** Identity provider name, e.g. "AD" or "PeoplePicker". */
+  providerId?: string;
+}
+
+/**
+ * An `@person` mention inside a threaded comment's text. Indices are
+ * UTF-16 code-unit offsets into the comment text.
+ */
+export interface ThreadedCommentMention {
+  mentionPersonId: string;
+  mentionId: string;
+  startIndex: number;
+  length: number;
+}
+
+/**
+ * A single message in a thread on `xl/threadedComments/threadedCommentN.xml`.
+ * Top-level messages declare a `ref`; replies omit it and link to their
+ * parent through `parentId`.
+ */
+export interface ThreadedComment {
+  id: string;
+  /** A1-style cell ref. Required for thread roots, omitted for replies. */
+  ref?: string;
+  /** GUID matching a {@link ThreadedCommentPerson.id}. */
+  personId: string;
+  /** GUID of the parent comment when this is a reply. */
+  parentId?: string;
+  /** ISO-8601 timestamp from the `dT` attribute. */
+  date?: string;
+  /** Comment body. */
+  text: string;
+  /** Whether the thread is marked resolved. */
+  done?: boolean;
+  /** `@person` mentions inside the text. */
+  mentions?: ThreadedCommentMention[];
+}
+
 // ── Image ──────────────────────────────────────────────────────────
 
 export interface SheetImage {
@@ -594,6 +645,12 @@ export interface Sheet {
   sparklines?: Sparkline[];
   /** Text boxes (shapes with text) */
   textBoxes?: SheetTextBox[];
+  /**
+   * Excel 365 threaded comments for this sheet. Stored physically in
+   * `xl/threadedComments/threadedCommentN.xml` and resolved against
+   * the workbook-wide person list (`Workbook.persons`).
+   */
+  threadedComments?: ThreadedComment[];
 }
 
 // ── Workbook Properties ────────────────────────────────────────────
@@ -633,6 +690,11 @@ export interface Workbook {
     lockStructure?: boolean;
     lockWindows?: boolean;
   };
+  /**
+   * Workbook-wide person directory referenced from threaded comments.
+   * Each `ThreadedComment.personId` resolves against this list.
+   */
+  persons?: ThreadedCommentPerson[];
 }
 
 // ── Read Options ───────────────────────────────────────────────────
@@ -754,6 +816,8 @@ export interface WriteSheet {
   sparklines?: Sparkline[];
   /** Text boxes (shapes with text) */
   textBoxes?: SheetTextBox[];
+  /** Excel 365 threaded comments for this sheet. */
+  threadedComments?: ThreadedComment[];
 }
 
 // ── Outline Properties ────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,10 @@ export type { XmlReadOptions, XmlReadResult, XmlWriteOptions } from "./xml";
 // ── Schema Validation ──────────────────────────────────────────────
 export { validateWithSchema } from "./_schema";
 
+// ── Threaded Comments (Excel 365+) ─────────────────────────────────
+export { parsePersons, parseThreadedComments } from "./xlsx/threaded-comments-reader";
+export type { ThreadedComment, ThreadedCommentMention, ThreadedCommentPerson } from "./_types";
+
 // ── Date Utilities ─────────────────────────────────────────────────
 export {
   serialToDate,

--- a/src/xlsx/content-types-writer.ts
+++ b/src/xlsx/content-types-writer.ts
@@ -19,6 +19,8 @@ const CT_COMMENTS = "application/vnd.openxmlformats-officedocument.spreadsheetml
 const CT_VML = "application/vnd.openxmlformats-officedocument.vmlDrawing";
 const CT_TABLE = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml";
 const CT_THEME = "application/vnd.openxmlformats-officedocument.theme+xml";
+const CT_THREADED_COMMENTS = "application/vnd.ms-excel.threadedcomments+xml";
+const CT_PERSON = "application/vnd.ms-excel.person+xml";
 
 /** Image extension → content type mapping */
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
@@ -40,6 +42,13 @@ export interface ContentTypesOptions {
   commentIndices?: number[];
   /** 1-based indices of tables (e.g. [1, 2, 3] means table1.xml, table2.xml, table3.xml exist) */
   tableIndices?: number[];
+  /**
+   * 1-based indices of sheets that have a threadedComments part. Each
+   * entry adds an `Override` for `/xl/threadedComments/threadedCommentN.xml`.
+   */
+  threadedCommentSheetIndices?: number[];
+  /** Whether `xl/persons/person.xml` is present. */
+  hasPersons?: boolean;
   /** Whether docProps/core.xml is present */
   hasCoreProps?: boolean;
   /** Whether docProps/app.xml is present */
@@ -172,6 +181,28 @@ export function writeContentTypes(
         }),
       );
     }
+  }
+
+  // Override for each threadedComments part (Excel 365)
+  if (opts.threadedCommentSheetIndices) {
+    for (const idx of opts.threadedCommentSheetIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/threadedComments/threadedComment${idx}.xml`,
+          ContentType: CT_THREADED_COMMENTS,
+        }),
+      );
+    }
+  }
+
+  // Override for the workbook-wide persons directory
+  if (opts.hasPersons) {
+    children.push(
+      xmlSelfClose("Override", {
+        PartName: "/xl/persons/person.xml",
+        ContentType: CT_PERSON,
+      }),
+    );
   }
 
   // Override for FeaturePropertyBag (Excel 2024 checkboxes)

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -10,7 +10,9 @@ import type {
   NamedRange,
   TableDefinition,
   TableColumn,
+  ThreadedCommentPerson,
 } from "../_types";
+import { parsePersons, parseThreadedComments } from "./threaded-comments-reader";
 import { ParseError, ZipError } from "../errors";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
@@ -185,6 +187,18 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     themeColors = parseThemeColors(themeXml);
   }
 
+  // 7c. Parse the workbook-wide threaded-comments person directory
+  // (xl/persons/person.xml). Linked from workbook.xml.rels by Type=".../person".
+  let persons: ThreadedCommentPerson[] | undefined;
+  const personsRel = workbookRels.find((r) => matchesRelType(r.type, "person"));
+  if (personsRel) {
+    const personsPath = resolvePath(workbookDir, personsRel.target);
+    if (zip.has(personsPath)) {
+      const personsXml = decodeUtf8(await zip.extract(personsPath));
+      persons = parsePersons(personsXml);
+    }
+  }
+
   // 8. Build a map of rId → sheet relationship for worksheet paths
   const sheetRelMap = new Map<string, string>();
   for (const rel of workbookRels) {
@@ -276,6 +290,20 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
           }
         }
       }
+
+      // Extract Excel 365 threaded comments if present.
+      // Sheets can have BOTH legacy comments and threaded comments — Excel
+      // writes a legacy stub for backward compat, so we treat them as
+      // independent surfaces rather than overwriting each other.
+      const threadedRel = worksheetRels.find((r) => matchesRelType(r.type, "threadedComment"));
+      if (threadedRel) {
+        const tcPath = resolvePath(wsDir, threadedRel.target);
+        if (zip.has(tcPath)) {
+          const tcXml = decodeUtf8(await zip.extract(tcPath));
+          const threaded = parseThreadedComments(tcXml);
+          if (threaded.length > 0) sheet.threadedComments = threaded;
+        }
+      }
     }
 
     // Extract tables if present
@@ -361,6 +389,10 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
 
   if (workbookProtection) {
     workbook.workbookProtection = workbookProtection;
+  }
+
+  if (persons && persons.length > 0) {
+    workbook.persons = persons;
   }
 
   return workbook;

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -54,6 +54,9 @@ const REL_COMMENTS = "http://schemas.openxmlformats.org/officeDocument/2006/rela
 const REL_VML_DRAWING =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing";
 const REL_TABLE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table";
+const REL_THREADED_COMMENT =
+  "http://schemas.microsoft.com/office/2017/10/relationships/threadedComment";
+const REL_PERSON = "http://schemas.microsoft.com/office/2017/10/relationships/person";
 
 /**
  * Parts that defter regenerates from parsed data.
@@ -280,6 +283,16 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     }
   }
 
+  // Detect Excel 365 threaded comments + persons surviving in raw entries.
+  // Threaded comments live at xl/threadedComments/threadedCommentN.xml where
+  // N matches the worksheet's 1-based index, so we just probe each sheet.
+  const threadedCommentSheetIndices: number[] = [];
+  for (let i = 0; i < worksheetResults.length; i++) {
+    const probe = `xl/threadedComments/threadedComment${i + 1}.xml`;
+    if (workbook._rawEntries.has(probe)) threadedCommentSheetIndices.push(i + 1);
+  }
+  const hasPersons = workbook._rawEntries.has("xl/persons/person.xml");
+
   // Build ZIP archive
   const zip = new ZipWriter();
 
@@ -324,6 +337,9 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     imageExtensions: imageExtensions.size > 0 ? imageExtensions : undefined,
     commentIndices: commentIndices.length > 0 ? commentIndices : undefined,
     tableIndices: allTableIndices.length > 0 ? allTableIndices : undefined,
+    threadedCommentSheetIndices:
+      threadedCommentSheetIndices.length > 0 ? threadedCommentSheetIndices : undefined,
+    hasPersons: hasPersons || undefined,
     hasCoreProps: true,
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
@@ -354,7 +370,15 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
   // xl/_rels/workbook.xml.rels
   zip.add(
     "xl/_rels/workbook.xml.rels",
-    encoder.encode(writeWorkbookRels(writeSheets.length, hasSharedStrings, workbook.hasMacros)),
+    encoder.encode(
+      writeWorkbookRels(
+        writeSheets.length,
+        hasSharedStrings,
+        workbook.hasMacros,
+        false, // hasFeaturePropertyBag — not yet roundtripped
+        hasPersons,
+      ),
+    ),
   );
 
   // xl/styles.xml
@@ -378,8 +402,9 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     const hasDrawing = drawing !== null && result.drawingRId !== null;
     const hasComments = comments !== null && result.legacyDrawingRId !== null;
     const hasTables = result.tables.length > 0;
+    const hasThreadedComments = threadedCommentSheetIndices.includes(i + 1);
 
-    if (hasHyperlinks || hasDrawing || hasComments || hasTables) {
+    if (hasHyperlinks || hasDrawing || hasComments || hasTables || hasThreadedComments) {
       const relElements: string[] = [];
 
       for (const rel of result.hyperlinkRelationships) {
@@ -430,6 +455,27 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         );
       }
 
+      // Threaded comments (Excel 365). The rId only needs to be unique
+      // within this rels file — pick the next id past everything we've
+      // already emitted for this sheet.
+      if (hasThreadedComments) {
+        const usedIds = new Set<number>();
+        for (const r of result.hyperlinkRelationships) usedIds.add(relIdNum(r.id));
+        if (result.drawingRId) usedIds.add(relIdNum(result.drawingRId));
+        if (result.legacyDrawingRId) usedIds.add(relIdNum(result.legacyDrawingRId));
+        if (result.commentsRId) usedIds.add(relIdNum(result.commentsRId));
+        for (const t of result.tables) usedIds.add(relIdNum(t.rId));
+        let next = 1;
+        while (usedIds.has(next)) next++;
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: `rId${next}`,
+            Type: REL_THREADED_COMMENT,
+            Target: `../threadedComments/threadedComment${i + 1}.xml`,
+          }),
+        );
+      }
+
       const relsXml = xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, relElements);
       zip.add(`xl/worksheets/_rels/sheet${i + 1}.xml.rels`, encoder.encode(relsXml));
     }
@@ -473,6 +519,12 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+/** Numeric value for the digits at the end of an `rIdNN` identifier. */
+function relIdNum(rId: string): number {
+  const m = rId.match(/(\d+)$/);
+  return m ? parseInt(m[1], 10) : 0;
+}
 
 /**
  * Build the full list of named ranges, merging user-defined ranges with

--- a/src/xlsx/threaded-comments-reader.ts
+++ b/src/xlsx/threaded-comments-reader.ts
@@ -1,0 +1,105 @@
+// ── Threaded Comments Reader ──────────────────────────────────────
+// Parses Excel 365's modern comment system:
+//   xl/persons/person.xml             — workbook-wide person directory
+//   xl/threadedComments/threadedComment{N}.xml — per-sheet comment threads
+//
+// Schema: http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments
+// Reference: [MS-XLSX] Threaded Comments
+//   https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/adb84732-9fc8-48b6-bddc-6b0bcdaad940
+
+import type { ThreadedComment, ThreadedCommentMention, ThreadedCommentPerson } from "../_types";
+import { parseXml } from "../xml/parser";
+import type { XmlElement, XmlNode } from "../xml/parser";
+
+/** Parse `xl/persons/person.xml` into a list of persons. */
+export function parsePersons(xml: string): ThreadedCommentPerson[] {
+  const root = parseXml(xml);
+  const persons: ThreadedCommentPerson[] = [];
+  for (const child of childElements(root)) {
+    if (child.local !== "person") continue;
+    const id = child.attrs.id;
+    const displayName = child.attrs.displayName;
+    if (!id || displayName === undefined) continue;
+    const entry: ThreadedCommentPerson = { id, displayName };
+    if (child.attrs.userId) entry.userId = child.attrs.userId;
+    if (child.attrs.providerId) entry.providerId = child.attrs.providerId;
+    persons.push(entry);
+  }
+  return persons;
+}
+
+/** Parse a single `xl/threadedComments/threadedCommentN.xml` part. */
+export function parseThreadedComments(xml: string): ThreadedComment[] {
+  const root = parseXml(xml);
+  const comments: ThreadedComment[] = [];
+  for (const child of childElements(root)) {
+    if (child.local !== "threadedComment") continue;
+    const id = child.attrs.id;
+    const personId = child.attrs.personId;
+    if (!id || !personId) continue;
+
+    const entry: ThreadedComment = {
+      id,
+      personId,
+      text: readChildText(child, "text"),
+    };
+    if (child.attrs.ref) entry.ref = child.attrs.ref;
+    if (child.attrs.parentId) entry.parentId = child.attrs.parentId;
+    if (child.attrs.dT) entry.date = child.attrs.dT;
+    if (child.attrs.done === "1" || child.attrs.done === "true") entry.done = true;
+
+    const mentionsEl = findChild(child, "mentions");
+    if (mentionsEl) {
+      const mentions: ThreadedCommentMention[] = [];
+      for (const m of childElements(mentionsEl)) {
+        if (m.local !== "mention") continue;
+        const mp = m.attrs.mentionpersonId;
+        const mid = m.attrs.mentionId;
+        if (!mp || !mid) continue;
+        mentions.push({
+          mentionPersonId: mp,
+          mentionId: mid,
+          startIndex: parseIntSafe(m.attrs.startIndex, 0),
+          length: parseIntSafe(m.attrs.length, 0),
+        });
+      }
+      if (mentions.length > 0) entry.mentions = mentions;
+    }
+
+    comments.push(entry);
+  }
+  return comments;
+}
+
+// ── Internals ─────────────────────────────────────────────────────
+
+function childElements(el: XmlElement): XmlElement[] {
+  const out: XmlElement[] = [];
+  for (const c of el.children) {
+    if (typeof c !== "string") out.push(c);
+  }
+  return out;
+}
+
+function findChild(el: XmlElement, localName: string): XmlElement | undefined {
+  for (const c of el.children) {
+    if (typeof c !== "string" && c.local === localName) return c;
+  }
+  return undefined;
+}
+
+function readChildText(el: XmlElement, localName: string): string {
+  const child = findChild(el, localName);
+  if (!child) return "";
+  let text = "";
+  for (const c of child.children as XmlNode[]) {
+    if (typeof c === "string") text += c;
+  }
+  return text;
+}
+
+function parseIntSafe(s: string | undefined, fallback: number): number {
+  if (s === undefined) return fallback;
+  const n = parseInt(s, 10);
+  return Number.isNaN(n) ? fallback : n;
+}

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -121,12 +121,15 @@ const REL_VBA_PROJECT = "http://schemas.microsoft.com/office/2006/relationships/
 const REL_FEATURE_PROPERTY_BAG =
   "http://schemas.microsoft.com/office/2022/11/relationships/FeaturePropertyBag";
 
+const REL_PERSON = "http://schemas.microsoft.com/office/2017/10/relationships/person";
+
 /** Generate xl/_rels/workbook.xml.rels */
 export function writeWorkbookRels(
   sheetCount: number,
   hasSharedStrings: boolean,
   hasMacros?: boolean,
   hasFeaturePropertyBag?: boolean,
+  hasPersons?: boolean,
 ): string {
   const children: string[] = [];
 
@@ -193,6 +196,18 @@ export function writeWorkbookRels(
         Id: `rId${nextRid}`,
         Type: REL_FEATURE_PROPERTY_BAG,
         Target: "featurePropertyBag/featurePropertyBag.xml",
+      }),
+    );
+    nextRid++;
+  }
+
+  // Threaded-comments person directory (Excel 365)
+  if (hasPersons) {
+    children.push(
+      xmlSelfClose("Relationship", {
+        Id: `rId${nextRid}`,
+        Type: REL_PERSON,
+        Target: "persons/person.xml",
       }),
     );
   }

--- a/test/threaded-comments.test.ts
+++ b/test/threaded-comments.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import { ZipWriter } from "../src/zip/writer";
+import { ZipReader } from "../src/zip/reader";
+import { readXlsx } from "../src/xlsx/reader";
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip";
+import { parsePersons, parseThreadedComments } from "../src/xlsx/threaded-comments-reader";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8");
+
+// ── parsePersons ────────────────────────────────────────────────────
+
+describe("parsePersons", () => {
+  it("parses required attributes (id + displayName)", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <person id="{11111111-1111-1111-1111-111111111111}" displayName="Alice"/>
+  <person id="{22222222-2222-2222-2222-222222222222}" displayName="Bob"
+          userId="bob@example.com" providerId="AD"/>
+</personList>`;
+    const persons = parsePersons(xml);
+    expect(persons).toHaveLength(2);
+    expect(persons[0]).toEqual({
+      id: "{11111111-1111-1111-1111-111111111111}",
+      displayName: "Alice",
+    });
+    expect(persons[1]).toEqual({
+      id: "{22222222-2222-2222-2222-222222222222}",
+      displayName: "Bob",
+      userId: "bob@example.com",
+      providerId: "AD",
+    });
+  });
+
+  it("skips entries missing id or displayName", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <person displayName="No id"/>
+  <person id="abc"/>
+  <person id="ok" displayName="OK"/>
+</personList>`;
+    const persons = parsePersons(xml);
+    expect(persons).toHaveLength(1);
+    expect(persons[0].displayName).toBe("OK");
+  });
+});
+
+// ── parseThreadedComments ───────────────────────────────────────────
+
+describe("parseThreadedComments", () => {
+  it("parses a thread root + one reply with mentions and a done flag", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <threadedComment ref="B5" dT="2026-04-01T10:00:00Z"
+    personId="{p1}" id="{c1}">
+    <text>Looks off — should this be in EUR?</text>
+    <mentions>
+      <mention mentionpersonId="{p2}" mentionId="{m1}" startIndex="0" length="10"/>
+    </mentions>
+  </threadedComment>
+  <threadedComment dT="2026-04-01T10:05:00Z" personId="{p2}" id="{c2}"
+    parentId="{c1}" done="1">
+    <text>Fixed in v2.</text>
+  </threadedComment>
+</ThreadedComments>`;
+    const comments = parseThreadedComments(xml);
+    expect(comments).toHaveLength(2);
+
+    expect(comments[0]).toMatchObject({
+      id: "{c1}",
+      ref: "B5",
+      personId: "{p1}",
+      date: "2026-04-01T10:00:00Z",
+      text: "Looks off — should this be in EUR?",
+    });
+    expect(comments[0].mentions).toEqual([
+      {
+        mentionPersonId: "{p2}",
+        mentionId: "{m1}",
+        startIndex: 0,
+        length: 10,
+      },
+    ]);
+
+    expect(comments[1]).toMatchObject({
+      id: "{c2}",
+      personId: "{p2}",
+      parentId: "{c1}",
+      done: true,
+      text: "Fixed in v2.",
+    });
+    // Replies omit ref — confirm it's actually undefined, not empty string.
+    expect(comments[1].ref).toBeUndefined();
+  });
+
+  it("treats `done=true` and `done=1` identically and treats other values as not done", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <threadedComment ref="A1" personId="{p}" id="{a}" done="1"><text>A</text></threadedComment>
+  <threadedComment ref="A2" personId="{p}" id="{b}" done="true"><text>B</text></threadedComment>
+  <threadedComment ref="A3" personId="{p}" id="{c}" done="0"><text>C</text></threadedComment>
+  <threadedComment ref="A4" personId="{p}" id="{d}"><text>D</text></threadedComment>
+</ThreadedComments>`;
+    const cs = parseThreadedComments(xml);
+    expect(cs.map((c) => c.done)).toEqual([true, true, undefined, undefined]);
+  });
+
+  it("skips entries missing required GUIDs", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <threadedComment ref="A1" id="missing-personId"><text>X</text></threadedComment>
+  <threadedComment ref="A2" personId="{p}"><text>missing id</text></threadedComment>
+  <threadedComment ref="A3" personId="{p}" id="{ok}"><text>OK</text></threadedComment>
+</ThreadedComments>`;
+    expect(parseThreadedComments(xml)).toHaveLength(1);
+  });
+
+  it("returns an empty mentions list as undefined rather than []", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <threadedComment ref="A1" personId="{p}" id="{c}"><text>plain</text></threadedComment>
+</ThreadedComments>`;
+    expect(parseThreadedComments(xml)[0].mentions).toBeUndefined();
+  });
+});
+
+// ── End-to-end fixture ──────────────────────────────────────────────
+
+async function buildXlsxWithThreadedComments(): Promise<Uint8Array> {
+  const z = new ZipWriter();
+
+  z.add(
+    "[Content_Types].xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/persons/person.xml" ContentType="application/vnd.ms-excel.person+xml"/>
+  <Override PartName="/xl/threadedComments/threadedComment1.xml" ContentType="application/vnd.ms-excel.threadedcomments+xml"/>
+</Types>`),
+  );
+
+  z.add(
+    "_rels/.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/workbook.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Main" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+  );
+
+  z.add(
+    "xl/_rels/workbook.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2017/10/relationships/person" Target="persons/person.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/worksheets/sheet1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData><row r="1"><c r="A1" t="n"><v>1</v></c></row></sheetData>
+</worksheet>`),
+  );
+
+  z.add(
+    "xl/worksheets/_rels/sheet1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2017/10/relationships/threadedComment" Target="../threadedComments/threadedComment1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/persons/person.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <person id="{p1}" displayName="Alice" providerId="AD"/>
+  <person id="{p2}" displayName="Bob"/>
+</personList>`),
+  );
+
+  z.add(
+    "xl/threadedComments/threadedComment1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <threadedComment ref="A1" dT="2026-04-01T10:00:00Z" personId="{p1}" id="{c1}"><text>Hello</text></threadedComment>
+  <threadedComment dT="2026-04-01T10:05:00Z" personId="{p2}" id="{c2}" parentId="{c1}"><text>Hi back</text></threadedComment>
+</ThreadedComments>`),
+  );
+
+  return await z.build();
+}
+
+describe("readXlsx — threaded comments integration", () => {
+  it("attaches workbook.persons and sheet.threadedComments", async () => {
+    const buf = await buildXlsxWithThreadedComments();
+    const wb = await readXlsx(buf);
+    expect(wb.persons).toEqual([
+      { id: "{p1}", displayName: "Alice", providerId: "AD" },
+      { id: "{p2}", displayName: "Bob" },
+    ]);
+    expect(wb.sheets[0].threadedComments).toHaveLength(2);
+    expect(wb.sheets[0].threadedComments?.[0].text).toBe("Hello");
+    expect(wb.sheets[0].threadedComments?.[1].parentId).toBe("{c1}");
+  });
+});
+
+describe("saveXlsx — threaded comments roundtrip", () => {
+  it("preserves the threadedComments + persons parts and re-declares all references", async () => {
+    const buf = await buildXlsxWithThreadedComments();
+    const rt = await openXlsx(buf);
+    const out = await saveXlsx(rt);
+    const zip = new ZipReader(out);
+
+    // Body parts must still be in the ZIP (they live in raw entries).
+    expect(zip.has("xl/persons/person.xml")).toBe(true);
+    expect(zip.has("xl/threadedComments/threadedComment1.xml")).toBe(true);
+
+    // workbook.xml.rels must declare the person directory.
+    const wbRels = decoder.decode(await zip.extract("xl/_rels/workbook.xml.rels"));
+    expect(wbRels).toContain("http://schemas.microsoft.com/office/2017/10/relationships/person");
+    expect(wbRels).toContain('Target="persons/person.xml"');
+
+    // Per-sheet rels must declare the threadedComments part.
+    const sheetRels = decoder.decode(await zip.extract("xl/worksheets/_rels/sheet1.xml.rels"));
+    expect(sheetRels).toContain(
+      "http://schemas.microsoft.com/office/2017/10/relationships/threadedComment",
+    );
+    expect(sheetRels).toContain('Target="../threadedComments/threadedComment1.xml"');
+
+    // Content types must declare overrides for both parts.
+    const ct = decoder.decode(await zip.extract("[Content_Types].xml"));
+    expect(ct).toContain("/xl/persons/person.xml");
+    expect(ct).toContain("/xl/threadedComments/threadedComment1.xml");
+    expect(ct).toContain("application/vnd.ms-excel.threadedcomments+xml");
+    expect(ct).toContain("application/vnd.ms-excel.person+xml");
+  });
+
+  it("re-reading the saved workbook recovers the same threaded structure", async () => {
+    const buf = await buildXlsxWithThreadedComments();
+    const rt = await openXlsx(buf);
+    const out = await saveXlsx(rt);
+    const reread = await readXlsx(out);
+    expect(reread.persons?.[0].displayName).toBe("Alice");
+    expect(reread.sheets[0].threadedComments?.[1].parentId).toBe("{c1}");
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class support for the **modern threaded comment** format introduced with Excel 365, distinct from the legacy VML-anchored comment system that hucre already handles.

Both formats can coexist on the same sheet (Excel writes a legacy stub for backward compat), so this PR treats them as independent surfaces — `cell.comment` for legacy notes, `sheet.threadedComments` for threads.

## API

```ts
import { readXlsx } from \"hucre\";

const wb = await readXlsx(buf);
console.log(wb.persons);  // [{ id, displayName, userId?, providerId? }, ...]

for (const sheet of wb.sheets) {
  for (const comment of sheet.threadedComments ?? []) {
    if (!comment.parentId) console.log(\"thread root at\", comment.ref);
    else console.log(\"  reply\", comment.text, \"to\", comment.parentId);
    for (const m of comment.mentions ?? []) console.log(\"  @\" + m.mentionPersonId);
  }
}
```

```ts
// Standalone parsers
import { parsePersons, parseThreadedComments } from \"hucre\";
```

## What changed

| Surface | Change |
| --- | --- |
| `Workbook.persons` | new optional `ThreadedCommentPerson[]` |
| `Sheet.threadedComments` | new optional `ThreadedComment[]` |
| `parsePersons` / `parseThreadedComments` | exported parsers |
| `reader.ts` | walks `Type=\".../person\"` (workbook) and `Type=\".../threadedComment\"` (per-sheet) |
| `writeContentTypes` | new `threadedCommentSheetIndices` + `hasPersons` options |
| `writeWorkbookRels` | new `hasPersons` parameter |
| `roundtrip.ts` | scans `_rawEntries` for both parts and re-emits the references in content-types, workbook rels, and each sheet's rels |

## Test plan

- [x] 2209 tests pass (9 new); `pnpm test` green (lint + typecheck + vitest)
- [x] `parsePersons`: required attrs, optional userId/providerId, skips entries without id+displayName
- [x] `parseThreadedComments`: thread root + reply chain, mentions, `done` accepts `1` and `true`, skips entries without id/personId, empty mentions returned as `undefined`
- [x] End-to-end: a full XLSX with threaded comments roundtrips through `openXlsx → saveXlsx` and a re-read recovers the same persons + thread structure
- [x] Output declares Override for `/xl/persons/person.xml` and `/xl/threadedComments/threadedComment1.xml`, the `Type=\".../person\"` rel in workbook.xml.rels, and the `Type=\".../threadedComment\"` rel in sheet rels

## Out of scope

Synthesizing threadedComments + persons from a model on a fresh `writeXlsx` call (i.e. without an existing source file) needs an XML serializer for both bodies. The infrastructure for the references is now in place — adding the body writers is a follow-up.

References:
- [MS-XLSX] Threaded Comments schema — https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/adb84732-9fc8-48b6-bddc-6b0bcdaad940
- [MS-XLSX] Threaded Comments overview — https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/e0fb917a-1107-409a-852f-13b47aea70dc

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)