### PR TITLE
feat(xlsx): surface chart series metadata in parseChart

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,8 +494,9 @@ or any sibling sheet, and accept either `rows` (raw 2-D arrays) or
 
 Charts (`xl/charts/chartN.xml` plus the optional `styleN.xml` /
 `colorsN.xml` companions) are read into a per-sheet `sheet.charts`
-array surfacing the chart kind(s), series count, and plain-text
-title. On `saveXlsx` the chart parts are re-declared in
+array surfacing the chart kind(s), series count, plain-text title,
+and per-series metadata (name, value/category ranges, fill color).
+On `saveXlsx` the chart parts are re-declared in
 `[Content_Types].xml`, the chart-bearing drawing and its rels are
 force-preserved, and the regenerated worksheet body gets a
 `<drawing r:id="..."/>` re-anchor — without these wirings Excel
@@ -511,6 +512,11 @@ for (const sheet of wb.sheets) {
   for (const chart of sheet.charts ?? []) {
     console.log(chart.kinds, chart.seriesCount, chart.title);
     // e.g. ["bar"], 2, "Quarterly Sales"
+
+    for (const s of chart.series ?? []) {
+      console.log(s.kind, s.index, s.name, s.valuesRef, s.categoriesRef, s.color);
+      // e.g. "bar" 0 "Revenue" "Sheet1!$B$2:$B$10" "Sheet1!$A$2:$A$10" "1F77B4"
+    }
   }
 }
 
@@ -520,7 +526,12 @@ const chart = parseChart(xml);
 
 `Chart.kinds` lists every chart-type element present under
 `<c:plotArea>` in declaration order, so combo charts surface as e.g.
