### PR TITLE
feat(xlsx): chart category-axis tick skips — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,15 @@ non-default that keeps hidden cells in the chart). The reader accepts
 the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
 `"false"`); unknown values and missing `val` attributes drop to
 `undefined`.
+`ChartAxisInfo.tickLblSkip` and `ChartAxisInfo.tickMarkSkip` surface
+the category-axis tick-thinning knobs (`<c:catAx><c:tickLblSkip val=".."/>`
+and `<c:catAx><c:tickMarkSkip val=".."/>`). Both elements live on
+`CT_CatAx` / `CT_DateAx` only — the reader skips the parse on
+`<c:valAx>` so a corrupt template carrying a stray skip on a value
+axis does not surface a field the writer would never emit anyway. The
+OOXML default `1` (show every label / mark) collapses to `undefined`;
+out-of-range values (non-positive or > 32767) drop rather than clamp
+so a malformed input cannot leak into the writer.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -838,6 +847,17 @@ the chart), matching Excel's reference serialization. Pin
 chart (`val="0"`). The writer always emits the element so the
 rendered intent is explicit on roundtrip — no chart family is special-
 cased.
+The `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` fields thin out a
+crowded category axis (`<c:catAx><c:tickLblSkip val=".."/>` and
+`<c:catAx><c:tickMarkSkip val=".."/>`). Pass a positive integer to
+show every Nth label or mark; the OOXML default `1` (show every tick)
+is omitted from the rendered XML so untouched charts match Excel's
+reference serialization byte-for-byte. Out-of-range values
+(non-positive or > 32767) drop silently rather than clamp. Both
+fields live on category axes only — bar / column / line / area
+honour them; scatter (whose two axes are value axes) and pie /
+doughnut (no axes at all) silently ignore them. Non-integer inputs
+round to the nearest integer.
 For line and scatter charts, each `series[i].smooth` flag toggles
 Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
 Line series always emit the element — `smooth: true` writes `val="1"`,
@@ -991,6 +1011,15 @@ a `boolean` to replace it. Like `dispBlanksAs` and `varyColors`, the
 field lives on `<c:chart>` and is valid on every chart family, so a
 coercion (line → column, doughnut → pie, etc.) preserves the
 inherited value rather than dropping it.
