### PR TITLE
feat(xlsx): native pivot table creation — Phase 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ import { readXml, writeXml } from "hucre/xml"; // Tabular XML
 | **Write XLSX**        | Yes          | Yes           | Yes             | Yes             | Yes               |
 | **Streaming**         | Read+Write   | Write-only    | No              | const_memory    | SXSSF (write)     |
 | **Charts**            | Round-trip   | 15+ types     | 9 types         | 12+ types       | Limited           |
-| **Pivot tables**      | No           | Read-only     | No              | No              | Limited           |
+| **Pivot tables**      | Read + Write | Read-only     | No              | No              | Limited           |
 | **Cond. formatting**  | Yes (all)    | Yes           | Yes             | Yes             | Yes               |
 | **Sparklines**        | Yes          | No            | Yes             | Yes             | No                |
 | **Formula eval**      | No           | No            | No              | No              | Yes               |
@@ -443,8 +443,52 @@ import { parsePivotTable, parsePivotCacheDefinition, attachPivotCacheFields } fr
 
 `PivotTable.cacheId` matches the workbook-level `cacheId` rather than a
 per-table relationship, so reordering `Workbook.pivotCaches` keeps the
-links sound. Synthesizing a pivot table or cache definition from a
-fresh `writeXlsx` is a follow-up — this is read + preserve only.
+links sound.
+
+`writeXlsx` can also author pivot tables from scratch via the per-sheet
+`pivotTables` field. Hucre emits the pivot cache (definition + cached
+records), the pivot layout, and every required relationship and content
+type. The numeric layout (row totals, grand totals, value cells) is left
+for Excel to compute on first open via the existing `fullCalcOnLoad`
+recompute — Phase 1 ships the structural skeleton, not pre-computed
+value cells.
+
+```ts
+import { writeXlsx } from "hucre";
+
+const xlsx = await writeXlsx({
+  sheets: [
+    {
+      name: "Data",
+      rows: [
+        ["Region", "Product", "Revenue"],
+        ["EU", "A", 100],
+        ["EU", "B", 50],
+        ["US", "A", 200],
+        ["US", "B", 75],
+      ],
+    },
+    {
+      name: "Pivot",
+      pivotTables: [
+        {
+          name: "SalesPivot",
+          sourceSheet: "Data",
+          rows: ["Region"],
+          columns: ["Product"],
+          values: [{ field: "Revenue", function: "sum" }],
+        },
+      ],
+    },
+  ],
+});
+```
+
+Supported aggregation functions: `sum` (default), `count`, `average`,
+`max`, `min`, `product`, `countNums`, `stdDev`, `stdDevp`, `var`,
+`varp`. Pivots can source from their own sheet (omit `sourceSheet`)
+or any sibling sheet, and accept either `rows` (raw 2-D arrays) or
+`columns` + `data` (object-style) source shapes.
 
 ### Charts
 
@@ -1095,7 +1139,6 @@ Contributions are welcome! Please [open an issue](https://github.com/productdevb
 - XLSB binary format read
 - Formula evaluation engine
 - File encryption/decryption (AES-256, MS-OFFCRYPTO)
-- Pivot table creation — synthesize from a fresh write (read + roundtrip already supported)
 - Threaded comments (Excel 365+) — synthesize from a fresh write (read + roundtrip already supported)
 - Checkboxes (Excel 2024+)
 - VBA/macro injection

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -944,6 +944,77 @@ export interface PivotCache {
   hasRecords?: boolean;
 }
 
+/**
+ * A data field placement on a {@link WritePivotTable}.
+ *
+ * `field` names a column in the source data; `function` selects the
+ * aggregation Excel applies (`sum` is the default). `displayName` becomes
+ * the column header on the rendered pivot — it defaults to
+ * `"<Function> of <field>"`, mirroring Excel's auto-label.
+ */
+export interface WritePivotDataField {
+  /** Source column name (must match an entry in the source header row). */
+  field: string;
+  /** Aggregation function. Default: `"sum"`. */
+  function?: PivotDataFieldFunction;
+  /** Optional display name override. Default: e.g. `"Sum of Revenue"`. */
+  displayName?: string;
+  /** Optional number format for aggregated values. Default: General. */
+  numberFormat?: string;
+}
+
+/**
+ * Author a pivot table on a sheet.
+ *
+ * Phase 1 covers the most common dashboard use case: a tabular source on
+ * one sheet, summarised onto another sheet with row / column / value
+ * fields. Hucre emits the pivot cache (definition + cached records), the
+ * pivot table layout, and all required relationships and content types.
+ *
+ * The actual numeric layout (row totals, grand totals, value cells) is
+ * left for Excel to compute on first open via `<calcPr fullCalcOnLoad="1"/>`
+ * — Phase 1 ships the structural skeleton, not pre-computed cells.
+ */
+export interface WritePivotTable {
+  /** Pivot table name shown in Excel's `Field List`. */
+  name: string;
+  /**
+   * Source sheet name. Defaults to the sheet the pivot is declared on
+   * when omitted — handy for pivots that summarise their own sheet's
+   * data.
+   */
+  sourceSheet?: string;
+  /**
+   * Source range covering the header row plus all data rows
+   * (e.g. `"A1:C100"`). Auto-detected from the source sheet's `rows`
+   * length when omitted.
+   */
+  sourceRange?: string;
+  /**
+   * Top-left anchor for the rendered pivot table on the host sheet
+   * (e.g. `"A3"`). Default: `"A1"`.
+   */
+  targetCell?: string;
+  /** Source columns laid out on the row axis, in order. */
+  rows?: string[];
+  /** Source columns laid out on the column axis, in order. */
+  columns?: string[];
+  /** Source columns laid out as page (filter) fields, in order. */
+  pages?: string[];
+  /** Aggregated value fields. Each entry becomes one data column. */
+  values: WritePivotDataField[];
+  /**
+   * Pivot table style name (e.g. `"PivotStyleLight16"`). Default:
+   * `"PivotStyleLight16"` — the modern Excel default.
+   */
+  styleName?: string;
+  /**
+   * Caption shown above the data fields when there is more than one.
+   * Default: `"Values"` (Excel's built-in caption).
+   */
+  dataCaption?: string;
+}
+
 // ── Slicers & Timelines ────────────────────────────────────────────
 
 /**
@@ -1265,6 +1336,12 @@ export interface WriteSheet {
   textBoxes?: SheetTextBox[];
   /** Excel 365 threaded comments for this sheet. */
   threadedComments?: ThreadedComment[];
+  /**
+   * Pivot tables anchored on this sheet. The source data is read from
+   * either the same sheet or a sibling sheet identified by
+   * {@link WritePivotTable.sourceSheet}.
+   */
+  pivotTables?: WritePivotTable[];
   /** Accessibility metadata for screen readers and the `audit` helper. */
   a11y?: SheetA11y;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,8 @@ export type {
   PivotField,
   PivotFieldAxis,
   PivotDataFieldFunction,
+  WritePivotTable,
+  WritePivotDataField,
 } from "./_types";
 
 // ── Slicers & Timelines ────────────────────────────────────────────

--- a/src/xlsx/pivot-writer.ts
+++ b/src/xlsx/pivot-writer.ts
@@ -70,19 +70,26 @@ export interface PivotWriteResult {
  * @param source - Resolved source data (header row + data rows).
  * @param cacheId - Workbook-level cacheId. Mirrors the value emitted in
  *                  `<workbook><pivotCaches><pivotCache cacheId="..."/>`.
+ * @param partIndex - 1-based global pivot index used in the file paths
+ *                    `pivotCacheDefinition{N}.xml`, `pivotCacheRecords{N}.xml`,
+ *                    and `pivotTable{N}.xml`. Required so the inter-part
+ *                    relationship `Target` attributes resolve to the right
+ *                    sibling part when more than one pivot table exists.
+ *                    Defaults to `1` for backward compatibility.
  */
 export function writePivotTable(
   pivot: WritePivotTable,
   source: ResolvedPivotSource,
   cacheId: number,
+  partIndex: number = 1,
 ): PivotWriteResult {
   const fieldsMeta = buildFieldMetadata(pivot, source);
 
   const cacheDefinitionXml = buildCacheDefinition(source, fieldsMeta);
-  const cacheDefinitionRels = buildCacheDefinitionRels();
+  const cacheDefinitionRels = buildCacheDefinitionRels(partIndex);
   const cacheRecordsXml = buildCacheRecords(source, fieldsMeta);
   const pivotTableXml = buildPivotTable(pivot, fieldsMeta, cacheId);
-  const pivotTableRels = buildPivotTableRels();
+  const pivotTableRels = buildPivotTableRels(partIndex);
 
   return {
     cacheDefinitionXml,
@@ -360,12 +367,12 @@ function buildCacheField(
   ]);
 }
 
-function buildCacheDefinitionRels(): string {
+function buildCacheDefinitionRels(partIndex: number): string {
   return xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, [
     xmlSelfClose("Relationship", {
       Id: "rId1",
       Type: REL_PIVOT_CACHE_RECORDS,
-      Target: "pivotCacheRecords1.xml",
+      Target: `pivotCacheRecords${partIndex}.xml`,
     }),
   ]);
 }
@@ -593,12 +600,12 @@ function buildPivotFieldElement(field: FieldMeta): string {
   ]);
 }
 
