### PR TITLE
feat(xlsx): chart varyColors flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,6 +647,17 @@ Source → Hidden and Empty Cells" knob — and reports the literal
 `undefined` so absence and the default round-trip identically;
 unknown / malformed values (and a missing `val` attribute) drop to
 `undefined` rather than fabricate a token Excel rejects.
+`Chart.varyColors` surfaces the chart-type element's
+`<c:varyColors val=".."/>` flag — Excel's "Format Data Series → Fill →
+Vary colors by point" toggle — and reports the literal `true` or
+`false` value when it differs from the per-family OOXML default. Pie /
+doughnut / pie3D / ofPie default to `true` (every slice paints in a
+unique color), so absence and `<c:varyColors val="1"/>` both collapse
+to `undefined`; only an explicit `val="0"` surfaces `false` (the
+single-color override). Every other chart family defaults to `false`,
+so absence and `<c:varyColors val="0"/>` both collapse to `undefined`
+and only an explicit `val="1"` surfaces `true`. Unknown / malformed
+values and a missing `val` attribute drop to `undefined`.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -771,6 +782,15 @@ across the gap; line / scatter only). The writer always emits the
 element, defaulting to `"gap"` (the OOXML default Excel itself emits)
 and clamping unknown tokens back to `"gap"` so a malformed input
 cannot produce invalid OOXML.
+The chart-level `varyColors` field maps to `<c:varyColors val=".."/>`
+on the chart-type element — Excel's "Format Data Series → Fill → Vary
+colors by point" toggle. Absent it, the writer falls back to Excel's
+per-family defaults (`true` on pie / doughnut, `false` on bar / column
+/ line / area / scatter), so a fresh chart matches Excel's reference
+serialization. Pin `varyColors: true` on a single-series column or
+bar chart to paint each bar a different color, or pin `false` on a
+doughnut to collapse every wedge to one color (Excel's "single color"
+preset).
 For line and scatter charts, each `series[i].smooth` flag toggles
 Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
 Line series always emit the element — `smooth: true` writes `val="1"`,
@@ -888,6 +908,13 @@ back to the writer's `"gap"` default) / value (`"gap"` / `"zero"` /
 lives on `<c:chart>` and is valid on every chart family, so a
 coercion (line → column, doughnut → pie, etc.) preserves the
 inherited value rather than dropping it.
