### PR TITLE
feat(xlsx): chart series line stroke — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -611,6 +611,59 @@ export interface ChartDataLabels {
 }
 
 /**
+ * Preset dash pattern for a chart series line stroke.
+ *
+ * Mirrors the OOXML `ST_PresetLineDashVal` enum exactly. Each value
+ * names a stock pattern Excel paints without needing a custom dash
+ * array. The Excel "Format Data Series → Line → Dash type" UI exposes
+ * these stock patterns; Excel ignores any unrecognized value.
+ */
+export type ChartLineDashStyle =
+  | "solid"
+  | "dot"
+  | "dash"
+  | "lgDash"
+  | "dashDot"
+  | "lgDashDot"
+  | "lgDashDotDot"
+  | "sysDash"
+  | "sysDot"
+  | "sysDashDot"
+  | "sysDashDotDot";
+
+/**
+ * Per-series line stroke styling for line / scatter charts.
+ *
+ * Maps to the `<a:ln>` element nested inside `<c:ser><c:spPr>` — the
+ * same wrapper that already carries the series fill color. Only
+ * meaningful on `line` and `scatter` series; the field is silently
+ * dropped on every other chart family at all three layers (read,
+ * write, clone), since dashing and stroke width have no visible effect
+ * on bar / pie / doughnut / area renderings.
+ *
+ * Every field is optional — a bare `{}` collapses to no stroke
+ * configuration and leaves Excel's per-series default in place. Set
+ * `dash: "solid"` to explicitly reset a template's dashed stroke back
+ * to a continuous line.
+ */
+export interface ChartLineStroke {
+  /**
+   * Preset dash pattern. See {@link ChartLineDashStyle} for the
+   * accepted set.
+   */
+  dash?: ChartLineDashStyle;
+  /**
+   * Stroke width in points. Excel's UI exposes the 0.25 – 13.5 pt band;
+   * the writer clamps anything outside that range and rounds to the
+   * nearest quarter-point so a round-trip cannot drift. The OOXML
+   * attribute is in EMU (1 pt = 12 700 EMU); the writer performs the
+   * conversion and the reader inverts it. Non-finite values are
+   * dropped so the writer can elide the attribute entirely.
+   */
+  width?: number;
+}
+
+/**
  * A single data series inside a chart.
  *
  * `values` and `categories` are A1-style cell range references.
@@ -645,6 +698,14 @@ export interface ChartSeries {
    * Smoothed line".
    */
   smooth?: boolean;
+  /**
+   * Per-series line stroke (dash pattern + width) for line / scatter
+   * charts. Maps to `<a:ln>` inside `<c:ser><c:spPr>`. Ignored on every
+   * other chart family — bar / column / pie / doughnut / area never
+   * render a connecting line, so dashing and stroke width have no
+   * visible effect there. See {@link ChartLineStroke}.
+   */
+  stroke?: ChartLineStroke;
 }
 
 /**
@@ -1442,6 +1503,15 @@ export interface ChartSeriesInfo {
    * round-trips identically with absence of the field.
    */
   smooth?: boolean;
