### PR TITLE
feat(xlsx): chart axis reverse (orientation) — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1068,6 +1068,21 @@ export interface SheetChart {
        * reference serialization. See {@link ChartAxisTickLabelPosition}.
        */
       tickLblPos?: ChartAxisTickLabelPosition;
+      /**
+       * Reverse the axis plotting order. Maps to
+       * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
+       * Excel's "Categories in reverse order" / "Values in reverse
+       * order" toggle. Default: `false` (the OOXML `"minMax"` default).
+       *
+       * On a category axis, reversing flips the order in which
+       * categories are drawn (right-to-left on a column chart, top-to-
+       * bottom on a bar chart). On a value axis, reversing flips the
+       * numeric direction so the maximum sits at the origin and the
+       * minimum at the far end. Useful when porting templates that
+       * pin a specific reading direction (e.g. dates on a horizontal
+       * bar chart with the most recent at the top).
+       */
+      reverse?: boolean;
     };
     /** Value axis. */
     y?: {
@@ -1093,6 +1108,16 @@ export interface SheetChart {
        * `"nextTo"`. See {@link ChartAxisTickLabelPosition}.
        */
       tickLblPos?: ChartAxisTickLabelPosition;
+      /**
+       * Reverse the value axis plotting order. Maps to
+       * `<c:valAx><c:scaling><c:orientation val="maxMin"/></c:scaling></c:valAx>`.
+       * Default: `false` (the OOXML `"minMax"` default).
+       *
+       * Mirrors {@link SheetChart.axes.x.reverse} for the value axis —
+       * setting `true` flips the numeric direction so the maximum sits
+       * at the origin and the minimum at the far end.
+       */
+      reverse?: boolean;
     };
   };
 }
@@ -1967,6 +1992,17 @@ export interface ChartAxisInfo {
    * shape minimal. See {@link ChartAxisTickLabelPosition}.
    */
   tickLblPos?: ChartAxisTickLabelPosition;
+  /**
+   * Reverse-axis flag pulled from
+   * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`
+   * only when the axis pinned `"maxMin"` (Excel's "Categories /
+   * Values in reverse order" toggle); the OOXML default `"minMax"`
+   * collapses to `undefined` so absence and the default round-trip
+   * identically through {@link cloneChart}. Mirrors the writer-side
+   * {@link SheetChart.axes.x.reverse} field, so a parsed value slots
+   * straight back into a clone target without transformation.
+   */
+  reverse?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -259,6 +259,13 @@ export interface CloneChartOptions {
        * replaces it.
        */
       tickLblPos?: ChartAxisTickLabelPosition | null;
+      /**
+       * Override the reverse-axis flag. `undefined` (or omitted)
+       * inherits the source axis' parsed value; `null` drops it (the
+       * writer falls back to the OOXML default `"minMax"` — forward
+       * orientation); `true` reverses, `false` forces forward.
+       */
+      reverse?: boolean | null;
     };
     y?: {
       title?: string | null;
@@ -271,6 +278,8 @@ export interface CloneChartOptions {
       minorTickMark?: ChartAxisTickMark | null;
       /** See {@link CloneChartOptions.axes.x.tickLblPos}. */
       tickLblPos?: ChartAxisTickLabelPosition | null;
+      /** See {@link CloneChartOptions.axes.x.reverse}. */
+      reverse?: boolean | null;
     };
   };
 }
@@ -867,6 +876,8 @@ function resolveAxes(
   );
   const xTickLblPos = applyTickLblPosOverride(sourceAxes?.x?.tickLblPos, overrides?.x?.tickLblPos);
   const yTickLblPos = applyTickLblPosOverride(sourceAxes?.y?.tickLblPos, overrides?.y?.tickLblPos);
