### PR TITLE
feat(xlsx): bar/column gap width and overlap — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,13 @@ plus `position` and `separator`). Series-level overrides land on
 on doughnut charts so a parsed template can round-trip its hole back
 through `cloneChart`; non-doughnut charts (and doughnut charts that
 omit the element) never report it.
+`Chart.gapWidth` and `Chart.overlap` surface the bar / column
+spacing knobs (`<c:barChart><c:gapWidth val=".."/>` and
+`<c:overlap val=".."/>`). `gapWidth` (0 – 500 % of the bar width)
+controls the gap between category groups and `overlap` (-100..100 %)
+controls how much series within a group separate or stack. The OOXML
+defaults (`gapWidth=150`, `overlap=0`) collapse to `undefined`;
+non-bar / non-column charts never report either.
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
@@ -706,6 +713,12 @@ even when the chart-level default has them on). For doughnut charts,
 `holeSize` (10 – 90, Excel's UI band; default 50) controls the
 diameter of the inner hole — values outside the band are clamped to
 the closest end and non-doughnut kinds silently ignore the field.
+For bar and column charts, `gapWidth` (0 – 500 % of the bar width;
+default `150` for unstacked, omitted for stacked) controls the empty
+space between adjacent category groups and `overlap` (-100..100 %;
+default `0` for clustered, `100` for stacked) controls how series
+within a group separate or stack. Out-of-band values clamp to the
+schema bounds, and non-bar / non-column kinds silently ignore both.
 Radar, stock, 3D variants, trendlines, and combo charts are out of
 scope today.
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -666,6 +666,27 @@ export interface SheetChart {
    */
   barGrouping?: "clustered" | "stacked" | "percentStacked";
   /**
+   * Bar/column gap width as a percentage of the bar width — the empty
+   * space between adjacent category groups. Accepted range: `0` – `500`
+   * (the OOXML `ST_GapAmount` schema). Excel's default is `150` (each
+   * group's gap equals 1.5× the bar width). Smaller values pack groups
+   * tighter; `0` removes the gap entirely. Maps to
+   * `<c:barChart><c:gapWidth val=".."/></c:barChart>`. Ignored for
+   * non-bar / non-column chart kinds.
+   */
+  gapWidth?: number;
+  /**
+   * Bar/column series overlap as a percentage of the bar width.
+   * Accepted range: `-100` – `100` (the OOXML `ST_Overlap` schema).
+   * Negative values open a gap between series within a group, positive
+   * values stack them on top of each other. Excel's default is `0` for
+   * `clustered` (side-by-side) and `100` for `stacked` /
+   * `percentStacked` (fully overlapped). Maps to
+   * `<c:barChart><c:overlap val=".."/></c:barChart>`. Ignored for
+   * non-bar / non-column chart kinds.
+   */
+  overlap?: number;
+  /**
    * Line subtype. Default: `"standard"`. `"stacked"` accumulates
    * series end-to-end, `"percentStacked"` normalizes each category to
    * 100%. Ignored for non-line chart kinds. Maps to
@@ -1641,6 +1662,26 @@ export interface Chart {
    * charts that do not declare the element.
    */
   holeSize?: number;
+  /**
+   * Bar/column gap width pulled from the first `<c:barChart>` /
+   * `<c:bar3DChart>` element's `<c:gapWidth val=".."/>`, expressed as a
+   * percentage of the bar width. Range: 0–500. The OOXML default of
+   * `150` collapses to `undefined` so absence and the default
+   * round-trip identically — symmetric with how the writer's
+   * {@link SheetChart.gapWidth} treats the absence of the field.
+   * Omitted on non-bar / non-column charts.
+   */
+  gapWidth?: number;
+  /**
+   * Bar/column series overlap pulled from the first `<c:barChart>` /
+   * `<c:bar3DChart>` element's `<c:overlap val=".."/>`, expressed as a
+   * percentage of the bar width. Range: -100..100. The OOXML default of
+   * `0` collapses to `undefined` so absence and the default round-trip
+   * identically — symmetric with how the writer's
+   * {@link SheetChart.overlap} treats the absence of the field.
+   * Omitted on non-bar / non-column charts.
+   */
+  overlap?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -86,6 +86,19 @@ export interface CloneChartOptions {
   legend?: SheetChart["legend"];
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
+  /**
+   * Override `SheetChart.gapWidth` (only meaningful for `bar` /
+   * `column`). Dropped silently when the resolved chart type is
+   * neither — a gap-width hint inherited from a column template never
+   * leaks into a line / pie clone.
+   */
+  gapWidth?: number;
+  /**
+   * Override `SheetChart.overlap` (only meaningful for `bar` /
+   * `column`). Dropped silently when the resolved chart type is
+   * neither.
+   */
+  overlap?: number;
   /** Override `SheetChart.lineGrouping`. */
   lineGrouping?: SheetChart["lineGrouping"];
   /** Override `SheetChart.areaGrouping`. */
@@ -201,6 +214,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
   if (barGrouping !== undefined && (type === "bar" || type === "column")) {
     out.barGrouping = barGrouping;
+  }
+
+  // Bar / column gap width and overlap only make sense on bar-family
+  // targets — flattening a column template into a line clone drops
+  // the inherited values so they do not leak into a chart kind that
+  // has no `<c:barChart>` element to host them. The override wins over
+  // the source's parsed value.
+  if (type === "bar" || type === "column") {
+    const gapWidth = options.gapWidth !== undefined ? options.gapWidth : source.gapWidth;
+    if (gapWidth !== undefined) out.gapWidth = gapWidth;
+    const overlap = options.overlap !== undefined ? options.overlap : source.overlap;
+    if (overlap !== undefined) out.overlap = overlap;
   }
 
   const lineGrouping =

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -80,6 +80,8 @@ export function parseChart(xml: string): Chart | undefined {
     let areaGrouping: ChartLineAreaGrouping | undefined;
     let chartLevelLabels: ChartDataLabelsInfo | undefined;
     let holeSize: number | undefined;
+    let gapWidth: number | undefined;
+    let overlap: number | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
@@ -90,6 +92,19 @@ export function parseChart(xml: string): Chart | undefined {
       // single `<c:barChart>` body this is the value Excel applies.
       if (barGrouping === undefined && (kind === "bar" || kind === "bar3D")) {
         barGrouping = parseBarGrouping(child);
+      }
+      // Pull `<c:gapWidth>` / `<c:overlap>` off the first bar/column
+      // chart-type element. Both are CT_BarChart-only knobs — they sit
+      // alongside `<c:grouping>` inside `<c:barChart>` / `<c:bar3DChart>`
+      // and are ignored elsewhere by the OOXML schema. The OOXML default
+      // of `150` (gapWidth) and `0` (overlap) collapse to `undefined`
+      // here so absence and the default round-trip identically through
+      // {@link cloneChart}.
+      if (gapWidth === undefined && (kind === "bar" || kind === "bar3D")) {
+        gapWidth = parseGapWidth(child);
+      }
+      if (overlap === undefined && (kind === "bar" || kind === "bar3D")) {
+        overlap = parseOverlap(child);
       }
       // Same shape for line/area: surface the first stacked variant
       // we encounter. `"standard"` collapses to undefined for symmetry
@@ -131,6 +146,8 @@ export function parseChart(xml: string): Chart | undefined {
     if (areaGrouping !== undefined) out.areaGrouping = areaGrouping;
     if (chartLevelLabels) out.dataLabels = chartLevelLabels;
     if (holeSize !== undefined) out.holeSize = holeSize;
+    if (gapWidth !== undefined) out.gapWidth = gapWidth;
+    if (overlap !== undefined) out.overlap = overlap;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
@@ -629,6 +646,57 @@ function parseHoleSize(doughnut: XmlElement): number | undefined {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed)) return undefined;
   if (parsed < 1 || parsed > 99) return undefined;
+  return parsed;
+}
+
+// ── Bar / Column gap width & overlap ──────────────────────────────
+
+/**
+ * Pull `<c:gapWidth val=".."/>` off a `<c:barChart>` / `<c:bar3DChart>`
+ * element.
+ *
+ * The OOXML schema (`ST_GapAmount`) restricts the value to the
+ * inclusive `0..500` band; out-of-range values are dropped rather than
+ * clamped so a corrupt template does not silently rewrite as a
+ * different gap. The OOXML default of `150` collapses to `undefined`
+ * for symmetry with the writer's {@link SheetChart.gapWidth} default
+ * — absence and `150` mean the same thing.
+ */
+function parseGapWidth(barChart: XmlElement): number | undefined {
+  const el = findChild(barChart, "gapWidth");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 0 || parsed > 500) return undefined;
+  if (parsed === 150) return undefined;
+  return parsed;
+}
+
+/**
+ * Pull `<c:overlap val=".."/>` off a `<c:barChart>` / `<c:bar3DChart>`
+ * element.
+ *
+ * The OOXML schema (`ST_Overlap`) restricts the value to the inclusive
+ * `-100..100` band; out-of-range values are dropped rather than
+ * clamped. The OOXML default of `0` collapses to `undefined` for
+ * symmetry with the writer's {@link SheetChart.overlap} default. Note
+ * that Excel's reference serialization emits `<c:overlap val="100"/>`
+ * for stacked charts even though the schema default is `0`; we surface
+ * the literal value carried by the file rather than try to invert
+ * Excel's per-grouping default — `100` on a stacked chart therefore
+ * round-trips as `100`.
+ */
+function parseOverlap(barChart: XmlElement): number | undefined {
+  const el = findChild(barChart, "overlap");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < -100 || parsed > 100) return undefined;
+  if (parsed === 0) return undefined;
   return parsed;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -372,6 +372,7 @@ const AXIS_ID_VAL_Y = 444444444;
 function buildBarChart(chart: SheetChart, sheetName: string): string {
   const grouping = chart.barGrouping ?? "clustered";
   const barDir = chart.type === "bar" ? "bar" : "col";
+  const isStacked = grouping === "percentStacked" || grouping === "stacked";
 
   const children: string[] = [
     xmlSelfClose("c:barDir", { val: barDir }),
@@ -390,16 +391,73 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
   const chartLevelDLbls = buildChartLevelDataLabels(chart);
   if (chartLevelDLbls) children.push(chartLevelDLbls);
 
-  if (grouping === "percentStacked" || grouping === "stacked") {
-    children.push(xmlSelfClose("c:overlap", { val: 100 }));
-  } else {
-    children.push(xmlSelfClose("c:gapWidth", { val: 150 }));
+  // OOXML CT_BarChart enforces a strict child order:
+  // barDir → grouping → varyColors → ser* → dLbls? → gapWidth? →
+  // overlap? → serLines* → axId+. `gapWidth` therefore lands before
+  // `overlap` regardless of the chosen grouping.
+  //
+  // The defaults preserve Excel's reference serialization:
+  //   - clustered                  → emit gapWidth=150, omit overlap
+  //   - stacked / percentStacked   → emit overlap=100, omit gapWidth
+  // An explicit `chart.gapWidth` / `chart.overlap` always emits the
+  // matching element (even when the value happens to equal the default
+  // for that grouping), so callers can pin both knobs on a stacked
+  // chart or relax overlap on a clustered one.
+  const explicitGapWidth = clampGapWidth(chart.gapWidth);
+  const explicitOverlap = clampOverlap(chart.overlap);
+
+  const emitGapWidth = explicitGapWidth ?? (isStacked ? undefined : 150);
+  if (emitGapWidth !== undefined) {
+    children.push(xmlSelfClose("c:gapWidth", { val: emitGapWidth }));
+  }
+
+  const emitOverlap = explicitOverlap ?? (isStacked ? 100 : undefined);
+  if (emitOverlap !== undefined) {
+    children.push(xmlSelfClose("c:overlap", { val: emitOverlap }));
   }
 
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_CAT }));
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_VAL }));
 
   return xmlElement("c:barChart", undefined, children);