+  /**
+   * Line stroke pulled from `<c:ser><c:spPr><a:ln>` — preset dash
+   * pattern and width in points. Surfaces only on `line` / `scatter`
+   * series so a dashed-stroke template round-trips through
+   * `parseChart` → {@link cloneChart} → `writeXlsx`. Field semantics
+   * mirror the write-side {@link ChartLineStroke}, so the value can be
+   * fed straight into a clone without transformation.
+   */
+  stroke?: ChartLineStroke;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,6 +146,8 @@ export type {
   ChartKind,
   ChartLegendPosition,
   ChartLineAreaGrouping,
+  ChartLineDashStyle,
+  ChartLineStroke,
   ChartSeriesInfo,
 } from "./_types";
 

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -18,6 +18,7 @@ import type {
   ChartDataLabels,
   ChartDataLabelsInfo,
   ChartKind,
+  ChartLineStroke,
   ChartSeries,
   ChartSeriesInfo,
   SheetChart,
@@ -58,6 +59,16 @@ export interface CloneChartSeriesOverride {
    * when the resolved chart type is anything else.
    */
   smooth?: boolean | null;
+  /**
+   * Line stroke override. `undefined` (or omitted) inherits the source
+   * series' `stroke`; `null` drops the inherited block (the cloned
+   * series falls back to Excel's per-series default); a
+   * {@link ChartLineStroke} object replaces the inherited block
+   * wholesale (no per-field merge — pass the full shape you want).
+   * Only meaningful for `line` and `scatter` clones — silently dropped
+   * from the output when the resolved chart type is anything else.
+   */
+  stroke?: ChartLineStroke | null;
 }
 
 /**
@@ -206,13 +217,15 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     series = buildSeriesFromSource(source, options.seriesOverrides);
   }
 
-  // `<c:smooth>` only lives on line / scatter series; drop the flag from
-  // every other resolved type so a doughnut → column flatten (or any
-  // other coercion) does not leak `smooth` into a chart kind whose
-  // schema rejects the element.
+  // `<c:smooth>` and `<a:ln>` (stroke) only render meaningfully on
+  // line / scatter series; drop them from every other resolved type
+  // so a doughnut → column flatten (or any other coercion) does not
+  // leak the fields into a chart kind whose schema rejects the
+  // element.
   if (type !== "line" && type !== "scatter") {
     for (const s of series) {
       if (s.smooth !== undefined) delete s.smooth;
+      if (s.stroke !== undefined) delete s.stroke;
     }
   }
 
@@ -425,7 +438,42 @@ function mergeSeries(
   const smooth = resolveSmooth(src?.smooth, ov?.smooth);
   if (smooth !== undefined) out.smooth = smooth;
 
+  const stroke = resolveStroke(src?.stroke, ov?.stroke);
+  if (stroke !== undefined) out.stroke = stroke;
+
   return out;
+}
+
+/**
+ * Resolve a per-series line-stroke override.
+ *
+ * `undefined` → inherit the source series' `stroke` (a fresh shallow
+ *               copy so the caller cannot mutate the parsed source).
+ * `null`      → drop the inherited block.
+ * object      → replace the inherited block wholesale (no per-field
+ *               merge; pass the full shape you want).
+ *
+ * An empty stroke block (no dash, no width) collapses to `undefined`
+ * so the writer can elide the element rather than emit a bare
+ * `<a:ln/>` that Excel paints with the inherited default.
+ */
+function resolveStroke(
+  sourceStroke: ChartLineStroke | undefined,
+  override: ChartLineStroke | null | undefined,
+): ChartLineStroke | undefined {
+  if (override === undefined) {
+    if (!sourceStroke) return undefined;
+    return cloneStroke(sourceStroke);
+  }
+  if (override === null) return undefined;
+  return cloneStroke(override);
+}
+
+function cloneStroke(source: ChartLineStroke): ChartLineStroke | undefined {
+  const out: ChartLineStroke = {};
+  if (source.dash !== undefined) out.dash = source.dash;
+  if (typeof source.width === "number" && Number.isFinite(source.width)) out.width = source.width;
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -24,6 +24,8 @@ import type {
   ChartKind,
   ChartLegendPosition,
   ChartLineAreaGrouping,
+  ChartLineDashStyle,
+  ChartLineStroke,
   ChartSeriesInfo,
 } from "../_types";
 import { parseXml } from "../xml/parser";
@@ -423,6 +425,14 @@ function parseSeries(ser: XmlElement, kind: ChartKind, index: number): ChartSeri
   if (kind === "line" || kind === "line3D" || kind === "scatter") {
     const smooth = parseSmooth(ser);
     if (smooth !== undefined) out.smooth = smooth;
+
+    // Stroke (dash + width) lives in `<c:spPr><a:ln>`. The same
+    // schema-only-on-line/scatter rule applies — bar / pie / area
+    // never paint a connecting line, so surfacing a stroke field
+    // there would mislead a clone consumer about what the chart
+    // actually renders.
+    const stroke = parseSeriesStroke(ser);
+    if (stroke !== undefined) out.stroke = stroke;
   }
 
   return out;
@@ -589,6 +599,75 @@ function parseSeriesColor(ser: XmlElement): string | undefined {
   if (typeof val !== "string") return undefined;
   const normalized = val.replace(/^#/, "").toUpperCase();
   return /^[0-9A-F]{6}$/.test(normalized) ? normalized : undefined;
+}
+
+// ── Stroke ────────────────────────────────────────────────────────
+
+const VALID_DASH_STYLES: ReadonlySet<ChartLineDashStyle> = new Set([
+  "solid",
+  "dot",
+  "dash",
+  "lgDash",
+  "dashDot",
+  "lgDashDot",
+  "lgDashDotDot",
+  "sysDash",
+  "sysDot",
+  "sysDashDot",
+  "sysDashDotDot",
+]);
+
+const STROKE_WIDTH_MIN_PT = 0.25;
+const STROKE_WIDTH_MAX_PT = 13.5;
+const EMU_PER_PT = 12700;
+
+/**
+ * Pull `<c:spPr><a:ln>` off a series and surface its dash + width as
+ * a {@link ChartLineStroke}. Returns `undefined` when the block is
+ * absent or carries no meaningful settings — an empty `<a:ln/>`
+ * collapses identically to absence through the writer's elision
+ * logic, so omitting it keeps the parsed shape minimal.
+ *
+ * `<a:ln>` also nests the line color (`<a:solidFill>`) which mirrors
+ * the series fill — parseSeriesColor already surfaces that as
+ * {@link ChartSeriesInfo.color}, so the stroke object intentionally
+ * does not duplicate the field.
+ */
+function parseSeriesStroke(ser: XmlElement): ChartLineStroke | undefined {
+  const spPr = findChild(ser, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+
+  const out: ChartLineStroke = {};
+
+  // Stroke width is on the `w` attribute of `<a:ln>` (EMU). Convert
+  // back to points and clamp to the band Excel's UI exposes so a
+  // template carrying an exotic width still round-trips through the
+  // writer's clamp.
+  const wAttr = ln.attrs.w;
+  if (typeof wAttr === "string") {
+    const emu = Number.parseFloat(wAttr);
+    if (Number.isFinite(emu) && emu > 0) {
+      // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+      const pt = Math.round((emu / EMU_PER_PT) * 4) / 4;
+      if (pt < STROKE_WIDTH_MIN_PT) out.width = STROKE_WIDTH_MIN_PT;
+      else if (pt > STROKE_WIDTH_MAX_PT) out.width = STROKE_WIDTH_MAX_PT;
+      else out.width = pt;
+    }
+  }
+
+  // Dash style is `<a:prstDash val="..."/>` inside `<a:ln>`.
+  const dashEl = findChild(ln, "prstDash");
+  if (dashEl) {
+    const v = dashEl.attrs.val;
+    if (typeof v === "string" && VALID_DASH_STYLES.has(v as ChartLineDashStyle)) {
+      out.dash = v as ChartLineDashStyle;
+    }
+  }
+
+  if (out.dash === undefined && out.width === undefined) return undefined;
+  return out;
 }
 
 // ── Legend ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -11,6 +11,8 @@ import type {
   ChartAxisNumberFormat,
   ChartAxisScale,
   ChartDataLabels,
+  ChartLineDashStyle,
+  ChartLineStroke,
   ChartSeries,
   SheetChart,
   WriteChartKind,
@@ -530,6 +532,7 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
     const seriesXml = buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
       smooth: chart.series[i].smooth === true,
       dataLabels: chart.dataLabels,
+      stroke: chart.series[i].stroke,
     });
     children.push(seriesXml);
   }
@@ -687,6 +690,7 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ true, {
         smooth: chart.series[i].smooth === true ? true : undefined,
         dataLabels: chart.dataLabels,
+        stroke: chart.series[i].stroke,
       }),
     );
   }
