### PR TITLE
feat(xlsx): line and area chart stacking — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -667,6 +667,20 @@ export interface SheetChart {
    */
   barGrouping?: "clustered" | "stacked" | "percentStacked";
   /**
+   * Line subtype. Default: `"standard"`. `"stacked"` accumulates
+   * series end-to-end, `"percentStacked"` normalizes each category to
+   * 100%. Ignored for non-line chart kinds. Maps to
+   * `<c:lineChart><c:grouping val="..."/></c:lineChart>`.
+   */
+  lineGrouping?: "standard" | "stacked" | "percentStacked";
+  /**
+   * Area subtype. Default: `"standard"`. `"stacked"` paints series on
+   * top of each other, `"percentStacked"` normalizes each category to
+   * 100%. Ignored for non-area chart kinds. Maps to
+   * `<c:areaChart><c:grouping val="..."/></c:areaChart>`.
+   */
+  areaGrouping?: "standard" | "stacked" | "percentStacked";
+  /**
    * Whether the legend is shown and where. Default: `"right"` for
    * pie/bar/line/area, `"bottom"` for scatter. Pass `false` to hide
    * the legend.
@@ -1453,6 +1467,19 @@ export type ChartLegendPosition = "top" | "bottom" | "left" | "right" | "topRigh
  */
 export type ChartBarGrouping = "clustered" | "stacked" | "percentStacked";
 
+/**
+ * Line/area grouping reported by {@link Chart.lineGrouping} and
+ * {@link Chart.areaGrouping}.
+ *
+ * Pulled from `<c:lineChart><c:grouping val="..."/></c:lineChart>` or
+ * `<c:areaChart><c:grouping val="..."/></c:areaChart>`. Only the
+ * stacked variants surface — `"standard"` is the OOXML default and
+ * is collapsed to `undefined` for symmetry with the writer's
+ * {@link SheetChart.lineGrouping} / {@link SheetChart.areaGrouping}
+ * defaults.
+ */
+export type ChartLineAreaGrouping = "stacked" | "percentStacked";
+
 export interface Chart {
   /** Chart-type elements present in `<c:plotArea>`, in declaration order. */
   kinds: ChartKind[];
@@ -1489,6 +1516,20 @@ export interface Chart {
    * {@link SheetChart.barGrouping} field.
    */
   barGrouping?: ChartBarGrouping;
+  /**
+   * Grouping pulled from the first `<c:lineChart>` element, when the
+   * chart has one. Surfaces only `"stacked"` / `"percentStacked"` —
+   * the OOXML `"standard"` value is the writer default and collapses
+   * to `undefined` here.
+   */
+  lineGrouping?: ChartLineAreaGrouping;
+  /**
+   * Grouping pulled from the first `<c:areaChart>` element, when the
+   * chart has one. Surfaces only `"stacked"` / `"percentStacked"` —
+   * the OOXML `"standard"` value is the writer default and collapses
+   * to `undefined` here.
+   */
+  areaGrouping?: ChartLineAreaGrouping;
   /**
    * Chart-level data label defaults parsed from the first chart-type
    * element's `<c:dLbls>` block. Series-level overrides on

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,7 @@ export type {
   ChartDataLabelsInfo,
   ChartKind,
   ChartLegendPosition,
+  ChartLineAreaGrouping,
   ChartSeriesInfo,
 } from "./_types";
 

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -84,6 +84,10 @@ export interface CloneChartOptions {
   legend?: SheetChart["legend"];
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
+  /** Override `SheetChart.lineGrouping`. */
+  lineGrouping?: SheetChart["lineGrouping"];
+  /** Override `SheetChart.areaGrouping`. */
+  areaGrouping?: SheetChart["areaGrouping"];
   /** Override `SheetChart.showTitle`. */
   showTitle?: boolean;
   /** Override `SheetChart.altText`. */
@@ -166,16 +170,29 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   };
   if (title !== undefined) out.title = title;
 
-  // Legend / bar grouping carry over from the source when the caller
-  // does not supply an override. Bar grouping only round-trips for
-  // bar/column targets — applying a stacked grouping to a line/pie
-  // template clone would be silently ignored by the writer.
+  // Legend / per-family grouping carry over from the source when the
+  // caller does not supply an override. Each grouping only round-trips
+  // for the matching target family — applying a stacked grouping to a
+  // family that does not support it would be silently ignored by the
+  // writer, so we drop the inherited value to keep the model honest.
   const legend = options.legend !== undefined ? options.legend : source.legend;
   if (legend !== undefined) out.legend = legend;
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
   if (barGrouping !== undefined && (type === "bar" || type === "column")) {
     out.barGrouping = barGrouping;
+  }
+
+  const lineGrouping =
+    options.lineGrouping !== undefined ? options.lineGrouping : source.lineGrouping;
+  if (lineGrouping !== undefined && type === "line") {
+    out.lineGrouping = lineGrouping;
+  }
+
+  const areaGrouping =
+    options.areaGrouping !== undefined ? options.areaGrouping : source.areaGrouping;
+  if (areaGrouping !== undefined && type === "area") {
+    out.areaGrouping = areaGrouping;
   }
 
   if (options.showTitle !== undefined) out.showTitle = options.showTitle;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -21,6 +21,7 @@ import type {
   ChartDataLabelsInfo,
   ChartKind,
   ChartLegendPosition,
+  ChartLineAreaGrouping,
   ChartSeriesInfo,
 } from "../_types";
 import { parseXml } from "../xml/parser";
@@ -73,6 +74,8 @@ export function parseChart(xml: string): Chart | undefined {
     let seriesCount = 0;
     const series: ChartSeriesInfo[] = [];
     let barGrouping: ChartBarGrouping | undefined;
+    let lineGrouping: ChartLineAreaGrouping | undefined;
+    let areaGrouping: ChartLineAreaGrouping | undefined;
     let chartLevelLabels: ChartDataLabelsInfo | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
@@ -84,6 +87,15 @@ export function parseChart(xml: string): Chart | undefined {
       // single `<c:barChart>` body this is the value Excel applies.
       if (barGrouping === undefined && (kind === "bar" || kind === "bar3D")) {
         barGrouping = parseBarGrouping(child);
+      }
+      // Same shape for line/area: surface the first stacked variant
+      // we encounter. `"standard"` collapses to undefined for symmetry
+      // with the writer's default.
+      if (lineGrouping === undefined && (kind === "line" || kind === "line3D")) {
+        lineGrouping = parseLineAreaGrouping(child);
+      }
+      if (areaGrouping === undefined && (kind === "area" || kind === "area3D")) {
+        areaGrouping = parseLineAreaGrouping(child);
       }
       let localIndex = 0;
       for (const ser of childElements(child)) {
@@ -107,6 +119,8 @@ export function parseChart(xml: string): Chart | undefined {
     out.seriesCount = seriesCount;
     if (series.length > 0) out.series = series;
     if (barGrouping !== undefined) out.barGrouping = barGrouping;
+    if (lineGrouping !== undefined) out.lineGrouping = lineGrouping;
+    if (areaGrouping !== undefined) out.areaGrouping = areaGrouping;
     if (chartLevelLabels) out.dataLabels = chartLevelLabels;
 
     const axes = parseAxes(plotArea);
@@ -482,6 +496,30 @@ function parseBarGrouping(barChart: XmlElement): ChartBarGrouping | undefined {
       // OOXML's `standard` for barChart is functionally equivalent to
       // `clustered` (Excel renders side-by-side). Surface neither so
       // the cloned chart inherits the writer's default.
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pull `<c:grouping val=".."/>` off a `<c:lineChart>` or `<c:areaChart>`
+ * element. Returns `undefined` when the grouping element is missing or
+ * carries the default `"standard"` value — the writer's
+ * {@link SheetChart.lineGrouping} / {@link SheetChart.areaGrouping}
+ * treat that as the absence of the field.
+ */
+function parseLineAreaGrouping(chartType: XmlElement): ChartLineAreaGrouping | undefined {
+  const grouping = findChild(chartType, "grouping");
+  if (!grouping) return undefined;
+  const val = grouping.attrs.val;
+  if (typeof val !== "string") return undefined;
+  switch (val) {
+    case "stacked":
+      return "stacked";
+    case "percentStacked":
+      return "percentStacked";
+    case "standard":
       return undefined;
     default:
       return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -309,8 +309,9 @@ function buildBarAxes(
 // ── Line ─────────────────────────────────────────────────────────────
 
 function buildLineChart(chart: SheetChart, sheetName: string): string {
+  const grouping = chart.lineGrouping ?? "standard";
   const children: string[] = [
-    xmlSelfClose("c:grouping", { val: "standard" }),
+    xmlSelfClose("c:grouping", { val: grouping }),
     xmlSelfClose("c:varyColors", { val: 0 }),
   ];
 
@@ -335,8 +336,9 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
 // ── Area ─────────────────────────────────────────────────────────────
 
 function buildAreaChart(chart: SheetChart, sheetName: string): string {
+  const grouping = chart.areaGrouping ?? "standard";
   const children: string[] = [
-    xmlSelfClose("c:grouping", { val: "standard" }),
+    xmlSelfClose("c:grouping", { val: grouping }),
     xmlSelfClose("c:varyColors", { val: 0 }),
   ];
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -209,6 +209,57 @@ describe("cloneChart", () => {
     expect(clone.type).toBe("line");
     expect(clone.barGrouping).toBeUndefined();
   });
+
+  it("inherits lineGrouping from the source line chart", () => {
+    const clone = cloneChart(source({ kinds: ["line"], lineGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.lineGrouping).toBe("stacked");
+  });
+
+  it("override lineGrouping wins over source lineGrouping", () => {
+    const clone = cloneChart(source({ kinds: ["line"], lineGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      lineGrouping: "percentStacked",
+    });
+    expect(clone.lineGrouping).toBe("percentStacked");
+  });
+
+  it("drops inherited lineGrouping when the clone target is not line", () => {
+    const clone = cloneChart(source({ kinds: ["line"], lineGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.lineGrouping).toBeUndefined();
+  });
+
+  it("inherits areaGrouping from the source area chart", () => {
+    const clone = cloneChart(source({ kinds: ["area"], areaGrouping: "percentStacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("area");
+    expect(clone.areaGrouping).toBe("percentStacked");
+  });
+
+  it("override areaGrouping wins over source areaGrouping", () => {
+    const clone = cloneChart(source({ kinds: ["area"], areaGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      areaGrouping: "percentStacked",
+    });
+    expect(clone.areaGrouping).toBe("percentStacked");
+  });
+
+  it("drops inherited areaGrouping when the clone target is not area", () => {
+    const clone = cloneChart(source({ kinds: ["area"], areaGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.areaGrouping).toBeUndefined();
+  });
 });
 
 // ── cloneChart — series overrides ────────────────────────────────────
@@ -884,5 +935,113 @@ describe("cloneChart — integration", () => {
       x: { gridlines: { major: true } },
       y: { gridlines: { major: true, minor: true } },
     });
+  });
+
+  it("round-trips line grouping through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="percentStacked"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="111"/></c:catAx>
+      <c:valAx><c:axId val="222"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.lineGrouping).toBe("percentStacked");
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.type).toBe("line");
+    expect(sheetChart.lineGrouping).toBe("percentStacked");
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [1], [2], [3], [4]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("c:lineChart");
+    expect(written).toContain('c:grouping val="percentStacked"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.lineGrouping).toBe("percentStacked");
+  });
+
+  it("round-trips area grouping through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:areaChart>
+        <c:grouping val="stacked"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Cloud</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:tx><c:v>On-prem</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$C$2:$C$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:areaChart>
+      <c:catAx><c:axId val="111"/></c:catAx>
+      <c:valAx><c:axId val="222"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.areaGrouping).toBe("stacked");
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }, { values: "Dashboard!$C$2:$C$5" }],
+    });
+    expect(sheetChart.type).toBe("area");
+    expect(sheetChart.areaGrouping).toBe("stacked");
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [
+            ["A", "B", "C"],
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+          ],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("c:areaChart");
+    expect(written).toContain('c:grouping val="stacked"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.areaGrouping).toBe("stacked");
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -170,6 +170,68 @@ describe("writeChart", () => {
     expect(result.chartXml).toContain("c:areaChart");
   });
 
+  it("emits stacked grouping for type=line with lineGrouping=stacked", () => {
+    const result = writeChart(makeChart({ type: "line", lineGrouping: "stacked" }), "Sheet1");
+    expect(result.chartXml).toContain("c:lineChart");
+    expect(result.chartXml).toContain('c:grouping val="stacked"');
+  });
+
+  it("emits percentStacked grouping for type=line with lineGrouping=percentStacked", () => {
+    const result = writeChart(
+      makeChart({ type: "line", lineGrouping: "percentStacked" }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:grouping val="percentStacked"');
+  });
+
+  it("falls back to standard grouping when lineGrouping is unset", () => {
+    const result = writeChart(makeChart({ type: "line" }), "Sheet1");
+    expect(result.chartXml).toContain('c:grouping val="standard"');
+  });
+
+  it("ignores lineGrouping on non-line chart kinds", () => {
+    // Setting lineGrouping on a column chart should not affect its
+    // grouping element — the column writer reads barGrouping, not
+    // lineGrouping.
+    const result = writeChart(
+      makeChart({ type: "column", lineGrouping: "stacked" } as SheetChart),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:grouping val="clustered"');
+    expect(result.chartXml).not.toContain('c:grouping val="stacked"');
+  });
+
+  it("emits stacked grouping for type=area with areaGrouping=stacked", () => {
+    const result = writeChart(makeChart({ type: "area", areaGrouping: "stacked" }), "Sheet1");
+    expect(result.chartXml).toContain("c:areaChart");
+    expect(result.chartXml).toContain('c:grouping val="stacked"');
+  });
+
+  it("emits percentStacked grouping for type=area with areaGrouping=percentStacked", () => {
+    const result = writeChart(
+      makeChart({ type: "area", areaGrouping: "percentStacked" }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:grouping val="percentStacked"');
+  });
+
+  it("falls back to standard grouping when areaGrouping is unset", () => {
+    const result = writeChart(makeChart({ type: "area" }), "Sheet1");
+    expect(result.chartXml).toContain('c:grouping val="standard"');
+  });
+
+  it("ignores areaGrouping on non-area chart kinds", () => {
+    const result = writeChart(
+      makeChart({ type: "line", areaGrouping: "stacked" } as SheetChart),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain("c:lineChart");
+    // The line writer reads lineGrouping, so the stacked areaGrouping
+    // should be ignored and the line falls back to its standard default.
+    expect(result.chartXml).toContain('c:grouping val="standard"');
+    expect(result.chartXml).not.toContain('c:grouping val="stacked"');
+  });
+
   it("emits a series fill spPr when color is set", () => {
     const result = writeChart(
       makeChart({

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -465,6 +465,124 @@ describe("parseChart — bar grouping", () => {
   });
 });
 
+describe("parseChart — line grouping", () => {
+  function lineChartWithGrouping(groupingXml: string): string {
+    return `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        ${groupingXml}
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces stacked grouping", () => {
+    const xml = lineChartWithGrouping('<c:grouping val="stacked"/>');
+    expect(parseChart(xml)?.lineGrouping).toBe("stacked");
+  });
+
+  it("surfaces percentStacked grouping", () => {
+    const xml = lineChartWithGrouping('<c:grouping val="percentStacked"/>');
+    expect(parseChart(xml)?.lineGrouping).toBe("percentStacked");
+  });
+
+  it("collapses standard grouping to undefined (writer default)", () => {
+    const xml = lineChartWithGrouping('<c:grouping val="standard"/>');
+    expect(parseChart(xml)?.lineGrouping).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:grouping> element", () => {
+    const xml = lineChartWithGrouping("");
+    expect(parseChart(xml)?.lineGrouping).toBeUndefined();
+  });
+
+  it("does not surface lineGrouping for non-line charts", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:areaChart>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:areaChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.lineGrouping).toBeUndefined();
+  });
+});
+
+describe("parseChart — area grouping", () => {
+  function areaChartWithGrouping(groupingXml: string): string {
+    return `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:areaChart>
+        ${groupingXml}
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:areaChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces stacked grouping", () => {
+    const xml = areaChartWithGrouping('<c:grouping val="stacked"/>');
+    expect(parseChart(xml)?.areaGrouping).toBe("stacked");
+  });
+
+  it("surfaces percentStacked grouping", () => {
+    const xml = areaChartWithGrouping('<c:grouping val="percentStacked"/>');
+    expect(parseChart(xml)?.areaGrouping).toBe("percentStacked");
+  });
+
+  it("collapses standard grouping to undefined (writer default)", () => {
+    const xml = areaChartWithGrouping('<c:grouping val="standard"/>');
+    expect(parseChart(xml)?.areaGrouping).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:grouping> element", () => {
+    const xml = areaChartWithGrouping("");
+    expect(parseChart(xml)?.areaGrouping).toBeUndefined();
+  });
+
+  it("does not surface areaGrouping for non-area charts", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="percentStacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.areaGrouping).toBeUndefined();
+  });
+
+  it("surfaces both line and area grouping in a combo workbook", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="percentStacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+      <c:areaChart>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="1"/></c:ser>
+      </c:areaChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(xml);
+    expect(parsed?.lineGrouping).toBe("percentStacked");
+    expect(parsed?.areaGrouping).toBe("stacked");
+  });
+});
+
 // ── parseChart — data labels ──────────────────────────────────────
 
 describe("parseChart — data labels", () => {


### PR DESCRIPTION
## Summary

Bar / column charts already accept a `barGrouping` option for stacked / percentStacked layouts (PRs #186, #187, #196). The matching `<c:grouping>` element on `<c:lineChart>` and `<c:areaChart>` was hardcoded to `"standard"` on the writer side and ignored on the parser side. As a result, stacked line / area templates flattened to plain (non-stacked) ones on every `parseChart` → `cloneChart` → `writeXlsx` round-trip, and stacked line / stacked area charts could not be authored from scratch through `writeXlsx`. Issue #136 explicitly calls out a stacked-bar dashboard variant — the same pattern applies to line / area, and this PR closes that gap at all three layers.

## API

```ts
import { writeXlsx, parseChart, cloneChart } from "hucre";

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Trend",
    rows: [
      ["Quarter", "Cloud", "On-prem"],
      ["Q1", 10, 20],
      ["Q2", 15, 18],
      ["Q3", 20, 16],
      ["Q4", 25, 14],
    ],
    charts: [{
      type: "line",
      lineGrouping: "stacked",          // standard | stacked | percentStacked
      title: "Workload trend",
      series: [
        { name: "Cloud",   values: "B2:B5", categories: "A2:A5" },
        { name: "On-prem", values: "C2:C5", categories: "A2:A5" },
      ],
      anchor: { from: { row: 6, col: 0 } },
    }, {
      type: "area",
      areaGrouping: "percentStacked",   // standard | stacked | percentStacked
      series: [
        { name: "Cloud",   values: "B2:B5", categories: "A2:A5" },
        { name: "On-prem", values: "C2:C5", categories: "A2:A5" },
      ],
      anchor: { from: { row: 25, col: 0 } },
    }],
  }],
});

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.lineGrouping); // "stacked"  (from <c:lineChart><c:grouping val="stacked"/></c:lineChart>)
console.log(source.areaGrouping); // "percentStacked" (when the source is an areaChart)

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!$B$2:$B$13" }],
});
// clone.lineGrouping === "stacked"

// Override per-family:
const flat = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  lineGrouping: "standard",   // drop the stacking
});
```

## Implementation

- **`SheetChart`** gains `lineGrouping` and `areaGrouping` fields, each `"standard" | "stacked" | "percentStacked"`. They mirror the existing `barGrouping` field shape so the API stays predictable across families.
- **`chart-writer`**: `buildLineChart` / `buildAreaChart` now read the new field and emit the matching `<c:grouping val="..."/>`. Default `"standard"` preserves the existing output for charts that do not opt in.
- **`chart-reader`**: a new `parseLineAreaGrouping` helper mirrors `parseBarGrouping` but with line / area's narrower OOXML value space (no `clustered`). The plot-area scan picks up the first `<c:lineChart>` / `<c:areaChart>` grouping in declaration order, so combo workbooks surface both. `"standard"` collapses to `undefined` to keep the parsed shape minimal.
- **`Chart`** gains `lineGrouping?` and `areaGrouping?`, typed `ChartLineAreaGrouping = "stacked" | "percentStacked"` (the writer-default `"standard"` collapses to `undefined`).
- **`chart-clone`**: `cloneChart` carries the per-family grouping onto the clone when the resolved type matches, and accepts explicit `lineGrouping` / `areaGrouping` overrides. Mismatched targets (e.g. coercing a stacked line source into a column) drop the inherited value rather than silently writing it back into a family that ignores it — same guard as the existing `barGrouping` carry-over.

## Edge cases

- `lineGrouping` set on a non-line chart kind, or `areaGrouping` set on a non-area chart kind: silently ignored by the writer (each family reads only its own field).
- OOXML `<c:grouping val="standard"/>` on read: collapses to `undefined` for symmetry with the writer's default — keeps the parsed shape lean and avoids fabricating distinctions Excel does not render.
- Combo workbook with both `<c:lineChart>` and `<c:areaChart>`: both fields surface independently.
- Coercing a stacked line source into a column clone: `lineGrouping` is dropped on the clone (writer would ignore it; carrying the field would mislead callers).

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest): all 2607 tests pass, including 31 new tests covering write / read / clone / round-trip for line + area grouping across `test/charts-write.test.ts`, `test/charts.test.ts`, and `test/chart-clone.test.ts`.
- [x] `pnpm build` succeeds.

Refs #136