### PR TITLE
feat(xlsx): surface chart cell anchors on parsed charts

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1248,6 +1248,28 @@ export interface ChartSeriesInfo {
 }
 
 /**
+ * Cell-anchored placement for a chart on its host sheet.
+ *
+ * Mirrors the `<xdr:from>` / `<xdr:to>` pair on the drawing-layer
+ * `xdr:twoCellAnchor` (or the `<xdr:from>` alone for a
+ * `xdr:oneCellAnchor`). Coordinates are 0-based row/col indices into
+ * the worksheet — identical to the convention used by
+ * {@link SheetImage.anchor} and {@link SheetChart.anchor}, so a parsed
+ * `ChartAnchor` slots straight back into the writer's shape.
+ *
+ * `to` is optional because Excel also supports `xdr:oneCellAnchor`
+ * (chart pinned to a single cell with intrinsic size).
+ * `xdr:absoluteAnchor` (EMU-positioned) does not surface here — those
+ * charts are reported with `anchor` undefined.
+ */
+export interface ChartAnchor {
+  /** Top-left cell (`<xdr:from>`). */
+  from: { row: number; col: number };
+  /** Bottom-right cell (`<xdr:to>`). Omitted for one-cell anchors. */
+  to?: { row: number; col: number };
+}
+
+/**
  * A chart anchored on a sheet via the sheet's drawing part.
  *
  * Charts come from `xl/charts/chartN.xml`. Hucre exposes the
@@ -1266,6 +1288,13 @@ export interface Chart {
    * declaration order. Empty when the chart has no `<c:ser>` children.
    */
   series?: ChartSeriesInfo[];
