### PR TITLE
feat(xlsx,ods): detect password-protected workbooks and surface EncryptedFileError

### DIFF
--- a/src/_input.ts
+++ b/src/_input.ts
@@ -12,7 +12,52 @@
 // ──────────────────────────────────────────────────────────────────────
 
 import type { ReadInput } from "./_types";
-import { ParseError } from "./errors";
+import { EncryptedFileError, ParseError } from "./errors";
+
+// ── OLE2 / Compound File Binary container detection ──────────────────
+//
+// Office password-protected XLSX / XLSM / ODS files are not ZIP archives —
+// they are OLE2 (a.k.a. Compound File Binary, CFB) containers carrying
+// `\EncryptionInfo` and `\EncryptedPackage` streams (MS-OFFCRYPTO
+// §2.3.4.x). They start with a fixed 8-byte magic header that has no
+// overlap with the ZIP / OOXML / ODF signatures, so a quick byte sniff
+// is enough to tell an encrypted container apart from a plain workbook.
+//
+// We don't actually decrypt the package here — full encryption support
+// is tracked in #156. Surfacing the situation early as a typed
+// `EncryptedFileError` saves callers from a confusing
+// `"not a valid ZIP archive"` ParseError several layers down.
+
+/** OLE2 / CFB magic header: `D0 CF 11 E0 A1 B1 1A E1`. */
+const OLE2_MAGIC = Object.freeze([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1] as const);
+
+/**
+ * Whether `data` starts with the OLE2 / CFB compound-document magic
+ * bytes — the envelope Office uses for password-protected XLSX, XLSM,
+ * and ODS files. Returns `false` for shorter buffers and for any other
+ * leading bytes (plain ZIP archives, XML, etc.).
+ */
+export function isOle2Container(data: Uint8Array): boolean {
+  if (data.length < OLE2_MAGIC.length) return false;
+  for (let i = 0; i < OLE2_MAGIC.length; i++) {
+    if (data[i] !== OLE2_MAGIC[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Throw {@link EncryptedFileError} when `data` is an OLE2 / CFB
+ * compound-document container — the envelope Office uses for
+ * password-protected XLSX / ODS workbooks. No-op for plain ZIP
+ * archives. `format` is recorded on the error so callers can
+ * distinguish XLSX vs. ODS encryption paths once decryption is wired
+ * up (see #156).
+ */
+export function assertNotEncrypted(data: Uint8Array, format: "xlsx" | "ods"): void {
+  if (isOle2Container(data)) {
+    throw new EncryptedFileError(format);
+  }
+}
 
 /**
  * Drain a {@link ReadableStream} of byte chunks into a single

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -18,8 +18,8 @@ import { readXlsx } from "./xlsx/reader";
 import { writeXlsx } from "./xlsx/writer";
 import { readOds } from "./ods/reader";
 import { writeOds } from "./ods/writer";
-import { UnsupportedFormatError } from "./errors";
-import { readInputToUint8Array } from "./_input";
+import { EncryptedFileError, UnsupportedFormatError } from "./errors";
+import { isOle2Container, readInputToUint8Array } from "./_input";
 
 // ── Format Detection ────────────────────────────────────────────────
 
@@ -83,6 +83,16 @@ function detectFormat(data: Uint8Array): "xlsx" | "ods" {
  */
 export async function read(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
   const data = await readInputToUint8Array(input);
+
+  // Surface password-protected workbooks (OLE2/CFB envelope) before
+  // `detectFormat` rejects them as "not a ZIP archive". The container
+  // alone doesn't tell us whether the encrypted package inside is XLSX
+  // or ODS, so we leave `format` unset on the error. Decryption is
+  // tracked in #156.
+  if (isOle2Container(data)) {
+    throw new EncryptedFileError();
+  }
+
   const format = detectFormat(data);
 
   if (format === "ods") {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -58,7 +58,22 @@ export class UnsupportedFormatError extends DefterError {
 export class EncryptedFileError extends DefterError {
   override name = "EncryptedFileError";
 
-  constructor() {
-    super("File is password-protected. Provide a password in options.");
+  /**
+   * Format hint for the encrypted container, when known. `"xlsx"` /
+   * `"ods"` mean the caller's reader detected the OLE2 / CFB envelope
+   * that Office uses for password-protected workbooks. Older callers
+   * that constructed `new EncryptedFileError()` without a hint still
+   * see `undefined` here.
+   */
+  readonly format?: "xlsx" | "ods";
+
+  constructor(format?: "xlsx" | "ods", message?: string) {
+    super(
+      message ??
+        (format
+          ? `File is password-protected (${format.toUpperCase()} encrypted with the OLE2/CFB container). Reading password-protected files is not yet supported.`
+          : "File is password-protected. Provide a password in options."),
+    );
+    this.format = format;
   }
 }

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -14,7 +14,7 @@ import type {
   Hyperlink,
 } from "../_types";
 import { ParseError, ZipError } from "../errors";
-import { readInputToUint8Array } from "../_input";
+import { assertNotEncrypted, readInputToUint8Array } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
 import type { XmlElement } from "../xml/parser";
@@ -570,6 +570,12 @@ function parseMetaXml(xml: string): Partial<WorkbookProperties> {
  */
 export async function readOds(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
   const data = await readInputToUint8Array(input);
+
+  // ODF supports password-encrypted documents via the same OLE2 / CFB
+  // envelope Office uses for XLSX. Catch it before the ZIP reader does
+  // so callers see a typed `EncryptedFileError` rather than a generic
+  // ZIP ParseError. Decryption is tracked in #156.
+  assertNotEncrypted(data, "ods");
 
   // 1. Open ZIP archive
   let zip: ZipReader;

--- a/src/ods/stream.ts
+++ b/src/ods/stream.ts
@@ -3,6 +3,7 @@
 
 import type { CellValue } from "../_types";
 import { ParseError, ZipError } from "../errors";
+import { assertNotEncrypted } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseSax } from "../xml/parser";
 
@@ -204,6 +205,11 @@ export async function* streamOdsRows(
   input: Uint8Array | ArrayBuffer,
 ): AsyncGenerator<OdsStreamRow, void, undefined> {
   const data = toUint8Array(input);
+
+  // Detect password-protected ODF workbooks (OLE2/CFB envelope) up
+  // front so streamers fail fast with a typed `EncryptedFileError`
+  // instead of a generic ZIP ParseError. Decryption is tracked in #156.
+  assertNotEncrypted(data, "ods");
 
   // 1. Open ZIP archive
   let zip: ZipReader;

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -30,7 +30,7 @@ import {
 } from "./slicer-reader";
 import { parseChart } from "./chart-reader";
 import { ParseError, ZipError } from "../errors";
-import { readInputToUint8Array } from "../_input";
+import { assertNotEncrypted, readInputToUint8Array } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseXml } from "../xml/parser";
 import { parseContentTypes } from "./content-types";
@@ -115,6 +115,12 @@ function dirname(path: string): string {
  */
 export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
   const data = await readInputToUint8Array(input);
+
+  // Detect password-protected workbooks (OLE2/CFB envelope) and surface
+  // a typed `EncryptedFileError` instead of letting the ZIP reader fail
+  // with a generic "not a valid ZIP archive" ParseError. Decryption
+  // itself is tracked in #156.
+  assertNotEncrypted(data, "xlsx");
 
   // 1. Open ZIP archive
   let zip: ZipReader;

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -8,7 +8,7 @@ import type { SharedString } from "./shared-strings";
 import type { ParsedStyles } from "./styles";
 import type { Relationship } from "./relationships";
 import { ParseError, ZipError } from "../errors";
-import { bufferReadableStream } from "../_input";
+import { assertNotEncrypted, bufferReadableStream } from "../_input";
 import { ZipReader } from "../zip/reader";
 import { parseXml, parseSaxStream, decodeOoxmlEscapes } from "../xml/parser";
 import { parseContentTypes } from "./content-types";
@@ -479,6 +479,11 @@ export async function* streamXlsxRows(
   } else {
     data = await bufferReadableStream(input);
   }
+
+  // Detect password-protected workbooks (OLE2/CFB envelope) up front so
+  // streamers fail fast with a typed `EncryptedFileError` instead of a
+  // generic ZIP ParseError. Decryption is tracked in #156.
+  assertNotEncrypted(data, "xlsx");
 
   // 1. Open ZIP archive
   let zip: ZipReader;

--- a/test/encrypted-file-detection.test.ts
+++ b/test/encrypted-file-detection.test.ts
@@ -1,0 +1,234 @@
+// ── Encrypted-workbook detection across reader entry points ────────────
+//
+// Office encrypts password-protected XLSX / XLSM / ODS files inside an
+// OLE2 / Compound File Binary container (MS-OFFCRYPTO). Until full
+// decryption lands (#156), every reader should recognize the OLE2
+// header up front and surface a typed `EncryptedFileError` rather than
+// the confusing `"not a valid ZIP archive"` ParseError that the ZIP
+// reader throws when it tries to open one.
+//
+// Each test here builds a synthetic OLE2 buffer (just the 8-byte magic
+// padded with zeros — enough to hit the byte-sniff path) and exercises
+// every public reader entry point.
+// ──────────────────────────────────────────────────────────────────────
+
+import { describe, expect, it } from "vitest";
+import { readXlsx } from "../src/xlsx/reader";
+import { streamXlsxRows } from "../src/xlsx/stream-reader";
+import { readOds } from "../src/ods/reader";
+import { read, readObjects } from "../src/defter";
+import { readXlsxObjects } from "../src/xlsx/objects";
+import { readOdsObjects } from "../src/ods/objects";
+import { isOle2Container } from "../src/_input";
+import { EncryptedFileError, DefterError, ZipError, ParseError } from "../src/errors";
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** OLE2 / CFB compound-document magic header. */
+const OLE2_MAGIC = new Uint8Array([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+
+/**
+ * Build a minimal OLE2 container — the 8-byte magic header plus enough
+ * padding zero bytes to clear the ZIP "data too small" guard. The byte
+ * sniff only inspects the first 8 bytes, so the rest of the buffer is
+ * irrelevant to the detection path under test.
+ */
+function makeOle2Container(extraBytes: number = 256): Uint8Array {
+  const buf = new Uint8Array(OLE2_MAGIC.length + extraBytes);
+  buf.set(OLE2_MAGIC, 0);
+  return buf;
+}
+
+function toReadableStream(data: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+}
+
+// ── isOle2Container ─────────────────────────────────────────────────
+
+describe("isOle2Container — byte-sniff helper", () => {
+  it("returns true for the 8-byte CFB magic header", () => {
+    expect(isOle2Container(OLE2_MAGIC)).toBe(true);
+  });
+
+  it("returns true for the magic followed by trailing bytes", () => {
+    expect(isOle2Container(makeOle2Container(64))).toBe(true);
+  });
+
+  it("returns false for a plain ZIP archive (PK\\x03\\x04)", () => {
+    const zipMagic = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0]);
+    expect(isOle2Container(zipMagic)).toBe(false);
+  });
+
+  it("returns false for buffers shorter than the magic", () => {
+    expect(isOle2Container(new Uint8Array(0))).toBe(false);
+    expect(isOle2Container(new Uint8Array([0xd0, 0xcf, 0x11]))).toBe(false);
+  });
+
+  it("returns false when only the first byte matches", () => {
+    const almost = new Uint8Array([0xd0, 0, 0, 0, 0, 0, 0, 0]);
+    expect(isOle2Container(almost)).toBe(false);
+  });
+});
+
+// ── readXlsx ────────────────────────────────────────────────────────
+
+describe("readXlsx — encrypted XLSX detection", () => {
+  it("throws EncryptedFileError for the OLE2 magic instead of a ZIP ParseError", async () => {
+    const data = makeOle2Container();
+
+    await expect(readXlsx(data)).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+
+  it('attaches format="xlsx" to the error so callers can branch', async () => {
+    const data = makeOle2Container();
+
+    try {
+      await readXlsx(data);
+      throw new Error("readXlsx should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EncryptedFileError);
+      const enc = err as EncryptedFileError;
+      expect(enc.format).toBe("xlsx");
+      expect(enc.message).toContain("password-protected");
+      expect(enc.message).toContain("XLSX");
+      // Must extend the project's base error so existing catch-all
+      // handlers `instanceof DefterError` keep working.
+      expect(err).toBeInstanceOf(DefterError);
+      // EncryptedFileError is intentionally distinct from ZipError /
+      // ParseError so callers can branch on it.
+      expect(err).not.toBeInstanceOf(ZipError);
+      expect(err).not.toBeInstanceOf(ParseError);
+    }
+  });
+
+  it("detects encryption when the input arrives as a ReadableStream", async () => {
+    const data = makeOle2Container();
+
+    await expect(readXlsx(toReadableStream(data))).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+
+  it("accepts ArrayBuffer encoding of the OLE2 container", async () => {
+    const data = makeOle2Container();
+    const ab = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+
+    await expect(readXlsx(ab)).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+});
+
+// ── streamXlsxRows ──────────────────────────────────────────────────
+
+describe("streamXlsxRows — encrypted XLSX detection", () => {
+  it("rejects the generator with EncryptedFileError before ZIP parsing runs", async () => {
+    const data = makeOle2Container();
+
+    const gen = streamXlsxRows(data);
+    await expect(gen.next()).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+
+  it("detects encryption from a chunked ReadableStream input", async () => {
+    const data = makeOle2Container();
+
+    const gen = streamXlsxRows(toReadableStream(data));
+    await expect(gen.next()).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+});
+
+// ── readOds ─────────────────────────────────────────────────────────
+
+describe("readOds — encrypted ODS detection", () => {
+  it('throws EncryptedFileError with format="ods" for the OLE2 magic', async () => {
+    const data = makeOle2Container();
+
+    try {
+      await readOds(data);
+      throw new Error("readOds should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EncryptedFileError);
+      const enc = err as EncryptedFileError;
+      expect(enc.format).toBe("ods");
+      expect(enc.message).toContain("ODS");
+    }
+  });
+
+  it("detects encryption from a ReadableStream input", async () => {
+    const data = makeOle2Container();
+
+    await expect(readOds(toReadableStream(data))).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+});
+
+// ── unified read() / readObjects() ──────────────────────────────────
+
+describe("read() — encrypted workbook detection (auto-detect path)", () => {
+  it("throws EncryptedFileError before format auto-detection runs", async () => {
+    const data = makeOle2Container();
+
+    try {
+      await read(data);
+      throw new Error("read() should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EncryptedFileError);
+      // The unified entry point can't tell whether the encrypted
+      // package is XLSX or ODS without decrypting, so `format` is
+      // intentionally undefined.
+      expect((err as EncryptedFileError).format).toBeUndefined();
+    }
+  });
+
+  it("readObjects() inherits the same detection path", async () => {
+    const data = makeOle2Container();
+
+    await expect(readObjects(data)).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+
+  it("detects encryption from a ReadableStream via read()", async () => {
+    const data = makeOle2Container();
+
+    await expect(read(toReadableStream(data))).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+});
+
+// ── Object shorthands ──────────────────────────────────────────────
+
+describe("readXlsxObjects / readOdsObjects — encrypted detection", () => {
+  it("readXlsxObjects throws EncryptedFileError", async () => {
+    const data = makeOle2Container();
+
+    await expect(readXlsxObjects(data)).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+
+  it("readOdsObjects throws EncryptedFileError", async () => {
+    const data = makeOle2Container();
+
+    await expect(readOdsObjects(data)).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+});
+
+// ── EncryptedFileError API ─────────────────────────────────────────
+
+describe("EncryptedFileError — constructor surface", () => {
+  it("supports the legacy zero-arg constructor with no format hint", () => {
+    const err = new EncryptedFileError();
+    expect(err.name).toBe("EncryptedFileError");
+    expect(err.format).toBeUndefined();
+    expect(err.message).toBe("File is password-protected. Provide a password in options.");
+  });
+
+  it("includes the format hint and a uppercase format token in the default message", () => {
+    const err = new EncryptedFileError("xlsx");
+    expect(err.format).toBe("xlsx");
+    expect(err.message).toContain("XLSX");
+    expect(err.message).toContain("password-protected");
+  });
+
+  it("accepts a fully custom message override while still tracking the format", () => {
+    const err = new EncryptedFileError("ods", "custom note");
+    expect(err.format).toBe("ods");
+    expect(err.message).toBe("custom note");
+  });
+});

--- a/test/encrypted-file-detection.test.ts
+++ b/test/encrypted-file-detection.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import { readXlsx } from "../src/xlsx/reader";
 import { streamXlsxRows } from "../src/xlsx/stream-reader";
 import { readOds } from "../src/ods/reader";
+import { streamOdsRows } from "../src/ods/stream";
 import { read, readObjects } from "../src/defter";
 import { readXlsxObjects } from "../src/xlsx/objects";
 import { readOdsObjects } from "../src/ods/objects";
@@ -159,6 +160,30 @@ describe("readOds — encrypted ODS detection", () => {
     const data = makeOle2Container();
 
     await expect(readOds(toReadableStream(data))).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+});
+
+// ── streamOdsRows ───────────────────────────────────────────────────
+
+describe("streamOdsRows — encrypted ODS detection", () => {
+  it("rejects the generator with EncryptedFileError before ZIP parsing runs", async () => {
+    const data = makeOle2Container();
+
+    const gen = streamOdsRows(data);
+    await expect(gen.next()).rejects.toBeInstanceOf(EncryptedFileError);
+  });
+
+  it('attaches format="ods" to the error', async () => {
+    const data = makeOle2Container();
+
+    const gen = streamOdsRows(data);
+    try {
+      await gen.next();
+      throw new Error("streamOdsRows should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(EncryptedFileError);
+      expect((err as EncryptedFileError).format).toBe("ods");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Office encrypts password-protected XLSX / XLSM / ODS files inside an OLE2 / Compound File Binary (CFB) container — `\EncryptionInfo` and `\EncryptedPackage` streams per MS-OFFCRYPTO. The container has a fixed 8-byte magic header (`D0 CF 11 E0 A1 B1 1A E1`) that does not overlap with the ZIP / OOXML / ODF signatures, so a quick byte sniff is enough to tell an encrypted workbook apart from a plain one.

Until this PR, every reader fed those files straight into `ZipReader` and callers got a confusing `"Failed to open XLSX file: not a valid ZIP archive"` `ParseError` several layers down. The already-exported `EncryptedFileError` was never actually thrown by any code path.

## What this PR does

- **`src/_input.ts`** — adds two helpers, `isOle2Container(data)` (byte-sniff) and `assertNotEncrypted(data, format)` (throws `EncryptedFileError` with a format hint).
- **`src/errors.ts`** — `EncryptedFileError` now accepts an optional `format: "xlsx" | "ods"` hint plus an optional message override. The zero-arg constructor stays backward-compatible.
- **Reader entry points** — `readXlsx`, `streamXlsxRows`, and `readOds` all sniff the buffered input before opening the ZIP. The unified `read()` / `readObjects()` dispatcher catches encrypted containers before `detectFormat()` rejects them as "not a ZIP archive". The `readXlsxObjects` / `readOdsObjects` shorthands inherit detection through the readers they delegate to.

```ts
import { read, EncryptedFileError } from "hucre";

try {
  await read(buffer);
} catch (err) {
  if (err instanceof EncryptedFileError) {
    // err.format → "xlsx" | "ods" | undefined (undefined from read() since
    // we cannot tell which format the encrypted package wraps without
    // decrypting it first)
    return showPasswordPrompt();
  }
  throw err;
}
```

## What is *not* in this PR

Actual decryption of the OLE2 envelope (the `\EncryptionInfo` parsing, AES-CBC + SHA-256/512 PBKDF, package extraction). That is the bulk of #156 and intentionally out of scope here — this PR only closes the UX gap so callers no longer see a misleading ZIP error and can branch on a typed error today. Full encryption support is tracked in #156.

Refs #156

## Test plan

- [x] New `test/encrypted-file-detection.test.ts` — 21 cases covering:
  - `isOle2Container` byte sniff (magic, padding, ZIP, short buffer, partial match)
  - `readXlsx` (Uint8Array, ArrayBuffer, ReadableStream) — error type, `format`, message, base-class chain
  - `streamXlsxRows` (Uint8Array, ReadableStream)
  - `readOds` (Uint8Array, ReadableStream) — `format="ods"` hint
  - Unified `read()` and `readObjects()` — `format` undefined since the dispatcher cannot disambiguate
  - `readXlsxObjects` / `readOdsObjects`
  - `EncryptedFileError` constructor surface (legacy, format hint, custom message)
- [x] `pnpm exec vitest run` — 980 files / 27924 tests green.
- [x] `pnpm lint` (oxlint + oxfmt --check) — 0 errors.
- [x] `pnpm typecheck` — green.
- [x] `pnpm build` — green.