### PR TITLE
feat(xlsx): chart series markers — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,15 @@ series (the OOXML schema places `<c:smooth>` exclusively on
 `CT_LineSer` and `CT_ScatterSer`). Absence and the OOXML default
 `val="0"` both collapse to `undefined`, so only an explicit
 `<c:smooth val="1"/>` round-trips as `smooth: true`.
+`ChartSeriesInfo.marker` surfaces the per-series `<c:ser><c:marker>`
+glyph configuration on `line` / `line3D` / `scatter` series (the
+schema places `<c:marker>` only on `CT_LineSer` and `CT_ScatterSer`).
+The reader pulls `symbol` (`circle` / `square` / `diamond` /
+`triangle` / `x` / `star` / `dot` / `dash` / `plus` / `auto` /
+`none`), `size` (clamped to the OOXML 2..72 band), and the marker's
+fill / outline colors out of `<c:spPr><a:solidFill>` and
+`<c:spPr><a:ln><a:solidFill>` — empty `<c:marker/>` elements collapse
+to `undefined` so absence and a bare element round-trip identically.
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
@@ -745,6 +754,16 @@ absence or `false` writes the OOXML default `val="0"`; scatter series
 only emit `<c:smooth val="1"/>` when `smooth` is explicitly `true` so
 untouched scatter charts stay byte-clean. Bar / column / pie /
 doughnut / area kinds silently ignore the flag.
+For line and scatter charts, each `series[i].marker` block also
+controls the per-point glyph: `symbol`
+(`circle` / `square` / `diamond` / `triangle` / `x` / `star` / `dot` /
+`dash` / `plus` / `auto` / `none`) picks the shape, `size` (2 – 72)
+sets the diameter, and `fill` / `line` (6-digit RGB hex) tint the
+glyph fill and outline. Out-of-range sizes clamp to the schema band,
+unknown symbols and malformed hex values are dropped so Excel never
+receives an attribute it would reject, and an empty marker (`{}`)
+collapses to no `<c:marker>` at all. Bar / column / pie / doughnut /
+area kinds silently ignore the field.
 Radar, stock, 3D variants, trendlines, and combo charts are out of
 scope today.
 
