### PR TITLE
feat(xlsx): getCharts / addChart helpers for chart composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,35 @@ writer can author collapse onto their write counterparts (`bar` /
 `surface`, `stock`, `ofPie`) require an explicit `options.type`
 override.
 
+#### Walking and adding charts with `getCharts` / `addChart`
+
+`getCharts(workbook)` flattens every chart anchored on the workbook's
+sheets into a single array, attaching the sheet name and indexes so
+callers don't have to walk `workbook.sheets[].charts` themselves.
+`addChart(sheet, chart)` is the symmetric writer-side helper that
+appends a `SheetChart` to a `WriteSheet`, lazily allocating the
+`charts` array on the first call:
+
+```ts
+import { addChart, getCharts, openXlsx, writeXlsx } from "hucre";
+
+// Read side — find every chart in a template workbook.
+const wb = await openXlsx(templateBytes);
+for (const { sheetName, chart } of getCharts(wb)) {
+  console.log(sheetName, chart.kinds, chart.title);
+}
+
+// Write side — declarative chart attachment.
+const dashboard = { name: "Dashboard", rows: dashboardRows };
+addChart(dashboard, {
+  type: "column",
+  title: "Q1 Revenue",
+  series: [{ name: "Revenue", values: "B2:B13", categories: "A2:A13" }],
+  anchor: { from: { row: 14, col: 0 } },
+});
+await writeXlsx({ sheets: [dashboard] });
+```
+
 ### Unified API
 
 Auto-detect format and work with simple helpers:
@@ -1092,6 +1121,8 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 | `parseChart(xml)`                  | Parse `xl/charts/chartN.xml` → `Chart \| undefined`                         |
 | `cloneChart(source, options)`      | Convert a parsed `Chart` into a writer-ready `SheetChart`                   |
 | `chartKindToWriteKind(kind)`       | Map a read-side `ChartKind` onto its writable counterpart, if any           |
