### PR TITLE
feat: accept ReadableStream input on every reader entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,7 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 
 | Function                           | Description                                                                 |
 | ---------------------------------- | --------------------------------------------------------------------------- |
-| `readXlsx(input, options?)`        | Parse XLSX from `Uint8Array \| ArrayBuffer`                                 |
+| `readXlsx(input, options?)`        | Parse XLSX from `Uint8Array \| ArrayBuffer \| ReadableStream<Uint8Array>`   |
 | `writeXlsx(options)`               | Generate XLSX, returns `Uint8Array`                                         |
 | `readXlsxObjects(input, options?)` | Read sheet as `{ data, headers }` — mirror of CSV                           |
 | `writeXlsxObjects(data, options?)` | Write objects to XLSX (auto-derives headers from keys)                      |
@@ -1048,13 +1048,13 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 
 ### ODS
 
-| Function                          | Description                          |
-| --------------------------------- | ------------------------------------ |
-| `readOds(input, options?)`        | Parse ODS (OpenDocument Spreadsheet) |
-| `writeOds(options)`               | Generate ODS                         |
-| `readOdsObjects(input, options?)` | Read sheet as `{ data, headers }`    |
-| `writeOdsObjects(data, options?)` | Write objects to ODS                 |
-| `streamOdsRows(input)`            | AsyncGenerator yielding ODS rows     |
+| Function                          | Description                                                           |
+| --------------------------------- | --------------------------------------------------------------------- |
+| `readOds(input, options?)`        | Parse ODS (`Uint8Array \| ArrayBuffer \| ReadableStream<Uint8Array>`) |
+| `writeOds(options)`               | Generate ODS                                                          |
+| `readOdsObjects(input, options?)` | Read sheet as `{ data, headers }`                                     |
+| `writeOdsObjects(data, options?)` | Write objects to ODS                                                  |
+| `streamOdsRows(input)`            | AsyncGenerator yielding ODS rows                                      |
 
 ### CSV
 

--- a/src/_input.ts
+++ b/src/_input.ts
@@ -1,0 +1,76 @@
+// ── ReadInput Normalization ────────────────────────────────────────────
+//
+// Helpers for normalizing the {@link ReadInput} union type into the byte
+// buffer that ZIP-based readers (XLSX, ODS, XLSB) need.
+//
+// `ReadableStream<Uint8Array>` input must be fully buffered because every
+// supported container format stores its central directory or directory
+// equivalent at the end of the file — true streaming is not possible
+// without random access. Buffering happens once and is shared by every
+// reader, so the unified `read()` API and `readXlsx`/`readOds` direct
+// entry points all accept streams uniformly.
+// ──────────────────────────────────────────────────────────────────────
+
+import type { ReadInput } from "./_types";
+import { ParseError } from "./errors";
+
+/**
+ * Drain a {@link ReadableStream} of byte chunks into a single
+ * {@link Uint8Array}. Allocates only one extra buffer when the stream
+ * yields more than one chunk.
+ */
+export async function bufferReadableStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLen = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      totalLen += value.length;
+    }
+  }
+
+  if (chunks.length === 0) return new Uint8Array(0);
+  if (chunks.length === 1) return chunks[0]!;
+
+  const result = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return result;
+}
+
+/**
+ * Detect whether a value is a ReadableStream of bytes. Avoids relying on
+ * `instanceof ReadableStream` so the check works across realms (Node
+ * worker threads, browser iframes, undici, etc.) where multiple
+ * `ReadableStream` constructors may exist.
+ */
+function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as ReadableStream<Uint8Array>).getReader === "function"
+  );
+}
+
+/**
+ * Normalize a {@link ReadInput} into a {@link Uint8Array}. Buffers any
+ * `ReadableStream<Uint8Array>` input fully. Throws {@link ParseError}
+ * for unsupported input shapes.
+ */
+export async function readInputToUint8Array(input: ReadInput): Promise<Uint8Array> {
+  if (input instanceof Uint8Array) return input;
+  if (input instanceof ArrayBuffer) return new Uint8Array(input);
+  if (isReadableStream(input)) return bufferReadableStream(input);
+  throw new ParseError(
+    "Unsupported input type. Expected Uint8Array, ArrayBuffer, or ReadableStream<Uint8Array>.",
+  );
+}

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -19,6 +19,7 @@ import { writeXlsx } from "./xlsx/writer";
 import { readOds } from "./ods/reader";
 import { writeOds } from "./ods/writer";
 import { UnsupportedFormatError } from "./errors";
+import { readInputToUint8Array } from "./_input";
 
 // ── Format Detection ────────────────────────────────────────────────
 
