### PR TITLE
feat(xlsx): pivot tables — read & roundtrip (Phase 1)

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -715,6 +715,12 @@ export interface Sheet {
   threadedComments?: ThreadedComment[];
   /** Accessibility metadata for screen readers and the `audit` helper. */
   a11y?: SheetA11y;
+  /**
+   * Pivot table instances hosted on this sheet. The body lives in
+   * `xl/pivotTables/pivotTableN.xml`; each instance points at a
+   * workbook-level cache via `cacheId`.
+   */
+  pivotTables?: PivotTable[];
 }
 
 // ── Workbook Properties ────────────────────────────────────────────
@@ -780,6 +786,123 @@ export interface ExternalLink {
   definedNames?: ExternalDefinedName[];
 }
 
+// ── Pivot Tables ───────────────────────────────────────────────────
+
+/**
+ * Aggregation function for a pivot table data field. Mirrors the
+ * `subtotal` attribute on `<c:dataField>` in OOXML.
+ */
+export type PivotDataFieldFunction =
+  | "sum"
+  | "count"
+  | "average"
+  | "max"
+  | "min"
+  | "product"
+  | "countNums"
+  | "stdDev"
+  | "stdDevp"
+  | "var"
+  | "varp";
+
+/**
+ * Field role in a pivot table layout. `row`, `col`, `page`, and `data`
+ * mirror the four standard axes; `hidden` means the field exists in the
+ * cache but is not currently placed on any axis.
+ */
+export type PivotFieldAxis = "row" | "col" | "page" | "data" | "hidden";
+
+export interface PivotField {
+  /**
+   * Display name. Reads from the `<cacheField name="...">` attribute on
+   * the matching field index in the pivot cache definition.
+   */
+  name: string;
+  /**
+   * Where the field appears in the pivot table. `hidden` covers cache
+   * fields that are present but not placed on any axis.
+   */
+  axis: PivotFieldAxis;
+  /** When `axis === "data"`, the aggregation applied to the values. */
+  function?: PivotDataFieldFunction;
+  /**
+   * Display name overlay for data fields (the `name` attribute on
+   * `<dataField>`). Falls back to `name` when absent.
+   */
+  displayName?: string;
+}
+
+/**
+ * A pivot table instance, attached to the sheet that hosts its layout.
+ * The `cacheId` references one of the workbook-level pivot caches that
+ * back this table.
+ */
+export interface PivotTable {
+  /** Pivot table name (`<pivotTableDefinition name="...">`). */
+  name: string;
+  /**
+   * Index into `Workbook.pivotCaches`. Mirrors the workbook-level
+   * `cacheId` attribute on `<pivotCache>` rather than the per-table
+   * relationship — that way a model author who reorders the cache
+   * array keeps the link sound.
+   */
+  cacheId: number;
+  /**
+   * Output range on the host sheet, e.g. `"A3:D20"`. Empty string when
+   * the source omits a `<location>` element.
+   */
+  location: string;
+  /** Number of header rows above the data rows. */
+  firstHeaderRow?: number;
+  /** Number of body rows reserved for column-axis labels. */
+  firstDataRow?: number;
+  /** Column index of the first data row (0-based). */
+  firstDataCol?: number;
+  /** Number of pages declared in `<pageFields>`. */
+  rowPageCount?: number;
+  /** Number of column-axis page-break positions. */
+  colPageCount?: number;
+  /**
+   * Pivot fields in declaration order. The position in this array is
+   * the field index used by `<rowItems>`, `<colItems>`, etc.
+   */
+  fields: PivotField[];
+  /** Pivot-table style name (`<pivotTableStyleInfo name="...">`). */
+  styleName?: string;
+  /** Whether the data field caption is shown. */
+  dataCaption?: string;
+}
+
+/**
+ * Workbook-level pivot cache: source range plus cached field metadata.
+ * Multiple pivot tables can share a cache so the same source data only
+ * gets indexed once.
+ */
+export interface PivotCache {
+  /**
+   * Cache id Excel uses to wire pivot tables to caches. Mirrors the
+   * `cacheId` attribute on `<workbook><pivotCaches><pivotCache>`.
+   */
+  cacheId: number;
+  /**
+   * Source range, e.g. `"Sheet1!$A$1:$C$100"` or a defined-name
+   * reference. Empty string for non-worksheet sources.
+   */
+  sourceRef?: string;
+  /** Source sheet name when the source is a worksheet range. */
+  sourceSheet?: string;
+  /**
+   * Source type: `worksheet` (range or table on a sheet), `external`
+   * (linked workbook / database), `consolidation`, or `scenario`. Most
+   * real workbooks use `worksheet`.
+   */
+  sourceType?: "worksheet" | "external" | "consolidation" | "scenario";
+  /** Cached field names in declaration order. */
+  fieldNames: string[];
+  /** Whether a `pivotCacheRecords{N}.xml` part is present. */
+  hasRecords?: boolean;
+}
+
 // ── Workbook ───────────────────────────────────────────────────────
 
 export interface Workbook {
@@ -810,6 +933,12 @@ export interface Workbook {
    * array matches the `[N]` prefix used in formulas like `[1]Sheet1!A1`.
    */
   externalLinks?: ExternalLink[];
+  /**
+   * Workbook-level pivot caches resolved from
+   * `xl/pivotCache/pivotCacheDefinitionN.xml`. Sheet-level
+   * `PivotTable.cacheId` references entries here.
+   */
+  pivotCaches?: PivotCache[];
 }
 
 // ── Read Options ───────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,20 @@ export type {
   ExternalDefinedName,
 } from "./_types";
 