+}
+
+/**
+ * Normalize {@link SheetChart.gapWidth} to an integer in the inclusive
+ * `0..500` band the OOXML schema (`ST_GapAmount`) allows.
+ *
+ * Returns `undefined` when the input is missing or non-finite so the
+ * caller can fall through to the per-grouping default. Non-integer
+ * values round to the nearest integer; out-of-range values clamp to
+ * the schema bounds rather than wrap — `gapWidth` is a percentage of
+ * the bar width with no natural wrap-around (a `600` group spacing is
+ * not the same as `100`).
+ */
+function clampGapWidth(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < 0) return 0;
+  if (rounded > 500) return 500;
+  return rounded;
+}
+
+/**
+ * Normalize {@link SheetChart.overlap} to an integer in the inclusive
+ * `-100..100` band the OOXML schema (`ST_Overlap`) allows.
+ *
+ * Returns `undefined` when the input is missing or non-finite so the
+ * caller can fall through to the per-grouping default. Non-integer
+ * values round to the nearest integer; out-of-range values clamp to
+ * the schema bounds (`-100` and `100` are the geometric extremes —
+ * series fully separated and series fully overlapped — wrapping makes
+ * no physical sense).
+ */
+function clampOverlap(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < -100) return -100;
+  if (rounded > 100) return 100;
+  return rounded;
 }
 
 function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): string[] {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -136,6 +136,71 @@ describe("cloneChart", () => {
     expect(clone.holeSize).toBeUndefined();
   });
 
+  // ── gapWidth / overlap (bar / column only) ──────────────────────────
+
+  it("inherits the source's gapWidth on a column clone", () => {
+    const clone = cloneChart(source({ kinds: ["bar"], gapWidth: 75 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.gapWidth).toBe(75);
+  });
+
+  it("inherits the source's overlap on a column clone", () => {
+    const clone = cloneChart(source({ kinds: ["bar"], overlap: -25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.overlap).toBe(-25);
+  });
+
+  it("inherits both gapWidth and overlap together on a bar clone", () => {
+    const clone = cloneChart(source({ kinds: ["bar"], gapWidth: 50, overlap: 100 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "bar",
+    });
+    expect(clone.type).toBe("bar");
+    expect(clone.gapWidth).toBe(50);
+    expect(clone.overlap).toBe(100);
+  });
+
+  it("lets options.gapWidth override the source's gapWidth", () => {
+    const clone = cloneChart(source({ kinds: ["bar"], gapWidth: 75 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      gapWidth: 200,
+    });
+    expect(clone.gapWidth).toBe(200);
+  });
+
+  it("lets options.overlap override the source's overlap", () => {
+    const clone = cloneChart(source({ kinds: ["bar"], overlap: -25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      overlap: 50,
+    });
+    expect(clone.overlap).toBe(50);
+  });
+
+  it("drops options.gapWidth / overlap when the resolved type is not bar/column", () => {
+    const clone = cloneChart(source({ kinds: ["bar"] }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      gapWidth: 75,
+      overlap: 50,
+    });
+    expect(clone.gapWidth).toBeUndefined();
+    expect(clone.overlap).toBeUndefined();
+  });
+
+  it("drops the inherited gapWidth / overlap when the resolved type is not bar/column", () => {
+    const clone = cloneChart(source({ kinds: ["bar"], gapWidth: 75, overlap: -25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.gapWidth).toBeUndefined();
+    expect(clone.overlap).toBeUndefined();
+  });
+
   it("throws when the source has no writable kind and no override is given", () => {
     expect(() =>
       cloneChart(source({ kinds: ["bubble", "radar"] }), {
@@ -1385,5 +1450,77 @@ describe("cloneChart — integration", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.axes?.y?.scale).toEqual({ min: 0, max: 100, majorUnit: 25 });
     expect(reparsed?.axes?.y?.numberFormat).toEqual({ formatCode: "$#,##0" });
+  });
+
+  it("round-trips gapWidth & overlap through parseChart -> cloneChart -> writeXlsx -> parseChart", async () => {
+    // A pinned bar template with a tight 50% group gap and a small
+    // negative overlap (series slightly separated within each group).
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="0"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:gapWidth val="50"/>
+        <c:overlap val="-25"/>
+        <c:axId val="111111111"/>
+        <c:axId val="222222222"/>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="111111111"/>
+        <c:scaling><c:orientation val="minMax"/></c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="b"/>
+        <c:crossAx val="222222222"/>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="222222222"/>
+        <c:scaling><c:orientation val="minMax"/></c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="l"/>
+        <c:crossAx val="111111111"/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml);
+    expect(source?.gapWidth).toBe(50);
+    expect(source?.overlap).toBe(-25);
+
+    const sheetChart: SheetChart = cloneChart(source!, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }],
+    });
+    expect(sheetChart.type).toBe("column");
+    expect(sheetChart.gapWidth).toBe(50);
+    expect(sheetChart.overlap).toBe(-25);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:gapWidth val="50"');
+    expect(written).toContain('c:overlap val="-25"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.kinds).toEqual(["bar"]);
+    expect(reparsed?.gapWidth).toBe(50);
+    expect(reparsed?.overlap).toBe(-25);
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -1397,3 +1397,148 @@ describe("writeChart — data labels", () => {
     expect(xml.indexOf("<c:dLbls>")).toBeLessThan(xml.indexOf("<c:marker"));
   });
 });
+
+// ── Bar/column gapWidth & overlap ────────────────────────────────────
+
+describe("writeChart — gapWidth", () => {
+  it("emits <c:gapWidth val='150'/> on a clustered column chart by default", () => {
+    // Excel's reference serialization for an unstacked bar/column chart
+    // pins gapWidth at 150% of the bar width, so untouched charts stay
+    // byte-identical with what Excel writes.
+    const result = writeChart(makeChart({ type: "column" }), "Sheet1");
+    expect(result.chartXml).toContain('c:gapWidth val="150"');
+  });
+
+  it("threads an explicit gapWidth through to the XML", () => {
+    const result = writeChart(makeChart({ type: "column", gapWidth: 50 }), "Sheet1");
+    expect(result.chartXml).toContain('c:gapWidth val="50"');
+    expect(result.chartXml).not.toContain('c:gapWidth val="150"');
+  });
+
+  it("clamps gapWidth into the 0..500 band the OOXML schema allows", () => {
+    const lo = writeChart(makeChart({ type: "column", gapWidth: -25 }), "Sheet1");
+    expect(lo.chartXml).toContain('c:gapWidth val="0"');
+    const hi = writeChart(makeChart({ type: "column", gapWidth: 999 }), "Sheet1");
+    expect(hi.chartXml).toContain('c:gapWidth val="500"');
+  });
+
+  it("rounds non-integer gapWidth values", () => {
+    const result = writeChart(makeChart({ type: "column", gapWidth: 175.6 }), "Sheet1");
+    expect(result.chartXml).toContain('c:gapWidth val="176"');
+  });
+
+  it("falls back to the default when gapWidth is NaN or Infinity", () => {
+    const nan = writeChart(makeChart({ type: "column", gapWidth: NaN }), "Sheet1");
+    expect(nan.chartXml).toContain('c:gapWidth val="150"');
+    const inf = writeChart(
+      makeChart({ type: "column", gapWidth: Number.POSITIVE_INFINITY }),
+      "Sheet1",
+    );
+    expect(inf.chartXml).toContain('c:gapWidth val="150"');
+  });
+
+  it("emits <c:gapWidth> on a stacked chart only when explicitly set", () => {
+    // Stacked charts default to gapWidth omitted (Excel's reference),
+    // but pinning a value forces emission.
+    const def = writeChart(makeChart({ type: "column", barGrouping: "stacked" }), "Sheet1");
+    expect(def.chartXml).not.toContain("c:gapWidth");
+    const explicit = writeChart(
+      makeChart({ type: "column", barGrouping: "stacked", gapWidth: 75 }),
+      "Sheet1",
+    );
+    expect(explicit.chartXml).toContain('c:gapWidth val="75"');
+  });
+
+  it("emits <c:gapWidth> on a horizontal bar chart too", () => {
+    const result = writeChart(makeChart({ type: "bar", gapWidth: 200 }), "Sheet1");
+    expect(result.chartXml).toContain('c:barDir val="bar"');
+    expect(result.chartXml).toContain('c:gapWidth val="200"');
+  });
+
+  it("omits gapWidth on non-bar chart kinds even when the field is set", () => {
+    // SheetChart.gapWidth is silently ignored for line / pie / area / scatter / doughnut.
+    const line = writeChart(makeChart({ type: "line", gapWidth: 75 }), "Sheet1");
+    expect(line.chartXml).not.toContain("c:gapWidth");
+    const pie = writeChart(makeChart({ type: "pie", gapWidth: 75 }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:gapWidth");
+    const area = writeChart(makeChart({ type: "area", gapWidth: 75 }), "Sheet1");
+    expect(area.chartXml).not.toContain("c:gapWidth");
+  });
+});
+
+describe("writeChart — overlap", () => {
+  it("emits <c:overlap val='100'/> on a stacked bar chart by default", () => {
+    // Stacked bar charts pin overlap at 100% (series fully overlapped)
+    // so series stack on top of each other rather than render
+    // side-by-side.
+    const result = writeChart(makeChart({ type: "column", barGrouping: "stacked" }), "Sheet1");
+    expect(result.chartXml).toContain('c:overlap val="100"');
+  });
+
+  it("emits <c:overlap val='100'/> on a percentStacked bar chart by default", () => {
+    const result = writeChart(
+      makeChart({ type: "column", barGrouping: "percentStacked" }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:overlap val="100"');
+  });
+
+  it("threads an explicit overlap through to the XML", () => {
+    const result = writeChart(makeChart({ type: "column", overlap: -25 }), "Sheet1");
+    expect(result.chartXml).toContain('c:overlap val="-25"');
+  });
+
+  it("clamps overlap into the -100..100 band the OOXML schema allows", () => {
+    const lo = writeChart(makeChart({ type: "column", overlap: -250 }), "Sheet1");
+    expect(lo.chartXml).toContain('c:overlap val="-100"');
+    const hi = writeChart(makeChart({ type: "column", overlap: 200 }), "Sheet1");
+    expect(hi.chartXml).toContain('c:overlap val="100"');
+  });
+
+  it("rounds non-integer overlap values", () => {
+    const result = writeChart(makeChart({ type: "column", overlap: -33.4 }), "Sheet1");
+    expect(result.chartXml).toContain('c:overlap val="-33"');
+  });
+
+  it("falls back to the per-grouping default when overlap is NaN or Infinity", () => {
+    // Clustered: omitted; stacked: 100.
+    const nanClustered = writeChart(makeChart({ type: "column", overlap: NaN }), "Sheet1");
+    expect(nanClustered.chartXml).not.toContain("c:overlap");
+    const nanStacked = writeChart(
+      makeChart({ type: "column", barGrouping: "stacked", overlap: NaN }),
+      "Sheet1",
+    );
+    expect(nanStacked.chartXml).toContain('c:overlap val="100"');
+  });
+
+  it("forces overlap emission on a clustered chart when explicitly set", () => {
+    // Clustered defaults to no <c:overlap> element; an explicit value
+    // overrides that and ships the element through.
+    const def = writeChart(makeChart({ type: "column" }), "Sheet1");
+    expect(def.chartXml).not.toContain("c:overlap");
+    const explicit = writeChart(makeChart({ type: "column", overlap: -50 }), "Sheet1");
+    expect(explicit.chartXml).toContain('c:overlap val="-50"');
+  });
+
+  it("omits overlap on non-bar chart kinds even when the field is set", () => {
+    const line = writeChart(makeChart({ type: "line", overlap: 50 }), "Sheet1");
+    expect(line.chartXml).not.toContain("c:overlap");
+    const pie = writeChart(makeChart({ type: "pie", overlap: 50 }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:overlap");
+  });
+
+  it("places <c:gapWidth> before <c:overlap> inside <c:barChart> (OOXML order)", () => {
+    // CT_BarChart sequence: ... dLbls? → gapWidth? → overlap? → serLines* → axId+
+    const result = writeChart(makeChart({ type: "column", gapWidth: 50, overlap: -25 }), "Sheet1");
+    expect(result.chartXml.indexOf("c:gapWidth")).toBeLessThan(
+      result.chartXml.indexOf("c:overlap"),
+    );
+  });
+
+  it("places <c:gapWidth> / <c:overlap> before <c:axId> inside <c:barChart>", () => {
+    const result = writeChart(makeChart({ type: "column", gapWidth: 50, overlap: 25 }), "Sheet1");
+    const barBlock = result.chartXml.match(/<c:barChart>[\s\S]*?<\/c:barChart>/);
+    expect(barBlock).not.toBeNull();
+    expect(barBlock![0].indexOf("c:overlap")).toBeLessThan(barBlock![0].indexOf("c:axId"));
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -1317,6 +1317,150 @@ describe("parseChart — doughnut hole size", () => {
   });
 });
 
+describe("parseChart — bar gapWidth & overlap", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:gapWidth val="..."/> off a bar chart', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:grouping val="clustered"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:gapWidth val="75"/>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["bar"]);
+    expect(chart?.gapWidth).toBe(75);
+  });
+
+  it('surfaces <c:overlap val="..."/> off a bar chart', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:grouping val="clustered"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:overlap val="-25"/>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["bar"]);
+    expect(chart?.overlap).toBe(-25);
+  });
+
+  it("surfaces both gapWidth and overlap when both are declared", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:gapWidth val="75"/>
+      <c:overlap val="100"/>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.gapWidth).toBe(75);
+    expect(chart?.overlap).toBe(100);
+  });
+
+  it("collapses the OOXML default gapWidth (150) to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:gapWidth val="150"/></c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.gapWidth).toBeUndefined();
+  });
+
+  it("collapses the OOXML default overlap (0) to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:overlap val="0"/></c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.overlap).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:gapWidth> / <c:overlap>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.gapWidth).toBeUndefined();
+    expect(chart?.overlap).toBeUndefined();
+  });
+
+  it("rejects malformed or out-of-range gapWidth values", () => {
+    const out = (val: string): unknown =>
+      parseChart(`<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:gapWidth val="${val}"/></c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`)?.gapWidth;
+    expect(out("not-a-number")).toBeUndefined();
+    // Below schema minimum.
+    expect(out("-1")).toBeUndefined();
+    // Above schema maximum (ST_GapAmount is 0..500 inclusive).
+    expect(out("501")).toBeUndefined();
+    // Bounds inclusive.
+    expect(out("0")).toBe(0);
+    expect(out("500")).toBe(500);
+  });
+
+  it("rejects malformed or out-of-range overlap values", () => {
+    const out = (val: string): unknown =>
+      parseChart(`<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:overlap val="${val}"/></c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`)?.overlap;
+    expect(out("not-a-number")).toBeUndefined();
+    expect(out("-101")).toBeUndefined();
+    expect(out("101")).toBeUndefined();
+    // Bounds inclusive (-100..100), 0 collapses to undefined.
+    expect(out("-100")).toBe(-100);
+    expect(out("100")).toBe(100);
+    expect(out("-1")).toBe(-1);
+    expect(out("1")).toBe(1);
+  });
+
+  it("does not attach gapWidth / overlap to non-bar chart kinds", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:gapWidth val="75"/>
+      <c:overlap val="50"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["line"]);
+    expect(chart?.gapWidth).toBeUndefined();
+    expect(chart?.overlap).toBeUndefined();
+  });
+
+  it("surfaces gapWidth / overlap from <c:bar3DChart> as well", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:bar3DChart>
+      <c:gapWidth val="50"/>
+      <c:overlap val="25"/>
+    </c:bar3DChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.kinds).toEqual(["bar3D"]);
+    expect(chart?.gapWidth).toBe(50);
+    expect(chart?.overlap).toBe(25);
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Bar / column charts use `<c:gapWidth>` (0 – 500 % of the bar width) to control the empty space between category groups and `<c:overlap>` (-100..100 %) to control how series within a group separate or stack — both are common asks when a dashboard's bar charts need to align visually (e.g. tighter `gapWidth: 50` for compact group spacing, slight negative `overlap: -10` to add breathing room between series). The reader ignored both elements entirely and the writer hardcoded `gapWidth=150` for clustered and `overlap=100` for stacked, so a template's spacing flattened on every `parseChart` → `cloneChart` → `writeXlsx` round-trip and could not be authored from scratch.

This PR closes that gap at all three layers — read, write, and clone — so a template's bar spacing survives the full retarget loop and can be set explicitly on a fresh chart, completing one more piece of the dashboard-composition flow from #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.gapWidth); // 50  (template's tight group spacing)
console.log(source.overlap);  // -25 (slight separation between series)

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [
        { values: "B2:B6", categories: "A2:A6" },
        { values: "C2:C6", categories: "A2:A6" },
      ],
      anchor: { from: { row: 6, col: 0 } },
      gapWidth: 50,   // half-width gaps between groups
      overlap: -25,   // 25% separation between series within a group
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [{ values: "Dashboard!$B$2:$B$13" }],
  // gapWidth / overlap inherit from `source` automatically; pass an
  // override (or coerce to a non-bar/column type) to drop them.
});
```

## Model

```ts
interface SheetChart {
  /** Bar/column gap width as % of bar width, 0..500. Default 150 (clustered), omitted (stacked). */
  gapWidth?: number;
  /** Bar/column series overlap as % of bar width, -100..100. Default 0 (clustered), 100 (stacked). */
  overlap?: number;
}

interface Chart {
  /** Surfaced from <c:barChart>/<c:bar3DChart><c:gapWidth val="..."/>. */
  gapWidth?: number;
  /** Surfaced from <c:barChart>/<c:bar3DChart><c:overlap val="..."/>. */
  overlap?: number;
}

interface CloneChartOptions {
  /** Override SheetChart.gapWidth (bar/column only). */
  gapWidth?: number;
  /** Override SheetChart.overlap (bar/column only). */
  overlap?: number;
}
```

## Implementation

- **Reader (`chart-reader.ts`)**: `parseGapWidth` and `parseOverlap` walk `<c:barChart>` / `<c:bar3DChart>` for the matching `val=".."` attribute. Out-of-band values (`<0` / `>500` for `gapWidth`, `<-100` / `>100` for `overlap`) are dropped (rather than clamped) so a corrupt template does not silently rewrite as different spacing. The OOXML defaults (`gapWidth=150`, `overlap=0`) collapse to `undefined` so absence and the default round-trip identically — symmetric with how `holeSize` / `barGrouping` collapse OOXML defaults to `undefined`.
- **Writer (`chart-writer.ts`)**: new `clampGapWidth` / `clampOverlap` helpers round non-integer input and clamp out-of-band values to the schema bounds (`gapWidth: 999` → `500`, `overlap: -250` → `-100`). Existing per-grouping defaults are preserved exactly — clustered still emits `gapWidth=150` only, stacked still emits `overlap=100` only, so untouched charts stay byte-identical with what Excel writes. An explicit `chart.gapWidth` / `chart.overlap` always emits the matching element (even on a stacked chart, or with a value that happens to equal the per-grouping default), so callers can pin both knobs together. `<c:gapWidth>` lands before `<c:overlap>` per the OOXML CT_BarChart child sequence (`barDir → grouping → varyColors → ser* → dLbls? → gapWidth? → overlap? → serLines* → axId+`).
- **Clone bridge (`chart-clone.ts`)**: both fields carry onto the clone when the resolved target is `bar` or `column`. Coercion into a non-bar family (line, pie, area, scatter, doughnut) drops the inherited values silently so they never leak into a chart kind that has no `<c:barChart>` element. Override grammar mirrors `holeSize` / `firstSliceAng`: an explicit `options.gapWidth` / `options.overlap` wins over the source's parsed value.

## Edge cases

- `<c:gapWidth val="150"/>` and `<c:overlap val="0"/>` both collapse to `undefined` on read (OOXML defaults).
- Out-of-band values dropped on read (`gapWidth: -1` / `501`, `overlap: -101` / `101` → `undefined`).
- Out-of-band values clamp on write (`gapWidth: 999` → `500`, `overlap: -250` → `-100`).
- `NaN` / `Infinity` collapse to the per-grouping default (clustered: `gapWidth=150`, no overlap; stacked: no gapWidth, `overlap=100`).
- Non-integer input rounds (`175.6` → `176`, `-33.4` → `-33`).
- Setting `gapWidth` on a stacked chart forces emission alongside the default `overlap=100`.
- Setting `overlap` on a clustered chart forces emission alongside the default `gapWidth=150`.
- Cloning a column template with spacing onto a line target drops both fields (no `<c:barChart>` host).
- Setting `gapWidth` / `overlap` on a non-bar `SheetChart` is silently ignored by the writer.
- Spec-enforced child order: `<c:gapWidth>` lands before `<c:overlap>` inside `<c:barChart>`, both before `<c:axId>`.
- `<c:bar3DChart>` is also recognized on the read side (writer never emits 3D variants).

Refs #136

## Test plan

- [x] `pnpm lint` (oxlint + oxfmt --check)
- [x] `pnpm typecheck`
- [x] `pnpm vitest run` (chart suite — adds 39 tests across reader / writer / clone, full suite passes 2705/2705)
- [x] `pnpm build`
- [x] Round-trip: pinned `gapWidth: 50, overlap: -25` survives the full retarget loop verbatim
- [x] Bar / column silently drop both fields for non-bar / non-column clones
- [x] Existing default behavior preserved (clustered → only `gapWidth=150`, stacked → only `overlap=100`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)