### PR TITLE
feat(xlsx): doughnut as a writable chart kind — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -540,15 +540,14 @@ export interface SheetImage {
 
 /**
  * Chart kinds supported by {@link writeXlsx} when authoring charts via
- * {@link WriteSheet.charts}. Phase 1 covers the four most common chart
- * families — bar/column, line, pie, and scatter — plus area as a
- * thin variant of `line`.
+ * {@link WriteSheet.charts}. Covers the most common chart families —
+ * bar/column, line, pie, doughnut, scatter, and area.
  *
  * Distinct from the read-side {@link ChartKind} (which mirrors the
  * full set of OOXML chart-type element local names) — the write side
  * exposes only the kinds the chart author can emit today.
  */
-export type WriteChartKind = "bar" | "column" | "line" | "pie" | "scatter" | "area";
+export type WriteChartKind = "bar" | "column" | "line" | "pie" | "doughnut" | "scatter" | "area";
 
 /**
  * Where a data label is placed relative to its data point.
@@ -667,9 +666,16 @@ export interface SheetChart {
    */
   barGrouping?: "clustered" | "stacked" | "percentStacked";
   /**
+   * Doughnut hole size as a percentage of the outer radius. Accepted
+   * range: 10 – 90 (Excel's UI clamps values outside this band).
+   * Default: `50` — the Excel default. Ignored for non-doughnut chart
+   * kinds.
+   */
+  holeSize?: number;
+  /**
    * Whether the legend is shown and where. Default: `"right"` for
-   * pie/bar/line/area, `"bottom"` for scatter. Pass `false` to hide
-   * the legend.
+   * pie/doughnut/bar/line/area, `"bottom"` for scatter. Pass `false`
+   * to hide the legend.
    */
   legend?: false | "top" | "bottom" | "left" | "right" | "topRight";
   /** Show the chart-level title element. Default: `true` when `title` is set. */
@@ -689,7 +695,7 @@ export interface SheetChart {
    * Per-axis labels rendered alongside the plot area. The `x` axis is
    * the category axis for bar/column/line/area (or the bottom value
    * axis for scatter); the `y` axis is the value axis. Ignored for
-   * `pie` charts because pie has no axes in OOXML.
+   * `pie` and `doughnut` charts because they have no axes in OOXML.
    *
    * Each entry maps to a `<c:title>` element nested inside the
    * matching `<c:catAx>` / `<c:valAx>`. Pass an empty string or omit
@@ -1478,6 +1484,13 @@ export interface Chart {
     x?: ChartAxisInfo;
     y?: ChartAxisInfo;
   };
+  /**
+   * Doughnut hole size pulled from the chart's `<c:doughnutChart>
+   * <c:holeSize val=".."/>`, expressed as a percentage of the outer
+   * radius (1–99). Omitted on non-doughnut charts and on doughnut
+   * charts that do not declare the element.
+   */
+  holeSize?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -65,7 +65,7 @@ export interface CloneChartOptions {
   /**
    * Override the chart family. When omitted, the source's first
    * write-compatible kind is used. An explicit value lets callers
-   * narrow a combo chart down to one renderable type or coerce a
+   * narrow a combo chart down to one renderable type or flatten a
    * `doughnut` template into a plain `pie`.
    */
   type?: WriteChartKind;
@@ -83,6 +83,13 @@ export interface CloneChartOptions {
   legend?: SheetChart["legend"];
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
+  /**
+   * Override `SheetChart.holeSize` (only meaningful for `doughnut`).
+   * When the resolved chart type is not `doughnut`, the field is
+   * dropped from the output so it does not leak into a cloned pie or
+   * column chart.
+   */
+  holeSize?: number;
   /** Override `SheetChart.showTitle`. */
   showTitle?: boolean;
   /** Override `SheetChart.altText`. */
@@ -101,8 +108,9 @@ export interface CloneChartOptions {
    * without that axis label even if the template carried one). Omit a
    * field to inherit the source.
    *
-   * Ignored when the resolved chart type is `pie` since pie has no
-   * axes; the writer drops the entire `axes` object in that case.
+   * Ignored when the resolved chart type is `pie` or `doughnut` since
+   * neither has axes; the writer drops the entire `axes` object in
+   * those cases.
    */
   axes?: {
     x?: { title?: string | null };
@@ -177,6 +185,15 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     out.barGrouping = barGrouping;
   }
 
+  // Doughnut hole size only makes sense when the resolved type is
+  // doughnut; flattening to pie (or any other kind) drops the hint so
+  // the writer does not silently ignore it. The override wins over the
+  // source's parsed `holeSize`.
+  if (type === "doughnut") {
+    const holeSize = options.holeSize !== undefined ? options.holeSize : source.holeSize;
+    if (holeSize !== undefined) out.holeSize = holeSize;
+  }
+
   if (options.showTitle !== undefined) out.showTitle = options.showTitle;
   if (options.altText !== undefined) out.altText = options.altText;
   if (options.frameTitle !== undefined) out.frameTitle = options.frameTitle;
@@ -184,9 +201,10 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   const resolvedDataLabels = resolveChartDataLabels(source.dataLabels, options.dataLabels);
   if (resolvedDataLabels !== undefined) out.dataLabels = resolvedDataLabels;
 
-  // Pie has no axes, so silently skip carrying over axis titles even
-  // when the source declared them or the caller passed an override.
-  if (type !== "pie") {
+  // Pie and doughnut have no axes, so silently skip carrying over axis
+  // titles even when the source declared them or the caller passed an
+  // override.
+  if (type !== "pie" && type !== "doughnut") {
     const axes = resolveAxes(source.axes, options.axes);
     if (axes !== undefined) out.axes = axes;
   }
@@ -200,11 +218,11 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
  * Map a read-side {@link ChartKind} to the writer's
  * {@link WriteChartKind}, or `undefined` when no equivalent exists.
  *
- * The writer authors the six families covered in chart writer Phase 1
- * (issue #152). 3D variants collapse onto their 2D counterparts;
- * `doughnut` collapses to `pie`. Kinds with no analog (`bubble`,
- * `radar`, `surface`, `stock`, `ofPie`) return `undefined` and force
- * the caller to pass an explicit `type` override.
+ * 3D variants collapse onto their 2D counterparts; `doughnut` keeps
+ * its own write-side kind so a doughnut template round-trips with the
+ * hole intact. Kinds with no analog (`bubble`, `radar`, `surface`,
+ * `stock`, `ofPie`) return `undefined` and force the caller to pass
+ * an explicit `type` override.
  */
 export function chartKindToWriteKind(kind: ChartKind): WriteChartKind | undefined {
   switch (kind) {
@@ -220,8 +238,9 @@ export function chartKindToWriteKind(kind: ChartKind): WriteChartKind | undefine
       return "line";
     case "pie":
     case "pie3D":
-    case "doughnut":
       return "pie";
+    case "doughnut":
+      return "doughnut";
     case "area":
     case "area3D":
       return "area";

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -73,6 +73,7 @@ export function parseChart(xml: string): Chart | undefined {
     const series: ChartSeriesInfo[] = [];
     let barGrouping: ChartBarGrouping | undefined;
     let chartLevelLabels: ChartDataLabelsInfo | undefined;
+    let holeSize: number | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
@@ -83,6 +84,11 @@ export function parseChart(xml: string): Chart | undefined {
       // single `<c:barChart>` body this is the value Excel applies.
       if (barGrouping === undefined && (kind === "bar" || kind === "bar3D")) {
         barGrouping = parseBarGrouping(child);
+      }
+      // Pull `<c:holeSize>` off a doughnut chart so a parsed template
+      // can round-trip its hole back through {@link cloneChart}.
+      if (holeSize === undefined && kind === "doughnut") {
+        holeSize = parseHoleSize(child);
       }
       let localIndex = 0;
       for (const ser of childElements(child)) {
@@ -107,6 +113,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (series.length > 0) out.series = series;
     if (barGrouping !== undefined) out.barGrouping = barGrouping;
     if (chartLevelLabels) out.dataLabels = chartLevelLabels;
+    if (holeSize !== undefined) out.holeSize = holeSize;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
@@ -460,6 +467,27 @@ function parseBarGrouping(barChart: XmlElement): ChartBarGrouping | undefined {
     default:
       return undefined;
   }
+}
+
+// ── Doughnut Hole ─────────────────────────────────────────────────
+
+/**
+ * Pull `<c:holeSize val=".."/>` off a `<c:doughnutChart>` element.
+ * Returns `undefined` when the attribute is missing, malformed, or
+ * outside the 1–99 range OOXML allows. Excel itself only writes values
+ * in 10–90 (the UI clamps to that band) but the spec is wider, so we
+ * accept the full schema range and let the writer re-clamp on the way
+ * back out.
+ */
+function parseHoleSize(doughnut: XmlElement): number | undefined {
+  const el = findChild(doughnut, "holeSize");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 1 || parsed > 99) return undefined;
+  return parsed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -145,6 +145,10 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
       children.push(buildPieChart(chart, sheetName));
       break;
     }
+    case "doughnut": {
+      children.push(buildDoughnutChart(chart, sheetName));
+      break;
+    }
     case "scatter": {
       children.push(buildScatterChart(chart, sheetName));
       children.push(...buildScatterAxes(xAxisTitle, yAxisTitle));
@@ -332,6 +336,48 @@ function buildPieChart(chart: SheetChart, sheetName: string): string {
   if (chartLevelDLbls) children.push(chartLevelDLbls);
 
   return xmlElement("c:pieChart", undefined, children);
+}
+
+// ── Doughnut ─────────────────────────────────────────────────────────
+
+const DOUGHNUT_HOLE_DEFAULT = 50;
+const DOUGHNUT_HOLE_MIN = 10;
+const DOUGHNUT_HOLE_MAX = 90;
+
+function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
+  const children: string[] = [xmlSelfClose("c:varyColors", { val: 1 })];
+
+  // Like pie, doughnut paints every declared series — Excel renders
+  // each as a concentric ring (rare in practice; most templates have
+  // one). Carry every series through so multi-ring templates round-trip.
+  for (let i = 0; i < chart.series.length; i++) {
+    children.push(
+      buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
+        dataLabels: chart.dataLabels,
+      }),
+    );
+  }
+
+  const chartLevelDLbls = buildChartLevelDataLabels(chart);
+  if (chartLevelDLbls) children.push(chartLevelDLbls);
+
+  // `<c:firstSliceAng>` and `<c:holeSize>` are the two doughnut-only
+  // knobs. firstSliceAng defaults to 0 (12 o'clock start); holeSize is
+  // required by OOXML — the schema rejects a `<c:doughnutChart>` without
+  // it. Clamp to the 10–90 band Excel's UI enforces; values outside
+  // this range render but trigger Excel's repair dialog.
+  children.push(xmlSelfClose("c:firstSliceAng", { val: 0 }));
+  children.push(xmlSelfClose("c:holeSize", { val: clampHoleSize(chart.holeSize) }));
+
+  return xmlElement("c:doughnutChart", undefined, children);
+}
+
+function clampHoleSize(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) return DOUGHNUT_HOLE_DEFAULT;
+  const rounded = Math.round(value);
+  if (rounded < DOUGHNUT_HOLE_MIN) return DOUGHNUT_HOLE_MIN;
+  if (rounded > DOUGHNUT_HOLE_MAX) return DOUGHNUT_HOLE_MAX;
+  return rounded;
 }
 
 // ── Scatter ──────────────────────────────────────────────────────────
@@ -676,6 +722,8 @@ export function chartKindElement(kind: WriteChartKind): string {
       return "c:lineChart";
     case "pie":
       return "c:pieChart";
+    case "doughnut":
+      return "c:doughnutChart";
     case "scatter":
       return "c:scatterChart";
     case "area":

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -18,7 +18,7 @@ describe("chartKindToWriteKind", () => {
     expect(chartKindToWriteKind("line3D")).toBe("line");
     expect(chartKindToWriteKind("pie")).toBe("pie");
     expect(chartKindToWriteKind("pie3D")).toBe("pie");
-    expect(chartKindToWriteKind("doughnut")).toBe("pie");
+    expect(chartKindToWriteKind("doughnut")).toBe("doughnut");
     expect(chartKindToWriteKind("area")).toBe("area");
     expect(chartKindToWriteKind("area3D")).toBe("area");
     expect(chartKindToWriteKind("scatter")).toBe("scatter");
@@ -82,18 +82,58 @@ describe("cloneChart", () => {
   });
 
   it("honors options.type to coerce kinds the writer cannot author", () => {
+    const clone = cloneChart(
+      source({
+        kinds: ["radar"],
+        series: [{ kind: "radar", index: 0, valuesRef: "Sheet1!$B$2:$B$5" }],
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "line",
+      },
+    );
+    expect(clone.type).toBe("line");
+  });
+
+  it("preserves doughnut as the writable kind when no type override is given", () => {
     const clone = cloneChart(source({ kinds: ["doughnut"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("doughnut");
+  });
+
+  it("flattens doughnut to pie when type='pie' is requested", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"], holeSize: 60 }), {
       anchor: { from: { row: 0, col: 0 } },
       type: "pie",
     });
     expect(clone.type).toBe("pie");
+    expect(clone.holeSize).toBeUndefined();
   });
 
-  it("auto-collapses doughnut to pie when no type override is given", () => {
-    const clone = cloneChart(source({ kinds: ["doughnut"] }), {
+  it("inherits the source's holeSize on a doughnut clone", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"], holeSize: 65 }), {
       anchor: { from: { row: 0, col: 0 } },
     });
-    expect(clone.type).toBe("pie");
+    expect(clone.type).toBe("doughnut");
+    expect(clone.holeSize).toBe(65);
+  });
+
+  it("lets options.holeSize override the source's holeSize", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"], holeSize: 65 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      holeSize: 30,
+    });
+    expect(clone.holeSize).toBe(30);
+  });
+
+  it("drops options.holeSize when the resolved type is not doughnut", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+      holeSize: 60,
+    });
+    expect(clone.holeSize).toBeUndefined();
   });
 
   it("throws when the source has no writable kind and no override is given", () => {
@@ -728,5 +768,60 @@ describe("cloneChart — integration", () => {
       x: { title: "Quarter" },
       y: { title: "Revenue (USD)" },
     });
+  });
+
+  it("clones a doughnut template through writeChart and back through parseChart with hole size intact", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:title><c:tx><c:rich><a:p><a:r><a:t>Distribution</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    <c:plotArea>
+      <c:doughnutChart>
+        <c:varyColors val="1"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Mix</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:firstSliceAng val="0"/>
+        <c:holeSize val="65"/>
+      </c:doughnutChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml);
+    expect(source?.kinds).toEqual(["doughnut"]);
+    expect(source?.holeSize).toBe(65);
+
+    // Default clone keeps the doughnut shape and inherits holeSize from
+    // the template.
+    const sheetChart: SheetChart = cloneChart(source!, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.type).toBe("doughnut");
+    expect(sheetChart.holeSize).toBe(65);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:doughnutChart>");
+    expect(written).toContain('c:holeSize val="65"');
+
+    // Re-read the emitted chart and confirm doughnut + holeSize survive.
+    const reparsed = parseChart(written);
+    expect(reparsed?.kinds).toEqual(["doughnut"]);
+    expect(reparsed?.title).toBe("Distribution");
+    expect(reparsed?.holeSize).toBe(65);
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3,6 +3,7 @@ import { ZipReader } from "../src/zip/reader";
 import { parseXml } from "../src/xml/parser";
 import { writeXlsx } from "../src/xlsx/writer";
 import { writeChart, chartKindElement } from "../src/xlsx/chart-writer";
+import { parseChart } from "../src/xlsx/chart-reader";
 import { writeDrawing } from "../src/xlsx/drawing-writer";
 import type { WriteChartKind, SheetChart, WriteSheet } from "../src/_types";
 
@@ -221,7 +222,7 @@ describe("writeChart", () => {
     expect(result.chartXml).toMatch(/c:idx val="1"[\s\S]*c:order val="1"/);
   });
 
-  it.each<WriteChartKind>(["bar", "column", "line", "pie", "scatter", "area"])(
+  it.each<WriteChartKind>(["bar", "column", "line", "pie", "doughnut", "scatter", "area"])(
     "kind %s parses as well-formed XML",
     (kind) => {
       const result = writeChart(makeChart({ type: kind }), "Sheet1");
@@ -230,6 +231,96 @@ describe("writeChart", () => {
       expect(doc).toBeTruthy();
     },
   );
+});
+
+// ── Doughnut ─────────────────────────────────────────────────────────
+
+describe("writeChart — doughnut", () => {
+  it("emits c:doughnutChart with varyColors=1 and no axes", () => {
+    const result = writeChart(makeChart({ type: "doughnut" }), "Sheet1");
+    expect(result.chartXml).toContain("c:doughnutChart");
+    expect(result.chartXml).toContain('c:varyColors val="1"');
+    // Doughnut, like pie, has no axes
+    expect(result.chartXml).not.toContain("c:catAx");
+    expect(result.chartXml).not.toContain("c:valAx");
+  });
+
+  it("declares the schema-required holeSize element with the Excel default of 50", () => {
+    const result = writeChart(makeChart({ type: "doughnut" }), "Sheet1");
+    expect(result.chartXml).toContain('c:holeSize val="50"');
+    expect(result.chartXml).toContain('c:firstSliceAng val="0"');
+  });
+
+  it("threads an explicit holeSize through to the XML", () => {
+    const result = writeChart(makeChart({ type: "doughnut", holeSize: 75 }), "Sheet1");
+    expect(result.chartXml).toContain('c:holeSize val="75"');
+  });
+
+  it("clamps holeSize to the 10–90 band Excel's UI enforces", () => {
+    const lo = writeChart(makeChart({ type: "doughnut", holeSize: 5 }), "Sheet1");
+    expect(lo.chartXml).toContain('c:holeSize val="10"');
+    const hi = writeChart(makeChart({ type: "doughnut", holeSize: 120 }), "Sheet1");
+    expect(hi.chartXml).toContain('c:holeSize val="90"');
+  });
+
+  it("rounds non-integer holeSize values", () => {
+    const result = writeChart(makeChart({ type: "doughnut", holeSize: 42.7 }), "Sheet1");
+    expect(result.chartXml).toContain('c:holeSize val="43"');
+  });
+
+  it("falls back to the default when holeSize is NaN or Infinity", () => {
+    const nan = writeChart(makeChart({ type: "doughnut", holeSize: NaN }), "Sheet1");
+    expect(nan.chartXml).toContain('c:holeSize val="50"');
+    const inf = writeChart(
+      makeChart({ type: "doughnut", holeSize: Number.POSITIVE_INFINITY }),
+      "Sheet1",
+    );
+    expect(inf.chartXml).toContain('c:holeSize val="50"');
+  });
+
+  it("paints every series declared on a doughnut chart (concentric rings)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        series: [
+          { name: "Inner", values: "B2:B4", categories: "A2:A4" },
+          { name: "Outer", values: "C2:C4", categories: "A2:A4" },
+        ],
+      }),
+      "Sheet1",
+    );
+    // Two <c:ser> entries with sequential idx/order.
+    expect(result.chartXml).toMatch(/c:idx val="0"[\s\S]*c:order val="0"/);
+    expect(result.chartXml).toMatch(/c:idx val="1"[\s\S]*c:order val="1"/);
+    expect(result.chartXml).toContain("Inner");
+    expect(result.chartXml).toContain("Outer");
+  });
+
+  it("omits holeSize on non-doughnut kinds even when the field is set", () => {
+    // SheetChart.holeSize is silently ignored for pie / column / line / etc.
+    const pie = writeChart(makeChart({ type: "pie", holeSize: 75 }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:holeSize");
+    const col = writeChart(makeChart({ type: "column", holeSize: 75 }), "Sheet1");
+    expect(col.chartXml).not.toContain("c:holeSize");
+  });
+
+  it("places the legend on the right by default for doughnut, matching pie", () => {
+    const result = writeChart(makeChart({ type: "doughnut" }), "Sheet1");
+    expect(result.chartXml).toContain('c:legendPos val="r"');
+  });
+
+  it("ignores the axes block on doughnut charts", () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        axes: { x: { title: "Should not render" }, y: { title: "Same" } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:catAx");
+    expect(result.chartXml).not.toContain("c:valAx");
+    expect(result.chartXml).not.toContain("Should not render");
+  });
 });
 
 // ── Axis titles ──────────────────────────────────────────────────────
@@ -371,6 +462,7 @@ describe("chartKindElement", () => {
     expect(chartKindElement("column")).toBe("c:barChart");
     expect(chartKindElement("line")).toBe("c:lineChart");
     expect(chartKindElement("pie")).toBe("c:pieChart");
+    expect(chartKindElement("doughnut")).toBe("c:doughnutChart");
     expect(chartKindElement("scatter")).toBe("c:scatterChart");
     expect(chartKindElement("area")).toBe("c:areaChart");
   });
@@ -693,6 +785,41 @@ describe("writeXlsx with charts", () => {
       const root = chartSpace ?? doc;
       expect(root).toBeTruthy();
     }
+  });
+
+  it("packages a doughnut chart that parseChart can re-read end-to-end", async () => {
+    const sheet: WriteSheet = {
+      name: "Distribution",
+      rows: [
+        ["Category", "Share"],
+        ["Cloud", 42],
+        ["On-prem", 28],
+        ["Hybrid", 30],
+      ],
+      charts: [
+        makeChart({
+          type: "doughnut",
+          title: "Workload Mix",
+          holeSize: 60,
+          series: [{ name: "Share", values: "B2:B4", categories: "A2:A4", color: "1070CA" }],
+        }),
+      ],
+    };
+
+    const data = await writeXlsx({ sheets: [sheet] });
+    expect(zipHas(data, "xl/charts/chart1.xml")).toBe(true);
+
+    const chartXml = await extractXml(data, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("c:doughnutChart");
+    expect(chartXml).toContain('c:holeSize val="60"');
+
+    const parsed = parseChart(chartXml);
+    expect(parsed?.kinds).toEqual(["doughnut"]);
+    expect(parsed?.title).toBe("Workload Mix");
+    expect(parsed?.holeSize).toBe(60);
+    expect(parsed?.seriesCount).toBe(1);
+    expect(parsed?.series?.[0]?.name).toBe("Share");
+    expect(parsed?.series?.[0]?.color).toBe("1070CA");
   });
 });
 

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -819,6 +819,63 @@ describe("parseChart — axis titles", () => {
   });
 });
 
