### PR TITLE
feat(xlsx): chart axis tick marks and tick label position — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,8 +543,11 @@ for (const sheet of wb.sheets) {
     // e.g. "bottom" "stacked" undefined undefined
 
     // chart.axes carries per-axis labels, gridline visibility, numeric
-    // scaling, and tick-label number format pulled from <c:catAx>/<c:valAx>.
-    // Only populated axes show up — pie/doughnut never do.
+    // scaling, tick-label number format and tick rendering (major /
+    // minor tick mark style and tick-label position) pulled from
+    // <c:catAx>/<c:valAx>. Only populated axes show up — pie/doughnut
+    // never do, and OOXML defaults collapse to undefined so absence
+    // and the default round-trip identically.
     console.log(chart.axes);
     // e.g. {
     //   x: { title: "Quarter" },
@@ -553,6 +556,8 @@ for (const sheet of wb.sheets) {
     //     gridlines: { major: true },
     //     scale: { min: 0, max: 100, majorUnit: 25 },
     //     numberFormat: { formatCode: "$#,##0" },
+    //     majorTickMark: "cross",
+    //     tickLblPos: "low",
     //   },
     // }
 
@@ -600,21 +605,28 @@ and non-bar charts never report a grouping). `lineGrouping` and
 `percentStacked` so combo workbooks can declare both alongside a bar
 grouping without colliding. `Chart.axes` mirrors
 the writer-side `SheetChart.axes` and surfaces per-axis labels,
-gridline visibility, numeric scaling and tick-label number format:
-`x` is the category axis (or, for scatter, the first value axis)
-and `y` is the value axis. Empty / whitespace-only `<c:title>` text
-is dropped, `gridlines: { major, minor }` flips on when the matching
-`<c:majorGridlines>` / `<c:minorGridlines>` element is present (any
-nested styling is tolerated), `scale: { min, max, majorUnit, minorUnit, logBase }`
-captures the explicit `<c:min>` / `<c:max>` / `<c:logBase>` (under
-`<c:scaling>`) and `<c:majorUnit>` / `<c:minorUnit>` (direct axis
-children) — fields Excel auto-computes are left off so the round
-trip never accidentally pins a value, and zero or negative tick
-spacings are filtered out — and `numberFormat: { formatCode, sourceLinked }`
+gridline visibility, numeric scaling, tick-label number format and
+tick rendering: `x` is the category axis (or, for scatter, the first
+value axis) and `y` is the value axis. Empty / whitespace-only
+`<c:title>` text is dropped, `gridlines: { major, minor }` flips on
+when the matching `<c:majorGridlines>` / `<c:minorGridlines>`
+element is present (any nested styling is tolerated),
+`scale: { min, max, majorUnit, minorUnit, logBase }` captures the
+explicit `<c:min>` / `<c:max>` / `<c:logBase>` (under `<c:scaling>`)
+and `<c:majorUnit>` / `<c:minorUnit>` (direct axis children) —
+fields Excel auto-computes are left off so the round trip never
+accidentally pins a value, and zero or negative tick spacings are
+filtered out — and `numberFormat: { formatCode, sourceLinked }`
 mirrors `<c:numFmt>` (an empty `formatCode` collapses the record).
-Charts without any axis label, gridline, scale, or number format
-leave `axes` undefined, and pie/doughnut charts (which have no axes
-in OOXML) never report one.
+`majorTickMark` / `minorTickMark` / `tickLblPos` mirror the
+matching axis children, surfacing only non-default values: the
+OOXML defaults `"out"` (major) / `"none"` (minor) / `"nextTo"` (tick
+labels) collapse to `undefined` so absence and the default
+round-trip identically through `cloneChart`. Unknown enum tokens
+are dropped rather than fabricated. Charts without any axis label,
+gridline, scale, number format, or tick override leave `axes`
+undefined, and pie/doughnut charts (which have no axes in OOXML)
+never report one.
 `Chart.dataLabels` mirrors the writer-side `SheetChart.dataLabels`
 and surfaces the toggles Excel carries inside `<c:dLbls>`
 (`showValue`, `showCategoryName`, `showSeriesName`, `showPercent`,
@@ -752,23 +764,36 @@ charts; `lineGrouping` and `areaGrouping` accept
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
 attributes for screen readers.
-`axes: { x: { title, gridlines, scale, numberFormat }, y: { title, gridlines, scale, numberFormat } }`
-attaches per-axis labels, gridlines, numeric scaling, and the
-tick-label number format — `x` lands inside `<c:catAx>` (or the X
-value axis for scatter), `y` inside the value axis. Empty or
-whitespace-only titles are silently dropped, `gridlines: { major,
-minor }` emits `<c:majorGridlines>` / `<c:minorGridlines>` in the
-spec-required position (after `<c:axPos>`, before any `<c:title>`,
-major before minor),
-`scale: { min, max, majorUnit, minorUnit, logBase }` pins explicit
-axis bounds (`<c:min>` / `<c:max>` / `<c:logBase>` go inside
+`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos } }`
+attaches per-axis labels, gridlines, numeric scaling, the tick-label
+number format and the tick-rendering trio — `x` lands inside
+`<c:catAx>` (or the X value axis for scatter), `y` inside the value
+axis. Empty or whitespace-only titles are silently dropped,
+`gridlines: { major, minor }` emits
+`<c:majorGridlines>` / `<c:minorGridlines>` in the spec-required
+position (after `<c:axPos>`, before any `<c:title>`, major before
+minor), `scale: { min, max, majorUnit, minorUnit, logBase }` pins
+explicit axis bounds (`<c:min>` / `<c:max>` / `<c:logBase>` go inside
 `<c:scaling>`; `<c:majorUnit>` / `<c:minorUnit>` are emitted after
 `<c:crossBetween>` per CT_ValAx) — non-finite numbers, zero/negative
 tick spacings, log bases outside `2..1000`, and `min >= max` ranges
-are filtered out so Excel never sees a value it would reject —
-and `numberFormat: { formatCode, sourceLinked }` emits
+are filtered out so Excel never sees a value it would reject — and
+`numberFormat: { formatCode, sourceLinked }` emits
 `<c:numFmt formatCode=".." sourceLinked="0|1"/>` between the axis
 title and `<c:crossAx>` (an empty `formatCode` skips emission).
+`majorTickMark` / `minorTickMark` accept `"none"` / `"in"` / `"out"`
+/ `"cross"` (the OOXML `ST_TickMark` enum) and emit
+`<c:majorTickMark val=".."/>` / `<c:minorTickMark val=".."/>` right
+after `<c:numFmt>`; absent fields fall back to Excel's reference
+defaults (`"out"` for major, `"none"` for minor) so a chart that
+omits both renders identically to one a freshly-drawn Excel chart
+would emit. `tickLblPos` accepts `"nextTo"` / `"low"` / `"high"` /
+`"none"` and lands in `<c:tickLblPos val=".."/>` immediately after
+the tick-mark elements — useful for pinning numeric axis labels to
+the chart edge when the value axis crosses elsewhere
+(`tickLblPos: "low"`) or hiding labels entirely
+(`tickLblPos: "none"`). Unknown enum values on either field are
+dropped silently so the writer never emits a token Excel rejects.
 Pie / doughnut charts ignore the entire `axes` field because OOXML
 defines no axes for them.
 `dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, position, separator }`
@@ -891,19 +916,24 @@ writer can author collapse onto their write counterparts (`bar` /
 its own kind so the hole survives), `line3D` → `line`, `area3D` →
 `area`); kinds with no analog (`bubble`, `radar`, `surface`, `stock`,
 `ofPie`) require an explicit `options.type` override. Axis titles,
-gridlines, scaling and tick-label number format inherit from the
-source by default; pass `axes: { y: { title: "Revenue" } }` to
-replace one side, `null` to drop an inherited label,
+gridlines, scaling, tick-label number format and the tick-rendering
+trio (`majorTickMark` / `minorTickMark` / `tickLblPos`) inherit
+from the source by default; pass `axes: { y: { title: "Revenue" } }`
+to replace one side, `null` to drop an inherited label,
 `axes: { y: { gridlines: { major: true, minor: true } } }` to
 replace inherited gridlines, `axes: { y: { scale: { min: 0, max: 50 } } }`
 to replace the inherited scale wholesale (overrides do **not** merge
 field-by-field — `{ min: 0 }` plus `{ max: 50 }` yields `{ max: 50 }`,
 not `{ min: 0, max: 50 }`), `axes: { y: { numberFormat: { formatCode: "0.00%" } } }`
-to replace the format, or `null` on any of the four to drop the
-inherited value. The writer drops the entire `axes` block
-automatically when the resolved type is `pie` or `doughnut`, so a
-template that happened to carry stray scale or numberFormat values
-does not poison a pie/doughnut clone. Per-family stacking
+to replace the format,
+`axes: { y: { majorTickMark: "cross", tickLblPos: "low" } }` to
+pin the tick-mark style or anchor labels to the chart edge, or
+`null` on any of the seven to drop the inherited value (the writer
+falls back to the OOXML default — `"out"` for major, `"none"` for
+minor, `"nextTo"` for tick labels). The writer drops the entire
+`axes` block automatically when the resolved type is `pie` or
+`doughnut`, so a template that happened to carry stray scale,
+numberFormat or tick values does not poison a pie/doughnut clone. Per-family stacking
 (`barGrouping`, `lineGrouping`, `areaGrouping`) is carried over only
 when the resolved clone target matches that family — flattening a
 stacked line template into a column drops the inherited grouping

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1029,6 +1029,27 @@ export interface SheetChart {
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
+      /**
+       * Major tick-mark style. Maps to
+       * `<c:catAx><c:majorTickMark val=".."/></c:catAx>` (or
+       * `<c:valAx>` for scatter). Default: `"out"` — Excel's reference
+       * serialization. See {@link ChartAxisTickMark}.
+       */
+      majorTickMark?: ChartAxisTickMark;
+      /**
+       * Minor tick-mark style. Maps to
+       * `<c:catAx><c:minorTickMark val=".."/></c:catAx>` (or
+       * `<c:valAx>` for scatter). Default: `"none"` — Excel's
+       * reference serialization. See {@link ChartAxisTickMark}.
+       */
+      minorTickMark?: ChartAxisTickMark;
+      /**
+       * Tick-label position. Maps to
+       * `<c:catAx><c:tickLblPos val=".."/></c:catAx>` (or
+       * `<c:valAx>` for scatter). Default: `"nextTo"` — Excel's
+       * reference serialization. See {@link ChartAxisTickLabelPosition}.
+       */
+      tickLblPos?: ChartAxisTickLabelPosition;
     };
     /** Value axis. */
     y?: {
@@ -1036,6 +1057,24 @@ export interface SheetChart {
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
+      /**
+       * Major tick-mark style for the value axis. Maps to
+       * `<c:valAx><c:majorTickMark val=".."/></c:valAx>`. Default:
+       * `"out"`. See {@link ChartAxisTickMark}.
+       */
+      majorTickMark?: ChartAxisTickMark;
+      /**
+       * Minor tick-mark style for the value axis. Maps to
+       * `<c:valAx><c:minorTickMark val=".."/></c:valAx>`. Default:
+       * `"none"`. See {@link ChartAxisTickMark}.
+       */
+      minorTickMark?: ChartAxisTickMark;
+      /**
+       * Tick-label position for the value axis. Maps to
+       * `<c:valAx><c:tickLblPos val=".."/></c:valAx>`. Default:
+       * `"nextTo"`. See {@link ChartAxisTickLabelPosition}.
+       */
+      tickLblPos?: ChartAxisTickLabelPosition;
     };
   };
 }
@@ -1825,6 +1864,47 @@ export interface ChartAxisNumberFormat {
   sourceLinked?: boolean;
 }
 
+/**
+ * Axis tick-mark style — where Excel paints the short tick lines that
+ * mark major or minor unit boundaries on a category or value axis.
+ *
+ * Maps to the OOXML `ST_TickMark` enumeration which sits inside
+ * `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` as
+ * `<c:majorTickMark val=".."/>` and `<c:minorTickMark val=".."/>`:
+ *
+ * - `"none"`  — no tick marks rendered at all.
+ * - `"in"`    — tick marks point inward (toward the plot area).
+ * - `"out"`   — tick marks point outward (away from the plot area).
+ *               OOXML default for `<c:majorTickMark>`.
+ * - `"cross"` — tick marks straddle the axis line.
+ *
+ * Excel's UI exposes the same four presets under "Format Axis →
+ * Tick Marks → Major type / Minor type". The OOXML default for
+ * `<c:minorTickMark>` is `"none"` (Excel's UI also defaults to "None"
+ * for the minor type on a freshly-drawn axis).
+ */
+export type ChartAxisTickMark = "none" | "in" | "out" | "cross";
+
+/**
+ * Axis tick-label position — where Excel paints the numeric / category
+ * labels relative to the axis line.
+ *
+ * Maps to the OOXML `ST_TickLblPos` enumeration which sits inside
+ * `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` as
+ * `<c:tickLblPos val=".."/>`:
+ *
+ * - `"nextTo"` — labels sit alongside the axis line at the closest
+ *                edge of the plot area. OOXML default.
+ * - `"low"`    — labels pinned to the low end of the perpendicular
+ *                axis (left for value axes, bottom for category axes).
+ *                Useful when the axis crosses elsewhere but labels
+ *                should stay anchored to the chart edge.
+ * - `"high"`   — mirror of `"low"`; labels pinned to the high end.
+ * - `"none"`   — no labels rendered. Excel's UI exposes this as
+ *                "Format Axis → Labels → Label Position → None".
+ */
+export type ChartAxisTickLabelPosition = "nextTo" | "low" | "high" | "none";
+
 export interface ChartAxisInfo {
   /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
   title?: string;
@@ -1847,6 +1927,28 @@ export interface ChartAxisInfo {
    * the writer side.
    */
   numberFormat?: ChartAxisNumberFormat;
+  /**
+   * Major tick-mark style pulled from `<c:majorTickMark>`. Omitted
+   * when absent or when the axis declared the OOXML default `"out"` —
+   * absence and the default round-trip identically through
+   * {@link cloneChart}, so collapsing the default keeps the parsed
+   * shape minimal. See {@link ChartAxisTickMark}.
+   */
+  majorTickMark?: ChartAxisTickMark;
+  /**
+   * Minor tick-mark style pulled from `<c:minorTickMark>`. Omitted
+   * when absent or when the axis declared the OOXML default `"none"`.
+   * See {@link ChartAxisTickMark}.
+   */
+  minorTickMark?: ChartAxisTickMark;
+  /**
+   * Tick-label position pulled from `<c:tickLblPos>`. Omitted when
+   * absent or when the axis declared the OOXML default `"nextTo"` —
+   * absence and the default round-trip identically through
+   * {@link cloneChart}, so collapsing the default keeps the parsed
+   * shape minimal. See {@link ChartAxisTickLabelPosition}.
+   */
+  tickLblPos?: ChartAxisTickLabelPosition;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,8 @@ export type {
   ChartAnchor,
   ChartAxisGridlines,
   ChartAxisInfo,
+  ChartAxisTickLabelPosition,
+  ChartAxisTickMark,
   ChartBarGrouping,
   ChartDataLabelPosition,
   ChartDataLabels,

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -15,6 +15,8 @@ import type {
   ChartAxisGridlines,
   ChartAxisNumberFormat,
   ChartAxisScale,
+  ChartAxisTickLabelPosition,
+  ChartAxisTickMark,
   ChartDataLabels,
   ChartDataLabelsInfo,
   ChartDisplayBlanksAs,
@@ -222,12 +224,39 @@ export interface CloneChartOptions {
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
+      /**
+       * Override the major tick-mark style. `undefined` (or omitted)
+       * inherits the source axis' parsed value; `null` drops it (the
+       * writer falls back to the OOXML default `"out"`); a value
+       * replaces it.
+       */
+      majorTickMark?: ChartAxisTickMark | null;
+      /**
+       * Override the minor tick-mark style. `undefined` (or omitted)
+       * inherits the source axis' parsed value; `null` drops it (the
+       * writer falls back to the OOXML default `"none"`); a value
+       * replaces it.
+       */
+      minorTickMark?: ChartAxisTickMark | null;
+      /**
+       * Override the tick-label position. `undefined` (or omitted)
+       * inherits the source axis' parsed value; `null` drops it (the
+       * writer falls back to the OOXML default `"nextTo"`); a value
+       * replaces it.
+       */
+      tickLblPos?: ChartAxisTickLabelPosition | null;
     };
     y?: {
       title?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
+      /** See {@link CloneChartOptions.axes.x.majorTickMark}. */
+      majorTickMark?: ChartAxisTickMark | null;
+      /** See {@link CloneChartOptions.axes.x.minorTickMark}. */
+      minorTickMark?: ChartAxisTickMark | null;
+      /** See {@link CloneChartOptions.axes.x.tickLblPos}. */
+      tickLblPos?: ChartAxisTickLabelPosition | null;
     };
   };
 }
@@ -783,31 +812,61 @@ function resolveAxes(
     sourceAxes?.y?.numberFormat,
     overrides?.y?.numberFormat,
   );
+  const xMajorTickMark = applyTickMarkOverride(
+    sourceAxes?.x?.majorTickMark,
+    overrides?.x?.majorTickMark,
+  );
+  const yMajorTickMark = applyTickMarkOverride(
+    sourceAxes?.y?.majorTickMark,
+    overrides?.y?.majorTickMark,
+  );
+  const xMinorTickMark = applyTickMarkOverride(
+    sourceAxes?.x?.minorTickMark,
+    overrides?.x?.minorTickMark,
+  );
+  const yMinorTickMark = applyTickMarkOverride(
+    sourceAxes?.y?.minorTickMark,
+    overrides?.y?.minorTickMark,
+  );
+  const xTickLblPos = applyTickLblPosOverride(sourceAxes?.x?.tickLblPos, overrides?.x?.tickLblPos);
+  const yTickLblPos = applyTickLblPosOverride(sourceAxes?.y?.tickLblPos, overrides?.y?.tickLblPos);
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
     xTitle !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
-    xNumFmt !== undefined
+    xNumFmt !== undefined ||
+    xMajorTickMark !== undefined ||
+    xMinorTickMark !== undefined ||
+    xTickLblPos !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
+    if (xMajorTickMark !== undefined) out.x.majorTickMark = xMajorTickMark;
+    if (xMinorTickMark !== undefined) out.x.minorTickMark = xMinorTickMark;
+    if (xTickLblPos !== undefined) out.x.tickLblPos = xTickLblPos;
   }
   if (
     yTitle !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
-    yNumFmt !== undefined
+    yNumFmt !== undefined ||
+    yMajorTickMark !== undefined ||
+    yMinorTickMark !== undefined ||
+    yTickLblPos !== undefined
   ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
+    if (yMajorTickMark !== undefined) out.y.majorTickMark = yMajorTickMark;
+    if (yMinorTickMark !== undefined) out.y.minorTickMark = yMinorTickMark;
+    if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
   }
 
   return out.x || out.y ? out : undefined;
@@ -904,4 +963,57 @@ function applyNumberFormatOverride(
   const out: ChartAxisNumberFormat = { formatCode: override.formatCode };
   if (override.sourceLinked === true) out.sourceLinked = true;
   return out;
+}
+
+/** Recognized values of `<c:majorTickMark>` / `<c:minorTickMark>`. */
+const VALID_TICK_MARK_VALUES: ReadonlySet<ChartAxisTickMark> = new Set([
+  "none",
+  "in",
+  "out",
+  "cross",
+]);
+
+/**
+ * Resolve a tick-mark override using the same `undefined` (inherit) /
+ * `null` (drop) / value (replace) grammar as the other axis helpers.
+ * Unknown / typo'd inputs collapse to `undefined` so the writer never
+ * emits a value the OOXML `ST_TickMark` enum rejects.
+ */
+function applyTickMarkOverride(
+  source: ChartAxisTickMark | undefined,
+  override: ChartAxisTickMark | null | undefined,
+): ChartAxisTickMark | undefined {
+  if (override === undefined) {
+    if (source === undefined) return undefined;
+    return VALID_TICK_MARK_VALUES.has(source) ? source : undefined;
+  }
+  if (override === null) return undefined;
+  return VALID_TICK_MARK_VALUES.has(override) ? override : undefined;
+}
+
+/** Recognized values of `<c:tickLblPos>`. */
+const VALID_TICK_LBL_POS_VALUES: ReadonlySet<ChartAxisTickLabelPosition> = new Set([
+  "nextTo",
+  "low",
+  "high",
+  "none",
+]);
+
+/**
+ * Resolve a tick-label-position override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Unknown / typo'd inputs collapse to `undefined` so
+ * the writer never emits a value the OOXML `ST_TickLblPos` enum
+ * rejects.
+ */
+function applyTickLblPosOverride(
+  source: ChartAxisTickLabelPosition | undefined,
+  override: ChartAxisTickLabelPosition | null | undefined,
+): ChartAxisTickLabelPosition | undefined {
+  if (override === undefined) {
+    if (source === undefined) return undefined;
+    return VALID_TICK_LBL_POS_VALUES.has(source) ? source : undefined;
+  }
+  if (override === null) return undefined;
+  return VALID_TICK_LBL_POS_VALUES.has(override) ? override : undefined;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -18,6 +18,8 @@ import type {
   ChartAxisInfo,
   ChartAxisNumberFormat,
   ChartAxisScale,
+  ChartAxisTickLabelPosition,
+  ChartAxisTickMark,
   ChartBarGrouping,
   ChartDataLabelPosition,
   ChartDataLabelsInfo,
@@ -254,11 +256,23 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
+  // Tick-mark and tick-label-position children sit alongside the
+  // gridlines / numFmt on every CT_CatAx / CT_ValAx / CT_DateAx /
+  // CT_SerAx — see CT_TickMark, ST_TickMark, ST_TickLblPos in
+  // ECMA-376 Part 1, §21.2.2. The reader collapses each value to
+  // `undefined` when it matches the OOXML default so absence and the
+  // default round-trip identically through {@link cloneChart}.
+  const majorTickMark = parseAxisTickMark(axis, "majorTickMark", "out");
+  const minorTickMark = parseAxisTickMark(axis, "minorTickMark", "none");
+  const tickLblPos = parseAxisTickLblPos(axis);
   if (
     title === undefined &&
     gridlines === undefined &&
     scale === undefined &&
-    numberFormat === undefined
+    numberFormat === undefined &&
+    majorTickMark === undefined &&
+    minorTickMark === undefined &&
+    tickLblPos === undefined
   ) {
     return undefined;
   }
@@ -267,7 +281,65 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
+  if (majorTickMark !== undefined) out.majorTickMark = majorTickMark;
+  if (minorTickMark !== undefined) out.minorTickMark = minorTickMark;
+  if (tickLblPos !== undefined) out.tickLblPos = tickLblPos;
   return out;
+}
+
+/**
+ * Recognized values of `<c:majorTickMark>` / `<c:minorTickMark>` per
+ * the OOXML `ST_TickMark` enumeration.
+ */
+const VALID_TICK_MARKS: ReadonlySet<ChartAxisTickMark> = new Set(["none", "in", "out", "cross"]);
+
+/**
+ * Pull `<c:majorTickMark val=".."/>` (or `<c:minorTickMark>`) off an
+ * axis element. Returns `undefined` when the element is absent, the
+ * `val` attribute is missing, the value is not in
+ * {@link VALID_TICK_MARKS}, or the value matches the per-element
+ * OOXML default — `"out"` for major, `"none"` for minor — so absence
+ * and the default round-trip identically.
+ */
+function parseAxisTickMark(
+  axis: XmlElement,
+  localName: "majorTickMark" | "minorTickMark",
+  defaultValue: ChartAxisTickMark,
+): ChartAxisTickMark | undefined {
+  const el = findChild(axis, localName);
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim() as ChartAxisTickMark;
+  if (!VALID_TICK_MARKS.has(value)) return undefined;
+  return value === defaultValue ? undefined : value;
+}
+
+/**
+ * Recognized values of `<c:tickLblPos>` per the OOXML
+ * `ST_TickLblPos` enumeration.
+ */
+const VALID_TICK_LBL_POSITIONS: ReadonlySet<ChartAxisTickLabelPosition> = new Set([
+  "nextTo",
+  "low",
+  "high",
+  "none",
+]);
+
+/**
+ * Pull `<c:tickLblPos val=".."/>` off an axis element. Returns
+ * `undefined` when the element is absent, the `val` attribute is
+ * missing or unrecognized, or the value matches the OOXML default
+ * `"nextTo"` so absence and the default round-trip identically.
+ */
+function parseAxisTickLblPos(axis: XmlElement): ChartAxisTickLabelPosition | undefined {
+  const el = findChild(axis, "tickLblPos");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim() as ChartAxisTickLabelPosition;
+  if (!VALID_TICK_LBL_POSITIONS.has(value)) return undefined;
+  return value === "nextTo" ? undefined : value;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -10,6 +10,8 @@ import type {
   ChartAxisGridlines,
   ChartAxisNumberFormat,
   ChartAxisScale,
+  ChartAxisTickLabelPosition,
+  ChartAxisTickMark,
   ChartDataLabels,
   ChartDisplayBlanksAs,
   ChartLineDashStyle,
@@ -133,9 +135,9 @@ function buildTitle(title: string): string {
 function buildPlotArea(chart: SheetChart, sheetName: string): string {
   const children: string[] = [xmlSelfClose("c:layout")];
 
-  // Axis titles, gridlines, scaling and number format surface for
-  // every chart family except pie/doughnut. Pull them once so each
-  // branch can hand them off to the matching axis builder.
+  // Axis titles, gridlines, scaling, number format and tick rendering
+  // surface for every chart family except pie/doughnut. Pull them once
+  // so each branch can hand them off to the matching axis builder.
   const opts: AxisRenderOptions = {
     xAxisTitle: normalizeAxisTitle(chart.axes?.x?.title),
     yAxisTitle: normalizeAxisTitle(chart.axes?.y?.title),
@@ -145,6 +147,12 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     yScale: normalizeAxisScale(chart.axes?.y?.scale),
     xNumFmt: normalizeAxisNumberFormat(chart.axes?.x?.numberFormat),
     yNumFmt: normalizeAxisNumberFormat(chart.axes?.y?.numberFormat),
+    xMajorTickMark: normalizeTickMark(chart.axes?.x?.majorTickMark),
+    yMajorTickMark: normalizeTickMark(chart.axes?.y?.majorTickMark),
+    xMinorTickMark: normalizeTickMark(chart.axes?.x?.minorTickMark),
+    yMinorTickMark: normalizeTickMark(chart.axes?.y?.minorTickMark),
+    xTickLblPos: normalizeTickLblPos(chart.axes?.x?.tickLblPos),
+    yTickLblPos: normalizeTickLblPos(chart.axes?.y?.tickLblPos),
   };
 
   switch (chart.type) {
@@ -196,6 +204,12 @@ interface AxisRenderOptions {
   yScale: ChartAxisScale | undefined;
   xNumFmt: ChartAxisNumberFormat | undefined;
   yNumFmt: ChartAxisNumberFormat | undefined;
+  xMajorTickMark: ChartAxisTickMark | undefined;
+  yMajorTickMark: ChartAxisTickMark | undefined;
+  xMinorTickMark: ChartAxisTickMark | undefined;
+  yMinorTickMark: ChartAxisTickMark | undefined;
+  xTickLblPos: ChartAxisTickLabelPosition | undefined;
+  yTickLblPos: ChartAxisTickLabelPosition | undefined;
 }
 
 /**
@@ -368,6 +382,69 @@ function buildAxisNumFmt(numFmt: ChartAxisNumberFormat | undefined): string[] {
   return [xmlSelfClose("c:numFmt", { formatCode: numFmt.formatCode, sourceLinked })];
 }
 
+/** Recognized values of `<c:majorTickMark>` / `<c:minorTickMark>`. */
+const TICK_MARK_VALUES: ReadonlySet<ChartAxisTickMark> = new Set(["none", "in", "out", "cross"]);
+
+/**
+ * Normalize a tick-mark value to a token Excel accepts. Unknown / typo'd
+ * inputs collapse to `undefined` so the writer never emits a value the
+ * OOXML `ST_TickMark` enum rejects.
+ */
+function normalizeTickMark(value: ChartAxisTickMark | undefined): ChartAxisTickMark | undefined {
+  if (value === undefined) return undefined;
+  return TICK_MARK_VALUES.has(value) ? value : undefined;
+}
+
+/** Recognized values of `<c:tickLblPos>`. */
+const TICK_LBL_POS_VALUES: ReadonlySet<ChartAxisTickLabelPosition> = new Set([
+  "nextTo",
+  "low",
+  "high",
+  "none",
+]);
+
+/**
+ * Normalize a tick-label-position value to a token Excel accepts.
+ * Unknown / typo'd inputs collapse to `undefined` so the writer never
+ * emits a value the OOXML `ST_TickLblPos` enum rejects.
+ */
+function normalizeTickLblPos(
+  value: ChartAxisTickLabelPosition | undefined,
+): ChartAxisTickLabelPosition | undefined {
+  if (value === undefined) return undefined;
+  return TICK_LBL_POS_VALUES.has(value) ? value : undefined;
+}
+
+/**
+ * Build the `<c:majorTickMark>` / `<c:minorTickMark>` / `<c:tickLblPos>`
+ * children for an axis. The OOXML schema (CT_CatAx / CT_ValAx /
+ * CT_DateAx / CT_SerAx) places the three elements together right after
+ * `<c:numFmt>` and before `<c:crossAx>`. Excel's strict validator
+ * rejects any other ordering — keep the tuple together.
+ *
+ * Each value is omitted when the caller did not pin it; the OOXML
+ * defaults (`majorTickMark="out"`, `minorTickMark="none"`,
+ * `tickLblPos="nextTo"`) match Excel's reference serialization, so
+ * absence and the default round-trip identically through the reader.
+ */
+function buildAxisTickRendering(
+  majorTickMark: ChartAxisTickMark | undefined,
+  minorTickMark: ChartAxisTickMark | undefined,
+  tickLblPos: ChartAxisTickLabelPosition | undefined,
+): string[] {
+  const out: string[] = [];
+  if (majorTickMark !== undefined) {
+    out.push(xmlSelfClose("c:majorTickMark", { val: majorTickMark }));
+  }
+  if (minorTickMark !== undefined) {
+    out.push(xmlSelfClose("c:minorTickMark", { val: minorTickMark }));
+  }
+  if (tickLblPos !== undefined) {
+    out.push(xmlSelfClose("c:tickLblPos", { val: tickLblPos }));
+  }
+  return out;
+}
+
 // ── Bar / Column ─────────────────────────────────────────────────────
 
 const AXIS_ID_CAT = 111111111;
@@ -476,8 +553,9 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
 
   // OOXML enforces a strict child order inside <c:catAx>/<c:valAx>:
   // axId → scaling → delete → axPos → majorGridlines → minorGridlines
-  // → title → numFmt → ... → crossAx → crosses → ... → majorUnit →
-  // minorUnit. Each block below mirrors that order.
+  // → title → numFmt → majorTickMark → minorTickMark → tickLblPos →
+  // crossAx → crosses → ... → majorUnit → minorUnit. Each block below
+  // mirrors that order.
   // The category axis on bar/column rarely uses scaling, but Excel
   // tolerates the augmentation either way; surface it whenever the
   // caller pinned a value so write-side templates round-trip.
@@ -491,6 +569,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   if (opts.xAxisTitle) catAxChildren.push(buildAxisTitle(opts.xAxisTitle));
   catAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
+    ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:auto", { val: 1 }),
@@ -509,6 +588,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   if (opts.yAxisTitle) valAxChildren.push(buildAxisTitle(opts.yAxisTitle));
   valAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
+    ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "between" }),
@@ -726,6 +806,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   if (opts.xAxisTitle) xAxChildren.push(buildAxisTitle(opts.xAxisTitle));
   xAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
+    ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
@@ -742,6 +823,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   if (opts.yAxisTitle) yAxChildren.push(buildAxisTitle(opts.yAxisTitle));
   yAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
+    ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2792,3 +2792,194 @@ describe("cloneChart — scatterStyle", () => {
     expect(reparsed?.scatterStyle).toBe("marker");
   });
 });
+
+// ── cloneChart — axis tick marks and tick label position ─────────────
+
+describe("cloneChart — axis tick marks and tick label position", () => {
+  const sourceWithTicks: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: {
+      y: {
+        majorTickMark: "cross",
+        minorTickMark: "in",
+        tickLblPos: "low",
+      },
+    },
+  };
+
+  it("inherits the source's tick rendering when no override is given", () => {
+    const clone = cloneChart(sourceWithTicks, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.majorTickMark).toBe("cross");
+    expect(clone.axes?.y?.minorTickMark).toBe("in");
+    expect(clone.axes?.y?.tickLblPos).toBe("low");
+  });
+
+  it("drops inherited values when the override is null", () => {
+    const clone = cloneChart(sourceWithTicks, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        y: { majorTickMark: null, minorTickMark: null, tickLblPos: null },
+      },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces inherited tick rendering with explicit overrides", () => {
+    const clone = cloneChart(sourceWithTicks, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        y: { majorTickMark: "out", minorTickMark: "out", tickLblPos: "high" },
+      },
+    });
+    expect(clone.axes?.y?.majorTickMark).toBe("out");
+    expect(clone.axes?.y?.minorTickMark).toBe("out");
+    expect(clone.axes?.y?.tickLblPos).toBe("high");
+  });
+
+  it("adds tick rendering to an axis the source did not declare it on", () => {
+    const noTicks: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noTicks, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { majorTickMark: "cross", tickLblPos: "low" } },
+    });
+    expect(clone.axes?.y?.majorTickMark).toBe("cross");
+    expect(clone.axes?.y?.tickLblPos).toBe("low");
+    expect(clone.axes?.y?.minorTickMark).toBeUndefined();
+  });
+
+  it("strips tick rendering silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        y: { majorTickMark: "cross", tickLblPos: "low" },
+      },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips tick rendering silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        y: { majorTickMark: "cross" },
+      },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("supports tick rendering on the X (category) axis", () => {
+    const xSource: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        x: { majorTickMark: "in", tickLblPos: "high" },
+      },
+    };
+    const clone = cloneChart(xSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.majorTickMark).toBe("in");
+    expect(clone.axes?.x?.tickLblPos).toBe("high");
+  });
+
+  it("ignores invalid tick-mark values on inherit", () => {
+    const bogus: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        // Cast to bypass the type guard so we can simulate a bad parse.
+        y: { majorTickMark: "zigzag" as unknown as "in" },
+      },
+    };
+    const clone = cloneChart(bogus, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the field when an invalid tick-label-position override is supplied", () => {
+    // An invalid override is treated as "no usable value" — the writer
+    // never receives a token the OOXML `ST_TickLblPos` enum rejects.
+    // The behavior mirrors `applyNumberFormatOverride` where an empty
+    // formatCode collapses the entire entry rather than silently
+    // falling back to the inherited value.
+    const clone = cloneChart(sourceWithTicks, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        // Cast to bypass the type guard so we can simulate a typo'd input.
+        y: { tickLblPos: "diagonal" as unknown as "high" },
+      },
+    });
+    expect(clone.axes?.y?.tickLblPos).toBeUndefined();
+    // The other inherited fields stay intact since their overrides were
+    // not supplied (undefined).
+    expect(clone.axes?.y?.majorTickMark).toBe("cross");
+    expect(clone.axes?.y?.minorTickMark).toBe("in");
+  });
+
+  it("round-trips through writeChart and parseChart", async () => {
+    const clone = cloneChart(sourceWithTicks, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    const written = writeChart(clone, "Sheet1").chartXml;
+    expect(written).toContain('c:majorTickMark val="cross"');
+    expect(written).toContain('c:minorTickMark val="in"');
+    expect(written).toContain('c:tickLblPos val="low"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.majorTickMark).toBe("cross");
+    expect(reparsed?.axes?.y?.minorTickMark).toBe("in");
+    expect(reparsed?.axes?.y?.tickLblPos).toBe("low");
+
+    // End-to-end: writeXlsx packages the clone into a valid OOXML file
+    // whose chart part round-trips its tick rendering.
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const packaged = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(packaged).toContain('c:majorTickMark val="cross"');
+    expect(packaged).toContain('c:minorTickMark val="in"');
+    expect(packaged).toContain('c:tickLblPos val="low"');
+  });
+
+  it("drops inherited tick rendering when the resolved type flattens to pie", () => {
+    const barSource: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        y: { majorTickMark: "cross", tickLblPos: "low" },
+      },
+    };
+    const clone = cloneChart(barSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2646,3 +2646,240 @@ describe("writeChart — scatterStyle", () => {
     expect(parseChart(written)?.scatterStyle).toBe("lineMarker");
   });
 });
+
+// ── writeChart — axis tick marks and tick label position ─────────────
+
+describe("writeChart — axis tick marks and tick label position", () => {
+  it("emits <c:majorTickMark> on the value axis when y.majorTickMark is set", () => {
+    const result = writeChart(makeChart({ axes: { y: { majorTickMark: "cross" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:majorTickMark val="cross"/>');
+  });
+
+  it("emits <c:minorTickMark> on the value axis when y.minorTickMark is set", () => {
+    const result = writeChart(makeChart({ axes: { y: { minorTickMark: "out" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:minorTickMark val="out"/>');
+  });
+
+  it("emits <c:tickLblPos> on the value axis when y.tickLblPos is set", () => {
+    const result = writeChart(makeChart({ axes: { y: { tickLblPos: "low" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:tickLblPos val="low"/>');
+  });
+
+  it("omits all three elements when none of the fields are set", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("c:majorTickMark");
+    expect(result.chartXml).not.toContain("c:minorTickMark");
+    expect(result.chartXml).not.toContain("c:tickLblPos");
+  });
+
+  it("places tick rendering after <c:numFmt> but before <c:crossAx> (OOXML order)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            numberFormat: { formatCode: "$#,##0" },
+            majorTickMark: "cross",
+            minorTickMark: "in",
+            tickLblPos: "low",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const numFmtIdx = valAxBlock.indexOf("<c:numFmt");
+    const majorIdx = valAxBlock.indexOf("<c:majorTickMark");
+    const minorIdx = valAxBlock.indexOf("<c:minorTickMark");
+    const tickLblIdx = valAxBlock.indexOf("<c:tickLblPos");
+    const crossAxIdx = valAxBlock.indexOf("c:crossAx");
+    expect(numFmtIdx).toBeGreaterThan(0);
+    expect(majorIdx).toBeGreaterThan(numFmtIdx);
+    expect(minorIdx).toBeGreaterThan(majorIdx);
+    expect(tickLblIdx).toBeGreaterThan(minorIdx);
+    expect(crossAxIdx).toBeGreaterThan(tickLblIdx);
+  });
+
+  it("emits tick rendering on the category axis when x.* is set", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { majorTickMark: "in", tickLblPos: "high" } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<c:majorTickMark val="in"/>');
+    expect(catAxBlock).toContain('<c:tickLblPos val="high"/>');
+    // The value axis should not pick up the X-axis settings.
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).not.toContain("c:majorTickMark");
+    expect(valAxBlock).not.toContain("c:tickLblPos");
+  });
+
+  it("works for line and area charts (which share the bar axis builder)", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { y: { majorTickMark: "cross" } } }),
+        "Sheet1",
+      );
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(valAxBlock).toContain('<c:majorTickMark val="cross"/>');
+    }
+  });
+
+  it("emits tick rendering on scatter X (axPos=b) and Y (axPos=l) value axes", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: {
+          x: { majorTickMark: "cross" },
+          y: { tickLblPos: "high" },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    // First valAx is the X axis (axPos="b"), second is Y (axPos="l").
+    expect(valAxBlocks[0]).toContain('c:axPos val="b"');
+    expect(valAxBlocks[0]).toContain('<c:majorTickMark val="cross"/>');
+    expect(valAxBlocks[0]).not.toContain("c:tickLblPos");
+    expect(valAxBlocks[1]).toContain('c:axPos val="l"');
+    expect(valAxBlocks[1]).toContain('<c:tickLblPos val="high"/>');
+    expect(valAxBlocks[1]).not.toContain("c:majorTickMark");
+  });
+
+  it("skips tick rendering on pie charts (pie has no axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        axes: {
+          y: { majorTickMark: "cross", minorTickMark: "in", tickLblPos: "low" },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:majorTickMark");
+    expect(result.chartXml).not.toContain("c:minorTickMark");
+    expect(result.chartXml).not.toContain("c:tickLblPos");
+  });
+
+  it("skips tick rendering on doughnut charts (doughnut has no axes either)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        axes: { y: { majorTickMark: "cross" } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:majorTickMark");
+  });
+
+  it("only emits the major element when minor and tickLblPos are unset", () => {
+    const result = writeChart(makeChart({ axes: { y: { majorTickMark: "in" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:majorTickMark val="in"/>');
+    expect(valAxBlock).not.toContain("c:minorTickMark");
+    expect(valAxBlock).not.toContain("c:tickLblPos");
+  });
+
+  it("drops invalid tick-mark values silently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          // @ts-expect-error — testing runtime guard against typo'd inputs.
+          y: { majorTickMark: "zigzag", minorTickMark: "diagonal" },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:majorTickMark");
+    expect(result.chartXml).not.toContain("c:minorTickMark");
+  });
+
+  it("drops invalid tick-label-position values silently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          // @ts-expect-error — testing runtime guard against typo'd inputs.
+          y: { tickLblPos: "diagonal" },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:tickLblPos");
+  });
+
+  it("round-trips a non-default majorTickMark / tickLblPos through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        axes: {
+          y: { majorTickMark: "cross", minorTickMark: "in", tickLblPos: "low" },
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written);
+    expect(parsed?.axes?.y?.majorTickMark).toBe("cross");
+    expect(parsed?.axes?.y?.minorTickMark).toBe("in");
+    expect(parsed?.axes?.y?.tickLblPos).toBe("low");
+  });
+
+  it("emits all four tick-mark presets on the value axis", () => {
+    for (const value of ["none", "in", "out", "cross"] as const) {
+      const result = writeChart(makeChart({ axes: { y: { majorTickMark: value } } }), "Sheet1");
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(valAxBlock).toContain(`<c:majorTickMark val="${value}"/>`);
+    }
+  });
+
+  it("emits all four tick-label-position presets on the value axis", () => {
+    for (const value of ["nextTo", "low", "high", "none"] as const) {
+      const result = writeChart(makeChart({ axes: { y: { tickLblPos: value } } }), "Sheet1");
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(valAxBlock).toContain(`<c:tickLblPos val="${value}"/>`);
+    }
+  });
+
+  it("co-emits tick rendering with title, gridlines, scale, and number format", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            title: "Revenue",
+            gridlines: { major: true },
+            scale: { min: 0, max: 100 },
+            numberFormat: { formatCode: "$#,##0" },
+            majorTickMark: "cross",
+            minorTickMark: "in",
+            tickLblPos: "low",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    // Spec order: scaling → axPos → majorGridlines → title → numFmt →
+    // majorTickMark → minorTickMark → tickLblPos → crossAx → ...
+    const scalingIdx = valAxBlock.indexOf("<c:scaling>");
+    const gridlinesIdx = valAxBlock.indexOf("<c:majorGridlines");
+    const titleIdx = valAxBlock.indexOf("<c:title>");
+    const numFmtIdx = valAxBlock.indexOf("<c:numFmt");
+    const majorIdx = valAxBlock.indexOf("<c:majorTickMark");
+    const minorIdx = valAxBlock.indexOf("<c:minorTickMark");
+    const tickLblIdx = valAxBlock.indexOf("<c:tickLblPos");
+    const crossAxIdx = valAxBlock.indexOf("c:crossAx");
+    expect(scalingIdx).toBeGreaterThan(0);
+    expect(gridlinesIdx).toBeGreaterThan(scalingIdx);
+    expect(titleIdx).toBeGreaterThan(gridlinesIdx);
+    expect(numFmtIdx).toBeGreaterThan(titleIdx);
+    expect(majorIdx).toBeGreaterThan(numFmtIdx);
+    expect(minorIdx).toBeGreaterThan(majorIdx);
+    expect(tickLblIdx).toBeGreaterThan(minorIdx);
+    expect(crossAxIdx).toBeGreaterThan(tickLblIdx);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3276,3 +3276,218 @@ describe("parseChart — series invertIfNegative flag", () => {
     expect(chart?.series?.[0].invertIfNegative).toBeUndefined();
   });
 });
+
+// ── parseChart — axis tick marks and tick label position ──────────
+
+describe("parseChart — axis tick marks and tick label position", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces non-default <c:majorTickMark val=".."/> off the value axis', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:majorTickMark val="cross"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.majorTickMark).toBe("cross");
+  });
+
+  it('surfaces non-default <c:minorTickMark val=".."/> off the value axis', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:minorTickMark val="out"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.minorTickMark).toBe("out");
+  });
+
+  it('surfaces non-default <c:tickLblPos val=".."/> off the value axis', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:tickLblPos val="low"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.tickLblPos).toBe("low");
+  });
+
+  it("collapses the OOXML default majorTickMark=out to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:majorTickMark val="out"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses the OOXML default minorTickMark=none to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:minorTickMark val="none"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses the OOXML default tickLblPos=nextTo to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:tickLblPos val="nextTo"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores unknown majorTickMark / minorTickMark values", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:majorTickMark val="zigzag"/>
+      <c:minorTickMark val="diagonal"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores unknown tickLblPos values", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:tickLblPos val="diagonal"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores tick-mark / tick-lbl-pos elements with no val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:majorTickMark/>
+      <c:minorTickMark/>
+      <c:tickLblPos/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("surfaces tick rendering on the category axis (catAx) too", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:majorTickMark val="in"/>
+      <c:tickLblPos val="high"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.majorTickMark).toBe("in");
+    expect(chart?.axes?.x?.tickLblPos).toBe("high");
+  });
+
+  it("surfaces tick rendering on the scatter X axis (first valAx)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:majorTickMark val="cross"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:tickLblPos val="none"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.majorTickMark).toBe("cross");
+    expect(chart?.axes?.y?.tickLblPos).toBe("none");
+  });
+
+  it("co-surfaces title, gridlines, scale, numberFormat, tick marks and tick label pos together", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="minMax"/><c:max val="100"/><c:min val="0"/></c:scaling>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:numFmt formatCode="$#,##0" sourceLinked="0"/>
+      <c:majorTickMark val="cross"/>
+      <c:minorTickMark val="in"/>
+      <c:tickLblPos val="low"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y).toEqual({
+      title: "Revenue",
+      gridlines: { major: true },
+      scale: { min: 0, max: 100 },
+      numberFormat: { formatCode: "$#,##0" },
+      majorTickMark: "cross",
+      minorTickMark: "in",
+      tickLblPos: "low",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:majorTickMark>` / `<c:minorTickMark>` / `<c:tickLblPos>` elements at the read, write, and clone layers so a template's tick rendering survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The three elements live alongside `<c:numFmt>` on every CT_CatAx / CT_ValAx / CT_DateAx / CT_SerAx and control where Excel paints the short tick marks (`none` / `in` / `out` / `cross`) and where the numeric or category tick labels sit relative to the axis line (`nextTo` / `low` / `high` / `none`). Until now hucre's writer never emitted any of the three, so a template that anchored axis labels to the chart edge with `tickLblPos="low"` or styled the value-axis ticks with `majorTickMark="cross"` flattened to Excel's defaults on every parse -> clone -> write loop. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.y?.majorTickMark); // "cross" when the template overrode the OOXML default,
                                            // undefined when the template used "out" (the default)
console.log(source.axes?.y?.tickLblPos);    // "low" when labels are pinned to the chart edge

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      axes: {
        y: {
          majorTickMark: "cross", // tick marks straddle the axis line
          minorTickMark: "in",    // minor ticks point inward
          tickLblPos: "low",      // labels pinned to the bottom edge
        },
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    y: {
      majorTickMark: "out",   // replace
      minorTickMark: null,    // drop the inherited flag (writer falls back to "none")
      // tickLblPos: undefined  // inherit the source's parsed value
    },
  },
});
```

## Model

```ts
export type ChartAxisTickMark = "none" | "in" | "out" | "cross";
export type ChartAxisTickLabelPosition = "nextTo" | "low" | "high" | "none";

interface ChartAxisInfo {
  /* ...existing fields... */
  majorTickMark?: ChartAxisTickMark;
  minorTickMark?: ChartAxisTickMark;
  tickLblPos?: ChartAxisTickLabelPosition;
}

interface SheetChart {
  axes?: {
    x?: { /* ... */; majorTickMark?: ChartAxisTickMark; minorTickMark?: ChartAxisTickMark; tickLblPos?: ChartAxisTickLabelPosition };
    y?: { /* ... */; majorTickMark?: ChartAxisTickMark; minorTickMark?: ChartAxisTickMark; tickLblPos?: ChartAxisTickLabelPosition };
  };
}

interface CloneChartOptions {
  axes?: {
    x?: { /* ... */; majorTickMark?: ChartAxisTickMark | null; minorTickMark?: ChartAxisTickMark | null; tickLblPos?: ChartAxisTickLabelPosition | null };
    y?: { /* ... */; majorTickMark?: ChartAxisTickMark | null; minorTickMark?: ChartAxisTickMark | null; tickLblPos?: ChartAxisTickLabelPosition | null };
  };
}
```

The read-side `ChartAxisInfo.{majorTickMark,minorTickMark,tickLblPos}` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls the three elements off `<c:catAx>` / `<c:valAx>`. The OOXML defaults (`majorTickMark="out"`, `minorTickMark="none"`, `tickLblPos="nextTo"`) collapse to `undefined` so absence and the default round-trip identically; only non-default values surface. Unknown enum tokens drop to `undefined` rather than fabricate a value Excel would reject.
- **Write** — Each element is emitted only when the matching field is pinned (no defaults injected), keeping fresh charts visually identical to Excel's reference serialization. The OOXML schema's strict child order is preserved: `axId` -> `scaling` -> `delete` -> `axPos` -> `majorGridlines` -> `minorGridlines` -> `title` -> `numFmt` -> `majorTickMark` -> `minorTickMark` -> `tickLblPos` -> `crossAx` -> ... Invalid enum tokens are filtered at write time so a typo'd input cannot produce invalid OOXML.
- **Clone** — Each axis override accepts the standard `undefined` (inherit) / `null` (drop the inherited flag, falling back to the writer's per-element default) / value (replace) grammar that mirrors `gridlines` / `scale` / `numberFormat`. When the resolved clone target is `pie` or `doughnut` the entire `axes` block is silently dropped (neither has axes in OOXML).

## Edge cases

- A chart with `majorTickMark: "out"` round-trips identically to a chart that omits the field — the writer omits the element on the second pass and the reader collapses both shapes to `undefined`.
- Values outside the `ST_TickMark` / `ST_TickLblPos` enums are filtered at every layer (read, write, clone) so a corrupt template cannot leak into the output.
- A `<c:majorTickMark/>` with no `val` attribute reads as `undefined` rather than fabricate a flag.
- Bar / column / line / area / scatter all support tick rendering on both axes; pie / doughnut silently drop the entire `axes` block since OOXML defines no axes for them.
- The element is placed in the spec-required slot inside `<c:catAx>` / `<c:valAx>` — after `<c:numFmt>` and before `<c:crossAx>` — so Excel's strict validator accepts the file.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm test` (lint + typecheck + vitest, all 2964 tests passing including 33 new tests across reader, writer, and clone for the three tick-rendering elements)
- [x] Reader, writer, and clone tests cover: defaults, every enum value, missing `val`, unknown tokens, OOXML element ordering inside the axis, single-emission guard, every chart family, scatter axis layout (axPos="b" vs "l"), pie/doughnut drop-through, and a full `parseChart -> cloneChart -> writeChart -> parseChart` round-trip with a `writeXlsx` end-to-end check.