@@ -784,6 +788,15 @@ interface SeriesOptions {
    * passing `dataLabels: false` always wins over this default.
    */
   dataLabels?: ChartDataLabels;
+  /**
+   * Per-series line stroke (dash pattern + width). Only meaningful for
+   * line / scatter series — every other family ignores the field. The
+   * OOXML schema places stroke styling inside `<c:spPr><a:ln>` which is
+   * shared with the series fill color, so the writer threads the
+   * stroke into the same `<c:spPr>` block whether or not a fill color
+   * is set.
+   */
+  stroke?: ChartLineStroke;
 }
 
 function buildSeries(
@@ -807,10 +820,12 @@ function buildSeries(
     );
   }
 
-  // Optional fill color
-  if (series.color) {
-    children.push(buildSpPr(series.color));
-  }
+  // Optional fill color and / or line stroke (line / scatter only emit
+  // `<a:ln>` width / dash from `options.stroke`; non-line callers leave
+  // `options.stroke` undefined so the field is silently dropped on
+  // every other chart family).
+  const spPr = buildSeriesSpPr(series.color, options?.stroke);
+  if (spPr) children.push(spPr);
 
   // Data labels — series-level override always wins over the chart-level
   // default. `<c:dLbls>` sits between <c:spPr> and <c:cat>/<c:val> per
@@ -859,14 +874,116 @@ function buildSeries(
   return xmlElement("c:ser", undefined, children);
 }
 