+  const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
+  const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -876,7 +887,8 @@ function resolveAxes(
     xNumFmt !== undefined ||
     xMajorTickMark !== undefined ||
     xMinorTickMark !== undefined ||
-    xTickLblPos !== undefined
+    xTickLblPos !== undefined ||
+    xReverse !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
@@ -886,6 +898,7 @@ function resolveAxes(
     if (xMajorTickMark !== undefined) out.x.majorTickMark = xMajorTickMark;
     if (xMinorTickMark !== undefined) out.x.minorTickMark = xMinorTickMark;
     if (xTickLblPos !== undefined) out.x.tickLblPos = xTickLblPos;
+    if (xReverse !== undefined) out.x.reverse = xReverse;
   }
   if (
     yTitle !== undefined ||
@@ -894,7 +907,8 @@ function resolveAxes(
     yNumFmt !== undefined ||
     yMajorTickMark !== undefined ||
     yMinorTickMark !== undefined ||
-    yTickLblPos !== undefined
+    yTickLblPos !== undefined ||
+    yReverse !== undefined
   ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
@@ -904,6 +918,7 @@ function resolveAxes(
     if (yMajorTickMark !== undefined) out.y.majorTickMark = yMajorTickMark;
     if (yMinorTickMark !== undefined) out.y.minorTickMark = yMinorTickMark;
     if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
+    if (yReverse !== undefined) out.y.reverse = yReverse;
   }
 
   return out.x || out.y ? out : undefined;
@@ -1053,4 +1068,28 @@ function applyTickLblPosOverride(
   }
   if (override === null) return undefined;
   return VALID_TICK_LBL_POS_VALUES.has(override) ? override : undefined;
+}
+
+/**
+ * Resolve a reverse-axis override using the same `undefined` (inherit) /
+ * `null` (drop) / value (replace) grammar as the other axis helpers.
+ *
+ * Only `true` round-trips meaningfully — `false` is the OOXML default
+ * (`orientation="minMax"`) so it collapses to `undefined` to keep the
+ * cloned shape minimal. A source carrying `false` (e.g. an over-eager
+ * parser that surfaced the default) collapses to `undefined` on
+ * inherit; an explicit `false` override likewise drops the field. The
+ * writer's per-axis `reverse: false` default already produces a forward
+ * orientation, so the dropped state is indistinguishable from a literal
+ * `false`.
+ */
+function applyReverseOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    return source === true ? true : undefined;
+  }
+  if (override === null) return undefined;
+  return override === true ? true : undefined;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -268,6 +268,11 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const majorTickMark = parseAxisTickMark(axis, "majorTickMark", "out");
   const minorTickMark = parseAxisTickMark(axis, "minorTickMark", "none");
   const tickLblPos = parseAxisTickLblPos(axis);
+  // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
+  // accepts "minMax" (default, low → high) and "maxMin" (reversed).
+  // The default collapses to undefined so a fresh chart and a chart
+  // that explicitly pins "minMax" round-trip identically.
+  const reverse = parseAxisReverse(axis);
   if (
     title === undefined &&
     gridlines === undefined &&
@@ -275,7 +280,8 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     numberFormat === undefined &&
     majorTickMark === undefined &&
     minorTickMark === undefined &&
-    tickLblPos === undefined
+    tickLblPos === undefined &&
+    reverse === undefined
   ) {
     return undefined;
   }
@@ -287,6 +293,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (majorTickMark !== undefined) out.majorTickMark = majorTickMark;
   if (minorTickMark !== undefined) out.minorTickMark = minorTickMark;
   if (tickLblPos !== undefined) out.tickLblPos = tickLblPos;
+  if (reverse !== undefined) out.reverse = reverse;
   return out;
 }
 
@@ -343,6 +350,28 @@ function parseAxisTickLblPos(axis: XmlElement): ChartAxisTickLabelPosition | und
   const value = raw.trim() as ChartAxisTickLabelPosition;
   if (!VALID_TICK_LBL_POSITIONS.has(value)) return undefined;
   return value === "nextTo" ? undefined : value;