@@ -813,7 +832,13 @@ a single series. Per-series smooth-line state inherits from the
 template by default; `seriesOverrides[i].smooth` accepts the same
 `undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar,
 and the inherited flag is dropped automatically when the resolved
-clone target is anything other than `line` or `scatter`.
+clone target is anything other than `line` or `scatter`. Per-series
+markers carry over the same way: `seriesOverrides[i].marker` accepts
+`undefined` (inherit), `null` (drop the inherited block), or a
+`ChartMarker` object (replace wholesale — there is no per-field
+merge, so pass every field you want preserved). The inherited block
+is also dropped automatically when the resolved clone target is
+anything other than `line` or `scatter`.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -611,6 +611,66 @@ export interface ChartDataLabels {
 }
 
 /**
+ * Marker symbol shape rendered at each data point on a line / scatter
+ * series.
+ *
+ * Mirrors the OOXML `ST_MarkerStyle` enum exactly. `"none"` suppresses
+ * the marker (the Excel default for line charts beyond the first
+ * series); `"auto"` defers to Excel's series-rotation default; every
+ * other value pins a specific shape. `"picture"` is intentionally
+ * omitted — it requires a separately-embedded picture part that Phase 1
+ * native chart authoring does not support.
+ */
+export type ChartMarkerSymbol =
+  | "none"
+  | "auto"
+  | "circle"
+  | "square"
+  | "diamond"
+  | "triangle"
+  | "x"
+  | "star"
+  | "dot"
+  | "dash"
+  | "plus";
+
+/**
+ * Per-series marker styling for line / scatter charts.
+ *
+ * Maps to `<c:marker>` inside `<c:ser>`. Only meaningful on `line` and
+ * `scatter` series — the OOXML schema places `<c:marker>` exclusively
+ * on `CT_LineSer` and `CT_ScatterSer`, so the field is silently
+ * dropped on every other chart family at all three layers (read,
+ * write, clone).
+ *
+ * Every field is optional — a bare `{}` collapses to no marker
+ * configuration and leaves Excel's per-series default in place. Set
+ * `symbol: "none"` to explicitly hide the marker (useful for a
+ * scatter clone whose template uses markers but the dashboard wants
+ * a clean line).
+ */
+export interface ChartMarker {
+  /** Shape of the marker glyph. See {@link ChartMarkerSymbol}. */
+  symbol?: ChartMarkerSymbol;
+  /**
+   * Marker glyph size in points, in the OOXML range `2..72`. Excel's
+   * UI clamps values outside this band. Default (when omitted): Excel
+   * picks a series-rotation default (typically `5`).
+   */
+  size?: number;
+  /**
+   * Marker fill color as a 6-digit RGB hex string (e.g. `"1F77B4"`).
+   * Maps to `<c:marker><c:spPr><a:solidFill><a:srgbClr val="..">`.
+   */
+  fill?: string;
+  /**
+   * Marker outline color as a 6-digit RGB hex string. Maps to
+   * `<c:marker><c:spPr><a:ln><a:solidFill><a:srgbClr val="..">`.
+   */
+  line?: string;
+}
+
+/**
  * A single data series inside a chart.
  *
  * `values` and `categories` are A1-style cell range references.
@@ -645,6 +705,13 @@ export interface ChartSeries {
    * Smoothed line".
    */
   smooth?: boolean;
+  /**
+   * Per-series marker styling. Only meaningful for `line` and
+   * `scatter` charts — the OOXML schema places `<c:marker>` on
+   * `CT_LineSer` / `CT_ScatterSer` only. Ignored on every other
+   * chart family at write time.
+   */
+  marker?: ChartMarker;
 }
 
 /**
@@ -1442,6 +1509,16 @@ export interface ChartSeriesInfo {
    * round-trips identically with absence of the field.
    */
   smooth?: boolean;
+  /**
+   * Marker styling parsed from `<c:ser><c:marker>`. Surfaces only on
+   * `line` / `scatter` series — the OOXML schema places `<c:marker>`
+   * exclusively on `CT_LineSer` and `CT_ScatterSer`. Empty marker
+   * blocks (no symbol, size, or color) collapse to `undefined` so a
+   * round-trip keeps the read-side shape minimal. Field semantics
+   * mirror the write-side {@link ChartMarker}, so the value can be
+   * fed straight into {@link cloneChart} without transformation.
+   */
+  marker?: ChartMarker;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,8 @@ export type {
   ChartKind,
   ChartLegendPosition,
   ChartLineAreaGrouping,
+  ChartMarker,
+  ChartMarkerSymbol,
   ChartSeriesInfo,
 } from "./_types";
 

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -18,6 +18,7 @@ import type {
   ChartDataLabels,
   ChartDataLabelsInfo,
   ChartKind,
+  ChartMarker,
   ChartSeries,
   ChartSeriesInfo,
   SheetChart,
@@ -58,6 +59,16 @@ export interface CloneChartSeriesOverride {
    * when the resolved chart type is anything else.
    */
   smooth?: boolean | null;
+  /**
+   * Marker override. `undefined` (or omitted) inherits the source
+   * series' `marker`; `null` drops the inherited block (the cloned
+   * series falls back to Excel's series-rotation default); a
+   * {@link ChartMarker} object replaces the inherited block wholesale
+   * (no per-field merging — pass every field you want preserved).
+   * Only meaningful for `line` and `scatter` clones — silently dropped
+   * from the output when the resolved chart type is anything else.
+   */
+  marker?: ChartMarker | null;
 }
 
 /**
@@ -206,13 +217,14 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     series = buildSeriesFromSource(source, options.seriesOverrides);
   }
 
-  // `<c:smooth>` only lives on line / scatter series; drop the flag from
-  // every other resolved type so a doughnut → column flatten (or any
-  // other coercion) does not leak `smooth` into a chart kind whose
-  // schema rejects the element.
+  // `<c:smooth>` and `<c:marker>` both live exclusively on line /
+  // scatter series; drop them from every other resolved type so a
+  // doughnut → column flatten (or any other coercion) does not leak
+  // either field into a chart kind whose schema rejects them.
   if (type !== "line" && type !== "scatter") {
     for (const s of series) {
       if (s.smooth !== undefined) delete s.smooth;
+      if (s.marker !== undefined) delete s.marker;
     }
   }
 
@@ -425,6 +437,9 @@ function mergeSeries(
   const smooth = resolveSmooth(src?.smooth, ov?.smooth);
   if (smooth !== undefined) out.smooth = smooth;
 
+  const marker = resolveMarker(src?.marker, ov?.marker);
+  if (marker !== undefined) out.marker = marker;
+
   return out;
 }
 
@@ -448,6 +463,40 @@ function resolveSmooth(
   }
   if (override === null) return undefined;
   return override === true ? true : undefined;
+}
+
+/**
+ * Resolve a per-series marker override.
+ *
+ * `undefined` → inherit the source series' `marker` (a fresh shallow
+ * copy so the caller cannot mutate the parsed source).
+ * `null`      → drop the inherited block (the cloned series falls back
+ *               to Excel's series-rotation default).
+ * object      → replace the inherited block wholesale.
+ *
+ * An empty marker block (no symbol, size, or color) collapses to
+ * `undefined` so the writer can elide the element rather than emit a
+ * bare `<c:marker/>` that Excel paints with the inherited default.
+ */
+function resolveMarker(
+  sourceMarker: ChartMarker | undefined,
+  override: ChartMarker | null | undefined,
+): ChartMarker | undefined {
+  if (override === undefined) {
+    if (!sourceMarker) return undefined;
+    return cloneMarker(sourceMarker);
+  }
+  if (override === null) return undefined;
+  return cloneMarker(override);
+}
+
+function cloneMarker(source: ChartMarker): ChartMarker | undefined {
+  const out: ChartMarker = {};
+  if (source.symbol !== undefined) out.symbol = source.symbol;
+  if (typeof source.size === "number" && Number.isFinite(source.size)) out.size = source.size;
+  if (typeof source.fill === "string" && source.fill.length > 0) out.fill = source.fill;
+  if (typeof source.line === "string" && source.line.length > 0) out.line = source.line;
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -24,6 +24,8 @@ import type {
   ChartKind,
   ChartLegendPosition,
   ChartLineAreaGrouping,
+  ChartMarker,
+  ChartMarkerSymbol,
   ChartSeriesInfo,
 } from "../_types";
 import { parseXml } from "../xml/parser";
@@ -425,6 +427,15 @@ function parseSeries(ser: XmlElement, kind: ChartKind, index: number): ChartSeri
     if (smooth !== undefined) out.smooth = smooth;
   }
 
+  // `<c:marker>` mirrors the same scope — CT_LineSer / CT_ScatterSer
+  // only. Skip the element on every other family so a stray
+  // `<c:marker>` on a bar / pie / area template does not surface a
+  // setting that the writer would never emit anyway.
+  if (kind === "line" || kind === "line3D" || kind === "scatter") {
+    const marker = parseMarker(ser);
+    if (marker !== undefined) out.marker = marker;
+  }
+
   return out;
 }
 
@@ -441,6 +452,101 @@ function parseSmooth(ser: XmlElement): boolean | undefined {
   const v = readBoolAttr(el);
   if (v !== true) return undefined;
   return true;
+}
+
+// ── Marker ────────────────────────────────────────────────────────
+
+const VALID_MARKER_SYMBOLS: ReadonlySet<ChartMarkerSymbol> = new Set([
+  "none",
+  "auto",
+  "circle",
+  "square",
+  "diamond",
+  "triangle",
+  "x",
+  "star",
+  "dot",
+  "dash",
+  "plus",
+]);
+
+/**
+ * Pull `<c:marker>` off a line / scatter series. Returns `undefined`
+ * when the marker block is absent or carries no meaningful settings —
+ * an empty `<c:marker/>` element collapses identically to absence
+ * through the writer's elision logic, so omitting it keeps the parsed
+ * shape minimal.
+ *
+ * Field semantics mirror {@link ChartMarker}: an unknown `<c:symbol>`
+ * value is dropped (rather than surfaced), `<c:size>` outside the
+ * 2..72 band is clamped, and the fill / outline colors come from
+ * `<c:spPr><a:solidFill>` and `<c:spPr><a:ln><a:solidFill>`
+ * respectively.
+ */
+function parseMarker(ser: XmlElement): ChartMarker | undefined {
+  const el = findChild(ser, "marker");
+  if (!el) return undefined;
+
+  const out: ChartMarker = {};
+
+  const sym = findChild(el, "symbol");
+  if (sym) {
+    const v = sym.attrs.val;
+    if (typeof v === "string" && VALID_MARKER_SYMBOLS.has(v as ChartMarkerSymbol)) {
+      out.symbol = v as ChartMarkerSymbol;
+    }
+  }
+
+  const sizeEl = findChild(el, "size");
+  if (sizeEl) {
+    const v = sizeEl.attrs.val;
+    if (typeof v === "string") {
+      const n = Number.parseInt(v, 10);
+      if (Number.isFinite(n)) {
+        // OOXML ST_MarkerSize is `xsd:unsignedByte` constrained to
+        // 2..72; clamp anything outside that band on the way in so a
+        // template with an out-of-range value still round-trips.
+        if (n < 2) out.size = 2;
+        else if (n > 72) out.size = 72;
+        else out.size = n;
+      }
+    }
+  }
+
+  const spPr = findChild(el, "spPr");
+  if (spPr) {
+    const fill = findChild(spPr, "solidFill");
+    if (fill) {
+      const srgb = findChild(fill, "srgbClr");
+      const v = srgb?.attrs.val;
+      if (typeof v === "string") {
+        const hex = v.replace(/^#/, "").toUpperCase();
+        if (/^[0-9A-F]{6}$/.test(hex)) out.fill = hex;
+      }
+    }
+    const ln = findChild(spPr, "ln");
+    if (ln) {
+      const lnFill = findChild(ln, "solidFill");
+      if (lnFill) {
+        const srgb = findChild(lnFill, "srgbClr");
+        const v = srgb?.attrs.val;
+        if (typeof v === "string") {
+          const hex = v.replace(/^#/, "").toUpperCase();
+          if (/^[0-9A-F]{6}$/.test(hex)) out.line = hex;
+        }
+      }
+    }
+  }
+
+  if (
+    out.symbol === undefined &&
+    out.size === undefined &&
+    out.fill === undefined &&
+    out.line === undefined
+  ) {
+    return undefined;
+  }
+  return out;
 }
 
 // ── Data Labels ───────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -11,6 +11,8 @@ import type {
   ChartAxisNumberFormat,
   ChartAxisScale,
   ChartDataLabels,
+  ChartMarker,
+  ChartMarkerSymbol,
   ChartSeries,
   SheetChart,
   WriteChartKind,
@@ -530,6 +532,7 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
     const seriesXml = buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
       smooth: chart.series[i].smooth === true,
       dataLabels: chart.dataLabels,
+      marker: chart.series[i].marker,
     });
     children.push(seriesXml);
   }
@@ -687,6 +690,7 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ true, {
         smooth: chart.series[i].smooth === true ? true : undefined,
         dataLabels: chart.dataLabels,
+        marker: chart.series[i].marker,
       }),
     );
   }
@@ -784,6 +788,14 @@ interface SeriesOptions {
    * passing `dataLabels: false` always wins over this default.
    */
   dataLabels?: ChartDataLabels;
+  /**
+   * Per-series marker styling. Only meaningful for line / scatter
+   * series — every other family ignores the field. The OOXML schema
+   * places `<c:marker>` between `<c:spPr>` and `<c:dLbls>` on
+   * `CT_LineSer` / `CT_ScatterSer`, so the writer slots it there
+   * regardless of which fields are populated.
+   */
+  marker?: ChartMarker;
 }
 
 function buildSeries(
@@ -811,6 +823,14 @@ function buildSeries(
   if (series.color) {
     children.push(buildSpPr(series.color));
   }
+
+  // Marker — only line/scatter series honor `<c:marker>` per the OOXML
+  // schema (CT_LineSer / CT_ScatterSer). The element sits between
+  // `<c:spPr>` and `<c:dLbls>`; non-line/non-scatter callers leave
+  // `options.marker` undefined so the field is silently dropped on
+  // every other chart family.
+  const markerXml = buildSeriesMarker(options?.marker);
+  if (markerXml) children.push(markerXml);
 
   // Data labels — series-level override always wins over the chart-level
   // default. `<c:dLbls>` sits between <c:spPr> and <c:cat>/<c:val> per
@@ -867,6 +887,104 @@ function buildSpPr(rgbHex: string): string {
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: normalized })]),
     ]),
   ]);
+}
+
+// ── Marker ───────────────────────────────────────────────────────────
+
+const VALID_MARKER_SYMBOLS: ReadonlySet<ChartMarkerSymbol> = new Set([
+  "none",
+  "auto",
+  "circle",
+  "square",
+  "diamond",
+  "triangle",
+  "x",
+  "star",
+  "dot",
+  "dash",
+  "plus",
+]);
+
+const MARKER_SIZE_MIN = 2;
+const MARKER_SIZE_MAX = 72;
+
+/**
+ * Normalize a marker size to the OOXML 2..72 band (`ST_MarkerSize`).
+ * Excel's UI clamps anything outside this range; we mirror that on the
+ * write side so an out-of-range hint never reaches the chart XML.
+ *
+ * Returns `undefined` for non-finite values so the writer can elide
+ * `<c:size>` (Excel falls back to its series-rotation default).
+ */
+function clampMarkerSize(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < MARKER_SIZE_MIN) return MARKER_SIZE_MIN;
+  if (rounded > MARKER_SIZE_MAX) return MARKER_SIZE_MAX;
+  return rounded;
+}
+
+/**
+ * Validate a marker symbol against the OOXML `ST_MarkerStyle` enum.
+ * Returns `undefined` for unrecognized values so the writer can elide
+ * `<c:symbol>` rather than emit a token Excel will reject.
+ */
+function normalizeMarkerSymbol(
+  value: ChartMarkerSymbol | undefined,
+): ChartMarkerSymbol | undefined {
+  if (value === undefined) return undefined;
+  return VALID_MARKER_SYMBOLS.has(value) ? value : undefined;
+}
+
+/**
+ * Build a `<c:marker>` element for a series. Returns `undefined` when
+ * the marker block carries no meaningful settings — an empty marker
+ * element collapses to the inherited series-rotation default Excel
+ * picks anyway, so omitting it keeps untouched XML byte-clean.
+ */
+function buildSeriesMarker(marker: ChartMarker | undefined): string | undefined {
+  if (!marker) return undefined;
+  const symbol = normalizeMarkerSymbol(marker.symbol);
+  const size = clampMarkerSize(marker.size);
+  const fill = normalizeRgbHex(marker.fill);
+  const line = normalizeRgbHex(marker.line);
+
+  if (symbol === undefined && size === undefined && !fill && !line) return undefined;
+
+  const children: string[] = [];
+  if (symbol !== undefined) children.push(xmlSelfClose("c:symbol", { val: symbol }));
+  if (size !== undefined) children.push(xmlSelfClose("c:size", { val: size }));
+
+  if (fill || line) {
+    const spPrChildren: string[] = [];
+    if (fill) {
+      spPrChildren.push(
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fill })]),
+      );
+    }
+    if (line) {
+      spPrChildren.push(
+        xmlElement("a:ln", undefined, [
+          xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: line })]),
+        ]),
+      );
+    }
+    children.push(xmlElement("c:spPr", undefined, spPrChildren));
+  }
+
+  return xmlElement("c:marker", undefined, children);
+}
+
+/**
+ * Validate a 6-digit RGB hex string and return the uppercase form.
+ * Strips a leading `#`. Returns `undefined` for missing or malformed
+ * values so the writer can elide colored sub-elements that would
+ * otherwise carry a token Excel rejects.
+ */
+function normalizeRgbHex(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const stripped = value.replace(/^#/, "").toUpperCase();
+  return /^[0-9A-F]{6}$/.test(stripped) ? stripped : undefined;
 }
 
 // ── Data Labels ──────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4,7 +4,7 @@ import { parseChart } from "../src/xlsx/chart-reader";
 import { writeChart } from "../src/xlsx/chart-writer";
 import { writeXlsx } from "../src/xlsx/writer";
 import { ZipReader } from "../src/zip/reader";
-import type { Chart, SheetChart } from "../src/_types";
+import type { Chart, ChartMarker, SheetChart } from "../src/_types";
 
 const decoder = new TextDecoder("utf-8");
 
@@ -1813,5 +1813,254 @@ describe("cloneChart — series smooth flag", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.series?.[0].smooth).toBe(true);
     expect(reparsed?.series?.[1].smooth).toBeUndefined();
+  });
+});
+
+// ── cloneChart — series marker ──────────────────────────────────────
+
+describe("cloneChart — series marker", () => {
+  function lineSource(marker?: ChartMarker): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          ...(marker ? { marker } : {}),
+        },
+      ],
+    };
+  }
+
+  it("inherits the marker block from a line series source", () => {
+    const clone = cloneChart(
+      lineSource({ symbol: "diamond", size: 10, fill: "1F77B4", line: "0F3F60" }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.type).toBe("line");
+    expect(clone.series[0].marker).toEqual({
+      symbol: "diamond",
+      size: 10,
+      fill: "1F77B4",
+      line: "0F3F60",
+    });
+  });
+
+  it("does not surface marker when the source series did not declare one", () => {
+    const clone = cloneChart(lineSource(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].marker).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].marker replace an inherited block wholesale", () => {
+    const clone = cloneChart(lineSource({ symbol: "circle", size: 6, fill: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ marker: { symbol: "square", size: 8 } }],
+    });
+    // No per-field merge — the override replaces the inherited block,
+    // so the inherited fill is dropped along with the inherited symbol.
+    expect(clone.series[0].marker).toEqual({ symbol: "square", size: 8 });
+  });
+
+  it("lets seriesOverrides[i].marker=null drop an inherited marker block", () => {
+    const clone = cloneChart(lineSource({ symbol: "diamond" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ marker: null }],
+    });
+    expect(clone.series[0].marker).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].marker={} collapse to undefined", () => {
+    // An empty marker carries no meaningful settings; the writer will
+    // never emit a `<c:marker>` for it, so the resolver collapses it to
+    // undefined to keep the materialized SheetChart honest.
+    const clone = cloneChart(lineSource({ symbol: "diamond" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ marker: {} }],
+    });
+    expect(clone.series[0].marker).toBeUndefined();
+  });
+
+  it("carries marker onto a scatter clone", () => {
+    const scatterSource: Chart = {
+      kinds: ["scatter"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "scatter",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          marker: { symbol: "x", size: 8 },
+        },
+      ],
+    };
+    const clone = cloneChart(scatterSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("scatter");
+    expect(clone.series[0].marker).toEqual({ symbol: "x", size: 8 });
+  });
+
+  it("drops inherited marker when the resolved type is not line/scatter", () => {
+    // A line template flattened to area / column / pie / doughnut must
+    // not leak <c:marker> — the OOXML schema rejects it on every other
+    // chart family's series element.
+    for (const type of ["column", "bar", "pie", "doughnut", "area"] as const) {
+      const clone = cloneChart(lineSource({ symbol: "diamond", size: 10 }), {
+        anchor: { from: { row: 0, col: 0 } },
+        type,
+        seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+      });
+      expect(clone.type).toBe(type);
+      expect(clone.series[0].marker).toBeUndefined();
+    }
+  });
+
+  it("drops marker from explicit options.series when the resolved type is not line/scatter", () => {
+    // Replacing the entire series array via options.series still goes
+    // through the post-build marker-strip, so a stray marker does not
+    // leak into a non-line/scatter target.
+    const clone = cloneChart(lineSource({ symbol: "diamond" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      series: [{ values: "Sheet1!$B$2:$B$5", marker: { symbol: "circle" } }],
+    });
+    expect(clone.series[0].marker).toBeUndefined();
+  });
+
+  it("propagates marker across a multi-series line clone", () => {
+    const multi: Chart = {
+      kinds: ["line"],
+      seriesCount: 3,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          marker: { symbol: "circle", size: 6 },
+        },
+        { kind: "line", index: 1, valuesRef: "Tpl!$C$2:$C$5" },
+        { kind: "line", index: 2, valuesRef: "Tpl!$D$2:$D$5", marker: { symbol: "square" } },
+      ],
+    };
+    const clone = cloneChart(multi, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].marker).toEqual({ symbol: "circle", size: 6 });
+    expect(clone.series[1].marker).toBeUndefined();
+    expect(clone.series[2].marker).toEqual({ symbol: "square" });
+  });
+
+  it("returns a fresh marker object so callers cannot mutate the parsed source", () => {
+    const sourceMarker = { symbol: "circle" as const, size: 6 };
+    const src: Chart = {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          marker: sourceMarker,
+        },
+      ],
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].marker).not.toBe(sourceMarker);
+    // Mutating the clone does not bleed back into the parsed source.
+    if (clone.series[0].marker) clone.series[0].marker.size = 99;
+    expect(sourceMarker.size).toBe(6);
+  });
+
+  it("round-trips marker through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="standard"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Diamonds</c:v></c:tx>
+          <c:marker>
+            <c:symbol val="diamond"/>
+            <c:size val="10"/>
+            <c:spPr>
+              <a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill>
+              <a:ln><a:solidFill><a:srgbClr val="0F3F60"/></a:solidFill></a:ln>
+            </c:spPr>
+          </c:marker>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:tx><c:v>Bare</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$C$2:$C$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="111"/></c:catAx>
+      <c:valAx><c:axId val="222"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.series?.[0].marker).toEqual({
+      symbol: "diamond",
+      size: 10,
+      fill: "1F77B4",
+      line: "0F3F60",
+    });
+    expect(source.series?.[1].marker).toBeUndefined();
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }, { values: "Dashboard!$C$2:$C$5" }],
+    });
+    expect(sheetChart.type).toBe("line");
+    expect(sheetChart.series[0].marker).toEqual({
+      symbol: "diamond",
+      size: 10,
+      fill: "1F77B4",
+      line: "0F3F60",
+    });
+    expect(sheetChart.series[1].marker).toBeUndefined();
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [
+            ["A", "B", "C"],
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+          ],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // First series gets a full marker block; second has none at the
+    // series level.
+    const markerBlocks = written.match(/<c:marker>[\s\S]*?<\/c:marker>/g) ?? [];
+    expect(markerBlocks).toHaveLength(1);
+    expect(markerBlocks[0]).toContain('c:symbol val="diamond"');
+    expect(markerBlocks[0]).toContain('c:size val="10"');
+    expect(markerBlocks[0]).toContain('a:srgbClr val="1F77B4"');
+    expect(markerBlocks[0]).toContain('a:srgbClr val="0F3F60"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.series?.[0].marker).toEqual({
+      symbol: "diamond",
+      size: 10,
+      fill: "1F77B4",
+      line: "0F3F60",
+    });
+    expect(reparsed?.series?.[1].marker).toBeUndefined();
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -587,6 +587,268 @@ describe("writeChart — series smooth flag", () => {
   });
 });
 
