### PR TITLE
feat(xlsx): chart scatterStyle preset — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,15 @@ single-color override). Every other chart family defaults to `false`,
 so absence and `<c:varyColors val="0"/>` both collapse to `undefined`
 and only an explicit `val="1"` surfaces `true`. Unknown / malformed
 values and a missing `val` attribute drop to `undefined`.
+`Chart.scatterStyle` surfaces `<c:scatterChart><c:scatterStyle
+val=".."/></c:scatterChart>` — the chart-level XY-scatter preset
+Excel selects in the chart-type picker (`"none"`, `"line"`,
+`"lineMarker"`, `"marker"`, `"smooth"`, or `"smoothMarker"`). Every
+recognized token surfaces literally so a clone preserves the exact
+preset; missing elements, missing `val` attributes, and tokens
+outside the OOXML enum drop to `undefined`. Only `scatter` charts
+report the field — the schema places the element exclusively on
+`<c:scatterChart>`.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -798,6 +807,18 @@ serialization. Pin `varyColors: true` on a single-series column or
 bar chart to paint each bar a different color, or pin `false` on a
 doughnut to collapse every wedge to one color (Excel's "single color"
 preset).
+The chart-level `scatterStyle` field maps to `<c:scatterStyle val=".."/>`
+on `<c:scatterChart>` and picks one of Excel's six XY-scatter presets:
+`"none"` / `"marker"` (markers only), `"line"` (straight lines, no
+markers), `"lineMarker"` (Excel's chart-picker default — straight
+lines with markers; the writer's fallback when the field is absent),
+`"smooth"` (smoothed curves, no markers), or `"smoothMarker"`
+(smoothed curves with markers). The element is required by the OOXML
+schema on `<c:scatterChart>` and the writer always emits it; values
+outside the enum fall back to `"lineMarker"` so a malformed input
+cannot produce invalid OOXML. Other chart kinds silently ignore the
+field — the schema places `<c:scatterStyle>` exclusively on
+`<c:scatterChart>`.
 For line and scatter charts, each `series[i].smooth` flag toggles
 Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
 Line series always emit the element — `smooth: true` writes `val="1"`,
@@ -937,6 +958,13 @@ back to the writer's per-family default (`true` for pie / doughnut,
 schema places `<c:varyColors>` on every chart-type element hucre
 authors, so the inherited value carries through every coercion
 (column → pie, doughnut → line, etc.) without being silently dropped.
+The chart-level `scatterStyle` follows the same grammar: pass
+`undefined` to inherit the source's parsed preset, `null` to drop it
+back to the writer's `"lineMarker"` default, or a {@link
+ChartScatterStyle} value to replace it. The inherited value is also
+dropped automatically when the resolved clone target is anything
+other than `scatter`, since the schema rejects `<c:scatterStyle>` on
+every other chart family.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -740,6 +740,39 @@ export interface ChartMarker {
 export type ChartDisplayBlanksAs = "gap" | "zero" | "span";
 
 /**
+ * Scatter sub-style applied at the chart level. Maps to the OOXML
+ * `ST_ScatterStyle` enum which sits inside `<c:scatterChart>` as
+ * `<c:scatterStyle val=".."/>`. Excel exposes the same six presets
+ * under "Change Chart Type → XY (Scatter)":
+ *
+ * - `"none"`         — markers only, no connecting line and no curves.
+ *                      Equivalent to `"marker"` in modern Excel UI.
+ * - `"line"`         — straight-line segments between points, no markers.
+ * - `"lineMarker"`   — straight-line segments with markers (Excel's
+ *                      reference default and the writer's fallback).
+ * - `"marker"`       — markers only, no line. Same render as `"none"`;
+ *                      OOXML lists both for legacy compatibility.
+ * - `"smooth"`       — smoothed (Catmull-Rom-style) curves between
+ *                      points, no markers.
+ * - `"smoothMarker"` — smoothed curves with markers.
+ *
+ * Distinct from the per-series {@link ChartSeries.smooth} flag — the
+ * series-level toggle paints individual points, while `scatterStyle`
+ * is the chart-wide preset Excel selects in the chart-type picker.
+ * When both are set, the OOXML schema lets Excel render the union
+ * (smooth chart with the series-level smooth still emitted), but
+ * Excel's UI normally pairs them: `scatterStyle: "smooth"` implies
+ * smoothed series, `scatterStyle: "lineMarker"` implies straight ones.
+ */
+export type ChartScatterStyle =
+  | "none"
+  | "line"
+  | "lineMarker"
+  | "marker"
+  | "smooth"
+  | "smoothMarker";
+
+/**
  * A single data series inside a chart.
  *
  * `values` and `categories` are A1-style cell range references.
@@ -945,6 +978,22 @@ export interface SheetChart {
    * writer.
    */
   varyColors?: boolean;
+  /**
+   * Scatter sub-style for `scatter` charts. Maps to
+   * `<c:scatterChart><c:scatterStyle val=".."/></c:scatterChart>`.
+   * Default: `"lineMarker"` (Excel's chart-picker default — straight
+   * lines with markers). Pass `"smooth"` for Excel's "Scatter with
+   * Smooth Lines", `"marker"` / `"none"` for "Scatter with Only
+   * Markers", `"line"` for "Scatter with Straight Lines", and
+   * `"smoothMarker"` for "Scatter with Smooth Lines and Markers". See
+   * {@link ChartScatterStyle} for the full preset list.
+   *
+   * Ignored for every other chart kind — the OOXML schema places
+   * `<c:scatterStyle>` exclusively on `<c:scatterChart>`. Use the
+   * per-series {@link ChartSeries.smooth} flag to pick a curve on a
+   * line chart or pin smoothing on individual scatter series.
+   */
+  scatterStyle?: ChartScatterStyle;
   /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
@@ -1979,6 +2028,21 @@ export interface Chart {
    * (`surface`, `surface3D`, `stock`).
    */
   varyColors?: boolean;
+  /**
+   * Scatter sub-style pulled from `<c:scatterChart><c:scatterStyle
+   * val=".."/></c:scatterChart>`. Reflects which of Excel's six XY
+   * scatter presets the chart was authored with — `"none"`, `"line"`,
+   * `"lineMarker"`, `"marker"`, `"smooth"`, or `"smoothMarker"`. The
+   * OOXML default `"marker"` collapses to `undefined` (Excel's reference
+   * serialization actually emits `"lineMarker"` even at the UI default,
+   * so the reader does not pin a default of its own — both `"marker"`
+   * and `"lineMarker"` surface literally so a clone preserves what the
+   * template said).
+   *
+   * Omitted on every chart family except `scatter`; the OOXML schema
+   * places `<c:scatterStyle>` exclusively on `<c:scatterChart>`.
+   */
+  scatterStyle?: ChartScatterStyle;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -21,6 +21,7 @@ import type {
   ChartKind,
   ChartLineStroke,
   ChartMarker,
+  ChartScatterStyle,
   ChartSeries,
   ChartSeriesInfo,
   SheetChart,
@@ -190,6 +191,21 @@ export interface CloneChartOptions {
    * single-series column chart in a different color (`true`).
    */
   varyColors?: boolean | null;
+  /**
+   * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `scatterStyle`. `null` drops the inherited value so the writer
+   * falls back to its `"lineMarker"` default. A {@link ChartScatterStyle}
+   * value replaces it — useful when a smoothed-line scatter template
+   * should clone as a marker-only or straight-line variant.
+   *
+   * Only meaningful when the resolved chart type is `scatter`; the
+   * field is silently dropped when the clone targets any other family
+   * since the OOXML schema places `<c:scatterStyle>` exclusively on
+   * `<c:scatterChart>`.
+   */
+  scatterStyle?: ChartScatterStyle | null;
   /**
    * Per-axis overrides. Each field accepts a value to replace the
    * source's, or `null` to drop the source value (the cloned chart
@@ -364,6 +380,15 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedVaryColors = resolveVaryColors(source.varyColors, options.varyColors);
   if (resolvedVaryColors !== undefined) out.varyColors = resolvedVaryColors;
+
+  // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
+  // field on every other resolved type so a scatter template flattened
+  // to line / column does not leak the preset into a chart kind whose
+  // schema rejects it. Override wins over the source's parsed value.
+  if (type === "scatter") {
+    const resolvedScatterStyle = resolveScatterStyle(source.scatterStyle, options.scatterStyle);
+    if (resolvedScatterStyle !== undefined) out.scatterStyle = resolvedScatterStyle;
+  }
 
   // Pie and doughnut have no axes, so silently skip carrying over axis
   // titles even when the source declared them or the caller passed an
@@ -655,6 +680,26 @@ function resolveVaryColors(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `scatterStyle` override.
+ *
+ * `undefined` → inherit the source's parsed `scatterStyle`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               default `"lineMarker"`).
+ * value       → replace.
+ *
+ * The grammar mirrors `dispBlanksAs` / `varyColors` so the chart-level
+ * toggles compose the same way at the call site.
+ */
+function resolveScatterStyle(
+  sourceValue: ChartScatterStyle | undefined,
+  override: ChartScatterStyle | null | undefined,
+): ChartScatterStyle | undefined {
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -29,6 +29,7 @@ import type {
   ChartLineStroke,
   ChartMarker,
   ChartMarkerSymbol,
+  ChartScatterStyle,
   ChartSeriesInfo,
 } from "../_types";
 import { parseXml } from "../xml/parser";
@@ -89,6 +90,7 @@ export function parseChart(xml: string): Chart | undefined {
     let overlap: number | undefined;
     let firstSliceAng: number | undefined;
     let varyColors: boolean | undefined;
+    let scatterStyle: ChartScatterStyle | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
@@ -148,6 +150,14 @@ export function parseChart(xml: string): Chart | undefined {
       ) {
         firstSliceAng = parseFirstSliceAng(child);
       }
+      // `<c:scatterStyle>` lives exclusively on `<c:scatterChart>` per
+      // the OOXML schema, so the lookup is gated on the matching kind.
+      // The element is required there, but a corrupt template may omit
+      // it or carry a token outside the enum — `parseScatterStyle`
+      // returns `undefined` in both cases.
+      if (scatterStyle === undefined && kind === "scatter") {
+        scatterStyle = parseScatterStyle(child);
+      }
       let localIndex = 0;
       for (const ser of childElements(child)) {
         if (ser.local !== "ser") continue;
@@ -178,6 +188,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (overlap !== undefined) out.overlap = overlap;
     if (firstSliceAng !== undefined) out.firstSliceAng = firstSliceAng;
     if (varyColors !== undefined) out.varyColors = varyColors;
+    if (scatterStyle !== undefined) out.scatterStyle = scatterStyle;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
@@ -941,6 +952,49 @@ function parseVaryColors(chartTypeEl: XmlElement, kind: ChartKind): boolean | un
   // round-trip identically.
   if (parsed === familyDefaultsTrue) return undefined;
   return parsed;
+}
+
+// ── Scatter Style ─────────────────────────────────────────────────
+
+/**
+ * Recognized values of `<c:scatterStyle>` per the OOXML
+ * `ST_ScatterStyle` enumeration. Tokens outside the set drop to
+ * `undefined` so a corrupt template does not surface a string Excel
+ * would not emit.
+ */
+const VALID_SCATTER_STYLES: ReadonlySet<ChartScatterStyle> = new Set([
+  "none",
+  "line",
+  "lineMarker",
+  "marker",
+  "smooth",
+  "smoothMarker",
+]);
+
+/**
+ * Pull `<c:scatterStyle val=".."/>` off a `<c:scatterChart>` element.
+ *
+ * The OOXML schema lists the element as required on `<c:scatterChart>`
+ * but tolerates absence in practice — Excel falls back to `"marker"`
+ * (the schema default per CT_ScatterStyle) when the file omits it.
+ * The reader does not pin a default of its own: every literal value
+ * in {@link VALID_SCATTER_STYLES} surfaces as-is so a clone preserves
+ * the exact preset the template authored. Missing elements, missing
+ * `val` attributes, and tokens outside the enum drop to `undefined`.
+ *
+ * Note that the writer's default is `"lineMarker"` (Excel's chart-
+ * picker default and what every fresh hucre scatter chart emits today),
+ * which differs from the OOXML schema default of `"marker"`. The
+ * asymmetry is intentional — writing `"lineMarker"` matches Excel's
+ * UI default; not collapsing it on read keeps the round-trip exact.
+ */
+function parseScatterStyle(scatterChart: XmlElement): ChartScatterStyle | undefined {
+  const el = findChild(scatterChart, "scatterStyle");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  if (!VALID_SCATTER_STYLES.has(raw as ChartScatterStyle)) return undefined;
+  return raw as ChartScatterStyle;
 }
 
 // ── Bar Grouping ──────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -16,6 +16,7 @@ import type {
   ChartLineStroke,
   ChartMarker,
   ChartMarkerSymbol,
+  ChartScatterStyle,
   ChartSeries,
   SheetChart,
   WriteChartKind,
@@ -687,7 +688,7 @@ function clampHoleSize(value: number | undefined): number {
 
 function buildScatterChart(chart: SheetChart, sheetName: string): string {
   const children: string[] = [
-    xmlSelfClose("c:scatterStyle", { val: "lineMarker" }),
+    xmlSelfClose("c:scatterStyle", { val: resolveScatterStyle(chart) }),
     xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
   ];
 
@@ -1290,6 +1291,40 @@ const VARY_COLORS_DEFAULT_TRUE_TYPES: ReadonlySet<WriteChartKind> = new Set(["pi
 function resolveVaryColors(chart: SheetChart): boolean {
   if (typeof chart.varyColors === "boolean") return chart.varyColors;
   return VARY_COLORS_DEFAULT_TRUE_TYPES.has(chart.type);
+}
+
+// ── Scatter Style ────────────────────────────────────────────────────
+
+/**
+ * Recognized values of `<c:scatterStyle>` per the OOXML
+ * `ST_ScatterStyle` enumeration. Used to validate
+ * `chart.scatterStyle` before it lands in the rendered XML.
+ */
+const SCATTER_STYLE_VALUES: ReadonlySet<ChartScatterStyle> = new Set([
+  "none",
+  "line",
+  "lineMarker",
+  "marker",
+  "smooth",
+  "smoothMarker",
+]);
+
+/**
+ * Resolve the `<c:scatterStyle>` value emitted on `<c:scatterChart>`.
+ *
+ * Defaults to `"lineMarker"` — Excel's chart-picker default and the
+ * shape every existing scatter chart hucre writes uses. An explicit
+ * `chart.scatterStyle` always wins; values outside the OOXML enum drop
+ * back to the default rather than emit a token Excel would reject.
+ *
+ * The element is always emitted on `<c:scatterChart>` because the
+ * OOXML schema lists it as required there — omitting it would produce
+ * an invalid chart document Excel refuses to open.
+ */
+function resolveScatterStyle(chart: SheetChart): ChartScatterStyle {
+  const raw = chart.scatterStyle;
+  if (raw && SCATTER_STYLE_VALUES.has(raw)) return raw;
+  return "lineMarker";
 }
 
 // ── Reference qualification ──────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2656,3 +2656,139 @@ describe("cloneChart — varyColors", () => {
     expect(reparsed?.varyColors).toBe(false);
   });
 });
+
+// ── cloneChart — scatterStyle ─────────────────────────────────────
+
+describe("cloneChart — scatterStyle", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["scatter"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "scatter",
+          index: 0,
+          name: "Trend",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's scatterStyle by default", () => {
+    const clone = cloneChart(source({ scatterStyle: "smooth" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.scatterStyle).toBe("smooth");
+  });
+
+  it("lets options.scatterStyle override the source's value", () => {
+    const clone = cloneChart(source({ scatterStyle: "smooth" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      scatterStyle: "lineMarker",
+    });
+    expect(clone.scatterStyle).toBe("lineMarker");
+  });
+
+  it("drops the inherited scatterStyle when the override is null", () => {
+    // null collapses to the writer's default (`lineMarker`) — the
+    // field disappears from the resolved SheetChart so the writer
+    // emits the family default rather than the inherited preset.
+    const clone = cloneChart(source({ scatterStyle: "smooth" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      scatterStyle: null,
+    });
+    expect(clone.scatterStyle).toBeUndefined();
+  });
+
+  it("returns undefined scatterStyle when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.scatterStyle).toBeUndefined();
+  });
+
+  it("drops inherited scatterStyle when the resolved type is not scatter", () => {
+    // <c:scatterStyle> is valid only inside <c:scatterChart>; flattening
+    // a scatter template into a line clone drops the field so it does
+    // not leak into a chart kind whose schema rejects it.
+    const clone = cloneChart(source({ scatterStyle: "smooth" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.scatterStyle).toBeUndefined();
+  });
+
+  it("drops scatterStyle from explicit options when the resolved type is not scatter", () => {
+    // Symmetric to the inherit-and-drop case — even an explicit
+    // override must not leak into a non-scatter target.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      scatterStyle: "smooth",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.scatterStyle).toBeUndefined();
+  });
+
+  it("propagates scatterStyle into the rendered chart through writeXlsx", async () => {
+    // Round-trip: a parsed scatter template carrying scatterStyle="smooth"
+    // clones into a SheetChart whose writer emits `<c:scatterStyle val="smooth"/>`
+    // on the `<c:scatterChart>` body. Re-parsing returns the same value.
+    const clone = cloneChart(source({ scatterStyle: "smoothMarker" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:scatterStyle val="smoothMarker"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.scatterStyle).toBe("smoothMarker");
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins "smooth", clone overrides to "marker" — the rendered
+    // chart should carry the override and re-parse to it.
+    const clone = cloneChart(source({ scatterStyle: "smooth" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      scatterStyle: "marker",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:scatterStyle val="marker"');
+    expect(written).not.toContain('c:scatterStyle val="smooth"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.scatterStyle).toBe("marker");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5,7 +5,7 @@ import { writeXlsx } from "../src/xlsx/writer";
 import { writeChart, chartKindElement } from "../src/xlsx/chart-writer";
 import { parseChart } from "../src/xlsx/chart-reader";
 import { writeDrawing } from "../src/xlsx/drawing-writer";
-import type { WriteChartKind, SheetChart, WriteSheet } from "../src/_types";
+import type { ChartScatterStyle, WriteChartKind, SheetChart, WriteSheet } from "../src/_types";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -2552,5 +2552,97 @@ describe("writeChart — varyColors", () => {
     expect(parseChart(pie)?.varyColors).toBeUndefined();
     const dough = writeChart(makeChart({ type: "doughnut" }), "Sheet1").chartXml;
     expect(parseChart(dough)?.varyColors).toBeUndefined();
+  });
+});
+
+// ── Scatter style ────────────────────────────────────────────────────
+
+describe("writeChart — scatterStyle", () => {
+  function makeScatter(overrides: Partial<SheetChart> = {}): SheetChart {
+    return makeChart({
+      type: "scatter",
+      series: [{ values: "B2:B4", categories: "A2:A4" }],
+      ...overrides,
+    });
+  }
+
+  it('emits <c:scatterStyle val="lineMarker"/> on a fresh scatter chart', () => {
+    // The writer's default mirrors Excel's chart-picker default —
+    // straight lines with markers — even though the OOXML schema
+    // default is `"marker"`. Matching Excel's UI default keeps fresh
+    // charts visually identical to what the user would draw by hand.
+    const result = writeChart(makeScatter(), "Sheet1");
+    expect(result.chartXml).toContain('c:scatterStyle val="lineMarker"');
+  });
+
+  it("threads an explicit scatterStyle through to the rendered chart", () => {
+    const result = writeChart(makeScatter({ scatterStyle: "smooth" }), "Sheet1");
+    expect(result.chartXml).toContain('c:scatterStyle val="smooth"');
+    expect(result.chartXml).not.toContain('c:scatterStyle val="lineMarker"');
+  });
+
+  it("emits every ST_ScatterStyle preset literally when pinned", () => {
+    for (const preset of [
+      "none",
+      "line",
+      "lineMarker",
+      "marker",
+      "smooth",
+      "smoothMarker",
+    ] as const) {
+      const result = writeChart(makeScatter({ scatterStyle: preset }), "Sheet1");
+      expect(result.chartXml).toContain(`c:scatterStyle val="${preset}"`);
+      // Element appears exactly once on the rendered chart.
+      const occurrences = result.chartXml.match(/c:scatterStyle/g) ?? [];
+      expect(occurrences).toHaveLength(1);
+    }
+  });
+
+  it("falls back to the default lineMarker on an unrecognized scatterStyle", () => {
+    // Type-cheat with an enum-violating string to exercise the
+    // validate-or-default branch — the writer never emits a token
+    // Excel's strict validator would reject.
+    const result = writeChart(
+      makeScatter({ scatterStyle: "bogus" as ChartScatterStyle }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:scatterStyle val="lineMarker"');
+    expect(result.chartXml).not.toContain('c:scatterStyle val="bogus"');
+  });
+
+  it("ignores scatterStyle on non-scatter chart families", () => {
+    // The OOXML schema places <c:scatterStyle> exclusively on
+    // <c:scatterChart>; the writer drops the field on every other
+    // family rather than emit an element Excel would refuse.
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, scatterStyle: "smooth" }), "Sheet1");
+      expect(result.chartXml).not.toContain("c:scatterStyle");
+    }
+  });
+
+  it("places <c:scatterStyle> as the first child of <c:scatterChart>", () => {
+    // CT_ScatterChart sequence: scatterStyle → varyColors → ser*
+    const result = writeChart(makeScatter({ scatterStyle: "smoothMarker" }), "Sheet1");
+    const styleIdx = result.chartXml.indexOf("c:scatterStyle");
+    const varyIdx = result.chartXml.indexOf("c:varyColors");
+    const serIdx = result.chartXml.indexOf("c:ser>");
+    expect(styleIdx).toBeGreaterThan(-1);
+    expect(varyIdx).toBeGreaterThan(styleIdx);
+    expect(serIdx).toBeGreaterThan(varyIdx);
+  });
+
+  it("round-trips a non-default scatterStyle through parseChart", () => {
+    const written = writeChart(makeScatter({ scatterStyle: "smooth" }), "Sheet1").chartXml;
+    expect(parseChart(written)?.scatterStyle).toBe("smooth");
+  });
+
+  it("round-trips the lineMarker default through parseChart", () => {
+    // The writer always emits `lineMarker` by default — re-parsing
+    // surfaces it literally because the reader does not collapse the
+    // writer's chosen default (only the OOXML schema default `marker`
+    // would be a candidate for collapse, but the reader keeps every
+    // token literal so a clone preserves the exact preset).
+    const written = writeChart(makeScatter(), "Sheet1").chartXml;
+    expect(parseChart(written)?.scatterStyle).toBe("lineMarker");
   });
 });

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -2361,6 +2361,146 @@ describe("parseChart — varyColors", () => {
   });
 });
 
+// ── parseChart — scatterStyle ─────────────────────────────────────
+
+describe("parseChart — scatterStyle", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:scatterStyle val="lineMarker"/> on a scatter chart', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:scatterStyle val="lineMarker"/>
+        <c:varyColors val="0"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBe("lineMarker");
+  });
+
+  it('surfaces <c:scatterStyle val="smooth"/> on a smooth-line scatter', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:scatterStyle val="smooth"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBe("smooth");
+  });
+
+  it("surfaces every other ST_ScatterStyle preset literally", () => {
+    // Walk the remaining four enum tokens — each one round-trips
+    // verbatim with no per-family default collapse.
+    for (const preset of ["none", "line", "marker", "smoothMarker"] as const) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:scatterStyle val="${preset}"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.scatterStyle).toBe(preset);
+    }
+  });
+
+  it("returns undefined when the scatter chart omits <c:scatterStyle>", () => {
+    // The OOXML schema lists the element as required, but Excel falls
+    // back to the schema default `"marker"` when the file omits it. The
+    // reader does not fabricate a value — absence stays absence so the
+    // clone layer can decide whether to inherit the writer's own default.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBeUndefined();
+  });
+
+  it("ignores a <c:scatterStyle> with no val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:scatterStyle/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBeUndefined();
+  });
+
+  it("drops unknown scatterStyle values rather than fabricate one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:scatterStyle val="bogus"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBeUndefined();
+  });
+
+  it("does not surface scatterStyle on non-scatter charts", () => {
+    // The OOXML schema places <c:scatterStyle> exclusively on
+    // <c:scatterChart>; even if a hand-edited bar chart somehow carries
+    // the element, the reader does not surface it because the parse is
+    // gated on the matching kind.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:scatterStyle val="lineMarker"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBeUndefined();
+  });
+
+  it("surfaces scatterStyle from the first scatterChart in a combo chart", () => {
+    // Combo charts are rare but Excel supports an arbitrary mix of
+    // chart-type elements inside one plot area. The reader latches onto
+    // the first <c:scatterChart>'s scatterStyle, mirroring how it
+    // handles other chart-type-level fields.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:scatterChart>
+        <c:scatterStyle val="smoothMarker"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:scatterChart>
+      <c:scatterChart>
+        <c:scatterStyle val="line"/>
+        <c:ser><c:idx val="1"/></c:ser>
+      </c:scatterChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.scatterStyle).toBe("smoothMarker");
+  });
+});
+
 // ── End-to-end: full XLSX with a chart ────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Surfaces the chart-level `<c:scatterStyle>` element at the read, write, and clone layers so a scatter template's chart-picker preset (`"none"` / `"line"` / `"lineMarker"` / `"marker"` / `"smooth"` / `"smoothMarker"`) survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:scatterStyle>` is the OOXML element behind Excel's "Change Chart Type → XY (Scatter)" picker. The OOXML schema places the element exclusively on `<c:scatterChart>` and lists it as required there. Until now hucre's writer hardcoded `val="lineMarker"` and `parseChart` did not surface the value, so a template authored with smoothed lines or markers-only could not round-trip through clone. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.scatterStyle); // "smooth" on a smooth-line scatter,
                                  // "marker" on a markers-only scatter,
                                  // undefined when the chart is not scatter
                                  // or omits the element

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      // Scatter with smoothed curves and markers.
      {
        type: "scatter",
        series: [{ name: "Trend", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        scatterStyle: "smoothMarker",
      },
      // Markers only (no connecting line).
      {
        type: "scatter",
        series: [{ name: "Sample", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 8 } },
        scatterStyle: "marker",
      },
    ],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  scatterStyle: "smooth",          // replace
  // scatterStyle: null,           // drop the inherited preset (writer falls back to "lineMarker")
  // scatterStyle: undefined,      // inherit the source's parsed value
});
```

## Model

```ts
type ChartScatterStyle =
  | "none"
  | "line"
  | "lineMarker"
  | "marker"
  | "smooth"
  | "smoothMarker";

interface SheetChart {
  /** ...existing fields... */
  scatterStyle?: ChartScatterStyle;
}

interface Chart {
  /** ...existing fields... */
  scatterStyle?: ChartScatterStyle;
}

interface CloneChartOptions {
  /** ...existing fields... */
  scatterStyle?: ChartScatterStyle | null;
}
```

The read-side `Chart.scatterStyle` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<c:scatterStyle val=".."/>` off the first `<c:scatterChart>` element. Every literal value in the OOXML `ST_ScatterStyle` enum surfaces as-is so a clone preserves the exact preset; missing elements, missing `val` attributes, and tokens outside the enum drop to `undefined`. The reader does not collapse the writer's `lineMarker` default — keeping every recognized token literal makes the round-trip exact.
- **Write** — The writer always emits `<c:scatterStyle>` on `<c:scatterChart>` (the OOXML schema lists it as required there). Absent `scatterStyle`, the writer falls back to `"lineMarker"` — Excel's chart-picker default and what every fresh hucre scatter chart already used. Values outside the enum fall back to the same default rather than emit a token Excel's strict validator would reject. Non-scatter chart families silently ignore the field.
- **Clone** — `options.scatterStyle` accepts the standard `undefined` (inherit) / `null` (drop, fall back to the writer's `"lineMarker"` default) / value (replace) override grammar that mirrors `dispBlanksAs` / `varyColors`. The inherited value is silently dropped when the resolved clone target is anything other than `scatter` since the schema rejects `<c:scatterStyle>` on every other chart family.

## Edge cases

- A scatter chart authored with `scatterStyle: "lineMarker"` round-trips identically to one that omits the field — the writer emits the same default token either way and the reader surfaces it literally.
- A `<c:scatterStyle/>` element with no `val` attribute reads as `undefined` rather than fabricate a preset.
- An out-of-enum token on the read side (e.g. `val="bogus"`) drops to `undefined`; the writer never emits an unknown token even when one is set on `SheetChart` directly.
- A scatter template flattened to a column / line clone drops the inherited preset so it does not leak into a chart kind whose schema rejects the element.
- The element is placed in the spec-required slot inside `<c:scatterChart>` (before `<c:varyColors>` and `<c:ser>`) so Excel's strict validator accepts the file.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm test` (lint + typecheck + vitest) passes — all 2924 tests, including 24 new `scatterStyle` tests across reader, writer, and clone
- [x] Reader, writer, and clone tests cover: every enum value, the writer's `lineMarker` default, missing `val`, unknown tokens, omitted element, gating on the `<c:scatterChart>` parent, OOXML element ordering inside `<c:scatterChart>`, drop-on-non-scatter coercion, and a full `parseChart → cloneChart → writeXlsx → parseChart` round-trip