### PR TITLE
feat(xlsx): charts — read & roundtrip preservation (Phase 1)

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -725,6 +725,13 @@ export interface Sheet {
    * `xl/timelines/timelineN.xml` parts referenced via this sheet's rels.
    */
   timelines?: Timeline[];
+  /**
+   * Charts anchored on this sheet, resolved from `xl/charts/chartN.xml`
+   * parts referenced via the sheet's drawing. Hucre does not yet author
+   * charts; the entries surface for inspection on read and survive
+   * roundtrip when the sheet has no hucre-managed images.
+   */
+  charts?: Chart[];
 }
 
 // ── Workbook Properties ────────────────────────────────────────────
@@ -890,6 +897,48 @@ export interface TimelineCache {
   sourceName?: string;
   /** Pivot tables this cache filters. */
   pivotTables?: SlicerCachePivotTable[];
+}
+
+// ── Charts ────────────────────────────────────────────────────────
+
+/**
+ * Chart kind reported by {@link Chart.kinds}. Mirrors the OOXML
+ * chart-type element local names (`c:barChart`, `c:lineChart`, ...).
+ * A single chart can mix multiple kinds (combo chart), in which case
+ * every kind appears in `kinds` in the order it's declared.
+ */
+export type ChartKind =
+  | "bar"
+  | "bar3D"
+  | "line"
+  | "line3D"
+  | "pie"
+  | "pie3D"
+  | "doughnut"
+  | "area"
+  | "area3D"
+  | "scatter"
+  | "bubble"
+  | "radar"
+  | "surface"
+  | "surface3D"
+  | "stock"
+  | "ofPie";
+
+/**
+ * A chart anchored on a sheet via the sheet's drawing part.
+ *
+ * Charts come from `xl/charts/chartN.xml`. Hucre exposes only the
+ * fields needed to recognize the chart on read; the chart body is
+ * preserved verbatim through roundtrip.
+ */
+export interface Chart {
+  /** Chart-type elements present in `<c:plotArea>`, in declaration order. */
+  kinds: ChartKind[];
+  /** Number of `<c:ser>` series across every chart-type element. */
+  seriesCount: number;
+  /** Plain-text title pulled from `<c:title>`, when present. */
+  title?: string;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,10 @@ export type {
   TimelineCache,
 } from "./_types";
 
+// ── Charts ─────────────────────────────────────────────────────────
+export { parseChart } from "./xlsx/chart-reader";
+export type { Chart, ChartKind } from "./_types";
+
 // ── Date Utilities ─────────────────────────────────────────────────
 export {
   serialToDate,

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -1,0 +1,157 @@
+// ── Chart Reader ──────────────────────────────────────────────────
+// Parses xl/charts/chartN.xml into a minimal structured record.
+//
+// Charts in OOXML live under the `c` (DrawingML chart) namespace. The
+// root element is `<c:chartSpace>` and the visible chart sits inside
+// `<c:chart>`. The `<c:plotArea>` child contains one or more chart-type
+// elements (`<c:barChart>`, `<c:lineChart>`, `<c:pieChart>`, ...) — each
+// chart-type element holds the series and axis bindings.
+//
+// This reader only extracts metadata that's cheap to surface: the chart
+// kind(s), title, and series count. It does not decode series bindings.
+//
+// OOXML reference: ECMA-376 Part 1, §21.2 (DrawingML — Charts).
+
+import type { Chart, ChartKind } from "../_types";
+import { parseXml } from "../xml/parser";
+import type { XmlElement } from "../xml/parser";
+
+/** All chart-type element local names recognized by Excel. */
+const CHART_KIND_TAGS: ReadonlyMap<string, ChartKind> = new Map([
+  ["barChart", "bar"],
+  ["bar3DChart", "bar3D"],
+  ["lineChart", "line"],
+  ["line3DChart", "line3D"],
+  ["pieChart", "pie"],
+  ["pie3DChart", "pie3D"],
+  ["doughnutChart", "doughnut"],
+  ["areaChart", "area"],
+  ["area3DChart", "area3D"],
+  ["scatterChart", "scatter"],
+  ["bubbleChart", "bubble"],
+  ["radarChart", "radar"],
+  ["surfaceChart", "surface"],
+  ["surface3DChart", "surface3D"],
+  ["stockChart", "stock"],
+  ["ofPieChart", "ofPie"],
+]);
+
+/**
+ * Parse a chart file (`xl/charts/chartN.xml`) into a {@link Chart}.
+ *
+ * Returns `undefined` when the document is not recognizable as a
+ * `c:chartSpace`. Returns a record with `kinds: []` when the chart has
+ * no chart-type element (extremely rare, but possible for empty charts).
+ */
+export function parseChart(xml: string): Chart | undefined {
+  const root = parseXml(xml);
+  // chartSpace can be the root, or wrapped if the file has been
+  // pre-processed; tolerate both shapes.
+  const chartSpace = root.local === "chartSpace" ? root : findDescendant(root, "chartSpace");
+  if (!chartSpace) return undefined;
+
+  const chartEl = findChild(chartSpace, "chart");
+  if (!chartEl) return { kinds: [], seriesCount: 0 };
+
+  const out: Chart = { kinds: [], seriesCount: 0 };
+
+  const title = parseTitle(chartEl);
+  if (title !== undefined) out.title = title;
+
+  const plotArea = findChild(chartEl, "plotArea");
+  if (plotArea) {
+    let seriesCount = 0;
+    for (const child of childElements(plotArea)) {
+      const kind = CHART_KIND_TAGS.get(child.local);
+      if (!kind) continue;
+      if (!out.kinds.includes(kind)) out.kinds.push(kind);
+      for (const ser of childElements(child)) {
+        if (ser.local === "ser") seriesCount++;
+      }
+    }
+    out.seriesCount = seriesCount;
+  }
+
+  return out;
+}
+
+// ── Internals ─────────────────────────────────────────────────────
+
+/**
+ * Read `<c:title>` text. The title may be a rich-text run tree or a
+ * formula reference; we only surface plain text runs joined together.
+ */
+function parseTitle(chartEl: XmlElement): string | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  // tx can hold either <c:rich> (literal text) or <c:strRef> (formula).
+  const rich = findChild(tx, "rich");
+  if (rich) {
+    const parts: string[] = [];
+    collectTextRuns(rich, parts);
+    const joined = parts.join("").trim();
+    return joined.length > 0 ? joined : undefined;
+  }
+  const strRef = findChild(tx, "strRef");
+  if (strRef) {
+    const cache = findChild(strRef, "strCache");
+    if (cache) {
+      for (const pt of childElements(cache)) {
+        if (pt.local !== "pt") continue;
+        const v = findChild(pt, "v");
+        if (v) {
+          const text = elementText(v).trim();
+          if (text.length > 0) return text;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function collectTextRuns(el: XmlElement, out: string[]): void {
+  for (const child of el.children) {
+    if (typeof child === "string") continue;
+    if (child.local === "t") {
+      out.push(elementText(child));
+    } else {
+      collectTextRuns(child, out);
+    }
+  }
+}
+
+function elementText(el: XmlElement): string {
+  let buf = "";
+  for (const child of el.children) {
+    if (typeof child === "string") buf += child;
+    else buf += elementText(child);
+  }
+  return buf;
+}
+
+function findChild(el: XmlElement, localName: string): XmlElement | undefined {
+  for (const c of el.children) {
+    if (typeof c !== "string" && c.local === localName) return c;
+  }
+  return undefined;
+}
+
+function findDescendant(el: XmlElement, localName: string): XmlElement | undefined {
+  if (el.local === localName) return el;
+  for (const c of el.children) {
+    if (typeof c === "string") continue;
+    const hit = findDescendant(c, localName);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+function childElements(el: XmlElement): XmlElement[] {
+  const out: XmlElement[] = [];
+  for (const c of el.children) {
+    if (typeof c !== "string") out.push(c);
+  }
+  return out;
+}

--- a/src/xlsx/content-types-writer.ts
+++ b/src/xlsx/content-types-writer.ts
@@ -27,6 +27,9 @@ const CT_SLICER = "application/vnd.ms-excel.slicer+xml";
 const CT_SLICER_CACHE = "application/vnd.ms-excel.slicerCache+xml";
 const CT_TIMELINE = "application/vnd.ms-excel.timeline+xml";
 const CT_TIMELINE_CACHE = "application/vnd.ms-excel.timelineCache+xml";
+const CT_CHART = "application/vnd.openxmlformats-officedocument.drawingml.chart+xml";
+const CT_CHART_STYLE = "application/vnd.ms-office.chartstyle+xml";
+const CT_CHART_COLORS = "application/vnd.ms-office.chartcolorstyle+xml";
 
 /** Image extension → content type mapping */
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
@@ -80,6 +83,21 @@ export interface ContentTypesOptions {
    * adds an `Override` for `/xl/timelineCaches/timelineCacheN.xml`.
    */
   timelineCacheIndices?: number[];
+  /**
+   * 1-based indices of chart parts. Each entry adds an `Override` for
+   * `/xl/charts/chartN.xml`. Charts are referenced from drawings.
+   */
+  chartIndices?: number[];
+  /**
+   * 1-based indices of chart style parts (`/xl/charts/styleN.xml`).
+   * Excel 2013+ writes one style file per chart. Older charts omit it.
+   */
+  chartStyleIndices?: number[];
+  /**
+   * 1-based indices of chart color parts (`/xl/charts/colorsN.xml`).
+   * Excel 2013+ writes one colors file per chart. Older charts omit it.
+   */
+  chartColorsIndices?: number[];
   /** Whether docProps/core.xml is present */
   hasCoreProps?: boolean;
   /** Whether docProps/app.xml is present */
@@ -291,6 +309,42 @@ export function writeContentTypes(
         xmlSelfClose("Override", {
           PartName: `/xl/timelineCaches/timelineCache${idx}.xml`,
           ContentType: CT_TIMELINE_CACHE,
+        }),
+      );
+    }
+  }
+
+  // Override for each chart
+  if (opts.chartIndices) {
+    for (const idx of opts.chartIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/charts/chart${idx}.xml`,
+          ContentType: CT_CHART,
+        }),
+      );
+    }
+  }
+
+  // Override for each chart style (Excel 2013+)
+  if (opts.chartStyleIndices) {
+    for (const idx of opts.chartStyleIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/charts/style${idx}.xml`,
+          ContentType: CT_CHART_STYLE,
+        }),
+      );
+    }
+  }
+
+  // Override for each chart colors part (Excel 2013+)
+  if (opts.chartColorsIndices) {
+    for (const idx of opts.chartColorsIndices) {
+      children.push(
+        xmlSelfClose("Override", {
+          PartName: `/xl/charts/colors${idx}.xml`,
+          ContentType: CT_CHART_COLORS,
         }),
       );
     }

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -23,6 +23,7 @@ import {
   parseTimelines,
   parseTimelineCache,
 } from "./slicer-reader";
+import { parseChart } from "./chart-reader";
 import { ParseError, ZipError } from "../errors";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
@@ -316,6 +317,20 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
         if (drawing.textBoxes.length > 0) {
           sheet.textBoxes = drawing.textBoxes;
         }
+        // Resolve chart parts referenced from the drawing. Each
+        // graphicFrame's chart rel was resolved against the drawing's
+        // package directory in extractSheetDrawing; here we simply
+        // parse the chart bodies.
+        if (drawing.chartPaths.length > 0) {
+          const charts: import("../_types").Chart[] = [];
+          for (const chartPath of drawing.chartPaths) {
+            if (!zip.has(chartPath)) continue;
+            const chartXml = decodeUtf8(await zip.extract(chartPath));
+            const chart = parseChart(chartXml);
+            if (chart) charts.push(chart);
+          }
+          if (charts.length > 0) sheet.charts = charts;
+        }
       }
     }
 
@@ -547,6 +562,12 @@ const EXT_TO_IMAGE_TYPE: Record<string, SheetImage["type"]> = {
 interface DrawingExtraction {
   images: SheetImage[];
   textBoxes: SheetTextBox[];
+  /**
+   * Paths to chart parts referenced by this drawing (resolved against
+   * the package root). Empty when the drawing has no `c:chart` graphic
+   * frames or the rels file is missing.
+   */
+  chartPaths: string[];
 }
 
 /**
@@ -558,7 +579,7 @@ async function extractSheetDrawing(
   zip: ZipReader,
   drawingPath: string,
 ): Promise<DrawingExtraction> {
-  if (!zip.has(drawingPath)) return { images: [], textBoxes: [] };
+  if (!zip.has(drawingPath)) return { images: [], textBoxes: [], chartPaths: [] };
 
   const drawingXml = decodeUtf8(await zip.extract(drawingPath));
 
@@ -570,12 +591,18 @@ async function extractSheetDrawing(
     : `_rels/${drawFileName}.rels`;
 
   const imageRelMap = new Map<string, string>();
+  // Chart relationships are resolved by the same .rels file. We collect
+  // them as `rId → resolved package path` so the drawing-level
+  // graphicFrame walk below can map each chart reference to a file.
+  const chartRelMap = new Map<string, string>();
   if (zip.has(drawRelsPath)) {
     const drawRelsXml = decodeUtf8(await zip.extract(drawRelsPath));
     const drawRels = parseRelationships(drawRelsXml);
     for (const rel of drawRels) {
       if (matchesRelType(rel.type, "image")) {
         imageRelMap.set(rel.id, resolvePath(drawDir, rel.target));
+      } else if (matchesRelType(rel.type, "chart")) {
+        chartRelMap.set(rel.id, resolvePath(drawDir, rel.target));
       }
     }
   }
@@ -584,10 +611,23 @@ async function extractSheetDrawing(
   const doc = parseXml(drawingXml);
   const images: SheetImage[] = [];
   const textBoxes: SheetTextBox[] = [];
+  const chartPaths: string[] = [];
 
   for (const child of doc.children) {
     if (typeof child === "string") continue;
     const local = child.local || child.tag;
+
+    if (local === "twoCellAnchor" || local === "oneCellAnchor" || local === "absoluteAnchor") {
+      // Charts are anchored via <xdr:graphicFrame> wrapping a
+      // <a:graphic>/<a:graphicData uri="...chart"><c:chart r:id="rIdN"/>
+      // — collect any chart references regardless of anchor flavor so
+      // the roundtrip can declare the chart parts later.
+      const chartRid = findChartRid(child);
+      if (chartRid) {
+        const chartPath = chartRelMap.get(chartRid);
+        if (chartPath && !chartPaths.includes(chartPath)) chartPaths.push(chartPath);
+      }
+    }
 
     if (local === "twoCellAnchor") {
       // Check if this anchor contains a textbox shape
@@ -634,7 +674,33 @@ async function extractSheetDrawing(
     }
   }
 
-  return { images, textBoxes };
+  return { images, textBoxes, chartPaths };
+}
+
+/**
+ * Walk an anchor element looking for `<c:chart r:id="...">` (the
+ * standard chart embed inside `<xdr:graphicFrame>/<a:graphic>/<a:graphicData>`).
+ * Returns the rId attribute or undefined if no chart is found.
+ */
+function findChartRid(el: { children: Array<unknown> }): string | undefined {
+  for (const child of el.children) {
+    if (typeof child === "string") continue;
+    const c = child as {
+      local?: string;
+      tag: string;
+      children: Array<unknown>;
+      attrs: Record<string, string>;
+    };
+    const local = c.local || c.tag;
+    if (local === "chart") {
+      // r:id is namespaced; try common attribute spellings.
+      const rid = c.attrs["r:id"] ?? c.attrs["id"];
+      if (rid) return rid;
+    }
+    const nested = findChartRid(c);
+    if (nested) return nested;
+  }
+  return undefined;
 }
 
 /** Parse a twoCellAnchor element to extract image position and reference */

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -370,6 +370,111 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
   const sheetSlicerTargets = collectSheetCacheTargets(workbook, sheets, "slicer");
   const sheetTimelineTargets = collectSheetCacheTargets(workbook, sheets, "timeline");
 
+  // ── Chart preservation ─────────────────────────────────────────
+  // Detect chart parts that survived in the raw entries. We need to:
+  //   1. declare Override entries in [Content_Types].xml so Excel
+  //      treats the part as a known type rather than an orphan,
+  //   2. force-preserve the original drawing XML (and its rels) for
+  //      sheets where hucre is *not* regenerating the drawing —
+  //      otherwise the drawing-level chart graphicFrame disappears
+  //      and Excel drops the chart on next open.
+  //
+  // For sheets that hucre *does* regenerate (because the sheet has
+  // hucre-managed images), the chart graphicFrame inside the drawing
+  // is currently rebuilt without the chart anchor; that's a Phase 2
+  // limitation — for now we still preserve the chart bodies so a
+  // future merge step can re-anchor them.
+  const chartIndices: number[] = [];
+  const chartStyleIndices: number[] = [];
+  const chartColorsIndices: number[] = [];
+  for (const path of workbook._rawEntries.keys()) {
+    let m = path.match(/^xl\/charts\/chart(\d+)\.xml$/i);
+    if (m) {
+      chartIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/charts\/style(\d+)\.xml$/i);
+    if (m) {
+      chartStyleIndices.push(parseInt(m[1], 10));
+      continue;
+    }
+    m = path.match(/^xl\/charts\/colors(\d+)\.xml$/i);
+    if (m) chartColorsIndices.push(parseInt(m[1], 10));
+  }
+  chartIndices.sort((a, b) => a - b);
+  chartStyleIndices.sort((a, b) => a - b);
+  chartColorsIndices.sort((a, b) => a - b);
+
+  // Build the set of drawing paths to force-preserve. A drawing is
+  // force-preserved when:
+  //   • its XML references at least one chart, AND
+  //   • hucre is not regenerating that exact drawing path (i.e. the
+  //     drawing's number does not match a sheet that hucre is
+  //     re-emitting drawings for).
+  //
+  // `preservedDrawingNumbers` mirrors the same set in numeric form so
+  // `[Content_Types].xml` can declare an Override for each preserved
+  // drawing (those wouldn't otherwise appear in `drawingIndices`).
+  //
+  // `sheetPreservedDrawingTargets[i]` is set to the rels-relative
+  // target (e.g. `"../drawings/drawing3.xml"`) for sheet `i` when the
+  // sheet's original rels pointed at a chart-only drawing. It tells
+  // the per-sheet rels emitter to declare a drawing relationship and
+  // the worksheet-body post-processor to inject `<drawing r:id="..."/>`.
+  const preservedDrawingPaths = new Set<string>();
+  const preservedDrawingNumbers: number[] = [];
+  const sheetPreservedDrawingTargets: Array<string | undefined> = sheets.map(() => undefined);
+  if (chartIndices.length > 0) {
+    const regeneratedDrawingNumbers = new Set<number>();
+    for (let i = 0; i < drawingResults.length; i++) {
+      if (drawingResults[i]) regeneratedDrawingNumbers.add(i + 1);
+    }
+    // First pass: discover which drawing files have chart references.
+    const chartDrawingNumbers = new Set<number>();
+    for (const [path, data] of workbook._rawEntries) {
+      const m = path.match(/^xl\/drawings\/drawing(\d+)\.xml$/i);
+      if (!m) continue;
+      const drawingNum = parseInt(m[1], 10);
+      if (regeneratedDrawingNumbers.has(drawingNum)) continue;
+      if (!hasChartReference(data)) continue;
+      chartDrawingNumbers.add(drawingNum);
+      preservedDrawingPaths.add(path.toLowerCase());
+      preservedDrawingNumbers.push(drawingNum);
+      const relsPath = `xl/drawings/_rels/drawing${drawingNum}.xml.rels`;
+      if (workbook._rawEntries.has(relsPath)) {
+        preservedDrawingPaths.add(relsPath.toLowerCase());
+      }
+    }
+    preservedDrawingNumbers.sort((a, b) => a - b);
+    // Second pass: map each sheet to the drawing target it originally
+    // pointed at (if any of those targets is a preserved chart drawing).
+    if (chartDrawingNumbers.size > 0) {
+      const decoder = new TextDecoder("utf-8");
+      for (let i = 0; i < sheets.length; i++) {
+        const expected = `xl/worksheets/_rels/sheet${i + 1}.xml.rels`;
+        let bytes: Uint8Array | undefined;
+        for (const [p, d] of workbook._rawEntries) {
+          if (p.toLowerCase() === expected) {
+            bytes = d;
+            break;
+          }
+        }
+        if (!bytes) continue;
+        const rels = parseRelationships(decoder.decode(bytes));
+        for (const rel of rels) {
+          if (!rel.type.endsWith("/relationships/drawing")) continue;
+          const drawingMatch = rel.target.match(/drawing(\d+)\.xml$/i);
+          if (!drawingMatch) continue;
+          const drawingNum = parseInt(drawingMatch[1], 10);
+          if (chartDrawingNumbers.has(drawingNum)) {
+            sheetPreservedDrawingTargets[i] = rel.target;
+          }
+          break;
+        }
+      }
+    }
+  }
+
   // Build ZIP archive
   const zip = new ZipWriter();
 
@@ -397,6 +502,12 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
           }
         }
       }
+      // Drawings whose only contents are chart graphicFrames don't get
+      // re-emitted by hucre's drawing writer; force-preserve them so
+      // the chart references survive intact.
+      if (isRegenerated && preservedDrawingPaths.has(lowerPath)) {
+        isRegenerated = false;
+      }
       if (!isRegenerated) {
         // Preserve this entry as-is (don't compress, keep original bytes)
         zip.add(path, data, { compress: false });
@@ -407,10 +518,14 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
   // 2. Generate and add regenerated parts
 
   // [Content_Types].xml
+  // `drawingIndices` covers the drawings hucre regenerated; we also
+  // need to declare any drawings we force-preserved (chart-only) so
+  // Excel doesn't see the preserved bytes as orphan.
+  const allDrawingIndices = mergeSortedUnique(drawingIndices, preservedDrawingNumbers);
   const ctOpts: ContentTypesOptions = {
     sheetCount: writeSheets.length,
     hasSharedStrings,
-    drawingIndices: drawingIndices.length > 0 ? drawingIndices : undefined,
+    drawingIndices: allDrawingIndices.length > 0 ? allDrawingIndices : undefined,
     imageExtensions: imageExtensions.size > 0 ? imageExtensions : undefined,
     commentIndices: commentIndices.length > 0 ? commentIndices : undefined,
     tableIndices: allTableIndices.length > 0 ? allTableIndices : undefined,
@@ -422,6 +537,9 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     slicerCacheIndices: slicerCacheIndices.length > 0 ? slicerCacheIndices : undefined,
     timelineIndices: timelineIndices.length > 0 ? timelineIndices : undefined,
     timelineCacheIndices: timelineCacheIndices.length > 0 ? timelineCacheIndices : undefined,
+    chartIndices: chartIndices.length > 0 ? chartIndices : undefined,
+    chartStyleIndices: chartStyleIndices.length > 0 ? chartStyleIndices : undefined,
+    chartColorsIndices: chartColorsIndices.length > 0 ? chartColorsIndices : undefined,
     hasCoreProps: true,
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
@@ -484,8 +602,6 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     const drawing = drawingResults[i];
     const comments = commentsResults[i];
 
-    zip.add(`xl/worksheets/sheet${i + 1}.xml`, encoder.encode(result.xml));
-
     // Generate worksheet .rels if needed
     const hasHyperlinks = result.hyperlinkRelationships.length > 0;
     const hasDrawing = drawing !== null && result.drawingRId !== null;
@@ -496,6 +612,14 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     const hasSlicers = slicerTargets.length > 0;
     const hasTimelines = timelineTargets.length > 0;
     const hasThreadedComments = threadedCommentSheetIndices.includes(i + 1);
+    // When the sheet's original drawing held charts and hucre is not
+    // rebuilding the drawing for this sheet, we'll re-anchor the
+    // preserved drawing into the regenerated worksheet body. The rId
+    // is finalized below once we know how many other rels we emit.
+    const preservedDrawingTarget = sheetPreservedDrawingTargets[i];
+    const hasPreservedDrawing = preservedDrawingTarget !== undefined && !hasDrawing;
+    let preservedDrawingRId: string | undefined;
+    let worksheetXml = result.xml;
 
     if (
       hasHyperlinks ||
@@ -504,6 +628,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
       hasTables ||
       hasSlicers ||
       hasTimelines ||
+      hasPreservedDrawing ||
       hasThreadedComments
     ) {
       const relElements: string[] = [];
@@ -596,6 +721,23 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         );
       }
 
+      // Re-anchor the preserved chart-bearing drawing. The worksheet
+      // body's regenerated form has no `<drawing>` element (hucre only
+      // emits one when the sheet has hucre-managed images), so we
+      // inject one immediately below pointing at the rId we just
+      // assigned.
+      if (hasPreservedDrawing && preservedDrawingTarget) {
+        preservedDrawingRId = `rId${nextSheetRid++}`;
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: preservedDrawingRId,
+            Type: REL_DRAWING,
+            Target: preservedDrawingTarget,
+          }),
+        );
+        worksheetXml = injectWorksheetDrawing(worksheetXml, preservedDrawingRId);
+      }
+
       // Threaded comments (Excel 365). The rId only needs to be unique
       // within this rels file — `nextSheetRid` already tracks the next
       // free rId past every relationship emitted above (including the
