### PR TITLE
feat(xlsx): chart axis scale and number format — read, write, and clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,11 +540,19 @@ for (const sheet of wb.sheets) {
     console.log(chart.legend, chart.barGrouping);
     // e.g. "bottom" "stacked"
 
-    // chart.axes carries per-axis labels and gridline visibility pulled
-    // from <c:catAx>/<c:valAx>. Only populated axes show up — pie/doughnut
-    // never do.
+    // chart.axes carries per-axis labels, gridline visibility, numeric
+    // scaling, and tick-label number format pulled from <c:catAx>/<c:valAx>.
+    // Only populated axes show up — pie/doughnut never do.
     console.log(chart.axes);
-    // e.g. { x: { title: "Quarter" }, y: { title: "Revenue (USD)", gridlines: { major: true } } }
+    // e.g. {
+    //   x: { title: "Quarter" },
+    //   y: {
+    //     title: "Revenue (USD)",
+    //     gridlines: { major: true },
+    //     scale: { min: 0, max: 100, majorUnit: 25 },
+    //     numberFormat: { formatCode: "$#,##0" },
+    //   },
+    // }
 
     // chart.dataLabels surfaces the chart-type-level <c:dLbls> block.
     // showValue / showCategoryName / showSeriesName / showPercent and
@@ -585,14 +593,22 @@ without a `legendPos`, and the matching writer label otherwise;
 surfaces the stacked variants (the OOXML `standard` value collapses
 to `undefined` since the writer treats it as the unspecified default,
 and non-bar charts never report a grouping). `Chart.axes` mirrors
-the writer-side `SheetChart.axes` and surfaces per-axis labels and
-gridline visibility: `x` is the category axis (or, for scatter, the
-first value axis) and `y` is the value axis. Empty / whitespace-only
-`<c:title>` text is dropped, `gridlines: { major, minor }` flips on
-when the matching `<c:majorGridlines>` / `<c:minorGridlines>` element
-is present (any nested styling is tolerated), charts without any
-axis label or gridline leave `axes` undefined, and pie/doughnut
-charts (which have no axes in OOXML) never report one.
+the writer-side `SheetChart.axes` and surfaces per-axis labels,
+gridline visibility, numeric scaling and tick-label number format:
+`x` is the category axis (or, for scatter, the first value axis)
+and `y` is the value axis. Empty / whitespace-only `<c:title>` text
+is dropped, `gridlines: { major, minor }` flips on when the matching
+`<c:majorGridlines>` / `<c:minorGridlines>` element is present (any
+nested styling is tolerated), `scale: { min, max, majorUnit, minorUnit, logBase }`
+captures the explicit `<c:min>` / `<c:max>` / `<c:logBase>` (under
+`<c:scaling>`) and `<c:majorUnit>` / `<c:minorUnit>` (direct axis
+children) — fields Excel auto-computes are left off so the round
+trip never accidentally pins a value, and zero or negative tick
+spacings are filtered out — and `numberFormat: { formatCode, sourceLinked }`
+mirrors `<c:numFmt>` (an empty `formatCode` collapses the record).
+Charts without any axis label, gridline, scale, or number format
+leave `axes` undefined, and pie/doughnut charts (which have no axes
+in OOXML) never report one.
 `Chart.dataLabels` mirrors the writer-side `SheetChart.dataLabels`
 and surfaces the toggles Excel carries inside `<c:dLbls>`
 (`showValue`, `showCategoryName`, `showSeriesName`, `showPercent`,
@@ -652,14 +668,26 @@ embedded apostrophes are doubled per the OOXML spec). `barGrouping`
 toggles `clustered` / `stacked` / `percentStacked`, `legend` accepts
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
-attributes for screen readers. `axes: { x: { title, gridlines }, y: { title, gridlines } }`
-attaches per-axis labels and gridlines — `x` lands inside `<c:catAx>`
-(or the X value axis for scatter), `y` inside the value axis. Empty
-or whitespace-only titles are silently dropped, `gridlines: { major,
+attributes for screen readers.
+`axes: { x: { title, gridlines, scale, numberFormat }, y: { title, gridlines, scale, numberFormat } }`
+attaches per-axis labels, gridlines, numeric scaling, and the
+tick-label number format — `x` lands inside `<c:catAx>` (or the X
+value axis for scatter), `y` inside the value axis. Empty or
+whitespace-only titles are silently dropped, `gridlines: { major,
 minor }` emits `<c:majorGridlines>` / `<c:minorGridlines>` in the
 spec-required position (after `<c:axPos>`, before any `<c:title>`,
-major before minor), and pie / doughnut charts ignore the entire
-`axes` field because OOXML defines no axes for them.
+major before minor),
+`scale: { min, max, majorUnit, minorUnit, logBase }` pins explicit
+axis bounds (`<c:min>` / `<c:max>` / `<c:logBase>` go inside
+`<c:scaling>`; `<c:majorUnit>` / `<c:minorUnit>` are emitted after
+`<c:crossBetween>` per CT_ValAx) — non-finite numbers, zero/negative
+tick spacings, log bases outside `2..1000`, and `min >= max` ranges
+are filtered out so Excel never sees a value it would reject —
+and `numberFormat: { formatCode, sourceLinked }` emits
+`<c:numFmt formatCode=".." sourceLinked="0|1"/>` between the axis
+title and `<c:crossAx>` (an empty `formatCode` skips emission).
+Pie / doughnut charts ignore the entire `axes` field because OOXML
+defines no axes for them.
 `dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, position, separator }`
 attaches Excel's small in-chart annotations: set at the chart level
 to label every series, or set on a single `series[i].dataLabels` to
@@ -703,14 +731,20 @@ writer can author collapse onto their write counterparts (`bar` /
 `bar3D` → `column`, `pie3D` → `pie`, `doughnut` → `doughnut` (kept as
 its own kind so the hole survives), `line3D` → `line`, `area3D` →
 `area`); kinds with no analog (`bubble`, `radar`, `surface`, `stock`,
-`ofPie`) require an explicit `options.type` override. Axis titles
-and gridlines inherit from the source by default; pass
-`axes: { y: { title: "Revenue" } }` to replace one side, `null` to
-drop an inherited label, `axes: { y: { gridlines: { major: true,
-minor: true } } }` to replace inherited gridlines, or
-`axes: { y: { gridlines: null } }` to drop them. The writer drops
-the entire `axes` block automatically when the resolved type is
-`pie` or `doughnut`. Doughnut clones also inherit the parsed
+`ofPie`) require an explicit `options.type` override. Axis titles,
+gridlines, scaling and tick-label number format inherit from the
+source by default; pass `axes: { y: { title: "Revenue" } }` to
+replace one side, `null` to drop an inherited label,
+`axes: { y: { gridlines: { major: true, minor: true } } }` to
+replace inherited gridlines, `axes: { y: { scale: { min: 0, max: 50 } } }`
+to replace the inherited scale wholesale (overrides do **not** merge
+field-by-field — `{ min: 0 }` plus `{ max: 50 }` yields `{ max: 50 }`,
+not `{ min: 0, max: 50 }`), `axes: { y: { numberFormat: { formatCode: "0.00%" } } }`
+to replace the format, or `null` on any of the four to drop the
+inherited value. The writer drops the entire `axes` block
+automatically when the resolved type is `pie` or `doughnut`, so a
+template that happened to carry stray scale or numberFormat values
+does not poison a pie/doughnut clone. Doughnut clones also inherit the parsed
 `holeSize` from the template; pass `holeSize: 60` to override or
 `type: "pie"` to flatten into a plain pie (the hole hint is dropped
 silently in that case). Data labels inherit too: omit `dataLabels`

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -707,12 +707,33 @@ export interface SheetChart {
    * across cloned charts. Set `major: true` to draw the heavier
    * reference lines that Excel shows by default on the value axis;
    * `minor: true` adds the lighter half-step lines.
+   *
+   * `scale` pins the value axis to explicit `<c:min>` / `<c:max>` /
+   * `<c:majorUnit>` / `<c:minorUnit>` / `<c:logBase>` bounds. Excel
+   * auto-computes any field omitted from the object. Bar/column/line/
+   * area charts apply scaling to the Y axis (`<c:valAx>`); scatter
+   * charts apply it to whichever axis the field is set on.
+   *
+   * `numberFormat` pins the tick-label format via `<c:numFmt>` —
+   * useful when the cloned chart needs a different format from the
+   * source data range (e.g. forcing `"0.00%"` on a percentage chart
+   * whose underlying cells are stored as decimals).
    */
   axes?: {
     /** Category axis (bar/column/line/area) or X value axis (scatter). */
-    x?: { title?: string; gridlines?: ChartAxisGridlines };
+    x?: {
+      title?: string;
+      gridlines?: ChartAxisGridlines;
+      scale?: ChartAxisScale;
+      numberFormat?: ChartAxisNumberFormat;
+    };
     /** Value axis. */
-    y?: { title?: string; gridlines?: ChartAxisGridlines };
+    y?: {
+      title?: string;
+      gridlines?: ChartAxisGridlines;
+      scale?: ChartAxisScale;
+      numberFormat?: ChartAxisNumberFormat;
+    };
   };
 }
 
@@ -1419,6 +1440,52 @@ export interface ChartAxisGridlines {
  * preserve through a `parseChart` → {@link cloneChart} → `writeXlsx`
  * round-trip — currently the axis title and the gridline visibility.
  */
+/**
+ * Value-axis scaling pulled from `<c:scaling>` — bounds plus tick
+ * spacing. Excel reports a numeric scale for any value-axis chart;
+ * absent on category axes (`<c:catAx>` tolerates `<c:scaling>` but
+ * populates only `<c:orientation>` there).
+ *
+ * All four numeric fields are optional — a chart may declare any
+ * subset and Excel auto-computes the rest. Hucre surfaces only the
+ * explicitly declared values, so a round-trip cannot accidentally pin
+ * an axis to numbers Excel would otherwise have inferred.
+ */
+export interface ChartAxisScale {
+  /** `<c:min>` — value where the axis starts. */
+  min?: number;
+  /** `<c:max>` — value where the axis ends. */
+  max?: number;
+  /** `<c:majorUnit>` — spacing between major tick marks. Must be > 0. */
+  majorUnit?: number;
+  /** `<c:minorUnit>` — spacing between minor tick marks. Must be > 0. */
+  minorUnit?: number;
+  /**
+   * `<c:logBase>` — log base for a logarithmic scale. Excel restricts
+   * this to 2–1000; the parser does not enforce that range, but the
+   * writer rejects values outside it.
+   */
+  logBase?: number;
+}
+
+/**
+ * Axis number-format spec pulled from `<c:numFmt>`. Mirrors what Excel
+ * emits for tick labels — an OOXML number-format code (e.g.
+ * `"#,##0"`, `"0.00%"`, `"$#,##0.00"`) and a `sourceLinked` flag that
+ * tells Excel whether to inherit the cell number format from the
+ * underlying data range.
+ */
+export interface ChartAxisNumberFormat {
+  /** OOXML format code (e.g. `"#,##0"`, `"0.00%"`). */
+  formatCode: string;
+  /**
+   * When `true`, Excel ignores `formatCode` and pulls the format
+   * straight from the source data range. Defaults to `false` when
+   * omitted — the pinned `formatCode` wins.
+   */
+  sourceLinked?: boolean;
+}
+
 export interface ChartAxisInfo {
   /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
   title?: string;
@@ -1428,6 +1495,19 @@ export interface ChartAxisInfo {
    * axis (i.e. Excel's "no gridlines" state for both).
    */
   gridlines?: ChartAxisGridlines;
+  /**
+   * Numeric scaling (`<c:min>` / `<c:max>` / `<c:majorUnit>` /
+   * `<c:minorUnit>` / `<c:logBase>`). Omitted when the axis declared
+   * none of those children — Excel auto-computes the bounds in that
+   * case and the reader leaves the inference up to the consumer.
+   */
+  scale?: ChartAxisScale;
+  /**
+   * Tick-label number format (`<c:numFmt>`). Omitted when the axis
+   * does not declare one. Mirrors `formatCode` / `sourceLinked` on
+   * the writer side.
+   */
+  numberFormat?: ChartAxisNumberFormat;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -13,6 +13,8 @@
 import type {
   Chart,
   ChartAxisGridlines,
+  ChartAxisNumberFormat,
+  ChartAxisScale,
   ChartDataLabels,
   ChartDataLabelsInfo,
   ChartKind,
@@ -114,8 +116,18 @@ export interface CloneChartOptions {
    * those cases.
    */
   axes?: {
-    x?: { title?: string | null; gridlines?: ChartAxisGridlines | null };
-    y?: { title?: string | null; gridlines?: ChartAxisGridlines | null };
+    x?: {
+      title?: string | null;
+      gridlines?: ChartAxisGridlines | null;
+      scale?: ChartAxisScale | null;
+      numberFormat?: ChartAxisNumberFormat | null;
+    };
+    y?: {
+      title?: string | null;
+      gridlines?: ChartAxisGridlines | null;
+      scale?: ChartAxisScale | null;
+      numberFormat?: ChartAxisNumberFormat | null;
+    };
   };
 }
 
@@ -401,17 +413,41 @@ function resolveAxes(
   const yTitle = applyOverride(sourceAxes?.y?.title, overrides?.y?.title);
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
+  const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
+  const yScale = applyScaleOverride(sourceAxes?.y?.scale, overrides?.y?.scale);
+  const xNumFmt = applyNumberFormatOverride(
+    sourceAxes?.x?.numberFormat,
+    overrides?.x?.numberFormat,
+  );
+  const yNumFmt = applyNumberFormatOverride(
+    sourceAxes?.y?.numberFormat,
+    overrides?.y?.numberFormat,
+  );
 
   const out: NonNullable<SheetChart["axes"]> = {};
-  if (xTitle !== undefined || xGridlines !== undefined) {
+  if (
+    xTitle !== undefined ||
+    xGridlines !== undefined ||
+    xScale !== undefined ||
+    xNumFmt !== undefined
+  ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
+    if (xScale !== undefined) out.x.scale = xScale;
+    if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
   }
-  if (yTitle !== undefined || yGridlines !== undefined) {
+  if (
+    yTitle !== undefined ||
+    yGridlines !== undefined ||
+    yScale !== undefined ||
+    yNumFmt !== undefined
+  ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
+    if (yScale !== undefined) out.y.scale = yScale;
+    if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
   }
 
   return out.x || out.y ? out : undefined;
@@ -439,4 +475,73 @@ function applyGridlinesOverride(
   if (override.major === true) out.major = true;
   if (override.minor === true) out.minor = true;
   return out.major || out.minor ? out : undefined;
+}
+
+/**
+ * Resolve a scale override using the same `undefined` / `null` /
+ * object grammar as {@link applyGridlinesOverride}. The override
+ * replaces the source wholesale rather than merging field-by-field —
+ * a partial template scale `{ min: 0 }` plus an override
+ * `{ max: 100 }` yields `{ max: 100 }`, not `{ min: 0, max: 100 }`.
+ * Per-field merges proved confusing in the dashboard composition flow
+ * (callers expected the override to fully describe the target scale),
+ * so wholesale replacement is the simpler contract.
+ */
+function applyScaleOverride(
+  source: ChartAxisScale | undefined,
+  override: ChartAxisScale | null | undefined,
+): ChartAxisScale | undefined {
+  if (override === undefined) {
+    if (!source) return undefined;
+    return cloneScale(source);
+  }
+  if (override === null) return undefined;
+  return cloneScale(override);
+}
+
+function cloneScale(source: ChartAxisScale): ChartAxisScale | undefined {
+  const out: ChartAxisScale = {};
+  if (typeof source.min === "number" && Number.isFinite(source.min)) out.min = source.min;
+  if (typeof source.max === "number" && Number.isFinite(source.max)) out.max = source.max;
+  if (
+    typeof source.majorUnit === "number" &&
+    Number.isFinite(source.majorUnit) &&
+    source.majorUnit > 0
+  ) {
+    out.majorUnit = source.majorUnit;
+  }
+  if (
+    typeof source.minorUnit === "number" &&
+    Number.isFinite(source.minorUnit) &&
+    source.minorUnit > 0
+  ) {
+    out.minorUnit = source.minorUnit;
+  }
+  if (typeof source.logBase === "number" && Number.isFinite(source.logBase)) {
+    out.logBase = source.logBase;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Resolve a number-format override. Same grammar as the other
+ * per-axis helpers: `undefined` inherits, `null` drops, an object
+ * replaces.
+ */
+function applyNumberFormatOverride(
+  source: ChartAxisNumberFormat | undefined,
+  override: ChartAxisNumberFormat | null | undefined,
+): ChartAxisNumberFormat | undefined {
+  if (override === undefined) {
+    if (!source) return undefined;
+    if (typeof source.formatCode !== "string" || source.formatCode.length === 0) return undefined;
+    const out: ChartAxisNumberFormat = { formatCode: source.formatCode };
+    if (source.sourceLinked === true) out.sourceLinked = true;
+    return out;
+  }
+  if (override === null) return undefined;
+  if (typeof override.formatCode !== "string" || override.formatCode.length === 0) return undefined;
+  const out: ChartAxisNumberFormat = { formatCode: override.formatCode };
+  if (override.sourceLinked === true) out.sourceLinked = true;
+  return out;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -16,6 +16,8 @@ import type {
   Chart,
   ChartAxisGridlines,
   ChartAxisInfo,
+  ChartAxisNumberFormat,
+  ChartAxisScale,
   ChartBarGrouping,
   ChartDataLabelPosition,
   ChartDataLabelsInfo,
@@ -175,11 +177,111 @@ function parseAxes(plotArea: XmlElement): { x?: ChartAxisInfo; y?: ChartAxisInfo
 function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const title = parseAxisTitle(axis);
   const gridlines = parseAxisGridlines(axis);
-  if (title === undefined && gridlines === undefined) return undefined;
+  const scale = parseAxisScale(axis);
+  const numberFormat = parseAxisNumberFormat(axis);
+  if (
+    title === undefined &&
+    gridlines === undefined &&
+    scale === undefined &&
+    numberFormat === undefined
+  ) {
+    return undefined;
+  }
   const out: ChartAxisInfo = {};
   if (title !== undefined) out.title = title;
   if (gridlines !== undefined) out.gridlines = gridlines;
+  if (scale !== undefined) out.scale = scale;
+  if (numberFormat !== undefined) out.numberFormat = numberFormat;
   return out;
+}
+
+/**
+ * Read an axis's numeric scale block. The scale lives inside
+ * `<c:scaling>`, with one optional child per pinned bound:
+ *
+ *   <c:scaling>
+ *     <c:orientation val="minMax"/>
+ *     <c:logBase val="10"/>
+ *     <c:min val="0"/>
+ *     <c:max val="100"/>
+ *     <c:majorUnit val="20"/>
+ *     <c:minorUnit val="5"/>
+ *   </c:scaling>
+ *
+ * Returns `undefined` when none of the numeric children declare a
+ * usable value — the orientation child alone (Excel's autoscale
+ * baseline) does not surface a scale.
+ */
+function parseAxisScale(axis: XmlElement): ChartAxisScale | undefined {
+  const out: ChartAxisScale = {};
+
+  // <c:min>, <c:max>, and <c:logBase> live inside <c:scaling>; the
+  // tick-spacing children <c:majorUnit> / <c:minorUnit> sit directly
+  // under <c:catAx>/<c:valAx> per CT_CatAx / CT_ValAx in ECMA-376.
+  const scaling = findChild(axis, "scaling");
+  if (scaling) {
+    const min = parseNumericChildVal(scaling, "min");
+    if (min !== undefined) out.min = min;
+
+    const max = parseNumericChildVal(scaling, "max");
+    if (max !== undefined) out.max = max;
+
+    const logBase = parseNumericChildVal(scaling, "logBase");
+    if (logBase !== undefined) out.logBase = logBase;
+  }
+
+  const majorUnit = parseNumericChildVal(axis, "majorUnit");
+  if (majorUnit !== undefined && majorUnit > 0) out.majorUnit = majorUnit;
+
+  const minorUnit = parseNumericChildVal(axis, "minorUnit");
+  if (minorUnit !== undefined && minorUnit > 0) out.minorUnit = minorUnit;
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Read an axis's `<c:numFmt formatCode=".." sourceLinked=".."/>`.
+ * Returns `undefined` when the element is absent or carries an empty
+ * `formatCode`. `sourceLinked` is normalized to a boolean — `0`/`1`
+ * and `"true"`/`"false"` are both accepted.
+ */
+function parseAxisNumberFormat(axis: XmlElement): ChartAxisNumberFormat | undefined {
+  const numFmt = findChild(axis, "numFmt");
+  if (!numFmt) return undefined;
+  const formatCode = numFmt.attrs.formatCode;
+  if (typeof formatCode !== "string" || formatCode.length === 0) return undefined;
+  const out: ChartAxisNumberFormat = { formatCode };
+  const sourceLinked = numFmt.attrs.sourceLinked;
+  if (sourceLinked !== undefined && parseBoolAttr(sourceLinked) === true) {
+    out.sourceLinked = true;
+  }
+  return out;
+}
+
+/**
+ * Pull a finite numeric `val=".."` attribute off a named child of
+ * `parent`. Tolerates whitespace and trailing zeros; returns
+ * `undefined` for missing children, missing attributes, and values
+ * that fail `Number.isFinite`.
+ */
+function parseNumericChildVal(parent: XmlElement, localName: string): number | undefined {
+  const child = findChild(parent, localName);
+  if (!child) return undefined;
+  const raw = child.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const value = Number(trimmed);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+/** Coerce an XML boolean attribute (`"0"`, `"1"`, `"true"`, `"false"`). */
+function parseBoolAttr(value: unknown): boolean | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "1" || v === "true") return true;
+  if (v === "0" || v === "false") return false;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -8,6 +8,8 @@
 
 import type {
   ChartAxisGridlines,
+  ChartAxisNumberFormat,
+  ChartAxisScale,
   ChartDataLabels,
   ChartSeries,
   SheetChart,
@@ -125,29 +127,35 @@ function buildTitle(title: string): string {
 function buildPlotArea(chart: SheetChart, sheetName: string): string {
   const children: string[] = [xmlSelfClose("c:layout")];
 
-  // Axis titles and gridlines surface for every chart family except
-  // pie. Pull them once so each branch can hand them off to the
-  // matching axis builder.
-  const xAxisTitle = normalizeAxisTitle(chart.axes?.x?.title);
-  const yAxisTitle = normalizeAxisTitle(chart.axes?.y?.title);
-  const xGridlines = normalizeAxisGridlines(chart.axes?.x?.gridlines);
-  const yGridlines = normalizeAxisGridlines(chart.axes?.y?.gridlines);
+  // Axis titles, gridlines, scaling and number format surface for
+  // every chart family except pie/doughnut. Pull them once so each
+  // branch can hand them off to the matching axis builder.
+  const opts: AxisRenderOptions = {
+    xAxisTitle: normalizeAxisTitle(chart.axes?.x?.title),
+    yAxisTitle: normalizeAxisTitle(chart.axes?.y?.title),
+    xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
+    yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
+    xScale: normalizeAxisScale(chart.axes?.x?.scale),
+    yScale: normalizeAxisScale(chart.axes?.y?.scale),
+    xNumFmt: normalizeAxisNumberFormat(chart.axes?.x?.numberFormat),
+    yNumFmt: normalizeAxisNumberFormat(chart.axes?.y?.numberFormat),
+  };
 
   switch (chart.type) {
     case "bar":
     case "column": {
       children.push(buildBarChart(chart, sheetName));
-      children.push(...buildBarAxes(chart.type, xAxisTitle, yAxisTitle, xGridlines, yGridlines));
+      children.push(...buildBarAxes(chart.type, opts));
       break;
     }
     case "line": {
       children.push(buildLineChart(chart, sheetName));
-      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle, xGridlines, yGridlines));
+      children.push(...buildBarAxes("column", opts));
       break;
     }
     case "area": {
       children.push(buildAreaChart(chart, sheetName));
-      children.push(...buildBarAxes("column", xAxisTitle, yAxisTitle, xGridlines, yGridlines));
+      children.push(...buildBarAxes("column", opts));
       break;
     }
     case "pie": {
@@ -160,7 +168,7 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     }
     case "scatter": {
       children.push(buildScatterChart(chart, sheetName));
-      children.push(...buildScatterAxes(xAxisTitle, yAxisTitle, xGridlines, yGridlines));
+      children.push(...buildScatterAxes(opts));
       break;
     }
     default: {
@@ -171,6 +179,17 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
   }
 
   return xmlElement("c:plotArea", undefined, children);
+}
+
+interface AxisRenderOptions {
+  xAxisTitle: string | undefined;
+  yAxisTitle: string | undefined;
+  xGridlines: { major: boolean; minor: boolean } | undefined;
+  yGridlines: { major: boolean; minor: boolean } | undefined;
+  xScale: ChartAxisScale | undefined;
+  yScale: ChartAxisScale | undefined;
+  xNumFmt: ChartAxisNumberFormat | undefined;
+  yNumFmt: ChartAxisNumberFormat | undefined;
 }
 
 /**
@@ -215,6 +234,134 @@ function buildAxisGridlines(gridlines: { major: boolean; minor: boolean } | unde
   return out;
 }
 
+/**
+ * Drop fields that won't survive Excel's strict validator. Non-finite
+ * numbers, `min >= max`, and zero/negative tick spacings all collapse
+ * the corresponding entry to `undefined` so the writer never emits a
+ * `<c:min>`/`<c:max>`/`<c:majorUnit>`/`<c:minorUnit>` Excel would
+ * reject.
+ *
+ * Returns `undefined` when nothing usable remains so the writer can
+ * skip the entire `<c:scaling>` augmentation.
+ */
+function normalizeAxisScale(value: ChartAxisScale | undefined): ChartAxisScale | undefined {
+  if (!value) return undefined;
+  const out: ChartAxisScale = {};
+  if (typeof value.min === "number" && Number.isFinite(value.min)) out.min = value.min;
+  if (typeof value.max === "number" && Number.isFinite(value.max)) out.max = value.max;
+  if (out.min !== undefined && out.max !== undefined && out.min >= out.max) {
+    // min >= max is meaningless; preserve the user-supplied min only
+    // so validators don't choke on a flipped/empty axis range.
+    delete out.max;
+  }
+  if (
+    typeof value.majorUnit === "number" &&
+    Number.isFinite(value.majorUnit) &&
+    value.majorUnit > 0
+  ) {
+    out.majorUnit = value.majorUnit;
+  }
+  if (
+    typeof value.minorUnit === "number" &&
+    Number.isFinite(value.minorUnit) &&
+    value.minorUnit > 0
+  ) {
+    out.minorUnit = value.minorUnit;
+  }
+  if (
+    typeof value.logBase === "number" &&
+    Number.isFinite(value.logBase) &&
+    value.logBase >= 2 &&
+    value.logBase <= 1000
+  ) {
+    out.logBase = value.logBase;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Normalize a tick-label number format to a value the writer can emit.
+ * An empty `formatCode` collapses the whole record — Excel rejects
+ * `<c:numFmt formatCode=""/>`.
+ */
+function normalizeAxisNumberFormat(
+  value: ChartAxisNumberFormat | undefined,
+): ChartAxisNumberFormat | undefined {
+  if (!value) return undefined;
+  const formatCode = typeof value.formatCode === "string" ? value.formatCode : "";
+  if (formatCode.length === 0) return undefined;
+  const out: ChartAxisNumberFormat = { formatCode };
+  if (value.sourceLinked === true) out.sourceLinked = true;
+  return out;
+}
+
+/**
+ * Build the children that augment a `<c:scaling>` element. Order is
+ * spec-enforced: `<c:logBase>` → `<c:orientation>` → `<c:max>` →
+ * `<c:min>`. The orientation child is always emitted by the caller
+ * (every axis declares `minMax`); this helper handles the rest.
+ *
+ * Returns the children to splice in after `<c:orientation>`.
+ */
+function buildAxisScalingExtras(scale: ChartAxisScale | undefined): {
+  before: string[];
+  after: string[];
+} {
+  if (!scale) return { before: [], after: [] };
+  const before: string[] = [];
+  const after: string[] = [];
+  // logBase comes before orientation per CT_Scaling.
+  if (scale.logBase !== undefined) {
+    before.push(xmlSelfClose("c:logBase", { val: scale.logBase }));
+  }
+  // max and min come after orientation, with max first (CT_Scaling).
+  if (scale.max !== undefined) after.push(xmlSelfClose("c:max", { val: scale.max }));
+  if (scale.min !== undefined) after.push(xmlSelfClose("c:min", { val: scale.min }));
+  return { before, after };
+}
+
+/**
+ * Build the `<c:scaling>` element. Always emits `<c:orientation>` so
+ * the axis renders correctly even when no extra scale fields are set.
+ */
+function buildAxisScaling(scale: ChartAxisScale | undefined): string {
+  const { before, after } = buildAxisScalingExtras(scale);
+  const children: string[] = [
+    ...before,
+    xmlSelfClose("c:orientation", { val: "minMax" }),
+    ...after,
+  ];
+  return xmlElement("c:scaling", undefined, children);
+}
+
+/**
+ * Build the optional `<c:majorUnit>` / `<c:minorUnit>` siblings that
+ * sit later in the axis-element child sequence (after `<c:numFmt>`,
+ * before `<c:crossAx>` per CT_CatAx / CT_ValAx).
+ */
+function buildAxisTickUnits(scale: ChartAxisScale | undefined): string[] {
+  if (!scale) return [];
+  const out: string[] = [];
+  if (scale.majorUnit !== undefined) {
+    out.push(xmlSelfClose("c:majorUnit", { val: scale.majorUnit }));
+  }
+  if (scale.minorUnit !== undefined) {
+    out.push(xmlSelfClose("c:minorUnit", { val: scale.minorUnit }));
+  }
+  return out;
+}
+
+/**
+ * Build the axis tick-label `<c:numFmt formatCode=".." sourceLinked=".."/>`.
+ * Returns an empty array when the axis declares no number format — the
+ * writer then leaves Excel's default linked behaviour untouched.
+ */
+function buildAxisNumFmt(numFmt: ChartAxisNumberFormat | undefined): string[] {
+  if (!numFmt) return [];
+  const sourceLinked = numFmt.sourceLinked === true ? 1 : 0;
+  return [xmlSelfClose("c:numFmt", { formatCode: numFmt.formatCode, sourceLinked })];
+}
+
 // ── Bar / Column ─────────────────────────────────────────────────────
 
 const AXIS_ID_CAT = 111111111;
@@ -255,13 +402,7 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
   return xmlElement("c:barChart", undefined, children);
 }
 
-function buildBarAxes(
-  orientation: "bar" | "column",
-  xAxisTitle: string | undefined,
-  yAxisTitle: string | undefined,
-  xGridlines: { major: boolean; minor: boolean } | undefined,
-  yGridlines: { major: boolean; minor: boolean } | undefined,
-): string[] {
+function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): string[] {
   // For a vertical column chart, categories sit on the bottom (catAx)
   // and values run vertically (valAx). For a horizontal bar chart the
   // axes swap orientation.
@@ -270,18 +411,21 @@ function buildBarAxes(
 
   // OOXML enforces a strict child order inside <c:catAx>/<c:valAx>:
   // axId → scaling → delete → axPos → majorGridlines → minorGridlines
-  // → title → numFmt → crossAx → ...
-  // Gridlines and title must therefore land before crossAx/crosses,
-  // and gridlines must come before the title or Excel ignores them.
+  // → title → numFmt → ... → crossAx → crosses → ... → majorUnit →
+  // minorUnit. Each block below mirrors that order.
+  // The category axis on bar/column rarely uses scaling, but Excel
+  // tolerates the augmentation either way; surface it whenever the
+  // caller pinned a value so write-side templates round-trip.
   const catAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_CAT }),
-    xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
+    buildAxisScaling(opts.xScale),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: catPos }),
-    ...buildAxisGridlines(xGridlines),
+    ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (xAxisTitle) catAxChildren.push(buildAxisTitle(xAxisTitle));
+  if (opts.xAxisTitle) catAxChildren.push(buildAxisTitle(opts.xAxisTitle));
   catAxChildren.push(
+    ...buildAxisNumFmt(opts.xNumFmt),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:auto", { val: 1 }),
@@ -292,16 +436,18 @@ function buildBarAxes(
 
   const valAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL }),
-    xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
+    buildAxisScaling(opts.yScale),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: valPos }),
-    ...buildAxisGridlines(yGridlines),
+    ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (yAxisTitle) valAxChildren.push(buildAxisTitle(yAxisTitle));
+  if (opts.yAxisTitle) valAxChildren.push(buildAxisTitle(opts.yAxisTitle));
   valAxChildren.push(
+    ...buildAxisNumFmt(opts.yNumFmt),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "between" }),
+    ...buildAxisTickUnits(opts.yScale),
   );
 
   return [
@@ -449,38 +595,37 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
   return xmlElement("c:scatterChart", undefined, children);
 }
 
-function buildScatterAxes(
-  xAxisTitle: string | undefined,
-  yAxisTitle: string | undefined,
-  xGridlines: { major: boolean; minor: boolean } | undefined,
-  yGridlines: { major: boolean; minor: boolean } | undefined,
-): string[] {
+function buildScatterAxes(opts: AxisRenderOptions): string[] {
   const xAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_X }),
-    xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
+    buildAxisScaling(opts.xScale),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "b" }),
-    ...buildAxisGridlines(xGridlines),
+    ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (xAxisTitle) xAxChildren.push(buildAxisTitle(xAxisTitle));
+  if (opts.xAxisTitle) xAxChildren.push(buildAxisTitle(opts.xAxisTitle));
   xAxChildren.push(
+    ...buildAxisNumFmt(opts.xNumFmt),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
+    ...buildAxisTickUnits(opts.xScale),
   );
 
   const yAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_Y }),
-    xmlElement("c:scaling", undefined, [xmlSelfClose("c:orientation", { val: "minMax" })]),
+    buildAxisScaling(opts.yScale),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "l" }),
-    ...buildAxisGridlines(yGridlines),
+    ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (yAxisTitle) yAxChildren.push(buildAxisTitle(yAxisTitle));
+  if (opts.yAxisTitle) yAxChildren.push(buildAxisTitle(opts.yAxisTitle));
   yAxChildren.push(
+    ...buildAxisNumFmt(opts.yNumFmt),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
+    ...buildAxisTickUnits(opts.yScale),
   );
 
   return [

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -539,6 +539,190 @@ describe("cloneChart — axis gridlines", () => {
   });
 });
 
+// ── cloneChart — axis scale ─────────────────────────────────────────
+
+describe("cloneChart — axis scale", () => {
+  const sourceWithScale: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: {
+      y: { scale: { min: 0, max: 100, majorUnit: 25 } },
+    },
+  };
+
+  it("inherits the source's scale when no override is given", () => {
+    const clone = cloneChart(sourceWithScale, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.scale).toEqual({ min: 0, max: 100, majorUnit: 25 });
+  });
+
+  it("drops inherited scale when override is null", () => {
+    const clone = cloneChart(sourceWithScale, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { scale: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited scale wholesale (does not merge field-by-field)", () => {
+    const clone = cloneChart(sourceWithScale, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { scale: { max: 50 } } },
+    });
+    // No min should leak through from the source — wholesale replace.
+    expect(clone.axes?.y?.scale).toEqual({ max: 50 });
+  });
+
+  it("adds a scale to an axis the source did not declare it on", () => {
+    const noScale: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noScale, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { scale: { min: 0, max: 200 } } },
+    });
+    expect(clone.axes?.y?.scale).toEqual({ min: 0, max: 200 });
+  });
+
+  it("strips scale silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { scale: { min: 0, max: 100 } } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("filters out non-finite, zero, and negative tick spacings on inherit", () => {
+    const dirty: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        y: {
+          scale: {
+            min: 0,
+            max: 100,
+            majorUnit: Number.NaN,
+            minorUnit: 0,
+          } as never,
+        },
+      },
+    };
+    const clone = cloneChart(dirty, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.scale).toEqual({ min: 0, max: 100 });
+  });
+
+  it("co-inherits the title, gridlines and scale on the same axis", () => {
+    const all: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        y: { title: "Revenue", gridlines: { major: true }, scale: { min: 0, max: 100 } },
+      },
+    };
+    const clone = cloneChart(all, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y).toEqual({
+      title: "Revenue",
+      gridlines: { major: true },
+      scale: { min: 0, max: 100 },
+    });
+  });
+});
+
+// ── cloneChart — axis number format ─────────────────────────────────
+
+describe("cloneChart — axis number format", () => {
+  const sourceWithNumFmt: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: {
+      y: { numberFormat: { formatCode: "$#,##0" } },
+    },
+  };
+
+  it("inherits the source's number format when no override is given", () => {
+    const clone = cloneChart(sourceWithNumFmt, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.numberFormat).toEqual({ formatCode: "$#,##0" });
+  });
+
+  it("drops inherited number format when override is null", () => {
+    const clone = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { numberFormat: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces inherited format with the override", () => {
+    const clone = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { numberFormat: { formatCode: "0.00%" } } },
+    });
+    expect(clone.axes?.y?.numberFormat).toEqual({ formatCode: "0.00%" });
+  });
+
+  it("adds a number format to an axis the source did not declare it on", () => {
+    const noFmt: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { numberFormat: { formatCode: "#,##0" } } },
+    });
+    expect(clone.axes?.y?.numberFormat).toEqual({ formatCode: "#,##0" });
+  });
+
+  it("preserves sourceLinked on inherit", () => {
+    const linked: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { numberFormat: { formatCode: "0.0", sourceLinked: true } } },
+    };
+    const clone = cloneChart(linked, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.numberFormat).toEqual({ formatCode: "0.0", sourceLinked: true });
+  });
+
+  it("strips number format silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { numberFormat: { formatCode: "$#,##0" } } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("ignores empty formatCode strings on both inherit and override", () => {
+    const empty: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { numberFormat: { formatCode: "" } } },
+    };
+    const clone = cloneChart(empty, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toBeUndefined();
+
+    const cloneOverride = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { numberFormat: { formatCode: "" } } },
+    });
+    expect(cloneOverride.axes).toBeUndefined();
+  });
+});
+
 // ── cloneChart — round-trip with parseChart and writeXlsx ────────────
 
 describe("cloneChart — integration", () => {
@@ -979,5 +1163,68 @@ describe("cloneChart — integration", () => {
     expect(reparsed?.kinds).toEqual(["doughnut"]);
     expect(reparsed?.title).toBe("Distribution");
     expect(reparsed?.holeSize).toBe(65);
+  });
+
+  it("round-trips axis scale and number format through parseChart -> cloneChart -> writeXlsx", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="111111111"/>
+        <c:axId val="222222222"/>
+      </c:barChart>
+      <c:catAx><c:axId val="111111111"/></c:catAx>
+      <c:valAx>
+        <c:axId val="222222222"/>
+        <c:scaling>
+          <c:orientation val="minMax"/>
+          <c:max val="100"/>
+          <c:min val="0"/>
+        </c:scaling>
+        <c:numFmt formatCode="$#,##0" sourceLinked="0"/>
+        <c:majorUnit val="25"/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml);
+    expect(source?.axes?.y?.scale).toEqual({ min: 0, max: 100, majorUnit: 25 });
+    expect(source?.axes?.y?.numberFormat).toEqual({ formatCode: "$#,##0" });
+
+    // Default clone inherits scale + numberFormat off the template.
+    const sheetChart: SheetChart = cloneChart(source!, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.axes?.y?.scale).toEqual({ min: 0, max: 100, majorUnit: 25 });
+    expect(sheetChart.axes?.y?.numberFormat).toEqual({ formatCode: "$#,##0" });
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:max val="100"/>');
+    expect(written).toContain('<c:min val="0"/>');
+    expect(written).toContain('<c:majorUnit val="25"/>');
+    expect(written).toContain('formatCode="$#,##0"');
+
+    // Re-read the emitted chart and confirm everything survives.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.scale).toEqual({ min: 0, max: 100, majorUnit: 25 });
+    expect(reparsed?.axes?.y?.numberFormat).toEqual({ formatCode: "$#,##0" });
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -580,6 +580,238 @@ describe("writeChart — axis gridlines", () => {
   });
 });
 
+// ── writeChart — axis scale (min/max/majorUnit/minorUnit/logBase) ────
+
+describe("writeChart — axis scale", () => {
+  it("emits <c:min> and <c:max> inside <c:scaling> on the value axis", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { scale: { min: 0, max: 100 } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const scalingBlock = valAxBlock.match(/<c:scaling>[\s\S]*?<\/c:scaling>/)![0];
+    expect(scalingBlock).toContain('<c:max val="100"/>');
+    expect(scalingBlock).toContain('<c:min val="0"/>');
+    // Spec order: orientation must precede max which precedes min.
+    const orientationIdx = scalingBlock.indexOf("c:orientation");
+    const maxIdx = scalingBlock.indexOf("c:max");
+    const minIdx = scalingBlock.indexOf("c:min");
+    expect(orientationIdx).toBeLessThan(maxIdx);
+    expect(maxIdx).toBeLessThan(minIdx);
+  });
+
+  it("does not pollute the category axis scaling when only y.scale is set", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { scale: { min: 0, max: 100 } } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:min");
+    expect(catAxBlock).not.toContain("<c:max");
+  });
+
+  it("emits <c:majorUnit> and <c:minorUnit> as siblings of crossBetween (after)", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { scale: { majorUnit: 25, minorUnit: 5 } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:majorUnit val="25"/>');
+    expect(valAxBlock).toContain('<c:minorUnit val="5"/>');
+    // Tick units come AFTER crossBetween per CT_ValAx.
+    const crossBetweenIdx = valAxBlock.indexOf("c:crossBetween");
+    const majorUnitIdx = valAxBlock.indexOf("c:majorUnit");
+    const minorUnitIdx = valAxBlock.indexOf("c:minorUnit");
+    expect(crossBetweenIdx).toBeGreaterThan(0);
+    expect(majorUnitIdx).toBeGreaterThan(crossBetweenIdx);
+    expect(minorUnitIdx).toBeGreaterThan(majorUnitIdx);
+  });
+
+  it("emits <c:logBase> before <c:orientation> per CT_Scaling order", () => {
+    const result = writeChart(makeChart({ axes: { y: { scale: { logBase: 10 } } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const scalingBlock = valAxBlock.match(/<c:scaling>[\s\S]*?<\/c:scaling>/)![0];
+    expect(scalingBlock).toContain('<c:logBase val="10"/>');
+    const logBaseIdx = scalingBlock.indexOf("c:logBase");
+    const orientationIdx = scalingBlock.indexOf("c:orientation");
+    expect(logBaseIdx).toBeLessThan(orientationIdx);
+  });
+
+  it("drops max when min >= max (degenerate range)", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { scale: { min: 10, max: 10 } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const scalingBlock = valAxBlock.match(/<c:scaling>[\s\S]*?<\/c:scaling>/)![0];
+    expect(scalingBlock).toContain('<c:min val="10"/>');
+    expect(scalingBlock).not.toContain("<c:max");
+  });
+
+  it("ignores non-finite, zero, and negative tick spacings", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            scale: {
+              majorUnit: Number.NaN,
+              minorUnit: 0,
+            },
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:majorUnit");
+    expect(result.chartXml).not.toContain("c:minorUnit");
+  });
+
+  it("ignores log bases outside the spec-allowed 2..1000 band", () => {
+    const result = writeChart(makeChart({ axes: { y: { scale: { logBase: 1 } } } }), "Sheet1");
+    expect(result.chartXml).not.toContain("c:logBase");
+    const result2 = writeChart(makeChart({ axes: { y: { scale: { logBase: 5000 } } } }), "Sheet1");
+    expect(result2.chartXml).not.toContain("c:logBase");
+  });
+
+  it("emits scale on the scatter X axis when xScale is set", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { scale: { min: 0, max: 50 } } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    expect(valAxBlocks).toHaveLength(2);
+    // First valAx is the X axis (axPos="b").
+    expect(valAxBlocks[0]).toContain('c:axPos val="b"');
+    expect(valAxBlocks[0]).toContain('<c:max val="50"/>');
+    expect(valAxBlocks[0]).toContain('<c:min val="0"/>');
+    expect(valAxBlocks[1]).not.toContain('<c:max val="50"/>');
+  });
+
+  it("skips scaling extras on pie charts (pie has no axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        axes: { y: { scale: { min: 0, max: 100 } } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:max");
+    expect(result.chartXml).not.toContain("<c:majorUnit");
+  });
+
+  it("renders well-formed XML when scale extras coexist with title and gridlines", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            title: "Revenue",
+            gridlines: { major: true },
+            scale: { min: 0, max: 100, majorUnit: 25 },
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const doc = parseXml(result.chartXml);
+    expect(doc).toBeTruthy();
+  });
+});
+
+// ── writeChart — axis number format ──────────────────────────────────
+
+describe("writeChart — axis number format", () => {
+  it("emits <c:numFmt> with the formatCode and sourceLinked=0 by default", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { numberFormat: { formatCode: "#,##0" } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('formatCode="#,##0"');
+    expect(valAxBlock).toContain('sourceLinked="0"');
+  });
+
+  it("emits sourceLinked=1 when explicitly set", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { y: { numberFormat: { formatCode: "0.00%", sourceLinked: true } } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('formatCode="0.00%"');
+    expect(valAxBlock).toContain('sourceLinked="1"');
+  });
+
+  it("places <c:numFmt> after the optional <c:title> and before <c:crossAx>", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: { title: "Revenue", numberFormat: { formatCode: "$#,##0" } },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const titleIdx = valAxBlock.indexOf("<c:title>");
+    const numFmtIdx = valAxBlock.indexOf("<c:numFmt");
+    const crossAxIdx = valAxBlock.indexOf("c:crossAx");
+    expect(titleIdx).toBeGreaterThan(0);
+    expect(numFmtIdx).toBeGreaterThan(titleIdx);
+    expect(crossAxIdx).toBeGreaterThan(numFmtIdx);
+  });
+
+  it("omits <c:numFmt> when formatCode is empty", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { numberFormat: { formatCode: "" } } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:numFmt");
+  });
+
+  it("escapes XML-special characters in the formatCode", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { numberFormat: { formatCode: '"<x>"&"y"' } } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('formatCode="&quot;&lt;x&gt;&quot;&amp;&quot;y&quot;"');
+  });
+
+  it("emits a number format on the scatter Y axis", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { numberFormat: { formatCode: "0.00%" } } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    // Y axis is the second valAx (axPos="l").
+    expect(valAxBlocks[1]).toContain('c:axPos val="l"');
+    expect(valAxBlocks[1]).toContain('formatCode="0.00%"');
+    expect(valAxBlocks[0]).not.toContain('formatCode="0.00%"');
+  });
+
+  it("skips number format on pie charts (pie has no axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        axes: { y: { numberFormat: { formatCode: "#,##0" } } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:numFmt");
+  });
+});
+
 describe("chartKindElement", () => {
   it("maps each chart kind to the matching DrawingML element", () => {
     expect(chartKindElement("bar")).toBe("c:barChart");

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -968,6 +968,180 @@ describe("parseChart — axis gridlines", () => {
   });
 });
 
+// ── parseChart — axis scale ───────────────────────────────────────
+
+describe("parseChart — axis scale", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces <c:min> / <c:max> / <c:majorUnit> / <c:minorUnit> off the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling>
+        <c:orientation val="minMax"/>
+        <c:max val="100"/>
+        <c:min val="0"/>
+      </c:scaling>
+      <c:majorUnit val="25"/>
+      <c:minorUnit val="5"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.scale).toEqual({ min: 0, max: 100, majorUnit: 25, minorUnit: 5 });
+  });
+
+  it("surfaces <c:logBase> from inside <c:scaling>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling>
+        <c:logBase val="10"/>
+        <c:orientation val="minMax"/>
+      </c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.scale).toEqual({ logBase: 10 });
+  });
+
+  it("does not surface a scale when <c:scaling> only carries <c:orientation>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="minMax"/></c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores non-finite, zero, and negative tick spacings", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="minMax"/></c:scaling>
+      <c:majorUnit val="0"/>
+      <c:minorUnit val="-2"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("maps scatter axes to x = first valAx, y = second valAx", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:scaling><c:orientation val="minMax"/><c:max val="50"/><c:min val="0"/></c:scaling>
+      <c:axPos val="b"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="minMax"/><c:max val="200"/><c:min val="-200"/></c:scaling>
+      <c:axPos val="l"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.scale).toEqual({ min: 0, max: 50 });
+    expect(chart?.axes?.y?.scale).toEqual({ min: -200, max: 200 });
+  });
+});
+
+// ── parseChart — axis number format ───────────────────────────────
+
+describe("parseChart — axis number format", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:numFmt formatCode="..."/> off the value axis', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:numFmt formatCode="#,##0" sourceLinked="0"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.numberFormat).toEqual({ formatCode: "#,##0" });
+  });
+
+  it("surfaces sourceLinked when set to 1", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:numFmt formatCode="0.00%" sourceLinked="1"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.numberFormat).toEqual({ formatCode: "0.00%", sourceLinked: true });
+  });
+
+  it("ignores empty formatCode attributes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:numFmt formatCode="" sourceLinked="1"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces axis title, gridlines, scale and number format together", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="minMax"/><c:max val="100"/><c:min val="0"/></c:scaling>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:numFmt formatCode="$#,##0" sourceLinked="0"/>
+      <c:majorUnit val="25"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y).toEqual({
+      title: "Revenue",
+      gridlines: { major: true },
+      scale: { min: 0, max: 100, majorUnit: 25 },
+      numberFormat: { formatCode: "$#,##0" },
+    });
+  });
+});
+
 // ── parseChart — doughnut hole size ───────────────────────────────
 
 describe("parseChart — doughnut hole size", () => {


### PR DESCRIPTION
## Summary

`parseChart` and the chart writer carried axis title (#197), gridlines (#199), and data labels (#198) through the read / write / clone bridge, but the value-axis numeric scaling (`<c:min>` / `<c:max>` / `<c:majorUnit>` / `<c:minorUnit>` / `<c:logBase>`) and the tick-label number format (`<c:numFmt>`) were ignored on both sides. A `parseChart` → `cloneChart` → `writeXlsx` round-trip therefore stripped pinned axis bounds and currency / percent / thousands formatting from any template chart that had them, breaking the dashboard-composition flow from #136 for the very common "explicit min/max + currency tick labels" look.

This PR closes that gap at all three layers — read, write, and clone — so a templated chart's scale and tick-label format survive the full retarget loop without the caller having to thread them manually.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes);
// {
//   y: {
//     scale: { min: 0, max: 100, majorUnit: 25 },
//     numberFormat: { formatCode: "$#,##0" },
//   },
// }

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ values: "B2:B13" }],
      anchor: { from: { row: 14, col: 0 } },
      axes: {
        y: {
          title: "Revenue (USD)",
          gridlines: { major: true },
          scale: { min: 0, max: 100, majorUnit: 25 },
          numberFormat: { formatCode: "$#,##0" },
        },
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!\$B\$2:\$B\$13" }],
  // scale and numberFormat inherit from `source` automatically; pass
  // overrides to remap.
});

// Drop the inherited scale on a single axis:
const auto = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: { y: { scale: null } },
});
```

