### PR TITLE
feat(xlsx): chart axis titles — read, write, and clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -611,6 +611,23 @@ export interface SheetChart {
   altText?: string;
   /** Caption for the chart frame (lands in xdr:cNvPr/@title). */
   frameTitle?: string;
+  /**
+   * Per-axis labels rendered alongside the plot area. The `x` axis is
+   * the category axis for bar/column/line/area (or the bottom value
+   * axis for scatter); the `y` axis is the value axis. Ignored for
+   * `pie` charts because pie has no axes in OOXML.
+   *
+   * Each entry maps to a `<c:title>` element nested inside the
+   * matching `<c:catAx>` / `<c:valAx>`. Pass an empty string or omit
+   * the entry to skip the title — Excel renders no axis label by
+   * default.
+   */
+  axes?: {
+    /** Category axis (bar/column/line/area) or X value axis (scatter). */
+    x?: { title?: string };
+    /** Value axis. */
+    y?: { title?: string };
+  };
 }
 
 // ── Accessibility ──────────────────────────────────────────────────
@@ -1270,6 +1287,20 @@ export interface ChartAnchor {
 }
 
 /**
+ * Per-axis metadata pulled from the chart's `<c:catAx>` / `<c:valAx>`
+ * elements.
+ *
+ * Currently only the axis title is surfaced — Excel stores it as a
+ * `<c:title>` child element inside each axis, and it's the field that
+ * dashboard cloning needs to preserve through a `parseChart` →
+ * {@link cloneChart} → `writeXlsx` round-trip.
+ */
+export interface ChartAxisInfo {
+  /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
+  title?: string;
+}
+
+/**
  * A chart anchored on a sheet via the sheet's drawing part.
  *
  * Charts come from `xl/charts/chartN.xml`. Hucre exposes the
@@ -1295,6 +1326,17 @@ export interface Chart {
    * or when the drawing's anchor element is missing the `from` block.
    */
   anchor?: ChartAnchor;
+  /**
+   * Per-axis metadata. `x` corresponds to the chart's `<c:catAx>`
+   * (category axis on bar/column/line/area) or the first `<c:valAx>`
+   * on scatter. `y` corresponds to the value axis. Both fields are
+   * omitted on charts that have no axes (e.g. pie/doughnut) or when
+   * neither axis carries a title.
+   */
+  axes?: {
+    x?: ChartAxisInfo;
+    y?: ChartAxisInfo;
+  };
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ export { cloneChart, chartKindToWriteKind } from "./xlsx/chart-clone";
 export type { CloneChartOptions, CloneChartSeriesOverride } from "./xlsx/chart-clone";
 export { addChart, getCharts } from "./xlsx/chart-helpers";
 export type { ChartLocation } from "./xlsx/chart-helpers";