@@ -613,6 +755,10 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
       const relsXml = xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, relElements);
       zip.add(`xl/worksheets/_rels/sheet${i + 1}.xml.rels`, encoder.encode(relsXml));
     }
+
+    // Worksheet body — added after rels processing so the chart
+    // re-anchor injection above can patch the XML before it's written.
+    zip.add(`xl/worksheets/sheet${i + 1}.xml`, encoder.encode(worksheetXml));
 
     // Add drawing files
     if (drawing) {
@@ -656,6 +802,83 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
 
 const REL_TYPE_SLICER = /\/relationships\/slicer$/;
 const REL_TYPE_TIMELINE = /\/relationships\/timeline$/;
+
+/**
+ * Insert `<drawing r:id="rIdN"/>` into a worksheet body emitted by the
+ * worksheet writer. Per OOXML schema (CT_Worksheet) the element must
+ * appear after `cellWatches`/`ignoredErrors`/`smartTags` and before
+ * `legacyDrawing` / `legacyDrawingHF` / `picture` / `oleObjects` /
+ * `controls` / `webPublishItems` / `tableParts` / `extLst`.
+ *
+ * The writer never emits a `<drawing>` for chart-only sheets, so we
+ * splice one into the regenerated XML at the first valid insertion
+ * point. Falls back to inserting just before `</worksheet>` when none
+ * of the later-position siblings are present.
+ */
+function injectWorksheetDrawing(worksheetXml: string, rId: string): string {
+  if (worksheetXml.includes("<drawing ")) return worksheetXml; // already present
+  const tag = `<drawing r:id="${rId}"/>`;
+  const candidates = [
+    "<legacyDrawing ",
+    "<legacyDrawingHF ",
+    "<picture ",
+    "<oleObjects ",
+    "<oleObjects>",
+    "<controls ",
+    "<controls>",
+    "<webPublishItems ",
+    "<webPublishItems>",
+    "<tableParts ",
+    "<tableParts>",
+    "<extLst ",
+    "<extLst>",
+  ];
+  for (const c of candidates) {
+    const idx = worksheetXml.indexOf(c);
+    if (idx >= 0) return worksheetXml.slice(0, idx) + tag + worksheetXml.slice(idx);
+  }
+  const closeIdx = worksheetXml.lastIndexOf("</worksheet>");
+  if (closeIdx < 0) return worksheetXml;
+  return worksheetXml.slice(0, closeIdx) + tag + worksheetXml.slice(closeIdx);
+}
+
+/**
+ * Cheap detector for `<c:chart` references inside drawing XML. Tolerates
+ * any namespace prefix because the prefix is determined by the
+ * `xmlns:c` declaration; the local name is always `chart`. Avoids
+ * re-parsing the XML — drawings can be large and we only need a
+ * boolean "does this contain a chart anchor?" answer.
+ */
+function hasChartReference(data: Uint8Array): boolean {
+  const text = new TextDecoder("utf-8").decode(data);
+  const idx = text.indexOf(":chart");
+  if (idx < 0) return false;
+  // Make sure we matched a `:chart` element, not something like
+  // `:chartSpace` or `:chartstyle` that happens to share the prefix.
+  // Any of `< `, `\t`, `\n`, `\r`, `>`, `/` immediately after `:chart`
+  // unambiguously closes the local name.
+  let i = idx;
+  while ((i = text.indexOf(":chart", i)) !== -1) {
+    const end = text.charAt(i + ":chart".length);
+    if (end === " " || end === "\t" || end === "\n" || end === "\r" || end === ">" || end === "/") {
+      return true;
+    }
+    i++;
+  }
+  return false;
+}
+
+/**
+ * Merge two ascending number arrays into a sorted, de-duplicated list.
+ * Used to combine the indices of drawings hucre regenerated with the
+ * indices of drawings we force-preserved.
+ */
+function mergeSortedUnique(a: number[], b: number[]): number[] {
+  if (b.length === 0) return a.slice();
+  const out = new Set<number>(a);
+  for (const n of b) out.add(n);
+  return Array.from(out).sort((x, y) => x - y);
+}
 
 /**
  * Walk each sheet's original `xl/worksheets/_rels/sheetN.xml.rels` (when

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect } from "vitest";
+import { parseChart } from "../src/xlsx/chart-reader";
+import { ZipWriter } from "../src/zip/writer";
+import { ZipReader } from "../src/zip/reader";
+import { readXlsx } from "../src/xlsx/reader";
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder("utf-8");
+
+// ── parseChart ────────────────────────────────────────────────────
+
+describe("parseChart", () => {
+  it("returns undefined for documents that aren't c:chartSpace", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<root/>`;
+    expect(parseChart(xml)).toBeUndefined();
+  });
+
+  it("returns kinds=[] when chartSpace has no chart child", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"/>`;
+    expect(parseChart(xml)).toEqual({ kinds: [], seriesCount: 0 });
+  });
+
+  it("parses a single bar chart with two series", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:p xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:r><a:t>Sales</a:t></a:r></a:p></c:rich></c:tx>
+    </c:title>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:ser><c:idx val="1"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)).toEqual({
+      kinds: ["bar"],
+      seriesCount: 2,
+      title: "Sales",
+    });
+  });
+
+  it("collects every chart-type element (combo charts)", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser/>
+      </c:barChart>
+      <c:lineChart>
+        <c:ser/>
+        <c:ser/>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)).toEqual({
+      kinds: ["bar", "line"],
+      seriesCount: 3,
+    });
+  });
+
+  it("recognizes pie / doughnut / scatter / area / bubble / radar / surface / stock / 3D", () => {
+    for (const [tag, expected] of [
+      ["pieChart", "pie"],
+      ["pie3DChart", "pie3D"],
+      ["doughnutChart", "doughnut"],
+      ["scatterChart", "scatter"],
+      ["areaChart", "area"],
+      ["area3DChart", "area3D"],
+      ["bubbleChart", "bubble"],
+      ["radarChart", "radar"],
+      ["surfaceChart", "surface"],
+      ["surface3DChart", "surface3D"],
+      ["stockChart", "stock"],
+      ["bar3DChart", "bar3D"],
+      ["line3DChart", "line3D"],
+      ["ofPieChart", "ofPie"],
+    ] as const) {
+      const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart><c:plotArea><c:${tag}/></c:plotArea></c:chart></c:chartSpace>`;
+      expect(parseChart(xml)?.kinds).toEqual([expected]);
+    }
+  });
+
+  it("falls back to strRef cached value when title is a formula", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache>
+            <c:ptCount val="1"/>
+            <c:pt idx="0"><c:v>Quarterly Revenue</c:v></c:pt>
+          </c:strCache>
+        </c:strRef>
+      </c:tx>
+    </c:title>
+    <c:plotArea><c:barChart/></c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Quarterly Revenue");
+  });
+});
+
+// ── End-to-end: full XLSX with a chart ────────────────────────────
+
+/**
+ * Build a minimal XLSX where Sheet1 references a drawing that anchors
+ * one bar chart. Mirrors the part shape Excel writes for a single
+ * inserted chart (drawing -> _rels -> chart -> style -> colors).
+ */
+async function buildXlsxWithChart(): Promise<Uint8Array> {
+  const z = new ZipWriter();
+
+  z.add(
+    "[Content_Types].xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>
+  <Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+  <Override PartName="/xl/charts/style1.xml" ContentType="application/vnd.ms-office.chartstyle+xml"/>
+  <Override PartName="/xl/charts/colors1.xml" ContentType="application/vnd.ms-office.chartcolorstyle+xml"/>
+</Types>`),
+  );
+
+  z.add(
+    "_rels/.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/workbook.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Data" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+  );
+
+  z.add(
+    "xl/_rels/workbook.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/worksheets/sheet1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+           xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetData>
+    <row r="1"><c r="A1" t="n"><v>1</v></c><c r="B1" t="n"><v>10</v></c></row>
+    <row r="2"><c r="A2" t="n"><v>2</v></c><c r="B2" t="n"><v>20</v></c></row>
+  </sheetData>
+  <drawing r:id="rId1"/>
+</worksheet>`),
+  );
+
+  z.add(
+    "xl/worksheets/_rels/sheet1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/>
+</Relationships>`),
+  );
+
+  // Drawing with one chart anchor
+  z.add(
+    "xl/drawings/drawing1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+          xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <xdr:twoCellAnchor>
+    <xdr:from><xdr:col>3</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>1</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    <xdr:to><xdr:col>10</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>16</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+    <xdr:graphicFrame>
+      <xdr:nvGraphicFramePr>
+        <xdr:cNvPr id="2" name="Chart 1"/>
+        <xdr:cNvGraphicFramePr/>
+      </xdr:nvGraphicFramePr>
+      <xdr:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></xdr:xfrm>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:chart r:id="rId1"/>
+        </a:graphicData>
+      </a:graphic>
+    </xdr:graphicFrame>
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>
+</xdr:wsDr>`),
+  );
+
+  z.add(
+    "xl/drawings/_rels/drawing1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/charts/chart1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:p xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:r><a:t>Quarterly Sales</a:t></a:r></a:p></c:rich></c:tx>
+    </c:title>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Data!$B$1:$B$2</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+  <c:externalData r:id="rId1"/>
+</c:chartSpace>`),
+  );
+
+  z.add(
+    "xl/charts/_rels/chart1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2011/relationships/chartStyle" Target="style1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2011/relationships/chartColorStyle" Target="colors1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/charts/style1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cs:chartStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" id="201"/>`),
+  );
+
+  z.add(
+    "xl/charts/colors1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cs:colorStyle xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" meth="cycle" id="10"/>`),
+  );
+
+  return await z.build();
+}
+
+// ── readXlsx — chart integration ─────────────────────────────────
+
+describe("readXlsx — chart integration", () => {
+  it("attaches sheet.charts when the drawing references a chart", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await readXlsx(buf);
+    expect(wb.sheets).toHaveLength(1);
+    expect(wb.sheets[0].charts).toHaveLength(1);
+    expect(wb.sheets[0].charts?.[0]).toEqual({
+      kinds: ["bar"],
+      seriesCount: 1,
+      title: "Quarterly Sales",
+    });
+  });
+
+  it("does not set sheet.charts when the workbook has none", async () => {
+    const z = new ZipWriter();
+    z.add(
+      "[Content_Types].xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>`),
+    );
+    z.add(
+      "_rels/.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/workbook.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Main" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+    );
+    z.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/worksheets/sheet1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>`),
+    );
+
+    const wb = await readXlsx(await z.build());
+    expect(wb.sheets[0].charts).toBeUndefined();
+  });
+});
+
+// ── Roundtrip preservation ───────────────────────────────────────
+
+describe("roundtrip — chart preservation", () => {
+  it("preserves chart, style, colors, drawing, and drawing rels", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const zip = new ZipReader(out);
+
+    expect(zip.has("xl/charts/chart1.xml")).toBe(true);
+    expect(zip.has("xl/charts/style1.xml")).toBe(true);
+    expect(zip.has("xl/charts/colors1.xml")).toBe(true);
+    expect(zip.has("xl/charts/_rels/chart1.xml.rels")).toBe(true);
+    expect(zip.has("xl/drawings/drawing1.xml")).toBe(true);
+    expect(zip.has("xl/drawings/_rels/drawing1.xml.rels")).toBe(true);
+
+    // Chart body must survive byte-identical (it carries the title).
+    const chartXml = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(chartXml).toContain("Quarterly Sales");
+
+    // Drawing body keeps the chart graphicFrame.
+    const drawingXml = decoder.decode(await zip.extract("xl/drawings/drawing1.xml"));
+    expect(drawingXml).toContain("c:chart");
+  });
+
+  it("declares chart parts in [Content_Types].xml", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const zip = new ZipReader(out);
+
+    const ct = decoder.decode(await zip.extract("[Content_Types].xml"));
+    expect(ct).toContain("/xl/charts/chart1.xml");
+    expect(ct).toContain("/xl/charts/style1.xml");
+    expect(ct).toContain("/xl/charts/colors1.xml");
+    expect(ct).toContain("application/vnd.openxmlformats-officedocument.drawingml.chart+xml");
+    expect(ct).toContain("application/vnd.ms-office.chartstyle+xml");
+    expect(ct).toContain("application/vnd.ms-office.chartcolorstyle+xml");
+    // The chart-bearing drawing must be declared too — without this
+    // the drawing bytes survive but Excel treats them as orphan.
+    expect(ct).toContain("/xl/drawings/drawing1.xml");
+  });
+
+  it("re-anchors the drawing into the regenerated worksheet body", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const zip = new ZipReader(out);
+
+    const wsXml = decoder.decode(await zip.extract("xl/worksheets/sheet1.xml"));
+    expect(wsXml).toMatch(/<drawing r:id="rId\d+"\/>/);
+
+    const sheetRels = decoder.decode(await zip.extract("xl/worksheets/_rels/sheet1.xml.rels"));
+    expect(sheetRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing"',
+    );
+    expect(sheetRels).toContain('Target="../drawings/drawing1.xml"');
+  });
+
+  it("re-reading the saved workbook still surfaces the chart", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const reread = await readXlsx(out);
+
+    expect(reread.sheets[0].charts).toHaveLength(1);
+    expect(reread.sheets[0].charts?.[0].title).toBe("Quarterly Sales");
+    expect(reread.sheets[0].charts?.[0].kinds).toEqual(["bar"]);
+  });
+
+  it("survives a cell modification — does not lose the chart", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await openXlsx(buf);
+    // Touch a cell so the worksheet is definitively regenerated.
+    wb.sheets[0].rows[0][0] = 99;
+    const out = await saveXlsx(wb);
+    const zip = new ZipReader(out);
+
+    expect(zip.has("xl/charts/chart1.xml")).toBe(true);
+    expect(zip.has("xl/drawings/drawing1.xml")).toBe(true);
+
+    const reread = await readXlsx(out);
+    expect(reread.sheets[0].rows[0][0]).toBe(99);
+    expect(reread.sheets[0].charts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds first-class **read** support and full **roundtrip preservation** for chart parts that hucre previously dropped on save. Implements **Phase 1 (Preservation)** of #32 — chart creation is a future phase.

Before this PR the `xl/charts/chartN.xml` body survived in the raw ZIP but every reference that wired it into the workbook was silently regenerated without the chart declarations, so Excel saw orphan parts and discarded the charts on next open. This PR re-injects them into `[Content_Types].xml`, the chart-bearing drawing, the drawing's rels, and the worksheet body.

## API

```ts
import { readXlsx, openXlsx, saveXlsx, parseChart } from "hucre";

