### PR TITLE
feat(xlsx): chart axis gridlines — read, write, and clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,10 +540,11 @@ for (const sheet of wb.sheets) {
     console.log(chart.legend, chart.barGrouping);
     // e.g. "bottom" "stacked"
 
-    // chart.axes carries per-axis labels pulled from <c:catAx>/<c:valAx>
-    // <c:title>. Only populated axes show up — pie/doughnut never do.
+    // chart.axes carries per-axis labels and gridline visibility pulled
+    // from <c:catAx>/<c:valAx>. Only populated axes show up — pie/doughnut
+    // never do.
     console.log(chart.axes);
-    // e.g. { x: { title: "Quarter" }, y: { title: "Revenue (USD)" } }
+    // e.g. { x: { title: "Quarter" }, y: { title: "Revenue (USD)", gridlines: { major: true } } }
 
     // chart.dataLabels surfaces the chart-type-level <c:dLbls> block.
     // showValue / showCategoryName / showSeriesName / showPercent and
@@ -584,11 +585,14 @@ without a `legendPos`, and the matching writer label otherwise;
 surfaces the stacked variants (the OOXML `standard` value collapses
 to `undefined` since the writer treats it as the unspecified default,
 and non-bar charts never report a grouping). `Chart.axes` mirrors
-the writer-side `SheetChart.axes` and surfaces per-axis labels: `x`
-is the category axis (or, for scatter, the first value axis) and
-`y` is the value axis. Empty / whitespace-only `<c:title>` text is
-dropped, charts without any axis label leave `axes` undefined, and
-pie/doughnut charts (which have no axes in OOXML) never report one.
+the writer-side `SheetChart.axes` and surfaces per-axis labels and
+gridline visibility: `x` is the category axis (or, for scatter, the
+first value axis) and `y` is the value axis. Empty / whitespace-only
+`<c:title>` text is dropped, `gridlines: { major, minor }` flips on
+when the matching `<c:majorGridlines>` / `<c:minorGridlines>` element
+is present (any nested styling is tolerated), charts without any
+axis label or gridline leave `axes` undefined, and pie/doughnut
+charts (which have no axes in OOXML) never report one.
 `Chart.dataLabels` mirrors the writer-side `SheetChart.dataLabels`
 and surfaces the toggles Excel carries inside `<c:dLbls>`
 (`showValue`, `showCategoryName`, `showSeriesName`, `showPercent`,
@@ -643,11 +647,14 @@ embedded apostrophes are doubled per the OOXML spec). `barGrouping`
 toggles `clustered` / `stacked` / `percentStacked`, `legend` accepts
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
-attributes for screen readers. `axes: { x: { title }, y: { title } }`
-attaches per-axis labels — `x` lands inside `<c:catAx>` (or the X
-value axis for scatter), `y` inside the value axis. Empty or
-whitespace-only titles are silently dropped, and pie charts ignore
-the field because OOXML defines no axes for them. `dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, position, separator }`
+attributes for screen readers. `axes: { x: { title, gridlines }, y: { title, gridlines } }`
+attaches per-axis labels and gridlines — `x` lands inside `<c:catAx>`
+(or the X value axis for scatter), `y` inside the value axis. Empty
+or whitespace-only titles are silently dropped, `gridlines: { major,
+minor }` emits `<c:majorGridlines>` / `<c:minorGridlines>` in the
+spec-required position (after `<c:axPos>`, before any `<c:title>`,
+major before minor), and pie charts ignore the entire `axes` field
+because OOXML defines no axes for them. `dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, position, separator }`
 attaches Excel's small in-chart annotations: set at the chart level
 to label every series, or set on a single `series[i].dataLabels` to
 override (passing `false` suppresses labels for that series alone
@@ -687,10 +694,13 @@ writer can author collapse onto their write counterparts (`bar` /
 `bar3D` → `column`, `doughnut` / `pie3D` → `pie`, `line3D` → `line`,
 `area3D` → `area`); kinds with no analog (`bubble`, `radar`,
 `surface`, `stock`, `ofPie`) require an explicit `options.type`
-override. Axis titles inherit from the source by default; pass
+override. Axis titles and gridlines inherit from the source by default; pass
 `axes: { y: { title: "Revenue" } }` to replace one side, `null` to
-drop an inherited label, and the writer drops the entire `axes`
-block automatically when the resolved type is `pie`. Data labels
+drop an inherited label, `axes: { y: { gridlines: { major: true,
+minor: true } } }` to replace inherited gridlines, or
+`axes: { y: { gridlines: null } }` to drop them. The writer drops
+the entire `axes` block automatically when the resolved type is
+`pie`. Data labels
 inherit too: omit `dataLabels` to carry the source's chart-level
 labels through, pass an object to replace, or `null` to drop them;
 per-series overrides accept the same `undefined`/`null`/object

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -686,21 +686,26 @@ export interface SheetChart {
    */
   dataLabels?: ChartDataLabels;
   /**
-   * Per-axis labels rendered alongside the plot area. The `x` axis is
-   * the category axis for bar/column/line/area (or the bottom value
-   * axis for scatter); the `y` axis is the value axis. Ignored for
-   * `pie` charts because pie has no axes in OOXML.
+   * Per-axis configuration rendered alongside the plot area. The `x`
+   * axis is the category axis for bar/column/line/area (or the bottom
+   * value axis for scatter); the `y` axis is the value axis. Ignored
+   * for `pie` charts because pie has no axes in OOXML.
    *
-   * Each entry maps to a `<c:title>` element nested inside the
-   * matching `<c:catAx>` / `<c:valAx>`. Pass an empty string or omit
-   * the entry to skip the title — Excel renders no axis label by
-   * default.
+   * `title` maps to a `<c:title>` element nested inside the matching
+   * `<c:catAx>` / `<c:valAx>`. Pass an empty string or omit the entry
+   * to skip the title — Excel renders no axis label by default.
+   *
+   * `gridlines` toggles `<c:majorGridlines>` / `<c:minorGridlines>`.
+   * Omitting the field skips both — useful when porting a clean look
+   * across cloned charts. Set `major: true` to draw the heavier
+   * reference lines that Excel shows by default on the value axis;
+   * `minor: true` adds the lighter half-step lines.
    */
   axes?: {
     /** Category axis (bar/column/line/area) or X value axis (scatter). */
-    x?: { title?: string };
+    x?: { title?: string; gridlines?: ChartAxisGridlines };
     /** Value axis. */
-    y?: { title?: string };
+    y?: { title?: string; gridlines?: ChartAxisGridlines };
   };
 }
 
@@ -1382,17 +1387,40 @@ export interface ChartAnchor {
 }
 
 /**
+ * Major / minor gridline visibility for a chart axis.
+ *
+ * Excel paints horizontal or vertical reference lines across the plot
+ * area, anchored to the major or minor tick marks of an axis. The
+ * presence of `<c:majorGridlines>` / `<c:minorGridlines>` inside an
+ * `<c:catAx>` or `<c:valAx>` toggles them on; absence of the element
+ * means the gridline is off (Excel's default for the value axis is
+ * major-on/minor-off, but the OOXML serialization is explicit either
+ * way — the writer mirrors what the model says).
+ */
+export interface ChartAxisGridlines {
+  /** Whether the axis declares `<c:majorGridlines>`. */
+  major?: boolean;
+  /** Whether the axis declares `<c:minorGridlines>`. */
+  minor?: boolean;
+}
+
+/**
  * Per-axis metadata pulled from the chart's `<c:catAx>` / `<c:valAx>`
  * elements.
  *
- * Currently only the axis title is surfaced — Excel stores it as a
- * `<c:title>` child element inside each axis, and it's the field that
- * dashboard cloning needs to preserve through a `parseChart` →
- * {@link cloneChart} → `writeXlsx` round-trip.
+ * Surfaces the structural pieces that dashboard cloning needs to
+ * preserve through a `parseChart` → {@link cloneChart} → `writeXlsx`
+ * round-trip — currently the axis title and the gridline visibility.
  */
 export interface ChartAxisInfo {
   /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
   title?: string;
+  /**
+   * Major / minor gridline visibility. Omitted when neither
+   * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the
+   * axis (i.e. Excel's "no gridlines" state for both).
+   */
+  gridlines?: ChartAxisGridlines;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export type { ChartLocation } from "./xlsx/chart-helpers";
 export type {
   Chart,
   ChartAnchor,
+  ChartAxisGridlines,
   ChartAxisInfo,
   ChartBarGrouping,
   ChartDataLabelPosition,

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -12,6 +12,7 @@
 
 import type {
   Chart,
+  ChartAxisGridlines,
   ChartDataLabels,
   ChartDataLabelsInfo,
   ChartKind,
@@ -96,17 +97,17 @@ export interface CloneChartOptions {
    */
   dataLabels?: ChartDataLabels | null;
   /**
-   * Per-axis title overrides. Each field accepts a string to replace,
-   * or `null` to drop the source value (the cloned chart will render
-   * without that axis label even if the template carried one). Omit a
-   * field to inherit the source.
+   * Per-axis overrides. Each field accepts a value to replace the
+   * source's, or `null` to drop the source value (the cloned chart
+   * will render without that axis label / gridline even if the
+   * template carried one). Omit a field to inherit the source.
    *
    * Ignored when the resolved chart type is `pie` since pie has no
    * axes; the writer drops the entire `axes` object in that case.
    */
   axes?: {
-    x?: { title?: string | null };
-    y?: { title?: string | null };
+    x?: { title?: string | null; gridlines?: ChartAxisGridlines | null };
+    y?: { title?: string | null; gridlines?: ChartAxisGridlines | null };
   };
 }
 
@@ -371,7 +372,7 @@ function applyOverride(
  * Merge the source chart's `axes` block with per-axis overrides. The
  * result mirrors the writer's {@link SheetChart.axes} shape — missing
  * fields are dropped so the writer doesn't emit empty `<c:title>`
- * elements.
+ * elements or redundant gridline blocks.
  */
 function resolveAxes(
   sourceAxes: Chart["axes"],
@@ -379,10 +380,44 @@ function resolveAxes(
 ): SheetChart["axes"] | undefined {
   const xTitle = applyOverride(sourceAxes?.x?.title, overrides?.x?.title);
   const yTitle = applyOverride(sourceAxes?.y?.title, overrides?.y?.title);
+  const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
+  const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
 
   const out: NonNullable<SheetChart["axes"]> = {};
-  if (xTitle !== undefined) out.x = { title: xTitle };
-  if (yTitle !== undefined) out.y = { title: yTitle };
+  if (xTitle !== undefined || xGridlines !== undefined) {
+    out.x = {};
+    if (xTitle !== undefined) out.x.title = xTitle;
+    if (xGridlines !== undefined) out.x.gridlines = xGridlines;
+  }
+  if (yTitle !== undefined || yGridlines !== undefined) {
+    out.y = {};
+    if (yTitle !== undefined) out.y.title = yTitle;
+    if (yGridlines !== undefined) out.y.gridlines = yGridlines;
+  }
 
   return out.x || out.y ? out : undefined;
+}
+
+/**
+ * Resolve gridlines using the same `undefined` (inherit) / `null`
+ * (drop) / object (replace) grammar as the other axis overrides.
+ * Returns `undefined` when neither source nor override declares a
+ * non-empty gridline configuration.
+ */
+function applyGridlinesOverride(
+  source: ChartAxisGridlines | undefined,
+  override: ChartAxisGridlines | null | undefined,
+): ChartAxisGridlines | undefined {
+  if (override === undefined) {
+    if (!source) return undefined;
+    const out: ChartAxisGridlines = {};
+    if (source.major) out.major = true;
+    if (source.minor) out.minor = true;
+    return out.major || out.minor ? out : undefined;
+  }
+  if (override === null) return undefined;
+  const out: ChartAxisGridlines = {};
+  if (override.major === true) out.major = true;
+  if (override.minor === true) out.minor = true;
+  return out.major || out.minor ? out : undefined;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -14,6 +14,7 @@
 
 import type {
   Chart,
+  ChartAxisGridlines,
   ChartAxisInfo,
   ChartBarGrouping,
   ChartDataLabelPosition,
@@ -166,8 +167,33 @@ function parseAxes(plotArea: XmlElement): { x?: ChartAxisInfo; y?: ChartAxisInfo
 
 function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const title = parseAxisTitle(axis);
-  if (title === undefined) return undefined;
-  return { title };
+  const gridlines = parseAxisGridlines(axis);
+  if (title === undefined && gridlines === undefined) return undefined;
+  const out: ChartAxisInfo = {};
+  if (title !== undefined) out.title = title;
+  if (gridlines !== undefined) out.gridlines = gridlines;
+  return out;
+}
+
+/**
+ * Detect `<c:majorGridlines>` / `<c:minorGridlines>` children on an
+ * axis element. The mere presence of either child element flips the
+ * corresponding flag on — Excel allows but does not require nested
+ * `<c:spPr>` styling, and the toggle survives even when the body is
+ * empty.
+ *
+ * Returns `undefined` when neither element is present so the consumer
+ * never sees a "{ major: false, minor: false }" record that
+ * round-trips into a redundant write.
+ */
+function parseAxisGridlines(axis: XmlElement): ChartAxisGridlines | undefined {
+  const major = findChild(axis, "majorGridlines") !== undefined;
+  const minor = findChild(axis, "minorGridlines") !== undefined;
+  if (!major && !minor) return undefined;
+  const out: ChartAxisGridlines = {};
+  if (major) out.major = true;
+  if (minor) out.minor = true;
+  return out;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -6,7 +6,13 @@
 // Chapter 21). Each chart is a self-contained <c:chartSpace> document
 // referenced from a drawing part via a `chart` relationship.
 
-import type { WriteChartKind, ChartDataLabels, ChartSeries, SheetChart } from "../_types";
+import type {
+  ChartAxisGridlines,
+  ChartDataLabels,
+  ChartSeries,
+  SheetChart,
+  WriteChartKind,
+} from "../_types";
 import { xmlDocument, xmlElement, xmlEscape, xmlSelfClose } from "../xml/writer";
 
 // ── Namespaces ───────────────────────────────────────────────────────
@@ -119,26 +125,29 @@ function buildTitle(title: string): string {
 function buildPlotArea(chart: SheetChart, sheetName: string): string {
   const children: string[] = [xmlSelfClose("c:layout")];
 
-  // Axis titles surface for every chart family except pie. Pull them
-  // once so each branch can hand them off to the matching axis builder.
+  // Axis titles and gridlines surface for every chart family except
+  // pie. Pull them once so each branch can hand them off to the
+  // matching axis builder.
   const xAxisTitle = normalizeAxisTitle(chart.axes?.x?.title);
   const yAxisTitle = normalizeAxisTitle(chart.axes?.y?.title);
+  const xGridlines = normalizeAxisGridlines(chart.axes?.x?.gridlines);
+  const yGridlines = normalizeAxisGridlines(chart.axes?.y?.gridlines);
 
   switch (chart.type) {
     case "bar":
     case "column": {
       children.push(buildBarChart(chart, sheetName));
-      children.push(...buildBarAxes(chart.type, xAxisTitle, yAxisTitle));
+      children.push(...buildBarAxes(chart.type, xAxisTitle, yAxisTitle, xGridlines, yGridlines));
       break;
     }
     case "line": {
       children.push(buildLineChart(chart, sheetName));
-      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle));
+      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle, xGridlines, yGridlines));
       break;
     }
     case "area": {
       children.push(buildAreaChart(chart, sheetName));
-      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle));
+      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle, xGridlines, yGridlines));
       break;
     }
     case "pie": {
@@ -147,7 +156,7 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     }
     case "scatter": {
       children.push(buildScatterChart(chart, sheetName));
-      children.push(...buildScatterAxes(xAxisTitle, yAxisTitle));
+      children.push(...buildScatterAxes(xAxisTitle, yAxisTitle, xGridlines, yGridlines));
       break;
     }
     default: {
@@ -170,6 +179,36 @@ function normalizeAxisTitle(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Resolve the gridline toggles to a stable record (or `undefined` when
+ * neither is on). Mirrors {@link normalizeAxisTitle} so the per-branch
+ * code in `buildPlotArea` only needs a single null check.
+ */
+function normalizeAxisGridlines(
+  value: ChartAxisGridlines | undefined,
+): { major: boolean; minor: boolean } | undefined {
+  if (!value) return undefined;
+  const major = value.major === true;
+  const minor = value.minor === true;
+  if (!major && !minor) return undefined;
+  return { major, minor };
+}
+
+/**
+ * Build the `<c:majorGridlines>` / `<c:minorGridlines>` block for an
+ * axis. The returned XML fragments must be appended in spec order
+ * (major before minor) and slot in immediately after `<c:axPos>`,
+ * before the optional `<c:title>`. Excel's strict-validator rejects
+ * any other position.
+ */
+function buildAxisGridlines(gridlines: { major: boolean; minor: boolean } | undefined): string[] {
+  if (!gridlines) return [];
+  const out: string[] = [];
+  if (gridlines.major) out.push(xmlElement("c:majorGridlines", undefined, []));
+  if (gridlines.minor) out.push(xmlElement("c:minorGridlines", undefined, []));
+  return out;
 }
 
 // ── Bar / Column ─────────────────────────────────────────────────────
@@ -216,6 +255,8 @@ function buildBarAxes(
   orientation: "bar" | "column",
   xAxisTitle: string | undefined,
   yAxisTitle: string | undefined,
+  xGridlines: { major: boolean; minor: boolean } | undefined,
+  yGridlines: { major: boolean; minor: boolean } | undefined,
 ): string[] {
   // For a vertical column chart, categories sit on the bottom (catAx)
   // and values run vertically (valAx). For a horizontal bar chart the
@@ -224,14 +265,16 @@ function buildBarAxes(
   const valPos = orientation === "column" ? "l" : "b";
 
   // OOXML enforces a strict child order inside <c:catAx>/<c:valAx>:
-  // axId → scaling → delete → axPos → (majorGridlines) → title → ...
-  // Title must therefore land before crossAx/crosses, otherwise Excel
-  // refuses to render the axis label.
+  // axId → scaling → delete → axPos → majorGridlines → minorGridlines
+  // → title → numFmt → crossAx → ...
+  // Gridlines and title must therefore land before crossAx/crosses,
+  // and gridlines must come before the title or Excel ignores them.
   const catAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_CAT }),
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: catPos }),
+    ...buildAxisGridlines(xGridlines),
   ];
   if (xAxisTitle) catAxChildren.push(buildAxisTitle(xAxisTitle));
   catAxChildren.push(
@@ -248,6 +291,7 @@ function buildBarAxes(
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: valPos }),
+    ...buildAxisGridlines(yGridlines),
   ];
   if (yAxisTitle) valAxChildren.push(buildAxisTitle(yAxisTitle));
   valAxChildren.push(
@@ -362,12 +406,15 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
 function buildScatterAxes(
   xAxisTitle: string | undefined,
   yAxisTitle: string | undefined,
+  xGridlines: { major: boolean; minor: boolean } | undefined,
+  yGridlines: { major: boolean; minor: boolean } | undefined,
 ): string[] {
   const xAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_X }),
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "b" }),
+    ...buildAxisGridlines(xGridlines),
   ];
   if (xAxisTitle) xAxChildren.push(buildAxisTitle(xAxisTitle));
   xAxChildren.push(
@@ -381,6 +428,7 @@ function buildScatterAxes(
     xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "l" }),
