### PR TITLE
feat(xlsx): slicers & timeline filters — read & roundtrip

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -658,6 +658,16 @@ export interface Sheet {
   textBoxes?: SheetTextBox[];
   /** Accessibility metadata for screen readers and the `audit` helper. */
   a11y?: SheetA11y;
+  /**
+   * Slicers attached to this sheet (Excel 2010+). Resolved from
+   * `xl/slicers/slicerN.xml` parts referenced via this sheet's rels.
+   */
+  slicers?: Slicer[];
+  /**
+   * Timeline slicers attached to this sheet (Excel 2013+). Resolved from
+   * `xl/timelines/timelineN.xml` parts referenced via this sheet's rels.
+   */
+  timelines?: Timeline[];
 }
 
 // ── Workbook Properties ────────────────────────────────────────────
@@ -723,6 +733,108 @@ export interface ExternalLink {
   definedNames?: ExternalDefinedName[];
 }
 
+// ── Slicers & Timelines ────────────────────────────────────────────
+
+/**
+ * A slicer (Excel 2010+ visual filter). Slicers live on a worksheet and
+ * are backed by a {@link SlicerCache} that holds the actual filter state.
+ *
+ * Slicers come from `xl/slicers/slicerN.xml`. Each slicer entry inside
+ * a slicer file is exposed as one record in {@link Sheet.slicers}.
+ */
+export interface Slicer {
+  /** Programmatic name. Mirrors `slicer/@name`. */
+  name: string;
+  /** Slicer cache identifier this slicer references. Mirrors `slicer/@cache`. */
+  cache: string;
+  /** Display caption shown in the header. Mirrors `slicer/@caption`. */
+  caption?: string;
+  /** Number of columns in the slicer button grid. Mirrors `slicer/@columnCount`. */
+  columnCount?: number;
+  /** Built-in style id, e.g. `SlicerStyleLight1`. Mirrors `slicer/@style`. */
+  style?: string;
+  /** Sort order for items. Mirrors `slicer/@sortOrder` (e.g. `ascending`, `descending`). */
+  sortOrder?: string;
+  /** Row height in EMUs. Mirrors `slicer/@rowHeight`. */
+  rowHeight?: number;
+}
+
+/**
+ * Workbook-level slicer cache. Stores the filter source and selection
+ * state shared by one or more {@link Slicer} instances.
+ *
+ * Slicer caches come from `xl/slicerCaches/slicerCacheN.xml`.
+ */
+export interface SlicerCache {
+  /** Programmatic name. Mirrors `slicerCacheDefinition/@name`. */
+  name: string;
+  /** Source identifier — typically the cache definition's source ref. */
+  sourceName?: string;
+  /**
+   * Pivot tables this cache filters, when sourced from a pivot table.
+   * Each entry is the `tabId` (sheet index) + `name` of a pivot table.
+   */
+  pivotTables?: SlicerCachePivotTable[];
+  /** Excel Table this cache filters, when sourced from a table. */
+  tableSource?: SlicerCacheTableSource;
+}
+
+export interface SlicerCachePivotTable {
+  /** 0-based sheet tab id of the sheet hosting the pivot table. */
+  tabId: number;
+  /** Pivot table name. */
+  name: string;
+}
+
+export interface SlicerCacheTableSource {
+  /** Excel Table name. */
+  name: string;
+  /** Column referenced in the table. */
+  column?: string;
+}
+
+/**
+ * Timeline slicer (Excel 2013+ date-range filter). Like {@link Slicer}
+ * but constrained to date columns and rendered as a draggable date band.
+ *
+ * Timelines come from `xl/timelines/timelineN.xml`.
+ */
+export interface Timeline {
+  /** Programmatic name. */
+  name: string;
+  /** Cache identifier this timeline references. */
+  cache: string;
+  /** Display caption. */
+  caption?: string;
+  /** Built-in style id, e.g. `TimeSlicerStyleLight1`. */
+  style?: string;
+  /** Granularity: `years`, `quarters`, `months`, or `days`. */
+  level?: string;
+  /** Whether the time-level selector is shown. */
+  showHeader?: boolean;
+  /** Whether the selection-label band is shown. */
+  showSelectionLabel?: boolean;
+  /** Whether the time-level row is shown. */
+  showTimeLevel?: boolean;
+  /** Whether the horizontal scrollbar is shown. */
+  showHorizontalScrollbar?: boolean;
+}
+
+/**
+ * Workbook-level timeline cache. Stores the date column and selected
+ * range shared by one or more {@link Timeline} instances.
+ *
+ * Timeline caches come from `xl/timelineCaches/timelineCacheN.xml`.
+ */
+export interface TimelineCache {
+  /** Programmatic name. */
+  name: string;
+  /** Source identifier. */
+  sourceName?: string;
+  /** Pivot tables this cache filters. */
+  pivotTables?: SlicerCachePivotTable[];
+}
+
 // ── Workbook ───────────────────────────────────────────────────────
 
 export interface Workbook {
@@ -748,6 +860,16 @@ export interface Workbook {
    * array matches the `[N]` prefix used in formulas like `[1]Sheet1!A1`.
    */
   externalLinks?: ExternalLink[];
+  /**
+   * Slicer caches resolved from `xl/slicerCaches/slicerCacheN.xml`.
+   * The 1-based position in this array matches the `N` in the source path.
+   */
+  slicerCaches?: SlicerCache[];
+  /**
+   * Timeline caches resolved from `xl/timelineCaches/timelineCacheN.xml`.
+   * The 1-based position in this array matches the `N` in the source path.
+   */
+  timelineCaches?: TimelineCache[];
 }
 
 // ── Read Options ───────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,22 @@ export type {
   ExternalDefinedName,
 } from "./_types";
 