@@ -71,24 +72,17 @@ function detectFormat(data: Uint8Array): "xlsx" | "ods" {
   return "xlsx";
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────
-
-function toUint8Array(input: ReadInput): Uint8Array {
-  if (input instanceof Uint8Array) return input;
-  if (input instanceof ArrayBuffer) return new Uint8Array(input);
-  throw new UnsupportedFormatError(
-    "ReadableStream input is not supported by the unified read() API. Use readXlsx/readOds directly.",
-  );
-}
-
 // ── Public API ──────────────────────────────────────────────────────
 
 /**
  * Read any supported spreadsheet file. Auto-detects format from content.
  * Supports: XLSX, ODS (CSV uses parseCsv separately since it's string input).
+ *
+ * Input can be Uint8Array, ArrayBuffer, or ReadableStream&lt;Uint8Array&gt;.
+ * ReadableStream input is buffered fully before format detection runs.
  */
 export async function read(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  const data = toUint8Array(input);
+  const data = await readInputToUint8Array(input);
   const format = detectFormat(data);
 
   if (format === "ods") {

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -14,17 +14,12 @@ import type {
   Hyperlink,
 } from "../_types";
 import { ParseError, ZipError } from "../errors";
+import { readInputToUint8Array } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
 import type { XmlElement } from "../xml/parser";
 
 // ── Helpers ─────────────────────────────────────────────────────────
-
-function toUint8Array(input: ReadInput): Uint8Array {
-  if (input instanceof Uint8Array) return input;
-  if (input instanceof ArrayBuffer) return new Uint8Array(input);
-  throw new ParseError("Unsupported input type. Expected Uint8Array or ArrayBuffer.");
-}
 
 function decodeUtf8(data: Uint8Array): string {
   return new TextDecoder("utf-8").decode(data);
@@ -568,10 +563,13 @@ function parseMetaXml(xml: string): Partial<WorkbookProperties> {
 
 /**
  * Read an ODS file and return a Workbook.
- * Input can be Uint8Array or ArrayBuffer.
+ * Input can be Uint8Array, ArrayBuffer, or ReadableStream&lt;Uint8Array&gt;.
+ *
+ * For ReadableStream input, the stream is fully buffered before parsing
+ * because the ZIP central directory lives at the end of the archive.
  */
 export async function readOds(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  const data = toUint8Array(input);
+  const data = await readInputToUint8Array(input);
 
   // 1. Open ZIP archive
   let zip: ZipReader;

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -30,6 +30,7 @@ import {
 } from "./slicer-reader";
 import { parseChart } from "./chart-reader";
 import { ParseError, ZipError } from "../errors";
+import { readInputToUint8Array } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
 import { parseContentTypes } from "./content-types";
@@ -65,12 +66,6 @@ function matchesRelType(rel: string, type: string): boolean {
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
-
-function toUint8Array(input: ReadInput): Uint8Array {
-  if (input instanceof Uint8Array) return input;
-  if (input instanceof ArrayBuffer) return new Uint8Array(input);
-  throw new ParseError("Unsupported input type. Expected Uint8Array or ArrayBuffer.");
-}
 
 function decodeUtf8(data: Uint8Array): string {
   return new TextDecoder("utf-8").decode(data);
@@ -111,10 +106,15 @@ function dirname(path: string): string {
 
 /**
  * Read an XLSX file and return a Workbook.
- * Input can be Uint8Array or ArrayBuffer.
+ * Input can be Uint8Array, ArrayBuffer, or ReadableStream&lt;Uint8Array&gt;.
+ *
+ * For ReadableStream input, the stream is fully buffered before parsing
+ * because the ZIP central directory lives at the end of the archive —
+ * true streaming requires random access. Use {@link streamXlsxRows} when
+ * you need row-level streaming with low per-row memory.
  */
 export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  const data = toUint8Array(input);
+  const data = await readInputToUint8Array(input);
 
   // 1. Open ZIP archive
   let zip: ZipReader;

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -8,6 +8,7 @@ import type { SharedString } from "./shared-strings";
 import type { ParsedStyles } from "./styles";
 import type { Relationship } from "./relationships";
 import { ParseError, ZipError } from "../errors";
+import { bufferReadableStream } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseXml, parseSaxStream, decodeOoxmlEscapes } from "../xml/parser";
 import { parseContentTypes } from "./content-types";
@@ -451,31 +452,6 @@ function resolveStreamCellValue(
   }
 }
 
-// ── Helper: buffer a ReadableStream into Uint8Array ────────────────
-
-async function bufferStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let totalLen = 0;
-
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    chunks.push(value);
-    totalLen += value.length;
-  }
-
-  if (chunks.length === 1) return chunks[0];
-
-  const result = new Uint8Array(totalLen);
-  let offset = 0;
-  for (const chunk of chunks) {
-    result.set(chunk, offset);
-    offset += chunk.length;
-  }
-  return result;
-}
-
 // ── Main streaming reader ───────────────────────────────────────────
 
 /**
@@ -501,7 +477,7 @@ export async function* streamXlsxRows(
   } else if (input instanceof ArrayBuffer) {
     data = new Uint8Array(input);
   } else {
-    data = await bufferStream(input);
+    data = await bufferReadableStream(input);
   }
 
   // 1. Open ZIP archive

--- a/test/readable-stream-input.test.ts
+++ b/test/readable-stream-input.test.ts
@@ -1,0 +1,190 @@
+// ── ReadableStream<Uint8Array> input across reader entry points ────────
+//
+// `ReadInput` is documented as `Uint8Array | ArrayBuffer |
+// ReadableStream<Uint8Array>`, but until now only `streamXlsxRows` honored
+// the third arm. These tests lock in stream support across `readXlsx`,
+// `readOds`, the unified `read()` dispatcher, and the object shorthands.
+// ──────────────────────────────────────────────────────────────────────
+
+import { describe, expect, it } from "vitest";
+import { readXlsx } from "../src/xlsx/reader";
+import { writeXlsx } from "../src/xlsx/writer";
+import { readOds } from "../src/ods/reader";
+import { writeOds } from "../src/ods/writer";
+import { read, readObjects } from "../src/defter";
+import { readXlsxObjects } from "../src/xlsx/objects";
+import { readOdsObjects } from "../src/ods/objects";
+import { ParseError } from "../src/errors";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Wrap a Uint8Array in a ReadableStream that delivers it as a single chunk. */
+function toReadableStream(data: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Wrap a Uint8Array in a ReadableStream that delivers it across many
+ * fixed-size chunks. Exercises the multi-chunk path of
+ * `bufferReadableStream`.
+ */
+function toChunkedReadableStream(data: Uint8Array, chunkSize: number): ReadableStream<Uint8Array> {
+  let offset = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= data.length) {
+        controller.close();
+        return;
+      }
+      const end = Math.min(offset + chunkSize, data.length);
+      controller.enqueue(data.slice(offset, end));
+      offset = end;
+    },
+  });
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const SAMPLE_SHEETS = [
+  {
+    name: "Data",
+    rows: [
+      ["id", "name", "amount"],
+      [1, "alpha", 10.5],
+      [2, "beta", 20.25],
+    ],
+  },
+];
+
+// ── readXlsx ────────────────────────────────────────────────────────
+
+describe("readXlsx — ReadableStream input", () => {
+  it("reads a workbook from a single-chunk ReadableStream", async () => {
+    const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS });
+
+    const wb = await readXlsx(toReadableStream(xlsx));
+
+    expect(wb.sheets).toHaveLength(1);
+    expect(wb.sheets[0]!.name).toBe("Data");
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["id", "name", "amount"],
+      [1, "alpha", 10.5],
+      [2, "beta", 20.25],
+    ]);
+  });
+
+  it("matches Uint8Array output when input arrives as many small chunks", async () => {
+    const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS });
+
+    const fromBytes = await readXlsx(xlsx);
+    const fromStream = await readXlsx(toChunkedReadableStream(xlsx, 64));
+
+    expect(fromStream.sheets[0]!.rows).toEqual(fromBytes.sheets[0]!.rows);
+    expect(fromStream.sheets[0]!.name).toEqual(fromBytes.sheets[0]!.name);
+  });
+
+  it("accepts ArrayBuffer alongside Uint8Array (regression guard)", async () => {
+    const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS });
+    const ab = xlsx.buffer.slice(xlsx.byteOffset, xlsx.byteOffset + xlsx.byteLength) as ArrayBuffer;
+
+    const wb = await readXlsx(ab);
+    expect(wb.sheets[0]!.rows[1]).toEqual([1, "alpha", 10.5]);
+  });
+
+  it("throws ParseError for unsupported input shapes", async () => {
+    await expect(readXlsx("not-a-buffer" as unknown as Uint8Array)).rejects.toBeInstanceOf(
+      ParseError,
+    );
+  });
+});
+
+// ── readOds ─────────────────────────────────────────────────────────
+
+describe("readOds — ReadableStream input", () => {
+  it("reads an ODS workbook from a ReadableStream", async () => {
+    const ods = await writeOds({ sheets: SAMPLE_SHEETS });
+
+    const wb = await readOds(toReadableStream(ods));
+
+    expect(wb.sheets).toHaveLength(1);
+    expect(wb.sheets[0]!.name).toBe("Data");
+    // ODS preserves cell content but not always exact numeric typing —
+    // assert string-equivalent values rather than strict equality.
+    const row = wb.sheets[0]!.rows[1]!;
+    expect(String(row[1])).toBe("alpha");
+  });
+
+  it("matches Uint8Array output when input arrives chunked", async () => {
+    const ods = await writeOds({ sheets: SAMPLE_SHEETS });
+
+    const fromBytes = await readOds(ods);
+    const fromStream = await readOds(toChunkedReadableStream(ods, 128));
+
+    expect(fromStream.sheets[0]!.rows).toEqual(fromBytes.sheets[0]!.rows);
+  });
+});
+
+// ── unified read() ──────────────────────────────────────────────────
+
+describe("read() — ReadableStream input", () => {
+  it("auto-detects XLSX from a stream", async () => {
+    const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS });
+
+    const wb = await read(toReadableStream(xlsx));
+
+    expect(wb.sheets[0]!.name).toBe("Data");
+    expect(wb.sheets[0]!.rows[2]).toEqual([2, "beta", 20.25]);
+  });
+
+  it("auto-detects ODS from a stream", async () => {
+    const ods = await writeOds({ sheets: SAMPLE_SHEETS });
+
+    const wb = await read(toReadableStream(ods));
+
+    expect(wb.sheets[0]!.name).toBe("Data");
+    expect(wb.sheets[0]!.rows[0]).toEqual(["id", "name", "amount"]);
+  });
+
+  it("readObjects accepts a stream", async () => {
+    const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS });
+
+    const objects = await readObjects(toReadableStream(xlsx));
+
+    expect(objects).toEqual([
+      { id: 1, name: "alpha", amount: 10.5 },
+      { id: 2, name: "beta", amount: 20.25 },
+    ]);
+  });
+});
+
+// ── *Objects shorthands ─────────────────────────────────────────────
+
+describe("readXlsxObjects / readOdsObjects — ReadableStream input", () => {
+  it("readXlsxObjects accepts a stream", async () => {
+    const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS });
+
+    const { headers, data } = await readXlsxObjects(toChunkedReadableStream(xlsx, 256));
+
+    expect(headers).toEqual(["id", "name", "amount"]);
+    expect(data).toEqual([
+      { id: 1, name: "alpha", amount: 10.5 },
+      { id: 2, name: "beta", amount: 20.25 },
+    ]);
+  });
+
+  it("readOdsObjects accepts a stream", async () => {
+    const ods = await writeOds({ sheets: SAMPLE_SHEETS });
+
+    const { headers, data } = await readOdsObjects(toReadableStream(ods));
+
+    expect(headers).toEqual(["id", "name", "amount"]);
+    expect(data).toHaveLength(2);
+    expect(data[0]!.name).toBe("alpha");
+    expect(data[1]!.name).toBe("beta");
+  });
+});