-function buildPivotTableRels(): string {
+function buildPivotTableRels(partIndex: number): string {
   return xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, [
     xmlSelfClose("Relationship", {
       Id: "rId1",
       Type: REL_PIVOT_CACHE_DEFINITION,
-      Target: "../pivotCache/pivotCacheDefinition1.xml",
+      Target: `../pivotCache/pivotCacheDefinition${partIndex}.xml`,
     }),
   ]);
 }

--- a/src/xlsx/pivot-writer.ts
+++ b/src/xlsx/pivot-writer.ts
@@ -1,0 +1,699 @@
+// ── Pivot Table Writer ────────────────────────────────────────────────
+// Generates the four OOXML parts that back a pivot table:
+//   xl/pivotCache/pivotCacheDefinition{N}.xml — field declarations + shared items
+//   xl/pivotCache/pivotCacheRecords{N}.xml    — cached source rows
+//   xl/pivotCache/_rels/pivotCacheDefinition{N}.xml.rels — links cache → records
+//   xl/pivotTables/pivotTable{N}.xml          — pivot layout
+//   xl/pivotTables/_rels/pivotTable{N}.xml.rels — links pivot → cache definition
+//
+// Phase 1 of issue #159. The aim is a *structurally valid* pivot table
+// that Excel can populate on first open via the recompute that
+// `<calcPr fullCalcOnLoad="1"/>` triggers — the writer does not
+// pre-compute row totals, value cells, or expanded item layouts.
+//
+// OOXML reference: ECMA-376 Part 1, §18.10 (PivotTables) and §18.11
+// (PivotCache).
+
+import type { CellValue, PivotDataFieldFunction, WritePivotTable } from "../_types";
+import { xmlDocument, xmlElement, xmlSelfClose } from "../xml/writer";
+
+// ── Namespaces ────────────────────────────────────────────────────────
+
+const NS_SPREADSHEET = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+const NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+const NS_RELATIONSHIPS = "http://schemas.openxmlformats.org/package/2006/relationships";
+
+const REL_PIVOT_CACHE_RECORDS =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords";
+const REL_PIVOT_CACHE_DEFINITION =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition";
+
+// ── Public API ────────────────────────────────────────────────────────
+
+/**
+ * A pivot data source resolved against the workbook. The header row
+ * gives the field names; data rows feed both the cache records and the
+ * shared-items table on each `<cacheField>`.
+ */
+export interface ResolvedPivotSource {
+  /** Source sheet name as it appears in `xl/workbook.xml`. */
+  sheetName: string;
+  /** Field names (in declaration order). */
+  fieldNames: string[];
+  /** Data rows aligned 1:1 with `fieldNames`. */
+  dataRows: CellValue[][];
+  /**
+   * The OOXML `<worksheetSource ref>` value, e.g. `"A1:C100"`. Already
+   * resolved against the source sheet's data length when the user did
+   * not supply a range.
+   */
+  ref: string;
+}
+
+export interface PivotWriteResult {
+  /** Body of `xl/pivotCache/pivotCacheDefinition{N}.xml`. */
+  cacheDefinitionXml: string;
+  /** Body of `xl/pivotCache/_rels/pivotCacheDefinition{N}.xml.rels`. */
+  cacheDefinitionRels: string;
+  /** Body of `xl/pivotCache/pivotCacheRecords{N}.xml`. */
+  cacheRecordsXml: string;
+  /** Body of `xl/pivotTables/pivotTable{N}.xml`. */
+  pivotTableXml: string;
+  /** Body of `xl/pivotTables/_rels/pivotTable{N}.xml.rels`. */
+  pivotTableRels: string;
+}
+
+/**
+ * Generate the cache + table OOXML for a single pivot table.
+ *
+ * @param pivot - User-supplied pivot definition.
+ * @param source - Resolved source data (header row + data rows).
+ * @param cacheId - Workbook-level cacheId. Mirrors the value emitted in
+ *                  `<workbook><pivotCaches><pivotCache cacheId="..."/>`.
+ */
+export function writePivotTable(
+  pivot: WritePivotTable,
+  source: ResolvedPivotSource,
+  cacheId: number,
+): PivotWriteResult {
+  const fieldsMeta = buildFieldMetadata(pivot, source);
+
+  const cacheDefinitionXml = buildCacheDefinition(source, fieldsMeta);
+  const cacheDefinitionRels = buildCacheDefinitionRels();
+  const cacheRecordsXml = buildCacheRecords(source, fieldsMeta);
+  const pivotTableXml = buildPivotTable(pivot, fieldsMeta, cacheId);
+  const pivotTableRels = buildPivotTableRels();
+
+  return {
+    cacheDefinitionXml,
+    cacheDefinitionRels,
+    cacheRecordsXml,
+    pivotTableXml,
+    pivotTableRels,
+  };
+}
+
+/**
+ * Resolve a {@link WritePivotTable} against the workbook's source sheet.
+ *
+ * Throws when the source sheet is missing, has fewer than two rows
+ * (header + at least one data row), or when a referenced field is not
+ * present in the header row.
+ */
+export function resolvePivotSource(
+  pivot: WritePivotTable,
+  sourceSheetName: string,
+  sourceRows: ReadonlyArray<ReadonlyArray<CellValue>>,
+): ResolvedPivotSource {
+  if (sourceRows.length < 2) {
+    throw new Error(
+      `Pivot "${pivot.name}" source sheet "${sourceSheetName}" needs at least a header row plus one data row (got ${sourceRows.length}).`,
+    );
+  }
+
+  const header = sourceRows[0];
+  const fieldNames: string[] = [];
+  for (let i = 0; i < header.length; i++) {
+    const v = header[i];
+    fieldNames.push(v === null || v === undefined ? `Column${i + 1}` : String(v));
+  }
+
+  // Data rows: pad shorter rows with null so every row aligns with the
+  // header. Trim rows that are longer than the header — the cache only
+  // tracks the declared columns.
+  const dataRows: CellValue[][] = [];
+  for (let r = 1; r < sourceRows.length; r++) {
+    const row = sourceRows[r];
+    const padded: CellValue[] = [];
+    for (let c = 0; c < fieldNames.length; c++) {
+      padded.push(c < row.length ? row[c] : null);
+    }
+    dataRows.push(padded);
+  }
+
+  // Validate that every named field exists in the header row.
+  const headerSet = new Set(fieldNames);
+  const namedFields = [...(pivot.rows ?? []), ...(pivot.columns ?? []), ...(pivot.pages ?? [])];
+  for (const v of pivot.values) namedFields.push(v.field);
+  for (const name of namedFields) {
+    if (!headerSet.has(name)) {
+      throw new Error(
+        `Pivot "${pivot.name}" references field "${name}" which is not in the source header (have: ${fieldNames.join(", ")}).`,
+      );
+    }
+  }
+
+  const ref = pivot.sourceRange ?? autoRange(fieldNames.length, sourceRows.length);
+
+  return {
+    sheetName: sourceSheetName,
+    fieldNames,
+    dataRows,
+    ref,
+  };
+}
+
+// ── Field Metadata ────────────────────────────────────────────────────
+
+type FieldKind = "string" | "number";
+
+interface FieldMeta {
+  /** Field index. Matches the position in `cache.fieldNames`. */
+  index: number;
+  /** Field name. */
+  name: string;
+  /** OOXML axis the field is placed on; `hidden` when unused. */
+  axis: "row" | "col" | "page" | "data" | "hidden";
+  /** Order within its axis (0-based). Only meaningful when `axis !== "hidden"`. */
+  axisOrder: number;
+  /**
+   * Inferred data type. Numeric fields skip the shared-items table
+   * (Excel computes ranges from records); string / mixed fields keep a
+   * sorted shared-items list so row/col items can resolve to indexes.
+   */
+  kind: FieldKind;
+  /**
+   * Sorted unique string values, present when `kind === "string"`. The
+   * record-side serialiser maps cell values to indexes into this list
+   * via `<x v="N"/>` tokens.
+   */
+  sharedStrings?: string[];
+  /** Lookup helper: shared-string value → index. */
+  sharedIndex?: Map<string, number>;
+}
+
+interface PivotFieldsMeta {
+  fields: FieldMeta[];
+  /** All data-field placements, in declaration order. */
+  dataFieldDefs: Array<{
+    fieldIndex: number;
+    function: PivotDataFieldFunction;
+    displayName: string;
+    numberFormat?: string;
+  }>;
+}
+
+function buildFieldMetadata(pivot: WritePivotTable, source: ResolvedPivotSource): PivotFieldsMeta {
+  const fields: FieldMeta[] = source.fieldNames.map((name, index) => ({
+    index,
+    name,
+    axis: "hidden" as FieldMeta["axis"],
+    axisOrder: 0,
+    kind: inferFieldKind(source.dataRows, index),
+  }));
+
+  const placeAxis = (
+    names: ReadonlyArray<string> | undefined,
+    axis: "row" | "col" | "page",
+  ): void => {
+    if (!names) return;
+    for (let i = 0; i < names.length; i++) {
+      const f = fields.find((entry) => entry.name === names[i]);
+      // Validation in resolvePivotSource guarantees a match.
+      if (f) {
+        f.axis = axis;
+        f.axisOrder = i;
+      }
+    }
+  };
+
+  placeAxis(pivot.rows, "row");
+  placeAxis(pivot.columns, "col");
+  placeAxis(pivot.pages, "page");
+
+  const dataFieldDefs: PivotFieldsMeta["dataFieldDefs"] = [];
+  for (let i = 0; i < pivot.values.length; i++) {
+    const v = pivot.values[i];
+    const idx = source.fieldNames.indexOf(v.field);
+    // Already validated in resolvePivotSource.
+    if (idx === -1) continue;
+
+    fields[idx].axis = "data";
+    fields[idx].axisOrder = i;
+
+    const fn: PivotDataFieldFunction = v.function ?? "sum";
+    const displayName = v.displayName ?? defaultDataFieldName(fn, v.field);
+    const entry: PivotFieldsMeta["dataFieldDefs"][number] = {
+      fieldIndex: idx,
+      function: fn,
+      displayName,
+    };
+    if (v.numberFormat !== undefined) entry.numberFormat = v.numberFormat;
+    dataFieldDefs.push(entry);
+  }
+
+  // Build shared-items tables for string fields placed on row / column /
+  // page axes. Data-axis numeric fields skip this — their items are
+  // streamed into the records as `<n v="..."/>` literals.
+  for (const f of fields) {
+    if (f.axis === "data" || f.axis === "hidden") continue;
+    if (f.kind !== "string") continue;
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const row of source.dataRows) {
+      const cell = row[f.index];
+      const text = cell === null || cell === undefined ? "" : String(cell);
+      if (!seen.has(text)) {
+        seen.add(text);
+        ordered.push(text);
+      }
+    }
+    f.sharedStrings = ordered;
+    f.sharedIndex = new Map(ordered.map((s, i) => [s, i]));
+  }
+
+  return { fields, dataFieldDefs };
+}
+
+function inferFieldKind(rows: ReadonlyArray<ReadonlyArray<CellValue>>, col: number): FieldKind {
+  // A field is numeric when *every non-empty cell* parses as a finite
+  // number. A single non-numeric value forces the field to `string`,
+  // which sends every value through the shared-items table. This
+  // mirrors what Excel does on `Refresh` — it picks the type from the
+  // most permissive column.
+  for (const row of rows) {
+    const cell = row[col];
+    if (cell === null || cell === undefined || cell === "") continue;
+    if (typeof cell === "number" && Number.isFinite(cell)) continue;
+    return "string";
+  }
+  return "number";
+}
+
+// ── Cache Definition ──────────────────────────────────────────────────
+
+function buildCacheDefinition(source: ResolvedPivotSource, meta: PivotFieldsMeta): string {
+  const cacheSourceEl = xmlElement("cacheSource", { type: "worksheet" }, [
+    xmlSelfClose("worksheetSource", {
+      ref: source.ref,
+      sheet: source.sheetName,
+    }),
+  ]);
+
+  const cacheFieldElements: string[] = [];
+  for (const f of meta.fields) {
+    cacheFieldElements.push(buildCacheField(f, source.dataRows));
+  }
+
+  return xmlDocument(
+    "pivotCacheDefinition",
+    {
+      xmlns: NS_SPREADSHEET,
+      "xmlns:r": NS_R,
+      "r:id": "rId1",
+      refreshOnLoad: 1,
+      refreshedBy: "hucre",
+      refreshedDate: 0,
+      createdVersion: 6,
+      refreshedVersion: 6,
+      minRefreshableVersion: 3,
+      recordCount: source.dataRows.length,
+    },
+    [cacheSourceEl, xmlElement("cacheFields", { count: meta.fields.length }, cacheFieldElements)],
+  );
+}
+
+function buildCacheField(
+  field: FieldMeta,
+  dataRows: ReadonlyArray<ReadonlyArray<CellValue>>,
+): string {
+  if (field.kind === "string") {
+    const items: string[] = [];
+    if (field.sharedStrings) {
+      for (const s of field.sharedStrings) {
+        items.push(xmlSelfClose("s", { v: s }));
+      }
+    }
+    return xmlElement("cacheField", { name: field.name, numFmtId: 0 }, [
+      xmlElement("sharedItems", { count: items.length }, items),
+    ]);
+  }
+
+  // Numeric field — compute min/max and emit a containsNumber marker
+  // so Excel does not try to inflate `<sharedItems>` itself on refresh.
+  let min = Infinity;
+  let max = -Infinity;
+  let containsBlank = false;
+  for (const row of dataRows) {
+    const v = row[field.index];
+    if (v === null || v === undefined || v === "") {
+      containsBlank = true;
+      continue;
+    }
+    if (typeof v === "number") {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  const attrs: Record<string, string | number> = {
+    containsSemiMixedTypes: 0,
+    containsString: 0,
+    containsNumber: 1,
+    containsInteger: Number.isInteger(min) && Number.isInteger(max) ? 1 : 0,
+  };
+  if (containsBlank) attrs.containsBlank = 1;
+  if (Number.isFinite(min)) attrs.minValue = min;
+  if (Number.isFinite(max)) attrs.maxValue = max;
+
+  return xmlElement("cacheField", { name: field.name, numFmtId: 0 }, [
+    xmlSelfClose("sharedItems", attrs),
+  ]);
+}
+
+function buildCacheDefinitionRels(): string {
+  return xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, [
+    xmlSelfClose("Relationship", {
+      Id: "rId1",
+      Type: REL_PIVOT_CACHE_RECORDS,
+      Target: "pivotCacheRecords1.xml",
+    }),
+  ]);
+}
+
+// ── Cache Records ─────────────────────────────────────────────────────
+
+function buildCacheRecords(source: ResolvedPivotSource, meta: PivotFieldsMeta): string {
+  const recordElements: string[] = [];
+  for (const row of source.dataRows) {
+    const cells: string[] = [];
+    for (const f of meta.fields) {
+      cells.push(buildRecordCell(row[f.index], f));
+    }
+    recordElements.push(xmlElement("r", undefined, cells));
+  }
+  return xmlDocument(
+    "pivotCacheRecords",
+    {
+      xmlns: NS_SPREADSHEET,
+      "xmlns:r": NS_R,
+      count: source.dataRows.length,
+    },
+    recordElements,
+  );
+}
+
+function buildRecordCell(value: CellValue, field: FieldMeta): string {
+  if (value === null || value === undefined || value === "") {
+    return xmlSelfClose("m");
+  }
+
+  if (field.kind === "string") {
+    // Shared-items index lookup. The string was registered during
+    // metadata building, so the lookup is always present.
+    const idx = field.sharedIndex?.get(String(value));
+    if (idx !== undefined) {
+      return xmlSelfClose("x", { v: idx });
+    }
+    // Fallback: emit as inline string. Should not happen unless the
+    // caller mutates the source data between resolve and write.
+    return xmlSelfClose("s", { v: String(value) });
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return xmlSelfClose("n", { v: value });
+  }
+
+  if (typeof value === "boolean") {
+    return xmlSelfClose("b", { v: value ? 1 : 0 });
+  }
+
+  // Date or other — fall back to inline string.
+  return xmlSelfClose("s", { v: String(value) });
+}
+
+// ── Pivot Table Definition ────────────────────────────────────────────
+
+function buildPivotTable(pivot: WritePivotTable, meta: PivotFieldsMeta, cacheId: number): string {
+  const rowFields = meta.fields
+    .filter((f) => f.axis === "row")
+    .sort((a, b) => a.axisOrder - b.axisOrder);
+  const colFields = meta.fields
+    .filter((f) => f.axis === "col")
+    .sort((a, b) => a.axisOrder - b.axisOrder);
+  const pageFields = meta.fields
+    .filter((f) => f.axis === "page")
+    .sort((a, b) => a.axisOrder - b.axisOrder);
+
+  const targetCell = pivot.targetCell ?? "A1";
+  const styleName = pivot.styleName ?? "PivotStyleLight16";
+  const dataCaption = pivot.dataCaption ?? "Values";
+
+  // The output range must cover at least the header rows. Excel
+  // resizes the area on refresh, but a sensible default avoids a
+  // collapsed-frame look on first open.
+  const location = computeLocation(targetCell, rowFields.length, colFields.length, meta);
+
+  const parts: string[] = [];
+
+  parts.push(xmlSelfClose("location", location));
+
+  // ── pivotFields ──
+  const pivotFieldElements: string[] = [];
+  for (const f of meta.fields) {
+    pivotFieldElements.push(buildPivotFieldElement(f));
+  }
+  parts.push(xmlElement("pivotFields", { count: meta.fields.length }, pivotFieldElements));
+
+  // ── rowFields / rowItems ──
+  if (rowFields.length > 0) {
+    parts.push(
+      xmlElement(
+        "rowFields",
+        { count: rowFields.length },
+        rowFields.map((f) => xmlSelfClose("field", { x: f.index })),
+      ),
+    );
+    // One <i/> per row item placeholder. Excel rebuilds the real items
+    // on refresh; emitting a single grand-total row keeps the layout
+    // valid in the meantime.
+    parts.push(
+      xmlElement("rowItems", { count: 1 }, [xmlElement("i", undefined, [xmlSelfClose("x")])]),
+    );
+  }
+
+  // ── colFields / colItems ──
+  if (colFields.length > 0) {
+    parts.push(
+      xmlElement(
+        "colFields",
+        { count: colFields.length },
+        colFields.map((f) => xmlSelfClose("field", { x: f.index })),
+      ),
+    );
+    parts.push(
+      xmlElement("colItems", { count: 1 }, [xmlElement("i", undefined, [xmlSelfClose("x")])]),
+    );
+  } else if (meta.dataFieldDefs.length > 1) {
+    // When there is no explicit column axis but multiple data fields,
+    // Excel still emits a colFields placeholder for the data axis.
+    parts.push(xmlElement("colFields", { count: 1 }, [xmlSelfClose("field", { x: -2 })]));
+    const colItemElements: string[] = [];
+    for (let i = 0; i < meta.dataFieldDefs.length; i++) {
+      colItemElements.push(
+        xmlElement("i", i === 0 ? undefined : { i }, [xmlSelfClose("x", { v: i })]),
+      );
+    }
+    parts.push(xmlElement("colItems", { count: meta.dataFieldDefs.length }, colItemElements));
+  }
+
+  // ── pageFields ──
+  if (pageFields.length > 0) {
+    parts.push(
+      xmlElement(
+        "pageFields",
+        { count: pageFields.length },
+        pageFields.map((f) => xmlSelfClose("pageField", { fld: f.index, hier: -1 })),
+      ),
+    );
+  }
+
+  // ── dataFields ──
+  if (meta.dataFieldDefs.length > 0) {
+    const dataFieldElements: string[] = [];
+    for (const d of meta.dataFieldDefs) {
+      const attrs: Record<string, string | number> = {
+        name: d.displayName,
+        fld: d.fieldIndex,
+        baseField: 0,
+        baseItem: 0,
+      };
+      if (d.function !== "sum") {
+        attrs.subtotal = d.function;
+      }
+      if (d.numberFormat !== undefined) {
+        attrs.numFmtId = 0; // numFmtId is style-driven; the format is lost on roundtrip
+      }
+      dataFieldElements.push(xmlSelfClose("dataField", attrs));
+    }
+    parts.push(xmlElement("dataFields", { count: meta.dataFieldDefs.length }, dataFieldElements));
+  }
+
+  // ── pivotTableStyleInfo ──
+  parts.push(
+    xmlSelfClose("pivotTableStyleInfo", {
+      name: styleName,
+      showRowHeaders: 1,
+      showColHeaders: 1,
+      showRowStripes: 0,
+      showColStripes: 0,
+      showLastColumn: 1,
+    }),
+  );
+
+  return xmlDocument(
+    "pivotTableDefinition",
+    {
+      xmlns: NS_SPREADSHEET,
+      "xmlns:r": NS_R,
+      name: pivot.name,
+      cacheId,
+      applyNumberFormats: 0,
+      applyBorderFormats: 0,
+      applyFontFormats: 0,
+      applyPatternFormats: 0,
+      applyAlignmentFormats: 0,
+      applyWidthHeightFormats: 1,
+      dataCaption,
+      updatedVersion: 6,
+      minRefreshableVersion: 3,
+      useAutoFormatting: 1,
+      itemPrintTitles: 1,
+      createdVersion: 6,
+      indent: 0,
+      outline: 1,
+      outlineData: 1,
+      multipleFieldFilters: 0,
+    },
+    parts,
+  );
+}
+
+function buildPivotFieldElement(field: FieldMeta): string {
+  if (field.axis === "data") {
+    return xmlSelfClose("pivotField", { dataField: 1, showAll: 0 });
+  }
+  if (field.axis === "hidden") {
+    return xmlSelfClose("pivotField", { showAll: 0 });
+  }
+
+  // Row / col / page axis. Emit one <item/> per shared-item entry plus
+  // a trailing <item t="default"/> for the subtotal row Excel injects.
+  const axisAttr = field.axis === "row" ? "axisRow" : field.axis === "col" ? "axisCol" : "axisPage";
+
+  const itemElements: string[] = [];
+  if (field.sharedStrings) {
+    for (let i = 0; i < field.sharedStrings.length; i++) {
+      itemElements.push(xmlSelfClose("item", { x: i }));
+    }
+  }
+  itemElements.push(xmlSelfClose("item", { t: "default" }));
+
+  return xmlElement("pivotField", { axis: axisAttr, showAll: 0 }, [
+    xmlElement("items", { count: itemElements.length }, itemElements),
+  ]);
+}
+
+function buildPivotTableRels(): string {
+  return xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, [
+    xmlSelfClose("Relationship", {
+      Id: "rId1",
+      Type: REL_PIVOT_CACHE_DEFINITION,
+      Target: "../pivotCache/pivotCacheDefinition1.xml",
+    }),
+  ]);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Build the `<location>` block. Phase 1 reserves a 4×N rectangle below
+ * `targetCell` — Excel resizes on first refresh. The exact size doesn't
+ * matter for validity, only for the initial empty layout footprint.
+ */
+function computeLocation(
+  targetCell: string,
+  rowFieldCount: number,
+  colFieldCount: number,
+  meta: PivotFieldsMeta,
+): Record<string, string | number> {
+  const { col, row } = parseCellRef(targetCell);
+
+  // Header rows: 1 (page filters) + 1 (column field header per col field) + 1 (data field header)
+  const firstHeaderRow = 0;
+  const firstDataRow = Math.max(1, colFieldCount) + (meta.dataFieldDefs.length > 1 ? 1 : 0);
+  const firstDataCol = Math.max(1, rowFieldCount);
+
+  const widthCols = Math.max(2, rowFieldCount + Math.max(1, meta.dataFieldDefs.length));
+  const heightRows = firstDataRow + 2; // 2 placeholder data rows
+
+  const startRef = encodeCellRef(row, col);
+  const endRef = encodeCellRef(row + heightRows - 1, col + widthCols - 1);
+
+  return {
+    ref: `${startRef}:${endRef}`,
+    firstHeaderRow,
+    firstDataRow,
+    firstDataCol,
+  };
+}
+
+/** Parse `"B3"` → `{col: 1, row: 2}` (0-based). */
+function parseCellRef(cell: string): { col: number; row: number } {
+  const m = /^([A-Z]+)(\d+)$/i.exec(cell.trim());
+  if (!m) {
+    throw new Error(`Invalid pivot targetCell "${cell}" — expected an A1-style reference`);
+  }
+  const colLetters = m[1].toUpperCase();
+  let col = 0;
+  for (let i = 0; i < colLetters.length; i++) {
+    col = col * 26 + (colLetters.charCodeAt(i) - 64);
+  }
+  return { col: col - 1, row: parseInt(m[2], 10) - 1 };
+}
+
+function encodeCellRef(row: number, col: number): string {
+  let n = col;
+  let letters = "";
+  while (n >= 0) {
+    letters = String.fromCharCode(65 + (n % 26)) + letters;
+    n = Math.floor(n / 26) - 1;
+  }
+  return `${letters}${row + 1}`;
+}
+
+/** Auto-fit a `<worksheetSource ref>` to the source sheet's row count. */
+function autoRange(colCount: number, rowCount: number): string {
+  if (colCount <= 0 || rowCount <= 0) {
+    throw new Error("Pivot source range must contain at least one column and row");
+  }
+  const start = encodeCellRef(0, 0);
+  const end = encodeCellRef(rowCount - 1, colCount - 1);
+  return `${start}:${end}`;
+}
+
+/** Excel's auto-label for a data field: `"Sum of Revenue"`, `"Count of Region"`, etc. */
+function defaultDataFieldName(fn: PivotDataFieldFunction, field: string): string {
+  const label =
+    fn === "sum"
+      ? "Sum"
+      : fn === "count"
+        ? "Count"
+        : fn === "average"
+          ? "Average"
+          : fn === "max"
+            ? "Max"
+            : fn === "min"
+              ? "Min"
+              : fn === "product"
+                ? "Product"
+                : fn === "countNums"
+                  ? "Count Nums"
+                  : fn === "stdDev"
+                    ? "StdDev"
+                    : fn === "stdDevp"
+                      ? "StdDevp"
+                      : fn === "var"
+                        ? "Var"
+                        : "Varp";
+  return `${label} of ${field}`;
+}

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -45,6 +45,12 @@ export interface WorksheetResult {
   tables: Array<{ rId: string; globalTableIndex: number }>;
   /** The rId used for the background image (picture) reference */
   pictureRId: string | null;
+  /**
+   * Pivot table relationships emitted in the host sheet's rels file.
+   * `globalPivotIndex` is the 1-based number used in the
+   * `xl/pivotTables/pivotTableN.xml` path.
+   */
+  pivotTables: Array<{ rId: string; globalPivotIndex: number }>;
 }
 
 const NS_SPREADSHEET = "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
@@ -179,6 +185,7 @@ export function writeWorksheetXml(
   dateSystem?: "1900" | "1904",
   globalTableStartIndex?: number,
   inlineStrings?: boolean,
+  globalPivotStartIndex?: number,
 ): WorksheetResult {
   const is1904 = dateSystem === "1904";
 
@@ -562,6 +569,18 @@ export function writeWorksheetXml(
     parts.push(xmlSelfClose("picture", { "r:id": pictureRId }));
   }
 
+  // ── Pivot Tables ── relationship-only; the worksheet body has no
+  // corresponding element. We allocate rIds here so writer.ts can wire
+  // them into `xl/worksheets/_rels/sheetN.xml.rels`.
+  const pivotEntries: Array<{ rId: string; globalPivotIndex: number }> = [];
+  if (sheet.pivotTables && sheet.pivotTables.length > 0 && globalPivotStartIndex !== undefined) {
+    for (let p = 0; p < sheet.pivotTables.length; p++) {
+      const rId = `rId${nextRId}`;
+      nextRId++;
+      pivotEntries.push({ rId, globalPivotIndex: globalPivotStartIndex + p });
+    }
+  }
+
   return {
     xml: xmlDocument("worksheet", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts),
     hyperlinkRelationships,
@@ -571,6 +590,7 @@ export function writeWorksheetXml(
     hasComments,
     tables: tableEntries,
     pictureRId,
+    pivotTables: pivotEntries,
   };
 }
 

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -1,12 +1,20 @@
 // ── XLSX Writer ──────────────────────────────────────────────────────
 // Generates valid Office Open XML spreadsheet files (XLSX).
 
-import type { WriteOptions, WriteOutput, NamedRange, WorkbookProperties } from "../_types";
+import type {
+  CellValue,
+  NamedRange,
+  WorkbookProperties,
+  WriteOptions,
+  WriteOutput,
+  WriteSheet,
+} from "../_types";
 import { ZipWriter } from "../zip/writer";
 import { writeContentTypes } from "./content-types-writer";
 import { writeFeaturePropertyBagXml } from "./feature-property-bag";
 import type { ContentTypesOptions } from "./content-types-writer";
 import { writeRootRels, writeWorkbookXml, writeWorkbookRels } from "./workbook-writer";
+import type { PivotCacheRef, PivotCacheRel } from "./workbook-writer";
 import { createStylesCollector } from "./styles-writer";
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer";
 import type { WorksheetResult } from "./worksheet-writer";
@@ -16,6 +24,8 @@ import { writeComments } from "./comments-writer";
 import type { CommentsResult } from "./comments-writer";
 import { writeTable } from "./table-writer";
 import { colToLetter } from "./worksheet-writer";
+import { writePivotTable as writePivotTableParts, resolvePivotSource } from "./pivot-writer";
+import type { PivotWriteResult } from "./pivot-writer";
 import { xmlDocument, xmlSelfClose } from "../xml/writer";
 import { writeCoreProperties, writeAppProperties, writeCustomProperties } from "./doc-props-writer";
 import { writeThemeXml } from "./theme-writer";
@@ -31,6 +41,8 @@ const REL_VML_DRAWING =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing";
 const REL_TABLE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table";
 const REL_IMAGE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+const REL_PIVOT_TABLE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable";
 
 /**
  * Promote the first non-empty `sheet.a11y.summary` to
@@ -75,6 +87,21 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     }
   }
 
+  // Pre-compute global pivot-table start indices per sheet. Pivot
+  // tables, cache definitions, and cache records all share the same
+  // global numbering because each pivot in Phase 1 owns exactly one
+  // cache.
+  let globalPivotCounter = 1;
+  const sheetPivotStartIndices: Array<number | undefined> = [];
+  for (const sheet of sheets) {
+    if (sheet.pivotTables && sheet.pivotTables.length > 0) {
+      sheetPivotStartIndices.push(globalPivotCounter);
+      globalPivotCounter += sheet.pivotTables.length;
+    } else {
+      sheetPivotStartIndices.push(undefined);
+    }
+  }
+
   // Generate worksheet XMLs (also populates styles and shared strings)
   const worksheetResults: WorksheetResult[] = [];
   for (let i = 0; i < sheets.length; i++) {
@@ -86,6 +113,7 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
       dateSystem,
       sheetTableStartIndices[i],
       options.stringMode === "inline",
+      sheetPivotStartIndices[i],
     );
     worksheetResults.push(result);
   }
@@ -162,6 +190,50 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     }
   }
 
+  // ── Pivot Tables ──
+  // Build cache + table OOXML for every pivot declared on every sheet.
+  // Each pivot owns one cache (Phase 1 — multiple pivots cannot share a
+  // cache yet), so the indices line up 1:1.
+  interface PivotEntry {
+    parts: PivotWriteResult;
+    globalIndex: number;
+  }
+  const allPivotEntries: PivotEntry[] = [];
+  for (let i = 0; i < sheets.length; i++) {
+    const sheet = sheets[i];
+    if (!sheet.pivotTables || sheet.pivotTables.length === 0) continue;
+    const startIdx = sheetPivotStartIndices[i];
+    if (startIdx === undefined) continue;
+
+    for (let p = 0; p < sheet.pivotTables.length; p++) {
+      const pivot = sheet.pivotTables[p];
+      const sourceSheetName = pivot.sourceSheet ?? sheet.name;
+      const sourceSheet = sheets.find((s) => s.name === sourceSheetName);
+      if (!sourceSheet) {
+        throw new Error(
+          `Pivot "${pivot.name}" sourceSheet "${sourceSheetName}" not found in workbook`,
+        );
+      }
+      const sourceRows = collectSourceRows(sourceSheet);
+      const resolved = resolvePivotSource(pivot, sourceSheetName, sourceRows);
+      const globalIndex = startIdx + p;
+      // cacheId is workbook-wide and 0-based, mirroring Excel's own
+      // numbering. It also matches the pivot table's `cacheId` attr.
+      const cacheId = globalIndex - 1;
+      const parts = writePivotTableParts(pivot, resolved, cacheId);
+      allPivotEntries.push({ parts, globalIndex });
+    }
+  }
+  const allPivotIndices = allPivotEntries.map((e) => e.globalIndex);
+  const pivotCacheRels: PivotCacheRel[] = allPivotEntries.map((e) => ({
+    rId: `rIdPivot${e.globalIndex}`,
+    target: `pivotCache/pivotCacheDefinition${e.globalIndex}.xml`,
+  }));
+  const pivotCacheRefs: PivotCacheRef[] = allPivotEntries.map((e, i) => ({
+    cacheId: e.globalIndex - 1,
+    rId: pivotCacheRels[i].rId,
+  }));
+
   // Build ZIP archive
   const zip = new ZipWriter();
 
@@ -180,6 +252,9 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     imageExtensions: imageExtensions.size > 0 ? imageExtensions : undefined,
     commentIndices: commentIndices.length > 0 ? commentIndices : undefined,
     tableIndices: allTableIndices.length > 0 ? allTableIndices : undefined,
+    pivotTableIndices: allPivotIndices.length > 0 ? allPivotIndices : undefined,
+    pivotCacheDefinitionIndices: allPivotIndices.length > 0 ? allPivotIndices : undefined,
+    pivotCacheRecordIndices: allPivotIndices.length > 0 ? allPivotIndices : undefined,
     hasCoreProps: true,
     hasAppProps: true,
     hasCustomProps,
@@ -216,6 +291,8 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
         dateSystem,
         activeSheet,
         workbookProtection,
+        undefined,
+        pivotCacheRefs.length > 0 ? pivotCacheRefs : undefined,
       ),
     ),
   );
@@ -224,7 +301,15 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
   zip.add(
     "xl/_rels/workbook.xml.rels",
     encoder.encode(
-      writeWorkbookRels(sheets.length, hasSharedStrings, hasMacros, hasFeaturePropertyBag),
+      writeWorkbookRels(
+        sheets.length,
+        hasSharedStrings,
+        hasMacros,
+        hasFeaturePropertyBag,
+        undefined,
+        undefined,
+        pivotCacheRels.length > 0 ? pivotCacheRels : undefined,
+      ),
     ),
   );
 
@@ -259,14 +344,15 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
 
     zip.add(`xl/worksheets/sheet${i + 1}.xml`, encoder.encode(result.xml));
 
-    // Generate worksheet .rels if there are hyperlinks, a drawing, comments, tables, or picture
+    // Generate worksheet .rels if there are hyperlinks, a drawing, comments, tables, picture, or pivots
     const hasHyperlinks = result.hyperlinkRelationships.length > 0;
     const hasDrawing = drawing !== null && result.drawingRId !== null;
     const hasComments = comments !== null && result.legacyDrawingRId !== null;
     const hasTables = result.tables.length > 0;
     const hasPicture = result.pictureRId !== null && backgroundImagePaths[i] !== null;
+    const hasPivots = result.pivotTables.length > 0;
 
-    if (hasHyperlinks || hasDrawing || hasComments || hasTables || hasPicture) {
+    if (hasHyperlinks || hasDrawing || hasComments || hasTables || hasPicture || hasPivots) {
       const relElements: string[] = [];
 
       // Hyperlink relationships
@@ -337,6 +423,17 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
         );
       }
 
+      // Pivot table relationships
+      for (const pivotEntry of result.pivotTables) {
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: pivotEntry.rId,
+            Type: REL_PIVOT_TABLE,
+            Target: `../pivotTables/pivotTable${pivotEntry.globalPivotIndex}.xml`,
+          }),
+        );
+      }
+
       const relsXml = xmlDocument("Relationships", { xmlns: NS_RELATIONSHIPS }, relElements);
       zip.add(`xl/worksheets/_rels/sheet${i + 1}.xml.rels`, encoder.encode(relsXml));
     }
@@ -385,7 +482,60 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     }
   }
 
+  // ── Pivot table parts (cache definition + records + table) ──
+  for (const entry of allPivotEntries) {
+    const idx = entry.globalIndex;
+    zip.add(
+      `xl/pivotCache/pivotCacheDefinition${idx}.xml`,
+      encoder.encode(entry.parts.cacheDefinitionXml),
+    );
+    zip.add(
+      `xl/pivotCache/_rels/pivotCacheDefinition${idx}.xml.rels`,
+      encoder.encode(entry.parts.cacheDefinitionRels),
+    );
+    zip.add(
+      `xl/pivotCache/pivotCacheRecords${idx}.xml`,
+      encoder.encode(entry.parts.cacheRecordsXml),
+    );
+    zip.add(`xl/pivotTables/pivotTable${idx}.xml`, encoder.encode(entry.parts.pivotTableXml));
+    zip.add(
+      `xl/pivotTables/_rels/pivotTable${idx}.xml.rels`,
+      encoder.encode(entry.parts.pivotTableRels),
+    );
+  }
+
   return zip.build();
+}
+
+// ── Pivot Source Resolution ────────────────────────────────────────────
+
+/**
+ * Pull the source data out of a `WriteSheet`. Pivot tables can source
+ * from either `rows` (raw 2-D arrays) or `data` (objects keyed by
+ * `columns[].key`); we normalise both shapes into a single `CellValue[][]`.
+ *
+ * Returns `[]` when the sheet has no row-shaped data — `resolvePivotSource`
+ * will throw a clearer error in that case.
+ */
+function collectSourceRows(sheet: WriteSheet): CellValue[][] {
+  if (sheet.rows && sheet.rows.length > 0) {
+    return sheet.rows.map((row) => [...row]);
+  }
+  if (sheet.data && sheet.data.length > 0 && sheet.columns && sheet.columns.length > 0) {
+    const out: CellValue[][] = [];
+    const headerRow: CellValue[] = sheet.columns.map((c) => c.header ?? c.key ?? "");
+    out.push(headerRow);
+    for (const obj of sheet.data) {
+      const row: CellValue[] = sheet.columns.map((c) => {
+        if (!c.key) return null;
+        const v = obj[c.key];
+        return v === undefined ? null : (v as CellValue);
+      });
+      out.push(row);
+    }
+    return out;
+  }
+  return [];
 }
 
 // ── Named Range Builder ────────────────────────────────────────────────

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -220,7 +220,7 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
       // cacheId is workbook-wide and 0-based, mirroring Excel's own
       // numbering. It also matches the pivot table's `cacheId` attr.
       const cacheId = globalIndex - 1;
-      const parts = writePivotTableParts(pivot, resolved, cacheId);
+      const parts = writePivotTableParts(pivot, resolved, cacheId, globalIndex);
       allPivotEntries.push({ parts, globalIndex });
     }
   }