-export type { Chart, ChartAnchor, ChartKind, ChartSeriesInfo } from "./_types";
+export type { Chart, ChartAnchor, ChartAxisInfo, ChartKind, ChartSeriesInfo } from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────
 export {

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -79,6 +79,19 @@ export interface CloneChartOptions {
   altText?: string;
   /** Override `SheetChart.frameTitle`. */
   frameTitle?: string;
+  /**
+   * Per-axis title overrides. Each field accepts a string to replace,
+   * or `null` to drop the source value (the cloned chart will render
+   * without that axis label even if the template carried one). Omit a
+   * field to inherit the source.
+   *
+   * Ignored when the resolved chart type is `pie` since pie has no
+   * axes; the writer drops the entire `axes` object in that case.
+   */
+  axes?: {
+    x?: { title?: string | null };
+    y?: { title?: string | null };
+  };
 }
 
 /**
@@ -140,6 +153,13 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (options.showTitle !== undefined) out.showTitle = options.showTitle;
   if (options.altText !== undefined) out.altText = options.altText;
   if (options.frameTitle !== undefined) out.frameTitle = options.frameTitle;
+
+  // Pie has no axes, so silently skip carrying over axis titles even
+  // when the source declared them or the caller passed an override.
+  if (type !== "pie") {
+    const axes = resolveAxes(source.axes, options.axes);
+    if (axes !== undefined) out.axes = axes;
+  }
 
   return out;
 }
@@ -272,4 +292,24 @@ function applyOverride(
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;
+}
+
+/**
+ * Merge the source chart's `axes` block with per-axis overrides. The
+ * result mirrors the writer's {@link SheetChart.axes} shape — missing
+ * fields are dropped so the writer doesn't emit empty `<c:title>`
+ * elements.
+ */
+function resolveAxes(
+  sourceAxes: Chart["axes"],
+  overrides: CloneChartOptions["axes"],
+): SheetChart["axes"] | undefined {
+  const xTitle = applyOverride(sourceAxes?.x?.title, overrides?.x?.title);
+  const yTitle = applyOverride(sourceAxes?.y?.title, overrides?.y?.title);
+
+  const out: NonNullable<SheetChart["axes"]> = {};
+  if (xTitle !== undefined) out.x = { title: xTitle };
+  if (yTitle !== undefined) out.y = { title: yTitle };
+
+  return out.x || out.y ? out : undefined;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -12,7 +12,7 @@
 //
 // OOXML reference: ECMA-376 Part 1, §21.2 (DrawingML — Charts).
 
-import type { Chart, ChartKind, ChartSeriesInfo } from "../_types";
+import type { Chart, ChartAxisInfo, ChartKind, ChartSeriesInfo } from "../_types";
 import { parseXml } from "../xml/parser";
 import type { XmlElement } from "../xml/parser";
 
@@ -76,9 +76,97 @@ export function parseChart(xml: string): Chart | undefined {
     }
     out.seriesCount = seriesCount;
     if (series.length > 0) out.series = series;
+
+    const axes = parseAxes(plotArea);
+    if (axes !== undefined) out.axes = axes;
   }
 
   return out;
+}
+
+// ── Axes ──────────────────────────────────────────────────────────
+
+/**
+ * Pull per-axis metadata from the plot area's `<c:catAx>` / `<c:valAx>`
+ * children.
+ *
+ * The mapping mirrors the writer side:
+ *   - bar / column / line / area: `x` = `<c:catAx>`, `y` = first `<c:valAx>`.
+ *   - scatter / bubble:           `x` = first `<c:valAx>`, `y` = second `<c:valAx>`.
+ *
+ * Returns `undefined` when neither axis surfaces a title — keeps the
+ * default `Chart` shape lean.
+ */
+function parseAxes(plotArea: XmlElement): { x?: ChartAxisInfo; y?: ChartAxisInfo } | undefined {
+  let catAx: XmlElement | undefined;
+  const valAxes: XmlElement[] = [];
+  for (const child of childElements(plotArea)) {
+    if (child.local === "catAx") {
+      catAx ??= child;
+    } else if (child.local === "valAx") {
+      valAxes.push(child);
+    }
+  }
+
+  let xAxis: XmlElement | undefined;
+  let yAxis: XmlElement | undefined;
+  if (catAx) {
+    xAxis = catAx;
+    yAxis = valAxes[0];
+  } else {
+    // Scatter / bubble: both axes are valAx. The first declared one is
+    // the X axis (`axPos="b"`), the second is the Y axis (`axPos="l"`).
+    xAxis = valAxes[0];
+    yAxis = valAxes[1];
+  }
+
+  const x = xAxis ? parseAxisInfo(xAxis) : undefined;
+  const y = yAxis ? parseAxisInfo(yAxis) : undefined;
+
+  if (!x && !y) return undefined;
+  const out: { x?: ChartAxisInfo; y?: ChartAxisInfo } = {};
+  if (x) out.x = x;
+  if (y) out.y = y;
+  return out;
+}
+
+function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
+  const title = parseAxisTitle(axis);
+  if (title === undefined) return undefined;
+  return { title };
+}
+
+/**
+ * Read an axis's `<c:title>` text. Mirrors {@link parseTitle} but
+ * scoped to a single axis element rather than the chart root.
+ */
+function parseAxisTitle(axis: XmlElement): string | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (rich) {
+    const parts: string[] = [];
+    collectTextRuns(rich, parts);
+    const joined = parts.join("").trim();
+    return joined.length > 0 ? joined : undefined;
+  }
+  const strRef = findChild(tx, "strRef");
+  if (strRef) {
+    const cache = findChild(strRef, "strCache");
+    if (cache) {
+      for (const pt of childElements(cache)) {
+        if (pt.local !== "pt") continue;
+        const v = findChild(pt, "v");
+        if (v) {
+          const text = elementText(v).trim();
+          if (text.length > 0) return text;
+        }
+      }
+    }
+  }
+  return undefined;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -119,21 +119,26 @@ function buildTitle(title: string): string {
 function buildPlotArea(chart: SheetChart, sheetName: string): string {
   const children: string[] = [xmlSelfClose("c:layout")];
 
+  // Axis titles surface for every chart family except pie. Pull them
+  // once so each branch can hand them off to the matching axis builder.
+  const xAxisTitle = normalizeAxisTitle(chart.axes?.x?.title);
+  const yAxisTitle = normalizeAxisTitle(chart.axes?.y?.title);
+
   switch (chart.type) {
     case "bar":
     case "column": {
       children.push(buildBarChart(chart, sheetName));
-      children.push(...buildBarAxes(chart.type));
+      children.push(...buildBarAxes(chart.type, xAxisTitle, yAxisTitle));
       break;
     }
     case "line": {
       children.push(buildLineChart(chart, sheetName));
-      children.push(...buildBarAxes("column"));
+      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle));
       break;
     }
     case "area": {
       children.push(buildAreaChart(chart, sheetName));
-      children.push(...buildBarAxes("column"));
+      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle));
       break;
     }
     case "pie": {
@@ -142,7 +147,7 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     }
     case "scatter": {
       children.push(buildScatterChart(chart, sheetName));
-      children.push(...buildScatterAxes());
+      children.push(...buildScatterAxes(xAxisTitle, yAxisTitle));
       break;
     }
     default: {
@@ -153,6 +158,18 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
   }
 
   return xmlElement("c:plotArea", undefined, children);