+| `getCharts(workbook)`              | Enumerate every chart anchored on the workbook with its sheet context       |
+| `addChart(sheet, chart)`           | Append a `SheetChart` to a `WriteSheet`, lazily creating the array          |
 
 ### ODS
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,8 @@ export type {
 export { parseChart } from "./xlsx/chart-reader";
 export { cloneChart, chartKindToWriteKind } from "./xlsx/chart-clone";
 export type { CloneChartOptions, CloneChartSeriesOverride } from "./xlsx/chart-clone";
+export { addChart, getCharts } from "./xlsx/chart-helpers";
+export type { ChartLocation } from "./xlsx/chart-helpers";
 export type { Chart, ChartKind, ChartSeriesInfo } from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────

--- a/src/xlsx/chart-helpers.ts
+++ b/src/xlsx/chart-helpers.ts
@@ -1,0 +1,126 @@
+// ── Chart Helpers ────────────────────────────────────────────────────
+// High-level convenience helpers around the chart read/write data
+// model. `getCharts(workbook)` enumerates every chart anchored on the
+// workbook's sheets, in workbook order, with its sheet context attached
+// so callers don't have to walk `workbook.sheets[].charts` themselves.
+// `addChart(sheet, chart)` pushes a `SheetChart` onto a `WriteSheet`'s
+// chart list, creating the array on the fly.
+//
+// These mirror the `getCharts(workbook)` / `addChart(sheet, ...)`
+// shorthand sketched in the dashboard composition issue (#136).
+
+import type { Chart, Sheet, SheetChart, WriteSheet, Workbook } from "../_types";
+
+// ── getCharts ────────────────────────────────────────────────────────
+
+/**
+ * One entry returned by {@link getCharts}. Carries enough sheet context
+ * (name + 0-based index) for callers to look up siblings on the same
+ * sheet without walking the workbook a second time.
+ *
+ * `chartIndex` is 0-based inside the sheet's `charts` array, in the
+ * order the chart parts were resolved off the drawing — typically the
+ * authoring order in Excel.
+ */
+export interface ChartLocation {
+  /** Reference to the sheet that owns the chart. Same identity as `workbook.sheets[sheetIndex]`. */
+  sheet: Sheet;
+  /** Sheet name as declared in `xl/workbook.xml`. */
+  sheetName: string;
+  /** 0-based position of the sheet inside `workbook.sheets`. */
+  sheetIndex: number;
+  /** The parsed chart record. Same identity as `sheet.charts[chartIndex]`. */
+  chart: Chart;
+  /** 0-based position of the chart inside `sheet.charts`. */
+  chartIndex: number;
+}
+
+/**
+ * Enumerate every chart anchored on the workbook's sheets.
+ *
+ * Visits sheets in workbook order; within a sheet, visits charts in
+ * the order surfaced by the reader. Sheets without charts are skipped.
+ * Returns an empty array when the workbook has no charts at all.
+ *
+ * @example
+ * ```ts
+ * import { openXlsx, getCharts } from "hucre";
+ *
+ * const wb = await openXlsx(bytes);
+ * for (const { sheetName, chart } of getCharts(wb)) {
+ *   console.log(sheetName, chart.kinds, chart.title);
+ * }
+ * ```
+ */
+export function getCharts(workbook: Workbook): ChartLocation[] {
+  const out: ChartLocation[] = [];
+  for (let sheetIndex = 0; sheetIndex < workbook.sheets.length; sheetIndex++) {
+    const sheet = workbook.sheets[sheetIndex];
+    const charts = sheet.charts;
+    if (!charts || charts.length === 0) continue;
+    for (let chartIndex = 0; chartIndex < charts.length; chartIndex++) {
+      out.push({
+        sheet,
+        sheetName: sheet.name,
+        sheetIndex,
+        chart: charts[chartIndex],
+        chartIndex,
+      });
+    }
+  }
+  return out;
+}
+
+// ── addChart ─────────────────────────────────────────────────────────
+
+/**
+ * Append a {@link SheetChart} to a {@link WriteSheet}'s `charts` list,
+ * lazily creating the array on the first call. Returns the same chart
+ * object so callers can inline declarations:
+ *
+ * @example
+ * ```ts
+ * import { addChart, writeXlsx } from "hucre";
+ *
+ * const sheet = {
+ *   name: "Dashboard",
+ *   rows: [
+ *     ["Quarter", "Revenue"],
+ *     ["Q1", 12000],
+ *     ["Q2", 15500],
+ *   ],
+ * };
+ *
+ * addChart(sheet, {
+ *   type: "column",
+ *   title: "Revenue",
+ *   series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
+ *   anchor: { from: { row: 5, col: 0 } },
+ * });
+ *
+ * await writeXlsx({ sheets: [sheet] });
+ * ```
+ *
+ * Equivalent to:
+ *
+ * ```ts
+ * (sheet.charts ??= []).push(chart);
+ * ```
+ */
+export function addChart(sheet: WriteSheet, chart: SheetChart): SheetChart {
+  if (!chart || typeof chart !== "object") {
+    throw new TypeError("addChart: chart is required");
+  }
+  if (!chart.type) {
+    throw new TypeError("addChart: chart.type is required");
+  }
+  if (!Array.isArray(chart.series) || chart.series.length === 0) {
+    throw new TypeError("addChart: chart.series must contain at least one entry");
+  }
+  if (!chart.anchor || !chart.anchor.from) {
+    throw new TypeError("addChart: chart.anchor.from is required");
+  }
+  const list = sheet.charts ?? (sheet.charts = []);
+  list.push(chart);
+  return chart;
+}

--- a/test/chart-helpers.test.ts
+++ b/test/chart-helpers.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+import { addChart, getCharts } from "../src/xlsx/chart-helpers";
+import { writeXlsx } from "../src/xlsx/writer";
+import { ZipReader } from "../src/zip/reader";
+import type { Chart, SheetChart, Workbook, WriteSheet } from "../src/_types";
+
+const decoder = new TextDecoder("utf-8");
+
+// ── getCharts ────────────────────────────────────────────────────────
+
+describe("getCharts", () => {
+  function makeChart(title: string): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      title,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: title,
+          valuesRef: "Sheet1!$B$2:$B$5",
+        },
+      ],
+    };
+  }
+
+  it("returns an empty array when the workbook has no sheets", () => {
+    expect(getCharts({ sheets: [] })).toEqual([]);
+  });
+
+  it("returns an empty array when no sheet has charts", () => {
+    const workbook: Workbook = {
+      sheets: [
+        { name: "S1", rows: [[1]] },
+        { name: "S2", rows: [[2]] },
+      ],
+    };
+    expect(getCharts(workbook)).toEqual([]);
+  });
+
+  it("skips sheets whose `charts` is the empty array", () => {
+    const workbook: Workbook = {
+      sheets: [
+        { name: "Empty", rows: [], charts: [] },
+        { name: "Has", rows: [], charts: [makeChart("only")] },
+      ],
+    };
+    const found = getCharts(workbook);
+    expect(found).toHaveLength(1);
+    expect(found[0].sheetName).toBe("Has");
+    expect(found[0].sheetIndex).toBe(1);
+    expect(found[0].chartIndex).toBe(0);
+  });
+
+  it("walks sheets in workbook order and charts in their declared order", () => {
+    const a1 = makeChart("A1");
+    const a2 = makeChart("A2");
+    const b1 = makeChart("B1");
+    const workbook: Workbook = {
+      sheets: [
+        { name: "Alpha", rows: [], charts: [a1, a2] },
+        { name: "Beta", rows: [], charts: [b1] },
+      ],
+    };
+
+    const found = getCharts(workbook);
+    expect(found).toHaveLength(3);
+
+    expect(found[0]).toMatchObject({
+      sheetName: "Alpha",
+      sheetIndex: 0,
+      chartIndex: 0,
+    });
+    expect(found[0].chart).toBe(a1);
+    expect(found[0].sheet).toBe(workbook.sheets[0]);
+
+    expect(found[1]).toMatchObject({
+      sheetName: "Alpha",
+      sheetIndex: 0,
+      chartIndex: 1,
+    });
+    expect(found[1].chart).toBe(a2);
+
+    expect(found[2]).toMatchObject({
+      sheetName: "Beta",
+      sheetIndex: 1,
+      chartIndex: 0,
+    });
+    expect(found[2].chart).toBe(b1);
+  });
+
+  it("preserves identity — the returned `chart` and `sheet` are the same references", () => {
+    const chart = makeChart("Identity");
+    const sheet = { name: "S", rows: [], charts: [chart] };
+    const workbook: Workbook = { sheets: [sheet] };
+
+    const [loc] = getCharts(workbook);
+    expect(loc.sheet).toBe(sheet);
+    expect(loc.chart).toBe(chart);
+    // Mutating the returned reference flows back to the workbook.
+    loc.chart.title = "Mutated";
+    expect(chart.title).toBe("Mutated");
+  });
+
+  it("handles a workbook where only the last sheet carries charts", () => {
+    const tail = makeChart("Tail");
+    const workbook: Workbook = {
+      sheets: [
+        { name: "S1", rows: [] },
+        { name: "S2", rows: [] },
+        { name: "S3", rows: [], charts: [tail] },
+      ],
+    };
+    const found = getCharts(workbook);
+    expect(found).toHaveLength(1);
+    expect(found[0].sheetIndex).toBe(2);
+    expect(found[0].sheetName).toBe("S3");
+    expect(found[0].chart).toBe(tail);
+  });
+});
+
+// ── addChart ─────────────────────────────────────────────────────────
+
+describe("addChart", () => {
+  function validChart(): SheetChart {
+    return {
+      type: "column",
+      title: "Revenue",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+    };
+  }
+
+  it("creates the `charts` array on first call", () => {
+    const sheet: WriteSheet = { name: "Dashboard" };
+    expect(sheet.charts).toBeUndefined();
+    const chart = validChart();
+    addChart(sheet, chart);
+    expect(sheet.charts).toEqual([chart]);
+  });
+
+  it("appends to an existing `charts` array in order", () => {
+    const c1 = validChart();
+    c1.title = "First";
+    const c2 = validChart();
+    c2.title = "Second";
+
+    const sheet: WriteSheet = { name: "S", charts: [c1] };
+    addChart(sheet, c2);
+
+    expect(sheet.charts).toHaveLength(2);
+    expect(sheet.charts?.[0].title).toBe("First");
+    expect(sheet.charts?.[1].title).toBe("Second");
+  });
+
+  it("returns the chart instance for inline use", () => {
+    const sheet: WriteSheet = { name: "S" };
+    const chart = validChart();
+    const returned = addChart(sheet, chart);
+    expect(returned).toBe(chart);
+  });
+
+  it("rejects a missing chart argument", () => {
+    const sheet: WriteSheet = { name: "S" };
+    // @ts-expect-error — testing runtime guard
+    expect(() => addChart(sheet, undefined)).toThrow(/chart is required/);
+    // @ts-expect-error — testing runtime guard for non-object input
+    expect(() => addChart(sheet, 42)).toThrow(/chart is required/);
+  });
+
+  it("rejects a chart that is missing required fields", () => {
+    const sheet: WriteSheet = { name: "S" };
+    expect(() =>
+      addChart(sheet, {
+        // @ts-expect-error — missing type on purpose
+        type: undefined,
+        series: [{ values: "A1:A2" }],
+        anchor: { from: { row: 0, col: 0 } },
+      }),
+    ).toThrow(/chart\.type/);
+
+    expect(() =>
+      addChart(sheet, {
+        type: "column",
+        // @ts-expect-error — missing series on purpose
+        series: undefined,
+        anchor: { from: { row: 0, col: 0 } },
+      }),
+    ).toThrow(/chart\.series/);
+
+    expect(() =>
+      addChart(sheet, {
+        type: "column",
+        series: [],
+        anchor: { from: { row: 0, col: 0 } },
+      }),
+    ).toThrow(/chart\.series/);
+
+    expect(() =>
+      addChart(sheet, {
+        type: "column",
+        series: [{ values: "A1:A2" }],
+        // @ts-expect-error — missing anchor on purpose
+        anchor: undefined,
+      }),
+    ).toThrow(/chart\.anchor/);
+
+    expect(() =>
+      addChart(sheet, {
+        type: "column",
+        series: [{ values: "A1:A2" }],
+        // @ts-expect-error — anchor.from is required
+        anchor: {},
+      }),
+    ).toThrow(/chart\.anchor/);
+  });
+
+  it("end-to-end — addChart → writeXlsx emits a chart part", async () => {
+    const sheet: WriteSheet = {
+      name: "Dashboard",
+      rows: [
+        ["Quarter", "Revenue"],
+        ["Q1", 12_000],
+        ["Q2", 15_500],
+        ["Q3", 14_000],
+      ],
+    };
+
+    addChart(sheet, {
+      type: "column",
+      title: "Revenue",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+    });
+
+    const xlsx = await writeXlsx({ sheets: [sheet] });
+    const zip = new ZipReader(xlsx);
+    expect(zip.has("xl/charts/chart1.xml")).toBe(true);
+    const chartXml = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(chartXml).toContain("<c:barChart>");
+    expect(chartXml).toContain("Revenue");
+  });
+});
+
+// ── interop with cloneChart / parseChart ─────────────────────────────
+
+describe("getCharts + addChart compose with the rest of the chart API", () => {
+  it("walks a workbook with multiple sheets and surfaces every chart", () => {
+    const workbook: Workbook = {
+      sheets: [
+        {
+          name: "Sales",
+          rows: [],
+          charts: [
+            { kinds: ["bar"], seriesCount: 1, title: "Sales-bar" },
+            { kinds: ["line"], seriesCount: 2, title: "Sales-line" },
+          ],
+        },
+        {
+          name: "Marketing",
+          rows: [],
+          charts: [{ kinds: ["pie"], seriesCount: 1, title: "Marketing-pie" }],
+        },
+        // Sheet without charts shouldn't show up.
+        { name: "Notes", rows: [["x"]] },
+      ],
+    };
+
+    const titles = getCharts(workbook).map((loc) => loc.chart.title);
+    expect(titles).toEqual(["Sales-bar", "Sales-line", "Marketing-pie"]);
+  });
+});