+  /**
+   * Cell anchor pulled from the host drawing's `<xdr:twoCellAnchor>` /
+   * `<xdr:oneCellAnchor>`. Undefined when the drawing positions the
+   * chart with `<xdr:absoluteAnchor>` (EMU-positioned, no cell anchor)
+   * or when the drawing's anchor element is missing the `from` block.
+   */
+  anchor?: ChartAnchor;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,7 @@ export type {
 export { parseChart } from "./xlsx/chart-reader";
 export { cloneChart, chartKindToWriteKind } from "./xlsx/chart-clone";
 export type { CloneChartOptions, CloneChartSeriesOverride } from "./xlsx/chart-clone";
-export type { Chart, ChartKind, ChartSeriesInfo } from "./_types";
+export type { Chart, ChartAnchor, ChartKind, ChartSeriesInfo } from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────
 export {

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -17,6 +17,7 @@ import type {
   PivotTable,
   SlicerCache,
   TimelineCache,
+  ChartAnchor,
 } from "../_types";
 import { parsePersons, parseThreadedComments } from "./threaded-comments-reader";
 import { parseExternalLink } from "./external-link-reader";
@@ -402,14 +403,17 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
         // Resolve chart parts referenced from the drawing. Each
         // graphicFrame's chart rel was resolved against the drawing's
         // package directory in extractSheetDrawing; here we simply
-        // parse the chart bodies.
-        if (drawing.chartPaths.length > 0) {
+        // parse the chart bodies and pin each chart back to the cell
+        // anchor reported by the drawing layer.
+        if (drawing.chartRefs.length > 0) {
           const charts: import("../_types").Chart[] = [];
-          for (const chartPath of drawing.chartPaths) {
-            if (!zip.has(chartPath)) continue;
-            const chartXml = decodeUtf8(await zip.extract(chartPath));
+          for (const chartRef of drawing.chartRefs) {
+            if (!zip.has(chartRef.path)) continue;
+            const chartXml = decodeUtf8(await zip.extract(chartRef.path));
             const chart = parseChart(chartXml);
-            if (chart) charts.push(chart);
+            if (!chart) continue;
+            if (chartRef.anchor) chart.anchor = chartRef.anchor;
+            charts.push(chart);
           }
           if (charts.length > 0) sheet.charts = charts;
         }
@@ -696,15 +700,32 @@ const EXT_TO_IMAGE_TYPE: Record<string, SheetImage["type"]> = {
   webp: "webp",
 };
 
+/**
+ * Pairing of a chart part path with the cell anchor that pins the
+ * chart to its host sheet. The anchor mirrors the drawing-layer
+ * `<xdr:from>` / `<xdr:to>` pair, dropped through to {@link Chart.anchor}
+ * by the reader.
+ *
+ * `anchor` is omitted when the drawing positions the chart via
+ * `<xdr:absoluteAnchor>` (EMU-positioned, no cell anchor) or when the
+ * `<xdr:from>` element itself is missing — both are rare but possible.
+ */
+interface DrawingChartRef {
+  /** Path to `xl/charts/chartN.xml`, resolved against the package root. */
+  path: string;
+  /** Cell anchor surfaced through {@link Chart.anchor}. */
+  anchor?: ChartAnchor;
+}
+
 interface DrawingExtraction {
   images: SheetImage[];
   textBoxes: SheetTextBox[];
   /**
-   * Paths to chart parts referenced by this drawing (resolved against
-   * the package root). Empty when the drawing has no `c:chart` graphic
-   * frames or the rels file is missing.
+   * Chart parts referenced by this drawing, paired with the cell
+   * anchor that pins each chart to its host sheet. Empty when the
+   * drawing has no `c:chart` graphic frames or the rels file is missing.
    */
-  chartPaths: string[];
+  chartRefs: DrawingChartRef[];
 }
 
 /**
@@ -716,7 +737,7 @@ async function extractSheetDrawing(
   zip: ZipReader,
   drawingPath: string,
 ): Promise<DrawingExtraction> {
-  if (!zip.has(drawingPath)) return { images: [], textBoxes: [], chartPaths: [] };
+  if (!zip.has(drawingPath)) return { images: [], textBoxes: [], chartRefs: [] };
 
   const drawingXml = decodeUtf8(await zip.extract(drawingPath));
 
@@ -748,7 +769,7 @@ async function extractSheetDrawing(
   const doc = parseXml(drawingXml);
   const images: SheetImage[] = [];
   const textBoxes: SheetTextBox[] = [];
-  const chartPaths: string[] = [];
+  const chartRefs: DrawingChartRef[] = [];
 
   for (const child of doc.children) {
     if (typeof child === "string") continue;
@@ -762,7 +783,16 @@ async function extractSheetDrawing(
       const chartRid = findChartRid(child);
       if (chartRid) {
         const chartPath = chartRelMap.get(chartRid);
-        if (chartPath && !chartPaths.includes(chartPath)) chartPaths.push(chartPath);
+        if (chartPath && !chartRefs.some((r) => r.path === chartPath)) {
+          // absoluteAnchor positions in EMU rather than cells — skip
+          // its anchor extraction so we don't fabricate a (0,0) cell
+          // anchor that doesn't match the underlying placement.
+          const anchor =
+            local === "absoluteAnchor" ? undefined : parseChartCellAnchor(child, local);
+          const ref: DrawingChartRef = { path: chartPath };
+          if (anchor) ref.anchor = anchor;
+          chartRefs.push(ref);
+        }
       }
     }
 
@@ -811,7 +841,39 @@ async function extractSheetDrawing(
     }
   }
 
-  return { images, textBoxes, chartPaths };
+  return { images, textBoxes, chartRefs };
+}
+
+/**
+ * Extract the cell anchor (`<xdr:from>` / `<xdr:to>`) from a drawing
+ * anchor element that wraps a chart graphic frame. Used by the reader
+ * to surface {@link Chart.anchor}.
+ *
+ * For `xdr:twoCellAnchor` we read both `<xdr:from>` and `<xdr:to>`.
+ * For `xdr:oneCellAnchor` we read `<xdr:from>` only — the chart is
+ * pinned to a single cell with intrinsic width/height stored in
+ * `<xdr:ext>`, so a `to` cell is not meaningful.
+ *
+ * Returns `undefined` when no `<xdr:from>` block is present.
+ */
+function parseChartCellAnchor(
+  el: { children: Array<unknown> },
+  anchorKind: string,
+): ChartAnchor | undefined {
+  let from: { row: number; col: number } | undefined;
+  let to: { row: number; col: number } | undefined;
+
+  for (const child of el.children) {
+    if (typeof child === "string") continue;
+    const c = child as { local?: string; tag: string; children: Array<unknown> };
+    const local = c.local || c.tag;
+    if (local === "from") from = parseAnchorPosition(c);
+    else if (local === "to") to = parseAnchorPosition(c);
+  }
+
+  if (!from) return undefined;
+  if (anchorKind === "twoCellAnchor" && to) return { from, to };
+  return { from };
 }
 
 /**

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -499,6 +499,10 @@ describe("readXlsx — chart integration", () => {
       seriesCount: 1,
       title: "Quarterly Sales",
       series: [{ kind: "bar", index: 0, valuesRef: "Data!$B$1:$B$2" }],
+      anchor: {
+        from: { row: 1, col: 3 },
+        to: { row: 16, col: 10 },
+      },
     });
   });
 
@@ -631,5 +635,316 @@ describe("roundtrip — chart preservation", () => {
     const reread = await readXlsx(out);
     expect(reread.sheets[0].rows[0][0]).toBe(99);
     expect(reread.sheets[0].charts).toHaveLength(1);
+  });
+});
+
+// ── readXlsx — chart cell anchor ─────────────────────────────────
+
+/**
+ * Build a minimal XLSX where Sheet1's drawing anchors a single chart
+ * with a custom anchor flavor (`twoCellAnchor`, `oneCellAnchor`, or
+ * `absoluteAnchor`). Used to verify {@link Chart.anchor} extraction.
+ */
+async function buildXlsxWithAnchor(anchorXml: string): Promise<Uint8Array> {
+  const z = new ZipWriter();
+
+  z.add(
+    "[Content_Types].xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>
+  <Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+</Types>`),
+  );
+
+  z.add(
+    "_rels/.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/workbook.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Data" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+  );
+
+  z.add(
+    "xl/_rels/workbook.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/worksheets/sheet1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+           xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetData/>
+  <drawing r:id="rId1"/>
+</worksheet>`),
+  );
+
+  z.add(
+    "xl/worksheets/_rels/sheet1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/drawings/drawing1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+          xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+${anchorXml}
+</xdr:wsDr>`),
+  );
+
+  z.add(
+    "xl/drawings/_rels/drawing1.xml.rels",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+</Relationships>`),
+  );
+
+  z.add(
+    "xl/charts/chart1.xml",
+    encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart><c:plotArea><c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>`),
+  );
+
+  return await z.build();
+}
+
+/**
+ * Builds a `<xdr:graphicFrame>` payload with a chart reference. Used
+ * inside the anchor builders below to keep the test data compact.
+ */
+const CHART_GRAPHIC_FRAME = `<xdr:graphicFrame>
+      <xdr:nvGraphicFramePr>
+        <xdr:cNvPr id="2" name="Chart 1"/>
+        <xdr:cNvGraphicFramePr/>
+      </xdr:nvGraphicFramePr>
+      <xdr:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></xdr:xfrm>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart">
+          <c:chart r:id="rId1"/>
+        </a:graphicData>
+      </a:graphic>
+    </xdr:graphicFrame>`;
+
+describe("readXlsx — chart cell anchor", () => {
+  it("surfaces from/to from a twoCellAnchor", async () => {
+    const buf = await buildXlsxWithAnchor(`<xdr:twoCellAnchor>
+    <xdr:from><xdr:col>2</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>5</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    <xdr:to><xdr:col>9</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>20</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+    ${CHART_GRAPHIC_FRAME}
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>`);
+    const wb = await readXlsx(buf);
+    expect(wb.sheets[0].charts?.[0].anchor).toEqual({
+      from: { row: 5, col: 2 },
+      to: { row: 20, col: 9 },
+    });
+  });
+
+  it("surfaces from-only for a oneCellAnchor (intrinsic size lives in <xdr:ext>)", async () => {
+    const buf = await buildXlsxWithAnchor(`<xdr:oneCellAnchor>
+    <xdr:from><xdr:col>1</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>2</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    <xdr:ext cx="6000000" cy="3500000"/>
+    ${CHART_GRAPHIC_FRAME}
+    <xdr:clientData/>
+  </xdr:oneCellAnchor>`);
+    const wb = await readXlsx(buf);
+    const anchor = wb.sheets[0].charts?.[0].anchor;
+    expect(anchor).toEqual({ from: { row: 2, col: 1 } });
+    expect(anchor?.to).toBeUndefined();
+  });
+
+  it("omits anchor for an absoluteAnchor (EMU-positioned, no cell anchor)", async () => {
+    const buf = await buildXlsxWithAnchor(`<xdr:absoluteAnchor>
+    <xdr:pos x="914400" y="685800"/>
+    <xdr:ext cx="6000000" cy="3500000"/>
+    ${CHART_GRAPHIC_FRAME}
+    <xdr:clientData/>
+  </xdr:absoluteAnchor>`);
+    const wb = await readXlsx(buf);
+    expect(wb.sheets[0].charts?.[0].anchor).toBeUndefined();
+  });
+
+  it("omits anchor when the twoCellAnchor is missing its <xdr:from> block", async () => {
+    // Pathological — Excel always writes <xdr:from>, but defensive
+    // parsing should not invent a (0,0) anchor.
+    const buf = await buildXlsxWithAnchor(`<xdr:twoCellAnchor>
+    ${CHART_GRAPHIC_FRAME}
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>`);
+    const wb = await readXlsx(buf);
+    expect(wb.sheets[0].charts?.[0].anchor).toBeUndefined();
+  });
+
+  it("falls back to from-only when the twoCellAnchor is missing its <xdr:to> block", async () => {
+    // Some authoring tools omit <xdr:to> for one-cell-style charts
+    // even though the anchor element is twoCellAnchor.
+    const buf = await buildXlsxWithAnchor(`<xdr:twoCellAnchor>
+    <xdr:from><xdr:col>4</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>7</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    ${CHART_GRAPHIC_FRAME}
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>`);
+    const wb = await readXlsx(buf);
+    expect(wb.sheets[0].charts?.[0].anchor).toEqual({ from: { row: 7, col: 4 } });
+  });
+
+  it("attaches the correct anchor to each chart when the drawing carries multiple", async () => {
+    // Build a drawing with two anchors, each pointing at its own chart
+    // part. Verifies the per-anchor pairing rather than a coarse
+    // "any anchor" pickup.
+    const z = new ZipWriter();
+    z.add(
+      "[Content_Types].xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/>
+  <Override PartName="/xl/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+  <Override PartName="/xl/charts/chart2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>
+</Types>`),
+    );
+    z.add(
+      "_rels/.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/workbook.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Data" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`),
+    );
+    z.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/worksheets/sheet1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+           xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetData/>
+  <drawing r:id="rId1"/>
+</worksheet>`),
+    );
+    z.add(
+      "xl/worksheets/_rels/sheet1.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/drawings/drawing1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+          xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+          xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <xdr:twoCellAnchor>
+    <xdr:from><xdr:col>0</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>0</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    <xdr:to><xdr:col>5</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>10</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+    <xdr:graphicFrame>
+      <xdr:nvGraphicFramePr><xdr:cNvPr id="2" name="A"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr>
+      <xdr:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></xdr:xfrm>
+      <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rId1"/></a:graphicData></a:graphic>
+    </xdr:graphicFrame>
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>
+  <xdr:twoCellAnchor>
+    <xdr:from><xdr:col>6</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>12</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:from>
+    <xdr:to><xdr:col>13</xdr:col><xdr:colOff>0</xdr:colOff><xdr:row>30</xdr:row><xdr:rowOff>0</xdr:rowOff></xdr:to>
+    <xdr:graphicFrame>
+      <xdr:nvGraphicFramePr><xdr:cNvPr id="3" name="B"/><xdr:cNvGraphicFramePr/></xdr:nvGraphicFramePr>
+      <xdr:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/></xdr:xfrm>
+      <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart r:id="rId2"/></a:graphicData></a:graphic>
+    </xdr:graphicFrame>
+    <xdr:clientData/>
+  </xdr:twoCellAnchor>
+</xdr:wsDr>`),
+    );
+    z.add(
+      "xl/drawings/_rels/drawing1.xml.rels",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart2.xml"/>
+</Relationships>`),
+    );
+    z.add(
+      "xl/charts/chart1.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart><c:title><c:tx><c:rich><a:p xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:r><a:t>First</a:t></a:r></a:p></c:rich></c:tx></c:title><c:plotArea><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart></c:plotArea></c:chart>
+</c:chartSpace>`),
+    );
+    z.add(
+      "xl/charts/chart2.xml",
+      encoder.encode(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart><c:title><c:tx><c:rich><a:p xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><a:r><a:t>Second</a:t></a:r></a:p></c:rich></c:tx></c:title><c:plotArea><c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart></c:plotArea></c:chart>
+</c:chartSpace>`),
+    );
+
+    const wb = await readXlsx(await z.build());
+    const charts = wb.sheets[0].charts;
+    expect(charts).toHaveLength(2);
+    // Order tracks the drawing's anchor sequence — the first
+    // graphicFrame becomes charts[0], the second becomes charts[1].
+    const byTitle = new Map(charts!.map((c) => [c.title, c]));
+    expect(byTitle.get("First")?.anchor).toEqual({
+      from: { row: 0, col: 0 },
+      to: { row: 10, col: 5 },
+    });
+    expect(byTitle.get("Second")?.anchor).toEqual({
+      from: { row: 12, col: 6 },
+      to: { row: 30, col: 13 },
+    });
+  });
+
+  it("survives roundtrip — re-reading the saved file still reports the anchor", async () => {
+    const buf = await buildXlsxWithChart();
+    const wb = await openXlsx(buf);
+    const out = await saveXlsx(wb);
+    const reread = await readXlsx(out);
+    expect(reread.sheets[0].charts?.[0].anchor).toEqual({
+      from: { row: 1, col: 3 },
+      to: { row: 16, col: 10 },
+    });
   });
 });