### PR DESCRIPTION
## Summary

`ReadInput` is already typed as `Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>`, but only `streamXlsxRows` actually honored the stream arm. `readXlsx`, `readOds`, and the unified `read()` / `readObjects()` dispatcher all threw `"ReadableStream input is not supported by the unified read() API. Use readXlsx/readOds directly."` — and `readXlsx` itself just threw `"Unsupported input type. Expected Uint8Array or ArrayBuffer."`. The shorthand helpers (`readXlsxObjects`, `readOdsObjects`) inherited the gap.

This PR fills the gap so every `ReadInput`-typed entry point accepts a stream:

- New `src/_input.ts` exports `bufferReadableStream` and `readInputToUint8Array`. The `ReadableStream` check is duck-typed (`getReader`), so streams from other realms — Node worker threads, undici, browser iframes — are accepted.
- `readXlsx`, `readOds`, and `read()` now `await readInputToUint8Array(input)` instead of the per-file `toUint8Array` helpers.
- `streamXlsxRows` reuses `bufferReadableStream` (its private `bufferStream` was removed) so there is one canonical implementation.
- `readXlsxObjects`, `readOdsObjects`, `readObjects` inherit support automatically since they delegate to the format readers.

Streams are fully buffered before parsing because XLSX and ODS both store the ZIP central directory at the end of the archive — true streaming requires random access. `streamXlsxRows` remains the path for row-level streaming with low per-row memory.

Refs #77 (item 1 of the proposed-improvements list — surface-level API gap. The "true streaming without full ZIP in memory" main goal is intentionally out of scope; that requires a streaming ZIP reader and is called out as high-complexity in the issue.)

## Test plan

- [x] New `test/readable-stream-input.test.ts` covers single-chunk, multi-chunk (64-byte and 256-byte slices), `ArrayBuffer` regression, and unsupported-input error paths across `readXlsx`, `readOds`, `read()`, `readObjects`, `readXlsxObjects`, `readOdsObjects` — 11 cases, all passing.
- [x] `pnpm test` (lint + typecheck + 2371 vitest cases) green.
- [x] `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)