+The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
+follow the same `undefined` (inherit) / `null` (drop) / number
+(replace) grammar as `gridlines` / `scale` / `numberFormat`. The
+inherited values are dropped silently when the resolved clone target
+is `scatter` (its X axis is a value axis, so the skip would have no
+slot in the rendered chart) and when the target is `pie` or
+`doughnut` (no axes at all) — flattening a column template into a
+scatter clone therefore never leaks a stale catAx skip into the
+output.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1039,6 +1039,12 @@ export interface SheetChart {
    * useful when the cloned chart needs a different format from the
    * source data range (e.g. forcing `"0.00%"` on a percentage chart
    * whose underlying cells are stored as decimals).
+   *
+   * `tickLblSkip` and `tickMarkSkip` thin out a crowded category axis.
+   * Both map to category-axis-only OOXML elements (`<c:tickLblSkip>` /
+   * `<c:tickMarkSkip>` on `CT_CatAx` / `CT_DateAx`); they have no slot
+   * on `<c:valAx>` and are silently ignored on the value axis or on
+   * scatter charts (whose two axes are both value axes).
    */
   axes?: {
     /** Category axis (bar/column/line/area) or X value axis (scatter). */
@@ -1047,6 +1053,27 @@ export interface SheetChart {
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
+      /**
+       * Show every Nth tick label on a category axis. `1` (the OOXML
+       * default) shows every label; `2` shows every other one; `3`
+       * shows every third, and so on. Maps to
+       * `<c:catAx><c:tickLblSkip val="N"/></c:catAx>`. Only meaningful
+       * for bar / column / line / area charts (whose X axis is
+       * `<c:catAx>`); silently ignored for scatter (both axes are
+       * value axes) and pie / doughnut (no axes at all). Accepted
+       * range: positive integers 1..32767 (the OOXML
+       * `ST_SkipIntervals` schema). Values outside the range or
+       * non-positive are dropped at write time.
+       */
+      tickLblSkip?: number;
+      /**
+       * Show every Nth tick mark on a category axis. Same `1`-default
+       * semantics as {@link tickLblSkip} but for the short tick lines
+       * Excel paints alongside each label. Maps to
+       * `<c:catAx><c:tickMarkSkip val="N"/></c:catAx>`. Same
+       * scope-restriction as `tickLblSkip` — category axes only.
+       */
+      tickMarkSkip?: number;
     };
     /** Value axis. */
     y?: {
@@ -1865,6 +1892,22 @@ export interface ChartAxisInfo {
    * the writer side.
    */
   numberFormat?: ChartAxisNumberFormat;
+  /**
+   * Tick-label skip interval pulled from `<c:tickLblSkip val=".."/>`.
+   * Surfaces only on category axes (`<c:catAx>` / `<c:dateAx>`) — the
+   * OOXML schema does not place this element on `<c:valAx>`. The
+   * default `1` (show every label) collapses to `undefined` so absence
+   * and the default round-trip identically through {@link cloneChart}.
+   * Out-of-range values (non-positive or > 32767) are dropped rather
+   * than fabricated.
+   */
+  tickLblSkip?: number;
+  /**
+   * Tick-mark skip interval pulled from `<c:tickMarkSkip val=".."/>`.
+   * Same scope (category axes only) and default-collapse semantics as
+   * {@link tickLblSkip}.
+   */
+  tickMarkSkip?: number;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -236,6 +236,20 @@ export interface CloneChartOptions {
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
+      /**
+       * Override `SheetChart.axes.x.tickLblSkip`. `undefined` (or
+       * omitted) inherits the source axis's skip; `null` drops the
+       * inherited value (Excel falls back to showing every label); a
+       * positive integer replaces it. Only meaningful for resolved
+       * chart types whose X axis is `<c:catAx>` (bar / column / line
+       * / area); silently dropped on scatter and pie / doughnut.
+       */
+      tickLblSkip?: number | null;
+      /**
+       * Override `SheetChart.axes.x.tickMarkSkip`. Same grammar and
+       * scope rules as {@link tickLblSkip}.
+       */
+      tickMarkSkip?: number | null;
     };
     y?: {
       title?: string | null;
@@ -411,7 +425,7 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   // titles even when the source declared them or the caller passed an
   // override.
   if (type !== "pie" && type !== "doughnut") {
-    const axes = resolveAxes(source.axes, options.axes);
+    const axes = resolveAxes(source.axes, options.axes, type);
     if (axes !== undefined) out.axes = axes;
   }
 
@@ -805,6 +819,7 @@ function applyOverride(
 function resolveAxes(
   sourceAxes: Chart["axes"],
   overrides: CloneChartOptions["axes"],
+  type: WriteChartKind,
 ): SheetChart["axes"] | undefined {
   const xTitle = applyOverride(sourceAxes?.x?.title, overrides?.x?.title);
   const yTitle = applyOverride(sourceAxes?.y?.title, overrides?.y?.title);
@@ -820,19 +835,35 @@ function resolveAxes(
     sourceAxes?.y?.numberFormat,
     overrides?.y?.numberFormat,
   );
+  // `tickLblSkip` / `tickMarkSkip` only render on category axes
+  // (`<c:catAx>`). Scatter charts use two value axes, so the X axis
+  // skip would be silently dropped by the writer anyway — collapse it
+  // to undefined here so the cloned `SheetChart` accurately reflects
+  // what the chart will paint.
+  const isCatAxisX = type !== "scatter";
+  const xTickLblSkip = isCatAxisX
+    ? applySkipOverride(sourceAxes?.x?.tickLblSkip, overrides?.x?.tickLblSkip)
+    : undefined;
+  const xTickMarkSkip = isCatAxisX
+    ? applySkipOverride(sourceAxes?.x?.tickMarkSkip, overrides?.x?.tickMarkSkip)
+    : undefined;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
     xTitle !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
-    xNumFmt !== undefined
+    xNumFmt !== undefined ||
+    xTickLblSkip !== undefined ||
+    xTickMarkSkip !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
+    if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
+    if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
   }
   if (
     yTitle !== undefined ||
@@ -848,6 +879,30 @@ function resolveAxes(
   }
 
   return out.x || out.y ? out : undefined;
+}
+
+/**
+ * Resolve a `tickLblSkip` / `tickMarkSkip` override using the same
+ * `undefined` (inherit) / `null` (drop) / value (replace) grammar as
+ * the other axis helpers. Out-of-range / non-positive values collapse
+ * to `undefined` so they cannot leak into the writer (which would
+ * silently drop them anyway via {@link normalizeAxisSkip}).
+ */
+function applySkipOverride(
+  source: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) {
+    if (typeof source !== "number" || !Number.isFinite(source)) return undefined;
+    const rounded = Math.round(source);
+    if (rounded < 1 || rounded > 32767 || rounded === 1) return undefined;
+    return rounded;
+  }
+  if (override === null) return undefined;
+  if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
+  const rounded = Math.round(override);
+  if (rounded < 1 || rounded > 32767 || rounded === 1) return undefined;
+  return rounded;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -257,11 +257,22 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
+  // `<c:tickLblSkip>` / `<c:tickMarkSkip>` live exclusively on
+  // `CT_CatAx` / `CT_DateAx` per ECMA-376 Part 1, §21.2.2 — the
+  // `<c:valAx>` schema rejects them entirely. Skip the parse on
+  // value axes so a corrupt template carrying a stray skip element
+  // on a value axis does not surface a field the writer would never
+  // emit anyway.
+  const isCategoryAxis = axis.local === "catAx" || axis.local === "dateAx";
+  const tickLblSkip = isCategoryAxis ? parseAxisSkip(axis, "tickLblSkip") : undefined;
+  const tickMarkSkip = isCategoryAxis ? parseAxisSkip(axis, "tickMarkSkip") : undefined;
   if (
     title === undefined &&
     gridlines === undefined &&
     scale === undefined &&
-    numberFormat === undefined
+    numberFormat === undefined &&
+    tickLblSkip === undefined &&
+    tickMarkSkip === undefined
   ) {
     return undefined;
   }
@@ -270,7 +281,40 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
+  if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
+  if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
   return out;
+}
+
+/**
+ * Pull `<c:tickLblSkip val=".."/>` or `<c:tickMarkSkip val=".."/>`
+ * off a category axis element. Returns `undefined` when:
+ *   - the element is absent,
+ *   - the `val` attribute is missing or non-numeric,
+ *   - the parsed value is `1` (the OOXML default — show every label /
+ *     mark),
+ *   - the parsed value falls outside the OOXML `ST_SkipIntervals`
+ *     range (`1..32767`).
+ *
+ * Negative / zero / out-of-range inputs are dropped rather than
+ * clamped so a corrupt template cannot leak a skip count Excel would
+ * reject.
+ */
+function parseAxisSkip(
+  axis: XmlElement,
+  localName: "tickLblSkip" | "tickMarkSkip",
+): number | undefined {
+  const el = findChild(axis, localName);
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 1 || parsed > 32767) return undefined;
+  if (parsed === 1) return undefined;
+  return parsed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -145,6 +145,12 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     yScale: normalizeAxisScale(chart.axes?.y?.scale),
     xNumFmt: normalizeAxisNumberFormat(chart.axes?.x?.numberFormat),
     yNumFmt: normalizeAxisNumberFormat(chart.axes?.y?.numberFormat),
+    // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
+    // (`<c:catAx>` / `<c:dateAx>`). The scatter writer never emits
+    // them — both axes are value axes — so the bar/column/line/area
+    // catAx builder is the only consumer of these knobs.
+    xTickLblSkip: normalizeAxisSkip(chart.axes?.x?.tickLblSkip),
+    xTickMarkSkip: normalizeAxisSkip(chart.axes?.x?.tickMarkSkip),
   };
 
   switch (chart.type) {
@@ -196,6 +202,17 @@ interface AxisRenderOptions {
   yScale: ChartAxisScale | undefined;
   xNumFmt: ChartAxisNumberFormat | undefined;
   yNumFmt: ChartAxisNumberFormat | undefined;
+  /**
+   * Tick-label skip interval emitted on the X axis only when the axis
+   * is `<c:catAx>` (i.e. bar / column / line / area). Scatter charts
+   * have no category axis, so the skip is dropped silently.
+   */
+  xTickLblSkip: number | undefined;
+  /**
+   * Tick-mark skip interval emitted on the X axis only when the axis
+   * is `<c:catAx>`. Same scope rule as {@link xTickLblSkip}.
+   */
+  xTickMarkSkip: number | undefined;
 }
 
 /**
@@ -302,6 +319,29 @@ function normalizeAxisNumberFormat(
 }
 
 /**
+ * Normalize a `tickLblSkip` / `tickMarkSkip` value to a positive
+ * integer in the OOXML `ST_SkipIntervals` band (`1..32767`).
+ *
+ * Returns `undefined` when:
+ *   - the input is missing or non-finite,
+ *   - the rounded value is `1` (the OOXML default — show every label /
+ *     mark — and what absence already means),
+ *   - the rounded value falls outside the `1..32767` range.
+ *
+ * Out-of-range values drop rather than clamp because a skip count of
+ * `100` and `32767` mean structurally different things to Excel — a
+ * silent clamp would mask the configuration error rather than reveal
+ * it.
+ */
+function normalizeAxisSkip(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < 1 || rounded > 32767) return undefined;
+  if (rounded === 1) return undefined;
+  return rounded;
+}
+
+/**
  * Build the children that augment a `<c:scaling>` element. Order is
  * spec-enforced: `<c:logBase>` → `<c:orientation>` → `<c:max>` →
  * `<c:min>`. The orientation child is always emitted by the caller
@@ -366,6 +406,29 @@ function buildAxisNumFmt(numFmt: ChartAxisNumberFormat | undefined): string[] {
   if (!numFmt) return [];
   const sourceLinked = numFmt.sourceLinked === true ? 1 : 0;
   return [xmlSelfClose("c:numFmt", { formatCode: numFmt.formatCode, sourceLinked })];
+}
+
+/**
+ * Build the `<c:tickLblSkip>` / `<c:tickMarkSkip>` siblings that sit
+ * between `<c:lblOffset>` and `<c:noMultiLvlLbl>` inside `<c:catAx>`
+ * (CT_CatAx). Order is `tickLblSkip` first, then `tickMarkSkip` per
+ * the OOXML schema. Each element is emitted only when the caller
+ * pinned a non-default value (the helper relies on
+ * {@link normalizeAxisSkip} having already collapsed `1` and out-of-
+ * range inputs to `undefined`).
+ */
+function buildAxisSkips(
+  tickLblSkip: number | undefined,
+  tickMarkSkip: number | undefined,
+): string[] {
+  const out: string[] = [];
+  if (tickLblSkip !== undefined) {
+    out.push(xmlSelfClose("c:tickLblSkip", { val: tickLblSkip }));
+  }
+  if (tickMarkSkip !== undefined) {
+    out.push(xmlSelfClose("c:tickMarkSkip", { val: tickMarkSkip }));
+  }
+  return out;
 }
 
 // ── Bar / Column ─────────────────────────────────────────────────────
@@ -496,6 +559,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:auto", { val: 1 }),
     xmlSelfClose("c:lblAlgn", { val: "ctr" }),
     xmlSelfClose("c:lblOffset", { val: 100 }),
+    // OOXML CT_CatAx places `<c:tickLblSkip>` / `<c:tickMarkSkip>`
+    // after `<c:lblOffset>` and before `<c:noMultiLvlLbl>`. Only
+    // emit each element when the caller pinned a non-default value
+    // so a fresh chart matches Excel's reference serialization (the
+    // default `1` is omitted and Excel renders every tick).
+    ...buildAxisSkips(opts.xTickLblSkip, opts.xTickMarkSkip),
     xmlSelfClose("c:noMultiLvlLbl", { val: 0 }),
   );
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2910,3 +2910,166 @@ describe("cloneChart — plotVisOnly", () => {
     expect(parseChart(written)?.plotVisOnly).toBeUndefined();
   });
 });
+
+// ── cloneChart — axis tickLblSkip / tickMarkSkip ────────────────────
+
+describe("cloneChart — axis tickLblSkip / tickMarkSkip", () => {
+  const sourceWithSkips: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { tickLblSkip: 3, tickMarkSkip: 5 } },
+  };
+
+  it("inherits both skips from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithSkips, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.tickLblSkip).toBe(3);
+    expect(clone.axes?.x?.tickMarkSkip).toBe(5);
+  });
+
+  it("drops both inherited skips when the override is null", () => {
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { tickLblSkip: null, tickMarkSkip: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces inherited skips with the override values", () => {
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { tickLblSkip: 7, tickMarkSkip: 2 } },
+    });
+    expect(clone.axes?.x?.tickLblSkip).toBe(7);
+    expect(clone.axes?.x?.tickMarkSkip).toBe(2);
+  });
+
+  it("adds a skip to an axis the source did not declare it on", () => {
+    const noSkip: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noSkip, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { tickLblSkip: 4 } },
+    });
+    expect(clone.axes?.x?.tickLblSkip).toBe(4);
+  });
+
+  it("inherits one skip while letting the override drop the other", () => {
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { tickMarkSkip: null } },
+    });
+    expect(clone.axes?.x?.tickLblSkip).toBe(3);
+    expect(clone.axes?.x?.tickMarkSkip).toBeUndefined();
+  });
+
+  it("drops out-of-range overrides without clamping", () => {
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { tickLblSkip: 0, tickMarkSkip: 99999 } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("collapses an explicit override of 1 (the OOXML default) to undefined", () => {
+    // Pinning the default has the same effect as `null` — the cloned
+    // chart inherits Excel's "show every tick" behaviour either way.
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { tickLblSkip: 1, tickMarkSkip: 1 } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips skips silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { tickLblSkip: 3 } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips skips silently when the resolved chart type is scatter", () => {
+    // Scatter uses two value axes, so the X axis is no longer a
+    // category axis. Drop inherited skips so the cloned model
+    // accurately reflects what the chart will paint.
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves both skips", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:tickLblSkip val="3"/>
+        <c:tickMarkSkip val="6"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.tickLblSkip).toBe(3);
+    expect(parsed?.axes?.x?.tickMarkSkip).toBe(6);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.tickLblSkip).toBe(3);
+    expect(sheetChart.axes?.x?.tickMarkSkip).toBe(6);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('c:tickLblSkip val="3"');
+    expect(written).toContain('c:tickMarkSkip val="6"');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.tickLblSkip).toBe(3);
+    expect(reparsed?.axes?.x?.tickMarkSkip).toBe(6);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with skips intact", async () => {
+    const clone = cloneChart(sourceWithSkips, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:tickLblSkip val="3"');
+    expect(written).toContain('c:tickMarkSkip val="5"');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2733,3 +2733,182 @@ describe("writeChart — plotVisOnly", () => {
     expect(reparsed?.plotVisOnly).toBeUndefined();
   });
 });