## Model

```ts
export interface ChartAxisScale {
  min?: number;
  max?: number;
  majorUnit?: number;   // tick spacing, must be > 0
  minorUnit?: number;   // tick spacing, must be > 0
  logBase?: number;     // 2..1000
}

export interface ChartAxisNumberFormat {
  formatCode: string;       // OOXML number-format code
  sourceLinked?: boolean;   // true → ignore formatCode, inherit from data range
}

interface ChartAxisInfo {
  title?: string;
  gridlines?: ChartAxisGridlines;
  scale?: ChartAxisScale;
  numberFormat?: ChartAxisNumberFormat;
}

interface SheetChart {
  axes?: {
    x?: { title?: string; gridlines?: ChartAxisGridlines; scale?: ChartAxisScale; numberFormat?: ChartAxisNumberFormat };
    y?: { title?: string; gridlines?: ChartAxisGridlines; scale?: ChartAxisScale; numberFormat?: ChartAxisNumberFormat };
  };
}
```

## Implementation

- **Reader (`chart-reader.ts`)**: `parseAxisScale` walks `<c:scaling>` for `<c:min>` / `<c:max>` / `<c:logBase>` and the axis itself for `<c:majorUnit>` / `<c:minorUnit>` (tick spacings live directly under `<c:catAx>` / `<c:valAx>` per CT_CatAx / CT_ValAx, not inside `<c:scaling>`). `parseAxisNumberFormat` reads `<c:numFmt formatCode="…" sourceLinked="…"/>` and normalizes `sourceLinked` from the boolean-attribute set Excel emits (`0` / `1` / `"true"` / `"false"`). Empty `formatCode` strings collapse the whole record so the consumer never sees `<c:numFmt formatCode=""/>`. `parseAxisInfo` now folds title / gridlines / scale / numberFormat into the same axis record.
- **Writer (`chart-writer.ts`)**: a single `AxisRenderOptions` struct now carries the four per-axis fields through `buildBarAxes` / `buildScatterAxes`. `buildAxisScaling` slots `<c:logBase>` before `<c:orientation>` and `<c:max>` / `<c:min>` after it (the order CT_Scaling enforces). `buildAxisNumFmt` lands `<c:numFmt>` after the optional `<c:title>` and before `<c:crossAx>`; `buildAxisTickUnits` lands `<c:majorUnit>` / `<c:minorUnit>` after `<c:crossBetween>`, the position CT_ValAx / CT_CatAx require. Pie and doughnut have no axes, so the writer silently skips the field there. `normalizeAxisScale` drops non-finite numbers, zero/negative tick spacings, log bases outside 2..1000, and degenerate `min >= max` ranges (preserving min, dropping max) so the writer can never emit a `<c:scaling>` Excel rejects.
- **Clone bridge (`chart-clone.ts`)**: `applyScaleOverride` and `applyNumberFormatOverride` carry the same `undefined` (inherit) / `null` (drop) / object (replace) grammar already used for axis titles and gridlines. `resolveAxes` now folds title / gridlines / scale / numberFormat into the same `axes.{x,y}` record, dropping it entirely when all four resolve to `undefined`. When the resolved chart type is `pie` or `doughnut` the whole axes block is dropped, so a doughnut template that happened to carry stray scale/numFmt values does not poison the clone.