+}
+
+/**
+ * Normalize an axis title input to either a non-empty trimmed string
+ * or `undefined`. Empty strings are dropped so the writer never emits
+ * an empty `<c:title>` element (Excel renders that as an unintended
+ * blank label).
+ */
+function normalizeAxisTitle(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 // ── Bar / Column ─────────────────────────────────────────────────────
@@ -188,37 +205,54 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
   return xmlElement("c:barChart", undefined, children);
 }
 
-function buildBarAxes(orientation: "bar" | "column"): string[] {
+function buildBarAxes(
+  orientation: "bar" | "column",
+  xAxisTitle: string | undefined,
+  yAxisTitle: string | undefined,
+): string[] {
   // For a vertical column chart, categories sit on the bottom (catAx)
   // and values run vertically (valAx). For a horizontal bar chart the
   // axes swap orientation.
   const catPos = orientation === "column" ? "b" : "l";
   const valPos = orientation === "column" ? "l" : "b";
 
-  const catAx = xmlElement("c:catAx", undefined, [
+  // OOXML enforces a strict child order inside <c:catAx>/<c:valAx>:
+  // axId → scaling → delete → axPos → (majorGridlines) → title → ...
+  // Title must therefore land before crossAx/crosses, otherwise Excel
+  // refuses to render the axis label.
+  const catAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_CAT }),
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: catPos }),
+  ];
+  if (xAxisTitle) catAxChildren.push(buildAxisTitle(xAxisTitle));
+  catAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:auto", { val: 1 }),
     xmlSelfClose("c:lblAlgn", { val: "ctr" }),
     xmlSelfClose("c:lblOffset", { val: 100 }),
     xmlSelfClose("c:noMultiLvlLbl", { val: 0 }),