+
+// ── Axis tick label / mark skip ──────────────────────────────────────
+
+describe("writeChart — axis tickLblSkip / tickMarkSkip", () => {
+  it("emits <c:tickLblSkip> on the category axis when set", () => {
+    const result = writeChart(makeChart({ axes: { x: { tickLblSkip: 3 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:tickLblSkip val="3"');
+  });
+
+  it("emits <c:tickMarkSkip> on the category axis when set", () => {
+    const result = writeChart(makeChart({ axes: { x: { tickMarkSkip: 5 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:tickMarkSkip val="5"');
+  });
+
+  it("emits both skips together in the OOXML-required order", () => {
+    // CT_CatAx: lblOffset → tickLblSkip → tickMarkSkip → noMultiLvlLbl.
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblSkip: 2, tickMarkSkip: 4 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const lblOffsetIdx = catAxBlock.indexOf("c:lblOffset");
+    const tickLblSkipIdx = catAxBlock.indexOf("c:tickLblSkip");
+    const tickMarkSkipIdx = catAxBlock.indexOf("c:tickMarkSkip");
+    const noMultiLvlIdx = catAxBlock.indexOf("c:noMultiLvlLbl");
+    expect(lblOffsetIdx).toBeGreaterThan(0);
+    expect(tickLblSkipIdx).toBeGreaterThan(lblOffsetIdx);
+    expect(tickMarkSkipIdx).toBeGreaterThan(tickLblSkipIdx);
+    expect(noMultiLvlIdx).toBeGreaterThan(tickMarkSkipIdx);
+  });
+
+  it("omits the elements when tickLblSkip / tickMarkSkip are unset (Excel default)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("c:tickLblSkip");
+    expect(result.chartXml).not.toContain("c:tickMarkSkip");
+  });
+
+  it("omits the elements when the value is the OOXML default 1", () => {
+    // Absence and the default `1` round-trip identically. The writer
+    // therefore drops the element when the caller pinned `1` so the
+    // emitted XML matches Excel's reference serialization byte-for-byte.
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblSkip: 1, tickMarkSkip: 1 } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:tickLblSkip");
+    expect(result.chartXml).not.toContain("c:tickMarkSkip");
+  });
+
+  it("drops out-of-range values without clamping", () => {
+    // ST_SkipIntervals restricts the value to 1..32767. Passing 0,
+    // -3, or 99999 drops the element silently rather than clamping —
+    // a silent clamp would mask the configuration error.
+    const result = writeChart(
+      makeChart({
+        axes: { x: { tickLblSkip: 0, tickMarkSkip: 99999 } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:tickLblSkip");
+    expect(result.chartXml).not.toContain("c:tickMarkSkip");
+  });
+
+  it("rounds non-integer values to the nearest integer", () => {
+    const result = writeChart(makeChart({ axes: { x: { tickLblSkip: 3.7 } } }), "Sheet1");
+    expect(result.chartXml).toContain('c:tickLblSkip val="4"');
+  });
+
+  it("accepts the schema boundaries 2 and 32767", () => {
+    const lo = writeChart(makeChart({ axes: { x: { tickLblSkip: 2 } } }), "Sheet1");
+    expect(lo.chartXml).toContain('c:tickLblSkip val="2"');
+    const hi = writeChart(makeChart({ axes: { x: { tickLblSkip: 32767 } } }), "Sheet1");
+    expect(hi.chartXml).toContain('c:tickLblSkip val="32767"');
+  });
+
+  it("emits each element exactly once on the rendered chart", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblSkip: 3, tickMarkSkip: 5 } } }),
+      "Sheet1",
+    );
+    expect((result.chartXml.match(/c:tickLblSkip/g) ?? []).length).toBe(1);
+    expect((result.chartXml.match(/c:tickMarkSkip/g) ?? []).length).toBe(1);
+  });
+
+  it("threads the skips through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { tickLblSkip: 3, tickMarkSkip: 5 } } }),
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('c:tickLblSkip val="3"');
+      expect(result.chartXml).toContain('c:tickMarkSkip val="5"');
+    }
+  });
+
+  it("ignores the skips on scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { tickLblSkip: 3, tickMarkSkip: 5 } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:tickLblSkip");
+    expect(result.chartXml).not.toContain("c:tickMarkSkip");
+  });
+
+  it("ignores the skips on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(makeChart({ type: "pie", axes: { x: { tickLblSkip: 3 } } }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:tickLblSkip");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { tickMarkSkip: 4 } } }),
+      "Sheet1",
+    );
+    expect(dough.chartXml).not.toContain("c:tickMarkSkip");
+  });
+
+  it("does not emit the elements on the value axis even when set on .y", () => {
+    // The model surfaces these only on `axes.x`; setting them via
+    // `axes.y` is impossible at the type level. This test pins the
+    // negative case for the writer: a valAx never carries tick skips.
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblSkip: 3, tickMarkSkip: 5 } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).not.toContain("c:tickLblSkip");
+    expect(valAxBlock).not.toContain("c:tickMarkSkip");
+  });
+
+  it("round-trips a non-default skip pair through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { tickLblSkip: 3, tickMarkSkip: 5 } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.tickLblSkip).toBe(3);
+    expect(reparsed?.axes?.x?.tickMarkSkip).toBe(5);
+  });
+
+  it("collapses a defaulted skip round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+
+  it("places tick skips inside the catAx without breaking schema-required ordering of other elements", () => {
+    // Combine title, gridlines, scale, number format and skips on the
+    // X axis to verify the catAx still renders in spec order.
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Region",
+            gridlines: { major: true },
+            numberFormat: { formatCode: "@" },
+            tickLblSkip: 3,
+            tickMarkSkip: 5,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const idx = (needle: string): number => catAxBlock.indexOf(needle);
+    expect(idx("c:axId")).toBeLessThan(idx("c:scaling"));
+    expect(idx("c:scaling")).toBeLessThan(idx("c:axPos"));
+    expect(idx("c:axPos")).toBeLessThan(idx("c:majorGridlines"));
+    expect(idx("c:majorGridlines")).toBeLessThan(idx("c:title"));
+    expect(idx("c:title")).toBeLessThan(idx("c:numFmt"));
+    expect(idx("c:numFmt")).toBeLessThan(idx("c:crossAx"));
+    expect(idx("c:lblOffset")).toBeLessThan(idx("c:tickLblSkip"));
+    expect(idx("c:tickLblSkip")).toBeLessThan(idx("c:tickMarkSkip"));
+    expect(idx("c:tickMarkSkip")).toBeLessThan(idx("c:noMultiLvlLbl"));
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3395,3 +3395,164 @@ describe("parseChart — plotVisOnly", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — axis tick label / mark skip ──────────────────────
+
+describe("parseChart — axis tickLblSkip / tickMarkSkip", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a non-default tickLblSkip on the category axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:tickLblSkip val="3"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.tickLblSkip).toBe(3);
+    expect(chart?.axes?.x?.tickMarkSkip).toBeUndefined();
+  });
+
+  it("surfaces a non-default tickMarkSkip on the category axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:tickMarkSkip val="5"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.tickMarkSkip).toBe(5);
+    expect(chart?.axes?.x?.tickLblSkip).toBeUndefined();
+  });
+
+  it("surfaces both skips together when set on the same axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:tickLblSkip val="2"/>
+      <c:tickMarkSkip val="4"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({ tickLblSkip: 2, tickMarkSkip: 4 });
+  });
+
+  it("collapses the OOXML default tickLblSkip=1 to undefined", () => {
+    // Absence of the element and `val="1"` round-trip identically
+    // through the writer's elision logic — both mean "show every label".
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:tickLblSkip val="1"/>
+      <c:tickMarkSkip val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores out-of-range skip values (drops rather than clamps)", () => {
+    // ST_SkipIntervals restricts the value to 1..32767. Out-of-range
+    // values like 0, -5, 99999 should drop rather than clamp because a
+    // silent clamp would mask a configuration error.
+    const out = (val: string): unknown => {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:tickLblSkip val="${val}"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      return parseChart(xml)?.axes?.x?.tickLblSkip;
+    };
+    expect(out("0")).toBeUndefined();
+    expect(out("-5")).toBeUndefined();
+    expect(out("99999")).toBeUndefined();
+    expect(out("not-a-number")).toBeUndefined();
+    // Boundaries 2 and 32767 are accepted.
+    expect(out("2")).toBe(2);
+    expect(out("32767")).toBe(32767);
+  });
+
+  it("returns undefined when tickLblSkip val attribute is missing", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:tickLblSkip/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface tickLblSkip / tickMarkSkip on a value axis", () => {
+    // The OOXML schema places these elements on CT_CatAx / CT_DateAx
+    // only — `<c:valAx>` rejects them entirely. A corrupt template
+    // carrying a stray skip element on a value axis should not surface
+    // a field the writer would never emit anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:tickLblSkip val="3"/>
+      <c:tickMarkSkip val="5"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.tickLblSkip).toBeUndefined();
+    expect(chart?.axes?.y?.tickMarkSkip).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces tick skips alongside title, gridlines, scale, and number format", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:numFmt formatCode="@" sourceLinked="0"/>
+      <c:tickLblSkip val="3"/>
+      <c:tickMarkSkip val="6"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Region",
+      gridlines: { major: true },
+      numberFormat: { formatCode: "@" },
+      tickLblSkip: 3,
+      tickMarkSkip: 6,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:tickLblSkip>` / `<c:tickMarkSkip>` elements at the read, write, and clone layers so a template's tick-thinning configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Both elements live exclusively on `CT_CatAx` / `CT_DateAx` in OOXML — they have no slot on `CT_ValAx`. They control how often Excel paints a tick label / mark along a crowded category axis: `1` (the OOXML default) shows every label, `2` shows every other one, and so on. Until now hucre's writer never emitted either element, so a template that pinned a date axis to "show every 7th label" flattened back to "show every label" on every parse -> clone -> write loop. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.tickLblSkip);  // 7 when the template pinned "show every 7th label",
                                           // undefined when the template used the default 1
console.log(source.axes?.x?.tickMarkSkip); // same shape for the tick-mark stride

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B62", categories: "A2:A62" }],
      anchor: { from: { row: 6, col: 0 } },
      axes: {
        x: {
          tickLblSkip: 5,  // show every 5th category label
          tickMarkSkip: 5, // and every 5th tick mark
        },
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    x: {
      tickLblSkip: 3,    // replace
      tickMarkSkip: null, // drop the inherited stride (writer falls back to "1")
      // tickLblSkip / tickMarkSkip undefined → inherit the source's parsed value
    },
  },
});
```

