### PR TITLE
feat(xlsx): chart series invertIfNegative flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,13 @@ and `width` is reported in points after converting from EMU and
 clamping to Excel's 0.25 – 13.5 pt UI band. Empty `<a:ln/>` blocks,
 unknown dash tokens, and out-of-band widths collapse to `undefined`
 so the parsed shape stays minimal.
+`ChartSeriesInfo.invertIfNegative` surfaces the per-series
+`<c:ser><c:invertIfNegative val=".."/>` flag — Excel's "Format Data
+Series → Fill → Invert if negative" toggle — only on `bar` / `bar3D`
+series (the OOXML schema places `<c:invertIfNegative>` exclusively on
+`CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
+`val="0"` both collapse to `undefined`, so only an explicit
+`<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
@@ -785,6 +792,13 @@ so a `color + stroke` combo behaves like Excel's UI: the line picks
 up the fill color, and dash / width override visibility-only
 attributes. Bar / column / pie / doughnut / area kinds silently
 ignore the field.
+For bar and column charts, each `series[i].invertIfNegative` flag
+mirrors Excel's "Format Data Series → Fill → Invert if negative"
+toggle (`<c:invertIfNegative val=".."/>` inside `<c:ser>`). The
+writer only emits the element when `invertIfNegative` is explicitly
+`true` — `false` and absence both round-trip as the OOXML default
+(omission), so untouched bar charts stay byte-clean. Line / pie /
+doughnut / area / scatter kinds silently ignore the flag.
 Radar, stock, 3D variants, trendlines, and combo charts are out of
 scope today.
 
@@ -866,6 +880,14 @@ Per-series line strokes follow the same grammar:
 (replace wholesale — `dash` and `width` together, no per-field
 merge). The inherited stroke is also dropped automatically when the
 resolved clone target is anything other than `line` or `scatter`.
+Per-series `invertIfNegative` follows the same grammar:
+`seriesOverrides[i].invertIfNegative` accepts `undefined` (inherit),
+`null` (drop the inherited flag), or a `boolean` (replace). `false`
+collapses to `undefined` for symmetry with the OOXML default — the
+writer omits `<c:invertIfNegative>` either way. The inherited flag
+is also dropped automatically when the resolved clone target is
+anything other than `bar` or `column`, since the schema rejects the
+element on every other chart family.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -773,6 +773,20 @@ export interface ChartSeries {
    * chart family at write time.
    */
   marker?: ChartMarker;
+  /**
+   * Invert the fill color when the value is negative. Maps to
+   * `<c:invertIfNegative val=".."/>` inside the `<c:ser>` element.
+   * Only meaningful for `bar` and `column` charts — the OOXML schema
+   * places `<c:invertIfNegative>` exclusively on `CT_BarSer` and
+   * `CT_Bar3DSer`, so the field is silently dropped on every other
+   * chart family at write time.
+   *
+   * Default: `false` (negative bars share the series fill color).
+   * Set `true` to mirror Excel's "Format Data Series → Fill → Invert
+   * if negative" toggle, which paints negative bars with white (or
+   * the inverted color when the spreadsheet supplies one).
+   */
+  invertIfNegative?: boolean;
 }
 
 /**
@@ -1589,6 +1603,15 @@ export interface ChartSeriesInfo {
    * fed straight into {@link cloneChart} without transformation.
    */
   marker?: ChartMarker;
+  /**
+   * Invert-if-negative flag pulled from
+   * `<c:ser><c:invertIfNegative val=".."/>`. Surfaces only on `bar`
+   * (and `bar3D`) series — the OOXML schema places
+   * `<c:invertIfNegative>` exclusively on `CT_BarSer` / `CT_Bar3DSer`.
+   * `false` collapses to `undefined` because it matches the OOXML
+   * default and round-trips identically with absence of the field.
+   */
+  invertIfNegative?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -80,6 +80,15 @@ export interface CloneChartSeriesOverride {
    * from the output when the resolved chart type is anything else.
    */
   marker?: ChartMarker | null;
+  /**
+   * Invert-if-negative override. `undefined` (or omitted) inherits the
+   * source series' `invertIfNegative`; `null` drops the inherited flag
+   * (the cloned series renders negatives in the series fill color);
+   * a `boolean` replaces it wholesale. Only meaningful for `bar` and
+   * `column` clones — silently dropped from the output when the
+   * resolved chart type is anything else.
+   */
+  invertIfNegative?: boolean | null;
 }
 
 /**
@@ -238,6 +247,16 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       if (s.smooth !== undefined) delete s.smooth;
       if (s.stroke !== undefined) delete s.stroke;
       if (s.marker !== undefined) delete s.marker;
+    }
+  }
+
+  // `<c:invertIfNegative>` lives exclusively on bar / column series
+  // (CT_BarSer / CT_Bar3DSer); drop the field from every other
+  // resolved type so a column → line flatten (or any other coercion)
+  // does not leak the flag into a chart kind whose schema rejects it.
+  if (type !== "bar" && type !== "column") {
+    for (const s of series) {
+      if (s.invertIfNegative !== undefined) delete s.invertIfNegative;
     }
   }
 
@@ -456,6 +475,9 @@ function mergeSeries(
   const marker = resolveMarker(src?.marker, ov?.marker);
   if (marker !== undefined) out.marker = marker;
 
+  const invertIfNegative = resolveInvertIfNegative(src?.invertIfNegative, ov?.invertIfNegative);
+  if (invertIfNegative !== undefined) out.invertIfNegative = invertIfNegative;
+
   return out;
 }
 
@@ -508,6 +530,29 @@ function resolveSmooth(
 ): boolean | undefined {
   if (override === undefined) {
     return sourceSmooth === true ? true : undefined;
+  }
+  if (override === null) return undefined;
+  return override === true ? true : undefined;
+}
+
+/**
+ * Resolve a per-series invert-if-negative override.
+ *
+ * `undefined` → inherit the source series' `invertIfNegative`.
+ * `null`      → drop the inherited flag (the cloned series renders
+ *               negatives in the series fill color).
+ * `boolean`   → replace.
+ *
+ * Only the `true` outcome materializes on the result — `false` collapses
+ * to `undefined` so absence and the OOXML default round-trip identically
+ * (the writer omits `<c:invertIfNegative>` either way).
+ */
+function resolveInvertIfNegative(
+  sourceFlag: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    return sourceFlag === true ? true : undefined;
   }
   if (override === null) return undefined;
   return override === true ? true : undefined;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -444,6 +444,16 @@ function parseSeries(ser: XmlElement, kind: ChartKind, index: number): ChartSeri
     if (marker !== undefined) out.marker = marker;
   }
 