+// ── Slicers & Timelines ────────────────────────────────────────────
+export {
+  parseSlicers,
+  parseSlicerCache,
+  parseTimelines,
+  parseTimelineCache,
+} from "./xlsx/slicer-reader";
+export type {
+  Slicer,
+  SlicerCache,
+  SlicerCachePivotTable,
+  SlicerCacheTableSource,
+  Timeline,
+  TimelineCache,
+} from "./_types";
+
 // ── Date Utilities ─────────────────────────────────────────────────
 export {
   serialToDate,

--- a/src/xlsx/content-types-writer.ts
+++ b/src/xlsx/content-types-writer.ts
@@ -21,6 +21,10 @@ const CT_TABLE = "application/vnd.openxmlformats-officedocument.spreadsheetml.ta
 const CT_THEME = "application/vnd.openxmlformats-officedocument.theme+xml";
 const CT_EXTERNAL_LINK =
   "application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml";
+const CT_SLICER = "application/vnd.ms-excel.slicer+xml";
+const CT_SLICER_CACHE = "application/vnd.ms-excel.slicerCache+xml";
+const CT_TIMELINE = "application/vnd.ms-excel.timeline+xml";
+const CT_TIMELINE_CACHE = "application/vnd.ms-excel.timelineCache+xml";
 
 /** Image extension → content type mapping */
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
@@ -47,6 +51,26 @@ export interface ContentTypesOptions {
    * `Override` for `/xl/externalLinks/externalLinkN.xml`.
    */
   externalLinkIndices?: number[];
+  /**
+   * 1-based indices of per-sheet slicer parts. Each entry adds an
+   * `Override` for `/xl/slicers/slicerN.xml`.
+   */
+  slicerIndices?: number[];
+  /**
+   * 1-based indices of workbook-level slicer cache parts. Each entry
+   * adds an `Override` for `/xl/slicerCaches/slicerCacheN.xml`.
+   */
+  slicerCacheIndices?: number[];
+  /**
+   * 1-based indices of per-sheet timeline parts. Each entry adds an
+   * `Override` for `/xl/timelines/timelineN.xml`.
+   */
+  timelineIndices?: number[];
+  /**
+   * 1-based indices of workbook-level timeline cache parts. Each entry
+   * adds an `Override` for `/xl/timelineCaches/timelineCacheN.xml`.
+   */
+  timelineCacheIndices?: number[];
   /** Whether docProps/core.xml is present */
   hasCoreProps?: boolean;
   /** Whether docProps/app.xml is present */
@@ -188,6 +212,54 @@ export function writeContentTypes(
         xmlSelfClose("Override", {
           PartName: `/xl/externalLinks/externalLink${idx}.xml`,
           ContentType: CT_EXTERNAL_LINK,
+        }),
+      );
+    }
+  }
+
+  // Override for each slicer
+  if (opts.slicerIndices) {
+    for (const idx of opts.slicerIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/slicers/slicer${idx}.xml`,
+          ContentType: CT_SLICER,
+        }),
+      );
+    }
+  }
+
+  // Override for each slicer cache
+  if (opts.slicerCacheIndices) {
+    for (const idx of opts.slicerCacheIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/slicerCaches/slicerCache${idx}.xml`,
+          ContentType: CT_SLICER_CACHE,
+        }),
+      );
+    }
+  }
+
+  // Override for each timeline
+  if (opts.timelineIndices) {
+    for (const idx of opts.timelineIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/timelines/timeline${idx}.xml`,
+          ContentType: CT_TIMELINE,
+        }),
+      );
+    }
+  }
+
+  // Override for each timeline cache
+  if (opts.timelineCacheIndices) {
+    for (const idx of opts.timelineCacheIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/timelineCaches/timelineCache${idx}.xml`,
+          ContentType: CT_TIMELINE_CACHE,
         }),
       );
     }

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -11,8 +11,16 @@ import type {
   TableDefinition,
   TableColumn,
   ExternalLink,
+  SlicerCache,
+  TimelineCache,
 } from "../_types";
 import { parseExternalLink } from "./external-link-reader";
+import {
+  parseSlicers,
+  parseSlicerCache,
+  parseTimelines,
+  parseTimelineCache,
+} from "./slicer-reader";
 import { ParseError, ZipError } from "../errors";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
@@ -206,6 +214,36 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     externalLinks.push(parseExternalLink(linkXml, linkRelsXml));
   }
 
+  // 7d. Parse slicer caches (xl/slicerCaches/slicerCacheN.xml).
+  // Excel 2010+ slicers — declared from workbook.xml.rels with
+  // Type=".../slicerCache". Sort by trailing index so the array order is
+  // stable across files.
+  const slicerCacheRels = workbookRels
+    .filter((r) => matchesRelType(r.type, "slicerCache"))
+    .sort((a, b) => slicerNumFromTarget(a.target) - slicerNumFromTarget(b.target));
+  const slicerCaches: SlicerCache[] = [];
+  for (const rel of slicerCacheRels) {
+    const cachePath = resolvePath(workbookDir, rel.target);
+    if (!zip.has(cachePath)) continue;
+    const cacheXml = decodeUtf8(await zip.extract(cachePath));
+    const cache = parseSlicerCache(cacheXml);
+    if (cache) slicerCaches.push(cache);
+  }
+
+  // 7e. Parse timeline caches (xl/timelineCaches/timelineCacheN.xml).
+  // Excel 2013+ timeline slicers — Type=".../timelineCache".
+  const timelineCacheRels = workbookRels
+    .filter((r) => matchesRelType(r.type, "timelineCache"))
+    .sort((a, b) => slicerNumFromTarget(a.target) - slicerNumFromTarget(b.target));
+  const timelineCaches: TimelineCache[] = [];
+  for (const rel of timelineCacheRels) {
+    const cachePath = resolvePath(workbookDir, rel.target);
+    if (!zip.has(cachePath)) continue;
+    const cacheXml = decodeUtf8(await zip.extract(cachePath));
+    const cache = parseTimelineCache(cacheXml);
+    if (cache) timelineCaches.push(cache);
+  }
+
   // 8. Build a map of rId → sheet relationship for worksheet paths
   const sheetRelMap = new Map<string, string>();
   for (const rel of workbookRels) {
@@ -331,6 +369,35 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       }
     }
 
+    // Extract slicers attached to this sheet (Excel 2010+).
+    // The worksheet rels declare them with Type=".../slicer".
+    if (worksheetRels) {
+      const slicerRels = worksheetRels.filter((r) => matchesRelType(r.type, "slicer"));
+      if (slicerRels.length > 0) {
+        const slicers: import("../_types").Slicer[] = [];
+        for (const rel of slicerRels) {
+          const path = resolvePath(wsDir, rel.target);
+          if (!zip.has(path)) continue;
+          const slicerXml = decodeUtf8(await zip.extract(path));
+          for (const s of parseSlicers(slicerXml)) slicers.push(s);
+        }
+        if (slicers.length > 0) sheet.slicers = slicers;
+      }
+
+      // Timeline slicers (Excel 2013+) — Type=".../timeline".
+      const timelineRels = worksheetRels.filter((r) => matchesRelType(r.type, "timeline"));
+      if (timelineRels.length > 0) {
+        const timelines: import("../_types").Timeline[] = [];
+        for (const rel of timelineRels) {
+          const path = resolvePath(wsDir, rel.target);
+          if (!zip.has(path)) continue;
+          const tlXml = decodeUtf8(await zip.extract(path));
+          for (const t of parseTimelines(tlXml)) timelines.push(t);
+        }
+        if (timelines.length > 0) sheet.timelines = timelines;
+      }
+    }
+
     sheets.push(sheet);
   }
 
@@ -388,7 +455,27 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     workbook.externalLinks = externalLinks;
   }
 
+  if (slicerCaches.length > 0) {
+    workbook.slicerCaches = slicerCaches;
+  }
+
+  if (timelineCaches.length > 0) {
+    workbook.timelineCaches = timelineCaches;
+  }
+
   return workbook;
