### PR TITLE
feat(xlsx): cloneChart — bridge parseChart output into SheetChart

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,40 @@ toggles `clustered` / `stacked` / `percentStacked`, `legend` accepts
 attributes for screen readers. Doughnut, radar, stock, 3D variants,
 trendlines, and combo charts are out of scope for Phase 1.
 
+#### Cloning a parsed chart with `cloneChart`
+
+`cloneChart(source, options)` bridges the read-side `Chart` produced by
+`parseChart` to the write-side `SheetChart` consumed by `writeXlsx`, so
+a template workbook can supply the visual styling for a new export and
+the caller only needs to swap the data ranges:
+
+```ts
+import { parseChart, cloneChart, writeXlsx } from "hucre";
+
+const template = parseChart(templateChartXml)!;
+
+const chart = cloneChart(template, {
+  anchor: { from: { row: 14, col: 0 }, to: { row: 28, col: 8 } },
+  title: "Q1 Revenue",
+  seriesOverrides: [{ values: "Dashboard!$B$2:$B$13", color: "1070CA" }],
+});
+
+await writeXlsx({
+  sheets: [{ name: "Dashboard", rows: dashboardRows, charts: [chart] }],
+});
+```
+
+`anchor` is required (the read side has no placement metadata).
+Per-series overrides accept `null` to drop an inherited value (e.g.
+`color: null` strips the template tint), can append new series past
+the source length, and fall back to the source's `valuesRef` /
+`categoriesRef` / `name` / `color` when omitted. Source kinds the
+writer can author collapse onto their write counterparts (`bar` /
+`bar3D` → `column`, `doughnut` / `pie3D` → `pie`, `line3D` → `line`,
+`area3D` → `area`); kinds with no analog (`bubble`, `radar`,
+`surface`, `stock`, `ofPie`) require an explicit `options.type`
+override.
+
 ### Unified API
 
 Auto-detect format and work with simple helpers:
@@ -1056,6 +1090,8 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 | `parsePivotCacheDefinition(xml)`   | Parse `xl/pivotCache/pivotCacheDefinitionN.xml` → `PivotCache \| undefined` |
 | `attachPivotCacheFields(pt, c)`    | Overlay `PivotCache.fieldNames` onto a `PivotTable.fields[].name`           |
 | `parseChart(xml)`                  | Parse `xl/charts/chartN.xml` → `Chart \| undefined`                         |
