### PR TITLE
feat(xlsx): chart dispBlanksAs — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,13 @@ clockwise from 12 o'clock) on pie and doughnut charts. The OOXML
 default `0` (and the schema-equivalent `360`) collapses to
 `undefined` so absence and the default round-trip identically;
 non-pie / non-doughnut charts never report it.
+`Chart.dispBlanksAs` surfaces the chart-level
+`<c:chart><c:dispBlanksAs val=".."/>` element — Excel's "Select Data
+Source → Hidden and Empty Cells" knob — and reports the literal
+`"zero"` or `"span"` token. The OOXML default `"gap"` collapses to
+`undefined` so absence and the default round-trip identically;
+unknown / malformed values (and a missing `val` attribute) drop to
+`undefined` rather than fabricate a token Excel rejects.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -756,6 +763,14 @@ For pie and doughnut charts, `firstSliceAng` (0 – 360 degrees, default
 aligning paired charts in a dashboard. Out-of-band values wrap modulo
 360 (380 → 20, -90 → 270) the same way Excel's chart-formatting pane
 does, and non-pie / non-doughnut kinds silently ignore the field.
+The chart-level `dispBlanksAs` field maps to
+`<c:chart><c:dispBlanksAs val=".."/>` — Excel's "Select Data Source →
+Hidden and Empty Cells" toggle — and accepts `"gap"` (leave a break),
+`"zero"` (drop missing points to the X axis) or `"span"` (connect
+across the gap; line / scatter only). The writer always emits the
+element, defaulting to `"gap"` (the OOXML default Excel itself emits)
+and clamping unknown tokens back to `"gap"` so a malformed input
+cannot produce invalid OOXML.
 For line and scatter charts, each `series[i].smooth` flag toggles
 Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
 Line series always emit the element — `smooth: true` writes `val="1"`,
@@ -866,6 +881,13 @@ Per-series line strokes follow the same grammar:
 (replace wholesale — `dash` and `width` together, no per-field
 merge). The inherited stroke is also dropped automatically when the
 resolved clone target is anything other than `line` or `scatter`.
+The chart-level `dispBlanksAs` follows the standard
+`undefined` (inherit) / `null` (drop the inherited value, falling
+back to the writer's `"gap"` default) / value (`"gap"` / `"zero"` /
+`"span"`) override grammar. Unlike smooth and marker, this field
+lives on `<c:chart>` and is valid on every chart family, so a
+coercion (line → column, doughnut → pie, etc.) preserves the
+inherited value rather than dropping it.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -671,6 +671,22 @@ export interface ChartMarker {
 }
 
 /**
+ * How Excel paints a series across cells whose value is missing or
+ * blank. Mirrors the OOXML `ST_DispBlanksAs` enum exactly and matches
+ * the three options Excel exposes under "Select Data Source → Hidden
+ * and Empty Cells":
+ *
+ * - `"gap"` — leave a gap at the missing point (the OOXML default and
+ *   what Excel selects in fresh chart UI). A line chart shows a break,
+ *   a bar chart simply skips the bar.
+ * - `"zero"` — substitute `0` for the missing value, so a line chart
+ *   drops to the X axis and bar charts render a flush-zero bar.
+ * - `"span"` — connect adjacent points across the gap (line / scatter
+ *   only; Excel falls back to `"gap"` for bar / pie / area).
+ */
+export type ChartDisplayBlanksAs = "gap" | "zero" | "span";
+
+/**
  * A single data series inside a chart.
  *
  * `values` and `categories` are A1-style cell range references.
@@ -817,6 +833,15 @@ export interface SheetChart {
    * value/category annotations.
    */
   dataLabels?: ChartDataLabels;
+  /**
+   * How Excel renders missing / blank cells in the source data. Maps
+   * to `<c:dispBlanksAs val=".."/>` on `<c:chart>`. Default: `"gap"`
+   * (the OOXML default Excel itself emits). Set `"zero"` to anchor the
+   * line / bar to the X axis at missing points, or `"span"` to
+   * connect across the gap on line and scatter charts. See
+   * {@link ChartDisplayBlanksAs} for the accepted set.
+   */
+  dispBlanksAs?: ChartDisplayBlanksAs;
   /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
@@ -1801,6 +1826,16 @@ export interface Chart {
    * the same way. Omitted on non-pie / non-doughnut charts.
    */
   firstSliceAng?: number;
+  /**
+   * How the chart renders missing / blank cells, pulled from
+   * `<c:chart><c:dispBlanksAs val=".."/>`. The OOXML default of
+   * `"gap"` collapses to `undefined` so absence and the default
+   * round-trip identically through {@link cloneChart} — symmetric with
+   * the writer's {@link SheetChart.dispBlanksAs} field. Surfaces
+   * `"zero"` and `"span"` literally; unknown values are dropped rather
+   * than fabricated.
+   */
+  dispBlanksAs?: ChartDisplayBlanksAs;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,7 @@ export type {
   ChartDataLabelPosition,
   ChartDataLabels,
   ChartDataLabelsInfo,
+  ChartDisplayBlanksAs,
   ChartKind,
   ChartLegendPosition,
   ChartLineAreaGrouping,

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -17,6 +17,7 @@ import type {
   ChartAxisScale,
   ChartDataLabels,
   ChartDataLabelsInfo,
+  ChartDisplayBlanksAs,
   ChartKind,
   ChartMarker,
   ChartSeries,
@@ -149,6 +150,15 @@ export interface CloneChartOptions {
    * block; a `ChartDataLabels` object replaces it.
    */
   dataLabels?: ChartDataLabels | null;
+  /**
+   * Override how the chart renders missing / blank cells. `undefined`
+   * (or omitted) inherits the source's `dispBlanksAs`; `null` drops
+   * the inherited value (the writer falls back to the OOXML `"gap"`
+   * default); a {@link ChartDisplayBlanksAs} value replaces it. Useful
+   * when a template uses `"span"` to bridge gaps but the cloned
+   * dashboard chart should render the gaps explicitly (or vice versa).
+   */
+  dispBlanksAs?: ChartDisplayBlanksAs | null;
   /**
    * Per-axis overrides. Each field accepts a value to replace the
    * source's, or `null` to drop the source value (the cloned chart
@@ -305,6 +315,9 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedDataLabels = resolveChartDataLabels(source.dataLabels, options.dataLabels);
   if (resolvedDataLabels !== undefined) out.dataLabels = resolvedDataLabels;
+
+  const resolvedDispBlanks = resolveDispBlanksAs(source.dispBlanksAs, options.dispBlanksAs);
+  if (resolvedDispBlanks !== undefined) out.dispBlanksAs = resolvedDispBlanks;
 
   // Pie and doughnut have no axes, so silently skip carrying over axis
   // titles even when the source declared them or the caller passed an
@@ -497,6 +510,26 @@ function cloneMarker(source: ChartMarker): ChartMarker | undefined {
   if (typeof source.fill === "string" && source.fill.length > 0) out.fill = source.fill;
   if (typeof source.line === "string" && source.line.length > 0) out.line = source.line;
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Resolve a `dispBlanksAs` override.
+ *
+ * `undefined` → inherit the source's parsed `dispBlanksAs`.
+ * `null`      → drop the inherited value (the writer falls back to
+ *               the OOXML `"gap"` default).
+ * value       → replace.
+ *
+ * Unknown strings are ignored (treated as `undefined`); only the three
+ * OOXML-defined tokens propagate through to the writer.
+ */
+function resolveDispBlanksAs(
+  sourceValue: ChartDisplayBlanksAs | undefined,
+  override: ChartDisplayBlanksAs | null | undefined,
+): ChartDisplayBlanksAs | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -21,6 +21,7 @@ import type {
   ChartBarGrouping,
   ChartDataLabelPosition,
   ChartDataLabelsInfo,
+  ChartDisplayBlanksAs,
   ChartKind,
   ChartLegendPosition,
   ChartLineAreaGrouping,
@@ -171,6 +172,9 @@ export function parseChart(xml: string): Chart | undefined {
 
   const legend = parseLegend(chartEl);
   if (legend !== undefined) out.legend = legend;
+
+  const dispBlanksAs = parseDispBlanksAs(chartEl);
+  if (dispBlanksAs !== undefined) out.dispBlanksAs = dispBlanksAs;
 
   return out;
 }
@@ -738,6 +742,36 @@ function parseLegend(chartEl: XmlElement): false | ChartLegendPosition | undefin
       return "topRight";
     default:
       // Unknown legendPos values are dropped rather than fabricated.
+      return undefined;
+  }
+}
+
+// ── Display Blanks As ─────────────────────────────────────────────
+
+/**
+ * Pull `<c:dispBlanksAs val=".."/>` off `<c:chart>`. The OOXML default
+ * is `"gap"`, which collapses to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart}.
+ *
+ * Only the three values OOXML defines (`"gap"`, `"zero"`, `"span"`)
+ * surface; unknown or malformed values drop to `undefined` rather than
+ * fabricate a token Excel rejects.
+ */
+function parseDispBlanksAs(chartEl: XmlElement): ChartDisplayBlanksAs | undefined {
+  const el = findChild(chartEl, "dispBlanksAs");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "zero":
+      return "zero";
+    case "span":
+      return "span";
+    case "gap":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `dispBlanksAs` field.
+      return undefined;
+    default:
       return undefined;
   }
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -11,6 +11,7 @@ import type {
   ChartAxisNumberFormat,
   ChartAxisScale,
   ChartDataLabels,
+  ChartDisplayBlanksAs,
   ChartMarker,
   ChartMarkerSymbol,
   ChartSeries,
@@ -69,7 +70,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   }
 
   chartChildren.push(xmlSelfClose("c:plotVisOnly", { val: 1 }));
-  chartChildren.push(xmlSelfClose("c:dispBlanksAs", { val: "gap" }));
+  chartChildren.push(xmlSelfClose("c:dispBlanksAs", { val: resolveDispBlanksAs(chart) }));
 
   const chartElement = xmlElement("c:chart", undefined, chartChildren);
 
@@ -1096,6 +1097,25 @@ function buildLegend(pos: LegendPos): string {
     xmlSelfClose("c:legendPos", { val: pos }),
     xmlSelfClose("c:overlay", { val: 0 }),
   ]);
+}
+
+// ── Display Blanks As ────────────────────────────────────────────────
+
+const DISP_BLANKS_AS_VALUES: ReadonlySet<ChartDisplayBlanksAs> = new Set(["gap", "zero", "span"]);
+
+/**
+ * Resolve the `<c:dispBlanksAs>` value emitted on `<c:chart>`.
+ *
+ * Defaults to `"gap"` (the OOXML default) when the chart does not set
+ * the field. Unknown / unsupported tokens collapse to `"gap"` rather
+ * than emit an attribute Excel ignores. The writer always emits the
+ * element so the file's intent is explicit even on roundtrip — Excel
+ * itself includes it in every reference serialization.
+ */
+function resolveDispBlanksAs(chart: SheetChart): ChartDisplayBlanksAs {
+  const raw = chart.dispBlanksAs;
+  if (raw && DISP_BLANKS_AS_VALUES.has(raw)) return raw;
+  return "gap";
 }
 
 // ── Reference qualification ──────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2064,3 +2064,94 @@ describe("cloneChart — series marker", () => {
     expect(reparsed?.series?.[1].marker).toBeUndefined();
   });
 });