### PR DESCRIPTION
## Summary

- `getCharts(workbook)` walks every chart anchored on the workbook's sheets and surfaces a flat `ChartLocation[]` with `sheetName`, `sheetIndex`, `chartIndex`, and live references back to the owning `Sheet` and `Chart`. Sheets without charts are skipped; sheet/chart order matches the workbook's read order.
- `addChart(sheet, chart)` appends a `SheetChart` to a `WriteSheet`'s `charts` list, lazily allocating the array on the first call. It validates that the chart carries the writer's three mandatory fields (`type`, non-empty `series`, `anchor.from`) so authoring mistakes are caught at the call site instead of deep inside `writeXlsx`. Returns the chart instance so callers can use it inline.

## Why

This closes the explicit Phase 2 follow-up from the dashboard composition issue: `parseChart` (#190) decodes a chart, `cloneChart` (#192) bridges it onto the writer's shape, and these two helpers wrap the workbook-level walk and the per-sheet attachment so callers don't have to dig into `workbook.sheets[].charts` directly.

## Out of scope

Chart drawing-position read support (surfacing the `xdr:twoCellAnchor` `from`/`to` from the drawing layer back onto the read-side `Chart` record) is still left for a future PR — it threads through `extractSheetDrawing`, the roundtrip carry-over logic, and the `Chart` type, which is more than fits in a single focused change.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 30 454 vitest cases, including 13 new `chart-helpers` tests)
- [x] `pnpm build`
- [x] End-to-end: `addChart(sheet, …)` + `writeXlsx` emits `xl/charts/chart1.xml` with the expected `<c:barChart>` body
- [x] `getCharts` preserves identity — returned `chart` and `sheet` references mutate back into the original workbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)