+    ...buildAxisGridlines(yGridlines),
   ];
   if (yAxisTitle) yAxChildren.push(buildAxisTitle(yAxisTitle));
   yAxChildren.push(

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -823,4 +823,66 @@ describe("cloneChart — integration", () => {
       y: { title: "Revenue (USD)" },
     });
   });
+
+  it("round-trips axis gridlines through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="111"/>
+        <c:majorGridlines/>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="222"/>
+        <c:majorGridlines/>
+        <c:minorGridlines/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.axes).toEqual({
+      x: { gridlines: { major: true } },
+      y: { gridlines: { major: true, minor: true } },
+    });
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.axes).toEqual({
+      x: { gridlines: { major: true } },
+      y: { gridlines: { major: true, minor: true } },
+    });
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [1], [2], [3], [4]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("c:majorGridlines");
+    expect(written).toContain("c:minorGridlines");
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toEqual({
+      x: { gridlines: { major: true } },
+      y: { gridlines: { major: true, minor: true } },
+    });
+  });
 });

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -405,6 +405,100 @@ describe("cloneChart — axis titles", () => {
   });
 });
 
+// ── cloneChart — axis gridlines ─────────────────────────────────────
+
+describe("cloneChart — axis gridlines", () => {
+  const sourceWithGridlines: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: {
+      y: { gridlines: { major: true } },
+    },
+  };
+
+  it("inherits the source's gridlines when no override is given", () => {
+    const clone = cloneChart(sourceWithGridlines, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toEqual({
+      y: { gridlines: { major: true } },
+    });
+  });
+
+  it("inherits both major and minor gridlines together", () => {
+    const both: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { gridlines: { major: true, minor: true } } },
+    };
+    const clone = cloneChart(both, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.gridlines).toEqual({ major: true, minor: true });
+  });
+
+  it("co-inherits the title and gridlines on the same axis", () => {
+    const both: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { title: "Revenue", gridlines: { major: true } } },
+    };
+    const clone = cloneChart(both, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y).toEqual({
+      title: "Revenue",
+      gridlines: { major: true },
+    });
+  });
+
+  it("drops inherited gridlines when override is null", () => {
+    const clone = cloneChart(sourceWithGridlines, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { gridlines: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces inherited gridlines with the override", () => {
+    const clone = cloneChart(sourceWithGridlines, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { gridlines: { major: true, minor: true } } },
+    });
+    expect(clone.axes?.y?.gridlines).toEqual({ major: true, minor: true });
+  });
+
+  it("adds gridlines to an axis the source did not declare them on", () => {
+    const noGridlines: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noGridlines, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { gridlines: { major: true } } },
+    });
+    expect(clone.axes?.y?.gridlines).toEqual({ major: true });
+  });
+
+  it("strips gridlines silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { gridlines: { major: true } } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("treats { major: false, minor: false } overrides as no gridlines", () => {
+    const clone = cloneChart(sourceWithGridlines, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { gridlines: { major: false, minor: false } } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+});
+
 // ── cloneChart — round-trip with parseChart and writeXlsx ────────────
 
 describe("cloneChart — integration", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -365,6 +365,130 @@ describe("writeChart — axis titles", () => {
   });
 });
 