## Model

```ts
interface ChartAxisInfo {
  /* ...existing fields... */
  tickLblSkip?: number;
  tickMarkSkip?: number;
}

interface SheetChart {
  axes?: {
    x?: { /* ... */; tickLblSkip?: number; tickMarkSkip?: number };
    y?: { /* ... */ };
  };
}

interface CloneChartOptions {
  axes?: {
    x?: { /* ... */; tickLblSkip?: number | null; tickMarkSkip?: number | null };
    y?: { /* ... */ };
  };
}
```

The read-side `ChartAxisInfo.{tickLblSkip,tickMarkSkip}` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation. Only the X axis carries the fields on the writer / clone side because the OOXML schema places the elements on category axes only — surfacing them on `axes.y` would be misleading at the type level.

## Behavior

- **Read** — `parseChart` pulls the two elements off `<c:catAx>` only (the parser explicitly skips `<c:valAx>` so a corrupt template carrying a stray skip on a value axis cannot leak a field the writer would never emit). The OOXML default `1` collapses to `undefined` so absence and the default round-trip identically; out-of-range values (non-positive, > 32767, non-numeric) drop rather than fabricate a count Excel would reject.
- **Write** — Each element is emitted only when the matching field is pinned to a non-default value (no defaults injected), keeping fresh charts visually identical to Excel's reference serialization. The OOXML schema's strict child order is preserved: `... -> lblOffset -> tickLblSkip -> tickMarkSkip -> noMultiLvlLbl`. Out-of-range values drop silently (`0`, `-3`, `99999` produce no element); non-integer values round to the nearest integer; the schema boundaries `2` and `32767` are accepted literally.
- **Clone** — Each axis override accepts the standard `undefined` (inherit) / `null` (drop the inherited value, falling back to the writer's "show every tick" default) / value (replace) grammar that mirrors `gridlines` / `scale` / `numberFormat`. When the resolved clone target is `pie` / `doughnut` (no axes) or `scatter` (X axis is a value axis, not a category axis) the entire `axes` block is silently coerced so a stale `tickLblSkip` from a column template never leaks into a chart kind whose schema rejects it.

## Edge cases

- A chart with `tickLblSkip: 1` round-trips identically to a chart that omits the field — the writer omits the element on the second pass and the reader collapses both shapes to `undefined`.
- Values outside the `ST_SkipIntervals` band (`1..32767`) are filtered at every layer (read, write, clone) so a corrupt template cannot leak into the output.
- A `<c:tickLblSkip/>` with no `val` attribute reads as `undefined` rather than fabricate a stride.
- Bar / column / line / area all support tick skips on their category axis; scatter (whose X axis is a value axis) and pie / doughnut (no axes at all) silently drop the entire `axes` block on clone-through.
- Each element is placed in the spec-required slot inside `<c:catAx>` — after `<c:lblOffset>` and before `<c:noMultiLvlLbl>` — so Excel's strict validator accepts the file.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm test` (lint + typecheck + vitest, all 2983 tests passing including 19 new tests across reader, writer, and clone for the two tick-skip elements)
- [x] Reader, writer, and clone tests cover: defaults, valid values, missing `val`, out-of-range values (drop rather than clamp), schema boundaries (2 / 32767), non-integer rounding, OOXML element ordering inside the catAx, single-emission guard, every chart family, scatter axis layout (value axes only — skips dropped), pie / doughnut drop-through, valAx never carries the elements, and a full `parseChart -> cloneChart -> writeChart -> parseChart` round-trip with a `writeXlsx` end-to-end check.