+// ── parseChart — doughnut hole size ───────────────────────────────
+
+describe("parseChart — doughnut hole size", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:holeSize val="..."/> off a doughnut chart', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart>
+      <c:varyColors val="1"/>
+      <c:firstSliceAng val="0"/>
+      <c:holeSize val="65"/>
+    </c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["doughnut"]);
+    expect(chart?.holeSize).toBe(65);
+  });
+
+  it("omits holeSize when the doughnut chart does not declare one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart><c:varyColors val="1"/></c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.holeSize).toBeUndefined();
+  });
+
+  it("rejects malformed or out-of-range holeSize values", () => {
+    const out = (val: string): unknown =>
+      parseChart(`<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart><c:holeSize val="${val}"/></c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`)?.holeSize;
+    expect(out("not-a-number")).toBeUndefined();
+    expect(out("0")).toBeUndefined();
+    expect(out("100")).toBeUndefined();
+    // 1–99 inclusive is what the OOXML schema allows.
+    expect(out("1")).toBe(1);
+    expect(out("99")).toBe(99);
+  });
+
+  it("does not attach holeSize to non-doughnut charts", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart><c:varyColors val="1"/></c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["pie"]);
+    expect(chart?.holeSize).toBeUndefined();
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

`doughnut` is one of the chart families issue #136 explicitly calls out for the dashboard composition flow: a template workbook stores a donut chart, the caller pulls it via `parseChart`, retargets the data ranges through `cloneChart`, and re-emits the result. Previously the writer had no doughnut case — `cloneChart` silently flattened doughnut sources into plain pies, dropping the hole the dashboard relied on. This PR closes that gap at all three layers (read, write, clone-through) so a templated doughnut survives the full retarget loop with its hole intact.