+// ── Series markers ───────────────────────────────────────────────────
+
+describe("writeChart — series marker", () => {
+  it("omits <c:marker> on a line series when marker is not set", () => {
+    // The line writer keeps the chart-type-level `<c:marker val="1"/>`
+    // toggle (Excel's per-series default) but does not emit a per-series
+    // marker block until the caller pins one.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+      }),
+      "Sheet1",
+    );
+    // The chart-type-level toggle is still present.
+    expect(result.chartXml).toContain('c:marker val="1"');
+    // No per-series marker element though.
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).not.toContain("<c:marker>");
+  });
+
+  it("emits <c:marker> with <c:symbol> on a line series", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", marker: { symbol: "diamond" } }],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).toContain("<c:marker>");
+    expect(serBlock).toContain('c:symbol val="diamond"');
+  });
+
+  it("emits <c:size> inside <c:marker>", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", marker: { symbol: "circle", size: 12 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:size val="12"');
+  });
+
+  it("clamps size into the OOXML 2..72 band", () => {
+    const lo = writeChart(
+      makeChart({ type: "line", series: [{ values: "B2:B4", marker: { size: 0 } }] }),
+      "Sheet1",
+    );
+    expect(lo.chartXml).toContain('c:size val="2"');
+    const hi = writeChart(
+      makeChart({ type: "line", series: [{ values: "B2:B4", marker: { size: 999 } }] }),
+      "Sheet1",
+    );
+    expect(hi.chartXml).toContain('c:size val="72"');
+  });
+
+  it("rounds non-integer size values", () => {
+    const result = writeChart(
+      makeChart({ type: "line", series: [{ values: "B2:B4", marker: { size: 7.6 } }] }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:size val="8"');
+  });
+
+  it("emits <c:spPr> with <a:solidFill> when marker.fill is set", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", marker: { symbol: "circle", fill: "1F77B4" } }],
+      }),
+      "Sheet1",
+    );
+    const markerBlock = result.chartXml.match(/<c:marker>[\s\S]*?<\/c:marker>/)![0];
+    expect(markerBlock).toContain("<c:spPr>");
+    expect(markerBlock).toContain("<a:solidFill>");
+    expect(markerBlock).toContain('a:srgbClr val="1F77B4"');
+  });
+
+  it("emits <a:ln> with a solidFill when marker.line is set", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", marker: { symbol: "circle", line: "FF0000" } }],
+      }),
+      "Sheet1",
+    );
+    const markerBlock = result.chartXml.match(/<c:marker>[\s\S]*?<\/c:marker>/)![0];
+    expect(markerBlock).toContain("<a:ln>");
+    expect(markerBlock).toMatch(/<a:ln>[\s\S]*a:srgbClr val="FF0000"/);
+  });
+
+  it("strips a leading '#' and uppercases hex color values", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", marker: { fill: "#1f77b4", line: "#aabbcc" } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('a:srgbClr val="1F77B4"');
+    expect(result.chartXml).toContain('a:srgbClr val="AABBCC"');
+  });
+
+  it("drops malformed hex color values", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", marker: { fill: "not-a-color", symbol: "circle" } }],
+      }),
+      "Sheet1",
+    );
+    // Symbol still surfaces, but fill is dropped — no <a:solidFill>
+    // for the marker, since the hex was invalid.
+    const markerBlock = result.chartXml.match(/<c:marker>[\s\S]*?<\/c:marker>/)![0];
+    expect(markerBlock).toContain('c:symbol val="circle"');
+    expect(markerBlock).not.toContain("<a:solidFill>");
+  });
+
+  it("drops unknown marker symbols rather than emit invalid XML", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        // @ts-expect-error: deliberately pass an out-of-enum symbol.
+        series: [{ values: "B2:B4", marker: { symbol: "pentagon", size: 5 } }],
+      }),
+      "Sheet1",
+    );
+    // The size still surfaces but the bogus symbol is dropped.
+    expect(result.chartXml).toContain('c:size val="5"');
+    expect(result.chartXml).not.toContain("c:symbol");
+  });
+
+  it("collapses an empty marker block to no <c:marker> at all", () => {
+    // No symbol, size, or color → nothing meaningful to write, so the
+    // writer omits the element entirely (same shape as if marker was
+    // never set on the series).
+    const result = writeChart(
+      makeChart({ type: "line", series: [{ values: "B2:B4", marker: {} }] }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).not.toContain("<c:marker>");
+  });
+
+  it("emits <c:marker> on a scatter series", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4", marker: { symbol: "x", size: 8 } }],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).toContain('c:symbol val="x"');
+    expect(serBlock).toContain('c:size val="8"');
+  });
+
+  it("renders markers per-series independently on a multi-series line chart", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          { name: "A", values: "B2:B4", marker: { symbol: "circle", size: 6 } },
+          { name: "B", values: "C2:C4", marker: { symbol: "square" } },
+          { name: "C", values: "D2:D4" },
+        ],
+      }),
+      "Sheet1",
+    );
+    const markers = result.chartXml.match(/<c:marker>[\s\S]*?<\/c:marker>/g) ?? [];
+    expect(markers).toHaveLength(2);
+    expect(markers[0]).toContain('c:symbol val="circle"');
+    expect(markers[1]).toContain('c:symbol val="square"');
+  });
+
+  it("ignores marker on chart families whose schema rejects <c:marker>", () => {
+    // The OOXML schema places <c:marker> on the series only on
+    // CT_LineSer and CT_ScatterSer. Setting marker on a bar / column /
+    // pie / doughnut / area series must not leak the element into the
+    // output.
+    for (const type of ["column", "bar", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4", marker: { symbol: "circle" } }],
+        }),
+        "Sheet1",
+      );
+      // No per-series marker block on these chart families.
+      const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+      expect(serBlock).not.toContain("<c:marker>");
+    }
+  });
+
+  it("places <c:marker> between <c:spPr> and <c:dLbls> inside <c:ser> (OOXML order)", () => {
+    // CT_LineSer / CT_ScatterSer order: idx, order, tx, spPr, marker,
+    // dPt*, dLbls?, ..., cat?, val?, smooth?. Excel's strict validator
+    // rejects markers placed elsewhere.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          {
+            values: "B2:B4",
+            categories: "A2:A4",
+            color: "1F77B4",
+            marker: { symbol: "circle" },
+            dataLabels: { showValue: true },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock.indexOf("<c:spPr>")).toBeLessThan(serBlock.indexOf("<c:marker>"));
+    expect(serBlock.indexOf("<c:marker>")).toBeLessThan(serBlock.indexOf("<c:dLbls>"));
+    expect(serBlock.indexOf("<c:dLbls>")).toBeLessThan(serBlock.indexOf("<c:cat>"));
+    expect(serBlock.indexOf("<c:cat>")).toBeLessThan(serBlock.indexOf("<c:val>"));
+    expect(serBlock.indexOf("<c:val>")).toBeLessThan(serBlock.indexOf("<c:smooth"));
+  });
+
+  it("survives a writeXlsx → parseChart round-trip", async () => {
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [
+            ["Q", "Rev"],
+            ["Q1", 100],
+            ["Q2", 150],
+            ["Q3", 175],
+          ],
+          charts: [
+            {
+              type: "line",
+              series: [
+                {
+                  name: "Rev",
+                  values: "B2:B4",
+                  categories: "A2:A4",
+                  marker: { symbol: "diamond", size: 10, fill: "1F77B4", line: "0F3F60" },
+                },
+              ],
+              anchor: { from: { row: 5, col: 0 } },
+            },
+          ],
+        },
+      ],
+    });
+    const chartXml = await extractXml(xlsx, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.series?.[0].marker).toEqual({
+      symbol: "diamond",
+      size: 10,
+      fill: "1F77B4",
+      line: "0F3F60",
+    });
+  });
+});
+
 // ── Axis titles ──────────────────────────────────────────────────────
 
 describe("writeChart — axis titles", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -1713,6 +1713,200 @@ describe("parseChart — series smooth flag", () => {
   });
 });
 