+  // `<c:invertIfNegative>` lives on `CT_BarSer` / `CT_Bar3DSer` only —
+  // every other chart family rejects the element. Surface the flag
+  // just for those two kinds so a corrupt template carrying
+  // `<c:invertIfNegative>` on a line/pie/area/scatter series does not
+  // silently flip a flag that the writer would never emit anyway.
+  if (kind === "bar" || kind === "bar3D") {
+    const invertIfNegative = parseInvertIfNegative(ser);
+    if (invertIfNegative !== undefined) out.invertIfNegative = invertIfNegative;
+  }
+
   return out;
 }
 
@@ -456,6 +466,21 @@ function parseSeries(ser: XmlElement, kind: ChartKind, index: number): ChartSeri
  */
 function parseSmooth(ser: XmlElement): boolean | undefined {
   const el = findChild(ser, "smooth");
+  if (!el) return undefined;
+  const v = readBoolAttr(el);
+  if (v !== true) return undefined;
+  return true;
+}
+
+/**
+ * Pull `<c:invertIfNegative val=".."/>` off a bar/column series
+ * element. Returns `undefined` when the attribute is absent,
+ * malformed, or carries the OOXML default `false` — absence and
+ * `false` round-trip identically through the writer's elision logic,
+ * so collapsing them keeps the parsed shape minimal.
+ */
+function parseInvertIfNegative(ser: XmlElement): boolean | undefined {
+  const el = findChild(ser, "invertIfNegative");
   if (!el) return undefined;
   const v = readBoolAttr(el);
   if (v !== true) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -388,6 +388,7 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
     children.push(
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
         dataLabels: chart.dataLabels,
+        invertIfNegative: chart.series[i].invertIfNegative === true,
       }),
     );
   }