-function buildSpPr(rgbHex: string): string {
-  const normalized = rgbHex.replace(/^#/, "").toUpperCase();
-  return xmlElement("c:spPr", undefined, [
-    xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: normalized })]),
-    xmlElement("a:ln", undefined, [
-      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: normalized })]),
-    ]),
-  ]);
+// ── Stroke ───────────────────────────────────────────────────────────
+
+const VALID_DASH_STYLES: ReadonlySet<ChartLineDashStyle> = new Set([
+  "solid",
+  "dot",
+  "dash",
+  "lgDash",
+  "dashDot",
+  "lgDashDot",
+  "lgDashDotDot",
+  "sysDash",
+  "sysDot",
+  "sysDashDot",
+  "sysDashDotDot",
+]);
+
+const STROKE_WIDTH_MIN_PT = 0.25;
+const STROKE_WIDTH_MAX_PT = 13.5;
+const EMU_PER_PT = 12700;
+
+/**
+ * Validate a dash style against `ST_PresetLineDashVal`. Returns
+ * `undefined` for unrecognized values so the writer can elide
+ * `<a:prstDash>` rather than emit a token Excel will reject.
+ */
+function normalizeDashStyle(value: ChartLineDashStyle | undefined): ChartLineDashStyle | undefined {
+  if (value === undefined) return undefined;
+  return VALID_DASH_STYLES.has(value) ? value : undefined;
+}
+
+/**
+ * Convert a stroke width in points to the integer EMU value the OOXML
+ * `w` attribute requires. Excel's UI exposes 0.25..13.5 pt — values
+ * outside that band are clamped to keep round-trips inside the range
+ * Excel will render. Non-finite values collapse to `undefined` so the
+ * writer can omit the attribute entirely. The point value is also
+ * snapped to the nearest quarter-point so a parsed-then-written stroke
+ * does not drift across round-trips (Excel rounds in the UI anyway).
+ */
+function clampStrokeWidthPt(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const snapped = Math.round(value * 4) / 4;
+  if (snapped < STROKE_WIDTH_MIN_PT) return STROKE_WIDTH_MIN_PT;
+  if (snapped > STROKE_WIDTH_MAX_PT) return STROKE_WIDTH_MAX_PT;
+  return snapped;
+}
+
+/**
+ * Build the `<c:spPr>` element shared by series fill color and series
+ * line stroke. Returns `undefined` when neither field carries any
+ * meaningful settings — an empty `<c:spPr/>` collapses to the
+ * inherited series-rotation default Excel picks anyway, so omitting it
+ * keeps untouched chart XML byte-clean.
+ *
+ * The OOXML `<a:ln>` element accepts both a `w` attribute (stroke
+ * width in EMU) and child elements `<a:solidFill>` / `<a:prstDash>` in
+ * a fixed order. When a fill color is set, the stroke also renders the
+ * same color (matching Excel's "Format Data Series → Fill" default
+ * which paints the line in the fill color). Stroke metadata (dash and
+ * width) layers on top without overriding the line color so a `color +
+ * stroke` combo behaves like Excel's UI: the line picks up the fill
+ * color and the dash / width override visibility-only attributes.
+ */
+function buildSeriesSpPr(
+  rgbHex: string | undefined,
+  stroke: ChartLineStroke | undefined,
+): string | undefined {
+  const fillHex = rgbHex ? rgbHex.replace(/^#/, "").toUpperCase() : undefined;
+  const dash = normalizeDashStyle(stroke?.dash);
+  const widthPt = clampStrokeWidthPt(stroke?.width);
+
+  if (!fillHex && dash === undefined && widthPt === undefined) {
+    return undefined;
+  }
+
+  const spPrChildren: string[] = [];
+  if (fillHex) {
+    spPrChildren.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
+    );
+  }
+
+  // `<a:ln>` carries stroke metadata. Emit it whenever a fill color is
+  // set (so the connecting line picks up the same color, matching the
+  // legacy behavior) or whenever stroke width / dash is configured.
+  if (fillHex || dash !== undefined || widthPt !== undefined) {
+    const lnAttrs: Record<string, string | number> = {};
+    if (widthPt !== undefined) {
+      // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
+      // the nearest integer because the schema types `w` as `xsd:int`.
+      lnAttrs.w = Math.round(widthPt * EMU_PER_PT);
+    }
+    const lnChildren: string[] = [];
+    if (fillHex) {
+      lnChildren.push(
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
+      );
+    }
+    if (dash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: dash }));
+    }
+    spPrChildren.push(
+      lnChildren.length === 0
+        ? xmlSelfClose("a:ln", lnAttrs)
+        : xmlElement("a:ln", Object.keys(lnAttrs).length > 0 ? lnAttrs : undefined, lnChildren),
+    );
+  }
+
+  return xmlElement("c:spPr", undefined, spPrChildren);
 }
 
 // ── Data Labels ──────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4,7 +4,7 @@ import { parseChart } from "../src/xlsx/chart-reader";
 import { writeChart } from "../src/xlsx/chart-writer";
 import { writeXlsx } from "../src/xlsx/writer";
 import { ZipReader } from "../src/zip/reader";