-  ]);
+  );
 
-  const valAx = xmlElement("c:valAx", undefined, [
+  const valAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL }),
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: valPos }),
+  ];
+  if (yAxisTitle) valAxChildren.push(buildAxisTitle(yAxisTitle));
+  valAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "between" }),
-  ]);
+  );
 
-  return [catAx, valAx];
+  return [
+    xmlElement("c:catAx", undefined, catAxChildren),
+    xmlElement("c:valAx", undefined, valAxChildren),
+  ];
 }
 
 // ── Line ─────────────────────────────────────────────────────────────
@@ -293,28 +327,75 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
   return xmlElement("c:scatterChart", undefined, children);
 }
 
-function buildScatterAxes(): string[] {
-  const xAx = xmlElement("c:valAx", undefined, [
+function buildScatterAxes(
+  xAxisTitle: string | undefined,
+  yAxisTitle: string | undefined,
+): string[] {
+  const xAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_X }),
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "b" }),
+  ];
+  if (xAxisTitle) xAxChildren.push(buildAxisTitle(xAxisTitle));
+  xAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
-  ]);
+  );
 
-  const yAx = xmlElement("c:valAx", undefined, [
+  const yAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_Y }),
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "l" }),
+  ];
+  if (yAxisTitle) yAxChildren.push(buildAxisTitle(yAxisTitle));
+  yAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
-  ]);
+  );
 
-  return [xAx, yAx];
+  return [
+    xmlElement("c:valAx", undefined, xAxChildren),
+    xmlElement("c:valAx", undefined, yAxChildren),
+  ];
+}
+
+/**
+ * Build a `<c:title>` for an axis. The structure mirrors the chart-
+ * level title but renders the label at a smaller default font (10pt vs
+ * 14pt) to match Excel's axis-title style.
+ */
+function buildAxisTitle(label: string): string {
+  return xmlElement("c:title", undefined, [
+    xmlElement("c:tx", undefined, [
+      xmlElement("c:rich", undefined, [
+        xmlElement(
+          "a:bodyPr",
+          {
+            rot: 0,
+            spcFirstLastPara: 1,
+            vertOverflow: "ellipsis",
+            wrap: "square",
+            anchor: "ctr",
+            anchorCtr: 1,
+          },
+          [],
+        ),
+        xmlSelfClose("a:lstStyle"),
+        xmlElement("a:p", undefined, [
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz: 1000, b: 0 })]),
+          xmlElement("a:r", undefined, [
+            xmlSelfClose("a:rPr", { lang: "en-US", sz: 1000, b: 0 }),
+            xmlElement("a:t", undefined, xmlEscape(label)),
+          ]),
+        ]),
+      ]),
+    ]),
+    xmlSelfClose("c:overlay", { val: 0 }),
+  ]);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -258,6 +258,94 @@ describe("cloneChart — series overrides", () => {
   });
 });
 