+// ── Pivot Tables ───────────────────────────────────────────────────
+export {
+  parsePivotTable,
+  parsePivotCacheDefinition,
+  attachPivotCacheFields,
+} from "./xlsx/pivot-reader";
+export type {
+  PivotTable,
+  PivotCache,
+  PivotField,
+  PivotFieldAxis,
+  PivotDataFieldFunction,
+} from "./_types";
+
 // ── Date Utilities ─────────────────────────────────────────────────
 export {
   serialToDate,

--- a/src/xlsx/content-types-writer.ts
+++ b/src/xlsx/content-types-writer.ts
@@ -23,6 +23,11 @@ const CT_THREADED_COMMENTS = "application/vnd.ms-excel.threadedcomments+xml";
 const CT_PERSON = "application/vnd.ms-excel.person+xml";
 const CT_EXTERNAL_LINK =
   "application/vnd.openxmlformats-officedocument.spreadsheetml.externalLink+xml";
+const CT_PIVOT_TABLE = "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml";
+const CT_PIVOT_CACHE_DEFINITION =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml";
+const CT_PIVOT_CACHE_RECORDS =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml";
 
 /** Image extension → content type mapping */
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
@@ -56,6 +61,21 @@ export interface ContentTypesOptions {
    * `Override` for `/xl/externalLinks/externalLinkN.xml`.
    */
   externalLinkIndices?: number[];
+  /**
+   * 1-based indices of pivot table parts. Each entry adds an
+   * `Override` for `/xl/pivotTables/pivotTableN.xml`.
+   */
+  pivotTableIndices?: number[];
+  /**
+   * 1-based indices of pivot cache definitions. Each entry adds an
+   * `Override` for `/xl/pivotCache/pivotCacheDefinitionN.xml`.
+   */
+  pivotCacheDefinitionIndices?: number[];
+  /**
+   * 1-based indices of pivot cache records. Each entry adds an
+   * `Override` for `/xl/pivotCache/pivotCacheRecordsN.xml`.
+   */
+  pivotCacheRecordIndices?: number[];
   /** Whether docProps/core.xml is present */
   hasCoreProps?: boolean;
   /** Whether docProps/app.xml is present */
@@ -219,6 +239,42 @@ export function writeContentTypes(
         xmlSelfClose("Override", {
           PartName: `/xl/externalLinks/externalLink${idx}.xml`,
           ContentType: CT_EXTERNAL_LINK,
+        }),
+      );
+    }
+  }
+
+  // Override for each pivot table
+  if (opts.pivotTableIndices) {
+    for (const idx of opts.pivotTableIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/pivotTables/pivotTable${idx}.xml`,
+          ContentType: CT_PIVOT_TABLE,
+        }),
+      );
+    }
+  }
+
+  // Override for each pivot cache definition
+  if (opts.pivotCacheDefinitionIndices) {
+    for (const idx of opts.pivotCacheDefinitionIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/pivotCache/pivotCacheDefinition${idx}.xml`,
+          ContentType: CT_PIVOT_CACHE_DEFINITION,
+        }),
+      );
+    }
+  }
+
+  // Override for each pivot cache records part
+  if (opts.pivotCacheRecordIndices) {
+    for (const idx of opts.pivotCacheRecordIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/pivotCache/pivotCacheRecords${idx}.xml`,
+          ContentType: CT_PIVOT_CACHE_RECORDS,
         }),
       );
     }

--- a/src/xlsx/pivot-reader.ts
+++ b/src/xlsx/pivot-reader.ts
@@ -1,0 +1,246 @@
+// ── Pivot Table Reader ────────────────────────────────────────────
+// Parses xl/pivotTables/pivotTable{N}.xml and
+// xl/pivotCache/pivotCacheDefinition{N}.xml into structured records.
+//
+// OOXML reference: ECMA-376 Part 1, §18.10 (PivotTables) and §18.11
+// (PivotCache).
+
+import type {
+  PivotCache,
+  PivotDataFieldFunction,
+  PivotField,
+  PivotFieldAxis,
+  PivotTable,
+} from "../_types";
+import { parseXml } from "../xml/parser";
+import type { XmlElement } from "../xml/parser";
+
+// ── Pivot Cache Definition (workbook-level) ────────────────────────
+
+/**
+ * Parse a pivot cache definition file
+ * (`xl/pivotCache/pivotCacheDefinition{N}.xml`).
+ *
+ * The OOXML root element is `<pivotCacheDefinition>`. The two pieces
+ * we surface are the source range — read off `<cacheSource>` and its
+ * `<worksheetSource>` child — and the cache field names, which line up
+ * 1:1 with the field indexes used by `<pivotField>` entries on the
+ * pivot table side.
+ */
+export function parsePivotCacheDefinition(xml: string): PivotCache | undefined {
+  const root = parseXml(xml);
+  const def =
+    root.local === "pivotCacheDefinition" ? root : findChild(root, "pivotCacheDefinition");
+  if (!def) return undefined;
+
+  // cacheId is not stored on the definition itself — it lives in
+  // workbook.xml. Default to 0; the reader fills in the real value
+  // from the workbook's <pivotCaches> block.
+  const cache: PivotCache = { cacheId: 0, fieldNames: [] };
+
+  // Source: <cacheSource type="..."><worksheetSource ref="..." sheet="..."/></cacheSource>
+  const source = findChild(def, "cacheSource");
+  if (source) {
+    const t = source.attrs.type;
+    if (t === "worksheet" || t === "external" || t === "consolidation" || t === "scenario") {
+      cache.sourceType = t;
+    }
+    const worksheetSource = findChild(source, "worksheetSource");
+    if (worksheetSource) {
+      // `ref` is the cell range. `name` (a defined name) is the
+      // alternative — both stash into `sourceRef`. `sheet` is optional.
+      if (worksheetSource.attrs.ref) cache.sourceRef = worksheetSource.attrs.ref;
+      else if (worksheetSource.attrs.name) cache.sourceRef = worksheetSource.attrs.name;
+      if (worksheetSource.attrs.sheet) cache.sourceSheet = worksheetSource.attrs.sheet;
+    }
+  }
+
+  // Cache fields: <cacheFields count="N"><cacheField name="..." ...>...</cacheField></cacheFields>
+  const cacheFields = findChild(def, "cacheFields");
+  if (cacheFields) {
+    for (const child of childElements(cacheFields)) {
+      if (child.local !== "cacheField") continue;
+      const name = child.attrs.name ?? "";
+      cache.fieldNames.push(name);
+    }
+  }
+
+  return cache;
+}
+
+// ── Pivot Table Definition (per-sheet) ─────────────────────────────
+
+/**
+ * Parse a pivot table definition file
+ * (`xl/pivotTables/pivotTable{N}.xml`).
+ *
+ * The body is dense — we keep just the layout-relevant attributes so
+ * roundtrip can carry them forward unmodified, and surface the field
+ * placement (row / col / page / data) that callers most often want to
+ * inspect.
+ */
+export function parsePivotTable(xml: string): PivotTable | undefined {
+  const root = parseXml(xml);
+  const def =
+    root.local === "pivotTableDefinition" ? root : findChild(root, "pivotTableDefinition");
+  if (!def) return undefined;
+
+  const name = def.attrs.name;
+  if (!name) return undefined;
+
+  const cacheIdRaw = parseIntSafe(def.attrs.cacheId, NaN);
+
+  const table: PivotTable = {
+    name,
+    // The per-table cacheId attribute matches the workbook's
+    // <pivotCache cacheId="..."> entry. Fall back to 0 when missing
+    // rather than throwing — Excel tolerates that.
+    cacheId: Number.isNaN(cacheIdRaw) ? 0 : cacheIdRaw,
+    location: "",
+    fields: [],
+  };
+
+  // Location block: <location ref="A3:D20" firstHeaderRow="0" firstDataRow="1" firstDataCol="0"/>
+  const location = findChild(def, "location");
+  if (location) {
+    if (location.attrs.ref) table.location = location.attrs.ref;
+    const fh = parseIntSafe(location.attrs.firstHeaderRow, NaN);
+    if (!Number.isNaN(fh)) table.firstHeaderRow = fh;
+    const fdr = parseIntSafe(location.attrs.firstDataRow, NaN);
+    if (!Number.isNaN(fdr)) table.firstDataRow = fdr;
+    const fdc = parseIntSafe(location.attrs.firstDataCol, NaN);
+    if (!Number.isNaN(fdc)) table.firstDataCol = fdc;
+    const rpc = parseIntSafe(location.attrs.rowPageCount, NaN);
+    if (!Number.isNaN(rpc)) table.rowPageCount = rpc;
+    const cpc = parseIntSafe(location.attrs.colPageCount, NaN);
+    if (!Number.isNaN(cpc)) table.colPageCount = cpc;
+  }
+
+  // Field declarations: <pivotFields><pivotField axis="..."/></pivotFields>
+  // The position in this list is the field's index everywhere else.
+  const pivotFields = findChild(def, "pivotFields");
+  const fieldDefs: Array<{ axis: PivotFieldAxis; raw: XmlElement }> = [];
+  if (pivotFields) {
+    for (const child of childElements(pivotFields)) {
+      if (child.local !== "pivotField") continue;
+      const axisAttr = child.attrs.axis;
+      const dataFlag = child.attrs.dataField === "1" || child.attrs.dataField === "true";
+      let axis: PivotFieldAxis = "hidden";
+      if (axisAttr === "axisRow") axis = "row";
+      else if (axisAttr === "axisCol") axis = "col";
+      else if (axisAttr === "axisPage") axis = "page";
+      else if (axisAttr === "axisValues" || dataFlag) axis = "data";
+      fieldDefs.push({ axis, raw: child });
+    }
+  }
+
+  // Walk the dataFields block to recover per-data-field aggregation +
+  // display name overrides. Each <dataField fld="N" subtotal="sum"/>
+  // points back into the pivotField at index `fld`.
+  const dataFields = findChild(def, "dataFields");
+  const dataFieldOverrides = new Map<
+    number,
+    { name?: string; subtotal?: PivotDataFieldFunction }
+  >();
+  if (dataFields) {
+    for (const child of childElements(dataFields)) {
+      if (child.local !== "dataField") continue;
+      const fldRaw = parseIntSafe(child.attrs.fld, NaN);
+      if (Number.isNaN(fldRaw)) continue;
+      const entry: { name?: string; subtotal?: PivotDataFieldFunction } = {};
+      if (child.attrs.name) entry.name = child.attrs.name;
+      const subtotal = mapAggregateFunction(child.attrs.subtotal);
+      if (subtotal) entry.subtotal = subtotal;
+      // dataFields may legally repeat the same fld — last write wins
+      // here so the surfaced override matches what Excel itself shows.
+      dataFieldOverrides.set(fldRaw, entry);
+    }
+  }
+
+  // Need the cache field names to populate PivotField.name. The reader
+  // doesn't have those at this layer (the cache definition is parsed
+  // separately), so emit synthetic names based on the field index. The
+  // caller (xlsx/reader.ts) overlays the real names afterwards.
+  for (let i = 0; i < fieldDefs.length; i++) {
+    const { axis } = fieldDefs[i];
+    const f: PivotField = { name: `field${i + 1}`, axis };
+    if (axis === "data") {
+      const ov = dataFieldOverrides.get(i);
+      if (ov?.subtotal) f.function = ov.subtotal;
+      else f.function = "sum"; // OOXML default
+      if (ov?.name) f.displayName = ov.name;
+    }
+    table.fields.push(f);
+  }
+
+  // Style info
+  const styleInfo = findChild(def, "pivotTableStyleInfo");
+  if (styleInfo?.attrs.name) table.styleName = styleInfo.attrs.name;
+
+  if (def.attrs.dataCaption) table.dataCaption = def.attrs.dataCaption;
+
+  return table;
+}
+
+/**
+ * Overlay cache field names onto a PivotTable's synthetic field names.
+ * Mutates `table.fields[i].name` for indexes the cache covers; out-of-
+ * range entries keep their `fieldN` placeholder.
+ */
+export function attachPivotCacheFields(table: PivotTable, cache: PivotCache): void {
+  for (let i = 0; i < table.fields.length; i++) {
+    const cacheName = cache.fieldNames[i];
+    if (cacheName) table.fields[i].name = cacheName;
+  }
+}
+
+// ── Internals ─────────────────────────────────────────────────────
+
+/**
+ * Map the OOXML `subtotal` enum (e.g. `"sum"`, `"countA"`) onto the
+ * narrower `PivotDataFieldFunction` we expose. Returns `undefined`
+ * for values we don't recognise — caller falls back to the spec default.
+ */
+function mapAggregateFunction(s: string | undefined): PivotDataFieldFunction | undefined {
+  if (!s) return undefined;
+  switch (s) {
+    case "sum":
+    case "count":
+    case "average":
+    case "max":
+    case "min":
+    case "product":
+    case "countNums":
+    case "stdDev":
+    case "stdDevp":
+    case "var":
+    case "varp":
+      return s;
+    case "countA":
+      // OOXML's countA collapses to count for our purposes.
+      return "count";
+    default:
+      return undefined;
+  }
+}
+
+function childElements(el: XmlElement): XmlElement[] {
+  const out: XmlElement[] = [];
+  for (const c of el.children) {
+    if (typeof c !== "string") out.push(c);
+  }
+  return out;
+}
+
+function findChild(el: XmlElement, localName: string): XmlElement | undefined {
+  for (const c of el.children) {
+    if (typeof c !== "string" && c.local === localName) return c;
+  }
+  return undefined;
+}
+
+function parseIntSafe(s: string | undefined, fallback: number): number {
+  if (s === undefined) return fallback;
+  const n = parseInt(s, 10);
+  return Number.isNaN(n) ? fallback : n;
+}

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -12,9 +12,12 @@ import type {
   TableColumn,
   ThreadedCommentPerson,
   ExternalLink,
+  PivotCache,
+  PivotTable,
 } from "../_types";
 import { parsePersons, parseThreadedComments } from "./threaded-comments-reader";
 import { parseExternalLink } from "./external-link-reader";
+import { attachPivotCacheFields, parsePivotCacheDefinition, parsePivotTable } from "./pivot-reader";
 import { ParseError, ZipError } from "../errors";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
@@ -157,6 +160,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     dateSystem,
     namedRanges,
     workbookProtection,
+    pivotCacheRefs,
   } = parseWorkbookXml(workbookXml, options);
 
   // 6. Parse shared strings if present
@@ -219,6 +223,40 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       : undefined;
     externalLinks.push(parseExternalLink(linkXml, linkRelsXml));
   }
+
+  // 7e. Parse pivot caches (xl/pivotCache/pivotCacheDefinitionN.xml).
+  // The workbook's <pivotCaches> block ties each cacheId to an rId in
+  // workbook.xml.rels; we walk that pairing and resolve each cache.
+  // The cache definitions also surface a `hasRecords` flag based on
+  // whether the sibling rels declare a pivotCacheRecords part.
+  const pivotCachesByCacheId = new Map<number, PivotCache>();
+  const pivotCachesByRId = new Map<string, PivotCache>();
+  for (const ref of pivotCacheRefs) {
+    const rel = workbookRels.find((r) => r.id === ref.rId);
+    if (!rel) continue;
+    const cachePath = resolvePath(workbookDir, rel.target);
+    if (!zip.has(cachePath)) continue;
+    const cacheXml = decodeUtf8(await zip.extract(cachePath));
+    const cache = parsePivotCacheDefinition(cacheXml);
+    if (!cache) continue;
+    cache.cacheId = ref.cacheId;
+    // Detect a sibling pivotCacheRecords part via the cache's _rels.
+    const cacheRelsPath = relsPathFor(cachePath);
+    if (zip.has(cacheRelsPath)) {
+      const cacheRelsXml = decodeUtf8(await zip.extract(cacheRelsPath));
+      const cacheRels = parseRelationships(cacheRelsXml);
+      if (cacheRels.some((r) => matchesRelType(r.type, "pivotCacheRecords"))) {
+        cache.hasRecords = true;
+      }
+    }
+    pivotCachesByCacheId.set(ref.cacheId, cache);
+    pivotCachesByRId.set(ref.rId, cache);
+  }
+  // Preserve the workbook's declaration order so caller-side cacheId
+  // lookups by array index match what Excel sees.
+  const pivotCaches: PivotCache[] = pivotCacheRefs
+    .map((ref) => pivotCachesByCacheId.get(ref.cacheId))
+    .filter((c): c is PivotCache => c !== undefined);
 
   // 8. Build a map of rId → sheet relationship for worksheet paths
   const sheetRelMap = new Map<string, string>();
@@ -359,6 +397,55 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       }
     }
 
+    // Extract pivot tables hosted on this sheet, if any. The sheet's
+    // _rels file declares `Type=".../pivotTable"` per instance; the
+    // body lives in xl/pivotTables/pivotTableN.xml and points at the
+    // owning cache through its sibling _rels file.
+    if (worksheetRels) {
+      const pivotTableRels = worksheetRels.filter((r) => matchesRelType(r.type, "pivotTable"));
+      if (pivotTableRels.length > 0) {
+        const pivotTables: PivotTable[] = [];
+        for (const ptRel of pivotTableRels) {
+          const ptPath = resolvePath(wsDir, ptRel.target);
+          if (!zip.has(ptPath)) continue;
+          const ptXml = decodeUtf8(await zip.extract(ptPath));
+          const pivot = parsePivotTable(ptXml);
+          if (!pivot) continue;
+          // Resolve the pivot's owning cache via its sibling _rels —
+          // pivot tables don't carry the rId in the body, only in the
+          // companion .rels file. Match by relative target so we
+          // stay tolerant of caches living anywhere under xl/.
+          const ptRelsPath = relsPathFor(ptPath);
+          if (zip.has(ptRelsPath)) {
+            const ptRelsXml = decodeUtf8(await zip.extract(ptRelsPath));
+            const ptInternalRels = parseRelationships(ptRelsXml);
+            const cacheRel = ptInternalRels.find((r) =>
+              matchesRelType(r.type, "pivotCacheDefinition"),
+            );
+            if (cacheRel) {
+              const resolvedCachePath = resolvePath(dirname(ptPath), cacheRel.target);
+              for (const ref of pivotCacheRefs) {
+                const wbRel = workbookRels.find((r) => r.id === ref.rId);
+                if (!wbRel) continue;
+                const wbCachePath = resolvePath(workbookDir, wbRel.target);
+                if (wbCachePath === resolvedCachePath) {
+                  pivot.cacheId = ref.cacheId;
+                  break;
+                }
+              }
+            }
+          }
+          // Overlay the cache's field names so consumers see the real
+          // names instead of the synthetic field1/field2 placeholders
+          // emitted by parsePivotTable when it has no cache context.
+          const owningCache = pivotCachesByCacheId.get(pivot.cacheId);
+          if (owningCache) attachPivotCacheFields(pivot, owningCache);
+          pivotTables.push(pivot);
+        }
+        if (pivotTables.length > 0) sheet.pivotTables = pivotTables;
+      }
+    }
+
     sheets.push(sheet);
   }
 
@@ -418,6 +505,10 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
 
   if (externalLinks.length > 0) {
     workbook.externalLinks = externalLinks;
+  }
+
+  if (pivotCaches.length > 0) {
+    workbook.pivotCaches = pivotCaches;
   }
 
   return workbook;
@@ -1005,11 +1096,18 @@ function parseWorkbookXml(
   dateSystem: "1900" | "1904";
   namedRanges: NamedRange[];
   workbookProtection?: { lockStructure?: boolean; lockWindows?: boolean };
+  /**
+   * Pivot cache wiring read off the workbook's `<pivotCaches>` block.
+   * Each entry maps a cacheId (Excel's stable handle) to an rId in
+   * `xl/_rels/workbook.xml.rels`.
+   */
+  pivotCacheRefs: Array<{ cacheId: number; rId: string }>;
 } {
   const doc = parseXml(xml);
 
   const sheets: SheetInfo[] = [];
   const namedRanges: NamedRange[] = [];
+  const pivotCacheRefs: Array<{ cacheId: number; rId: string }> = [];
   let dateSystem: "1900" | "1904" = "1900";
 
   // Check date system override from options
@@ -1072,6 +1170,22 @@ function parseWorkbookXml(
         }
       }
     }
+
+    if (local === "pivotCaches") {
+      for (const pcChild of child.children) {
+        if (typeof pcChild === "string") continue;
+        const pcLocal = pcChild.local || pcChild.tag;
+        if (pcLocal === "pivotCache") {
+          const cacheIdRaw = pcChild.attrs["cacheId"];
+          const cacheId = cacheIdRaw === undefined ? NaN : Number(cacheIdRaw);
+          const rId =
+            pcChild.attrs["r:id"] ?? pcChild.attrs["R:id"] ?? findRIdAttr(pcChild.attrs) ?? "";
+          if (rId && !Number.isNaN(cacheId)) {
+            pivotCacheRefs.push({ cacheId, rId });
+          }
+        }
+      }
+    }
   }
 
   // Second pass: collect defined names (named ranges)
@@ -1111,7 +1225,13 @@ function parseWorkbookXml(
     }
   }
 
-  return { sheets, dateSystem, namedRanges, workbookProtection: wbProtection };
+  return {
+    sheets,
+    dateSystem,
+    namedRanges,
+    workbookProtection: wbProtection,
+    pivotCacheRefs,
+  };
 }
 
 /** Find an r:id attribute regardless of namespace prefix */

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -9,7 +9,14 @@ import { ZipReader } from "../zip/reader";
 import { ZipWriter } from "../zip/writer";
 import { writeContentTypes } from "./content-types-writer";
 import type { ContentTypesOptions } from "./content-types-writer";
-import { writeRootRels, writeWorkbookXml, writeWorkbookRels } from "./workbook-writer";
+import {
+  writeRootRels,
+  writeWorkbookXml,
+  writeWorkbookRels,
+  type PivotCacheRef,
+  type PivotCacheRel,
+} from "./workbook-writer";
+import { parseRelationships } from "./relationships";
 import { createStylesCollector } from "./styles-writer";
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer";
 import type { WorksheetResult } from "./worksheet-writer";
@@ -57,6 +64,8 @@ const REL_TABLE = "http://schemas.openxmlformats.org/officeDocument/2006/relatio
 const REL_THREADED_COMMENT =
   "http://schemas.microsoft.com/office/2017/10/relationships/threadedComment";
 const REL_PERSON = "http://schemas.microsoft.com/office/2017/10/relationships/person";
+const REL_PIVOT_TABLE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable";
 
 /**
  * Parts that defter regenerates from parsed data.
@@ -303,6 +312,32 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     if (m) externalLinkIndices.push(parseInt(m[1], 10));
   }
   externalLinkIndices.sort((a, b) => a - b);
+
+  // Collect pivot cache definitions, pivot cache records, and per-sheet
+  // pivot tables that survived in raw entries. Each survives as a body
+  // file, but the references that wire them into the workbook get
+  // regenerated from scratch — so we must declare them here.
+  const pivotCacheDefinitionIndices: number[] = [];
+  const pivotCacheRecordIndices: number[] = [];
+  const pivotTableIndices: number[] = [];
+  for (const path of workbook._rawEntries.keys()) {
+    let m = path.match(/^xl\/pivotCache\/pivotCacheDefinition(\d+)\.xml$/i);
+    if (m) {
+      pivotCacheDefinitionIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/pivotCache\/pivotCacheRecords(\d+)\.xml$/i);
+    if (m) {
+      pivotCacheRecordIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/pivotTables\/pivotTable(\d+)\.xml$/i);
+    if (m) pivotTableIndices.push(parseInt(m[1], 10));
+  }
+  pivotCacheDefinitionIndices.sort((a, b) => a - b);
+  pivotCacheRecordIndices.sort((a, b) => a - b);
+  pivotTableIndices.sort((a, b) => a - b);
+
   // rIds for external link relationships: assigned after all
   // sheet/styles/sharedStrings/theme/macros/featurePropertyBag/persons rIds.
   const externalLinkRelStart = computeExternalLinkRelStart(
@@ -316,6 +351,30 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     rId: `rId${externalLinkRelStart + i}`,
     target: `externalLinks/externalLink${idx}.xml`,
   }));
+
+  // rIds for pivot cache definition relationships: continue numbering
+  // past the external link rIds. The same rIds also flow into the
+  // workbook.xml `<pivotCaches>` block so cache references stay sound.
+  const pivotCacheRelStart = externalLinkRelStart + externalLinkRels.length;
+  const pivotCacheRels: PivotCacheRel[] = pivotCacheDefinitionIndices.map((idx, i) => ({
+    rId: `rId${pivotCacheRelStart + i}`,
+    target: `pivotCache/pivotCacheDefinition${idx}.xml`,
+  }));
+  // Workbook-level pivotCaches block. cacheId is 0-based and must match
+  // the per-pivot-table `cacheId` attribute. We assign them in the
+  // order the cache definitions appear in the package — the original
+  // cacheIds aren't recoverable without parsing workbook.xml here, but
+  // Excel only requires cacheId/rId pairings to be self-consistent, so
+  // a 0..N-1 sequence is safe for roundtrip.
+  const pivotCacheRefs: PivotCacheRef[] = pivotCacheRels.map((rel, i) => ({
+    cacheId: i,
+    rId: rel.rId,
+  }));
+
+  // Map each pivot table to the sheet that hosts it. The mapping is
+  // recovered by walking each sheet's original _rels file — that's
+  // where Excel stored the pivotTable -> sheet wiring originally.
+  const sheetPivotTableTargets = collectSheetPivotTableTargets(workbook, sheets);
 
   // Build ZIP archive
   const zip = new ZipWriter();
@@ -365,6 +424,11 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
       threadedCommentSheetIndices.length > 0 ? threadedCommentSheetIndices : undefined,
     hasPersons: hasPersons || undefined,
     externalLinkIndices: externalLinkIndices.length > 0 ? externalLinkIndices : undefined,
+    pivotTableIndices: pivotTableIndices.length > 0 ? pivotTableIndices : undefined,
+    pivotCacheDefinitionIndices:
+      pivotCacheDefinitionIndices.length > 0 ? pivotCacheDefinitionIndices : undefined,
+    pivotCacheRecordIndices:
+      pivotCacheRecordIndices.length > 0 ? pivotCacheRecordIndices : undefined,
     hasCoreProps: true,
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
@@ -390,6 +454,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         activeSheet,
         undefined,
         externalLinkRels.length > 0 ? externalLinkRels : undefined,
+        pivotCacheRefs.length > 0 ? pivotCacheRefs : undefined,
       ),
     ),
   );
@@ -405,6 +470,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         false, // hasFeaturePropertyBag — not yet roundtripped
         hasPersons,
         externalLinkRels.length > 0 ? externalLinkRels : undefined,
+        pivotCacheRels.length > 0 ? pivotCacheRels : undefined,
       ),
     ),
   );
@@ -431,8 +497,17 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     const hasComments = comments !== null && result.legacyDrawingRId !== null;
     const hasTables = result.tables.length > 0;
     const hasThreadedComments = threadedCommentSheetIndices.includes(i + 1);
+    const sheetPivotTargets = sheetPivotTableTargets[i] ?? [];
+    const hasSheetPivotTables = sheetPivotTargets.length > 0;
 
-    if (hasHyperlinks || hasDrawing || hasComments || hasTables || hasThreadedComments) {
+    if (
+      hasHyperlinks ||
+      hasDrawing ||
+      hasComments ||
+      hasTables ||
+      hasThreadedComments ||
+      hasSheetPivotTables
+    ) {
       const relElements: string[] = [];
 
       for (const rel of result.hyperlinkRelationships) {
@@ -483,23 +558,42 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         );
       }
 
-      // Threaded comments (Excel 365). The rId only needs to be unique
-      // within this rels file — pick the next id past everything we've
-      // already emitted for this sheet.
-      if (hasThreadedComments) {
-        const usedIds = new Set<number>();
-        for (const r of result.hyperlinkRelationships) usedIds.add(relIdNum(r.id));
-        if (result.drawingRId) usedIds.add(relIdNum(result.drawingRId));
-        if (result.legacyDrawingRId) usedIds.add(relIdNum(result.legacyDrawingRId));
-        if (result.commentsRId) usedIds.add(relIdNum(result.commentsRId));
-        for (const t of result.tables) usedIds.add(relIdNum(t.rId));
+      // Track all rIds we've already used so threaded comment / pivot
+      // table rels pick non-colliding ids.
+      const usedIds = new Set<number>();
+      for (const r of result.hyperlinkRelationships) usedIds.add(relIdNum(r.id));
+      if (result.drawingRId) usedIds.add(relIdNum(result.drawingRId));
+      if (result.legacyDrawingRId) usedIds.add(relIdNum(result.legacyDrawingRId));
+      if (result.commentsRId) usedIds.add(relIdNum(result.commentsRId));
+      for (const t of result.tables) usedIds.add(relIdNum(t.rId));
+
+      const allocRid = (): string => {
         let next = 1;
         while (usedIds.has(next)) next++;
+        usedIds.add(next);
+        return `rId${next}`;
+      };
+
+      // Threaded comments (Excel 365).
+      if (hasThreadedComments) {
         relElements.push(
           xmlSelfClose("Relationship", {
-            Id: `rId${next}`,
+            Id: allocRid(),
             Type: REL_THREADED_COMMENT,
             Target: `../threadedComments/threadedComment${i + 1}.xml`,
+          }),
+        );
+      }
+
+      // Pivot tables hosted on this sheet. Re-emit each one we recovered
+      // from the original sheet rels — Excel needs the sheet -> pivot
+      // table wiring or it won't render the pivot at all.
+      for (const target of sheetPivotTargets) {
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: allocRid(),
+            Type: REL_PIVOT_TABLE,
+            Target: target,
           }),
         );
       }
@@ -552,6 +646,39 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
 function relIdNum(rId: string): number {
   const m = rId.match(/(\d+)$/);
   return m ? parseInt(m[1], 10) : 0;
+}
+
+/**
+ * Walk each preserved sheet rels file and pull out its pivot table
+ * targets so we can re-emit the sheet -> pivot wiring after the rels
+ * are regenerated. Returns one entry per sheet (in workbook order),
+ * each a list of relative `Target` paths suitable for plugging back
+ * into the regenerated rels.
+ */
+function collectSheetPivotTableTargets(
+  workbook: RoundtripWorkbook,
+  sheets: ReadonlyArray<{ name: string }>,
+): string[][] {
+  const decoder = new TextDecoder("utf-8");
+  const out: string[][] = sheets.map(() => []);
+  for (let i = 0; i < sheets.length; i++) {
+    const relsPath = `xl/worksheets/_rels/sheet${i + 1}.xml.rels`;
+    const data = workbook._rawEntries.get(relsPath);
+    if (!data) continue;
+    let rels;
+    try {
+      rels = parseRelationships(decoder.decode(data));
+    } catch {
+      continue;
+    }
+    for (const rel of rels) {
+      // Match by suffix to tolerate Strict/Transitional namespaces.
+      if (rel.type.endsWith("/pivotTable")) {
+        out[i].push(rel.target);
+      }
+    }
+  }
+  return out;
 }
 
 /**

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -19,6 +19,16 @@ const REL_WORKBOOK =
 
 const NS_RELATIONSHIPS = "http://schemas.openxmlformats.org/package/2006/relationships";
 
+/**
+ * A pivotCache wiring entry emitted in workbook.xml. `cacheId` is the
+ * stable handle pivot tables reference; `rId` resolves through
+ * `xl/_rels/workbook.xml.rels` to the cache definition path.
+ */
+export interface PivotCacheRef {
+  cacheId: number;
+  rId: string;
+}
+
 /** Generate xl/workbook.xml */
 export function writeWorkbookXml(
   sheets: WriteSheet[],
@@ -27,6 +37,7 @@ export function writeWorkbookXml(
   activeSheet?: number,
   workbookProtection?: { lockStructure?: boolean; lockWindows?: boolean; password?: string },
   externalLinkRels?: ReadonlyArray<{ rId: string }>,
+  pivotCacheRefs?: ReadonlyArray<PivotCacheRef>,
 ): string {
   const sheetElements: string[] = [];
 
@@ -125,6 +136,16 @@ export function writeWorkbookXml(
   // ── calcPr — tells Excel to recalculate all formulas on open ──
   parts.push(xmlSelfClose("calcPr", { calcId: 0, fullCalcOnLoad: 1 }));
 
+  // ── pivotCaches — wires cacheId values to workbook-rel rIds. ECMA-376
+  // §18.2.18 puts this block after calcPr; Excel won't recognise pivot
+  // tables on roundtrip without it.
+  if (pivotCacheRefs && pivotCacheRefs.length > 0) {
+    const cacheChildren = pivotCacheRefs.map((c) =>
+      xmlSelfClose("pivotCache", { cacheId: c.cacheId, "r:id": c.rId }),
+    );
+    parts.push(xmlElement("pivotCaches", undefined, cacheChildren));
+  }
+
   return xmlDocument("workbook", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts);
 }
 
@@ -135,11 +156,24 @@ const REL_FEATURE_PROPERTY_BAG =
 const REL_PERSON = "http://schemas.microsoft.com/office/2017/10/relationships/person";
 const REL_EXTERNAL_LINK =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink";
+const REL_PIVOT_CACHE_DEFINITION =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition";
 
 /** A relationship description for an externalLink emitted in workbook.xml.rels. */
 export interface ExternalLinkRel {
   rId: string;
   /** Path relative to the workbook directory, e.g. "externalLinks/externalLink1.xml". */
+  target: string;
+}
+
+/**
+ * A workbook-level pivot cache definition relationship. The rId is
+ * shared with the matching `<pivotCache cacheId="..." r:id="..."/>` in
+ * workbook.xml so the two stay in lockstep.
+ */
+export interface PivotCacheRel {
+  rId: string;
+  /** Path relative to xl/, e.g. "pivotCache/pivotCacheDefinition1.xml". */
   target: string;
 }
 
@@ -151,6 +185,7 @@ export function writeWorkbookRels(
   hasFeaturePropertyBag?: boolean,
   hasPersons?: boolean,
   externalLinkRels?: ReadonlyArray<ExternalLinkRel>,
+  pivotCacheRels?: ReadonlyArray<PivotCacheRel>,
 ): string {
   const children: string[] = [];
 
@@ -242,6 +277,21 @@ export function writeWorkbookRels(
           Id: link.rId,
           Type: REL_EXTERNAL_LINK,
           Target: link.target,
+        }),
+      );
+    }
+  }
+
+  // Pivot cache definition relationships (caller supplies pre-assigned rIds
+  // — the rIds also appear in workbook.xml's <pivotCaches> block, so the
+  // two must agree).
+  if (pivotCacheRels) {
+    for (const cache of pivotCacheRels) {
+      children.push(
+        xmlSelfClose("Relationship", {
+          Id: cache.rId,
+          Type: REL_PIVOT_CACHE_DEFINITION,
+          Target: cache.target,
         }),
       );
     }

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -44,7 +44,7 @@ function effectiveProperties(options: WriteOptions): WorkbookProperties | undefi
   for (const sheet of options.sheets) {
     const summary = sheet.a11y?.summary;
     if (summary && summary.trim().length > 0) {
-      return { ...(props ?? {}), description: summary };
+      return { ...props, description: summary };
     }
   }
   return props;

--- a/test/pivot-tables.test.ts
+++ b/test/pivot-tables.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect } from "vitest";
+import {
+  parsePivotCacheDefinition,
+  parsePivotTable,
+  attachPivotCacheFields,
+} from "../src/xlsx/pivot-reader";
+import { ZipWriter } from "../src/zip/writer";
+import { ZipReader } from "../src/zip/reader";
+import { readXlsx } from "../src/xlsx/reader";
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip";
+
+const encoder = new TextEncoder();
+
+// ── parsePivotCacheDefinition ──────────────────────────────────────
+
+describe("parsePivotCacheDefinition", () => {
+  it("returns undefined when the root element is wrong", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<notACache xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>`;
+    expect(parsePivotCacheDefinition(xml)).toBeUndefined();
+  });
+
+  it("parses worksheet source range and field names in declaration order", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                      xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                      r:id="rId1" recordCount="3">
+  <cacheSource type="worksheet">
+    <worksheetSource ref="A1:C4" sheet="Data"/>
+  </cacheSource>
+  <cacheFields count="3">
+    <cacheField name="Region" numFmtId="0"/>
+    <cacheField name="Product" numFmtId="0"/>
+    <cacheField name="Revenue" numFmtId="0"/>
+  </cacheFields>
+</pivotCacheDefinition>`;
+    const cache = parsePivotCacheDefinition(xml);
+    expect(cache).toBeDefined();
+    expect(cache!.sourceType).toBe("worksheet");
+    expect(cache!.sourceRef).toBe("A1:C4");
+    expect(cache!.sourceSheet).toBe("Data");
+    expect(cache!.fieldNames).toEqual(["Region", "Product", "Revenue"]);
+  });
+
+  it("falls back to the worksheetSource name attribute when ref is absent", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <cacheSource type="worksheet">
+    <worksheetSource name="SalesTable"/>
+  </cacheSource>
+  <cacheFields count="1"><cacheField name="X"/></cacheFields>
+</pivotCacheDefinition>`;
+    const cache = parsePivotCacheDefinition(xml);
+    expect(cache!.sourceRef).toBe("SalesTable");
+    expect(cache!.sourceSheet).toBeUndefined();
+  });
+
+  it("uses an empty string when a cacheField is missing its name attribute", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <cacheFields count="2">
+    <cacheField name="Has"/>
+    <cacheField/>
+  </cacheFields>
+</pivotCacheDefinition>`;
+    const cache = parsePivotCacheDefinition(xml);
+    expect(cache!.fieldNames).toEqual(["Has", ""]);
+  });
+
+  it("ignores an unknown cacheSource type", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <cacheSource type="hypothetical"/>
+</pivotCacheDefinition>`;
+    const cache = parsePivotCacheDefinition(xml);
+    expect(cache!.sourceType).toBeUndefined();
+  });
+});
+
+// ── parsePivotTable ────────────────────────────────────────────────
+
+describe("parsePivotTable", () => {
+  it("returns undefined when the root has no name attribute", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>`;
+    expect(parsePivotTable(xml)).toBeUndefined();
+  });
+
+  it("parses cacheId, location, and field axes", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                     name="SalesPivot" cacheId="0" applyNumberFormats="0"
+                     applyBorderFormats="0" applyFontFormats="0"
+                     applyPatternFormats="0" applyAlignmentFormats="0"
+                     applyWidthHeightFormats="1" dataCaption="Values"
+                     updatedVersion="6" minRefreshableVersion="3">
+  <location ref="A3:D20" firstHeaderRow="1" firstDataRow="2" firstDataCol="1"/>
+  <pivotFields count="3">
+    <pivotField axis="axisRow" showAll="0"/>
+    <pivotField axis="axisCol" showAll="0"/>
+    <pivotField dataField="1" showAll="0"/>
+  </pivotFields>
+  <dataFields count="1">
+    <dataField name="Sum of Revenue" fld="2" baseField="0" baseItem="0" subtotal="sum"/>
+  </dataFields>
+  <pivotTableStyleInfo name="PivotStyleLight16" showRowHeaders="1"
+                       showColHeaders="1" showRowStripes="0" showColStripes="0"
+                       showLastColumn="1"/>
+</pivotTableDefinition>`;
+    const pivot = parsePivotTable(xml);
+    expect(pivot).toBeDefined();
+    expect(pivot!.name).toBe("SalesPivot");
+    expect(pivot!.cacheId).toBe(0);
+    expect(pivot!.location).toBe("A3:D20");
+    expect(pivot!.firstHeaderRow).toBe(1);
+    expect(pivot!.firstDataRow).toBe(2);
+    expect(pivot!.firstDataCol).toBe(1);
+    expect(pivot!.fields).toHaveLength(3);
+    expect(pivot!.fields[0].axis).toBe("row");
+    expect(pivot!.fields[1].axis).toBe("col");
+    expect(pivot!.fields[2].axis).toBe("data");
+    expect(pivot!.fields[2].function).toBe("sum");
+    expect(pivot!.fields[2].displayName).toBe("Sum of Revenue");
+    expect(pivot!.styleName).toBe("PivotStyleLight16");
+    expect(pivot!.dataCaption).toBe("Values");
+  });
+
+  it("treats fields without an axis attribute and no dataField flag as hidden", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                     name="P" cacheId="0">
+  <location ref="A1:A1"/>
+  <pivotFields count="1">
+    <pivotField showAll="0"/>
+  </pivotFields>
+</pivotTableDefinition>`;
+    const pivot = parsePivotTable(xml);
+    expect(pivot!.fields[0].axis).toBe("hidden");
+  });
+
+  it("maps axisValues / dataField=true / countA appropriately", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                     name="P" cacheId="0">
+  <location ref="A1:A1"/>
+  <pivotFields count="2">
+    <pivotField axis="axisValues"/>
+    <pivotField dataField="true"/>
+  </pivotFields>
+  <dataFields count="2">
+    <dataField fld="0" subtotal="countA"/>
+    <dataField fld="1" subtotal="average"/>
+  </dataFields>
+</pivotTableDefinition>`;
+    const pivot = parsePivotTable(xml);
+    expect(pivot!.fields[0].axis).toBe("data");
+    expect(pivot!.fields[0].function).toBe("count"); // countA collapses to count
+    expect(pivot!.fields[1].axis).toBe("data");
+    expect(pivot!.fields[1].function).toBe("average");
+  });
+
+  it("falls back to cacheId 0 when the attribute is missing or unparseable", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                     name="P" cacheId="oops">
+  <location ref="A1:A1"/>
+</pivotTableDefinition>`;
+    const pivot = parsePivotTable(xml);
+    expect(pivot!.cacheId).toBe(0);
+  });
+});
+
+// ── attachPivotCacheFields ─────────────────────────────────────────
+
+describe("attachPivotCacheFields", () => {
+  it("overlays cache field names and leaves unmatched indexes alone", () => {
+    const pivot = parsePivotTable(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                     name="P" cacheId="0">
+  <location ref="A1:A1"/>
+  <pivotFields count="3">
+    <pivotField axis="axisRow"/>
+    <pivotField axis="axisCol"/>
+    <pivotField dataField="1"/>
+  </pivotFields>
+</pivotTableDefinition>`)!;
+    expect(pivot.fields.map((f) => f.name)).toEqual(["field1", "field2", "field3"]);
+    attachPivotCacheFields(pivot, {
+      cacheId: 0,
+      fieldNames: ["Region", "Product"], // shorter than pivot.fields
+    });
+    expect(pivot.fields.map((f) => f.name)).toEqual(["Region", "Product", "field3"]);
+  });
+});
+
+// ── Integration: end-to-end XLSX with pivot table ──────────────────
+
+async function buildXlsxWithPivotTable(): Promise<Uint8Array> {
+  const z = new ZipWriter();
+
+  z.add(
+    "[Content_Types].xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/pivotTables/pivotTable1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml"/>
+  <Override PartName="/xl/pivotCache/pivotCacheDefinition1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml"/>
+  <Override PartName="/xl/pivotCache/pivotCacheRecords1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml"/>
+</Types>`),
+  );
+
+  z.add(
+    "_rels/.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/workbook.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Data" sheetId="1" r:id="rId1"/>
+    <sheet name="Pivot" sheetId="2" r:id="rId2"/>
+  </sheets>
+  <pivotCaches>
+    <pivotCache cacheId="0" r:id="rId3"/>
+  </pivotCaches>
+</workbook>`),
+  );
+
+  z.add(
+    "xl/_rels/workbook.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" Target="pivotCache/pivotCacheDefinition1.xml"/>
+</Relationships>`),
+  );
+
+  // Source data sheet
+  z.add(
+    "xl/worksheets/sheet1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="inlineStr"><is><t>Region</t></is></c><c r="B1" t="inlineStr"><is><t>Revenue</t></is></c></row>
+    <row r="2"><c r="A2" t="inlineStr"><is><t>EU</t></is></c><c r="B2"><v>100</v></c></row>
+    <row r="3"><c r="A3" t="inlineStr"><is><t>US</t></is></c><c r="B3"><v>200</v></c></row>
+  </sheetData>
+</worksheet>`),
+  );
+
+  // Sheet that hosts the pivot table — its rels file declares the pivotTable rel.
+  z.add(
+    "xl/worksheets/sheet2.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>`),
+  );
+  z.add(
+    "xl/worksheets/_rels/sheet2.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable" Target="../pivotTables/pivotTable1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/pivotTables/pivotTable1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotTableDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                     name="SalesPivot" cacheId="0" applyNumberFormats="0"
+                     applyBorderFormats="0" applyFontFormats="0"
+                     applyPatternFormats="0" applyAlignmentFormats="0"
+                     applyWidthHeightFormats="1" dataCaption="Values">
+  <location ref="A3:B5" firstHeaderRow="0" firstDataRow="1" firstDataCol="1"/>
+  <pivotFields count="2">
+    <pivotField axis="axisRow" showAll="0"/>
+    <pivotField dataField="1" showAll="0"/>
+  </pivotFields>
+  <dataFields count="1">
+    <dataField name="Sum of Revenue" fld="1" subtotal="sum"/>
+  </dataFields>
+  <pivotTableStyleInfo name="PivotStyleLight16"/>
+</pivotTableDefinition>`),
+  );
+  z.add(
+    "xl/pivotTables/_rels/pivotTable1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition" Target="../pivotCache/pivotCacheDefinition1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/pivotCache/pivotCacheDefinition1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+                      xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                      r:id="rId1" recordCount="2">
+  <cacheSource type="worksheet">
+    <worksheetSource ref="A1:B3" sheet="Data"/>
+  </cacheSource>
+  <cacheFields count="2">
+    <cacheField name="Region" numFmtId="0"/>
+    <cacheField name="Revenue" numFmtId="0"/>
+  </cacheFields>
+</pivotCacheDefinition>`),
+  );
+  z.add(
+    "xl/pivotCache/_rels/pivotCacheDefinition1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords" Target="pivotCacheRecords1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/pivotCache/pivotCacheRecords1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<pivotCacheRecords xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="2">
+  <r><s v="EU"/><n v="100"/></r>
+  <r><s v="US"/><n v="200"/></r>
+</pivotCacheRecords>`),
+  );
+
+  return await z.build();
+}
+
+async function zipExtractText(buf: Uint8Array, path: string): Promise<string> {
+  const zr = new ZipReader(buf);
+  return new TextDecoder("utf-8").decode(await zr.extract(path));
+}
+
+function zipHas(buf: Uint8Array, path: string): boolean {
+  const zr = new ZipReader(buf);
+  return zr.has(path);
+}
+
+// ── Reader integration ────────────────────────────────────────────
+
+describe("readXlsx — pivot table integration", () => {
+  it("attaches workbook.pivotCaches with parsed source range and field names", async () => {
+    const buf = await buildXlsxWithPivotTable();
+    const wb = await readXlsx(buf);
+    expect(wb.pivotCaches).toBeDefined();
+    expect(wb.pivotCaches).toHaveLength(1);
+    const cache = wb.pivotCaches![0];
+    expect(cache.cacheId).toBe(0);
+    expect(cache.sourceType).toBe("worksheet");
+    expect(cache.sourceRef).toBe("A1:B3");
+    expect(cache.sourceSheet).toBe("Data");
+    expect(cache.fieldNames).toEqual(["Region", "Revenue"]);
+    expect(cache.hasRecords).toBe(true);
+  });
+
+  it("attaches sheet.pivotTables with names overlaid from the cache", async () => {
+    const buf = await buildXlsxWithPivotTable();
+    const wb = await readXlsx(buf);
+    const pivotSheet = wb.sheets.find((s) => s.name === "Pivot");
+    expect(pivotSheet?.pivotTables).toHaveLength(1);
+    const pt = pivotSheet!.pivotTables![0];
+    expect(pt.name).toBe("SalesPivot");
+    expect(pt.cacheId).toBe(0);
+    expect(pt.location).toBe("A3:B5");
+    expect(pt.fields).toHaveLength(2);
+    expect(pt.fields[0]).toMatchObject({ name: "Region", axis: "row" });
+    expect(pt.fields[1]).toMatchObject({
+      name: "Revenue",
+      axis: "data",
+      function: "sum",
+      displayName: "Sum of Revenue",
+    });
+    expect(pt.styleName).toBe("PivotStyleLight16");
+  });
+
+  it("does not set pivotCaches when the workbook has none", async () => {
+    const z = new ZipWriter();
+    z.add(
+      "[Content_Types].xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>`),
+    );
+    z.add(
+      "_rels/.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/workbook.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Main" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+    );
+    z.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/worksheets/sheet1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>`),
+    );
+
+    const wb = await readXlsx(await z.build());
+    expect(wb.pivotCaches).toBeUndefined();
+    for (const sheet of wb.sheets) {
+      expect(sheet.pivotTables).toBeUndefined();
+    }
+  });
+});
+
+// ── Roundtrip ──────────────────────────────────────────────────────
+
+describe("openXlsx -> saveXlsx — pivot table roundtrip", () => {
+  it("preserves the pivot table, cache definition, and records on roundtrip", async () => {
+    const buf = await buildXlsxWithPivotTable();
+    const wb = await openXlsx(buf);
+    const saved = await saveXlsx(wb);
+
+    // All four pivot parts survive intact.
+    expect(zipHas(saved, "xl/pivotTables/pivotTable1.xml")).toBe(true);
+    expect(zipHas(saved, "xl/pivotTables/_rels/pivotTable1.xml.rels")).toBe(true);
+    expect(zipHas(saved, "xl/pivotCache/pivotCacheDefinition1.xml")).toBe(true);
+    expect(zipHas(saved, "xl/pivotCache/_rels/pivotCacheDefinition1.xml.rels")).toBe(true);
+    expect(zipHas(saved, "xl/pivotCache/pivotCacheRecords1.xml")).toBe(true);
+  });
+
+  it("re-emits the references in workbook.xml, workbook.xml.rels, and content types", async () => {
+    const buf = await buildXlsxWithPivotTable();
+    const wb = await openXlsx(buf);
+    const saved = await saveXlsx(wb);
+
+    const wbXml = await zipExtractText(saved, "xl/workbook.xml");
+    expect(wbXml).toContain("<pivotCaches>");
+    expect(wbXml).toMatch(/<pivotCache cacheId="0" [^>]*r:id="rId\d+"/);
+
+    const wbRels = await zipExtractText(saved, "xl/_rels/workbook.xml.rels");
+    expect(wbRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"',
+    );
+    expect(wbRels).toContain('Target="pivotCache/pivotCacheDefinition1.xml"');
+
+    const ct = await zipExtractText(saved, "[Content_Types].xml");
+    expect(ct).toContain("/xl/pivotTables/pivotTable1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml",
+    );
+    expect(ct).toContain("/xl/pivotCache/pivotCacheDefinition1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml",
+    );
+    expect(ct).toContain("/xl/pivotCache/pivotCacheRecords1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml",
+    );
+  });
+
+  it("re-declares the pivot table relationship in the host sheet's rels", async () => {
+    const buf = await buildXlsxWithPivotTable();
+    const wb = await openXlsx(buf);
+    const saved = await saveXlsx(wb);
+
+    const sheet2Rels = await zipExtractText(saved, "xl/worksheets/_rels/sheet2.xml.rels");
+    expect(sheet2Rels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"',
+    );
+    expect(sheet2Rels).toContain('Target="../pivotTables/pivotTable1.xml"');
+  });
+
+  it("re-reading the saved workbook recovers the same pivot table model", async () => {
+    const buf = await buildXlsxWithPivotTable();
+    const wb = await openXlsx(buf);
+    const saved = await saveXlsx(wb);
+    const reread = await readXlsx(saved);
+
+    expect(reread.pivotCaches).toHaveLength(1);
+    expect(reread.pivotCaches?.[0].fieldNames).toEqual(["Region", "Revenue"]);
+
+    const pivotSheet = reread.sheets.find((s) => s.name === "Pivot");
+    expect(pivotSheet?.pivotTables).toHaveLength(1);
+    const pt = pivotSheet!.pivotTables![0];
+    expect(pt.name).toBe("SalesPivot");
+    expect(pt.fields[1].function).toBe("sum");
+  });
+
+  it("emits clean rels when the workbook has no pivot tables", async () => {
+    // A zero-pivot workbook should not gain any pivot-cache references.
+    const z = new ZipWriter();
+    z.add(
+      "[Content_Types].xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>`),
+    );
+    z.add(
+      "_rels/.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/workbook.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+    );
+    z.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/worksheets/sheet1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>`),
+    );
+
+    const wb = await openXlsx(await z.build());
+    const saved = await saveXlsx(wb);
+    const wbXml = await zipExtractText(saved, "xl/workbook.xml");
+    expect(wbXml).not.toContain("<pivotCaches>");
+    const wbRels = await zipExtractText(saved, "xl/_rels/workbook.xml.rels");
+    expect(wbRels).not.toContain("pivotCacheDefinition");
+    const ct = await zipExtractText(saved, "[Content_Types].xml");
+    expect(ct).not.toContain("/xl/pivotCache/");
+    expect(ct).not.toContain("/xl/pivotTables/");
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class **read** support and full **roundtrip preservation** for pivot tables, the workbook-level pivot caches that back them, and the cached records — all of which hucre previously dropped on save. Implements **Phase 1 (Preservation)** of #34.

Before this PR the `pivotTableN.xml` / `pivotCacheDefinitionN.xml` / `pivotCacheRecordsN.xml` bodies survived in the ZIP, but the references that wired them into the workbook were silently regenerated without the declarations, so Excel saw orphan parts and discarded the pivot tables on next open. This PR wires them back into `[Content_Types].xml`, `xl/_rels/workbook.xml.rels`, the workbook's `<pivotCaches>` block, and each sheet's `_rels`.

## API

```ts
import { readXlsx, openXlsx, saveXlsx } from "hucre";

const wb = await readXlsx(buf);

// Workbook-level cache definitions.
for (const cache of wb.pivotCaches ?? []) {
  console.log(cache.cacheId, cache.sourceSheet, cache.sourceRef, cache.fieldNames);
}

// Per-sheet pivot table instances.
for (const sheet of wb.sheets) {
  for (const pt of sheet.pivotTables ?? []) {
    console.log(pt.name, pt.location, pt.cacheId);
    for (const f of pt.fields) {
      console.log("  ", f.name, f.axis, f.function);
    }
  }
}
```

```ts
// Standalone parsers, useful when you already have the XML strings.
import {
  parsePivotTable,
  parsePivotCacheDefinition,
  attachPivotCacheFields,
} from "hucre";
```

## Model

```ts
interface PivotTable {
  name: string;
  cacheId: number;          // matches Workbook.pivotCaches[i].cacheId
  location: string;         // e.g. "A3:D20"
  firstHeaderRow?: number;
  firstDataRow?: number;
  firstDataCol?: number;
  fields: PivotField[];     // index = field's position everywhere else
  styleName?: string;
  dataCaption?: string;
}

interface PivotField {
  name: string;             // overlaid from the cache when available
  axis: "row" | "col" | "page" | "data" | "hidden";
  function?: PivotDataFieldFunction; // only on data fields
  displayName?: string;     // <dataField name=...> override
}

interface PivotCache {
  cacheId: number;          // workbook-level handle
  sourceRef?: string;       // "A1:C100" or a defined-name reference
  sourceSheet?: string;
  sourceType?: "worksheet" | "external" | "consolidation" | "scenario";
  fieldNames: string[];     // 1:1 with PivotField indexes
  hasRecords?: boolean;     // whether pivotCacheRecordsN.xml is present
}
```

`PivotTable.cacheId` matches the workbook-level `cacheId` rather than a per-table relationship — that way a model author who reorders the cache array keeps the link sound.

## What changed in the writer side

| Hook | Change |
| --- | --- |
| `ContentTypesOptions` | new `pivotTableIndices` / `pivotCacheDefinitionIndices` / `pivotCacheRecordIndices` options — emit Override per part |
| `writeWorkbookXml` | new `pivotCacheRefs` arg — emits `<pivotCaches><pivotCache cacheId="N" r:id="rIdX"/></pivotCaches>` after `calcPr` |
| `writeWorkbookRels` | new `pivotCacheRels` arg — emits `Type=".../pivotCacheDefinition"` relationships with rIds that follow worksheets / styles / sharedStrings / theme / vbaProject / FeaturePropertyBag / persons / externalLinks |
| `roundtrip` | scans `_rawEntries` for the three part families, threads the indices through, and re-reads each sheet's original rels to recover and re-emit `Type=".../pivotTable"` with non-colliding rIds |

## Test plan

- [x] 2274 tests pass (19 new); `pnpm test` green (lint + typecheck + vitest); `pnpm build` clean
- [x] `parsePivotCacheDefinition`: required attrs, source range / sheet / type, fallback to `worksheetSource[name]` when `ref` missing, empty-string field name when `name` attr absent, unknown source type ignored
- [x] `parsePivotTable`: required `name`, `cacheId` parsing (with NaN fallback to 0), location attrs, axis mapping (`axisRow` → `row`, `axisCol` → `col`, `axisPage` → `page`, `axisValues` / `dataField=1` / `dataField=true` → `data`, otherwise `hidden`), data-field aggregation override + `name` overlay, `countA` collapses to `count`
- [x] `attachPivotCacheFields`: overlays cache field names by index, leaves out-of-range entries on their `fieldN` placeholder
- [x] End-to-end: a full XLSX with a pivot table + cache definition + records roundtrips through `openXlsx → saveXlsx` and a re-read recovers the same model
- [x] Output declares Override for all three pivot part families, the workbook rels carry `pivotCacheDefinition` with the right Target, workbook.xml has the `<pivotCaches>` block with matching cacheId/rId pairs, and the sheet rels carry the per-sheet pivot table relationships
- [x] No-pivot workbooks emit clean rels — no spurious pivot entries

## Out of scope

Synthesizing a `pivotTable` / `pivotCacheDefinition` from a model on a fresh `writeXlsx` call (Phase 2 — pivot table creation, tracked separately as #159) needs XML serializers for both bodies; this PR only handles the read + preserve side. The infrastructure for the references is now in place — adding the body writers is a natural follow-up.

References:
- ECMA-376 Part 1, §18.10 (PivotTables) and §18.11 (PivotCache)
- [MS-XLSX] Working with PivotTables — https://learn.microsoft.com/en-us/office/open-xml/spreadsheet/working-with-pivottables

Closes #34