### PR TITLE
feat(xlsx): streamXlsxRows honors range and maxRows

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,21 @@ for await (const row of streamXlsxRows(buffer)) {
   console.log(row.index, row.values);
 }
 
+// Cap the number of rows yielded (preview / sampling). The underlying
+// ZIP/SAX stream is cancelled once the cap is reached, so very large
+// sheets stay cheap.
+for await (const row of streamXlsxRows(buffer, { maxRows: 100 })) {
+  console.log(row.index, row.values);
+}
+
+// Filter to an A1 range. Rows outside the row span are skipped; cells
+// outside the column span are masked to `null` (column indexes stay
+// stable). Parsing stops once a row past the end-row is observed.
+for await (const row of streamXlsxRows(buffer, { range: "B2:D1000" })) {
+  // row.values[0] === null (column A is outside)
+  // row.values[1..3] carry B/C/D
+}
+
 // Stream write — add rows incrementally
 const writer = new XlsxStreamWriter({
   name: "BigData",

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -27,6 +27,34 @@ export interface StreamRow {
   values: CellValue[];
 }
 
+// ── Range filter ────────────────────────────────────────────────────
+
+interface RangeFilter {
+  startRow: number;
+  endRow: number;
+  startCol: number;
+  endCol: number;
+}
+
+/**
+ * Parse a range reference like "A1:D10" into 0-based row/col bounds.
+ * Single-cell refs like "B2" are also accepted (start == end).
+ */
+function parseRangeFilter(ref: string): RangeFilter {
+  const parts = ref.split(":");
+  if (parts.length === 0 || parts.length > 2) {
+    throw new ParseError(`Invalid range reference: "${ref}"`);
+  }
+  const start = parseCellRef(parts[0]!);
+  const end = parts.length > 1 ? parseCellRef(parts[1]!) : start;
+  return {
+    startRow: Math.min(start.row, end.row),
+    endRow: Math.max(start.row, end.row),
+    startCol: Math.min(start.col, end.col),
+    endCol: Math.max(start.col, end.col),
+  };
+}
+
 // ── OOXML Relationship Types ─────────────────────────────────────────
 
 const REL_WORKBOOK =
@@ -341,6 +369,29 @@ function handleCloseTag(
   return null;
 }
 
+// ── Filter application ─────────────────────────────────────────────
+
+/**
+ * Apply the range filter to a freshly-yielded row. Returns the row to emit
+ * (with cells outside the column range nulled out) or `null` if the row
+ * itself falls outside the row range.
+ *
+ * Mirrors the batch reader (`parseWorksheet`): values stay aligned to
+ * their original column index, and cells outside the column window are
+ * masked to `null` rather than removed, so callers can still address
+ * `row.values[colIndex]` for columns inside the range.
+ */
+function applyRangeFilter(row: StreamRow, range: RangeFilter): StreamRow | null {
+  if (row.index < range.startRow || row.index > range.endRow) return null;
+  const len = Math.max(row.values.length, range.endCol + 1);
+  const out: CellValue[] = Array.from({ length: len }, () => null);
+  const upper = Math.min(row.values.length - 1, range.endCol);
+  for (let c = range.startCol; c <= upper; c++) {
+    out[c] = row.values[c] ?? null;
+  }
+  return { index: row.index, values: out };
+}
+
 // ── Streaming row parser via SAX (async — ReadableStream) ──────────
 
 async function* parseWorksheetRowsStreaming(
@@ -348,26 +399,84 @@ async function* parseWorksheetRowsStreaming(
   sharedStrings: SharedString[],
   styles: ParsedStyles | null,
   dateSystem: "1900" | "1904",
+  filters: { range?: RangeFilter; maxRows?: number } = {},
 ): AsyncGenerator<StreamRow, void, undefined> {
   const s = createRowSaxState();
   const pendingRows: StreamRow[] = [];
   let resolve: (() => void) | null = null;
   let done = false;
+  let aborted = false;
 
-  const parsePromise = parseSaxStream(stream, {
+  // Wrap the source reader so we can short-circuit chunk pulls (and cancel
+  // the underlying ZIP/decompression stream) once a stop condition fires.
+  // We hold the source reader exclusively here so that calling
+  // `cancel(reason)` propagates without conflicting with locks.
+  const sourceReader = stream.getReader();
+  const cancelSource = (reason?: unknown): void => {
+    sourceReader.cancel(reason).catch(() => {});
+  };
+  const cancellable = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (aborted) {
+        controller.close();
+        return;
+      }
+      try {
+        const { done: rDone, value } = await sourceReader.read();
+        if (rDone) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    cancel(reason) {
+      cancelSource(reason);
+    },
+  });
+
+  let emittedDataRows = 0;
+  const maxRows = filters.maxRows ?? 0;
+  const range = filters.range;
+
+  const parsePromise = parseSaxStream(cancellable, {
     onOpenTag(tag, attrs) {
+      if (aborted) return;
       handleOpenTag(tag, attrs, s);
     },
     onText(text) {
+      if (aborted) return;
       handleText(text, s);
     },
     onCloseTag(tag) {
+      if (aborted) return;
       const row = handleCloseTag(tag, s, sharedStrings, styles, dateSystem);
       if (row) {
-        pendingRows.push(row);
-        if (resolve) {
-          resolve();
-          resolve = null;
+        // If the SAX-emitted row is past the range end, we can stop now —
+        // worksheet rows are written in ascending order in valid OOXML.
+        if (range && row.index > range.endRow) {
+          aborted = true;
+          cancelSource();
+          if (resolve) {
+            resolve();
+            resolve = null;
+          }
+          return;
+        }
+        const filtered = range ? applyRangeFilter(row, range) : row;
+        if (filtered) {
+          pendingRows.push(filtered);
+          emittedDataRows++;
+          if (resolve) {
+            resolve();
+            resolve = null;
+          }
+          if (maxRows > 0 && emittedDataRows >= maxRows) {
+            aborted = true;
+            cancelSource();
+          }
         }
       }
     },
@@ -379,17 +488,25 @@ async function* parseWorksheetRowsStreaming(
     }
   });
 
-  while (!done || pendingRows.length > 0) {
-    if (pendingRows.length > 0) {
-      yield pendingRows.shift()!;
-    } else if (!done) {
-      await new Promise<void>((r) => {
-        resolve = r;
-      });
+  try {
+    while (!done || pendingRows.length > 0) {
+      if (pendingRows.length > 0) {
+        yield pendingRows.shift()!;
+      } else if (!done) {
+        await new Promise<void>((r) => {
+          resolve = r;
+        });
+      }
     }
+  } finally {
+    // Release the upstream reader if the consumer abandoned the generator
+    // before the stream finished. Cancellation is idempotent — if we've
+    // already cancelled because of maxRows/range, this is a no-op.
+    aborted = true;
+    cancelSource();
   }
 
-  await parsePromise;
+  await parsePromise.catch(() => {});
 }
 
 // ── Cell value resolution (streaming — no Cell objects) ──────────────
@@ -463,6 +580,15 @@ function resolveStreamCellValue(
  * For ReadableStream input, the stream is buffered to read the ZIP
  * central directory, then the worksheet entry is stream-decompressed
  * and piped through the SAX parser in chunks.
+ *
+ * Honored {@link ReadOptions} fields:
+ * - `sheet` — target sheet (number index or name). Default: first sheet.
+ * - `dateSystem` — `"1900"` / `"1904"` / `"auto"`. Default: auto-detect.
+ * - `range` — A1-style range filter (e.g. `"B2:D10"`). Rows outside the
+ *   row span are skipped; cells outside the column span are nulled out.
+ *   Parsing stops once a row past the end-row is observed.
+ * - `maxRows` — caps the number of rows yielded. Once the cap is hit the
+ *   underlying ZIP/SAX stream is cancelled so no further work is done.
  */
 export async function* streamXlsxRows(
   input: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
@@ -578,9 +704,24 @@ export async function* streamXlsxRows(
     throw new ParseError(`Invalid XLSX: missing worksheet file for sheet "${targetSheet.name}"`);
   }
 
-  // 10. Stream worksheet rows
+  // 10. Build optional row/cell filters from ReadOptions.
+  // `range` and `maxRows` mirror the batch-reader semantics: range filters
+  // both rows (skip outside) and cells (mask outside columns), maxRows
+  // caps the number of yielded rows. Both stop pulling from the worksheet
+  // stream as soon as no more rows can be emitted.
+  let rangeFilter: RangeFilter | undefined;
+  if (options?.range) {
+    rangeFilter = parseRangeFilter(options.range);
+  }
+  const maxRowsLimit =
+    typeof options?.maxRows === "number" && options.maxRows > 0 ? options.maxRows : 0;
+
+  // 11. Stream worksheet rows
   // Use streaming decompression: pipe ZIP entry through DecompressionStream
   // directly into the SAX parser, yielding rows as they complete.
   const wsStream = zip.extractStream(wsPath);
-  yield* parseWorksheetRowsStreaming(wsStream, sharedStrings, parsedStyles, dateSystem);
+  yield* parseWorksheetRowsStreaming(wsStream, sharedStrings, parsedStyles, dateSystem, {
+    range: rangeFilter,
+    maxRows: maxRowsLimit > 0 ? maxRowsLimit : undefined,
+  });
 }

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -267,6 +267,162 @@ describe("streamXlsxRows", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════
+// XLSX Stream Reader — ReadOptions: maxRows / range
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("streamXlsxRows — ReadOptions filters", () => {
+  it("respects maxRows: caps the yielded row count", async () => {
+    const rows: CellValue[][] = [];
+    for (let i = 0; i < 50; i++) {
+      rows.push([`Row${i + 1}`, i + 1]);
+    }
+    const xlsx = await createTestXlsx([{ name: "Sheet1", rows }]);
+
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { maxRows: 5 }));
+    expect(out).toHaveLength(5);
+    expect(out[0].values[0]).toBe("Row1");
+    expect(out[4].values[0]).toBe("Row5");
+  });
+
+  it("maxRows: 0 / undefined / negative read everything", async () => {
+    const rows: CellValue[][] = Array.from({ length: 8 }, (_, i) => [`R${i}`]);
+    const xlsx = await createTestXlsx([{ name: "Sheet1", rows }]);
+
+    const a = await collectStreamRows(streamXlsxRows(xlsx, { maxRows: 0 }));
+    const b = await collectStreamRows(streamXlsxRows(xlsx));
+    const c = await collectStreamRows(streamXlsxRows(xlsx, { maxRows: -3 }));
+
+    expect(a).toHaveLength(8);
+    expect(b).toHaveLength(8);
+    expect(c).toHaveLength(8);
+  });
+
+  it("maxRows larger than the sheet returns the whole sheet", async () => {
+    const rows: CellValue[][] = Array.from({ length: 4 }, (_, i) => [`R${i}`]);
+    const xlsx = await createTestXlsx([{ name: "Sheet1", rows }]);
+
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { maxRows: 100 }));
+    expect(out).toHaveLength(4);
+  });
+
+  it("range filters rows outside the row span and masks columns", async () => {
+    // 4×4 grid; range B2:C3 keeps rows 1..2 and cols 1..2
+    const rows: CellValue[][] = [
+      ["A1", "B1", "C1", "D1"],
+      ["A2", "B2", "C2", "D2"],
+      ["A3", "B3", "C3", "D3"],
+      ["A4", "B4", "C4", "D4"],
+    ];
+    const xlsx = await createTestXlsx([{ name: "S", rows }]);
+
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { range: "B2:C3" }));
+
+    // Only rows 1 and 2 (0-based) should survive.
+    expect(out).toHaveLength(2);
+    expect(out[0].index).toBe(1);
+    expect(out[1].index).toBe(2);
+    // Column 0 (A) and column 3 (D) are masked to null; B and C survive.
+    expect(out[0].values[0]).toBeNull();
+    expect(out[0].values[1]).toBe("B2");
+    expect(out[0].values[2]).toBe("C2");
+    expect(out[0].values[3]).toBeNull();
+    expect(out[1].values[1]).toBe("B3");
+    expect(out[1].values[2]).toBe("C3");
+  });
+
+  it("range supports a single-cell ref", async () => {
+    const rows: CellValue[][] = [
+      ["A1", "B1"],
+      ["A2", "B2"],
+    ];
+    const xlsx = await createTestXlsx([{ name: "S", rows }]);
+
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { range: "B2" }));
+    expect(out).toHaveLength(1);
+    expect(out[0].index).toBe(1);
+    expect(out[0].values[1]).toBe("B2");
+    expect(out[0].values[0]).toBeNull();
+  });
+
+  it("range stops parsing past the end-row (early termination)", async () => {
+    // Build a wide sheet with many rows below the range so that early
+    // termination is observable through the row count.
+    const rows: CellValue[][] = [];
+    for (let i = 0; i < 200; i++) {
+      rows.push([`R${i + 1}A`, `R${i + 1}B`]);
+    }
+    const xlsx = await createTestXlsx([{ name: "S", rows }]);
+
+    // Take rows 0..2 only. Whether the parser actually short-circuits is
+    // implementation detail, but the surfaced result must be 3 rows.
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { range: "A1:B3" }));
+    expect(out).toHaveLength(3);
+    expect(out[0].index).toBe(0);
+    expect(out[2].index).toBe(2);
+  });
+
+  it("range and maxRows compose: range first, maxRows caps survivors", async () => {
+    const rows: CellValue[][] = [];
+    for (let i = 0; i < 20; i++) {
+      rows.push([`R${i + 1}A`, `R${i + 1}B`, `R${i + 1}C`]);
+    }
+    const xlsx = await createTestXlsx([{ name: "S", rows }]);
+
+    // Range is rows 5..15 (11 rows, 0-based 4..14); maxRows caps to 4.
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { range: "A5:B15", maxRows: 4 }));
+    expect(out).toHaveLength(4);
+    expect(out[0].index).toBe(4); // 0-based row 4 == "R5..."
+    expect(out[0].values[0]).toBe("R5A");
+    expect(out[0].values[1]).toBe("R5B");
+    // Column C (index 2) is outside the range.
+    expect(out[0].values[2]).toBeNull();
+    expect(out[3].index).toBe(7);
+  });
+
+  it("rows entirely outside the range are skipped", async () => {
+    const rows: CellValue[][] = [
+      ["A1", "B1"],
+      ["A2", "B2"],
+      ["A3", "B3"],
+      ["A4", "B4"],
+      ["A5", "B5"],
+    ];
+    const xlsx = await createTestXlsx([{ name: "S", rows }]);
+
+    const out = await collectStreamRows(streamXlsxRows(xlsx, { range: "A3:A3" }));
+    expect(out).toHaveLength(1);
+    expect(out[0].index).toBe(2);
+    expect(out[0].values[0]).toBe("A3");
+    expect(out[0].values[1]).toBeNull();
+  });
+
+  it("invalid range string throws a ParseError", async () => {
+    const xlsx = await createTestXlsx([{ name: "S", rows: [["x"]] }]);
+    await expect(async () => {
+      // Drain the generator to surface the parse step.
+      for await (const _ of streamXlsxRows(xlsx, { range: "::not-a-range::" })) {
+        // unreachable
+      }
+    }).rejects.toThrow();
+  });
+
+  it("breaking out of the consumer loop early does not throw", async () => {
+    const rows: CellValue[][] = [];
+    for (let i = 0; i < 100; i++) {
+      rows.push([`R${i}`]);
+    }
+    const xlsx = await createTestXlsx([{ name: "S", rows }]);
+
+    let seen = 0;
+    for await (const row of streamXlsxRows(xlsx)) {
+      seen++;
+      if (row.index === 2) break;
+    }
+    expect(seen).toBe(3);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════
 // XLSX Stream Reader — ReadableStream Input
 // ═══════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

`streamXlsxRows` already accepted `sheet` and `dateSystem` from `ReadOptions`, but silently ignored two other widely-used fields: `range` and `maxRows`. The batch reader (`readXlsx`) honors both. This PR plumbs them through the streaming reader so callers can preview/sample/window-read large worksheets without buffering the whole sheet, and the parser actually stops doing work once the cap is hit.

## What changed

- `range` (A1-style ref like `"B2:D1000"`):
  - Rows outside the row span are skipped before they reach the consumer.
  - Cells outside the column span are masked to `null` so column indexes stay aligned (mirrors `parseWorksheet` semantics — the batch reader nulls cells, it doesn't shift them).
  - Parsing short-circuits as soon as the SAX layer emits a row past the end-row (worksheet rows are written in ascending order in valid OOXML).
- `maxRows`:
  - Caps the number of rows yielded.
  - Once the cap fires the underlying ZIP/decompression reader is cancelled, so very large sheets stay cheap when only the first N rows are needed.
- The generator's `finally` block also cancels the upstream reader when the consumer abandons the loop early (`for await … break`), so abandoned generators no longer leak the worksheet stream.

## Scope

This is a focused slice of #77 (memory-cheap streaming reads). The full issue also asks for true streaming without buffering the central directory, which the issue itself rates as high-complexity and beyond v1.0 scope. This PR does not change that constraint — it only lets streaming callers stop pulling and filter, which is the use case the issue sketches as "skip non-needed entries". `headerRow` is intentionally not wired up because in the rest of the codebase it's an `xlsx-objects` concern, not a base-reader concern.

Refs #77

## Test plan

- [x] `pnpm exec oxlint src/xlsx/stream-reader.ts test/streaming.test.ts` — 0 warnings, 0 errors
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run --exclude '**/.claude/**'` — 2443 / 2443 (86 files)
- [x] `pnpm build`
- [x] 9 new tests under `streamXlsxRows — ReadOptions filters` covering: maxRows cap, maxRows defaults (0/undefined/negative), oversized maxRows, range row+column masking, single-cell range, range early termination, range+maxRows composition, rows entirely outside range, invalid range error, early `break` doesn't throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)