## Edge cases

- `<c:scaling>` with only `<c:orientation>` (Excel's autoscale baseline) → reader returns `undefined`, writer emits the same minimal `<c:scaling>`.
- `<c:majorUnit val="0"/>` / negative tick spacing → reader filters it out, writer never emits it. Same for `Number.NaN`.
- `min >= max` on the write side → max is dropped, min is preserved.
- `logBase` outside 2..1000 → writer drops it (Excel rejects values outside that band).
- `numFmt formatCode=""` → reader returns `undefined`, writer skips emission.
- Override `axes: { y: { scale: null } }` drops the inherited scale while keeping title / gridlines / numFmt.
- Override `axes: { y: { scale: { max: 50 } } }` replaces the inherited scale wholesale (does **not** merge into a `{ min: 0, max: 50, majorUnit: 25 }` — wholesale replace is the contract).
- Cloning into `pie` / `doughnut` strips inherited scale and numberFormat along with axis titles / gridlines.
- XML-special characters in `formatCode` (e.g. `'"<x>"&"y"'`) are escaped on write.
- Spec-enforced child order on the writer side: `<c:logBase>` precedes `<c:orientation>` inside `<c:scaling>`; `<c:numFmt>` lands between `<c:title>` and `<c:crossAx>`; `<c:majorUnit>` / `<c:minorUnit>` land after `<c:crossBetween>`.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2642 vitest cases — adds 5 parser tests for scale, 4 parser tests for number format, 8 writer tests for scale, 7 writer tests for number format, 7 clone tests for scale, 7 clone tests for number format, plus 1 end-to-end round-trip via `parseChart` → `cloneChart` → `writeXlsx` → `parseChart`)
- [x] `pnpm build`
- [x] Round-trip: pinned `min` / `max` / `majorUnit` and `formatCode: "\$#,##0"` survive the full retarget loop verbatim
- [x] Scatter scale lands on the X (`axPos="b"`) value axis when `axes.x.scale` is set
- [x] Pie / doughnut charts silently drop scale / numberFormat on both write and clone paths
- [x] Spec-enforced child order verified by index-based assertions (orientation before max/min; logBase before orientation; majorUnit/minorUnit after crossBetween; numFmt between title and crossAx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)