+describe("writeChart — axis gridlines", () => {
+  it("emits <c:majorGridlines> inside the value axis when y.gridlines.major is true", () => {
+    const result = writeChart(makeChart({ axes: { y: { gridlines: { major: true } } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/);
+    expect(valAxBlock).not.toBeNull();
+    expect(valAxBlock![0]).toContain("c:majorGridlines");
+    // No minor gridlines should slip in.
+    expect(valAxBlock![0]).not.toContain("c:minorGridlines");
+  });
+
+  it("emits both <c:majorGridlines> and <c:minorGridlines> when both are true", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { gridlines: { major: true, minor: true } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain("c:majorGridlines");
+    expect(valAxBlock).toContain("c:minorGridlines");
+    // Major must precede minor per OOXML schema.
+    expect(valAxBlock.indexOf("c:majorGridlines")).toBeLessThan(
+      valAxBlock.indexOf("c:minorGridlines"),
+    );
+  });
+
+  it("places gridlines after axPos but before any axis title (OOXML order)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: { title: "Revenue", gridlines: { major: true } },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const axPosIdx = valAxBlock.indexOf("c:axPos");
+    const gridlinesIdx = valAxBlock.indexOf("c:majorGridlines");
+    const titleIdx = valAxBlock.indexOf("<c:title>");
+    const crossAxIdx = valAxBlock.indexOf("c:crossAx");
+    expect(axPosIdx).toBeGreaterThanOrEqual(0);
+    expect(gridlinesIdx).toBeGreaterThan(axPosIdx);
+    expect(titleIdx).toBeGreaterThan(gridlinesIdx);
+    expect(crossAxIdx).toBeGreaterThan(titleIdx);
+  });
+
+  it("emits gridlines on the category axis when x.gridlines is set", () => {
+    const result = writeChart(makeChart({ axes: { x: { gridlines: { major: true } } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("c:majorGridlines");
+  });
+
+  it("emits no gridlines when both flags are false or omitted", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { gridlines: { major: false, minor: false } } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:majorGridlines");
+    expect(result.chartXml).not.toContain("c:minorGridlines");
+  });
+
+  it("emits gridlines for line and area charts (sharing the bar axis builder)", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({
+          type,
+          axes: { y: { gridlines: { major: true } } },
+        }),
+        "Sheet1",
+      );
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(valAxBlock).toContain("c:majorGridlines");
+    }
+  });
+
+  it("emits scatter gridlines on the X (b) and Y (l) value axes respectively", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: {
+          x: { gridlines: { major: true } },
+          y: { gridlines: { minor: true } },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    expect(valAxBlocks).toHaveLength(2);
+    expect(valAxBlocks[0]).toContain('c:axPos val="b"');
+    expect(valAxBlocks[0]).toContain("c:majorGridlines");
+    expect(valAxBlocks[0]).not.toContain("c:minorGridlines");
+    expect(valAxBlocks[1]).toContain('c:axPos val="l"');
+    expect(valAxBlocks[1]).toContain("c:minorGridlines");
+    expect(valAxBlocks[1]).not.toContain("c:majorGridlines");
+  });
+
+  it("skips gridlines on pie charts (pie has no axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        axes: { y: { gridlines: { major: true, minor: true } } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:majorGridlines");
+    expect(result.chartXml).not.toContain("c:minorGridlines");
+  });
+
+  it("renders well-formed XML when titles and gridlines coexist", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Quarter", gridlines: { major: true } },
+          y: { title: "Revenue", gridlines: { major: true, minor: true } },
+        },
+      }),
+      "Sheet1",
+    );
+    const doc = parseXml(result.chartXml);
+    expect(doc).toBeTruthy();
+  });
+});
+
 describe("chartKindElement", () => {
   it("maps each chart kind to the matching DrawingML element", () => {
     expect(chartKindElement("bar")).toBe("c:barChart");

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -819,6 +819,155 @@ describe("parseChart — axis titles", () => {
   });
 });
 
+// ── parseChart — axis gridlines ──────────────────────────────────
+
+describe("parseChart — axis gridlines", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  it("surfaces major gridlines on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:majorGridlines/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toEqual({
+      y: { gridlines: { major: true } },
+    });
+  });
+
+  it("surfaces both major and minor gridlines when present", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:majorGridlines/>
+        <c:minorGridlines/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.gridlines).toEqual({ major: true, minor: true });
+  });
+
+  it("surfaces gridlines on both x and y axes simultaneously", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:majorGridlines/>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:minorGridlines/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toEqual({
+      x: { gridlines: { major: true } },
+      y: { gridlines: { minor: true } },
+    });
+  });
+
+  it("does not surface axes when neither title nor gridlines are declared", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces gridlines and the axis title when both are present", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:majorGridlines/>
+        <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y).toEqual({
+      title: "Revenue",
+      gridlines: { major: true },
+    });
+  });
+
+  it("ignores nested styling inside the gridline elements", () => {
+    // Excel sometimes nests <c:spPr> inside <c:majorGridlines> for line
+    // styling. The presence of the outer element is what flips the toggle.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:majorGridlines>
+          <c:spPr>
+            <a:ln w="9525"><a:solidFill><a:srgbClr val="D9D9D9"/></a:solidFill></a:ln>
+          </c:spPr>
+        </c:majorGridlines>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.gridlines).toEqual({ major: true });
+  });
+
+  it("maps scatter chart gridlines to x = first valAx, y = second valAx", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+      <c:valAx>
+        <c:axId val="1"/>
+        <c:axPos val="b"/>
+        <c:majorGridlines/>
+      </c:valAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:axPos val="l"/>
+        <c:minorGridlines/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toEqual({
+      x: { gridlines: { major: true } },
+      y: { gridlines: { minor: true } },
+    });
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

`parseChart` and the chart writer already carried the axis title across the read / write / clone bridge (#197), but the gridlines Excel paints across the plot area (`<c:majorGridlines>` / `<c:minorGridlines>`) were ignored on both sides. A `parseChart` → `cloneChart` → `writeXlsx` round-trip therefore stripped the reference lines from any template chart that had them on, breaking the dashboard composition flow from #136 for the common "value-axis with major gridlines" look.

This PR closes that hole at all three layers — read, write, and clone — so a templated chart's gridline configuration survives the full retarget loop without the caller having to thread it manually.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes);
// { y: { gridlines: { major: true } } }

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ values: "B2:B13" }],
      anchor: { from: { row: 14, col: 0 } },
      axes: {
        y: { title: "Revenue (USD)", gridlines: { major: true, minor: true } },
        x: { gridlines: { major: true } },
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!\$B\$2:\$B\$13" }],
  // gridlines inherit from `source` automatically; pass overrides to remap.
});