+}
+
+/**
+ * Trailing numeric suffix of a relationship target like
+ * `slicerCaches/slicerCache3.xml` or `timelines/timeline12.xml`. Used to
+ * sort caches in declaration order regardless of the rId order. Returns
+ * `+Infinity` for paths with no trailing number so malformed entries
+ * sort last instead of throwing.
+ */
+function slicerNumFromTarget(target: string): number {
+  const m = target.match(/(\d+)\.xml$/i);
+  return m ? parseInt(m[1], 10) : Number.POSITIVE_INFINITY;
 }
 
 /**

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -3,7 +3,7 @@
 // images, macros, shapes, or other features that defter doesn't natively
 // understand.
 
-import type { Workbook, ReadOptions, WriteSheet, NamedRange } from "../_types";
+import type { Sheet, Workbook, ReadOptions, WriteSheet, NamedRange } from "../_types";
 import { readXlsx } from "./reader";
 import { ZipReader } from "../zip/reader";
 import { ZipWriter } from "../zip/writer";
@@ -21,6 +21,7 @@ import { writeTable } from "./table-writer";
 import { colToLetter } from "./worksheet-writer";
 import { xmlDocument, xmlSelfClose } from "../xml/writer";
 import { writeCoreProperties, writeAppProperties } from "./doc-props-writer";
+import { parseRelationships } from "./relationships";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -54,6 +55,8 @@ const REL_COMMENTS = "http://schemas.openxmlformats.org/officeDocument/2006/rela
 const REL_VML_DRAWING =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing";
 const REL_TABLE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table";
+const REL_SLICER = "http://schemas.microsoft.com/office/2007/relationships/slicer";
+const REL_TIMELINE = "http://schemas.microsoft.com/office/2011/relationships/timeline";
 
 /**
  * Parts that defter regenerates from parsed data.
@@ -290,18 +293,68 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     if (m) externalLinkIndices.push(parseInt(m[1], 10));
   }
   externalLinkIndices.sort((a, b) => a - b);
+
+  // Collect slicer cache parts (xl/slicerCaches/slicerCacheN.xml) and
+  // timeline cache parts (xl/timelineCaches/timelineCacheN.xml). These
+  // live in the workbook rels and must be re-declared so Excel keeps
+  // them; workbook.xml also gains an extLst pointing at them.
+  const slicerCacheIndices: number[] = [];
+  const timelineCacheIndices: number[] = [];
+  // Per-sheet slicer / timeline parts. Indices are global across the
+  // workbook (xl/slicers/slicer3.xml may belong to sheet2, etc.).
+  const slicerIndices: number[] = [];
+  const timelineIndices: number[] = [];
+  for (const path of workbook._rawEntries.keys()) {
+    let m = path.match(/^xl\/slicerCaches\/slicerCache(\d+)\.xml$/i);
+    if (m) {
+      slicerCacheIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/timelineCaches\/timelineCache(\d+)\.xml$/i);
+    if (m) {
+      timelineCacheIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/slicers\/slicer(\d+)\.xml$/i);
+    if (m) {
+      slicerIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/timelines\/timeline(\d+)\.xml$/i);
+    if (m) timelineIndices.push(parseInt(m[1], 10));
+  }
+  slicerCacheIndices.sort((a, b) => a - b);
+  timelineCacheIndices.sort((a, b) => a - b);
+  slicerIndices.sort((a, b) => a - b);
+  timelineIndices.sort((a, b) => a - b);
+
   // rIds for external link relationships: assigned after all
   // sheet/styles/sharedStrings/theme/macros/featurePropertyBag rIds.
-  const externalLinkRelStart = computeExternalLinkRelStart(
+  let nextWorkbookRelId = computeExternalLinkRelStart(
     writeSheets.length,
     hasSharedStrings,
     !!workbook.hasMacros,
     false, // featurePropertyBag — not yet roundtripped
   );
-  const externalLinkRels = externalLinkIndices.map((idx, i) => ({
-    rId: `rId${externalLinkRelStart + i}`,
+  const externalLinkRels = externalLinkIndices.map((idx) => ({
+    rId: `rId${nextWorkbookRelId++}`,
     target: `externalLinks/externalLink${idx}.xml`,
   }));
+  const slicerCacheRels = slicerCacheIndices.map((idx) => ({
+    rId: `rId${nextWorkbookRelId++}`,
+    target: `slicerCaches/slicerCache${idx}.xml`,
+  }));
+  const timelineCacheRels = timelineCacheIndices.map((idx) => ({
+    rId: `rId${nextWorkbookRelId++}`,
+    target: `timelineCaches/timelineCache${idx}.xml`,
+  }));
+
+  // Per-sheet slicer / timeline relationships are recovered from each
+  // sheet's original rels (xl/worksheets/_rels/sheetN.xml.rels) so the
+  // regenerated rels can re-declare them. We only need the (sheetIndex
+  // → list of {target}) mapping; rIds are reassigned per sheet below.
+  const sheetSlicerTargets = collectSheetCacheTargets(workbook, sheets, "slicer");
+  const sheetTimelineTargets = collectSheetCacheTargets(workbook, sheets, "timeline");
 
   // Build ZIP archive
   const zip = new ZipWriter();
@@ -348,6 +401,10 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     commentIndices: commentIndices.length > 0 ? commentIndices : undefined,
     tableIndices: allTableIndices.length > 0 ? allTableIndices : undefined,
     externalLinkIndices: externalLinkIndices.length > 0 ? externalLinkIndices : undefined,
+    slicerIndices: slicerIndices.length > 0 ? slicerIndices : undefined,
+    slicerCacheIndices: slicerCacheIndices.length > 0 ? slicerCacheIndices : undefined,
+    timelineIndices: timelineIndices.length > 0 ? timelineIndices : undefined,
+    timelineCacheIndices: timelineCacheIndices.length > 0 ? timelineCacheIndices : undefined,
     hasCoreProps: true,
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
@@ -373,6 +430,8 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         activeSheet,
         undefined,
         externalLinkRels.length > 0 ? externalLinkRels : undefined,
+        slicerCacheRels.length > 0 ? slicerCacheRels : undefined,
+        timelineCacheRels.length > 0 ? timelineCacheRels : undefined,
       ),
     ),
   );
@@ -387,6 +446,8 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         workbook.hasMacros,
         false,
         externalLinkRels.length > 0 ? externalLinkRels : undefined,
+        slicerCacheRels.length > 0 ? slicerCacheRels : undefined,
+        timelineCacheRels.length > 0 ? timelineCacheRels : undefined,
       ),
     ),
   );
@@ -412,9 +473,24 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     const hasDrawing = drawing !== null && result.drawingRId !== null;
     const hasComments = comments !== null && result.legacyDrawingRId !== null;
     const hasTables = result.tables.length > 0;
+    const slicerTargets = sheetSlicerTargets[i] ?? [];
+    const timelineTargets = sheetTimelineTargets[i] ?? [];
+    const hasSlicers = slicerTargets.length > 0;
+    const hasTimelines = timelineTargets.length > 0;
 
-    if (hasHyperlinks || hasDrawing || hasComments || hasTables) {
+    if (hasHyperlinks || hasDrawing || hasComments || hasTables || hasSlicers || hasTimelines) {
       const relElements: string[] = [];
+      // Track the highest existing rId so newly added slicer/timeline
+      // relationships pick a number that doesn't collide with anything
+      // the worksheet writer already assigned.
+      let nextSheetRid = 1;
+      const bumpToAfter = (rId: string): void => {
+        const m = rId.match(/(\d+)$/);
+        if (m) {
+          const n = parseInt(m[1], 10);
+          if (n + 1 > nextSheetRid) nextSheetRid = n + 1;
+        }
+      };
 
       for (const rel of result.hyperlinkRelationships) {
         relElements.push(
@@ -425,6 +501,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
             TargetMode: "External",
           }),
         );
+        bumpToAfter(rel.id);
       }
 
       if (hasDrawing && result.drawingRId) {
@@ -435,6 +512,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
             Target: `../drawings/drawing${i + 1}.xml`,
           }),
         );
+        bumpToAfter(result.drawingRId);
       }
 
       if (hasComments && result.legacyDrawingRId && result.commentsRId) {
@@ -452,6 +530,8 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
             Target: `../comments${i + 1}.xml`,
           }),
         );
+        bumpToAfter(result.legacyDrawingRId);
+        bumpToAfter(result.commentsRId);
       }
 
       for (const tableEntry of result.tables) {
@@ -460,6 +540,31 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
             Id: tableEntry.rId,
             Type: REL_TABLE,
             Target: `../tables/table${tableEntry.globalTableIndex}.xml`,
+          }),
+        );
+        bumpToAfter(tableEntry.rId);
+      }
+
+      // Re-emit slicer relationships read from the original sheet rels.
+      // The rIds shift to avoid collisions; they don't need to match the
+      // original because hucre regenerates the worksheet body without
+      // the `<x14:slicerList>` extension that referenced them.
+      for (const target of slicerTargets) {
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: `rId${nextSheetRid++}`,
+            Type: REL_SLICER,
+            Target: target,
+          }),
+        );
+      }
+
+      for (const target of timelineTargets) {
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: `rId${nextSheetRid++}`,
+            Type: REL_TIMELINE,
+            Target: target,
           }),
         );
       }
@@ -507,6 +612,52 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+const REL_TYPE_SLICER = /\/relationships\/slicer$/;
+const REL_TYPE_TIMELINE = /\/relationships\/timeline$/;
+
+/**
+ * Walk each sheet's original `xl/worksheets/_rels/sheetN.xml.rels` (when
+ * present in the raw entries) and pull out the `Target` of every slicer
+ * or timeline relationship so the regenerated rels can re-emit them
+ * pointing at the same parts.
+ *
+ * Targets are returned relative to the sheet rels file (e.g.
+ * `"../slicers/slicer1.xml"`).
+ */
+function collectSheetCacheTargets(
+  workbook: { _rawEntries: Map<string, Uint8Array> },
+  sheets: Sheet[],
+  kind: "slicer" | "timeline",
+): string[][] {
+  const decoder = new TextDecoder("utf-8");
+  const out: string[][] = [];
+  const matcher = kind === "slicer" ? REL_TYPE_SLICER : REL_TYPE_TIMELINE;
+  for (let i = 0; i < sheets.length; i++) {
+    // Sheet rels are emitted as xl/worksheets/_rels/sheetN.xml.rels in
+    // the regenerated output, but the original file may use a different
+    // case — match case-insensitively.
+    const expected = `xl/worksheets/_rels/sheet${i + 1}.xml.rels`;
+    let bytes: Uint8Array | undefined;
+    for (const [path, data] of workbook._rawEntries) {
+      if (path.toLowerCase() === expected) {
+        bytes = data;
+        break;
+      }
+    }
+    if (!bytes) {
+      out.push([]);
+      continue;
+    }
+    const rels = parseRelationships(decoder.decode(bytes));
+    const targets: string[] = [];
+    for (const rel of rels) {
+      if (matcher.test(rel.type)) targets.push(rel.target);
+    }
+    out.push(targets);
+  }
+  return out;
+}
 
 /**
  * Mirror the `nextRid` counter inside `writeWorkbookRels` to determine

--- a/src/xlsx/slicer-reader.ts
+++ b/src/xlsx/slicer-reader.ts
@@ -1,0 +1,201 @@
+// ── Slicer & Timeline Reader ──────────────────────────────────────
+// Parses xl/slicers/slicerN.xml, xl/slicerCaches/slicerCacheN.xml,
+// xl/timelines/timelineN.xml, and xl/timelineCaches/timelineCacheN.xml
+// into structured records that callers can inspect.
+//
+// Slicers were introduced with Excel 2010 and live in the `x14` extension
+// namespace, hence the XML files use the `x14:slicer` element. Timeline
+// slicers were added in Excel 2013 under `x15`.
+//
+// OOXML reference: ECMA-376 Part 1, §18.10 (Slicers) and §18.13 (Timelines).
+
+import type {
+  Slicer,
+  SlicerCache,
+  SlicerCachePivotTable,
+  SlicerCacheTableSource,
+  Timeline,
+  TimelineCache,
+} from "../_types";
+import { parseXml } from "../xml/parser";
+import type { XmlElement } from "../xml/parser";
+
+// ── Slicers (per-sheet) ────────────────────────────────────────────
+
+/**
+ * Parse a slicer file (`xl/slicers/slicerN.xml`). One file may declare
+ * multiple `<slicer>` elements, so the result is an array.
+ */
+export function parseSlicers(xml: string): Slicer[] {
+  const root = parseXml(xml);
+  const out: Slicer[] = [];
+  for (const child of childElements(root)) {
+    if (child.local !== "slicer") continue;
+    const name = child.attrs.name;
+    const cache = child.attrs.cache;
+    if (!name || !cache) continue;
+    const slicer: Slicer = { name, cache };
+    if (child.attrs.caption) slicer.caption = child.attrs.caption;
+    if (child.attrs.columnCount !== undefined) {
+      const n = parseIntSafe(child.attrs.columnCount, NaN);
+      if (!Number.isNaN(n)) slicer.columnCount = n;
+    }
+    if (child.attrs.style) slicer.style = child.attrs.style;
+    if (child.attrs.sortOrder) slicer.sortOrder = child.attrs.sortOrder;
+    if (child.attrs.rowHeight !== undefined) {
+      const n = parseIntSafe(child.attrs.rowHeight, NaN);
+      if (!Number.isNaN(n)) slicer.rowHeight = n;
+    }
+    out.push(slicer);
+  }
+  return out;
+}
+
+// ── Slicer Caches (workbook-level) ─────────────────────────────────
+
+/**
+ * Parse a slicer cache file (`xl/slicerCaches/slicerCacheN.xml`).
+ *
+ * Structure:
+ *   <slicerCacheDefinition name="..." sourceName="...">
+ *     <pivotTables>
+ *       <pivotTable tabId="0" name="PivotTable1"/>
+ *     </pivotTables>
+ *     <data>
+ *       <tabular pivotCacheId="..."/>
+ *     </data>
+ *     <extLst>
+ *       <ext>
+ *         <x15:tableSlicerCache tableId="1" column="..."/>
+ *       </ext>
+ *     </extLst>
+ *   </slicerCacheDefinition>
+ */
+export function parseSlicerCache(xml: string): SlicerCache | undefined {
+  const root = parseXml(xml);
+  const def =
+    root.local === "slicerCacheDefinition" ? root : findChild(root, "slicerCacheDefinition");
+  if (!def) return undefined;
+  const name = def.attrs.name;
+  if (!name) return undefined;
+
+  const cache: SlicerCache = { name };
+  if (def.attrs.sourceName) cache.sourceName = def.attrs.sourceName;
+
+  const pivotTables = parsePivotTables(def);
+  if (pivotTables.length > 0) cache.pivotTables = pivotTables;
+
+  const tableSource = parseTableSlicerCache(def);
+  if (tableSource) cache.tableSource = tableSource;
+
+  return cache;
+}
+
+// ── Timelines (per-sheet) ──────────────────────────────────────────
+
+/**
+ * Parse a timeline file (`xl/timelines/timelineN.xml`). One file may
+ * declare multiple `<timeline>` elements.
+ */
+export function parseTimelines(xml: string): Timeline[] {
+  const root = parseXml(xml);
+  const out: Timeline[] = [];
+  for (const child of childElements(root)) {
+    if (child.local !== "timeline") continue;
+    const name = child.attrs.name;
+    const cache = child.attrs.cache;
+    if (!name || !cache) continue;
+    const tl: Timeline = { name, cache };
+    if (child.attrs.caption) tl.caption = child.attrs.caption;
+    if (child.attrs.style) tl.style = child.attrs.style;
+    if (child.attrs.level) tl.level = child.attrs.level;
+    if (child.attrs.showHeader !== undefined) tl.showHeader = parseBool(child.attrs.showHeader);
+    if (child.attrs.showSelectionLabel !== undefined)
+      tl.showSelectionLabel = parseBool(child.attrs.showSelectionLabel);
+    if (child.attrs.showTimeLevel !== undefined)
+      tl.showTimeLevel = parseBool(child.attrs.showTimeLevel);
+    if (child.attrs.showHorizontalScrollbar !== undefined)
+      tl.showHorizontalScrollbar = parseBool(child.attrs.showHorizontalScrollbar);
+    out.push(tl);
+  }
+  return out;
+}
+
+// ── Timeline Caches (workbook-level) ───────────────────────────────
+
+/**
+ * Parse a timeline cache file (`xl/timelineCaches/timelineCacheN.xml`).
+ */
+export function parseTimelineCache(xml: string): TimelineCache | undefined {
+  const root = parseXml(xml);
+  const def =
+    root.local === "timelineCacheDefinition" ? root : findChild(root, "timelineCacheDefinition");
+  if (!def) return undefined;
+  const name = def.attrs.name;
+  if (!name) return undefined;
+  const cache: TimelineCache = { name };
+  if (def.attrs.sourceName) cache.sourceName = def.attrs.sourceName;
+
+  const pivotTables = parsePivotTables(def);
+  if (pivotTables.length > 0) cache.pivotTables = pivotTables;
+
+  return cache;
+}
+
+// ── Internals ─────────────────────────────────────────────────────
+
+function parsePivotTables(def: XmlElement): SlicerCachePivotTable[] {
+  const pivotTables = findChild(def, "pivotTables");
+  if (!pivotTables) return [];
+  const out: SlicerCachePivotTable[] = [];
+  for (const child of childElements(pivotTables)) {
+    if (child.local !== "pivotTable") continue;
+    const name = child.attrs.name;
+    if (!name) continue;
+    const tabId = parseIntSafe(child.attrs.tabId, NaN);
+    if (Number.isNaN(tabId)) continue;
+    out.push({ tabId, name });
+  }
+  return out;
+}
+
+function parseTableSlicerCache(def: XmlElement): SlicerCacheTableSource | undefined {
+  const extLst = findChild(def, "extLst");
+  if (!extLst) return undefined;
+  for (const ext of childElements(extLst)) {
+    if (ext.local !== "ext") continue;
+    const tableSlicer = findChild(ext, "tableSlicerCache");
+    if (!tableSlicer) continue;
+    const name = tableSlicer.attrs.name ?? tableSlicer.attrs.tableId;
+    if (!name) continue;
+    const src: SlicerCacheTableSource = { name };
+    if (tableSlicer.attrs.column) src.column = tableSlicer.attrs.column;
+    return src;
+  }
+  return undefined;
+}
+
+function findChild(el: XmlElement, localName: string): XmlElement | undefined {
+  for (const c of el.children) {
+    if (typeof c !== "string" && c.local === localName) return c;
+  }
+  return undefined;
+}
+
+function childElements(el: XmlElement): XmlElement[] {
+  const out: XmlElement[] = [];
+  for (const c of el.children) {
+    if (typeof c !== "string") out.push(c);
+  }
+  return out;
+}
+
+function parseIntSafe(s: string | undefined, fallback: number): number {
+  if (s === undefined) return fallback;
+  const n = parseInt(s, 10);
+  return Number.isNaN(n) ? fallback : n;
+}
+
+function parseBool(s: string): boolean {
+  return s === "1" || s === "true";
+}

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -27,6 +27,8 @@ export function writeWorkbookXml(
   activeSheet?: number,
   workbookProtection?: { lockStructure?: boolean; lockWindows?: boolean; password?: string },
   externalLinkRels?: ReadonlyArray<{ rId: string }>,
+  slicerCacheRels?: ReadonlyArray<{ rId: string }>,
+  timelineCacheRels?: ReadonlyArray<{ rId: string }>,
 ): string {
   const sheetElements: string[] = [];
 
@@ -125,6 +127,51 @@ export function writeWorkbookXml(
   // ── calcPr — tells Excel to recalculate all formulas on open ──
   parts.push(xmlSelfClose("calcPr", { calcId: 0, fullCalcOnLoad: 1 }));
 
+  // ── extLst — slicer caches (x14) and timeline caches (x15) ──
+  // These extension blocks point Excel at the slicerCacheN.xml and
+  // timelineCacheN.xml parts via rIds declared in workbook.xml.rels.
+  // Without them Excel treats the cache parts as orphans and drops the
+  // associated slicers / timelines on next open.
+  const extElements: string[] = [];
+
+  if (slicerCacheRels && slicerCacheRels.length > 0) {
+    const slicerRefs = slicerCacheRels.map((r) =>
+      xmlSelfClose("x14:slicerCache", { "r:id": r.rId }),
+    );
+    const slicerCachesEl = xmlElement("x14:slicerCaches", undefined, slicerRefs);
+    extElements.push(
+      xmlElement(
+        "ext",
+        {
+          uri: "{BBE1A952-AA13-448E-AADC-164F8A28A991}",
+          "xmlns:x14": "http://schemas.microsoft.com/office/spreadsheetml/2009/9/main",
+        },
+        [slicerCachesEl],
+      ),
+    );
+  }
+
+  if (timelineCacheRels && timelineCacheRels.length > 0) {
+    const timelineRefs = timelineCacheRels.map((r) =>
+      xmlSelfClose("x15:timelineCachePivotCache", { "r:id": r.rId }),
+    );
+    const timelineCachesEl = xmlElement("x15:timelineCachePivotCaches", undefined, timelineRefs);
+    extElements.push(
+      xmlElement(
+        "ext",
+        {
+          uri: "{7E03D99C-DC04-49D9-9315-930204A7B6E9}",
+          "xmlns:x15": "http://schemas.microsoft.com/office/spreadsheetml/2010/11/main",
+        },
+        [timelineCachesEl],
+      ),
+    );
+  }
+
+  if (extElements.length > 0) {
+    parts.push(xmlElement("extLst", undefined, extElements));
+  }
+
   return xmlDocument("workbook", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts);
 }
 
@@ -134,11 +181,20 @@ const REL_FEATURE_PROPERTY_BAG =
 
 const REL_EXTERNAL_LINK =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink";
+const REL_SLICER_CACHE = "http://schemas.microsoft.com/office/2007/relationships/slicerCache";
+const REL_TIMELINE_CACHE = "http://schemas.microsoft.com/office/2011/relationships/timelineCache";
 
 /** A relationship description for an externalLink emitted in workbook.xml.rels. */
 export interface ExternalLinkRel {
   rId: string;
   /** Path relative to the workbook directory, e.g. "externalLinks/externalLink1.xml". */
+  target: string;
+}
+
+/** A workbook-level relationship to a slicerCache or timelineCache part. */
+export interface CacheRel {
+  rId: string;
+  /** Path relative to the workbook directory, e.g. "slicerCaches/slicerCache1.xml". */
   target: string;
 }
 
@@ -149,6 +205,8 @@ export function writeWorkbookRels(
   hasMacros?: boolean,
   hasFeaturePropertyBag?: boolean,
   externalLinkRels?: ReadonlyArray<ExternalLinkRel>,
+  slicerCacheRels?: ReadonlyArray<CacheRel>,
+  timelineCacheRels?: ReadonlyArray<CacheRel>,
 ): string {
   const children: string[] = [];
 
@@ -228,6 +286,32 @@ export function writeWorkbookRels(
           Id: link.rId,
           Type: REL_EXTERNAL_LINK,
           Target: link.target,
+        }),
+      );
+    }
+  }
+
+  // Slicer cache relationships (Excel 2010+)
+  if (slicerCacheRels) {
+    for (const r of slicerCacheRels) {
+      children.push(
+        xmlSelfClose("Relationship", {
+          Id: r.rId,
+          Type: REL_SLICER_CACHE,
+          Target: r.target,
+        }),
+      );
+    }
+  }
+
+  // Timeline cache relationships (Excel 2013+)
+  if (timelineCacheRels) {
+    for (const r of timelineCacheRels) {
+      children.push(
+        xmlSelfClose("Relationship", {
+          Id: r.rId,
+          Type: REL_TIMELINE_CACHE,
+          Target: r.target,
         }),
       );
     }

--- a/test/slicers.test.ts
+++ b/test/slicers.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSlicers,
+  parseSlicerCache,
+  parseTimelines,
+  parseTimelineCache,
+} from "../src/xlsx/slicer-reader";
+import { ZipWriter } from "../src/zip/writer";
+import { ZipReader } from "../src/zip/reader";
+import { readXlsx } from "../src/xlsx/reader";
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8");
+
+// ── parseSlicers ─────────────────────────────────────────────────
+
+describe("parseSlicers", () => {
+  it("returns an empty array when no slicer elements are present", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main"/>`;
+    expect(parseSlicers(xml)).toEqual([]);
+  });
+
+  it("parses required attributes and skips entries missing name or cache", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+  <slicer name="Region" cache="Slicer_Region" caption="Region"/>
+  <slicer name="OnlyName"/>
+  <slicer cache="Slicer_NoName"/>
+  <slicer name="Year" cache="Slicer_Year" caption="Year" columnCount="2"
+          style="SlicerStyleLight2" sortOrder="ascending" rowHeight="241300"/>
+</slicers>`;
+    const slicers = parseSlicers(xml);
+    expect(slicers).toHaveLength(2);
+    expect(slicers[0]).toEqual({
+      name: "Region",
+      cache: "Slicer_Region",
+      caption: "Region",
+    });
+    expect(slicers[1]).toEqual({
+      name: "Year",
+      cache: "Slicer_Year",
+      caption: "Year",
+      columnCount: 2,
+      style: "SlicerStyleLight2",
+      sortOrder: "ascending",
+      rowHeight: 241300,
+    });
+  });
+
+  it("ignores numeric attributes that fail to parse", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+  <slicer name="Bogus" cache="C" columnCount="abc" rowHeight=""/>
+</slicers>`;
+    const [slicer] = parseSlicers(xml);
+    expect(slicer.columnCount).toBeUndefined();
+    expect(slicer.rowHeight).toBeUndefined();
+  });
+});
+
+// ── parseSlicerCache ─────────────────────────────────────────────
+
+describe("parseSlicerCache", () => {
+  it("returns undefined when the root element is not a slicerCacheDefinition", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<root/>`;
+    expect(parseSlicerCache(xml)).toBeUndefined();
+  });
+
+  it("returns undefined when the cache has no name", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicerCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>`;
+    expect(parseSlicerCache(xml)).toBeUndefined();
+  });
+
+  it("parses pivot-table-sourced caches", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicerCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                       name="Slicer_Region" sourceName="Region">
+  <pivotTables>
+    <pivotTable tabId="0" name="PivotTable1"/>
+    <pivotTable tabId="1" name="PivotTable2"/>
+    <pivotTable name="MissingTab"/>
+  </pivotTables>
+</slicerCacheDefinition>`;
+    const cache = parseSlicerCache(xml);
+    expect(cache).toEqual({
+      name: "Slicer_Region",
+      sourceName: "Region",
+      pivotTables: [
+        { tabId: 0, name: "PivotTable1" },
+        { tabId: 1, name: "PivotTable2" },
+      ],
+    });
+  });
+
+  it("parses table-sourced caches via the x15 extension", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicerCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                       xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"
+                       name="Slicer_Status" sourceName="Status">
+  <extLst>
+    <ext uri="{2F2917AC-EB37-4324-AD4E-5DD8C200BD13}">
+      <x15:tableSlicerCache tableId="1" column="Status" name="Status"/>
+    </ext>
+  </extLst>
+</slicerCacheDefinition>`;
+    const cache = parseSlicerCache(xml);
+    expect(cache?.name).toBe("Slicer_Status");
+    expect(cache?.tableSource).toEqual({ name: "Status", column: "Status" });
+    expect(cache?.pivotTables).toBeUndefined();
+  });
+});
+
+// ── parseTimelines ───────────────────────────────────────────────
+
+describe("parseTimelines", () => {
+  it("parses required attributes and visibility flags", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelines xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main">
+  <timeline name="OrderDate" cache="NativeTimeline_OrderDate" caption="Order Date"
+            level="months" showHeader="1" showSelectionLabel="1" showTimeLevel="0"
+            showHorizontalScrollbar="true" style="TimeSlicerStyleLight2"/>
+  <timeline name="Incomplete"/>
+</timelines>`;
+    const timelines = parseTimelines(xml);
+    expect(timelines).toHaveLength(1);
+    expect(timelines[0]).toEqual({
+      name: "OrderDate",
+      cache: "NativeTimeline_OrderDate",
+      caption: "Order Date",
+      level: "months",
+      showHeader: true,
+      showSelectionLabel: true,
+      showTimeLevel: false,
+      showHorizontalScrollbar: true,
+      style: "TimeSlicerStyleLight2",
+    });
+  });
+});
+
+// ── parseTimelineCache ───────────────────────────────────────────
+
+describe("parseTimelineCache", () => {
+  it("requires a name", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelineCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"/>`;
+    expect(parseTimelineCache(xml)).toBeUndefined();
+  });
+
+  it("parses pivot-table sources", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelineCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"
+                         name="NativeTimeline_OrderDate" sourceName="OrderDate">
+  <pivotTables>
+    <pivotTable tabId="0" name="PivotTable1"/>
+  </pivotTables>
+</timelineCacheDefinition>`;
+    const cache = parseTimelineCache(xml);
+    expect(cache).toEqual({
+      name: "NativeTimeline_OrderDate",
+      sourceName: "OrderDate",
+      pivotTables: [{ tabId: 0, name: "PivotTable1" }],
+    });
+  });
+});
+
+// ── End-to-end: full XLSX with slicers & timelines ───────────────
+
+/**
+ * Build a minimal XLSX containing a worksheet that points at one slicer
+ * file and one timeline file, plus the matching workbook-level cache
+ * definitions.
+ */
+async function buildXlsxWithSlicersAndTimelines(): Promise<Uint8Array> {
+  const z = new ZipWriter();
+
+  z.add(
+    "[Content_Types].xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/slicers/slicer1.xml" ContentType="application/vnd.ms-excel.slicer+xml"/>
+  <Override PartName="/xl/slicerCaches/slicerCache1.xml" ContentType="application/vnd.ms-excel.slicerCache+xml"/>
+  <Override PartName="/xl/timelines/timeline1.xml" ContentType="application/vnd.ms-excel.timeline+xml"/>
+  <Override PartName="/xl/timelineCaches/timelineCache1.xml" ContentType="application/vnd.ms-excel.timelineCache+xml"/>
+</Types>`),
+  );
+
+  z.add(
+    "_rels/.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/workbook.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Data" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+  );
+
+  z.add(
+    "xl/_rels/workbook.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2007/relationships/slicerCache" Target="slicerCaches/slicerCache1.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2011/relationships/timelineCache" Target="timelineCaches/timelineCache1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/worksheets/sheet1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="n"><v>1</v></c></row>
+  </sheetData>
+</worksheet>`),
+  );
+
+  z.add(
+    "xl/worksheets/_rels/sheet1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2007/relationships/slicer" Target="../slicers/slicer1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2011/relationships/timeline" Target="../timelines/timeline1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/slicers/slicer1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+  <slicer name="Region" cache="Slicer_Region" caption="Region" columnCount="1"
+          style="SlicerStyleLight1" rowHeight="241300"/>
+</slicers>`),
+  );
+
+  z.add(
+    "xl/slicerCaches/slicerCache1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicerCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                       name="Slicer_Region" sourceName="Region">
+  <pivotTables>
+    <pivotTable tabId="0" name="PivotTable1"/>
+  </pivotTables>
+</slicerCacheDefinition>`),
+  );
+
+  z.add(
+    "xl/timelines/timeline1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelines xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main">
+  <timeline name="OrderDate" cache="NativeTimeline_OrderDate" caption="Order Date" level="months"/>
+</timelines>`),
+  );
+
+  z.add(
+    "xl/timelineCaches/timelineCache1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelineCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main"
+                         name="NativeTimeline_OrderDate" sourceName="OrderDate">
+  <pivotTables>
+    <pivotTable tabId="0" name="PivotTable1"/>
+  </pivotTables>
+</timelineCacheDefinition>`),
+  );
+
+  return await z.build();
+}
+
+describe("readXlsx — slicer & timeline integration", () => {
+  it("attaches workbook.slicerCaches, workbook.timelineCaches, and per-sheet slicers/timelines", async () => {
+    const buf = await buildXlsxWithSlicersAndTimelines();
+    const wb = await readXlsx(buf);
+
+    expect(wb.slicerCaches).toEqual([
+      {
+        name: "Slicer_Region",
+        sourceName: "Region",
+        pivotTables: [{ tabId: 0, name: "PivotTable1" }],
+      },
+    ]);
+    expect(wb.timelineCaches).toEqual([
+      {
+        name: "NativeTimeline_OrderDate",
+        sourceName: "OrderDate",
+        pivotTables: [{ tabId: 0, name: "PivotTable1" }],
+      },
+    ]);
+
+    const sheet = wb.sheets[0];
+    expect(sheet.slicers).toHaveLength(1);
+    expect(sheet.slicers?.[0]).toEqual({
+      name: "Region",
+      cache: "Slicer_Region",
+      caption: "Region",
+      columnCount: 1,
+      style: "SlicerStyleLight1",
+      rowHeight: 241300,
+    });
+    expect(sheet.timelines).toHaveLength(1);
+    expect(sheet.timelines?.[0]).toEqual({
+      name: "OrderDate",
+      cache: "NativeTimeline_OrderDate",
+      caption: "Order Date",
+      level: "months",
+    });
+  });
+
+  it("preserves slicer & timeline parts and re-emits all references on roundtrip", async () => {
+    const buf = await buildXlsxWithSlicersAndTimelines();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+
+    const zip = new ZipReader(out);
+
+    // The four bodies must survive byte-for-byte.
+    expect(zip.has("xl/slicers/slicer1.xml")).toBe(true);
+    expect(zip.has("xl/slicerCaches/slicerCache1.xml")).toBe(true);
+    expect(zip.has("xl/timelines/timeline1.xml")).toBe(true);
+    expect(zip.has("xl/timelineCaches/timelineCache1.xml")).toBe(true);
+
+    // [Content_Types].xml must declare every part as an Override or
+    // Excel will refuse to load them.
+    const ct = decoder.decode(await zip.extract("[Content_Types].xml"));
+    expect(ct).toContain("/xl/slicers/slicer1.xml");
+    expect(ct).toContain("/xl/slicerCaches/slicerCache1.xml");
+    expect(ct).toContain("/xl/timelines/timeline1.xml");
+    expect(ct).toContain("/xl/timelineCaches/timelineCache1.xml");
+    expect(ct).toContain("application/vnd.ms-excel.slicer+xml");
+    expect(ct).toContain("application/vnd.ms-excel.slicerCache+xml");
+    expect(ct).toContain("application/vnd.ms-excel.timeline+xml");
+    expect(ct).toContain("application/vnd.ms-excel.timelineCache+xml");
+
+    // Workbook rels must carry slicerCache and timelineCache rels.
+    const wbRels = decoder.decode(await zip.extract("xl/_rels/workbook.xml.rels"));
+    expect(wbRels).toContain(
+      'Type="http://schemas.microsoft.com/office/2007/relationships/slicerCache"',
+    );
+    expect(wbRels).toContain('Target="slicerCaches/slicerCache1.xml"');
+    expect(wbRels).toContain(
+      'Type="http://schemas.microsoft.com/office/2011/relationships/timelineCache"',
+    );
+    expect(wbRels).toContain('Target="timelineCaches/timelineCache1.xml"');
+
+    // workbook.xml must declare extLst pointing at both caches.
+    const wbXml = decoder.decode(await zip.extract("xl/workbook.xml"));
+    expect(wbXml).toContain("<extLst>");
+    expect(wbXml).toContain("<x14:slicerCaches>");
+    expect(wbXml).toContain("<x15:timelineCachePivotCaches>");
+
+    // Sheet rels must declare slicer + timeline relationships.
+    const sheetRels = decoder.decode(await zip.extract("xl/worksheets/_rels/sheet1.xml.rels"));
+    expect(sheetRels).toContain(
+      'Type="http://schemas.microsoft.com/office/2007/relationships/slicer"',
+    );
+    expect(sheetRels).toContain('Target="../slicers/slicer1.xml"');
+    expect(sheetRels).toContain(
+      'Type="http://schemas.microsoft.com/office/2011/relationships/timeline"',
+    );
+    expect(sheetRels).toContain('Target="../timelines/timeline1.xml"');
+  });
+
+  it("re-reading the saved workbook returns the same model", async () => {
+    const buf = await buildXlsxWithSlicersAndTimelines();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const reread = await readXlsx(out);
+
+    expect(reread.slicerCaches).toHaveLength(1);
+    expect(reread.slicerCaches?.[0].name).toBe("Slicer_Region");
+    expect(reread.timelineCaches).toHaveLength(1);
+    expect(reread.timelineCaches?.[0].name).toBe("NativeTimeline_OrderDate");
+
+    expect(reread.sheets[0].slicers?.[0].name).toBe("Region");
+    expect(reread.sheets[0].timelines?.[0].name).toBe("OrderDate");
+  });
+
+  it("does not set slicer/timeline fields when the workbook has none", async () => {
+    const z = new ZipWriter();
+    z.add(
+      "[Content_Types].xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>`),
+    );
+    z.add(
+      "_rels/.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/workbook.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Main" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+    );
+    z.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/worksheets/sheet1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>`),
+    );
+
+    const wb = await readXlsx(await z.build());
+    expect(wb.slicerCaches).toBeUndefined();
+    expect(wb.timelineCaches).toBeUndefined();
+    expect(wb.sheets[0].slicers).toBeUndefined();
+    expect(wb.sheets[0].timelines).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class **read** support and full **roundtrip preservation** for the slicer (Excel 2010+) and timeline slicer (Excel 2013+) parts that hucre previously dropped on save.

Before this PR the slicer / timeline body files survived inside the ZIP, but the references that wired them into the workbook were silently regenerated without the declarations, so Excel saw orphan parts and dropped the slicers / timelines on next open. This PR wires them back into `[Content_Types].xml`, `xl/_rels/workbook.xml.rels`, the workbook's `extLst`, and each sheet's `_rels`.

## API

```ts
import { readXlsx, openXlsx, saveXlsx } from "hucre";