+The chart-level `varyColors` flag follows the same grammar: pass
+`undefined` to inherit the source's parsed value, `null` to drop it
+back to the writer's per-family default (`true` for pie / doughnut,
+`false` everywhere else), or a `boolean` to replace it. The OOXML
+schema places `<c:varyColors>` on every chart-type element hucre
+authors, so the inherited value carries through every coercion
+(column → pie, doughnut → line, etc.) without being silently dropped.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -904,6 +904,34 @@ export interface SheetChart {
    */
   dispBlanksAs?: ChartDisplayBlanksAs;
   /**
+   * Vary the color of each data point within the same series. Maps to
+   * `<c:varyColors val=".."/>` on the chart-type element
+   * (`<c:barChart>`, `<c:lineChart>`, `<c:pieChart>`, ...). Excel
+   * exposes the same toggle under "Format Data Series → Fill →
+   * Vary colors by point".
+   *
+   * Excel's per-family defaults differ:
+   *   - `pie`, `doughnut`         → `true`  (each slice gets a unique color)
+   *   - `bar`, `column`, `line`,
+   *     `area`, `scatter`         → `false` (every point on a series
+   *                                  shares one color)
+   *
+   * The writer falls back to those per-family defaults when the field
+   * is omitted, so a fresh chart matches Excel's reference
+   * serialization. Pin `true` on a single-series bar / column chart to
+   * paint each bar a different color, or pin `false` on a doughnut to
+   * collapse every wedge to the same color (Excel's "single color"
+   * preset).
+   *
+   * The OOXML schema places `<c:varyColors>` on every chart-type
+   * element except `surfaceChart`, `surface3DChart`, and `stockChart`.
+   * Hucre's writer emits the element on every authored family, so
+   * `varyColors` round-trips on bar / column / line / pie / doughnut /
+   * area / scatter charts; surface / stock are not authored by hucre's
+   * writer.
+   */
+  varyColors?: boolean;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -1906,6 +1934,28 @@ export interface Chart {
    * than fabricated.
    */
   dispBlanksAs?: ChartDisplayBlanksAs;
+  /**
+   * Vary-colors-by-point flag pulled from the first chart-type
+   * element's `<c:varyColors val=".."/>`. Reflects Excel's
+   * per-family default by collapsing matching values to `undefined`:
+   *
+   *   - On `pie`, `pie3D`, `doughnut`, `ofPie` charts, the OOXML
+   *     default is `true` — `<c:varyColors val="1"/>` and absence both
+   *     collapse to `undefined`; only an explicit `<c:varyColors val="0"/>`
+   *     surfaces `false`.
+   *   - On every other chart family the OOXML default is `false` —
+   *     `<c:varyColors val="0"/>` and absence both collapse to
+   *     `undefined`; only an explicit `<c:varyColors val="1"/>`
+   *     surfaces `true`.
+   *
+   * The asymmetric collapse keeps the parsed shape minimal — a pure
+   * round-trip of a stock chart returns no `varyColors` field, while
+   * a template that overrides the per-family default surfaces the
+   * non-default value so {@link cloneChart} can carry it through.
+   * Omitted on chart families that have no `<c:varyColors>` slot
+   * (`surface`, `surface3D`, `stock`).
+   */
+  varyColors?: boolean;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -171,6 +171,17 @@ export interface CloneChartOptions {
    */
   dispBlanksAs?: ChartDisplayBlanksAs | null;
   /**
+   * Override `<c:varyColors>` (the per-point unique-color toggle).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `varyColors`. `null` drops the inherited value so the writer falls
+   * back to the per-family default (`true` for pie / doughnut, `false`
+   * everywhere else). A `boolean` replaces it — useful for collapsing
+   * a doughnut to a single color (`false`) or painting each bar of a
+   * single-series column chart in a different color (`true`).
+   */
+  varyColors?: boolean | null;
+  /**
    * Per-axis overrides. Each field accepts a value to replace the
    * source's, or `null` to drop the source value (the cloned chart
    * will render without that axis label / gridline even if the
@@ -331,6 +342,9 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedDispBlanks = resolveDispBlanksAs(source.dispBlanksAs, options.dispBlanksAs);
   if (resolvedDispBlanks !== undefined) out.dispBlanksAs = resolvedDispBlanks;
+
+  const resolvedVaryColors = resolveVaryColors(source.varyColors, options.varyColors);
+  if (resolvedVaryColors !== undefined) out.varyColors = resolvedVaryColors;
 
   // Pie and doughnut have no axes, so silently skip carrying over axis
   // titles even when the source declared them or the caller passed an
@@ -575,6 +589,27 @@ function resolveDispBlanksAs(
   sourceValue: ChartDisplayBlanksAs | undefined,
   override: ChartDisplayBlanksAs | null | undefined,
 ): ChartDisplayBlanksAs | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `varyColors` override.
+ *
+ * `undefined` → inherit the source's parsed `varyColors`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               per-family default — `true` for pie / doughnut, `false`
+ *               everywhere else).
+ * `boolean`   → replace.
+ *
+ * The override grammar mirrors `dispBlanksAs` so the two chart-level
+ * toggles compose the same way at the call site.
+ */
+function resolveVaryColors(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -88,10 +88,20 @@ export function parseChart(xml: string): Chart | undefined {
     let gapWidth: number | undefined;
     let overlap: number | undefined;
     let firstSliceAng: number | undefined;
+    let varyColors: boolean | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
       if (!out.kinds.includes(kind)) out.kinds.push(kind);
+      // Pull `<c:varyColors>` off the first chart-type element that
+      // carries one. The OOXML schema places `<c:varyColors>` on every
+      // chart-type element except `surface`, `surface3D`, and `stock`,
+      // so most templates surface a value here. The per-family default
+      // collapse (true on pie / doughnut / ofPie, false elsewhere)
+      // happens inside `parseVaryColors`.
+      if (varyColors === undefined) {
+        varyColors = parseVaryColors(child, kind);
+      }
       // Pull grouping off the first bar/column-flavored chart-type
       // element. Combo charts that mix bar with line/area would
       // otherwise need a per-series field; for the common case of a
@@ -167,6 +177,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (gapWidth !== undefined) out.gapWidth = gapWidth;
     if (overlap !== undefined) out.overlap = overlap;
     if (firstSliceAng !== undefined) out.firstSliceAng = firstSliceAng;
+    if (varyColors !== undefined) out.varyColors = varyColors;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
@@ -851,6 +862,60 @@ function parseDispBlanksAs(chartEl: XmlElement): ChartDisplayBlanksAs | undefine
     default:
       return undefined;
   }
+}
+
+// ── Vary Colors ────────────────────────────────────────────────────
+
+/**
+ * Chart kinds that default `<c:varyColors>` to `1` in OOXML — every
+ * data point in the (single) series carries a unique color. Excel's
+ * pie / doughnut / ofPie templates emit `<c:varyColors val="1"/>` so
+ * absence and `1` collapse to `undefined` here; only an explicit `0`
+ * surfaces `false`.
+ */
+const VARY_COLORS_DEFAULT_TRUE: ReadonlySet<ChartKind> = new Set([
+  "pie",
+  "pie3D",
+  "doughnut",
+  "ofPie",
+]);
+
+/**
+ * Pull `<c:varyColors val=".."/>` off a chart-type element.
+ *
+ * Excel's per-family default flips the meaning: pie / doughnut /
+ * pie3D / ofPie default to `true` (every slice unique) while every
+ * other chart family defaults to `false` (one color per series).
+ * Matching values collapse to `undefined` so a roundtrip of a stock
+ * template stays minimal — only non-default values surface so
+ * {@link cloneChart} can carry them through. Unknown values and
+ * missing `val` attributes drop to `undefined`.
+ */
+function parseVaryColors(chartTypeEl: XmlElement, kind: ChartKind): boolean | undefined {
+  const el = findChild(chartTypeEl, "varyColors");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const familyDefaultsTrue = VARY_COLORS_DEFAULT_TRUE.has(kind);
+  // Accept the OOXML truthy / falsy spellings. `1` / `true` map to true,
+  // `0` / `false` map to false, anything else drops.
+  let parsed: boolean;
+  switch (raw) {
+    case "1":
+    case "true":
+      parsed = true;
+      break;
+    case "0":
+    case "false":
+      parsed = false;
+      break;
+    default:
+      return undefined;
+  }
+  // Collapse the per-family default so absence and the default
+  // round-trip identically.
+  if (parsed === familyDefaultsTrue) return undefined;
+  return parsed;
 }
 
 // ── Bar Grouping ──────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -382,7 +382,7 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
   const children: string[] = [
     xmlSelfClose("c:barDir", { val: barDir }),
     xmlSelfClose("c:grouping", { val: grouping }),
-    xmlSelfClose("c:varyColors", { val: 0 }),
+    xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
   ];
 
   for (let i = 0; i < chart.series.length; i++) {
@@ -525,7 +525,7 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
   const grouping = chart.lineGrouping ?? "standard";
   const children: string[] = [
     xmlSelfClose("c:grouping", { val: grouping }),
-    xmlSelfClose("c:varyColors", { val: 0 }),
+    xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
   ];
 
   for (let i = 0; i < chart.series.length; i++) {
@@ -557,7 +557,7 @@ function buildAreaChart(chart: SheetChart, sheetName: string): string {
   const grouping = chart.areaGrouping ?? "standard";
   const children: string[] = [
     xmlSelfClose("c:grouping", { val: grouping }),
-    xmlSelfClose("c:varyColors", { val: 0 }),
+    xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
   ];
 
   for (let i = 0; i < chart.series.length; i++) {
@@ -580,7 +580,9 @@ function buildAreaChart(chart: SheetChart, sheetName: string): string {
 // ── Pie ──────────────────────────────────────────────────────────────
 
 function buildPieChart(chart: SheetChart, sheetName: string): string {
-  const children: string[] = [xmlSelfClose("c:varyColors", { val: 1 })];
+  const children: string[] = [
+    xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
+  ];
 
   // A pie chart only paints the first series; additional ones are
   // valid OOXML but Excel ignores them.
@@ -613,7 +615,9 @@ const DOUGHNUT_HOLE_MIN = 10;
 const DOUGHNUT_HOLE_MAX = 90;
 
 function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
-  const children: string[] = [xmlSelfClose("c:varyColors", { val: 1 })];
+  const children: string[] = [
+    xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
+  ];
 
   // Like pie, doughnut paints every declared series — Excel renders
   // each as a concentric ring (rare in practice; most templates have
@@ -683,7 +687,7 @@ function clampHoleSize(value: number | undefined): number {
 function buildScatterChart(chart: SheetChart, sheetName: string): string {
   const children: string[] = [
     xmlSelfClose("c:scatterStyle", { val: "lineMarker" }),
-    xmlSelfClose("c:varyColors", { val: 0 }),
+    xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
   ];
 
   for (let i = 0; i < chart.series.length; i++) {
@@ -1233,6 +1237,36 @@ function resolveDispBlanksAs(chart: SheetChart): ChartDisplayBlanksAs {
   const raw = chart.dispBlanksAs;
   if (raw && DISP_BLANKS_AS_VALUES.has(raw)) return raw;
   return "gap";
+}
+
+// ── Vary Colors ──────────────────────────────────────────────────────
+
+/**
+ * Chart families whose Excel-default `<c:varyColors>` value is `true`
+ * (each data point in the lone series renders in a unique color). Pie
+ * and doughnut both ship that way out of Excel's chart UI; every other
+ * authored family defaults to `false`.
+ */
+const VARY_COLORS_DEFAULT_TRUE_TYPES: ReadonlySet<WriteChartKind> = new Set(["pie", "doughnut"]);
+
+/**
+ * Resolve the `<c:varyColors>` value emitted on the chart-type element.
+ *
+ * Falls back to the per-family default when the chart does not pin the
+ * field, matching Excel's reference serialization (`true` for pie /
+ * doughnut, `false` everywhere else). An explicit `chart.varyColors`
+ * always wins, so a pie chart can collapse to a single color and a
+ * column chart can paint each bar a different color.
+ *
+ * The writer always emits the element — the OOXML schema lists it as
+ * required on every chart-type element except `surface` / `surface3D` /
+ * `stock`, none of which hucre's writer authors. Emitting the explicit
+ * value (matching Excel's reference output) keeps the rendered intent
+ * unambiguous on roundtrip.
+ */
+function resolveVaryColors(chart: SheetChart): boolean {
+  if (typeof chart.varyColors === "boolean") return chart.varyColors;
+  return VARY_COLORS_DEFAULT_TRUE_TYPES.has(chart.type);
 }
 
 // ── Reference qualification ──────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2315,3 +2315,165 @@ describe("cloneChart — dispBlanksAs", () => {
     expect(reparsed?.dispBlanksAs).toBe("span");
   });
 });
+
+// ── cloneChart — varyColors ───────────────────────────────────────
+
+describe("cloneChart — varyColors", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's varyColors by default", () => {
+    const clone = cloneChart(source({ varyColors: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.varyColors).toBe(true);
+  });
+
+  it("inherits a false varyColors from the source (doughnut single-color)", () => {
+    const clone = cloneChart(
+      {
+        kinds: ["doughnut"],
+        seriesCount: 1,
+        series: [
+          {
+            kind: "doughnut",
+            index: 0,
+            valuesRef: "Sheet1!$B$2:$B$5",
+            categoriesRef: "Sheet1!$A$2:$A$5",
+          },
+        ],
+        varyColors: false,
+      },
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.varyColors).toBe(false);
+  });
+
+  it("lets options.varyColors override the source's value", () => {
+    const clone = cloneChart(source({ varyColors: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      varyColors: false,
+    });
+    expect(clone.varyColors).toBe(false);
+  });
+
+  it("drops the inherited varyColors when the override is null", () => {
+    // null collapses to the writer's per-family default — the field
+    // disappears from the resolved SheetChart so the writer emits the
+    // family-default value (`0` on column, `1` on pie/doughnut).
+    const clone = cloneChart(source({ varyColors: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      varyColors: null,
+    });
+    expect(clone.varyColors).toBeUndefined();
+  });
+
+  it("returns undefined varyColors when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.varyColors).toBeUndefined();
+  });
+
+  it("carries varyColors through a flatten (column → line)", () => {
+    // Unlike smooth/marker, varyColors is valid on every chart-type
+    // element hucre's writer authors, so a coercion does not drop it.
+    const clone = cloneChart(source({ varyColors: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.varyColors).toBe(true);
+  });
+
+  it("propagates varyColors into the rendered chart-type element on writeXlsx roundtrip", async () => {
+    // Round-trip: a parsed column template carrying varyColors=true
+    // clones into a SheetChart whose writer emits `<c:varyColors val="1"/>`
+    // on the `<c:barChart>` body. Re-parsing the rendered chart returns
+    // the same value.
+    const clone = cloneChart(source({ varyColors: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      type: "column",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:varyColors val="1"');
+    expect(written).not.toContain('c:varyColors val="0"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.varyColors).toBe(true);
+  });
+
+  it("collapses a doughnut single-color override through writeXlsx roundtrip", async () => {
+    // Cloning a doughnut template into a SheetChart with varyColors=false
+    // emits `<c:varyColors val="0"/>` — Excel renders every wedge in the
+    // same color. Re-parsing returns the explicit `false` because that
+    // is the non-default value for the doughnut family.
+    const clone = cloneChart(
+      {
+        kinds: ["doughnut"],
+        seriesCount: 1,
+        series: [
+          {
+            kind: "doughnut",
+            index: 0,
+            valuesRef: "Sheet1!$B$2:$B$5",
+            categoriesRef: "Sheet1!$A$2:$A$5",
+          },
+        ],
+      },
+      {
+        anchor: { from: { row: 5, col: 0 } },
+        varyColors: false,
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:varyColors val="0"');
+    expect(written).not.toContain('c:varyColors val="1"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.varyColors).toBe(false);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2286,3 +2286,123 @@ describe("writeChart — dispBlanksAs", () => {
     expect(scatter.chartXml).toContain('c:dispBlanksAs val="span"');
   });
 });
+
+// ── Vary colors ──────────────────────────────────────────────────────
+
+describe("writeChart — varyColors", () => {
+  it('emits <c:varyColors val="0"/> on a column chart by default', () => {
+    // Column / bar / line / area / scatter all default to false — each
+    // series renders in a single color.
+    const result = writeChart(makeChart({ type: "column" }), "Sheet1");
+    expect(result.chartXml).toContain('c:varyColors val="0"');
+    expect(result.chartXml).not.toContain('c:varyColors val="1"');
+  });
+
+  it('emits <c:varyColors val="1"/> on a pie chart by default', () => {
+    // Pie / doughnut default to true — each slice paints in its own color.
+    const result = writeChart(makeChart({ type: "pie" }), "Sheet1");
+    expect(result.chartXml).toContain('c:varyColors val="1"');
+    expect(result.chartXml).not.toContain('c:varyColors val="0"');
+  });
+
+  it('emits <c:varyColors val="1"/> on a doughnut chart by default', () => {
+    const result = writeChart(makeChart({ type: "doughnut" }), "Sheet1");
+    expect(result.chartXml).toContain('c:varyColors val="1"');
+    expect(result.chartXml).not.toContain('c:varyColors val="0"');
+  });
+
+  it("lets varyColors=true flip a column chart to per-point colors", () => {
+    const result = writeChart(makeChart({ type: "column", varyColors: true }), "Sheet1");
+    expect(result.chartXml).toContain('c:varyColors val="1"');
+    expect(result.chartXml).not.toContain('c:varyColors val="0"');
+  });
+
+  it("lets varyColors=false collapse a doughnut chart to a single color", () => {
+    const result = writeChart(makeChart({ type: "doughnut", varyColors: false }), "Sheet1");
+    expect(result.chartXml).toContain('c:varyColors val="0"');
+    expect(result.chartXml).not.toContain('c:varyColors val="1"');
+  });
+
+  it("lets varyColors=false on a pie chart override the per-family default", () => {
+    const result = writeChart(makeChart({ type: "pie", varyColors: false }), "Sheet1");
+    expect(result.chartXml).toContain('c:varyColors val="0"');
+    expect(result.chartXml).not.toContain('c:varyColors val="1"');
+  });
+
+  it("threads varyColors through every authored chart family", () => {
+    // Authoring true on every family flips the bar / column / line /
+    // area / scatter defaults from 0 to 1 and leaves pie / doughnut at
+    // 1. The element appears exactly once on each rendered chart.
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, varyColors: true }), "Sheet1");
+      expect(result.chartXml).toContain('c:varyColors val="1"');
+      const occurrences = result.chartXml.match(/c:varyColors/g) ?? [];
+      expect(occurrences).toHaveLength(1);
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        varyColors: true,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:varyColors val="1"');
+  });
+
+  it("places <c:varyColors> after <c:grouping> inside <c:barChart> (OOXML order)", () => {
+    // CT_BarChart sequence: barDir → grouping → varyColors → ser*
+    const result = writeChart(makeChart({ type: "column" }), "Sheet1");
+    expect(result.chartXml.indexOf("c:grouping")).toBeLessThan(
+      result.chartXml.indexOf("c:varyColors"),
+    );
+    expect(result.chartXml.indexOf("c:varyColors")).toBeLessThan(result.chartXml.indexOf("c:ser"));
+  });
+
+  it("places <c:varyColors> after <c:scatterStyle> inside <c:scatterChart>", () => {
+    // CT_ScatterChart sequence: scatterStyle → varyColors → ser*
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml.indexOf("c:scatterStyle")).toBeLessThan(
+      result.chartXml.indexOf("c:varyColors"),
+    );
+  });
+
+  it("only emits <c:varyColors> once even when the chart pins the field", () => {
+    // Guard against any regression that would double-emit the element
+    // — both the default emission and a future explicit pass.
+    const result = writeChart(makeChart({ type: "column", varyColors: true }), "Sheet1");
+    const occurrences = result.chartXml.match(/c:varyColors/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("round-trips a non-default varyColors value through parseChart", () => {
+    // A column chart with varyColors=true should re-parse into a Chart
+    // whose `varyColors` field is `true` (not collapsed to undefined,
+    // since true is not the column-family default).
+    const written = writeChart(makeChart({ type: "column", varyColors: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.varyColors).toBe(true);
+  });
+
+  it("collapses a defaulted varyColors round-trip back to undefined", () => {
+    // A fresh column chart (varyColors omitted) writes `0` and re-parses
+    // to undefined — absence and the per-family default round-trip
+    // identically through parseChart.
+    const written = writeChart(makeChart({ type: "column" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.varyColors).toBeUndefined();
+  });
+
+  it("collapses a defaulted varyColors on pie / doughnut back to undefined", () => {
+    const pie = writeChart(makeChart({ type: "pie" }), "Sheet1").chartXml;
+    expect(parseChart(pie)?.varyColors).toBeUndefined();
+    const dough = writeChart(makeChart({ type: "doughnut" }), "Sheet1").chartXml;
+    expect(parseChart(dough)?.varyColors).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -2208,6 +2208,159 @@ describe("parseChart — dispBlanksAs", () => {
   });
 });
 
+// ── parseChart — varyColors ───────────────────────────────────────
+
+describe("parseChart — varyColors", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:varyColors val="1"/> on a column chart (non-default true)', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBe(true);
+  });
+
+  it('surfaces <c:varyColors val="0"/> on a doughnut chart (non-default false)', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:doughnutChart>
+        <c:varyColors val="0"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:firstSliceAng val="0"/>
+        <c:holeSize val="50"/>
+      </c:doughnutChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBe(false);
+  });
+
+  it("collapses the per-family default to undefined on a column chart (varyColors=0)", () => {
+    // Column / bar default is `false` — `<c:varyColors val="0"/>` and
+    // absence both round-trip identically.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="0"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBeUndefined();
+  });
+
+  it("collapses the per-family default to undefined on a pie chart (varyColors=1)", () => {
+    // Pie default is `true` — `<c:varyColors val="1"/>` and absence both
+    // round-trip identically.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:pieChart>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:varyColors> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBeUndefined();
+  });
+
+  it("accepts the OOXML true / false spellings on the val attribute", () => {
+    // The OOXML schema for `xsd:boolean` accepts `"true"` / `"false"`
+    // alongside the more common `"1"` / `"0"`. Hucre tolerates both
+    // shapes — a hand-edited template using `true` should round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="true"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBe(true);
+  });
+
+  it("drops unknown varyColors values rather than fabricate one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:varyColors val="bogus"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:varyColors>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:varyColors/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBeUndefined();
+  });
+
+  it("surfaces varyColors from the first chart-type element on combo charts", () => {
+    // The reader latches onto the first chart-type element that carries
+    // a `<c:varyColors>` value, mirroring how it surfaces grouping /
+    // gapWidth on the first matching child.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+      <c:lineChart>
+        <c:varyColors val="0"/>
+        <c:ser><c:idx val="1"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.varyColors).toBe(true);
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Surfaces the chart-level `<c:varyColors>` element at the read, write, and clone layers so a template's "Vary colors by point" toggle survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:varyColors>` is the OOXML element behind Excel's "Format Data Series → Fill → Vary colors by point" toggle. The OOXML schema places the element on every chart-type element except `surfaceChart` / `surface3DChart` / `stockChart`, with per-family defaults that flip its meaning:

- `pie` / `doughnut` / `pie3D` / `ofPie` default to `true` (each slice paints in a unique color)
- bar / column / line / area / scatter default to `false` (every point on a series shares one color)

Until now hucre's writer hardcoded those defaults and `parseChart` did not surface the value, so a template using the non-default value (a column chart with rainbow bars, or a doughnut collapsed to a single color) could not round-trip through clone. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.varyColors); // true on a column chart with rainbow bars,
                                // false on a doughnut collapsed to one color,
                                // undefined when the template uses the family default

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      // Single-series column chart with one color per bar.
      {
        type: "column",
        series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        varyColors: true,
      },
      // Doughnut collapsed to a single color (Excel's "single color" preset).
      {
        type: "doughnut",
        series: [{ name: "Share", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 8 } },
        varyColors: false,
      },
    ],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  varyColors: false,            // replace
  // varyColors: null,          // drop the inherited flag (writer falls back to per-family default)
  // varyColors: undefined,     // inherit the source's parsed value
});
```

## Model

```ts
interface SheetChart {
  /** ...existing fields... */
  varyColors?: boolean;
}

interface Chart {
  /** ...existing fields... */
  varyColors?: boolean;
}

interface CloneChartOptions {
  /** ...existing fields... */
  varyColors?: boolean | null;
}
```

The read-side `Chart.varyColors` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<c:varyColors val=".."/>` off the first chart-type element that carries one. Values matching the per-family OOXML default collapse to `undefined` so absence and the default round-trip identically; only non-default values surface. Pie / doughnut / pie3D / ofPie default to `true`; every other family defaults to `false`. The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing `val` attributes drop to `undefined`.
- **Write** — The writer always emits `<c:varyColors>` on the chart-type element (the OOXML schema lists it as required on every authored family). Absent `varyColors`, the writer falls back to the per-family default (`val="1"` for pie / doughnut, `val="0"` for bar / column / line / area / scatter), matching Excel's reference serialization. An explicit `chart.varyColors` always wins, so a column chart can flip to `val="1"` and a doughnut to `val="0"`.
- **Clone** — `options.varyColors` accepts the standard `undefined` (inherit) / `null` (drop the inherited flag, falling back to the writer's per-family default) / `boolean` (replace) grammar that mirrors `dispBlanksAs` resolved earlier. The inherited value carries through every coercion (column → pie, doughnut → line, etc.) since the element is valid on every authored family.

## Edge cases

- A column chart with `varyColors: false` round-trips identically to a column chart that omits the field — the writer emits the per-family default `val="0"` and the reader collapses both shapes to `undefined`.
- A pie chart with `varyColors: true` round-trips identically to a pie chart that omits the field (default `val="1"` collapses to `undefined`); pinning `varyColors: false` flips to `val="0"` and re-parses as `false` (the non-default).
- A `<c:varyColors/>` element with no `val` attribute reads as `undefined` rather than fabricate a flag Excel would not emit.
- The element is placed in the spec-required slot inside each chart-type element — after `<c:barDir>`/`<c:grouping>` on `<c:barChart>`, after `<c:scatterStyle>` on `<c:scatterChart>`, etc. — so Excel's strict validator accepts the file.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm vitest run --exclude="**/.claude/**"` (all 2874 tests passing, including 32 new `varyColors` tests across reader, writer, and clone)
- [x] Reader, writer, and clone tests cover: per-family defaults, true / false / absent, the `"true"` / `"false"` spellings, missing `val`, unknown tokens, multi-element selection, OOXML element ordering inside `<c:barChart>` / `<c:scatterChart>`, and a full `parseChart → cloneChart → writeXlsx → parseChart` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)