@@ -809,6 +810,16 @@ interface SeriesOptions {
    * regardless of which fields are populated.
    */
   marker?: ChartMarker;
+  /**
+   * Per-series invert-if-negative flag. Only meaningful for bar /
+   * column series — every other family ignores the field. The OOXML
+   * schema places `<c:invertIfNegative>` between `<c:spPr>` and
+   * `<c:dLbls>` on `CT_BarSer` / `CT_Bar3DSer`, so the writer slots
+   * it there. The element is only emitted when the field resolves to
+   * `true` — `false` is the OOXML default and absence round-trips
+   * identically.
+   */
+  invertIfNegative?: boolean;
 }
 
 function buildSeries(
@@ -846,6 +857,18 @@ function buildSeries(
   // every other chart family.
   const markerXml = buildSeriesMarker(options?.marker);
   if (markerXml) children.push(markerXml);
+
+  // `<c:invertIfNegative>` — only bar / column (CT_BarSer /
+  // CT_Bar3DSer) series carry the element per the OOXML schema. It
+  // sits between `<c:spPr>` (and the bar-irrelevant `<c:marker>`
+  // slot, which is never populated for bar/column callers anyway)
+  // and `<c:dLbls>`. Non-bar callers leave `options.invertIfNegative`
+  // undefined so the field is silently dropped on every other chart
+  // family. Emit only when the resolved value is `true` — `false`
+  // matches the OOXML default and absence round-trips identically.
+  if (options?.invertIfNegative === true) {
+    children.push(xmlSelfClose("c:invertIfNegative", { val: 1 }));
+  }
 
   // Data labels — series-level override always wins over the chart-level
   // default. `<c:dLbls>` sits between <c:spPr> and <c:cat>/<c:val> per

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2224,3 +2224,182 @@ describe("cloneChart — series marker", () => {
     expect(reparsed?.series?.[1].marker).toBeUndefined();
   });
 });
+
+// ── cloneChart — series invertIfNegative flag ───────────────────────
+
+describe("cloneChart — series invertIfNegative flag", () => {
+  function barSource(invertIfNegative: boolean | undefined): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          ...(invertIfNegative !== undefined ? { invertIfNegative } : {}),
+        },
+      ],
+    };
+  }
+
+  it("inherits invertIfNegative=true from a bar series source", () => {
+    const clone = cloneChart(barSource(true), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("column");
+    expect(clone.series[0].invertIfNegative).toBe(true);
+  });
+
+  it("does not surface invertIfNegative when the source series did not declare it", () => {
+    const clone = cloneChart(barSource(undefined), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].invertIfNegative).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].invertIfNegative=true override a source missing the flag", () => {
+    const clone = cloneChart(barSource(undefined), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ invertIfNegative: true }],
+    });
+    expect(clone.series[0].invertIfNegative).toBe(true);
+  });
+
+  it("lets seriesOverrides[i].invertIfNegative=null drop an inherited flag", () => {
+    const clone = cloneChart(barSource(true), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ invertIfNegative: null }],
+    });
+    expect(clone.series[0].invertIfNegative).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].invertIfNegative=false drop an inherited flag", () => {
+    // `false` collapses to undefined for symmetry with the OOXML
+    // default — non-inverted bars and absence round-trip identically.
+    const clone = cloneChart(barSource(true), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ invertIfNegative: false }],
+    });
+    expect(clone.series[0].invertIfNegative).toBeUndefined();
+  });
+
+  it("carries invertIfNegative onto a horizontal bar clone", () => {
+    const clone = cloneChart(barSource(true), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "bar",
+    });
+    expect(clone.type).toBe("bar");
+    expect(clone.series[0].invertIfNegative).toBe(true);
+  });
+
+  it("drops inherited invertIfNegative when the resolved type is not bar/column", () => {
+    // A bar template flattened to line / pie / doughnut / area /
+    // scatter must not leak <c:invertIfNegative> — the OOXML schema
+    // rejects it on every other chart family.
+    for (const type of ["line", "pie", "doughnut", "area", "scatter"] as const) {
+      const clone = cloneChart(barSource(true), {
+        anchor: { from: { row: 0, col: 0 } },
+        type,
+        seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+      });
+      expect(clone.type).toBe(type);
+      expect(clone.series[0].invertIfNegative).toBeUndefined();
+    }
+  });
+
+  it("drops invertIfNegative from explicit options.series when the resolved type is not bar/column", () => {
+    // Replacing the entire series array via options.series still goes
+    // through the post-build invert-strip, so a stray flag does not
+    // leak into a non-bar/column target.
+    const clone = cloneChart(barSource(true), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      series: [{ values: "Sheet1!$B$2:$B$5", invertIfNegative: true }],
+    });
+    expect(clone.series[0].invertIfNegative).toBeUndefined();
+  });
+
+  it("propagates invertIfNegative across a multi-series column clone", () => {
+    const multi: Chart = {
+      kinds: ["bar"],
+      seriesCount: 3,
+      series: [
+        { kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5", invertIfNegative: true },
+        { kind: "bar", index: 1, valuesRef: "Tpl!$C$2:$C$5" },
+        { kind: "bar", index: 2, valuesRef: "Tpl!$D$2:$D$5", invertIfNegative: true },
+      ],
+    };
+    const clone = cloneChart(multi, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].invertIfNegative).toBe(true);
+    expect(clone.series[1].invertIfNegative).toBeUndefined();
+    expect(clone.series[2].invertIfNegative).toBe(true);
+  });
+
+  it("round-trips invertIfNegative through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Inverted</c:v></c:tx>
+          <c:invertIfNegative val="1"/>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:tx><c:v>Default</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$C$2:$C$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="111"/>
+        <c:axId val="222"/>
+      </c:barChart>
+      <c:catAx><c:axId val="111"/></c:catAx>
+      <c:valAx><c:axId val="222"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.series?.[0].invertIfNegative).toBe(true);
+    expect(source.series?.[1].invertIfNegative).toBeUndefined();
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }, { values: "Dashboard!$C$2:$C$5" }],
+    });
+    expect(sheetChart.type).toBe("column");
+    expect(sheetChart.series[0].invertIfNegative).toBe(true);
+    expect(sheetChart.series[1].invertIfNegative).toBeUndefined();
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [
+            ["A", "B", "C"],
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+          ],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // Only the inverted series carries <c:invertIfNegative>; the
+    // second falls back to the OOXML default (absence of the element).
+    const matches = written.match(/c:invertIfNegative val="[01]"/g) ?? [];
+    expect(matches).toEqual(['c:invertIfNegative val="1"']);
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.series?.[0].invertIfNegative).toBe(true);
+    expect(reparsed?.series?.[1].invertIfNegative).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2221,3 +2221,151 @@ describe("writeChart — overlap", () => {
     expect(barBlock![0].indexOf("c:overlap")).toBeLessThan(barBlock![0].indexOf("c:axId"));
   });
 });