-import type { Chart, SheetChart } from "../src/_types";
+import type { Chart, ChartLineStroke, SheetChart } from "../src/_types";
 
 const decoder = new TextDecoder("utf-8");
 
@@ -1813,5 +1813,165 @@ describe("cloneChart — series smooth flag", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.series?.[0].smooth).toBe(true);
     expect(reparsed?.series?.[1].smooth).toBeUndefined();
+  });
+});
+
+// ── cloneChart — series line stroke ─────────────────────────────────
+
+describe("cloneChart — series line stroke", () => {
+  function lineSource(stroke?: ChartLineStroke): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          ...(stroke ? { stroke } : {}),
+        },
+      ],
+    };
+  }
+
+  it("inherits the stroke block from a line series source", () => {
+    const source = lineSource({ dash: "dash", width: 2.5 });
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("line");
+    expect(clone.series[0].stroke).toEqual({ dash: "dash", width: 2.5 });
+  });
+
+  it("does not surface stroke when the source series did not declare one", () => {
+    const clone = cloneChart(lineSource(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].stroke).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].stroke replace an inherited block wholesale", () => {
+    const source = lineSource({ dash: "dash", width: 2.5 });
+    const clone = cloneChart(source, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ stroke: { dash: "dot", width: 0.5 } }],
+    });
+    // Override replaces wholesale; old width does not leak through.
+    expect(clone.series[0].stroke).toEqual({ dash: "dot", width: 0.5 });
+  });
+
+  it("lets seriesOverrides[i].stroke=null drop an inherited stroke block", () => {
+    const source = lineSource({ dash: "dash", width: 2.5 });
+    const clone = cloneChart(source, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ stroke: null }],
+    });
+    expect(clone.series[0].stroke).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].stroke={} collapse to undefined", () => {
+    // An empty stroke carries no meaningful settings; the writer will
+    // never emit `<a:ln>` for it, so the resolver collapses it to
+    // undefined to keep the round-trip shape minimal.
+    const source = lineSource({ dash: "dash" });
+    const clone = cloneChart(source, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ stroke: {} }],
+    });
+    expect(clone.series[0].stroke).toBeUndefined();
+  });
+
+  it("carries stroke onto a scatter clone", () => {
+    const source: Chart = {
+      kinds: ["scatter"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "scatter",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          stroke: { dash: "lgDashDot", width: 1 },
+        },
+      ],
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("scatter");
+    expect(clone.series[0].stroke).toEqual({ dash: "lgDashDot", width: 1 });
+  });
+
+  it("drops inherited stroke when the resolved type is not line/scatter", () => {
+    // A clone that flattens a line template into a column / pie / area
+    // chart must not leak <a:ln> styling — the OOXML schema rejects it
+    // on every other family that does not paint a connecting line.
+    const types: Array<"column" | "bar" | "pie" | "doughnut" | "area"> = [
+      "column",
+      "bar",
+      "pie",
+      "doughnut",
+      "area",
+    ];
+    for (const type of types) {
+      const clone = cloneChart(lineSource({ dash: "dash" }), {
+        anchor: { from: { row: 0, col: 0 } },
+        type,
+      });
+      expect(clone.series[0].stroke).toBeUndefined();
+    }
+  });
+
+  it("drops stroke from explicit options.series when the resolved type is not line/scatter", () => {
+    // Even when the caller bypasses seriesOverrides and passes a fully
+    // built `series` array, a stroke field must not leak into a chart
+    // family whose schema rejects the element. The post-build sweep
+    // strips it after the merge.
+    const clone = cloneChart(lineSource(), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      series: [{ values: "Sheet1!$B$2:$B$5", stroke: { dash: "dot" } }],
+    });
+    expect(clone.series[0].stroke).toBeUndefined();
+  });
+
+  it("propagates stroke across a multi-series line clone", () => {
+    const source: Chart = {
+      kinds: ["line"],
+      seriesCount: 3,
+      series: [
+        { kind: "line", index: 0, valuesRef: "Tpl!$B$2:$B$5", stroke: { dash: "dash" } },
+        { kind: "line", index: 1, valuesRef: "Tpl!$C$2:$C$5" },
+        { kind: "line", index: 2, valuesRef: "Tpl!$D$2:$D$5", stroke: { width: 2.5 } },
+      ],
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series).toHaveLength(3);
+    expect(clone.series[0].stroke).toEqual({ dash: "dash" });
+    expect(clone.series[1].stroke).toBeUndefined();
+    expect(clone.series[2].stroke).toEqual({ width: 2.5 });
+  });
+
+  it("survives a parseChart → cloneChart → writeChart → parseChart round-trip", () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const source = parseChart(`<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln w="31750">
+            <a:prstDash val="dashDot"/>
+          </a:ln>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`);
+    const clone = cloneChart(source!, { anchor: { from: { row: 0, col: 0 } } });
+    const written = writeChart(clone, "Sheet1").chartXml;
+    expect(written).toContain('<a:prstDash val="dashDot"/>');
+    expect(written).toContain('w="31750"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.series?.[0].stroke).toEqual({ dash: "dashDot", width: 2.5 });
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -587,6 +587,221 @@ describe("writeChart — series smooth flag", () => {
   });
 });
 
