### PR TITLE
feat(xlsx): chart first slice angle — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,13 @@ plus `position` and `separator`). Series-level overrides land on
 on doughnut charts so a parsed template can round-trip its hole back
 through `cloneChart`; non-doughnut charts (and doughnut charts that
 omit the element) never report it.
+`Chart.firstSliceAng` surfaces the
+`<c:pieChart><c:firstSliceAng val=".."/>` /
+`<c:doughnutChart><c:firstSliceAng val=".."/>` rotation (degrees
+clockwise from 12 o'clock) on pie and doughnut charts. The OOXML
+default `0` (and the schema-equivalent `360`) collapses to
+`undefined` so absence and the default round-trip identically;
+non-pie / non-doughnut charts never report it.
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
@@ -678,6 +685,11 @@ even when the chart-level default has them on). For doughnut charts,
 `holeSize` (10 – 90, Excel's UI band; default 50) controls the
 diameter of the inner hole — values outside the band are clamped to
 the closest end and non-doughnut kinds silently ignore the field.
+For pie and doughnut charts, `firstSliceAng` (0 – 360 degrees, default
+0 = 12 o'clock) rotates the first wedge clockwise — useful for
+aligning paired charts in a dashboard. Out-of-band values wrap modulo
+360 (380 → 20, -90 → 270) the same way Excel's chart-formatting pane
+does, and non-pie / non-doughnut kinds silently ignore the field.
 Radar, stock, 3D variants, trendlines, and combo charts are out of
 scope today.
 
@@ -727,7 +739,11 @@ into a column drops the inherited grouping rather than silently
 emitting a value the writer would ignore. Doughnut clones also inherit
 the parsed `holeSize` from the template; pass `holeSize: 60` to
 override or `type: "pie"` to flatten into a plain pie (the hole hint
-is dropped silently in that case). Data labels inherit too: omit `dataLabels`
+is dropped silently in that case). Pie and doughnut clones inherit the
+parsed `firstSliceAng` from the template; the rotation also survives a
+`type: "pie"` flattening of a doughnut source (the element lives on
+both pie and doughnut), but is dropped when the resolved clone target
+is anything else. Data labels inherit too: omit `dataLabels`
 to carry the source's chart-level labels through, pass an object to
 replace, or `null` to drop them; per-series overrides accept the same
 `undefined`/`null`/object grammar plus `false` to suppress labels on

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -687,6 +687,18 @@ export interface SheetChart {
    */
   holeSize?: number;
   /**
+   * Pie / doughnut starting angle in degrees, measured clockwise from
+   * the 12 o'clock position. Accepted range: 0 – 360 (the OOXML schema
+   * range). Default: `0` — the Excel default (first slice begins at
+   * 12 o'clock). Maps to `<c:firstSliceAng val=".."/>`. Ignored for
+   * non-pie / non-doughnut chart kinds.
+   *
+   * Useful for rotating the first wedge into a specific quadrant when
+   * composing a dashboard whose pie / doughnut charts should align
+   * visually (e.g. `90` to start at 3 o'clock).
+   */
+  firstSliceAng?: number;
+  /**
    * Whether the legend is shown and where. Default: `"right"` for
    * pie/doughnut/bar/line/area, `"bottom"` for scatter. Pass `false`
    * to hide the legend.
@@ -1561,6 +1573,16 @@ export interface Chart {
    * charts that do not declare the element.
    */
   holeSize?: number;
+  /**
+   * Pie / doughnut starting angle in degrees pulled from the first
+   * `<c:pieChart>` / `<c:doughnutChart>` element's
+   * `<c:firstSliceAng val=".."/>`. Range: 0–360. `0` collapses to
+   * `undefined` because it is the OOXML default (first slice at the
+   * 12 o'clock position) — the writer's
+   * {@link SheetChart.firstSliceAng} treats the absence of the field
+   * the same way. Omitted on non-pie / non-doughnut charts.
+   */
+  firstSliceAng?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -95,6 +95,14 @@ export interface CloneChartOptions {
    * column chart.
    */
   holeSize?: number;
+  /**
+   * Override `SheetChart.firstSliceAng` (the pie / doughnut starting
+   * angle in degrees, clockwise from 12 o'clock). Only meaningful for
+   * `pie` and `doughnut`; dropped silently when the resolved chart
+   * type is anything else, so a rotation hint inherited from a
+   * doughnut template never leaks into a column or scatter clone.
+   */
+  firstSliceAng?: number;
   /** Override `SheetChart.showTitle`. */
   showTitle?: boolean;
   /** Override `SheetChart.altText`. */
@@ -210,6 +218,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (type === "doughnut") {
     const holeSize = options.holeSize !== undefined ? options.holeSize : source.holeSize;
     if (holeSize !== undefined) out.holeSize = holeSize;
+  }
+
+  // First slice angle round-trips for both pie and doughnut — the
+  // OOXML schema places the element on `<c:pieChart>` and
+  // `<c:doughnutChart>` alike. A doughnut template flattened to pie
+  // therefore keeps its rotation; coercion into a non-pie family drops
+  // the inherited value so it never leaks into a chart kind that has
+  // no rotation knob.
+  if (type === "pie" || type === "doughnut") {
+    const firstSliceAng =
+      options.firstSliceAng !== undefined ? options.firstSliceAng : source.firstSliceAng;
+    if (firstSliceAng !== undefined) out.firstSliceAng = firstSliceAng;
   }
 
   if (options.showTitle !== undefined) out.showTitle = options.showTitle;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -78,6 +78,7 @@ export function parseChart(xml: string): Chart | undefined {
     let areaGrouping: ChartLineAreaGrouping | undefined;
     let chartLevelLabels: ChartDataLabelsInfo | undefined;
     let holeSize: number | undefined;
+    let firstSliceAng: number | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
@@ -102,6 +103,18 @@ export function parseChart(xml: string): Chart | undefined {
       // can round-trip its hole back through {@link cloneChart}.
       if (holeSize === undefined && kind === "doughnut") {
         holeSize = parseHoleSize(child);
+      }
+      // `<c:firstSliceAng>` lives on `<c:pieChart>` and
+      // `<c:doughnutChart>` (also pie3D / ofPie which we lump in here
+      // for symmetry — the writer never emits those, but a parsed
+      // template carrying one round-trips cleanly into a pie/doughnut
+      // clone). `0` collapses to undefined because it is the OOXML
+      // default that the writer also treats as absence of the field.
+      if (
+        firstSliceAng === undefined &&
+        (kind === "pie" || kind === "pie3D" || kind === "doughnut" || kind === "ofPie")
+      ) {
+        firstSliceAng = parseFirstSliceAng(child);
       }
       let localIndex = 0;
       for (const ser of childElements(child)) {
@@ -129,6 +142,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (areaGrouping !== undefined) out.areaGrouping = areaGrouping;
     if (chartLevelLabels) out.dataLabels = chartLevelLabels;
     if (holeSize !== undefined) out.holeSize = holeSize;
+    if (firstSliceAng !== undefined) out.firstSliceAng = firstSliceAng;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
@@ -527,6 +541,34 @@ function parseHoleSize(doughnut: XmlElement): number | undefined {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed)) return undefined;
   if (parsed < 1 || parsed > 99) return undefined;
+  return parsed;
+}
+
+// ── First Slice Angle ─────────────────────────────────────────────
+
+/**
+ * Pull `<c:firstSliceAng val=".."/>` off a `<c:pieChart>` /
+ * `<c:doughnutChart>` element. Returns `undefined` when the attribute
+ * is missing, malformed, or carries the OOXML default of `0` — the
+ * writer's {@link SheetChart.firstSliceAng} treats absence and `0`
+ * identically, so collapsing here keeps the round-trip stable.
+ *
+ * The OOXML schema (CT_FirstSliceAng) restricts the value to the
+ * inclusive range `0..360`; out-of-range values are dropped rather
+ * than clamped so a corrupt template does not silently rewrite as a
+ * different angle.
+ */
+function parseFirstSliceAng(chartType: XmlElement): number | undefined {
+  const el = findChild(chartType, "firstSliceAng");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 0 || parsed > 360) return undefined;
+  // Collapse `0` and the schema-equivalent `360` to undefined — both
+  // mean "first slice at 12 o'clock", which is the writer's default.
+  if (parsed === 0 || parsed === 360) return undefined;
   return parsed;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -381,6 +381,14 @@ function buildPieChart(chart: SheetChart, sheetName: string): string {
   const chartLevelDLbls = buildChartLevelDataLabels(chart);
   if (chartLevelDLbls) children.push(chartLevelDLbls);
 
+  // `<c:firstSliceAng>` is optional on `<c:pieChart>` (CT_PieChart);
+  // omit it when the angle is the default `0` (12 o'clock start) so
+  // we do not bloat untouched chart XML.
+  const sliceAng = clampFirstSliceAng(chart.firstSliceAng);
+  if (sliceAng !== undefined) {
+    children.push(xmlSelfClose("c:firstSliceAng", { val: sliceAng }));
+  }
+
   return xmlElement("c:pieChart", undefined, children);
 }
 
@@ -412,10 +420,40 @@ function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
   // required by OOXML — the schema rejects a `<c:doughnutChart>` without
   // it. Clamp to the 10–90 band Excel's UI enforces; values outside
   // this range render but trigger Excel's repair dialog.
-  children.push(xmlSelfClose("c:firstSliceAng", { val: 0 }));
+  //
+  // The doughnut writer always emits `<c:firstSliceAng>`, falling back
+  // to the default `0` when the caller did not request a rotation —
+  // that mirrors the spec's reference serialization Excel produces.
+  children.push(
+    xmlSelfClose("c:firstSliceAng", { val: clampFirstSliceAng(chart.firstSliceAng) ?? 0 }),
+  );
   children.push(xmlSelfClose("c:holeSize", { val: clampHoleSize(chart.holeSize) }));
 
   return xmlElement("c:doughnutChart", undefined, children);
+}
+
+/**
+ * Normalize {@link SheetChart.firstSliceAng} to an integer in the
+ * inclusive 0..360 band the OOXML schema (CT_FirstSliceAng) allows.
+ *
+ * Returns `undefined` for the default `0` so the pie writer can elide
+ * the element entirely (Excel treats absence and `0` identically). The
+ * doughnut writer must always emit the element, so it explicitly
+ * substitutes `0` when the helper returns `undefined`.
+ *
+ * Out-of-range values are wrapped modulo 360 — `380` becomes `20`,
+ * `-90` becomes `270` — which matches how Excel itself renders an
+ * out-of-band value the user types into the chart-formatting pane.
+ */
+function clampFirstSliceAng(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  // Wrap into 0..360 (inclusive). The OOXML schema actually allows
+  // 360 as a value, so we keep it distinct from 0.
+  let normalized = rounded % 360;
+  if (normalized < 0) normalized += 360;
+  if (normalized === 0) return undefined;
+  return normalized;
 }
 
 function clampHoleSize(value: number | undefined): number {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -136,6 +136,61 @@ describe("cloneChart", () => {
     expect(clone.holeSize).toBeUndefined();
   });
 
+  it("inherits the source's firstSliceAng on a pie clone", () => {
+    const clone = cloneChart(source({ kinds: ["pie"], firstSliceAng: 90 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.firstSliceAng).toBe(90);
+  });
+
+  it("inherits the source's firstSliceAng on a doughnut clone", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"], firstSliceAng: 180 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.firstSliceAng).toBe(180);
+  });
+
+  it("carries firstSliceAng through when flattening doughnut to pie", () => {
+    // The element lives on both <c:pieChart> and <c:doughnutChart>, so
+    // a doughnut template flattened to pie keeps its rotation.
+    const clone = cloneChart(source({ kinds: ["doughnut"], firstSliceAng: 270 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.firstSliceAng).toBe(270);
+  });
+
+  it("lets options.firstSliceAng override the source's firstSliceAng", () => {
+    const clone = cloneChart(source({ kinds: ["pie"], firstSliceAng: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      firstSliceAng: 180,
+    });
+    expect(clone.firstSliceAng).toBe(180);
+  });
+
+  it("drops options.firstSliceAng when the resolved type is neither pie nor doughnut", () => {
+    const clone = cloneChart(source({ kinds: ["doughnut"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      firstSliceAng: 90,
+      seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+    });
+    expect(clone.firstSliceAng).toBeUndefined();
+  });
+
+  it("drops the inherited firstSliceAng when the resolved type is not pie/doughnut", () => {
+    const clone = cloneChart(source({ kinds: ["pie"], firstSliceAng: 90 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.firstSliceAng).toBeUndefined();
+  });
+
   it("throws when the source has no writable kind and no override is given", () => {
     expect(() =>
       cloneChart(source({ kinds: ["bubble", "radar"] }), {
@@ -1138,5 +1193,54 @@ describe("cloneChart — integration", () => {
     expect(reparsed?.kinds).toEqual(["doughnut"]);
     expect(reparsed?.title).toBe("Distribution");
     expect(reparsed?.holeSize).toBe(65);
+  });
+
+  it("round-trips firstSliceAng through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:doughnutChart>
+        <c:varyColors val="1"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Mix</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:firstSliceAng val="135"/>
+        <c:holeSize val="55"/>
+      </c:doughnutChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml);
+    expect(source?.firstSliceAng).toBe(135);
+
+    const sheetChart: SheetChart = cloneChart(source!, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.type).toBe("doughnut");
+    expect(sheetChart.firstSliceAng).toBe(135);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:firstSliceAng val="135"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.kinds).toEqual(["doughnut"]);
+    expect(reparsed?.firstSliceAng).toBe(135);
+    expect(reparsed?.holeSize).toBe(55);
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -385,6 +385,100 @@ describe("writeChart — doughnut", () => {
   });
 });
 
+// ── First slice angle ────────────────────────────────────────────────
+
+describe("writeChart — firstSliceAng", () => {
+  it("omits <c:firstSliceAng> on a pie chart with no rotation set", () => {
+    // The pie writer treats the OOXML default `0` as the absence of
+    // the element so untouched pie charts stay byte-clean.
+    const result = writeChart(makeChart({ type: "pie" }), "Sheet1");
+    expect(result.chartXml).not.toContain("c:firstSliceAng");
+  });
+
+  it("emits <c:firstSliceAng> on a pie chart when firstSliceAng is set", () => {
+    const result = writeChart(makeChart({ type: "pie", firstSliceAng: 90 }), "Sheet1");
+    expect(result.chartXml).toContain('c:firstSliceAng val="90"');
+  });
+
+  it("threads an explicit firstSliceAng through to a doughnut chart", () => {
+    const result = writeChart(makeChart({ type: "doughnut", firstSliceAng: 270 }), "Sheet1");
+    expect(result.chartXml).toContain('c:firstSliceAng val="270"');
+  });
+
+  it("falls back to the default 0 on doughnut when firstSliceAng is unset", () => {
+    // Doughnut always emits <c:firstSliceAng> — Excel's reference
+    // serialization includes it even at the default. Pie elides it.
+    const result = writeChart(makeChart({ type: "doughnut" }), "Sheet1");
+    expect(result.chartXml).toContain('c:firstSliceAng val="0"');
+  });
+
+  it("wraps angles into the 0..360 band by modulo (stays inside CT_FirstSliceAng)", () => {
+    // Excel itself normalizes wrap-arounds the same way when the user
+    // types e.g. 380 into the chart-formatting pane.
+    const wrap = writeChart(makeChart({ type: "pie", firstSliceAng: 380 }), "Sheet1");
+    expect(wrap.chartXml).toContain('c:firstSliceAng val="20"');
+    const neg = writeChart(makeChart({ type: "pie", firstSliceAng: -90 }), "Sheet1");
+    expect(neg.chartXml).toContain('c:firstSliceAng val="270"');
+  });
+
+  it("rounds non-integer firstSliceAng values", () => {
+    const result = writeChart(makeChart({ type: "pie", firstSliceAng: 47.6 }), "Sheet1");
+    expect(result.chartXml).toContain('c:firstSliceAng val="48"');
+  });
+
+  it("falls back to the default 0 when firstSliceAng is NaN or Infinity", () => {
+    // Pie elides on the default; doughnut still emits 0.
+    const pieNan = writeChart(makeChart({ type: "pie", firstSliceAng: NaN }), "Sheet1");
+    expect(pieNan.chartXml).not.toContain("c:firstSliceAng");
+    const ringNan = writeChart(makeChart({ type: "doughnut", firstSliceAng: NaN }), "Sheet1");
+    expect(ringNan.chartXml).toContain('c:firstSliceAng val="0"');
+    const ringInf = writeChart(
+      makeChart({ type: "doughnut", firstSliceAng: Number.POSITIVE_INFINITY }),
+      "Sheet1",
+    );
+    expect(ringInf.chartXml).toContain('c:firstSliceAng val="0"');
+  });
+
+  it("wraps the schema-equivalent 360 down to 0 (omitted on pie)", () => {
+    const result = writeChart(makeChart({ type: "pie", firstSliceAng: 360 }), "Sheet1");
+    expect(result.chartXml).not.toContain("c:firstSliceAng");
+  });
+
+  it("omits firstSliceAng on non-pie / non-doughnut kinds even when the field is set", () => {
+    const col = writeChart(makeChart({ type: "column", firstSliceAng: 90 }), "Sheet1");
+    expect(col.chartXml).not.toContain("c:firstSliceAng");
+    const line = writeChart(makeChart({ type: "line", firstSliceAng: 90 }), "Sheet1");
+    expect(line.chartXml).not.toContain("c:firstSliceAng");
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        firstSliceAng: 90,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).not.toContain("c:firstSliceAng");
+  });
+
+  it("places <c:firstSliceAng> inside <c:pieChart> (not at chart level)", () => {
+    const result = writeChart(makeChart({ type: "pie", firstSliceAng: 90 }), "Sheet1");
+    const pieBlock = result.chartXml.match(/<c:pieChart>[\s\S]*?<\/c:pieChart>/);
+    expect(pieBlock).not.toBeNull();
+    expect(pieBlock![0]).toContain('c:firstSliceAng val="90"');
+  });
+
+  it("places <c:firstSliceAng> before <c:holeSize> inside <c:doughnutChart> (OOXML order)", () => {
+    const result = writeChart(
+      makeChart({ type: "doughnut", firstSliceAng: 90, holeSize: 60 }),
+      "Sheet1",
+    );
+    // CT_DoughnutChart: varyColors, ser*, dLbls?, firstSliceAng?, holeSize?, extLst?
+    expect(result.chartXml.indexOf("c:firstSliceAng")).toBeLessThan(
+      result.chartXml.indexOf("c:holeSize"),
+    );
+  });
+});
+
 // ── Axis titles ──────────────────────────────────────────────────────
 
 describe("writeChart — axis titles", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -1143,6 +1143,118 @@ describe("parseChart — doughnut hole size", () => {
   });
 });
 
+describe("parseChart — first slice angle", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:firstSliceAng val="..."/> off a pie chart', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:varyColors val="1"/>
+      <c:firstSliceAng val="90"/>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["pie"]);
+    expect(chart?.firstSliceAng).toBe(90);
+  });
+
+  it('surfaces <c:firstSliceAng val="..."/> off a doughnut chart', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart>
+      <c:varyColors val="1"/>
+      <c:firstSliceAng val="180"/>
+      <c:holeSize val="50"/>
+    </c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["doughnut"]);
+    expect(chart?.firstSliceAng).toBe(180);
+  });
+
+  it("collapses the OOXML default 0 to undefined (writer absence)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart><c:firstSliceAng val="0"/></c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.firstSliceAng).toBeUndefined();
+  });
+
+  it("collapses the schema-equivalent 360 to undefined (same as 0)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart><c:firstSliceAng val="360"/></c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.firstSliceAng).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:firstSliceAng> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart><c:varyColors val="1"/></c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.firstSliceAng).toBeUndefined();
+  });
+
+  it("rejects malformed or out-of-range firstSliceAng values", () => {
+    const out = (val: string): unknown =>
+      parseChart(`<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart><c:firstSliceAng val="${val}"/></c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`)?.firstSliceAng;
+    expect(out("not-a-number")).toBeUndefined();
+    // Negative values fall outside the CT_FirstSliceAng band.
+    expect(out("-1")).toBeUndefined();
+    // 361 also falls outside the schema band (0..360 inclusive).
+    expect(out("361")).toBeUndefined();
+    // 1..359 are accepted verbatim.
+    expect(out("1")).toBe(1);
+    expect(out("270")).toBe(270);
+    expect(out("359")).toBe(359);
+  });
+
+  it("does not attach firstSliceAng to non-pie / non-doughnut charts", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:firstSliceAng val="90"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["bar"]);
+    expect(chart?.firstSliceAng).toBeUndefined();
+  });
+
+  it("ignores firstSliceAng outside of pie/doughnut even in combo charts", () => {
+    // A pie sibling in the same plotArea should win over a stray
+    // firstSliceAng that happens to sit on a non-pie chart-type
+    // element earlier in the document order.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:lineChart>
+    <c:pieChart>
+      <c:varyColors val="1"/>
+      <c:firstSliceAng val="45"/>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["line", "pie"]);
+    expect(chart?.firstSliceAng).toBe(45);
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Pie / doughnut charts use `<c:firstSliceAng>` to rotate the starting wedge clockwise from 12 o'clock — a common ask when composing dashboards whose pie / doughnut charts need to align visually (e.g. start at 3 o'clock = 90 degrees, paired pies that mirror each other at 0 / 180). The reader ignored the element entirely and the doughnut writer hardcoded `0`, so a template's rotation flattened on every `parseChart` → `cloneChart` → `writeXlsx` round-trip and could not be authored from scratch.

This PR closes that gap at all three layers — read, write, and clone — so a template's pie / doughnut rotation survives the full retarget loop and can be set explicitly on a fresh chart, completing one more piece of the dashboard-composition flow from #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.firstSliceAng); // 90  (template starts at 3 o'clock)

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "doughnut",
      series: [{ values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      firstSliceAng: 90,   // start at 3 o'clock
      holeSize: 60,
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!$B$2:$B$13" }],
  // firstSliceAng inherits from `source` automatically; pass an
  // override (or coerce to a non-pie/doughnut type) to drop it.
});

// Flatten doughnut → pie keeps the rotation:
const flat = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  type: "pie",
});
console.log(flat.firstSliceAng); // 90  (rotation survives the flatten)
```

## Model

```ts
interface SheetChart {
  /** Pie / doughnut starting angle in degrees, 0..360. Default 0. */
  firstSliceAng?: number;
}

interface Chart {
  /** Surfaced from <c:pieChart>/<c:doughnutChart><c:firstSliceAng val=".."/>. */
  firstSliceAng?: number;
}

interface CloneChartOptions {
  /** Override SheetChart.firstSliceAng. */
  firstSliceAng?: number;
}
```

## Implementation

- **Reader (`chart-reader.ts`)**: `parseFirstSliceAng` walks `<c:pieChart>` / `<c:pie3DChart>` / `<c:doughnutChart>` / `<c:ofPieChart>` for `<c:firstSliceAng val=".."/>` and parses the integer attribute. Values outside CT_FirstSliceAng's `0..360` band are dropped (rather than clamped) so a corrupt template does not silently rewrite as a different angle. `0` and the schema-equivalent `360` collapse to `undefined` so absence and the default round-trip identically — symmetric with how `holeSize` / `barGrouping` collapse OOXML defaults to `undefined`.
- **Writer (`chart-writer.ts`)**: a new `clampFirstSliceAng` helper rounds non-integer input, wraps out-of-band values modulo 360 (`380` → `20`, `-90` → `270` — what Excel's chart-formatting pane does when a user types an out-of-band value), and returns `undefined` for the default `0` so the pie writer can elide the element. The doughnut writer always emits `<c:firstSliceAng>` (matching Excel's reference serialization) and substitutes `0` when the helper returns `undefined`. `<c:firstSliceAng>` lands after `<c:dLbls>` and before `<c:holeSize>` — the order CT_PieChart / CT_DoughnutChart enforce.
- **Clone bridge (`chart-clone.ts`)**: the rotation carries onto the clone when the resolved target is `pie` or `doughnut` (including a doughnut → pie flatten — the element lives on both kinds, so the rotation survives). Coercion into a non-pie family drops the inherited value silently so it never leaks into a chart kind that has no rotation knob. Override grammar mirrors `holeSize`: an explicit `options.firstSliceAng` wins over the source's parsed value.

## Edge cases

- `<c:firstSliceAng val="0"/>` and `<c:firstSliceAng val="360"/>` both collapse to `undefined` on read.
- Negative or `>360` values are dropped on read (out of CT_FirstSliceAng band).
- Out-of-band values on write wrap modulo 360 (`380` → `20`, `-90` → `270`, `360` → `0` → omitted on pie / `0` on doughnut).
- `NaN` / `Infinity` collapse to the default (omitted on pie, `0` on doughnut).
- Non-integer input rounds (`47.6` → `48`).
- Pie with no rotation set elides `<c:firstSliceAng>`; doughnut always emits it (`val="0"` is the Excel reference baseline).
- Cloning a doughnut template with rotation onto a pie target keeps the angle (`type: "pie"` on a `firstSliceAng: 90` source → `firstSliceAng: 90`).
- Cloning into a non-pie / non-doughnut family (column, line, scatter, area) drops the inherited rotation.
- Setting `firstSliceAng` on a non-pie / non-doughnut `SheetChart` is silently ignored by the writer.
- Spec-enforced child order: `<c:firstSliceAng>` lands after `<c:dLbls>` and before `<c:holeSize>` on doughnut.

Refs #136

## Test plan

- [x] `pnpm lint` (oxlint + oxfmt --check)
- [x] `pnpm typecheck`
- [x] `pnpm vitest run` (chart suite — all 2276 tests pass; adds 8 parser tests, 11 writer tests, 6 clone tests, plus 1 end-to-end round-trip via `parseChart` → `cloneChart` → `writeXlsx` → `parseChart`)
- [x] `pnpm build`
- [x] Round-trip: pinned `firstSliceAng: 135` survives the full retarget loop verbatim
- [x] Doughnut → pie flatten preserves the inherited rotation
- [x] Pie / doughnut silently drop the field for non-pie / non-doughnut clones

🤖 Generated with [Claude Code](https://claude.com/claude-code)