+// ── Series marker ─────────────────────────────────────────────────
+
+describe("parseChart — series marker", () => {
+  const NS_C = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+  const NS_A = `xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  it("surfaces symbol + size on a <c:lineChart> series", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker>
+          <c:symbol val="diamond"/>
+          <c:size val="10"/>
+        </c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker).toEqual({ symbol: "diamond", size: 10 });
+  });
+
+  it("surfaces fill and outline colors from <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker>
+          <c:symbol val="circle"/>
+          <c:size val="6"/>
+          <c:spPr>
+            <a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill>
+            <a:ln><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln>
+          </c:spPr>
+        </c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker).toEqual({
+      symbol: "circle",
+      size: 6,
+      fill: "1F77B4",
+      line: "FF0000",
+    });
+  });
+
+  it("upper-cases hex color values pulled from the marker spPr", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker>
+          <c:spPr><a:solidFill><a:srgbClr val="1f77b4"/></a:solidFill></c:spPr>
+        </c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker?.fill).toBe("1F77B4");
+  });
+
+  it("clamps marker size into the OOXML 2..72 band", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker><c:size val="999"/></c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="1"/>
+        <c:marker><c:size val="0"/></c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$C$2:$C$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker?.size).toBe(72);
+    expect(chart?.series?.[1].marker?.size).toBe(2);
+  });
+
+  it("collapses an empty <c:marker/> to undefined", () => {
+    // No symbol, size, or color — there's nothing meaningful to surface.
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker).toBeUndefined();
+  });
+
+  it("drops unknown marker symbols rather than surface invalid values", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker><c:symbol val="pentagon"/><c:size val="5"/></c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    // Size still surfaces; the bogus symbol is dropped.
+    expect(chart?.series?.[0].marker).toEqual({ size: 5 });
+  });
+
+  it("surfaces marker on a <c:scatterChart> series", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker><c:symbol val="x"/><c:size val="8"/></c:marker>
+        <c:xVal><c:numRef><c:f>Sheet1!$A$2:$A$5</c:f></c:numRef></c:xVal>
+        <c:yVal><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:yVal>
+      </c:ser>
+    </c:scatterChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker).toEqual({ symbol: "x", size: 8 });
+  });
+
+  it("ignores <c:marker> on chart families whose schema rejects it", () => {
+    // A bar / pie / area template carrying a stray <c:marker> on its
+    // series should not surface a marker that the writer would never
+    // emit on those families anyway.
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker><c:symbol val="circle"/></c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].marker).toBeUndefined();
+  });
+
+  it("surfaces marker per-series independently across multi-series line charts", () => {
+    const xml = `<c:chartSpace ${NS_C} ${NS_A}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker><c:symbol val="circle"/><c:size val="6"/></c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="1"/>
+        <c:marker><c:symbol val="square"/></c:marker>
+        <c:val><c:numRef><c:f>Sheet1!$C$2:$C$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="2"/>
+        <c:val><c:numRef><c:f>Sheet1!$D$2:$D$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series).toHaveLength(3);
+    expect(chart?.series?.[0].marker).toEqual({ symbol: "circle", size: 6 });
+    expect(chart?.series?.[1].marker).toEqual({ symbol: "square" });
+    expect(chart?.series?.[2].marker).toBeUndefined();
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Surfaces the per-series `<c:marker>` block at the read, write, and clone layers so a template's marker styling (symbol shape, point size, fill / outline colors) survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:marker>` is the OOXML element that controls the per-data-point glyph rendered by line and scatter charts — Excel exposes the same knobs under "Format Data Series → Marker Options". Until now hucre's writer silently emitted the chart-type-level `<c:marker val="1"/>` toggle on line charts (so markers showed by default) but had no way to pin a specific shape, size, or color per series, and `parseChart` did not surface the parsed configuration. This bridges the last per-series styling gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.series?.[0].marker);
// { symbol: "diamond", size: 10, fill: "1F77B4", line: "0F3F60" }

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "line",
      series: [
        { name: "Revenue", values: "B2:B6", categories: "A2:A6",
          marker: { symbol: "circle", size: 8, fill: "1F77B4" } },
        { name: "Cost",    values: "C2:C6", categories: "A2:A6",
          marker: { symbol: "square", size: 6, fill: "FF7F0E" } },
      ],
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [
    { values: "Dashboard!$B$2:$B$13" },                       // marker inherits
    { values: "Dashboard!$C$2:$C$13", marker: { symbol: "x" } },  // replace wholesale
    { values: "Dashboard!$D$2:$D$13", marker: null },         // drop inherited block
  ],
});
```

## Model

```ts
type ChartMarkerSymbol =
  | "none" | "auto"
  | "circle" | "square" | "diamond" | "triangle"
  | "x" | "star" | "dot" | "dash" | "plus";