+
+// ── cloneChart — dispBlanksAs ─────────────────────────────────────
+
+describe("cloneChart — dispBlanksAs", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's dispBlanksAs by default", () => {
+    const clone = cloneChart(source({ dispBlanksAs: "span" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dispBlanksAs).toBe("span");
+  });
+
+  it("lets options.dispBlanksAs override the source's value", () => {
+    const clone = cloneChart(source({ dispBlanksAs: "span" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dispBlanksAs: "zero",
+    });
+    expect(clone.dispBlanksAs).toBe("zero");
+  });
+
+  it("drops the inherited dispBlanksAs when the override is null", () => {
+    // null means "fall back to the writer's OOXML default" — the field
+    // disappears from the resolved SheetChart so the writer emits the
+    // default `gap`.
+    const clone = cloneChart(source({ dispBlanksAs: "zero" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dispBlanksAs: null,
+    });
+    expect(clone.dispBlanksAs).toBeUndefined();
+  });
+
+  it("returns undefined dispBlanksAs when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dispBlanksAs).toBeUndefined();
+  });
+
+  it("carries dispBlanksAs through a flatten (line → column)", () => {
+    // Unlike smooth/marker, dispBlanksAs lives on `<c:chart>` and is
+    // valid on every chart family, so a coercion does not drop it.
+    const clone = cloneChart(source({ dispBlanksAs: "zero" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.dispBlanksAs).toBe("zero");
+  });
+
+  it("propagates dispBlanksAs into the rendered <c:chart> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dispBlanksAs: "span" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:dispBlanksAs val="span"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.dispBlanksAs).toBe("span");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2006,3 +2006,68 @@ describe("writeChart — overlap", () => {
     expect(barBlock![0].indexOf("c:overlap")).toBeLessThan(barBlock![0].indexOf("c:axId"));
   });
 });
+
+// ── Display blanks as ────────────────────────────────────────────────
+
+describe("writeChart — dispBlanksAs", () => {
+  it('emits <c:dispBlanksAs val="gap"/> when the field is unset (OOXML default)', () => {
+    // The writer always emits the element so the rendered intent is
+    // explicit on roundtrip — Excel itself includes it in every
+    // reference serialization.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).toContain('c:dispBlanksAs val="gap"');
+  });
+
+  it('threads dispBlanksAs="zero" through to <c:chart>', () => {
+    const result = writeChart(makeChart({ dispBlanksAs: "zero" }), "Sheet1");
+    expect(result.chartXml).toContain('c:dispBlanksAs val="zero"');
+  });
+
+  it('threads dispBlanksAs="span" through to <c:chart>', () => {
+    const result = writeChart(makeChart({ type: "line", dispBlanksAs: "span" }), "Sheet1");
+    expect(result.chartXml).toContain('c:dispBlanksAs val="span"');
+  });
+
+  it("falls back to gap on unknown dispBlanksAs values rather than emit one Excel rejects", () => {
+    const result = writeChart(
+      // @ts-expect-error — testing runtime guard for malformed input
+      makeChart({ dispBlanksAs: "bogus" }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:dispBlanksAs val="gap"');
+    expect(result.chartXml).not.toContain('c:dispBlanksAs val="bogus"');
+  });
+
+  it("places <c:dispBlanksAs> after <c:plotVisOnly> inside <c:chart> (OOXML order)", () => {
+    // CT_Chart sequence: ... plotArea, legend?, plotVisOnly?, dispBlanksAs?, ...
+    const result = writeChart(makeChart({ dispBlanksAs: "zero" }), "Sheet1");
+    expect(result.chartXml.indexOf("c:plotVisOnly")).toBeLessThan(
+      result.chartXml.indexOf("c:dispBlanksAs"),
+    );
+  });
+
+  it("only emits <c:dispBlanksAs> once even on a chart that overrides it", () => {
+    // Earlier writers emitted a hardcoded `gap` even when the chart
+    // requested a different value. Guard against any regression that
+    // would double-emit the element.
+    const result = writeChart(makeChart({ dispBlanksAs: "span" }), "Sheet1");
+    const occurrences = result.chartXml.match(/c:dispBlanksAs/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads dispBlanksAs through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, dispBlanksAs: "zero" }), "Sheet1");
+      expect(result.chartXml).toContain('c:dispBlanksAs val="zero"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        dispBlanksAs: "span",
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:dispBlanksAs val="span"');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -1907,6 +1907,89 @@ describe("parseChart — series marker", () => {
   });
 });
 
+// ── parseChart — dispBlanksAs ─────────────────────────────────────
+
+describe("parseChart — dispBlanksAs", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:dispBlanksAs val="zero"/> off <c:chart>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dispBlanksAs).toBe("zero");
+  });
+
+  it('surfaces <c:dispBlanksAs val="span"/> off <c:chart>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+    <c:dispBlanksAs val="span"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dispBlanksAs).toBe("span");
+  });
+
+  it("collapses the OOXML default 'gap' to undefined (writer absence)", () => {
+    // The default carried explicitly by Excel's reference serialization
+    // round-trips identically to absence of the field.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:dispBlanksAs val="gap"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dispBlanksAs).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:dispBlanksAs> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dispBlanksAs).toBeUndefined();
+  });
+
+  it("drops unknown dispBlanksAs values rather than fabricate one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:dispBlanksAs val="bogus"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dispBlanksAs).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:dispBlanksAs>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:dispBlanksAs/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dispBlanksAs).toBeUndefined();
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Surfaces the chart-level `<c:dispBlanksAs>` element at the read, write, and clone layers so a template's "Hidden and Empty Cells" configuration survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:dispBlanksAs>` is the OOXML element that controls how Excel paints series across cells whose value is missing or blank — Excel exposes the same knob under "Select Data Source → Hidden and Empty Cells". Until now hucre's writer always emitted a hardcoded `<c:dispBlanksAs val="gap"/>` and `parseChart` did not surface the parsed value, so a template using `span` to bridge gaps could not round-trip through clone. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.dispBlanksAs); // "span"

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "line",
      series: [
        { name: "Revenue", values: "B2:B6", categories: "A2:A6" },
      ],
      anchor: { from: { row: 6, col: 0 } },
      dispBlanksAs: "span", // bridge gaps in the source data
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  dispBlanksAs: "zero", // override the source: drop to zero instead
});
```

## Model

```ts
type ChartDisplayBlanksAs = "gap" | "zero" | "span";