+}
+
+/**
+ * Pull the `ST_Orientation` value off `<c:scaling><c:orientation/></c:scaling>`.
+ * Returns `true` only when the axis pinned `"maxMin"` (Excel's
+ * "Categories / Values in reverse order" toggle); the OOXML default
+ * `"minMax"` collapses to `undefined` so absence and the default
+ * round-trip identically. Unknown tokens (e.g. typo'd templates) drop
+ * to `undefined` rather than fabricate a flag.
+ */
+function parseAxisReverse(axis: XmlElement): boolean | undefined {
+  const scaling = findChild(axis, "scaling");
+  if (!scaling) return undefined;
+  const orientation = findChild(scaling, "orientation");
+  if (!orientation) return undefined;
+  const raw = orientation.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim();
+  if (value === "maxMin") return true;
+  // "minMax" and unknown tokens both fall through to undefined — only
+  // an explicit reversed orientation surfaces.
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -153,6 +153,8 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     yMinorTickMark: normalizeTickMark(chart.axes?.y?.minorTickMark),
     xTickLblPos: normalizeTickLblPos(chart.axes?.x?.tickLblPos),
     yTickLblPos: normalizeTickLblPos(chart.axes?.y?.tickLblPos),
+    xReverse: chart.axes?.x?.reverse === true,
+    yReverse: chart.axes?.y?.reverse === true,
   };
 
   switch (chart.type) {
@@ -210,6 +212,8 @@ interface AxisRenderOptions {
   yMinorTickMark: ChartAxisTickMark | undefined;
   xTickLblPos: ChartAxisTickLabelPosition | undefined;
   yTickLblPos: ChartAxisTickLabelPosition | undefined;
+  xReverse: boolean;
+  yReverse: boolean;
 }
 
 /**
@@ -342,13 +346,15 @@ function buildAxisScalingExtras(scale: ChartAxisScale | undefined): {
 
 /**
  * Build the `<c:scaling>` element. Always emits `<c:orientation>` so
- * the axis renders correctly even when no extra scale fields are set.
+ * the axis renders correctly even when no extra scale fields are set —
+ * `"minMax"` (the OOXML default) for a forward axis, `"maxMin"` when
+ * the caller pinned `reverse: true` to flip the plotting order.
  */
-function buildAxisScaling(scale: ChartAxisScale | undefined): string {
+function buildAxisScaling(scale: ChartAxisScale | undefined, reverse: boolean = false): string {
   const { before, after } = buildAxisScalingExtras(scale);
   const children: string[] = [
     ...before,
-    xmlSelfClose("c:orientation", { val: "minMax" }),
+    xmlSelfClose("c:orientation", { val: reverse ? "maxMin" : "minMax" }),
     ...after,
   ];
   return xmlElement("c:scaling", undefined, children);
@@ -561,7 +567,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // caller pinned a value so write-side templates round-trip.
   const catAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_CAT }),
-    buildAxisScaling(opts.xScale),
+    buildAxisScaling(opts.xScale, opts.xReverse),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: catPos }),
     ...buildAxisGridlines(opts.xGridlines),
@@ -580,7 +586,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
 
   const valAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL }),
-    buildAxisScaling(opts.yScale),
+    buildAxisScaling(opts.yScale, opts.yReverse),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: valPos }),
     ...buildAxisGridlines(opts.yGridlines),
@@ -798,7 +804,7 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
 function buildScatterAxes(opts: AxisRenderOptions): string[] {
   const xAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_X }),
-    buildAxisScaling(opts.xScale),
+    buildAxisScaling(opts.xScale, opts.xReverse),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "b" }),
     ...buildAxisGridlines(opts.xGridlines),
@@ -815,7 +821,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
 
   const yAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_Y }),
-    buildAxisScaling(opts.yScale),
+    buildAxisScaling(opts.yScale, opts.yReverse),
     xmlSelfClose("c:delete", { val: 0 }),
     xmlSelfClose("c:axPos", { val: "l" }),
     ...buildAxisGridlines(opts.yGridlines),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3101,3 +3101,173 @@ describe("cloneChart — plotVisOnly", () => {
     expect(parseChart(written)?.plotVisOnly).toBeUndefined();
   });
 });