### PR DESCRIPTION
## Summary

`parseChart` (and therefore `sheet.charts[i]`) only surfaced what was inside `xl/charts/chartN.xml`. The cell that pinned the chart to its host sheet — written on the *drawing* layer, one level up — was thrown away. PR #190 noted this gap explicitly: "Chart drawing-position read support … still left for a future PR — it threads through `extractSheetDrawing`, the roundtrip carry-over logic, and the `Chart` type." This PR closes that gap.

## API

```ts
import { readXlsx, type ChartAnchor } from "hucre";

const wb = await readXlsx(buffer);
for (const chart of wb.sheets[0].charts ?? []) {
  // chart.anchor is now populated when the drawing pinned the chart
  // to a cell range (the common case).
  console.log(chart.anchor);
  // { from: { row: 1, col: 3 }, to: { row: 16, col: 10 } }
}
```

## Model

```ts
interface ChartAnchor {
  from: { row: number; col: number };
  to?: { row: number; col: number };
}

interface Chart {
  kinds: ChartKind[];
  seriesCount: number;
  title?: string;
  series?: ChartSeriesInfo[];
  anchor?: ChartAnchor; // NEW
}
```

The shape mirrors `SheetChart.anchor` on the writer side, so a parsed `ChartAnchor` slots straight back into a clone target without remapping.