const wb = await readXlsx(buf);

// Workbook-level cache definitions.
console.log(wb.slicerCaches);    // SlicerCache[]
console.log(wb.timelineCaches);  // TimelineCache[]

// Per-sheet slicer / timeline instances.
for (const sheet of wb.sheets) {
  for (const s of sheet.slicers ?? [])    console.log(s.name, s.cache, s.caption);
  for (const t of sheet.timelines ?? [])  console.log(t.name, t.cache, t.level);
}

// Standalone parsers.
import {
  parseSlicers,
  parseSlicerCache,
  parseTimelines,
  parseTimelineCache,
} from "hucre";
```

## Model

```ts
interface Slicer {
  name: string;
  cache: string;
  caption?: string;
  columnCount?: number;
  style?: string;
  sortOrder?: string;
  rowHeight?: number;
}

interface SlicerCache {
  name: string;
  sourceName?: string;
  pivotTables?: SlicerCachePivotTable[];   // pivot-table-sourced caches
  tableSource?: SlicerCacheTableSource;    // x15:tableSlicerCache
}

interface Timeline {
  name: string;
  cache: string;
  caption?: string;
  level?: string;
  showHeader?: boolean;
  showSelectionLabel?: boolean;
  showTimeLevel?: boolean;
  showHorizontalScrollbar?: boolean;
  style?: string;
}