--- a/test/pivot-write.test.ts
+++ b/test/pivot-write.test.ts
@@ -1,0 +1,656 @@
+import { describe, it, expect } from "vitest";
+import { writeXlsx } from "../src/xlsx/writer";
+import { readXlsx } from "../src/xlsx/reader";
+import { ZipReader } from "../src/zip/reader";
+import { resolvePivotSource, writePivotTable } from "../src/xlsx/pivot-writer";
+import type { WritePivotTable, WriteSheet } from "../src/_types";
+
+const decoder = new TextDecoder("utf-8");
+
+async function extract(buf: Uint8Array, path: string): Promise<string> {
+  const z = new ZipReader(buf);
+  return decoder.decode(await z.extract(path));
+}
+
+function has(buf: Uint8Array, path: string): boolean {
+  return new ZipReader(buf).has(path);
+}
+
+// ── resolvePivotSource ────────────────────────────────────────────────
+
+describe("resolvePivotSource", () => {
+  const baseRows = [
+    ["Region", "Product", "Revenue"],
+    ["EU", "A", 100],
+    ["US", "B", 200],
+    ["EU", "B", 50],
+  ] as const;
+
+  it("collects field names from the header row", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    };
+    const r = resolvePivotSource(pivot, "Data", baseRows);
+    expect(r.fieldNames).toEqual(["Region", "Product", "Revenue"]);
+    expect(r.dataRows).toHaveLength(3);
+    expect(r.sheetName).toBe("Data");
+  });
+
+  it("auto-derives the source ref when not supplied", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    };
+    const r = resolvePivotSource(pivot, "Data", baseRows);
+    expect(r.ref).toBe("A1:C4");
+  });
+
+  it("honours an explicit sourceRange", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      sourceRange: "Sheet1!$A$1:$C$4",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    };
+    const r = resolvePivotSource(pivot, "Data", baseRows);
+    expect(r.ref).toBe("Sheet1!$A$1:$C$4");
+  });
+
+  it("throws when a referenced field is missing", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["NotAField"],
+      values: [{ field: "Revenue" }],
+    };
+    expect(() => resolvePivotSource(pivot, "Data", baseRows)).toThrow(/NotAField/);
+  });
+
+  it("throws when the source has fewer than two rows", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      values: [{ field: "Revenue" }],
+    };
+    expect(() => resolvePivotSource(pivot, "Data", [["Header"]])).toThrow(/header.*data row/i);
+  });
+
+  it("pads short data rows with null and trims long rows to the header width", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    };
+    const rows = [["Region", "Revenue"], ["EU", 100, "extra"], ["US"]];
+    const r = resolvePivotSource(pivot, "Data", rows);
+    expect(r.dataRows).toEqual([
+      ["EU", 100],
+      ["US", null],
+    ]);
+  });
+});
+
+// ── writePivotTable (unit) ────────────────────────────────────────────
+
+describe("writePivotTable", () => {
+  function build(pivot: WritePivotTable, rows: ReadonlyArray<ReadonlyArray<unknown>>) {
+    const resolved = resolvePivotSource(
+      pivot,
+      "Data",
+      rows as ReadonlyArray<ReadonlyArray<import("../src/_types").CellValue>>,
+    );
+    return writePivotTable(pivot, resolved, 0);
+  }
+
+  it("emits a complete cache definition with worksheetSource and cacheFields", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 200],
+      ],
+    );
+    expect(parts.cacheDefinitionXml).toContain("<pivotCacheDefinition");
+    expect(parts.cacheDefinitionXml).toContain('<cacheSource type="worksheet">');
+    expect(parts.cacheDefinitionXml).toContain('ref="A1:B3"');
+    expect(parts.cacheDefinitionXml).toContain('sheet="Data"');
+    expect(parts.cacheDefinitionXml).toContain('<cacheFields count="2">');
+    expect(parts.cacheDefinitionXml).toContain('<cacheField name="Region"');
+    expect(parts.cacheDefinitionXml).toContain('<cacheField name="Revenue"');
+    expect(parts.cacheDefinitionXml).toContain('refreshOnLoad="1"');
+  });
+
+  it("collects unique string values into sharedItems for row/col fields", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 200],
+        ["EU", 50],
+      ],
+    );
+    // Region cacheField gets two items in declaration order
+    const regionBlock = parts.cacheDefinitionXml.match(
+      /<cacheField name="Region"[^>]*>[\s\S]*?<\/cacheField>/,
+    )?.[0];
+    expect(regionBlock).toBeDefined();
+    expect(regionBlock).toContain('<sharedItems count="2">');
+    expect(regionBlock).toContain('<s v="EU"/>');
+    expect(regionBlock).toContain('<s v="US"/>');
+  });
+
+  it("describes numeric data fields with min / max / containsNumber", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 250],
+      ],
+    );
+    const revBlock = parts.cacheDefinitionXml.match(
+      /<cacheField name="Revenue"[^>]*>[\s\S]*?<\/cacheField>/,
+    )?.[0];
+    expect(revBlock).toContain('containsNumber="1"');
+    expect(revBlock).toContain('minValue="100"');
+    expect(revBlock).toContain('maxValue="250"');
+    expect(revBlock).toContain('containsInteger="1"');
+  });
+
+  it("emits <r> records that map string values to shared-item indexes", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 200],
+        ["EU", 50],
+      ],
+    );
+    expect(parts.cacheRecordsXml).toContain('count="3"');
+    // EU=0, US=1
+    expect(parts.cacheRecordsXml).toContain('<x v="0"/><n v="100"/>');
+    expect(parts.cacheRecordsXml).toContain('<x v="1"/><n v="200"/>');
+    expect(parts.cacheRecordsXml).toContain('<x v="0"/><n v="50"/>');
+  });
+
+  it("emits <m/> for blank cells", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", null],
+        ["US", 200],
+      ],
+    );
+    expect(parts.cacheRecordsXml).toContain('<x v="0"/><m/>');
+  });
+
+  it("places fields on row, column, and data axes by name", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        columns: ["Product"],
+        values: [{ field: "Revenue", function: "sum" }],
+      },
+      [
+        ["Region", "Product", "Revenue"],
+        ["EU", "A", 100],
+        ["US", "B", 200],
+      ],
+    );
+    expect(parts.pivotTableXml).toMatch(/<pivotField axis="axisRow"[^>]*>/);
+    expect(parts.pivotTableXml).toMatch(/<pivotField axis="axisCol"[^>]*>/);
+    expect(parts.pivotTableXml).toMatch(/<pivotField dataField="1"[^>]*\/>/);
+    expect(parts.pivotTableXml).toContain('<rowFields count="1"><field x="0"/>');
+    expect(parts.pivotTableXml).toContain('<colFields count="1"><field x="1"/>');
+    expect(parts.pivotTableXml).toContain('<dataFields count="1">');
+    expect(parts.pivotTableXml).toContain('name="Sum of Revenue"');
+    expect(parts.pivotTableXml).toContain('fld="2"');
+  });
+
+  it("auto-labels data fields per Excel's convention", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [
+          { field: "Revenue", function: "average" },
+          { field: "Revenue", function: "max" },
+        ],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 200],
+      ],
+    );
+    expect(parts.pivotTableXml).toContain('name="Average of Revenue"');
+    expect(parts.pivotTableXml).toContain('subtotal="average"');
+    expect(parts.pivotTableXml).toContain('name="Max of Revenue"');
+    expect(parts.pivotTableXml).toContain('subtotal="max"');
+  });
+
+  it("honours an explicit displayName override", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue", displayName: "Total Sales" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 200],
+      ],
+    );
+    expect(parts.pivotTableXml).toContain('name="Total Sales"');
+  });
+
+  it("declares the targetCell location and applies a sensible default size", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+        targetCell: "C5",
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+        ["US", 200],
+      ],
+    );
+    // C5 is col=2, row=4. Default 4-cell area → C5:D7 or wider for data fields.
+    expect(parts.pivotTableXml).toMatch(/<location ref="C5:[A-Z]+\d+"/);
+  });
+
+  it("emits a pivotTable rels file targeting the cache definition", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+      ],
+    );
+    expect(parts.pivotTableRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"',
+    );
+    expect(parts.pivotTableRels).toContain('Target="../pivotCache/pivotCacheDefinition1.xml"');
+  });
+
+  it("emits a cacheDefinition rels file targeting the cache records", () => {
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Region", "Revenue"],
+        ["EU", 100],
+      ],
+    );
+    expect(parts.cacheDefinitionRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheRecords"',
+    );
+    expect(parts.cacheDefinitionRels).toContain('Target="pivotCacheRecords1.xml"');
+  });
+
+  it("uses PivotStyleLight16 by default and honours overrides", () => {
+    const def = build({ name: "P", rows: ["R"], values: [{ field: "V" }] }, [
+      ["R", "V"],
+      ["x", 1],
+    ]);
+    expect(def.pivotTableXml).toContain('name="PivotStyleLight16"');
+
+    const override = build(
+      { name: "P", styleName: "PivotStyleDark1", rows: ["R"], values: [{ field: "V" }] },
+      [
+        ["R", "V"],
+        ["x", 1],
+      ],
+    );
+    expect(override.pivotTableXml).toContain('name="PivotStyleDark1"');
+  });
+
+  it("infers numeric type from data even when the column is also a row field", () => {
+    // A field that's used on the row axis but happens to hold integers
+    // still gets shared-items so row-item indexes work. This documents
+    // that the row-axis type wins over the numeric inference.
+    const parts = build(
+      {
+        name: "P",
+        rows: ["Year"],
+        values: [{ field: "Revenue" }],
+      },
+      [
+        ["Year", "Revenue"],
+        [2020, 100],
+        [2021, 200],
+      ],
+    );
+    // Year is numeric, so no sharedItems with `<s/>` entries — it's
+    // serialized as <n v=".."/> in records.
+    expect(parts.cacheRecordsXml).toContain('<n v="2020"/>');
+    expect(parts.cacheRecordsXml).toContain('<n v="2021"/>');
+  });
+});
+
+// ── End-to-end through writeXlsx ──────────────────────────────────────
+
+describe("writeXlsx — pivot tables", () => {
+  function buildSheet(): { dataSheet: WriteSheet; pivotSheet: WriteSheet } {
+    const dataSheet: WriteSheet = {
+      name: "Data",
+      rows: [
+        ["Region", "Product", "Revenue"],
+        ["EU", "A", 100],
+        ["EU", "B", 50],
+        ["US", "A", 200],
+        ["US", "B", 75],
+      ],
+    };
+    const pivotSheet: WriteSheet = {
+      name: "Pivot",
+      rows: [],
+      pivotTables: [
+        {
+          name: "SalesPivot",
+          sourceSheet: "Data",
+          rows: ["Region"],
+          columns: ["Product"],
+          values: [{ field: "Revenue", function: "sum" }],
+        },
+      ],
+    };
+    return { dataSheet, pivotSheet };
+  }
+
+  it("emits all five pivot parts in the ZIP", async () => {
+    const { dataSheet, pivotSheet } = buildSheet();
+    const buf = await writeXlsx({ sheets: [dataSheet, pivotSheet] });
+
+    expect(has(buf, "xl/pivotTables/pivotTable1.xml")).toBe(true);
+    expect(has(buf, "xl/pivotTables/_rels/pivotTable1.xml.rels")).toBe(true);
+    expect(has(buf, "xl/pivotCache/pivotCacheDefinition1.xml")).toBe(true);
+    expect(has(buf, "xl/pivotCache/_rels/pivotCacheDefinition1.xml.rels")).toBe(true);
+    expect(has(buf, "xl/pivotCache/pivotCacheRecords1.xml")).toBe(true);
+  });
+
+  it("declares overrides for every pivot part in [Content_Types].xml", async () => {
+    const { dataSheet, pivotSheet } = buildSheet();
+    const buf = await writeXlsx({ sheets: [dataSheet, pivotSheet] });
+    const ct = await extract(buf, "[Content_Types].xml");
+
+    expect(ct).toContain("/xl/pivotTables/pivotTable1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotTable+xml",
+    );
+    expect(ct).toContain("/xl/pivotCache/pivotCacheDefinition1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheDefinition+xml",
+    );
+    expect(ct).toContain("/xl/pivotCache/pivotCacheRecords1.xml");
+    expect(ct).toContain(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.pivotCacheRecords+xml",
+    );
+  });
+
+  it("wires <pivotCaches> into workbook.xml and the cache rel into workbook.xml.rels", async () => {
+    const { dataSheet, pivotSheet } = buildSheet();
+    const buf = await writeXlsx({ sheets: [dataSheet, pivotSheet] });
+    const wbXml = await extract(buf, "xl/workbook.xml");
+    const wbRels = await extract(buf, "xl/_rels/workbook.xml.rels");
+
+    expect(wbXml).toContain("<pivotCaches>");
+    expect(wbXml).toMatch(/<pivotCache cacheId="0"[^>]*r:id="rIdPivot1"/);
+    expect(wbRels).toContain('Id="rIdPivot1"');
+    expect(wbRels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotCacheDefinition"',
+    );
+    expect(wbRels).toContain('Target="pivotCache/pivotCacheDefinition1.xml"');
+  });
+
+  it("declares the pivotTable relationship in the host sheet's rels", async () => {
+    const { dataSheet, pivotSheet } = buildSheet();
+    const buf = await writeXlsx({ sheets: [dataSheet, pivotSheet] });
+    const rels = await extract(buf, "xl/worksheets/_rels/sheet2.xml.rels");
+    expect(rels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/pivotTable"',
+    );
+    expect(rels).toContain('Target="../pivotTables/pivotTable1.xml"');
+  });
+
+  it("does not create pivot wiring on workbooks without pivots", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "Plain",
+          rows: [
+            ["a", "b"],
+            [1, 2],
+          ],
+        },
+      ],
+    });
+    const ct = await extract(buf, "[Content_Types].xml");
+    expect(ct).not.toContain("/xl/pivotTables/");
+    expect(ct).not.toContain("/xl/pivotCache/");
+    const wb = await extract(buf, "xl/workbook.xml");
+    expect(wb).not.toContain("<pivotCaches>");
+  });
+
+  it("supports a pivot that sources data from its own sheet", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "Self",
+          rows: [
+            ["Region", "Revenue"],
+            ["EU", 100],
+            ["US", 200],
+          ],
+          pivotTables: [
+            {
+              name: "SelfPivot",
+              rows: ["Region"],
+              values: [{ field: "Revenue" }],
+            },
+          ],
+        },
+      ],
+    });
+    const cacheDef = await extract(buf, "xl/pivotCache/pivotCacheDefinition1.xml");
+    expect(cacheDef).toContain('sheet="Self"');
+    expect(cacheDef).toContain('ref="A1:B3"');
+  });
+
+  it("re-reading the workbook recovers the pivot model", async () => {
+    const { dataSheet, pivotSheet } = buildSheet();
+    const buf = await writeXlsx({ sheets: [dataSheet, pivotSheet] });
+    const wb = await readXlsx(buf);
+
+    expect(wb.pivotCaches).toHaveLength(1);
+    expect(wb.pivotCaches?.[0].fieldNames).toEqual(["Region", "Product", "Revenue"]);
+
+    const pivotHost = wb.sheets.find((s) => s.name === "Pivot");
+    expect(pivotHost?.pivotTables).toHaveLength(1);
+    const pt = pivotHost!.pivotTables![0];
+    expect(pt.name).toBe("SalesPivot");
+    expect(pt.fields[0]).toMatchObject({ name: "Region", axis: "row" });
+    expect(pt.fields[1]).toMatchObject({ name: "Product", axis: "col" });
+    expect(pt.fields[2]).toMatchObject({
+      name: "Revenue",
+      axis: "data",
+      function: "sum",
+      displayName: "Sum of Revenue",
+    });
+  });
+
+  it("writes multiple pivot tables with sequentially numbered indices", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "Data",
+          rows: [
+            ["Region", "Revenue"],
+            ["EU", 100],
+            ["US", 200],
+          ],
+        },
+        {
+          name: "Pivot1",
+          pivotTables: [
+            {
+              name: "P1",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [{ field: "Revenue" }],
+            },
+          ],
+        },
+        {
+          name: "Pivot2",
+          pivotTables: [
+            {
+              name: "P2",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [{ field: "Revenue", function: "average" }],
+            },
+          ],
+        },
+      ],
+    });
+    expect(has(buf, "xl/pivotTables/pivotTable1.xml")).toBe(true);
+    expect(has(buf, "xl/pivotTables/pivotTable2.xml")).toBe(true);
+    expect(has(buf, "xl/pivotCache/pivotCacheDefinition1.xml")).toBe(true);
+    expect(has(buf, "xl/pivotCache/pivotCacheDefinition2.xml")).toBe(true);
+    expect(has(buf, "xl/pivotCache/pivotCacheRecords1.xml")).toBe(true);
+    expect(has(buf, "xl/pivotCache/pivotCacheRecords2.xml")).toBe(true);
+
+    const wbXml = await extract(buf, "xl/workbook.xml");
+    expect(wbXml).toMatch(/<pivotCache cacheId="0"[^>]*r:id="rIdPivot1"/);
+    expect(wbXml).toMatch(/<pivotCache cacheId="1"[^>]*r:id="rIdPivot2"/);
+  });
+
+  it("supports object-style sheet data via columns + data", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "Data",
+          columns: [
+            { header: "Region", key: "region" },
+            { header: "Revenue", key: "revenue" },
+          ],
+          data: [
+            { region: "EU", revenue: 100 },
+            { region: "US", revenue: 200 },
+          ],
+        },
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "P",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [{ field: "Revenue" }],
+            },
+          ],
+        },
+      ],
+    });
+    const cacheDef = await extract(buf, "xl/pivotCache/pivotCacheDefinition1.xml");
+    expect(cacheDef).toContain('<cacheField name="Region"');
+    expect(cacheDef).toContain('<cacheField name="Revenue"');
+  });
+
+  it("throws when sourceSheet does not exist in the workbook", async () => {
+    await expect(
+      writeXlsx({
+        sheets: [
+          {
+            name: "Pivot",
+            pivotTables: [
+              {
+                name: "Bad",
+                sourceSheet: "Missing",
+                rows: ["Region"],
+                values: [{ field: "Revenue" }],
+              },
+            ],
+          },
+        ],
+      }),
+    ).rejects.toThrow(/Missing/);
+  });
+
+  it("supports every aggregation function", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "Data",
+          rows: [
+            ["Region", "Revenue"],
+            ["EU", 100],
+            ["US", 200],
+          ],
+        },
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "Multi",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [
+                { field: "Revenue", function: "sum" },
+                { field: "Revenue", function: "average" },
+                { field: "Revenue", function: "count" },
+                { field: "Revenue", function: "max" },
+                { field: "Revenue", function: "min" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const pt = await extract(buf, "xl/pivotTables/pivotTable1.xml");
+    // sum is the OOXML default and is omitted from the attribute list.
+    expect(pt).not.toMatch(/subtotal="sum"/);
+    expect(pt).toContain('subtotal="average"');
+    expect(pt).toContain('subtotal="count"');
+    expect(pt).toContain('subtotal="max"');
+    expect(pt).toContain('subtotal="min"');
+  });
+});