+// ── Line stroke (dash + width) ───────────────────────────────────────
+
+describe("writeChart — series line stroke", () => {
+  it("emits <a:prstDash> on a line series stroke.dash", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          { name: "Forecast", values: "B2:B4", categories: "A2:A4", stroke: { dash: "dash" } },
+        ],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("emits <a:ln w=...> in EMU for a line series stroke.width (1 pt = 12 700 EMU)", () => {
+    // 2.5 pt → 31 750 EMU.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { width: 2.5 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('w="31750"');
+  });
+
+  it("snaps a stroke.width to the 0.25 pt grid before converting to EMU", () => {
+    // 1.13 pt should snap to 1.25 pt → 15 875 EMU (matching what Excel
+    // rounds to in its UI).
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { width: 1.13 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('w="15875"');
+  });
+
+  it("clamps stroke.width below 0.25 pt to 0.25 pt", () => {
+    // 0.1 pt clamps to 0.25 pt → 3 175 EMU.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { width: 0.1 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('w="3175"');
+  });
+
+  it("clamps stroke.width above 13.5 pt to 13.5 pt", () => {
+    // 50 pt clamps to 13.5 pt → 171 450 EMU.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { width: 50 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('w="171450"');
+  });
+
+  it("drops an unknown dash value and emits no <a:prstDash>", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          // @ts-expect-error – exercising the runtime guard
+          { values: "B2:B4", categories: "A2:A4", stroke: { dash: "wiggle" } },
+        ],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("a:prstDash");
+  });
+
+  it("drops a non-finite stroke.width and emits no <a:ln w=...>", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { width: Number.NaN } }],
+      }),
+      "Sheet1",
+    );
+    // Line writer always emits the chart-type-level <c:marker val="1"/>;
+    // the regex below specifically targets the per-series <a:ln> attr.
+    expect(result.chartXml).not.toMatch(/<a:ln\s+w="/);
+  });
+
+  it("collapses an empty stroke {} to no <c:spPr> for a series without color", () => {
+    // Empty stroke + no fill color must not introduce a `<c:spPr>` block —
+    // an empty wrapper would override Excel's series-rotation default
+    // with no actual styling.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: {} }],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).not.toContain("<c:spPr>");
+  });
+
+  it("layers stroke.dash onto a series with an existing fill color", () => {
+    // Series.color emits both <a:solidFill> and a colored <a:ln>; adding
+    // stroke.dash should append <a:prstDash> inside the same <a:ln>.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          {
+            values: "B2:B4",
+            categories: "A2:A4",
+            color: "1F77B4",
+            stroke: { dash: "dashDot" },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).toMatch(/<a:ln[\s\S]*?<a:srgbClr val="1F77B4"\/>[\s\S]*?<a:prstDash/);
+  });
+
+  it("emits <a:ln> on a colorless line series when stroke.dash is set", () => {
+    // No fill color, but a dash style — the writer must still emit
+    // `<c:spPr><a:ln>` to carry the prstDash, otherwise the dash
+    // setting silently drops at write time.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { dash: "dot" } }],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    expect(serBlock).toContain("<c:spPr>");
+    expect(serBlock).toContain("<a:ln");
+    expect(serBlock).toContain('<a:prstDash val="dot"/>');
+    // No accidental fill block when only stroke is requested.
+    expect(serBlock).not.toContain("<a:solidFill>");
+  });
+
+  it("renders stroke per-series independently across a multi-series line chart", () => {
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          { name: "S1", values: "B2:B4", stroke: { dash: "dash" } },
+          { name: "S2", values: "C2:C4" },
+          { name: "S3", values: "D2:D4", stroke: { dash: "dot", width: 1.5 } },
+        ],
+      }),
+      "Sheet1",
+    );
+    const matches = result.chartXml.match(/<a:prstDash val="[^"]+"\/>/g) ?? [];
+    expect(matches).toEqual(['<a:prstDash val="dash"/>', '<a:prstDash val="dot"/>']);
+  });
+
+  it("emits stroke on a scatter series", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { dash: "lgDash", width: 0.75 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<a:prstDash val="lgDash"/>');
+    // 0.75 pt → 9 525 EMU.
+    expect(result.chartXml).toContain('w="9525"');
+  });
+
+  it("ignores stroke on chart kinds whose schema does not paint a connecting line", () => {
+    // Bar / column / pie / doughnut / area never render a per-series
+    // line stroke (each has its own per-data-point border instead). A
+    // stroke field on those series must drop at write time.
+    const cases: Array<["column" | "bar" | "pie" | "doughnut" | "area"]> = [
+      ["column"],
+      ["bar"],
+      ["pie"],
+      ["doughnut"],
+      ["area"],
+    ];
+    for (const [type] of cases) {
+      const result = writeChart(
+        makeChart({
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4", stroke: { dash: "dash", width: 2 } }],
+        }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("a:prstDash");
+      // The stroke width must not leak into a non-line family either.
+      expect(result.chartXml).not.toMatch(/<a:ln\s+w="/);
+    }
+  });
+
+  it("snaps a 9 525-EMU width back to 9 525 EMU on round-trip (idempotent)", () => {
+    // Half-EMU drift is the most common round-trip bug — ensure 0.75 pt
+    // (Excel default) is byte-stable.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [{ values: "B2:B4", categories: "A2:A4", stroke: { width: 0.75 } }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('w="9525"');
+  });
+});
+
 // ── Axis titles ──────────────────────────────────────────────────────
 
 describe("writeChart — axis titles", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -1713,6 +1713,224 @@ describe("parseChart — series smooth flag", () => {
   });
 });
 