-`["bar", "line"]`. Sheets that hucre actively regenerates because they
+`["bar", "line"]`. `Chart.series` mirrors the field shape that
+`ChartSeries` accepts on the write side — a parsed series can be
+fed back into `WriteSheet.charts` to clone or re-bind a chart.
+Bubble/scatter `<c:numLit>` series (literal embedded data, no
+formula) intentionally surface no `valuesRef`/`categoriesRef`.
+Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
 with the original chart graphicFrames is a follow-up.

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1221,11 +1221,38 @@ export type ChartKind =
   | "ofPie";
 
 /**
+ * A single series surfaced from a parsed chart.
+ *
+ * Field semantics mirror what {@link ChartSeries} accepts on the write
+ * side, so a `ChartSeriesInfo` returned by {@link Chart.series} can be
+ * used as the basis for cloning a chart with new bindings.
+ *
+ * `valuesRef` and `categoriesRef` are the raw `<c:f>` formula strings
+ * extracted from the chart XML — typically sheet-qualified A1 ranges
+ * like `"Sheet1!$B$2:$B$10"`. They may be `undefined` when the series
+ * embeds literal numbers (`<c:numLit>`) instead of referencing a range.
+ */
+export interface ChartSeriesInfo {
+  /** Chart kind that owns this series (matches {@link Chart.kinds}). */
+  kind: ChartKind;
+  /** 0-based position inside the chart-type element. */
+  index: number;
+  /** Series name pulled from `<c:tx>` (literal `<c:v>` or strRef cache). */
+  name?: string;
+  /** Raw `<c:f>` for `<c:val>` / `<c:yVal>`. */
+  valuesRef?: string;
+  /** Raw `<c:f>` for `<c:cat>` / `<c:xVal>`. */
+  categoriesRef?: string;
+  /** 6-digit RGB hex from `<c:spPr><a:solidFill><a:srgbClr val>`. */
+  color?: string;
+}
+
+/**
  * A chart anchored on a sheet via the sheet's drawing part.
  *
- * Charts come from `xl/charts/chartN.xml`. Hucre exposes only the
- * fields needed to recognize the chart on read; the chart body is
- * preserved verbatim through roundtrip.
+ * Charts come from `xl/charts/chartN.xml`. Hucre exposes the
+ * structural metadata needed to recognize, introspect, and clone the
+ * chart; the chart body is preserved verbatim through roundtrip.
  */
 export interface Chart {
   /** Chart-type elements present in `<c:plotArea>`, in declaration order. */
@@ -1234,6 +1261,11 @@ export interface Chart {
   seriesCount: number;
   /** Plain-text title pulled from `<c:title>`, when present. */
   title?: string;
+  /**
+   * Per-series metadata across every chart-type element, in
+   * declaration order. Empty when the chart has no `<c:ser>` children.
+   */
+  series?: ChartSeriesInfo[];
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export type {
 
 // ── Charts ─────────────────────────────────────────────────────────
 export { parseChart } from "./xlsx/chart-reader";
-export type { Chart, ChartKind } from "./_types";
+export type { Chart, ChartKind, ChartSeriesInfo } from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────
 export {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -12,7 +12,7 @@
 //
 // OOXML reference: ECMA-376 Part 1, §21.2 (DrawingML — Charts).
 
-import type { Chart, ChartKind } from "../_types";
+import type { Chart, ChartKind, ChartSeriesInfo } from "../_types";
 import { parseXml } from "../xml/parser";
 import type { XmlElement } from "../xml/parser";
 
@@ -61,18 +61,121 @@ export function parseChart(xml: string): Chart | undefined {
   const plotArea = findChild(chartEl, "plotArea");
   if (plotArea) {
     let seriesCount = 0;
+    const series: ChartSeriesInfo[] = [];
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
       if (!out.kinds.includes(kind)) out.kinds.push(kind);
+      let localIndex = 0;
       for (const ser of childElements(child)) {
-        if (ser.local === "ser") seriesCount++;
+        if (ser.local !== "ser") continue;
+        seriesCount++;
+        series.push(parseSeries(ser, kind, localIndex));
+        localIndex++;
       }
     }
     out.seriesCount = seriesCount;
+    if (series.length > 0) out.series = series;
   }
 
   return out;
+}
+
+// ── Series ────────────────────────────────────────────────────────
+
+/**
+ * Pull the metadata fields {@link ChartSeriesInfo} surfaces out of a
+ * single `<c:ser>` element. Missing pieces (no name, no categories,
+ * literal numbers instead of a range) are simply omitted.
+ */
+function parseSeries(ser: XmlElement, kind: ChartKind, index: number): ChartSeriesInfo {
+  const out: ChartSeriesInfo = { kind, index };
+
+  const name = parseSeriesName(ser);
+  if (name !== undefined) out.name = name;
+
+  // Numeric values land in <c:val> for most chart types; scatter and
+  // bubble use <c:yVal> instead.
+  const valuesRef = formulaText(findChild(ser, "val")) ?? formulaText(findChild(ser, "yVal"));
+  if (valuesRef !== undefined) out.valuesRef = valuesRef;
+
+  // Categories live in <c:cat> for category-axis charts and in
+  // <c:xVal> for scatter/bubble.
+  const catRef = formulaText(findChild(ser, "cat")) ?? formulaText(findChild(ser, "xVal"));
+  if (catRef !== undefined) out.categoriesRef = catRef;
+
+  const color = parseSeriesColor(ser);
+  if (color !== undefined) out.color = color;
+
+  return out;
+}
+
+/** Read the `<c:tx>` series-name element (literal or strRef cache). */
+function parseSeriesName(ser: XmlElement): string | undefined {
+  const tx = findChild(ser, "tx");
+  if (!tx) return undefined;
+  const literal = findChild(tx, "v");
+  if (literal) {
+    const text = elementText(literal).trim();
+    if (text.length > 0) return text;
+  }
+  const strRef = findChild(tx, "strRef");
+  if (strRef) {
+    const cache = findChild(strRef, "strCache");
+    if (cache) {
+      for (const pt of childElements(cache)) {
+        if (pt.local !== "pt") continue;
+        const v = findChild(pt, "v");
+        if (v) {
+          const text = elementText(v).trim();
+          if (text.length > 0) return text;
+        }
+      }
+    }
+    // Fall back to the formula reference itself when no cached value.
+    const f = formulaText(strRef);
+    if (f) return f;
+  }
+  return undefined;
+}
+
+/**
+ * Walk `<c:val>` / `<c:cat>` / `<c:xVal>` / `<c:yVal>` to its inner
+ * `<c:f>` formula text. Returns `undefined` for embedded `<c:numLit>`
+ * literal data (no formula) or when the element is absent.
+ */
+function formulaText(wrapper: XmlElement | undefined): string | undefined {
+  if (!wrapper) return undefined;
+  const numRef = findChild(wrapper, "numRef") ?? findChild(wrapper, "strRef");
+  if (numRef) {
+    const f = findChild(numRef, "f");
+    if (f) {
+      const text = elementText(f).trim();
+      if (text.length > 0) return text;
+    }
+  }
+  // Some writers put <c:f> directly under <c:strRef> (already handled
+  // above via numRef fallback) or under the wrapper itself.
+  const direct = findChild(wrapper, "f");
+  if (direct) {
+    const text = elementText(direct).trim();
+    if (text.length > 0) return text;
+  }
+  return undefined;
+}
+
+/** Pull the first `<a:srgbClr val="RRGGBB">` under `<c:spPr>`. */
+function parseSeriesColor(ser: XmlElement): string | undefined {
+  const spPr = findChild(ser, "spPr");
+  if (!spPr) return undefined;
+  const fill = findChild(spPr, "solidFill");
+  if (!fill) return undefined;
+  const srgb = findChild(fill, "srgbClr");
+  if (!srgb) return undefined;
+  const val = srgb.attrs.val;
+  if (typeof val !== "string") return undefined;
+  const normalized = val.replace(/^#/, "").toUpperCase();
+  return /^[0-9A-F]{6}$/.test(normalized) ? normalized : undefined;
 }
 
 // ── Internals ─────────────────────────────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -42,6 +42,10 @@ describe("parseChart", () => {
       kinds: ["bar"],
       seriesCount: 2,
       title: "Sales",
+      series: [
+        { kind: "bar", index: 0 },
+        { kind: "bar", index: 1 },
+      ],
     });
   });
 