interface ChartMarker {
  /** Marker glyph shape. */
  symbol?: ChartMarkerSymbol;
  /** Marker glyph size in points (clamped to OOXML 2..72). */
  size?: number;
  /** Marker fill color (6-digit RGB hex, e.g. "1F77B4"). */
  fill?: string;
  /** Marker outline color (6-digit RGB hex). */
  line?: string;
}

interface ChartSeries {
  /** ...existing fields... */
  marker?: ChartMarker;
}
```

The read-side `ChartSeriesInfo.marker` mirrors the same shape so a parsed marker slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<c:symbol>`, `<c:size>`, and the `<c:spPr>` fill / outline colors off `<c:marker>` only on `line` / `line3D` / `scatter` series. Empty `<c:marker/>` blocks collapse to `undefined`, unknown symbol values are dropped, sizes outside `2..72` are clamped, and malformed hex values are filtered out.
- **Write** — `<c:marker>` is emitted between `<c:spPr>` and `<c:dLbls>` per the OOXML series schema (CT_LineSer / CT_ScatterSer). The chart-type-level `<c:marker val="1"/>` toggle on line charts is preserved (Excel's per-series default), and the writer silently drops the field on every non-line/non-scatter family.
- **Clone** — `seriesOverrides[i].marker` accepts the standard `undefined` (inherit) / `null` (drop) / object (replace wholesale, no per-field merge) grammar that mirrors the smooth, dataLabels, and axis-scale resolvers shipped earlier. The inherited block is also dropped automatically when the resolved clone target is anything other than `line` or `scatter`.

Closes the marker piece of #136.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 67703 vitest tests) — all green
- [x] `pnpm build` — clean obuild
- [x] New tests cover: parse, parse-collapse-empty, clamp / drop invalid, multi-series independence, writer per-series emission, OOXML element ordering, kind-restriction, clone inherit / replace / null / drop on type-flatten, end-to-end `parseChart → cloneChart → writeXlsx → parseChart` round-trip preserving the full marker block