+// ── cloneChart — axis titles ────────────────────────────────────────
+
+describe("cloneChart — axis titles", () => {
+  const sourceWithAxes: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { title: "Quarter" }, y: { title: "Revenue" } },
+  };
+
+  it("inherits the source's axes when no override is given", () => {
+    const clone = cloneChart(sourceWithAxes, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toEqual({
+      x: { title: "Quarter" },
+      y: { title: "Revenue" },
+    });
+  });
+
+  it("does not set axes when the source has none", () => {
+    const noAxes: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noAxes, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces a single axis title via override", () => {
+    const clone = cloneChart(sourceWithAxes, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period" } },
+    });
+    expect(clone.axes).toEqual({
+      x: { title: "Period" },
+      y: { title: "Revenue" },
+    });
+  });
+
+  it("drops a source axis title when override is null", () => {
+    const clone = cloneChart(sourceWithAxes, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { title: null } },
+    });
+    expect(clone.axes).toEqual({ x: { title: "Quarter" } });
+    expect(clone.axes?.y).toBeUndefined();
+  });
+
+  it("adds an axis title that the source did not declare", () => {
+    const partial: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { title: "Quarter" } },
+    };
+    const clone = cloneChart(partial, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { title: "Revenue" } },
+    });
+    expect(clone.axes).toEqual({
+      x: { title: "Quarter" },
+      y: { title: "Revenue" },
+    });
+  });
+
+  it("drops axes silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      // Pie charts shouldn't carry axes, but the parser cannot know
+      // ahead of time — make sure cloneChart strips them on output.
+      axes: { x: { title: "Spurious" }, y: { title: "Spurious Y" } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("returns axes undefined when both x and y resolve to undefined", () => {
+    const clone = cloneChart(sourceWithAxes, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: null }, y: { title: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+});
+
 // ── cloneChart — round-trip with parseChart and writeXlsx ────────────
 
 describe("cloneChart — integration", () => {
@@ -352,5 +440,60 @@ describe("cloneChart — integration", () => {
     expect(clones[2].series[0].color).toBe("F76808");
     // Categories carry through unchanged.
     expect(clones.every((c) => c.series[0].categories === "Tpl!$A$2:$A$5")).toBe(true);
+  });
+
+  it("round-trips axis titles through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="111"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Quarter</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="222"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue (USD)</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.axes).toEqual({ x: { title: "Quarter" }, y: { title: "Revenue (USD)" } });
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.axes).toEqual({
+      x: { title: "Quarter" },
+      y: { title: "Revenue (USD)" },
+    });
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [1], [2], [3], [4]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toEqual({
+      x: { title: "Quarter" },
+      y: { title: "Revenue (USD)" },
+    });
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -232,6 +232,139 @@ describe("writeChart", () => {
   );
 });
 
+// ── Axis titles ──────────────────────────────────────────────────────
+
+describe("writeChart — axis titles", () => {
+  it("emits a <c:title> inside <c:catAx> when axes.x.title is set", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: "Quarter" } },
+      }),
+      "Sheet1",
+    );
+    // The axis title lives inside c:catAx, not at chart level.
+    expect(result.chartXml).toContain("<c:catAx>");
+    // Either form is fine, but the literal label must be present.
+    expect(result.chartXml).toContain("Quarter");
+    // catAx must contain the title (between catAx open and its close).
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/);
+    expect(catAxBlock).not.toBeNull();
+    expect(catAxBlock![0]).toContain("c:title");
+    expect(catAxBlock![0]).toContain("Quarter");
+  });
+
+  it("emits a <c:title> inside <c:valAx> when axes.y.title is set", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { y: { title: "Revenue (USD)" } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/);
+    expect(valAxBlock).not.toBeNull();
+    expect(valAxBlock![0]).toContain("c:title");
+    expect(valAxBlock![0]).toContain("Revenue (USD)");
+  });
+
+  it("places axis titles after axPos but before crossAx (OOXML order)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: "X" }, y: { title: "Y" } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const axPosIdx = catAxBlock.indexOf("c:axPos");
+    const titleIdx = catAxBlock.indexOf("<c:title>");
+    const crossAxIdx = catAxBlock.indexOf("c:crossAx");
+    expect(axPosIdx).toBeGreaterThanOrEqual(0);
+    expect(titleIdx).toBeGreaterThan(axPosIdx);
+    expect(crossAxIdx).toBeGreaterThan(titleIdx);
+  });
+
+  it("escapes XML-special characters in axis titles", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: 'A & "B" <C>' } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('A &amp; "B" &lt;C&gt;');
+    expect(result.chartXml).not.toContain("<C>");
+  });
+
+  it("drops empty / whitespace-only axis titles", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: "   " }, y: { title: "" } },
+      }),
+      "Sheet1",
+    );
+    // No title element should be emitted inside either axis.
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).not.toContain("c:title");
+    expect(valAxBlock).not.toContain("c:title");
+  });
+
+  it("works for line and area charts (which share the bar axis builder)", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Date" }, y: { title: "Score" } } }),
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain("Date");
+      expect(result.chartXml).toContain("Score");
+      const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(catAxBlock).toContain("c:title");
+      expect(valAxBlock).toContain("c:title");
+    }
+  });
+
+  it("emits scatter axis titles on the X (b) and Y (l) value axes respectively", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { title: "X-Time" }, y: { title: "Y-Mag" } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    expect(valAxBlocks).toHaveLength(2);
+    // First valAx is the X axis (axPos="b"), second is Y (axPos="l").
+    expect(valAxBlocks[0]).toContain('c:axPos val="b"');
+    expect(valAxBlocks[0]).toContain("X-Time");
+    expect(valAxBlocks[1]).toContain('c:axPos val="l"');
+    expect(valAxBlocks[1]).toContain("Y-Mag");
+  });
+
+  it("skips axes for pie charts even when axes.x is set", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        axes: { x: { title: "Ignored" } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:catAx");
+    expect(result.chartXml).not.toContain("c:valAx");
+    expect(result.chartXml).not.toContain("Ignored");
+  });
+
+  it("renders well-formed XML when both axes are titled", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "X" }, y: { title: "Y" } } }),
+      "Sheet1",
+    );
+    const doc = parseXml(result.chartXml);
+    expect(doc).toBeTruthy();
+  });
+});
+
 describe("chartKindElement", () => {
   it("maps each chart kind to the matching DrawingML element", () => {
     expect(chartKindElement("bar")).toBe("c:barChart");

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -333,6 +333,162 @@ describe("parseChart — series introspection", () => {
   });
 });
 
+// ── parseChart — axis titles ──────────────────────────────────────
+
+describe("parseChart — axis titles", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  it("surfaces x and y axis titles from <c:catAx>/<c:valAx> rich text", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Quarter</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue (USD)</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toEqual({
+      x: { title: "Quarter" },
+      y: { title: "Revenue (USD)" },
+    });
+  });
+
+  it("does not surface axes when neither axis carries a title", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("surfaces only the populated axis when one side is titled", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toEqual({ y: { title: "Revenue" } });
+    expect(chart?.axes?.x).toBeUndefined();
+  });
+
+  it("falls back to a strRef cache when the title is a formula", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title>
+          <c:tx>
+            <c:strRef>
+              <c:f>Sheet1!$A$1</c:f>
+              <c:strCache>
+                <c:ptCount val="1"/>
+                <c:pt idx="0"><c:v>Cached Y Label</c:v></c:pt>
+              </c:strCache>
+            </c:strRef>
+          </c:tx>
+        </c:title>
+      </c:valAx>
+      <c:catAx><c:axId val="1"/></c:catAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("Cached Y Label");
+  });
+
+  it("maps scatter axes to x = first valAx, y = second valAx", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+      <c:valAx>
+        <c:axId val="1"/>
+        <c:axPos val="b"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Time</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:valAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:axPos val="l"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Magnitude</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toEqual({
+      x: { title: "Time" },
+      y: { title: "Magnitude" },
+    });
+  });
+
+  it("ignores empty/whitespace-only axis titles", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>   </a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("joins multi-run rich titles into a single string", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx>
+            <c:rich>
+              <a:p>
+                <a:r><a:t>Region </a:t></a:r>
+                <a:r><a:t>(2024)</a:t></a:r>
+              </a:p>
+            </c:rich>
+          </c:tx>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Region (2024)");
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

`parseChart` and the chart writer surfaced/emitted the chart-level title, but per-axis titles — the labels Excel renders against `<c:catAx>` / `<c:valAx>` — were missing from both sides. A `parseChart` → `cloneChart` → `writeXlsx` round-trip therefore silently dropped axis labels that were present in a template workbook, breaking the dashboard composition use case from #136 for any chart whose axes carried a name like "Quarter" or "Revenue (USD)".

This PR closes that hole at all three layers — read, write, and clone — so a templated chart's axis text survives the full retarget loop without the caller having to thread it manually.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes); // { x: { title: "Quarter" }, y: { title: "Revenue (USD)" } }

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ values: "B2:B13" }],
      anchor: { from: { row: 14, col: 0 } },
      axes: { x: { title: "Quarter" }, y: { title: "Revenue (USD)" } },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!\$B\$2:\$B\$13" }],
  // axes inherit from `source` automatically; pass overrides to remap.
});
```

## Model

```ts
export interface ChartAxisInfo {
  title?: string;
}