// Drop the inherited gridlines on a single axis:
const clean = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: { y: { gridlines: null } },
});
```

## Model

```ts
export interface ChartAxisGridlines {
  major?: boolean;
  minor?: boolean;
}

interface ChartAxisInfo {
  title?: string;
  gridlines?: ChartAxisGridlines;
}

interface SheetChart {
  // ... existing fields ...
  axes?: {
    x?: { title?: string; gridlines?: ChartAxisGridlines };
    y?: { title?: string; gridlines?: ChartAxisGridlines };
  };
}
```

## Implementation

- **Reader (`chart-reader.ts`)**: walks each `<c:catAx>` / `<c:valAx>` for a `<c:majorGridlines>` / `<c:minorGridlines>` child and surfaces the flags. Nested `<c:spPr>` styling is tolerated — the presence of the outer element is what flips the toggle, matching how Excel reads the flag back. `parseAxisInfo` now considers both title and gridlines when deciding whether the axis surfaces; an axis with only gridlines (no title) still yields a `ChartAxisInfo`.
- **Writer (`chart-writer.ts`)**: `buildBarAxes` and `buildScatterAxes` accept `xGridlines` / `yGridlines` and slot the gridline elements between `<c:axPos>` and the optional `<c:title>`. OOXML enforces this child order — putting gridlines anywhere else causes Excel's strict validator to reject the file. Major-before-minor is also schema-enforced. Pie charts have no axes, so the writer silently skips the field there.
- **Clone bridge (`chart-clone.ts`)**: a new `applyGridlinesOverride` helper carries the same `undefined` (inherit) / `null` (drop) / object (replace) grammar already used for axis titles. `resolveAxes` now folds title and gridlines into the same `axes.{x,y}` record, dropping it entirely when both sides resolve to `undefined`. When the resolved chart type is `pie` the whole axes block is dropped, so a doughnut/pie template that happened to carry stray gridlines does not poison the clone.

## Edge cases

- `<c:majorGridlines>` containing nested `<c:spPr>` styling → the toggle still flips on (read), and the writer emits an empty element on round-trip (the styling is not yet round-tripped, but the gridline itself is preserved).
- Both flags omitted / set to `false` → reader returns `undefined`, writer emits no gridline element, clone returns `axes: undefined` if no other axis field is set.
- Override `axes: { y: { gridlines: null } }` drops the inherited gridlines while keeping the inherited title. Override `axes: { y: { gridlines: { major: true, minor: true } } }` replaces the inherited block wholesale.
- Combo charts that declare both `<c:catAx>` and one or more `<c:valAx>`: `parseAxes` already maps `x = catAx`, `y = first valAx` for bar/column/line/area, and `x = first valAx (axPos="b")`, `y = second valAx (axPos="l")` for scatter — the gridline detection inherits that mapping with no extra logic.
- Cloning into `pie` strips inherited gridlines along with axis titles; cloning into `column` from a `pie` source with no axes leaves `axes` undefined.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2579 vitest cases — adds 7 parser tests, 9 writer tests, 8 clone tests)
- [x] `pnpm build`