+
+// ── invertIfNegative (per-series flag, bar / column only) ────────────
+
+describe("writeChart — series invertIfNegative flag", () => {
+  it("omits <c:invertIfNegative> on a bar series with the flag left unset", () => {
+    // Absence of <c:invertIfNegative> matches the OOXML default
+    // (`val="0"`); the writer keeps untouched series byte-clean.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:invertIfNegative");
+  });
+
+  it('emits <c:invertIfNegative val="1"/> on a column series when invertIfNegative=true', () => {
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [{ values: "B2:B4", categories: "A2:A4", invertIfNegative: true }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:invertIfNegative val="1"');
+  });
+
+  it('emits <c:invertIfNegative val="1"/> on a horizontal bar series when invertIfNegative=true', () => {
+    const result = writeChart(
+      makeChart({
+        type: "bar",
+        series: [{ values: "B2:B4", categories: "A2:A4", invertIfNegative: true }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:invertIfNegative val="1"');
+  });
+
+  it("renders invertIfNegative per-series independently on a multi-series column chart", () => {
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [
+          { name: "Inverted", values: "B2:B4", invertIfNegative: true },
+          { name: "Default", values: "C2:C4" },
+          { name: "ExplicitFalse", values: "D2:D4", invertIfNegative: false },
+        ],
+      }),
+      "Sheet1",
+    );
+    // Only the first series carries <c:invertIfNegative>. Series with
+    // the flag explicitly false collapse to absence (the OOXML default).
+    const matches = result.chartXml.match(/c:invertIfNegative val="[01]"/g) ?? [];
+    expect(matches).toEqual(['c:invertIfNegative val="1"']);
+  });
+
+  it("ignores invertIfNegative on chart kinds whose schema rejects <c:invertIfNegative>", () => {
+    // The OOXML schema places <c:invertIfNegative> only on CT_BarSer
+    // and CT_Bar3DSer. Setting the flag on a line / pie / doughnut /
+    // area / scatter series must not leak the element into the output.
+    const cases: Array<["line" | "pie" | "doughnut" | "area" | "scatter"]> = [
+      ["line"],
+      ["pie"],
+      ["doughnut"],
+      ["area"],
+      ["scatter"],
+    ];
+    for (const [type] of cases) {
+      const result = writeChart(
+        makeChart({
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4", invertIfNegative: true }],
+        }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("c:invertIfNegative");
+    }
+  });
+
+  it("places <c:invertIfNegative> between <c:spPr> and <c:cat>/<c:val> (OOXML order)", () => {
+    // CT_BarSer puts <c:invertIfNegative> after <c:spPr> and before
+    // <c:dLbls> / <c:cat> / <c:val>. The element must land between the
+    // styling block and the data references so Excel's strict validator
+    // does not reject the file.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [
+          {
+            name: "Inverted",
+            values: "B2:B4",
+            categories: "A2:A4",
+            color: "FF0000",
+            invertIfNegative: true,
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    const spPrIdx = serBlock.indexOf("c:spPr");
+    const invertIdx = serBlock.indexOf("c:invertIfNegative");
+    const catIdx = serBlock.indexOf("c:cat");
+    const valIdx = serBlock.indexOf("c:val");
+    expect(spPrIdx).toBeLessThan(invertIdx);
+    expect(invertIdx).toBeLessThan(catIdx);
+    expect(invertIdx).toBeLessThan(valIdx);
+  });
+
+  it("emits <c:invertIfNegative> alongside other bar-only fields without disturbing them", () => {
+    // The barChart-level fields (<c:gapWidth>, <c:overlap>) are
+    // independent of the per-series invertIfNegative flag. Both must
+    // emit cleanly without interfering.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        gapWidth: 50,
+        overlap: -10,
+        series: [{ values: "B2:B4", categories: "A2:A4", invertIfNegative: true }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:invertIfNegative val="1"');
+    expect(result.chartXml).toContain('c:gapWidth val="50"');
+    expect(result.chartXml).toContain('c:overlap val="-10"');
+  });
+
+  it("survives a parseChart round-trip with invertIfNegative preserved", async () => {
+    // writeChart → parseChart pulls the flag straight back. Confirms the
+    // reader and writer agree on the element and that the value is
+    // surfaced on the resulting ChartSeriesInfo.
+    const written = writeChart(
+      makeChart({
+        type: "column",
+        series: [
+          { name: "Inverted", values: "B2:B4", invertIfNegative: true },
+          { name: "Default", values: "C2:C4" },
+        ],
+      }),
+      "Sheet1",
+    );
+    const parsed = parseChart(written.chartXml);
+    expect(parsed?.series).toHaveLength(2);
+    expect(parsed?.series?.[0].invertIfNegative).toBe(true);
+    expect(parsed?.series?.[1].invertIfNegative).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -2740,3 +2740,163 @@ describe("readXlsx — chart cell anchor", () => {
     });
   });
 });
+
+// ── parseChart — series invertIfNegative flag ─────────────────────
+
+describe("parseChart — series invertIfNegative flag", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces invertIfNegative=true on a <c:barChart> series with <c:invertIfNegative val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative val="1"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBe(true);
+  });
+
+  it("surfaces invertIfNegative=true on a horizontal bar chart series", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="bar"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative val="1"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBe(true);
+  });
+
+  it("collapses the OOXML default invertIfNegative=false to undefined", () => {
+    // Absence of <c:invertIfNegative> and `<c:invertIfNegative val="0"/>`
+    // round-trip identically through the writer's elision logic, so the
+    // parser collapses both to undefined to keep the read-side shape
+    // minimal.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative val="0"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBeUndefined();
+  });
+
+  it("returns invertIfNegative undefined when <c:invertIfNegative> is absent", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBeUndefined();
+  });
+
+  it('also accepts the "true" / "false" boolean spelling', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative val="true"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBe(true);
+  });
+
+  it("ignores <c:invertIfNegative> on chart families whose schema rejects the element", () => {
+    // The OOXML schema places <c:invertIfNegative> only on CT_BarSer
+    // and CT_Bar3DSer. A line/pie/area/scatter template carrying a
+    // stray invert element should not surface a flag that the writer
+    // would never emit anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative val="1"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:lineChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBeUndefined();
+  });
+
+  it("surfaces invertIfNegative per-series independently across multi-series bar charts", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative val="1"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="1"/>
+        <c:invertIfNegative val="0"/>
+        <c:val><c:numRef><c:f>Sheet1!$C$2:$C$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="2"/>
+        <c:val><c:numRef><c:f>Sheet1!$D$2:$D$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series).toHaveLength(3);
+    expect(chart?.series?.[0].invertIfNegative).toBe(true);
+    expect(chart?.series?.[1].invertIfNegative).toBeUndefined();
+    expect(chart?.series?.[2].invertIfNegative).toBeUndefined();
+  });
+
+  it("returns invertIfNegative undefined when val attribute is missing", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:invertIfNegative/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].invertIfNegative).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-series `<c:invertIfNegative>` flag at the read, write, and clone layers so a template's invert-if-negative state survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:invertIfNegative>` is the OOXML element behind Excel's "Format Data Series → Fill → Invert if negative" toggle on bar / column charts — it tells Excel to paint negative bars in the inverted fill color (white by default) so a series with mixed-sign values reads at a glance. Until now hucre had no way to pin the flag per series, and `parseChart` did not surface it. This bridges another per-series styling gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.series?.[0].invertIfNegative); // true

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [
        { name: "Net P&L", values: "B2:B6", categories: "A2:A6",
          invertIfNegative: true },
        { name: "Baseline", values: "C2:C6", categories: "A2:A6" },
      ],
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [
    { values: "Dashboard!$B$2:$B$13" },                          // inherits flag
    { values: "Dashboard!$C$2:$C$13", invertIfNegative: true },  // replace
    { values: "Dashboard!$D$2:$D$13", invertIfNegative: null },  // drop inherited
  ],
});
```

## Model

```ts
interface ChartSeries {
  /** ...existing fields... */
  invertIfNegative?: boolean;
}