+// ── parseChart — series line stroke ───────────────────────────────
+
+describe("parseChart — series line stroke", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  it('surfaces stroke.dash from <a:prstDash val="dash"/>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln>
+            <a:prstDash val="dash"/>
+          </a:ln>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toEqual({ dash: "dash" });
+  });
+
+  it('surfaces stroke.width from <a:ln w="..."/> by converting EMU back to points', () => {
+    // 31 750 EMU = 2.5 pt.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln w="31750"/>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toEqual({ width: 2.5 });
+  });
+
+  it("surfaces both dash and width when both are present", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln w="9525">
+            <a:prstDash val="lgDash"/>
+          </a:ln>
+        </c:spPr>
+        <c:xVal><c:numRef><c:f>Sheet1!$A$2:$A$5</c:f></c:numRef></c:xVal>
+        <c:yVal><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:yVal>
+      </c:ser>
+    </c:scatterChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toEqual({ dash: "lgDash", width: 0.75 });
+  });
+
+  it("returns stroke undefined when <a:ln> is absent", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toBeUndefined();
+  });
+
+  it("collapses an empty <a:ln/> (no width, no prstDash) to undefined", () => {
+    // An empty <a:ln/> carries no meaningful settings; don't surface a
+    // record the writer will never re-emit.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr><a:ln/></c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toBeUndefined();
+  });
+
+  it("drops an unknown dash value rather than surfacing a malformed token", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln>
+            <a:prstDash val="wiggle"/>
+          </a:ln>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toBeUndefined();
+  });
+
+  it("clamps an absurdly wide <a:ln w=...> back into the 0.25..13.5 pt band", () => {
+    // 999 999 EMU ≈ 78.7 pt; clamp to 13.5 pt.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln w="999999"/>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toEqual({ width: 13.5 });
+  });
+
+  it("ignores stroke on chart families whose schema does not paint a connecting line", () => {
+    // Even if a corrupt template carries <a:ln> on a bar/pie/area
+    // series, the read side should not surface the field — it would
+    // mislead a clone consumer about what the chart actually renders.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:ln w="31750">
+            <a:prstDash val="dash"/>
+          </a:ln>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].stroke).toBeUndefined();
+  });
+
+  it("surfaces stroke per-series independently across multi-series line charts", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr><a:ln w="31750"><a:prstDash val="dash"/></a:ln></c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="1"/>
+        <c:val><c:numRef><c:f>Sheet1!$C$2:$C$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="2"/>
+        <c:spPr><a:ln><a:prstDash val="sysDot"/></a:ln></c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$D$2:$D$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series).toHaveLength(3);
+    expect(chart?.series?.[0].stroke).toEqual({ dash: "dash", width: 2.5 });
+    expect(chart?.series?.[1].stroke).toBeUndefined();
+    expect(chart?.series?.[2].stroke).toEqual({ dash: "sysDot" });
+  });
+
+  it("does not let stroke shadow the existing series.color (parseSeriesColor still wins)", () => {
+    // A series with both a fill color and a stroke should surface
+    // `color` and `stroke` independently — the stroke object never
+    // duplicates the color (parseSeriesColor already covers it).
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:spPr>
+          <a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill>
+          <a:ln w="19050">
+            <a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill>
+            <a:prstDash val="dashDot"/>
+          </a:ln>
+        </c:spPr>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].color).toBe("1F77B4");
+    // 19 050 EMU = 1.5 pt.
+    expect(chart?.series?.[0].stroke).toEqual({ dash: "dashDot", width: 1.5 });
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Surfaces the per-series `<a:ln>` stroke (preset dash pattern + width in points) at the read, write, and clone layers so a template's line styling survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:ln>` is the OOXML element that controls how Excel paints the connecting line on `line` and `scatter` series — Excel exposes the same knobs under "Format Data Series → Line → Dash type / Width". Until now hucre had no way to pin a dash pattern or stroke width per series, and `parseChart` did not surface either field. This bridges another per-series styling gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.series?.[0].stroke);
// { dash: "dashDot", width: 2.5 }

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "line",
      series: [
        { name: "Forecast", values: "B2:B6", categories: "A2:A6",
          stroke: { dash: "dash", width: 1.5 } },
        { name: "Actual",   values: "C2:C6", categories: "A2:A6",
          stroke: { dash: "solid", width: 2.5 } },
      ],
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [
    { values: "Dashboard!$B$2:$B$13" },                            // stroke inherits
    { values: "Dashboard!$C$2:$C$13", stroke: { dash: "dot" } },  // replace wholesale
    { values: "Dashboard!$D$2:$D$13", stroke: null },             // drop inherited block
  ],
});
```

## Model

```ts
type ChartLineDashStyle =
  | "solid" | "dot" | "dash" | "lgDash"
  | "dashDot" | "lgDashDot" | "lgDashDotDot"
  | "sysDash" | "sysDot" | "sysDashDot" | "sysDashDotDot";