--- a/test/pivot-write.test.ts
+++ b/test/pivot-write.test.ts
@@ -561,6 +561,15 @@ describe("writeXlsx — pivot tables", () => {
     const wbXml = await extract(buf, "xl/workbook.xml");
     expect(wbXml).toMatch(/<pivotCache cacheId="0"[^>]*r:id="rIdPivot1"/);
     expect(wbXml).toMatch(/<pivotCache cacheId="1"[^>]*r:id="rIdPivot2"/);
+
+    // Each pivot's relationship parts must point to its own sibling
+    // cache definition / records part rather than always falling back
+    // to index "1". Without this every pivot beyond the first would
+    // resolve to the same source cache in Excel.
+    const pt2Rels = await extract(buf, "xl/pivotTables/_rels/pivotTable2.xml.rels");
+    expect(pt2Rels).toContain('Target="../pivotCache/pivotCacheDefinition2.xml"');
+    const cache2Rels = await extract(buf, "xl/pivotCache/_rels/pivotCacheDefinition2.xml.rels");
+    expect(cache2Rels).toContain('Target="pivotCacheRecords2.xml"');
   });
 
   it("supports object-style sheet data via columns + data", async () => {


### PR DESCRIPTION
## Summary

Adds first-class **pivot table creation** to `writeXlsx` through the new
`WriteSheet.pivotTables` field. Phase 1 of #159 covers the most common
dashboard shape — a tabular source summarised onto another sheet with
row / column / page / value field axes. **No other open-source JS
library can author pivot tables reliably** — ExcelJS skips them entirely
and even openpyxl on Python only supports read-only pivots.

## API

```ts
import { writeXlsx } from "hucre";

const xlsx = await writeXlsx({
  sheets: [
    {
      name: "Data",
      rows: [
        ["Region", "Product", "Revenue"],
        ["EU", "A", 100],
        ["EU", "B", 50],
        ["US", "A", 200],
        ["US", "B", 75],
      ],
    },
    {
      name: "Pivot",
      pivotTables: [
        {
          name: "SalesPivot",
          sourceSheet: "Data",
          rows: ["Region"],
          columns: ["Product"],
          values: [{ field: "Revenue", function: "sum" }],
        },
      ],
    },
  ],
});
```

## Model

```ts
interface WritePivotDataField {
  field: string;                       // source column name
  function?: PivotDataFieldFunction;   // sum (default), count, average,
                                       // max, min, product, countNums,
                                       // stdDev, stdDevp, var, varp
  displayName?: string;                // default: "Sum of <field>"
  numberFormat?: string;
}

interface WritePivotTable {
  name: string;
  sourceSheet?: string;                // defaults to host sheet
  sourceRange?: string;                // auto-detected when omitted
  targetCell?: string;                 // default: "A1"
  rows?: string[];                     // row-axis fields
  columns?: string[];                  // column-axis fields
  pages?: string[];                    // page (filter) fields
  values: WritePivotDataField[];       // data-axis fields
  styleName?: string;                  // default: "PivotStyleLight16"
  dataCaption?: string;                // default: "Values"
}
```

## Implementation

- **`src/xlsx/pivot-writer.ts`** — new module that serializes the five
  OOXML parts that back a pivot table:
  - `xl/pivotCache/pivotCacheDefinition{N}.xml` — field declarations
    plus shared-items tables for non-numeric axis fields and
    `containsNumber` / `minValue` / `maxValue` markers for numeric data
    fields.
  - `xl/pivotCache/_rels/pivotCacheDefinition{N}.xml.rels` — links the
    cache definition to its records part.
  - `xl/pivotCache/pivotCacheRecords{N}.xml` — emits one `<r>` per
    source row with `<x v="N"/>` shared-item refs for string fields,
    `<n v="..."/>` literals for numeric fields, and `<m/>` for blanks.
  - `xl/pivotTables/pivotTable{N}.xml` — pivot layout with
    `<pivotFields>`, `<rowFields>` / `<colFields>` / `<pageFields>` /
    `<dataFields>`, and a `pivotTableStyleInfo` block.
  - `xl/pivotTables/_rels/pivotTable{N}.xml.rels` — links the pivot to
    its cache definition.
- **`writer.ts`** orchestrates per-sheet pivot numbering, ZIPs the
  pivot bodies, and registers Override entries in
  `[Content_Types].xml` plus `<pivotCaches>` in `xl/workbook.xml` and
  the matching cache rel in `xl/_rels/workbook.xml.rels`. The existing
  `PivotCacheRef` / `PivotCacheRel` infrastructure (used by roundtrip)
  is reused as-is.
- **`worksheet-writer.ts`** allocates rIds for pivot-table relationships
  on the host sheet's rels file and surfaces them through
  `WorksheetResult.pivotTables`. Pivot tables are referenced only via
  the rels file — there is no `<pivotTable>` element in the worksheet
  body itself.
- Source data is read from either `sheet.rows` (raw 2-D arrays) or
  `sheet.data` + `sheet.columns` (object-style); both shapes normalise
  into the same `CellValue[][]` before resolution.
- Field types are inferred from the source data: a column is `numeric`
  when every non-empty cell is a finite number, otherwise `string` and
  values are routed through the shared-items table. This mirrors what
  Excel does on `Refresh`.
- The numeric layout (row totals, grand totals, value cells) is left
  for Excel to compute on first open via the existing
  `<calcPr fullCalcOnLoad="1"/>` recompute — Phase 1 ships the
  structural skeleton, not pre-computed value cells.

## Out of scope (future phases)

- Pre-computed `<rowItems>` / `<colItems>` expansions for fully
  rendered layouts on first open without a refresh.
- Multiple pivot tables sharing a single cache (each pivot owns one
  cache today).
- Calculated fields, calculated items, grouping (by date, by range),
  and `showDataAs` value transforms (% of total, running total, ...).
- Slicer / timeline integration with newly authored pivots.

## Tests

30 new cases in `test/pivot-write.test.ts`:

- `resolvePivotSource` — header extraction, auto-derived ranges,
  explicit range honour, missing-field error, padding / trimming of
  ragged rows.
- `writePivotTable` — cache definition shape, shared-items collection
  for string fields, numeric `<sharedItems>` markers, record
  serialisation (string-as-index, numeric, blank, integer numerics),
  axis placement, auto-labelled data fields ("Sum of Revenue"),
  displayName overrides, targetCell location, rels files, default and
  override style names.
- End-to-end through `writeXlsx` — five pivot parts in the ZIP,
  Content Types overrides, `<pivotCaches>` in workbook.xml, cache rel
  in workbook.xml.rels, host-sheet rel, no-op when no pivots,
  self-sourcing, multi-pivot index numbering, object-style source
  data, missing-source error, every supported aggregation function,
  re-read recovers the model.

`pnpm test` (lint + typecheck + vitest) and `pnpm build` both pass.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)