interface Chart {
  // ... existing fields ...
  axes?: { x?: ChartAxisInfo; y?: ChartAxisInfo };
}

interface SheetChart {
  // ... existing fields ...
  axes?: {
    x?: { title?: string };
    y?: { title?: string };
  };
}
```

## Implementation

- **Reader (`chart-reader.ts`)**: walks the plot area's `<c:catAx>` / `<c:valAx>` children. For bar/column/line/area: `x` = `<c:catAx>`, `y` = first `<c:valAx>`. For scatter (and bubble): both axes are `<c:valAx>` — first declared (`axPos="b"`) maps to `x`, second (`axPos="l"`) to `y`. Title text is pulled from rich runs or, when the axis title is a formula, from `<c:strCache>`. Empty / whitespace-only titles are dropped so the consumer never sees a phantom blank label.
- **Writer (`chart-writer.ts`)**: `buildBarAxes` and `buildScatterAxes` now accept `xAxisTitle` / `yAxisTitle` and inject a `<c:title>` element **after** `<c:axPos>` and **before** `<c:crossAx>`. OOXML enforces this child order — putting the title in the wrong position causes Excel to ignore the label entirely. A new `buildAxisTitle` helper mirrors the chart-level `buildTitle` but with a 10pt default font (matching Excel's axis-title style vs the 14pt chart title). Pie has no axes, so the writer silently skips the field there.
- **Clone bridge (`chart-clone.ts`)**: a new `resolveAxes` helper merges the source's `axes` with per-axis overrides via the same `applyOverride` semantics already used for series fields (`undefined` = inherit, `null` = drop, string = replace). When the resolved chart type is `pie`, the axes block is dropped entirely so a doughnut/pie template that happened to carry stray axis titles doesn't poison the clone.

## Edge cases

- `<c:title>` with whitespace-only text → not surfaced (read), not emitted (write).
- Multi-run rich titles like `<a:r>Region </a:r><a:r>(2024)</a:r>` → joined into a single string.
- Cloning into `pie` strips inherited axes; cloning into `column` from a `pie` source with no axes leaves `axes` undefined.
- One axis titled, the other not → only the populated side appears in `Chart.axes` / `SheetChart.axes`.
- Override `axes: { y: { title: null } }` drops the inherited Y label while keeping X.
- `<c:title>` placement in the writer is verified to land between `<c:axPos>` and `<c:crossAx>` (the OOXML-enforced position).

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2507 vitest cases, including 7 new parser tests, 9 new writer tests, 8 new clone tests, and 1 end-to-end round-trip via `writeXlsx`)
- [x] `pnpm build`
- [x] Round-trip: `parseChart` → `cloneChart` → `writeXlsx` → `parseChart` preserves both axis titles verbatim
- [x] Scatter chart axis titles map to the X (`axPos="b"`) and Y (`axPos="l"`) value axes correctly
- [x] Pie charts silently drop `axes` on both write and clone paths
- [x] Empty / whitespace-only titles are dropped on read and write
- [x] XML-special characters (`&`, `<`, `>`, `"`) in axis titles are escaped on write
- [x] OOXML child order enforced: `<c:title>` appears after `<c:axPos>` and before `<c:crossAx>` inside both `<c:catAx>` and `<c:valAx>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)