+
+// ── cloneChart — axis reverse (orientation) ──────────────────────────
+
+describe("cloneChart — axis reverse (orientation)", () => {
+  const sourceWithReverse: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: {
+      y: { reverse: true },
+    },
+  };
+
+  it("inherits the source's reverse flag when no override is given", () => {
+    const clone = cloneChart(sourceWithReverse, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.reverse).toBe(true);
+  });
+
+  it("drops the inherited reverse flag when override is null", () => {
+    const clone = cloneChart(sourceWithReverse, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { reverse: null } },
+    });
+    // The source had only `reverse: true`, so dropping it leaves the
+    // axis empty — which collapses the whole axes block.
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the inherited reverse flag when override is false", () => {
+    // Mirrors `null` — false is the OOXML default and the writer never
+    // emits a non-default orientation for it.
+    const clone = cloneChart(sourceWithReverse, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { reverse: false } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited reverse flag with an explicit true", () => {
+    const noReverse: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noReverse, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { reverse: true } },
+    });
+    expect(clone.axes?.y?.reverse).toBe(true);
+  });
+
+  it("supports reverse on the X (category) axis", () => {
+    const xSource: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { reverse: true } },
+    };
+    const clone = cloneChart(xSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.reverse).toBe(true);
+    expect(clone.axes?.y?.reverse).toBeUndefined();
+  });
+
+  it("strips reverse silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { reverse: true } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips reverse silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { reverse: true } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("preserves other axis fields when the reverse override is null", () => {
+    // A source carrying both gridlines and reverse — dropping just
+    // reverse should keep the gridlines slot intact.
+    const richSource: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { reverse: true, gridlines: { major: true } } },
+    };
+    const clone = cloneChart(richSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { reverse: null } },
+    });
+    expect(clone.axes?.y?.reverse).toBeUndefined();
+    expect(clone.axes?.y?.gridlines).toEqual({ major: true });
+  });
+
+  it("ignores a literal source `reverse: false` (OOXML default)", () => {
+    // A defensively-typed source (e.g. an over-eager parser that
+    // surfaced the default) should collapse on inherit so the writer
+    // never emits the redundant forward orientation as if it were
+    // pinned.
+    const bogus: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { reverse: false } },
+    };
+    const clone = cloneChart(bogus, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("round-trips through writeChart and parseChart", async () => {
+    const clone = cloneChart(sourceWithReverse, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    const written = writeChart(clone, "Sheet1").chartXml;
+    expect(written).toContain('c:orientation val="maxMin"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.reverse).toBe(true);
+
+    // End-to-end: writeXlsx packages the clone into a valid OOXML file
+    // whose chart part round-trips its reverse-axis flag.
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const fromZip = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(fromZip).toContain('c:orientation val="maxMin"');
+    expect(parseChart(fromZip)?.axes?.y?.reverse).toBe(true);
+  });
+
+  it("plays nicely alongside other axis overrides on the same axis", () => {
+    // Mixing reverse with a tick-mark / scale override should keep
+    // every field independent — the resolveAxes merge should not drop
+    // either one when both source and override are populated.
+    const richSource: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { majorTickMark: "cross", scale: { min: 0, max: 100 } } },
+    };
+    const clone = cloneChart(richSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { reverse: true } },
+    });
+    expect(clone.axes?.y?.majorTickMark).toBe("cross");
+    expect(clone.axes?.y?.scale).toEqual({ min: 0, max: 100 });
+    expect(clone.axes?.y?.reverse).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2970,3 +2970,152 @@ describe("writeChart — plotVisOnly", () => {
     expect(reparsed?.plotVisOnly).toBeUndefined();
   });
 });