@@ -63,6 +67,11 @@ describe("parseChart", () => {
     expect(parseChart(xml)).toEqual({
       kinds: ["bar", "line"],
       seriesCount: 3,
+      series: [
+        { kind: "bar", index: 0 },
+        { kind: "line", index: 0 },
+        { kind: "line", index: 1 },
+      ],
     });
   });
 
@@ -108,6 +117,219 @@ describe("parseChart", () => {
 </c:chartSpace>`;
     const chart = parseChart(xml);
     expect(chart?.title).toBe("Quarterly Revenue");
+  });
+});
+
+// ── parseChart — series introspection ─────────────────────────────
+
+describe("parseChart — series introspection", () => {
+  it("surfaces series name, value range, category range, and color", () => {
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:spPr><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></c:spPr>
+          <c:cat><c:strRef><c:f>Sheet1!$A$2:$A$10</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$10</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:tx><c:v>Cost</c:v></c:tx>
+          <c:val><c:numRef><c:f>Sheet1!$C$2:$C$10</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series).toEqual([
+      {
+        kind: "bar",
+        index: 0,
+        name: "Revenue",
+        valuesRef: "Sheet1!$B$2:$B$10",
+        categoriesRef: "Sheet1!$A$2:$A$10",
+        color: "1F77B4",
+      },
+      {
+        kind: "bar",
+        index: 1,
+        name: "Cost",
+        valuesRef: "Sheet1!$C$2:$C$10",
+      },
+    ]);
+  });
+
+  it("decodes scatter xVal / yVal series wiring", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Trend</c:v></c:tx>
+          <c:xVal><c:numRef><c:f>S!$A$2:$A$5</c:f></c:numRef></c:xVal>
+          <c:yVal><c:numRef><c:f>S!$B$2:$B$5</c:f></c:numRef></c:yVal>
+        </c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.series).toEqual([
+      {
+        kind: "scatter",
+        index: 0,
+        name: "Trend",
+        valuesRef: "S!$B$2:$B$5",
+        categoriesRef: "S!$A$2:$A$5",
+      },
+    ]);
+  });
+
+  it("falls back to strRef cache for the series name", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx>
+            <c:strRef>
+              <c:f>Sheet1!$B$1</c:f>
+              <c:strCache>
+                <c:ptCount val="1"/>
+                <c:pt idx="0"><c:v>From Cache</c:v></c:pt>
+              </c:strCache>
+            </c:strRef>
+          </c:tx>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.series?.[0].name).toBe("From Cache");
+  });
+
+  it("uses the strRef formula text when no cache is present", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx>
+            <c:strRef><c:f>Sheet1!$B$1</c:f></c:strRef>
+          </c:tx>
+        </c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.series?.[0].name).toBe("Sheet1!$B$1");
+  });
+
+  it("omits valuesRef and categoriesRef for literal numLit series", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val>
+            <c:numLit>
+              <c:formatCode>General</c:formatCode>
+              <c:ptCount val="2"/>
+              <c:pt idx="0"><c:v>1</c:v></c:pt>
+              <c:pt idx="1"><c:v>2</c:v></c:pt>
+            </c:numLit>
+          </c:val>
+        </c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const series = parseChart(xml)?.series;
+    expect(series).toEqual([{ kind: "bar", index: 0 }]);
+  });
+
+  it("ignores malformed srgbClr values", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:solidFill><a:srgbClr val="not-a-color"/></a:solidFill></c:spPr>
+        </c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.series?.[0].color).toBeUndefined();
+  });
+
+  it("strips a leading '#' from srgbClr values and uppercases the result", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+                              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:solidFill><a:srgbClr val="#aabbcc"/></a:solidFill></c:spPr>
+        </c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.series?.[0].color).toBe("AABBCC");
+  });
+
+  it("indexes series independently per chart-type element in combo charts", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Bar A</c:v></c:tx>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:tx><c:v>Bar B</c:v></c:tx>
+        </c:ser>
+      </c:barChart>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="2"/>
+          <c:tx><c:v>Line A</c:v></c:tx>
+        </c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.series).toEqual([
+      { kind: "bar", index: 0, name: "Bar A" },
+      { kind: "bar", index: 1, name: "Bar B" },
+      { kind: "line", index: 0, name: "Line A" },
+    ]);
+  });
+
+  it("does not set series when the chart has no <c:ser> children", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart><c:plotArea><c:barChart/></c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["bar"]);
+    expect(chart?.seriesCount).toBe(0);
+    expect(chart?.series).toBeUndefined();
   });
 });
 
@@ -276,6 +498,7 @@ describe("readXlsx — chart integration", () => {
       kinds: ["bar"],
       seriesCount: 1,
       title: "Quarterly Sales",
+      series: [{ kind: "bar", index: 0, valuesRef: "Data!$B$1:$B$2" }],
     });
   });
 


### PR DESCRIPTION
## Summary

`parseChart` (and therefore `sheet.charts[i]`) previously surfaced only `kinds`, `seriesCount`, and `title`. The series themselves were unreachable, so users could see *that* a workbook had a chart but not *what* the chart was wired to. That's the gap that blocks the cloning workflow described in #136 (item 1 of the proposed approach: read chart definitions into a data model).

This PR fills that gap on the read side. `Chart.series` is now an array of `ChartSeriesInfo` records that mirror what `ChartSeries` accepts on the write side, so a parsed series can be used as the basis for a new `SheetChart` without remapping field names.

## API

```ts
import { readXlsx, type ChartSeriesInfo } from "hucre";

const wb = await readXlsx(buffer);
for (const chart of wb.sheets[0].charts ?? []) {
  for (const s of chart.series ?? []) {
    console.log(s.kind, s.index, s.name, s.valuesRef, s.categoriesRef, s.color);
    // e.g.  "bar"  0  "Revenue"  "Sheet1!$B$2:$B$10"  "Sheet1!$A$2:$A$10"  "1F77B4"
  }
}
```

## Model

```ts
interface ChartSeriesInfo {
  kind: ChartKind;            // matches Chart.kinds
  index: number;              // 0-based position inside its chart-type element
  name?: string;
  valuesRef?: string;         // raw <c:f> formula
  categoriesRef?: string;     // raw <c:f> formula
  color?: string;             // 6-digit RGB hex, upper-cased
}

interface Chart {
  kinds: ChartKind[];
  seriesCount: number;
  title?: string;
  series?: ChartSeriesInfo[]; // NEW — undefined when the chart has zero series
}
```

## Implementation

The reader walks every `<c:ser>` under each chart-type element in `<c:plotArea>` and records:

- **Kind & local index** — combo charts get independent per-kind indexing so the indices match the order Excel writes back when remapping.
- **Name** — literal `<c:v>` first, then `<c:strCache>` cached value, then the bare `<c:f>` formula text as a last resort (matches what other tools display when the cache is missing).
- **Values & categories** — `<c:val>` / `<c:cat>` for category-axis charts, `<c:yVal>` / `<c:xVal>` for scatter and bubble. `<c:numLit>` series (literal embedded data, no formula) intentionally surface no ref.
- **Color** — first `<a:srgbClr val>` under `<c:spPr><a:solidFill>`, normalized to upper-case 6-digit hex; malformed values are dropped instead of leaking through.

Refs #136 — covers item 1 of the issue's proposed approach (read chart definitions). `cloneChart` and `addChart` are intentionally out of scope here; the next step is straightforward now that `valuesRef` / `categoriesRef` are exposed (a user can already construct a `SheetChart` from a parsed chart).

## Test plan

- [x] Series name from literal `<c:v>`
- [x] Series name from `<c:strCache>` cached `<c:pt><c:v>`
- [x] Series name fallback to bare strRef formula text
- [x] Bar/column wiring via `<c:val>` and `<c:cat>`
- [x] Scatter wiring via `<c:xVal>` and `<c:yVal>`
- [x] `<c:numLit>` series omit `valuesRef` / `categoriesRef`
- [x] Color extraction from `<a:srgbClr>`, including `#`-prefix and case normalization
- [x] Malformed color values dropped (not surfaced as garbage)
- [x] Combo charts index series independently per chart-type element
- [x] `series` is `undefined` when a chart has zero `<c:ser>` children
- [x] Existing roundtrip tests still pass (kinds/title/seriesCount unchanged)
- [x] Full suite: `pnpm test` (lint + typecheck + 27,841 vitest tests)
- [x] `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)