interface SheetChart {
  /** ...existing fields... */
  dispBlanksAs?: ChartDisplayBlanksAs;
}

interface Chart {
  /** ...existing fields... */
  dispBlanksAs?: ChartDisplayBlanksAs;
}
```

The read-side `Chart.dispBlanksAs` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<c:chart><c:dispBlanksAs val="..">` and surfaces the literal value. The OOXML default `"gap"` collapses to `undefined` so absence and the default round-trip identically; unknown / malformed values drop to `undefined` rather than fabricate a token Excel rejects.
- **Write** — The writer threads `chart.dispBlanksAs` through to the rendered `<c:dispBlanksAs val="..">` (defaulting to `"gap"` when absent). Unknown values fall back to `"gap"` so a malformed input cannot produce invalid OOXML. The element is always emitted — Excel itself includes it in every reference serialization, so writing it explicitly keeps the file's intent unambiguous.
- **Clone** — `options.dispBlanksAs` accepts the standard `undefined` (inherit) / `null` (drop the inherited value, falling back to the writer's default) / value (replace) grammar that mirrors the dataLabels / smooth / axis-scale resolvers shipped earlier. Unlike smooth and marker, `<c:dispBlanksAs>` lives on `<c:chart>` and is valid on every chart family, so a coercion (line → column) preserves the inherited value.

## Edge cases

- A chart whose `<c:dispBlanksAs val="gap"/>` is emitted explicitly round-trips identically to a chart that omits the element entirely — both surface as `undefined` on the read side and re-emit as `gap` on the write side.
- An unknown `<c:dispBlanksAs val="bogus"/>` reads as `undefined` rather than surface a token Excel rejects.
- A missing `val` attribute on `<c:dispBlanksAs/>` reads as `undefined`.
- `dispBlanksAs: null` on `cloneChart` drops the inherited value so the writer falls back to the OOXML `"gap"` default — useful when a template uses `"span"` but the cloned dashboard chart should render gaps explicitly.
- Only one `<c:dispBlanksAs>` element is emitted per chart, even when the field is overridden — guards against any regression that would double-emit.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2810 vitest tests, all passing)
- [x] `pnpm build`
- [x] Reader, writer, and clone tests cover: defaults, all three values, unknown/malformed inputs, missing `val`, and round-trip through `writeXlsx` → `parseChart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)