+| `cloneChart(source, options)`      | Convert a parsed `Chart` into a writer-ready `SheetChart`                   |
+| `chartKindToWriteKind(kind)`       | Map a read-side `ChartKind` onto its writable counterpart, if any           |
 
 ### ODS
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,8 @@ export type {
 
 // ── Charts ─────────────────────────────────────────────────────────
 export { parseChart } from "./xlsx/chart-reader";
+export { cloneChart, chartKindToWriteKind } from "./xlsx/chart-clone";
+export type { CloneChartOptions, CloneChartSeriesOverride } from "./xlsx/chart-clone";
 export type { Chart, ChartKind, ChartSeriesInfo } from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -1,0 +1,275 @@
+// ── Chart Clone ──────────────────────────────────────────────────────
+// Bridges the read-side `Chart` metadata produced by `parseChart` to the
+// write-side `SheetChart` shape consumed by `writeXlsx`.
+//
+// Use case (issue #136): a template workbook stores one of each chart
+// flavor; at export time the caller pulls a chart out, swaps its data
+// ranges and labels, and re-emits it (often several times) into a new
+// workbook. The two type families overlap — `ChartSeriesInfo` already
+// mirrors `ChartSeries` — but the read side has no anchor and supports
+// kinds the write side cannot author yet, so a dedicated converter
+// keeps the type-narrowing explicit.
+
+import type {
+  Chart,
+  ChartKind,
+  ChartSeries,
+  ChartSeriesInfo,
+  SheetChart,
+  WriteChartKind,
+} from "../_types";
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * Per-series override applied on top of the source chart's series.
+ *
+ * Each field defaults to the value carried by the source series at the
+ * matching position. Pass `null` to drop the source value entirely
+ * (e.g. `color: null` removes a series tint inherited from the
+ * template).
+ */
+export interface CloneChartSeriesOverride {
+  name?: string | null;
+  /** A1 range for `<c:val>` / `<c:yVal>`. Required when the source has none. */
+  values?: string;
+  /** A1 range for `<c:cat>` / `<c:xVal>`. */
+  categories?: string | null;
+  /** 6-digit RGB hex (e.g. `"1F77B4"`). */
+  color?: string | null;
+}
+
+/**
+ * Options accepted by {@link cloneChart}.
+ *
+ * `anchor` is required because the read-side `Chart` does not capture
+ * placement — drawings live in a separate part. Every other field
+ * defaults to the source chart.
+ */
+export interface CloneChartOptions {
+  /**
+   * Cell anchor for the cloned chart. `to` defaults to a 6×15 area
+   * below `from`, mirroring `SheetChart.anchor`.
+   */
+  anchor: SheetChart["anchor"];
+  /**
+   * Override the chart family. When omitted, the source's first
+   * write-compatible kind is used. An explicit value lets callers
+   * narrow a combo chart down to one renderable type or coerce a
+   * `doughnut` template into a plain `pie`.
+   */
+  type?: WriteChartKind;
+  /** Override the chart title. Pass `null` to drop the source title. */
+  title?: string | null;
+  /** Replace the entire series array (skips per-series merging). */
+  series?: ChartSeries[];
+  /**
+   * Per-series overrides. Indices line up with the source's
+   * {@link Chart.series}. Use this to remap data ranges without
+   * rewriting every other field.
+   */
+  seriesOverrides?: ReadonlyArray<CloneChartSeriesOverride | undefined>;
+  /** Override `SheetChart.legend`. */
+  legend?: SheetChart["legend"];
+  /** Override `SheetChart.barGrouping`. */
+  barGrouping?: SheetChart["barGrouping"];
+  /** Override `SheetChart.showTitle`. */
+  showTitle?: boolean;
+  /** Override `SheetChart.altText`. */
+  altText?: string;
+  /** Override `SheetChart.frameTitle`. */
+  frameTitle?: string;
+}
+
+/**
+ * Convert a parsed {@link Chart} into a {@link SheetChart} ready for
+ * `writeXlsx`. Series formula references (`valuesRef`, `categoriesRef`)
+ * become `values` / `categories` on the new chart; per-series colors
+ * carry over.
+ *
+ * @throws {Error} when the source chart kinds cannot be authored on
+ *   the write side and no `options.type` override is provided.
+ * @throws {Error} when a non-overridden series has no `valuesRef` —
+ *   `SheetChart.series[].values` is mandatory.
+ *
+ * @example
+ * ```ts
+ * import { parseChart, cloneChart } from "hucre";
+ *
+ * const source = parseChart(templateChartXml)!;
+ * const clone = cloneChart(source, {
+ *   anchor: { from: { row: 14, col: 0 } },
+ *   title: "Revenue",
+ *   seriesOverrides: [{ values: "Dashboard!$B$2:$B$13", color: "1070CA" }],
+ * });
+ * ```
+ */
+export function cloneChart(source: Chart, options: CloneChartOptions): SheetChart {
+  if (!options || !options.anchor) {
+    throw new Error("cloneChart: options.anchor is required");
+  }
+
+  const type = options.type ?? pickWritableKind(source);
+
+  // Pick a base title: explicit override (including `null` meaning drop)
+  // wins over the source's title.
+  const title = resolveTitle(source.title, options.title);
+
+  // Build the series array.
+  let series: ChartSeries[];
+  if (options.series) {
+    series = options.series.map((s) => ({ ...s }));
+  } else {
+    series = buildSeriesFromSource(source, options.seriesOverrides);
+  }
+
+  if (series.length === 0) {
+    throw new Error(
+      "cloneChart: produced 0 series; pass `series` or ensure the source has at least one series with a valuesRef",
+    );
+  }
+
+  const out: SheetChart = {
+    type,
+    series,
+    anchor: options.anchor,
+  };
+  if (title !== undefined) out.title = title;
+  if (options.legend !== undefined) out.legend = options.legend;
+  if (options.barGrouping !== undefined) out.barGrouping = options.barGrouping;
+  if (options.showTitle !== undefined) out.showTitle = options.showTitle;
+  if (options.altText !== undefined) out.altText = options.altText;
+  if (options.frameTitle !== undefined) out.frameTitle = options.frameTitle;
+
+  return out;
+}
+
+// ── Internals ────────────────────────────────────────────────────────
+
+/**
+ * Map a read-side {@link ChartKind} to the writer's
+ * {@link WriteChartKind}, or `undefined` when no equivalent exists.
+ *
+ * The writer authors the six families covered in chart writer Phase 1
+ * (issue #152). 3D variants collapse onto their 2D counterparts;
+ * `doughnut` collapses to `pie`. Kinds with no analog (`bubble`,
+ * `radar`, `surface`, `stock`, `ofPie`) return `undefined` and force
+ * the caller to pass an explicit `type` override.
+ */
+export function chartKindToWriteKind(kind: ChartKind): WriteChartKind | undefined {
+  switch (kind) {
+    case "bar":
+    case "bar3D":
+      // Read-side `bar` covers both `<c:barChart barDir="bar">` and
+      // `<c:barChart barDir="col">`; the parser does not split them.
+      // Default to the more common vertical orientation; callers who
+      // need horizontal pass `type: "bar"` explicitly.
+      return "column";
+    case "line":
+    case "line3D":
+      return "line";
+    case "pie":
+    case "pie3D":
+    case "doughnut":
+      return "pie";
+    case "area":
+    case "area3D":
+      return "area";
+    case "scatter":
+      return "scatter";
+    case "bubble":
+    case "radar":
+    case "surface":
+    case "surface3D":
+    case "stock":
+    case "ofPie":
+      return undefined;
+  }
+}
+
+function pickWritableKind(source: Chart): WriteChartKind {
+  if (source.kinds.length === 0) {
+    throw new Error("cloneChart: source chart has no kinds; pass `options.type` explicitly");
+  }
+  for (const k of source.kinds) {
+    const mapped = chartKindToWriteKind(k);
+    if (mapped) return mapped;
+  }
+  throw new Error(
+    `cloneChart: source kind${source.kinds.length > 1 ? "s" : ""} ${source.kinds
+      .map((k) => `"${k}"`)
+      .join(
+        ", ",
+      )} cannot be authored on the write side; pass \`options.type\` to coerce a renderable kind`,
+  );
+}
+
+function resolveTitle(
+  sourceTitle: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return sourceTitle;
+  if (override === null) return undefined;
+  return override;
+}
+
+function buildSeriesFromSource(
+  source: Chart,
+  overrides: ReadonlyArray<CloneChartSeriesOverride | undefined> | undefined,
+): ChartSeries[] {
+  const sourceSeries = source.series ?? [];
+  // The override array can be longer than the source (caller wants to
+  // append a fully-specified series). Walk the union of both lengths.
+  const length = Math.max(sourceSeries.length, overrides?.length ?? 0);
+  const out: ChartSeries[] = [];
+
+  for (let i = 0; i < length; i++) {
+    const src: ChartSeriesInfo | undefined = sourceSeries[i];
+    const ov = overrides?.[i];
+    const merged = mergeSeries(src, ov, i);
+    out.push(merged);
+  }
+
+  return out;
+}
+
+function mergeSeries(
+  src: ChartSeriesInfo | undefined,
+  ov: CloneChartSeriesOverride | undefined,
+  index: number,
+): ChartSeries {
+  // Resolve `values` first — it's the only mandatory field.
+  const values = ov?.values ?? src?.valuesRef;
+  if (!values) {
+    throw new Error(
+      `cloneChart: series #${index} has no values reference; provide \`seriesOverrides[${index}].values\``,
+    );
+  }
+
+  const out: ChartSeries = { values };
+
+  const name = applyOverride(src?.name, ov?.name);
+  if (name !== undefined) out.name = name;
+
+  const categories = applyOverride(src?.categoriesRef, ov?.categories);
+  if (categories !== undefined) out.categories = categories;
+
+  const color = applyOverride(src?.color, ov?.color);
+  if (color !== undefined) out.color = color;
+
+  return out;
+}
+
+/**
+ * Resolve a "source value + optional override" pair where the override
+ * may be `undefined` (no override), `null` (drop the source value), or
+ * a string (replace).
+ */
+function applyOverride(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it } from "vitest";
+import { chartKindToWriteKind, cloneChart } from "../src/xlsx/chart-clone";
+import { parseChart } from "../src/xlsx/chart-reader";
+import { writeChart } from "../src/xlsx/chart-writer";
+import { writeXlsx } from "../src/xlsx/writer";
+import { ZipReader } from "../src/zip/reader";
+import type { Chart, SheetChart } from "../src/_types";
+
+const decoder = new TextDecoder("utf-8");
+
+// ── chartKindToWriteKind ─────────────────────────────────────────────
+
+describe("chartKindToWriteKind", () => {
+  it("maps every read-side kind that has a write-side analog", () => {
+    expect(chartKindToWriteKind("bar")).toBe("column");
+    expect(chartKindToWriteKind("bar3D")).toBe("column");
+    expect(chartKindToWriteKind("line")).toBe("line");
+    expect(chartKindToWriteKind("line3D")).toBe("line");
+    expect(chartKindToWriteKind("pie")).toBe("pie");
+    expect(chartKindToWriteKind("pie3D")).toBe("pie");
+    expect(chartKindToWriteKind("doughnut")).toBe("pie");
+    expect(chartKindToWriteKind("area")).toBe("area");
+    expect(chartKindToWriteKind("area3D")).toBe("area");
+    expect(chartKindToWriteKind("scatter")).toBe("scatter");
+  });
+
+  it("returns undefined for kinds the writer cannot author", () => {
+    expect(chartKindToWriteKind("bubble")).toBeUndefined();
+    expect(chartKindToWriteKind("radar")).toBeUndefined();
+    expect(chartKindToWriteKind("surface")).toBeUndefined();
+    expect(chartKindToWriteKind("surface3D")).toBeUndefined();
+    expect(chartKindToWriteKind("stock")).toBeUndefined();
+    expect(chartKindToWriteKind("ofPie")).toBeUndefined();
+  });
+});
+
+// ── cloneChart — basics ──────────────────────────────────────────────
+
+describe("cloneChart", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      title: "Template Revenue",
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+          color: "1F77B4",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("requires options.anchor", () => {
+    expect(() =>
+      // @ts-expect-error — testing runtime guard for missing required field
+      cloneChart(source(), {}),
+    ).toThrow(/anchor is required/);
+  });
+
+  it("carries source title, name, ranges, and color through to the clone", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+    });
+
+    expect(clone.type).toBe("column"); // bar → column (vertical default)
+    expect(clone.title).toBe("Template Revenue");
+    expect(clone.anchor).toEqual({ from: { row: 5, col: 0 }, to: { row: 20, col: 6 } });
+    expect(clone.series).toEqual([
+      {
+        name: "Revenue",
+        values: "Sheet1!$B$2:$B$5",
+        categories: "Sheet1!$A$2:$A$5",
+        color: "1F77B4",
+      },
+    ]);
+  });
+
+  it("honors options.type to coerce kinds the writer cannot author", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+  });
+
+  it("auto-collapses doughnut to pie when no type override is given", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("pie");
+  });
+
+  it("throws when the source has no writable kind and no override is given", () => {
+    expect(() =>
+      cloneChart(source({ kinds: ["bubble", "radar"] }), {
+        anchor: { from: { row: 0, col: 0 } },
+      }),
+    ).toThrow(/cannot be authored on the write side/);
+  });
+
+  it("throws when the source has no kinds and no override is given", () => {
+    expect(() =>
+      cloneChart({ kinds: [], seriesCount: 0 }, { anchor: { from: { row: 0, col: 0 } } }),
+    ).toThrow(/no kinds/);
+  });
+
+  it("falls back to options.type when source has no writable kind", () => {
+    const clone = cloneChart(source({ kinds: ["bubble"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+  });
+
+  it("drops the source title when title=null is passed", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+  });
+
+  it("replaces the source title when a string is passed", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Q1 Revenue",
+    });
+    expect(clone.title).toBe("Q1 Revenue");
+  });
+
+  it("forwards legend, barGrouping, showTitle, altText, frameTitle", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "bottom",
+      barGrouping: "stacked",
+      showTitle: false,
+      altText: "Revenue chart",
+      frameTitle: "Revenue",
+    });
+    expect(clone.legend).toBe("bottom");
+    expect(clone.barGrouping).toBe("stacked");
+    expect(clone.showTitle).toBe(false);
+    expect(clone.altText).toBe("Revenue chart");
+    expect(clone.frameTitle).toBe("Revenue");
+  });
+});
+
+// ── cloneChart — series overrides ────────────────────────────────────
+
+describe("cloneChart — series overrides", () => {
+  const twoSeries: Chart = {
+    kinds: ["bar"],
+    seriesCount: 2,
+    series: [
+      {
+        kind: "bar",
+        index: 0,
+        name: "Revenue",
+        valuesRef: "Tpl!$B$2:$B$5",
+        categoriesRef: "Tpl!$A$2:$A$5",
+        color: "1070CA",
+      },
+      {
+        kind: "bar",
+        index: 1,
+        name: "Cost",
+        valuesRef: "Tpl!$C$2:$C$5",
+        categoriesRef: "Tpl!$A$2:$A$5",
+        color: "E54D2E",
+      },
+    ],
+  };
+
+  it("merges per-series overrides on top of the source", () => {
+    const clone = cloneChart(twoSeries, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [
+        { values: "Dashboard!$B$2:$B$13", color: "00C586" },
+        { name: "Total Cost" },
+      ],
+    });
+
+    expect(clone.series).toEqual([
+      {
+        name: "Revenue",
+        values: "Dashboard!$B$2:$B$13",
+        categories: "Tpl!$A$2:$A$5",
+        color: "00C586",
+      },
+      {
+        name: "Total Cost",
+        values: "Tpl!$C$2:$C$5",
+        categories: "Tpl!$A$2:$A$5",
+        color: "E54D2E",
+      },
+    ]);
+  });
+
+  it("treats null overrides as 'drop the inherited value'", () => {
+    const clone = cloneChart(twoSeries, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ name: null, color: null, categories: null }, undefined],
+    });
+
+    expect(clone.series[0].name).toBeUndefined();
+    expect(clone.series[0].color).toBeUndefined();
+    expect(clone.series[0].categories).toBeUndefined();
+    // Untouched series retains its source values.
+    expect(clone.series[1].name).toBe("Cost");
+  });
+
+  it("appends a new series past the source length when provided", () => {
+    const clone = cloneChart(twoSeries, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [undefined, undefined, { name: "Margin", values: "Dashboard!$D$2:$D$13" }],
+    });
+
+    expect(clone.series).toHaveLength(3);
+    expect(clone.series[2]).toEqual({
+      name: "Margin",
+      values: "Dashboard!$D$2:$D$13",
+    });
+  });
+
+  it("replaces the entire series array when options.series is provided", () => {
+    const clone = cloneChart(twoSeries, {
+      anchor: { from: { row: 0, col: 0 } },
+      series: [{ name: "Only", values: "Sheet1!$B$2:$B$10" }],
+    });
+
+    expect(clone.series).toEqual([{ name: "Only", values: "Sheet1!$B$2:$B$10" }]);
+  });
+
+  it("throws when a series ends up without a values reference", () => {
+    const noValues: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, name: "Empty" }],
+    };
+    expect(() =>
+      cloneChart(noValues, {
+        anchor: { from: { row: 0, col: 0 } },
+      }),
+    ).toThrow(/no values reference/);
+  });
+
+  it("throws when both source and options produce zero series", () => {
+    expect(() =>
+      cloneChart({ kinds: ["bar"], seriesCount: 0 }, { anchor: { from: { row: 0, col: 0 } } }),
+    ).toThrow(/0 series/);
+  });
+});
+
+// ── cloneChart — round-trip with parseChart and writeXlsx ────────────
+
+describe("cloneChart — integration", () => {
+  it("produces a SheetChart that writeChart accepts and writeXlsx packages", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:title><c:tx><c:rich><a:p><a:r><a:t>Template Title</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Series A</c:v></c:tx>
+          <c:spPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></c:spPr>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed).toBeDefined();
+
+    const sheetChart: SheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 14, col: 0 }, to: { row: 28, col: 8 } },
+      title: "Revenue",
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$13", color: "00C586" }],
+    });
+
+    // writeChart should accept the result and emit the expected fingerprints.
+    const result = writeChart(sheetChart, "Dashboard");
+    expect(result.chartXml).toContain("<c:lineChart>");
+    expect(result.chartXml).toContain("Revenue");
+    expect(result.chartXml).toContain("Dashboard!$B$2:$B$13");
+    expect(result.chartXml).toContain('val="00C586"');
+    // Categories from source should survive.
+    expect(result.chartXml).toContain("Tpl!$A$2:$A$5");
+
+    // End-to-end: writeXlsx packages the chart into a valid OOXML file.
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [1], [2], [3], [4]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+
+    const zip = new ZipReader(xlsx);
+    expect(zip.has("xl/charts/chart1.xml")).toBe(true);
+    const writtenChart = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(writtenChart).toContain("<c:lineChart>");
+    expect(writtenChart).toContain("Dashboard!$B$2:$B$13");
+  });
+
+  it("can clone the same template into multiple chart instances", () => {
+    const template: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      title: "Template",
+      series: [
+        {
+          kind: "pie",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          color: "1070CA",
+        },
+      ],
+    };
+
+    const dashboards = [
+      { title: "Q1", values: "Dash!$B$2:$B$5", color: "1070CA" },
+      { title: "Q2", values: "Dash!$C$2:$C$5", color: "00C586" },
+      { title: "Q3", values: "Dash!$D$2:$D$5", color: "F76808" },
+    ];
+
+    const clones = dashboards.map((d, i) =>
+      cloneChart(template, {
+        anchor: { from: { row: i * 16, col: 0 } },
+        title: d.title,
+        seriesOverrides: [{ values: d.values, color: d.color }],
+      }),
+    );
+
+    expect(clones).toHaveLength(3);
+    expect(clones[0].title).toBe("Q1");
+    expect(clones[0].series[0].values).toBe("Dash!$B$2:$B$5");
+    expect(clones[2].series[0].color).toBe("F76808");
+    // Categories carry through unchanged.
+    expect(clones.every((c) => c.series[0].categories === "Tpl!$A$2:$A$5")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- New `cloneChart(source, options)` converts a parsed `Chart` (read-side metadata produced by `parseChart`) into a `SheetChart` ready for `writeXlsx`. Together with `chartKindToWriteKind(kind)` it closes the missing template-composition step from issue #136: load a workbook with one of each chart flavor, pull out the chart, remap its series ranges, and re-emit it (often several times) into a new workbook.
- The bridge is type-narrowed: `Chart.series[].valuesRef` becomes `SheetChart.series[].values`, source colors / category ranges / series names carry through, and any of those fields can be replaced with a per-series override or dropped entirely with `null`. Read-side kinds collapse onto their write counterparts (bar/bar3D → column, doughnut/pie3D → pie, line3D → line, area3D → area, scatter passes through). Non-renderable kinds (bubble, radar, surface, stock, ofPie) require an explicit `options.type` override and otherwise throw with a clear error.
- The clone is then accepted unchanged by `writeChart` and end-to-end by `writeXlsx`, so callers can populate the dashboard sheet with data and immediately attach the cloned chart through the existing `WriteSheet.charts` array.

## What this PR does NOT do

This is a focused slice of #136 (chart composition / data remapping). The full issue also asks for chart drawing-position read support and high-level `getCharts(workbook)` / `addChart(sheet, ...)` shorthands; those remain out of scope here. `Chart.kinds` already drops the `bar` vs `column` orientation distinction at parse time, so cloned bar charts default to vertical (`column`) — callers who need horizontal pass `type: "bar"` explicitly.

## Test plan

- [x] `pnpm test` (lint + typecheck + 27 998 vitest cases, including 20 new `chart-clone` tests)
- [x] `pnpm build`
- [x] Round-trip integration: `parseChart` → `cloneChart` → `writeChart` and `writeXlsx` produce a valid `xl/charts/chart1.xml`
- [x] Three-way template reuse: a single source `Chart` cloned into three independent `SheetChart` instances with distinct titles, data ranges, and colors

Refs #136