## Implementation

`extractSheetDrawing` already walked every `xdr:twoCellAnchor` / `xdr:oneCellAnchor` / `xdr:absoluteAnchor` to collect chart part paths. It now also reads the `<xdr:from>` / `<xdr:to>` blocks via the existing `parseAnchorPosition` helper and pairs each chart path with its anchor. The reader's chart loop then attaches the anchor to the parsed `Chart` before pushing it onto `sheet.charts`.

Edge cases:
- **`xdr:twoCellAnchor`** — both `from` and `to` surfaced.
- **`xdr:oneCellAnchor`** — only `from` surfaced; `to` is intentionally absent because the size lives in `<xdr:ext>` (EMU width/height), not in a second cell.
- **`xdr:absoluteAnchor`** — `anchor` reported as `undefined`. The chart is positioned in EMU rather than against any cell; fabricating a `(0,0)` anchor would silently misrepresent the placement.
- **Missing `<xdr:from>`** — defensive parsing returns `undefined` rather than `(0,0)`.
- **Multiple charts on one drawing** — each chart gets its own anchor, paired by the drawing's `rId` → chart-part lookup.

## Out of scope

- Pixel-precision offsets (`<xdr:colOff>` / `<xdr:rowOff>`) and intrinsic `<xdr:ext>` size for one-cell anchors. The cell-grid anchor is what `SheetChart.anchor` accepts on the writer side, so the round-trip story is symmetric without those fields.
- Roundtrip preservation already works through #186 (charts pass through verbatim), so the saved drawing keeps the original anchor bytes regardless of whether the new field is consumed.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2 470 vitest cases, including 6 new anchor tests)
- [x] `pnpm build`
- [x] `xdr:twoCellAnchor` surfaces both `from` and `to`
- [x] `xdr:oneCellAnchor` surfaces `from` only (no fabricated `to`)
- [x] `xdr:absoluteAnchor` reports `anchor` undefined
- [x] Drawing missing `<xdr:from>` reports `anchor` undefined (no `(0,0)` fabrication)
- [x] Drawing missing `<xdr:to>` falls back to `from`-only
- [x] Multiple charts on one drawing each get their own anchor
- [x] Roundtrip — re-reading a saved workbook still reports the chart's anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)