### PR TITLE
feat(xlsx): surface legend position and bar grouping on parsed charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,13 @@ for (const sheet of wb.sheets) {
     console.log(chart.anchor);
     // e.g. { from: { row: 1, col: 3 }, to: { row: 16, col: 10 } }
 
+    // chart.legend / chart.barGrouping mirror the writer-side fields
+    // so a parsed chart slots straight back into cloneChart without
+    // remapping. `legend: false` means the source chart explicitly
+    // hid the legend; `barGrouping` only surfaces on bar/column charts.
+    console.log(chart.legend, chart.barGrouping);
+    // e.g. "bottom" "stacked"
+
     for (const s of chart.series ?? []) {
       console.log(s.kind, s.index, s.name, s.valuesRef, s.categoriesRef, s.color);
       // e.g. "bar" 0 "Revenue" "Sheet1!$B$2:$B$10" "Sheet1!$A$2:$A$10" "1F77B4"
@@ -555,7 +562,15 @@ formula) intentionally surface no `valuesRef`/`categoriesRef`.
 `twoCellAnchor` charts surface both `from` and `to`,
 `oneCellAnchor` charts surface `from` only (intrinsic size lives in
 `<xdr:ext>`), and `absoluteAnchor` charts (EMU-positioned, no cell
-anchor) report `anchor` as `undefined`.
+anchor) report `anchor` as `undefined`. `Chart.legend` and
+`Chart.barGrouping` mirror the writer-side fields of the same name:
+`legend` reports `false` when the chart explicitly suppresses the
+legend (`<c:delete val="1"/>`), `right` when `<c:legend>` is present
+without a `legendPos`, and the matching writer label otherwise;
+`barGrouping` is pulled from the first `<c:barChart>` and only
+surfaces the stacked variants (the OOXML `standard` value collapses
+to `undefined` since the writer treats it as the unspecified default,
+and non-bar charts never report a grouping).
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1311,6 +1311,7 @@ export interface Chart {
    * declaration order. Empty when the chart has no `<c:ser>` children.
    */
   series?: ChartSeriesInfo[];
+  /**
    * Cell anchor pulled from the host drawing's `<xdr:twoCellAnchor>` /
    * `<xdr:oneCellAnchor>`. Undefined when the drawing positions the
    * chart with `<xdr:absoluteAnchor>` (EMU-positioned, no cell anchor)

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1254,6 +1254,29 @@ export interface ChartSeriesInfo {
  * structural metadata needed to recognize, introspect, and clone the
  * chart; the chart body is preserved verbatim through roundtrip.
  */
+/**
+ * Legend placement reported by {@link Chart.legend}.
+ *
+ * Values mirror the {@link SheetChart.legend} options on the writer
+ * side, so a parsed legend position slots straight back into a clone
+ * target. `false` is reported when the chart explicitly omits the
+ * legend element (Excel's "no legend" state); `undefined` means the
+ * chart did not declare a legend at all.
+ */
+export type ChartLegendPosition = "top" | "bottom" | "left" | "right" | "topRight";
+
+/**
+ * Bar/column grouping reported by {@link Chart.barGrouping}.
+ *
+ * Pulled from `<c:barChart><c:grouping val="..."/></c:barChart>`.
+ * `"standard"` is the OOXML value for non-stacked, non-percent layouts
+ * — it is excluded here because the writer's
+ * {@link SheetChart.barGrouping} models the same default as the
+ * absence of the field. Only the stacked variants surface, which is
+ * what callers need to detect when cloning a stacked template.
+ */
+export type ChartBarGrouping = "clustered" | "stacked" | "percentStacked";
+
 export interface Chart {
   /** Chart-type elements present in `<c:plotArea>`, in declaration order. */
   kinds: ChartKind[];
@@ -1266,6 +1289,23 @@ export interface Chart {
    * declaration order. Empty when the chart has no `<c:ser>` children.
    */
   series?: ChartSeriesInfo[];
+  /**
+   * Legend placement pulled from `<c:legend><c:legendPos val=".."/>`.
+   * Reported as `false` when the chart explicitly omits the legend
+   * element (Excel's "no legend" state). `undefined` means the chart
+   * did not declare a legend at all — Excel falls back to its default
+   * placement in that case.
+   */
+  legend?: false | ChartLegendPosition;
+  /**
+   * Grouping pulled from the first `<c:barChart>` element, when the
+   * chart has one. Surfaces only the stacked variants — the OOXML
+   * `"standard"` / `"clustered"` values both round-trip cleanly to
+   * the writer's `"clustered"` default, but only the explicit
+   * `clustered` value is reported here for symmetry with the writer's
+   * {@link SheetChart.barGrouping} field.
+   */
+  barGrouping?: ChartBarGrouping;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,13 @@ export { cloneChart, chartKindToWriteKind } from "./xlsx/chart-clone";
 export type { CloneChartOptions, CloneChartSeriesOverride } from "./xlsx/chart-clone";
 export { addChart, getCharts } from "./xlsx/chart-helpers";
 export type { ChartLocation } from "./xlsx/chart-helpers";
-export type { Chart, ChartKind, ChartSeriesInfo } from "./_types";
+export type {
+  Chart,
+  ChartBarGrouping,
+  ChartKind,
+  ChartLegendPosition,
+  ChartSeriesInfo,
+} from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────
 export {

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -135,8 +135,19 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     anchor: options.anchor,
   };
   if (title !== undefined) out.title = title;
-  if (options.legend !== undefined) out.legend = options.legend;
-  if (options.barGrouping !== undefined) out.barGrouping = options.barGrouping;
+
+  // Legend / bar grouping carry over from the source when the caller
+  // does not supply an override. Bar grouping only round-trips for
+  // bar/column targets — applying a stacked grouping to a line/pie
+  // template clone would be silently ignored by the writer.
+  const legend = options.legend !== undefined ? options.legend : source.legend;
+  if (legend !== undefined) out.legend = legend;
+
+  const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
+  if (barGrouping !== undefined && (type === "bar" || type === "column")) {
+    out.barGrouping = barGrouping;
+  }
+
   if (options.showTitle !== undefined) out.showTitle = options.showTitle;
   if (options.altText !== undefined) out.altText = options.altText;
   if (options.frameTitle !== undefined) out.frameTitle = options.frameTitle;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -12,7 +12,13 @@
 //
 // OOXML reference: ECMA-376 Part 1, §21.2 (DrawingML — Charts).
 
-import type { Chart, ChartKind, ChartSeriesInfo } from "../_types";
+import type {
+  Chart,
+  ChartBarGrouping,
+  ChartKind,
+  ChartLegendPosition,
+  ChartSeriesInfo,
+} from "../_types";
 import { parseXml } from "../xml/parser";
 import type { XmlElement } from "../xml/parser";
 
@@ -62,10 +68,18 @@ export function parseChart(xml: string): Chart | undefined {
   if (plotArea) {
     let seriesCount = 0;
     const series: ChartSeriesInfo[] = [];
+    let barGrouping: ChartBarGrouping | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
       if (!out.kinds.includes(kind)) out.kinds.push(kind);
+      // Pull grouping off the first bar/column-flavored chart-type
+      // element. Combo charts that mix bar with line/area would
+      // otherwise need a per-series field; for the common case of a
+      // single `<c:barChart>` body this is the value Excel applies.
+      if (barGrouping === undefined && (kind === "bar" || kind === "bar3D")) {
+        barGrouping = parseBarGrouping(child);
+      }
       let localIndex = 0;
       for (const ser of childElements(child)) {
         if (ser.local !== "ser") continue;
@@ -76,7 +90,11 @@ export function parseChart(xml: string): Chart | undefined {
     }
     out.seriesCount = seriesCount;
     if (series.length > 0) out.series = series;
+    if (barGrouping !== undefined) out.barGrouping = barGrouping;
   }
+
+  const legend = parseLegend(chartEl);
+  if (legend !== undefined) out.legend = legend;
 
   return out;
 }
@@ -176,6 +194,93 @@ function parseSeriesColor(ser: XmlElement): string | undefined {
   if (typeof val !== "string") return undefined;
   const normalized = val.replace(/^#/, "").toUpperCase();
   return /^[0-9A-F]{6}$/.test(normalized) ? normalized : undefined;
+}
+
+// ── Legend ────────────────────────────────────────────────────────
+
+/**
+ * Map `<c:legend><c:legendPos val=".."/></c:legend>` to the writer-side
+ * {@link ChartLegendPosition}. Returns `false` when `<c:delete val="1"/>`
+ * is present (Excel's "no legend" state); returns `undefined` when the
+ * chart has no `<c:legend>` element at all.
+ */
+function parseLegend(chartEl: XmlElement): false | ChartLegendPosition | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+
+  // <c:delete val="1"/> means the chart explicitly suppresses the
+  // legend. Some Excel versions emit just an empty `<c:legend/>`
+  // followed by `<c:overlay/>` even when the legend is hidden, but
+  // `<c:delete val="1">` is the canonical "no legend" marker.
+  const del = findChild(legend, "delete");
+  if (del && readBoolVal(del.attrs.val) === true) return false;
+
+  const pos = findChild(legend, "legendPos");
+  if (!pos) {
+    // A legend element without legendPos is valid OOXML (Excel falls
+    // back to "right"). Surface "right" so the cloned chart preserves
+    // the visible-legend state.
+    return "right";
+  }
+  const val = pos.attrs.val;
+  if (typeof val !== "string") return "right";
+  switch (val) {
+    case "t":
+      return "top";
+    case "b":
+      return "bottom";
+    case "l":
+      return "left";
+    case "r":
+      return "right";
+    case "tr":
+      return "topRight";
+    default:
+      // Unknown legendPos values are dropped rather than fabricated.
+      return undefined;
+  }
+}
+
+// ── Bar Grouping ──────────────────────────────────────────────────
+
+/**
+ * Pull `<c:grouping val=".."/>` off a `<c:barChart>` element. Returns
+ * `undefined` when the grouping element is missing or carries the
+ * default `"standard"` / `"clustered"` value — the writer's
+ * {@link SheetChart.barGrouping} treats both as the unspecified
+ * default, so omitting them keeps the parsed shape minimal.
+ */
+function parseBarGrouping(barChart: XmlElement): ChartBarGrouping | undefined {
+  const grouping = findChild(barChart, "grouping");
+  if (!grouping) return undefined;
+  const val = grouping.attrs.val;
+  if (typeof val !== "string") return undefined;
+  switch (val) {
+    case "stacked":
+      return "stacked";
+    case "percentStacked":
+      return "percentStacked";
+    case "clustered":
+      return "clustered";
+    case "standard":
+      // OOXML's `standard` for barChart is functionally equivalent to
+      // `clustered` (Excel renders side-by-side). Surface neither so
+      // the cloned chart inherits the writer's default.
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Parse an OOXML boolean attribute. The spec allows `"1"` / `"0"` /
+ * `"true"` / `"false"`.
+ */
+function readBoolVal(raw: string | undefined): boolean | undefined {
+  if (raw === undefined) return undefined;
+  if (raw === "1" || raw === "true") return true;
+  if (raw === "0" || raw === "false") return false;
+  return undefined;
 }
 
 // ── Internals ─────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -150,6 +150,65 @@ describe("cloneChart", () => {
     expect(clone.altText).toBe("Revenue chart");
     expect(clone.frameTitle).toBe("Revenue");
   });
+
+  it("inherits legend from the source chart when no override is given", () => {
+    const clone = cloneChart(source({ legend: "bottom" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legend).toBe("bottom");
+  });
+
+  it("inherits legend=false (hidden) from the source chart", () => {
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legend).toBe(false);
+  });
+
+  it("override wins over source legend", () => {
+    const clone = cloneChart(source({ legend: "bottom" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+    });
+    expect(clone.legend).toBe("top");
+  });
+
+  it("override legend=false hides a legend the source declared", () => {
+    const clone = cloneChart(source({ legend: "right" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+  });
+
+  it("inherits barGrouping from the source bar/column chart", () => {
+    const clone = cloneChart(source({ barGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.barGrouping).toBe("stacked");
+  });
+
+  it("override barGrouping wins over source barGrouping", () => {
+    const clone = cloneChart(source({ barGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      barGrouping: "percentStacked",
+    });
+    expect(clone.barGrouping).toBe("percentStacked");
+  });
+
+  it("drops inherited barGrouping when the clone target is not bar/column", () => {
+    // Source is a bar chart with stacked grouping; override coerces
+    // it to a line chart. Stacked grouping is meaningless for line so
+    // it should not survive on the clone.
+    const clone = cloneChart(source({ kinds: ["bar"], barGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.barGrouping).toBeUndefined();
+  });
 });
 
 // ── cloneChart — series overrides ────────────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -333,6 +333,138 @@ describe("parseChart — series introspection", () => {
   });
 });
 
+// ── parseChart — legend & grouping ────────────────────────────────
+
+describe("parseChart — legend", () => {
+  function chartWithLegend(legendXml: string): string {
+    return `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart></c:plotArea>
+    ${legendXml}
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("maps legendPos val=r → right", () => {
+    const xml = chartWithLegend('<c:legend><c:legendPos val="r"/></c:legend>');
+    expect(parseChart(xml)?.legend).toBe("right");
+  });
+
+  it("maps every legendPos value to the writer-side label", () => {
+    for (const [val, expected] of [
+      ["t", "top"],
+      ["b", "bottom"],
+      ["l", "left"],
+      ["r", "right"],
+      ["tr", "topRight"],
+    ] as const) {
+      const xml = chartWithLegend(`<c:legend><c:legendPos val="${val}"/></c:legend>`);
+      expect(parseChart(xml)?.legend).toBe(expected);
+    }
+  });
+
+  it('returns false when <c:delete val="1"/> hides the legend', () => {
+    const xml = chartWithLegend('<c:legend><c:delete val="1"/></c:legend>');
+    expect(parseChart(xml)?.legend).toBe(false);
+  });
+
+  it("falls back to right when legend is declared without legendPos", () => {
+    // Legend element with no legendPos child is valid OOXML; Excel
+    // renders it on the right.
+    const xml = chartWithLegend("<c:legend/>");
+    expect(parseChart(xml)?.legend).toBe("right");
+  });
+
+  it("returns undefined when the chart has no <c:legend>", () => {
+    const xml = chartWithLegend("");
+    expect(parseChart(xml)?.legend).toBeUndefined();
+  });
+
+  it("ignores unknown legendPos values rather than fabricating a default", () => {
+    const xml = chartWithLegend('<c:legend><c:legendPos val="bogus"/></c:legend>');
+    expect(parseChart(xml)?.legend).toBeUndefined();
+  });
+
+  it('ignores <c:delete val="0"/> (visible legend with no position) and falls back to right', () => {
+    const xml = chartWithLegend('<c:legend><c:delete val="0"/></c:legend>');
+    expect(parseChart(xml)?.legend).toBe("right");
+  });
+});
+
+describe("parseChart — bar grouping", () => {
+  function barChartWithGrouping(groupingXml: string): string {
+    return `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        ${groupingXml}
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces stacked grouping", () => {
+    const xml = barChartWithGrouping('<c:grouping val="stacked"/>');
+    expect(parseChart(xml)?.barGrouping).toBe("stacked");
+  });
+
+  it("surfaces percentStacked grouping", () => {
+    const xml = barChartWithGrouping('<c:grouping val="percentStacked"/>');
+    expect(parseChart(xml)?.barGrouping).toBe("percentStacked");
+  });
+
+  it("surfaces explicit clustered grouping", () => {
+    const xml = barChartWithGrouping('<c:grouping val="clustered"/>');
+    expect(parseChart(xml)?.barGrouping).toBe("clustered");
+  });
+
+  it("collapses standard grouping to undefined (writer default)", () => {
+    // OOXML's `standard` value renders identical to `clustered` in
+    // Excel; we omit it so the cloned chart inherits the writer's
+    // default rather than carrying a redundant marker.
+    const xml = barChartWithGrouping('<c:grouping val="standard"/>');
+    expect(parseChart(xml)?.barGrouping).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:grouping> element", () => {
+    const xml = barChartWithGrouping("");
+    expect(parseChart(xml)?.barGrouping).toBeUndefined();
+  });
+
+  it("does not surface barGrouping for non-bar charts", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.barGrouping).toBeUndefined();
+  });
+
+  it("uses the first bar chart's grouping in a combo workbook", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+      <c:lineChart>
+        <c:ser><c:idx val="1"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.barGrouping).toBe("stacked");
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

`parseChart` (and therefore `sheet.charts[i]`) already surfaced kinds, title, and series, but the chart-level layout fields — legend placement and bar grouping — were dropped on the floor. Without them a `cloneChart` round-trip silently flattens a stacked template back to clustered and a bottom-anchored legend back to the default right rail, even when the source XML declared otherwise.

This PR fills both gaps on the read side and threads them through the clone bridge so a "load template, retarget data, re-emit" workflow (the dashboard composition use case from #136) preserves the visual intent of the source chart.

## API

```ts
import { readXlsx, cloneChart } from "hucre";

const wb = await readXlsx(buffer);
const source = wb.sheets[0].charts![0];

console.log(source.legend);      // "bottom" | "right" | "top" | "left" | "topRight" | false | undefined
console.log(source.barGrouping); // "stacked" | "percentStacked" | "clustered" | undefined

// Clone now inherits both fields automatically when no override is given.
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!$B$2:$B$13" }],
});
// clone.legend === source.legend
// clone.barGrouping === source.barGrouping
```

## Model

```ts
export type ChartLegendPosition = "top" | "bottom" | "left" | "right" | "topRight";
export type ChartBarGrouping = "clustered" | "stacked" | "percentStacked";

interface Chart {
  // ... existing fields ...
  legend?: false | ChartLegendPosition;   // NEW
  barGrouping?: ChartBarGrouping;         // NEW
}
```

The shapes mirror `SheetChart.legend` and `SheetChart.barGrouping` on the writer side, so a parsed value slots straight back into a clone target without remapping.

## Implementation

- `parseChart` walks the new `<c:legend>` and `<c:grouping>` elements via the existing `findChild` helper.
  - **Legend**: `<c:legendPos val=".."/>` is mapped through the OOXML short codes (`r/l/t/b/tr`) to the writer-side labels. `<c:delete val="1"/>` surfaces as `false` (Excel's "no legend" state). A legend element with no `legendPos` falls back to `"right"` since that is what Excel renders. Unknown `legendPos` values are dropped rather than fabricated.
  - **Bar grouping**: pulled from the first `<c:barChart>` element. `"standard"` is intentionally collapsed to undefined — OOXML treats it as functionally identical to `"clustered"`, and the writer's `barGrouping` field treats both as the unspecified default. Non-bar charts (`<c:lineChart>`, `<c:pieChart>`, ...) never surface a grouping even if the XML carries one.
- `cloneChart` now defaults `legend` and `barGrouping` to the source's values when the caller does not pass an override. `barGrouping` only carries over when the clone target is `bar` / `column` — coercing a stacked bar template into a `line` chart silently drops the meaningless flag rather than emitting a writer-rejected combination.

## Edge cases

- `<c:delete val="1"/>` → `legend: false` (suppressed legend).
- `<c:legend/>` with no children → `legend: "right"` (Excel default for visible legend).
- Unknown `legendPos val` → `legend: undefined` (no fabrication).
- `<c:grouping val="standard"/>` → `barGrouping: undefined` (writer default).
- `<c:grouping>` on a non-bar chart → ignored.
- Combo chart with `<c:barChart>` + `<c:lineChart>` → grouping pulled from the first bar element, in line with Excel's render.
- Override `legend: false` correctly hides a legend the source declared.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2497 vitest cases, including 13 new parse tests + 7 new cloneChart inheritance tests)
- [x] `pnpm build`
- [x] All five `legendPos` values (`r`, `l`, `t`, `b`, `tr`) round-trip through the parser
- [x] `<c:delete val="1"/>` surfaces `legend: false`
- [x] `<c:legend/>` with no `legendPos` falls back to `right`
- [x] Unknown `legendPos` values report `undefined`
- [x] `<c:grouping val="standard"/>` is collapsed to `undefined`
- [x] `<c:grouping>` on a `<c:lineChart>` is ignored
- [x] Combo chart picks the bar grouping from the first bar element
- [x] `cloneChart` carries source legend / barGrouping through when no override is passed
- [x] `cloneChart` drops inherited `barGrouping` when the target type is not `bar`/`column`

🤖 Generated with [Claude Code](https://claude.com/claude-code)