interface TimelineCache {
  name: string;
  sourceName?: string;
  pivotTables?: SlicerCachePivotTable[];
}
```

## What changed in the writer side

| Hook | Change |
| --- | --- |
| `ContentTypesOptions` | new `slicerIndices` / `slicerCacheIndices` / `timelineIndices` / `timelineCacheIndices` options — emit Override per part |
| `writeWorkbookXml` | new `slicerCacheRels` / `timelineCacheRels` args — emit `<extLst>` with `<x14:slicerCaches>` and `<x15:timelineCachePivotCaches>` |
| `writeWorkbookRels` | new `slicerCacheRels` / `timelineCacheRels` args — emit `Type=".../slicerCache"` and `Type=".../timelineCache"` relationships with rIds that follow externalLinks |
| `roundtrip` | scans `_rawEntries` for the four families, threads the indices through, and re-emits `Type=".../slicer"` / `Type=".../timeline"` in each sheet's regenerated rels (non-colliding rIds picked from each sheet's max existing rId) |

## Test plan

- [x] 2260 tests pass (14 new); `pnpm test` green (lint + typecheck + vitest)
- [x] `parseSlicers`: required attrs, skips entries missing name/cache, ignores numeric attrs that fail to parse
- [x] `parseSlicerCache`: returns undefined when root is wrong / name missing; parses pivot-table sources; parses `x15:tableSlicerCache` extension
- [x] `parseTimelines`: required attrs and visibility flags (`1`/`true`)
- [x] `parseTimelineCache`: name required, parses pivot-table sources
- [x] End-to-end: full XLSX with slicer + slicerCache + timeline + timelineCache roundtrips through `openXlsx → saveXlsx` and re-read recovers the same model
- [x] Output declares Override for all four part families, the workbook rels carry slicerCache/timelineCache types with proper Targets, workbook.xml has the `<extLst>` with `<x14:slicerCaches>` and `<x15:timelineCachePivotCaches>`, and the sheet rels carry the per-sheet slicer + timeline relationships
- [x] No-slicer workbooks still emit clean rels (no spurious slicer/timeline entries)

## Out of scope

The worksheet body's `<x14:slicerList>` and `<x15:timelines>` extension blocks are not yet re-injected when the worksheet XML is regenerated. Excel sees the slicer / timeline parts as wired up through rels and content-types so they survive as referenced parts, but the visual binding from worksheet → slicer instance still relies on the rels alone in the regenerated body. Serializing the worksheet extLst from the parsed model is a natural follow-up — the infrastructure for both directions is now in place.

References:
- ECMA-376 Part 1, §18.10 (Slicers) and §18.13 (Timelines)
- MS-XLSX Slicers — https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/bfeb551b-f590-4f68-aa8d-9edd824acefc

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)