interface ChartLineStroke {
  /** Preset dash pattern. */
  dash?: ChartLineDashStyle;
  /** Stroke width in points (clamped to Excel's 0.25..13.5 pt band). */
  width?: number;
}

interface ChartSeries {
  /** ...existing fields... */
  stroke?: ChartLineStroke;
}
```

The read-side `ChartSeriesInfo.stroke` mirrors the same shape so a parsed stroke slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<a:prstDash>` and the `w` attribute off `<c:spPr><a:ln>` only on `line` / `line3D` / `scatter` series. Empty `<a:ln/>` blocks collapse to `undefined`, unknown dash values are dropped, widths outside `0.25..13.5 pt` are clamped, and EMU is converted back to points (snapped to the 0.25 pt grid Excel exposes).
- **Write** — Stroke metadata layers onto the existing `<c:spPr>` that already carries `series.color`. A `color + stroke` combo behaves like Excel's UI: the line picks up the fill color, and the dash / width override visibility-only attributes. A colorless series with stroke now emits `<c:spPr><a:ln>` carrying just the dash and width. The writer silently drops the field on every non-line / non-scatter family.
- **Clone** — `seriesOverrides[i].stroke` accepts the standard `undefined` (inherit) / `null` (drop) / object (replace wholesale, no per-field merge) grammar that mirrors the smooth, dataLabels, and axis-scale resolvers shipped earlier. The inherited block is also dropped automatically when the resolved clone target is anything other than `line` or `scatter`.

## Edge cases

- `<a:ln w="31750"/>` reads as `{ width: 2.5 }` (1 pt = 12 700 EMU).
- Width inputs are snapped to the 0.25 pt grid before EMU conversion so a parsed-then-written stroke is byte-stable.
- Width above 13.5 pt or below 0.25 pt clamps on both read and write so Excel's UI band is preserved.
- Non-finite widths (NaN, Infinity) drop to `undefined` rather than emit an invalid `w` attribute.
- An unknown `<a:prstDash val="...">` reads as `undefined` rather than surface a token Excel rejects.
- Empty stroke `{}` collapses to no `<c:spPr>` at write time when the series has no fill color either, so untouched chart XML stays byte-clean.
- Bar / column / pie / doughnut / area templates carrying a stray `<a:ln>` on a series do not surface the stroke field — those families do not paint a connecting line.
- Clone flatten (line → column) post-build sweep strips both `smooth` and `stroke` so a coerced family does not carry leak-through styling the OOXML schema rejects.

Refs #136