## API

```ts
import { readXlsx, writeXlsx, parseChart, cloneChart } from "hucre";

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Distribution",
    rows: [["Category", "Share"], ["Cloud", 42], ["On-prem", 28], ["Hybrid", 30]],
    charts: [{
      type: "doughnut",
      title: "Workload Mix",
      holeSize: 60,                 // 10–90 (Excel's UI band; default 50)
      series: [{ values: "B2:B4", categories: "A2:A4" }],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.kinds, source.holeSize);
// ["doughnut"] 65

// ── Clone-through ──
// Default keeps the doughnut shape and inherits holeSize from the template.
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!\$B\$2:\$B\$13" }],
});
// → { type: "doughnut", holeSize: 65, ... }

// Override the hole or flatten to a plain pie when the dashboard wants one:
const flat = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  type: "pie",                       // drops holeSize
});
```

## Implementation

- **`WriteChartKind`** gains `"doughnut"`. `SheetChart` gains a numeric `holeSize?` field documented as the Excel 10–90 band with a 50 default.
- **`chart-writer`**: a new `buildDoughnutChart` mirrors the pie case (`varyColors=1`, every declared series, no axes) plus the schema-required `<c:firstSliceAng val="0">` and `<c:holeSize val=".."/>` block. `clampHoleSize` rounds, replaces non-finite values with the default, and clamps to 10–90 — matching Excel's UI behavior. `chartKindElement` learns the `doughnut → c:doughnutChart` mapping.
- **`chart-reader`**: `parseHoleSize` reads `<c:holeSize>` off the first `<c:doughnutChart>` and surfaces it on `Chart.holeSize`. The 1–99 OOXML schema range is honored on read; clamping happens on write.
- **`chart-clone`**: `chartKindToWriteKind("doughnut")` now returns `"doughnut"` (was `"pie"`). `cloneChart` carries `source.holeSize` onto the clone when the resolved type is `doughnut`, accepts an `options.holeSize` override, and drops the field whenever the type resolves to anything else (so flattening to pie or column does not leak the hole). The pie-guard around `axes` is widened to `pie` + `doughnut` since neither has axes.

## Edge cases

- `holeSize: NaN` / `Infinity` → fall back to Excel's 50 default (writer never emits an invalid integer).
- `holeSize: 5` / `120` → clamped to 10 / 90 respectively.
- Float `holeSize` (e.g. 42.7) → rounded to 43.
- `holeSize` set on a non-doughnut chart → silently ignored by the writer.
- Doughnut clone with `axes` overrides → axes block dropped (doughnut has no axes).
- Multi-ring templates (multiple `<c:ser>` under `<c:doughnutChart>`) → every series carried through, matching how Excel renders concentric rings.

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest): all 2576 tests pass, including the new write / read / clone / round-trip / integration suites added across `test/charts-write.test.ts`, `test/charts.test.ts`, and `test/chart-clone.test.ts`.
- [x] `pnpm build` succeeds.

Refs #136