interface ChartSeriesInfo {
  /** ...existing fields... */
  invertIfNegative?: boolean;
}
```

The read-side `ChartSeriesInfo.invertIfNegative` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<c:ser><c:invertIfNegative val=".."/>` only on `bar` / `bar3D` series. The OOXML default `false` collapses to `undefined` so absence and the default round-trip identically; missing `val` attributes drop to `undefined`; line / pie / doughnut / area / scatter templates carrying a stray `<c:invertIfNegative>` do not surface a setting that the writer would never emit anyway.
- **Write** — The writer emits `<c:invertIfNegative val="1"/>` only when the series sets the flag to `true`; `false` and absence both produce no element, matching Excel's reference serialization. The element lands between `<c:spPr>` and `<c:dLbls>` per the CT_BarSer schema (`idx → order → tx? → spPr? → invertIfNegative? → dLbls? → cat? → val?`). Non-bar / non-column families silently drop the field.
- **Clone** — `seriesOverrides[i].invertIfNegative` accepts the standard `undefined` (inherit) / `null` (drop the inherited flag) / `boolean` (replace) grammar that mirrors the smooth and stroke resolvers shipped earlier. The inherited flag is dropped automatically when the resolved clone target is anything other than `bar` or `column`, so a column → line flatten cannot leak the element into a chart kind whose schema rejects it.

## Edge cases

- A bar series with `invertIfNegative: false` round-trips identically to a series that omits the flag entirely — the writer omits `<c:invertIfNegative>` and the reader collapses both shapes to `undefined`.
- A line / pie / doughnut / area / scatter series carrying `invertIfNegative: true` is silently ignored at write time so the OOXML schema is never violated.
- An `<c:invertIfNegative/>` element with no `val` attribute reads as `undefined` rather than fabricate a flag Excel would not emit.
- The element is placed in the spec-required slot (after `<c:spPr>`, before `<c:cat>` / `<c:val>`) so Excel's strict validator accepts the file.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 2851 vitest tests, all passing)
- [x] `pnpm build`
- [x] Reader, writer, and clone tests cover: defaults, true / false / absent, missing `val`, multi-series independence, ignored on non-bar families, OOXML element ordering, and a full `parseChart → cloneChart → writeXlsx → parseChart` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)