+
+// ── writeChart — axis reverse (orientation) ──────────────────────────
+
+describe("writeChart — axis reverse (orientation)", () => {
+  it('emits <c:orientation val="maxMin"/> on the value axis when y.reverse is true', () => {
+    const result = writeChart(makeChart({ axes: { y: { reverse: true } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:orientation val="maxMin"/>');
+    expect(valAxBlock).not.toContain('val="minMax"');
+  });
+
+  it('emits <c:orientation val="maxMin"/> on the category axis when x.reverse is true', () => {
+    const result = writeChart(makeChart({ axes: { x: { reverse: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<c:orientation val="maxMin"/>');
+    // The value axis keeps the forward minMax default.
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:orientation val="minMax"/>');
+  });
+
+  it("falls back to minMax when reverse is unset, false, or absent", () => {
+    // A fresh chart (no axes block at all) emits the OOXML default on
+    // both axes — the writer never omits <c:orientation> because Excel
+    // requires it inside <c:scaling>.
+    const noAxes = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(noAxes.match(/<c:orientation val="minMax"\/>/g)?.length).toBe(2);
+    expect(noAxes).not.toContain('val="maxMin"');
+
+    const explicitFalse = writeChart(
+      makeChart({ axes: { x: { reverse: false }, y: { reverse: false } } }),
+      "Sheet1",
+    ).chartXml;
+    expect(explicitFalse.match(/<c:orientation val="minMax"\/>/g)?.length).toBe(2);
+    expect(explicitFalse).not.toContain('val="maxMin"');
+  });
+
+  it("places <c:orientation> in the spec-required slot inside <c:scaling>", () => {
+    // CT_Scaling sequence: logBase → orientation → max → min. The
+    // writer relies on this order for the OOXML schema validator to
+    // accept the chart.
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: { reverse: true, scale: { min: 0, max: 100, logBase: 10 } },
+        },
+      }),
+      "Sheet1",
+    );
+    const scaling = result.chartXml.match(/<c:scaling>[\s\S]*?<\/c:scaling>/g)!;
+    // Two scaling elements (catAx and valAx) — pick the one with logBase
+    // / max / min, that's the value axis.
+    const valScaling = scaling.find((s) => s.includes("logBase"))!;
+    const logIdx = valScaling.indexOf("c:logBase");
+    const orientIdx = valScaling.indexOf("c:orientation");
+    const maxIdx = valScaling.indexOf("c:max");
+    const minIdx = valScaling.indexOf("c:min");
+    expect(logIdx).toBeGreaterThan(0);
+    expect(orientIdx).toBeGreaterThan(logIdx);
+    expect(maxIdx).toBeGreaterThan(orientIdx);
+    expect(minIdx).toBeGreaterThan(maxIdx);
+  });
+
+  it("works for line and area charts (which share the bar axis builder)", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { y: { reverse: true } } }), "Sheet1");
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(valAxBlock).toContain('<c:orientation val="maxMin"/>');
+    }
+  });
+
+  it("emits reverse on scatter X (axPos=b) and Y (axPos=l) value axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { reverse: true }, y: { reverse: false } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    // First valAx is scatter X axis (axPos="b"), second is Y (axPos="l").
+    expect(valAxBlocks[0]).toContain('c:axPos val="b"');
+    expect(valAxBlocks[0]).toContain('<c:orientation val="maxMin"/>');
+    expect(valAxBlocks[1]).toContain('c:axPos val="l"');
+    expect(valAxBlocks[1]).toContain('<c:orientation val="minMax"/>');
+  });
+
+  it("skips orientation reverse on pie charts (pie has no axes)", () => {
+    const result = writeChart(makeChart({ type: "pie", axes: { y: { reverse: true } } }), "Sheet1");
+    // Pie writes no <c:catAx> / <c:valAx> at all, so no <c:scaling>
+    // / <c:orientation> elements appear.
+    expect(result.chartXml).not.toContain("c:orientation");
+    expect(result.chartXml).not.toContain("c:scaling");
+  });
+
+  it("skips orientation reverse on doughnut charts (doughnut has no axes either)", () => {
+    const result = writeChart(
+      makeChart({ type: "doughnut", axes: { y: { reverse: true } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:orientation");
+  });
+
+  it("only flips the targeted axis — the other stays at the forward default", () => {
+    // Reversing X must not propagate to Y (and vice versa) — each axis
+    // pulls its own reverse flag off chart.axes.{x,y}.reverse.
+    const result = writeChart(makeChart({ axes: { x: { reverse: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<c:orientation val="maxMin"/>');
+    expect(valAxBlock).toContain('<c:orientation val="minMax"/>');
+  });
+
+  it("treats truthy non-boolean values as forward (reverse only fires for `=== true`)", () => {
+    // A defensively-typed source (e.g. "yes" leaking past the type
+    // guard) should not silently flip orientation — only the literal
+    // boolean `true` triggers reverse.
+    const result = writeChart(
+      makeChart({
+        axes: {
+          // @ts-expect-error — testing runtime guard against typo'd inputs.
+          y: { reverse: "yes" },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:orientation val="minMax"/>');
+  });
+
+  it("round-trips reverse=true through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { y: { reverse: true } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.reverse).toBe(true);
+  });
+
+  it("round-trips reverse=false / absent back to undefined", () => {
+    // An unset reverse writes the forward minMax default; on re-parse
+    // that default collapses to undefined so absence and the default
+    // round-trip identically.
+    for (const chart of [makeChart(), makeChart({ axes: { y: { reverse: false } } })]) {
+      const written = writeChart(chart, "Sheet1").chartXml;
+      const reparsed = parseChart(written);
+      expect(reparsed?.axes?.y?.reverse).toBeUndefined();
+    }
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3610,3 +3610,158 @@ describe("parseChart — plotVisOnly", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — axis reverse (orientation) ──────────────────────────
+
+describe("parseChart — axis reverse (orientation)", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  it('surfaces reverse=true off <c:scaling><c:orientation val="maxMin"/>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="maxMin"/></c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.reverse).toBe(true);
+  });
+
+  it('collapses the OOXML default orientation="minMax" to undefined', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="minMax"/></c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    // Neither axis has any other surfaced field, so the whole axes block drops.
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses an axis with no <c:scaling> at all to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores unknown orientation tokens", () => {
+    // A typo'd template (e.g. "diagonal", "reverse", empty string) drops
+    // to undefined rather than fabricate a reverse flag the writer would
+    // pick up.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation val="diagonal"/></c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores <c:orientation/> with no val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling><c:orientation/></c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("surfaces reverse on the category axis (catAx) too", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:scaling><c:orientation val="maxMin"/></c:scaling>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.reverse).toBe(true);
+    expect(chart?.axes?.y?.reverse).toBeUndefined();
+  });
+
+  it("surfaces reverse on both scatter X (axPos=b) and Y (axPos=l) axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:scaling><c:orientation val="maxMin"/></c:scaling>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:scaling><c:orientation val="maxMin"/></c:scaling>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.reverse).toBe(true);
+    expect(chart?.axes?.y?.reverse).toBe(true);
+  });
+
+  it("surfaces reverse alongside other axis fields without interfering", () => {
+    // Co-existing with min/max scaling, gridlines, numFmt, and tick rendering
+    // exercises the parseAxisInfo merge — reverse pulls from <c:scaling>,
+    // the others from sibling elements, so they should slot independently.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:scaling>
+        <c:orientation val="maxMin"/>
+        <c:max val="100"/>
+        <c:min val="0"/>
+      </c:scaling>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Revenue</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:numFmt formatCode="$#,##0" sourceLinked="0"/>
+      <c:majorTickMark val="cross"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y).toEqual({
+      title: "Revenue",
+      gridlines: { major: true },
+      scale: { min: 0, max: 100 },
+      numberFormat: { formatCode: "$#,##0" },
+      majorTickMark: "cross",
+      reverse: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:scaling><c:orientation val="maxMin"/></c:scaling>` element at the read, write, and clone layers so a template's reverse-axis configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:orientation>` is the OOXML control behind Excel's "Categories in reverse order" / "Values in reverse order" toggle. On a category axis, reversing flips the order in which categories are drawn (right-to-left on a column chart, top-to-bottom on a bar chart). On a value axis, reversing flips the numeric direction so the maximum sits at the origin and the minimum at the far end. Until now hucre's writer always pinned `"minMax"`, so a template that reversed its date axis (the canonical "most recent first" idiom on a horizontal bar chart) flattened back to forward orientation on every parse -> clone -> write loop. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.y?.reverse);  // true when the template pinned "maxMin",
                                       // undefined when the template used the default "minMax"

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "bar",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      axes: {
        x: { reverse: true },  // categories drawn top-to-bottom (most recent first)
        y: { reverse: true },  // values drawn right-to-left
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    y: {
      reverse: true,   // replace
      // reverse: null  // drop the inherited flag (writer falls back to forward "minMax")
      // reverse: undefined  // inherit the source's parsed value
    },
  },
});
```

## Model

```ts
interface ChartAxisInfo {
  /* ...existing fields... */
  reverse?: boolean;
}

interface SheetChart {
  axes?: {
    x?: { /* ... */; reverse?: boolean };
    y?: { /* ... */; reverse?: boolean };
  };
}

interface CloneChartOptions {
  axes?: {
    x?: { /* ... */; reverse?: boolean | null };
    y?: { /* ... */; reverse?: boolean | null };
  };
}
```

The read-side `ChartAxisInfo.reverse` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:scaling><c:orientation val=".."/></c:scaling>` on every `CT_CatAx` / `CT_ValAx` / `CT_DateAx` / `CT_SerAx`. Only `"maxMin"` surfaces `true`; the OOXML default `"minMax"` (and unknown tokens, missing `val` attributes, missing `<c:orientation>`, missing `<c:scaling>`) all collapse to `undefined` so absence and the default round-trip identically.
- **Write** — `<c:orientation>` is always emitted because Excel requires it inside `<c:scaling>`. The writer pins `"maxMin"` only when `reverse === true` — a literal `false`, a non-boolean truthy value (e.g. `"yes"` leaking past the type guard), or an absent field all collapse to the forward `"minMax"` default. Each axis carries its own flag, so reversing X never propagates to Y. The OOXML schema's strict child order is preserved: `logBase` -> `orientation` -> `max` -> `min`.
- **Clone** — Each axis override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to forward `"minMax"`) / value (replace) grammar that mirrors `gridlines` / `scale` / `numberFormat`. A literal `false` override behaves identically to `null` / `undefined` because the OOXML default and an explicit `false` produce the same on-the-wire output. When the resolved clone target is `pie` / `doughnut` (no axes) the entire `axes` block is silently dropped.

## Edge cases

- A chart with `reverse: false` round-trips identically to a chart that omits the field — the writer emits `"minMax"` either way and the reader collapses both shapes to `undefined`.
- A typo'd `<c:orientation val="diagonal"/>` drops to `undefined` rather than fabricate a flag the writer would pick up.
- `<c:orientation/>` with no `val` attribute reads as `undefined`.
- A chart without any `<c:scaling>` element on the axis reads as `undefined`.
- Bar / column / line / area / scatter all support reverse on both axes; pie / doughnut silently drop the entire `axes` block since OOXML defines no axes for them.
- Mixing `reverse` with other axis fields (gridlines, scale, tick rendering) keeps every field independent — the `resolveAxes` merge does not drop either one when both source and override are populated.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm test` (lint + typecheck + vitest, all 3019 tests passing including 31 new tests across reader, writer, and clone for the reverse-axis flag)
- [x] Reader, writer, and clone tests cover: defaults, `"maxMin"` value, missing `<c:scaling>` / `<c:orientation>` / `val`, unknown tokens, OOXML element ordering inside `<c:scaling>`, single-axis isolation (X reverse does not propagate to Y), every chart family, scatter axis layout (axPos="b" / "l"), pie / doughnut drop-through, and a full `parseChart -> cloneChart -> writeChart -> parseChart` round-trip with a `writeXlsx` end-to-end check.