const wb = await readXlsx(buf);

for (const sheet of wb.sheets) {
  for (const chart of sheet.charts ?? []) {
    console.log(chart.kinds, chart.seriesCount, chart.title);
    // e.g. ["bar"], 2, "Quarterly Sales"
  }
}

// Standalone parser when you already have the chart XML.
const chart = parseChart(xml);
```

## Model

```ts
type ChartKind =
  | "bar" | "bar3D" | "line" | "line3D"
  | "pie" | "pie3D" | "doughnut"
  | "area" | "area3D"
  | "scatter" | "bubble" | "radar"
  | "surface" | "surface3D"
  | "stock" | "ofPie";

interface Chart {
  /** Chart-type elements present in <c:plotArea>, in declaration order. */
  kinds: ChartKind[];
  /** Number of <c:ser> series across every chart-type element. */
  seriesCount: number;
  /** Plain-text title pulled from <c:title>, when present. */
  title?: string;
}
```

## Implementation

**Read.** The drawing extractor now walks `<xdr:graphicFrame>` anchors for `<c:chart r:id="...">` references and resolves them against the drawing's rels file. Each sheet exposes `sheet.charts: Chart[]` populated by `parseChart`, which surfaces the chart kind(s), series count, and plain-text title (rich-text run or strRef cache fallback).

**Roundtrip.** The save path scans `_rawEntries` for `xl/charts/chartN.xml`, `xl/charts/styleN.xml`, and `xl/charts/colorsN.xml` and:

- declares `Override` entries for every chart / chartStyle / chartColors part in `[Content_Types].xml` (new `chartIndices` / `chartStyleIndices` / `chartColorsIndices` options on `ContentTypesOptions`),
- force-preserves the chart-bearing drawing XML and its rels when hucre is not regenerating that drawing (i.e. the sheet has no hucre-managed images),
- re-anchors the preserved drawing into the regenerated worksheet body — the writer never emits `<drawing>` for chart-only sheets, so we splice one in at the schema-correct insertion point and declare the matching drawing relationship in the sheet rels.

Sheets that hucre actively regenerates (because they carry hucre-managed images) currently keep the preserved chart bodies but lose the in-drawing chart anchor — merging hucre's drawing output with the original chart graphicFrames is a follow-up.

## Test plan

- [x] `parseChart` covers every chart-type element, combo charts, missing chartSpace, and strRef-cache title fallback.
- [x] `readXlsx` attaches `sheet.charts` for chart-bearing drawings and leaves it `undefined` otherwise.
- [x] Roundtrip preserves `chart1.xml`, `style1.xml`, `colors1.xml`, the drawing, and the chart's rels file.
- [x] `[Content_Types].xml` declares chart, chartstyle, chartcolorstyle, and the chart-bearing drawing.
- [x] The regenerated worksheet body carries `<drawing r:id="..."/>` and the sheet rels declare the drawing relationship.
- [x] Re-reading the saved workbook still surfaces the chart with title and kind intact.
- [x] `pnpm test` (lint + typecheck + 2282 vitest tests) and `pnpm build` both pass.

Closes #32