### PR TITLE
feat(xlsx): chart roundedCorners frame toggle — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1013,6 +1013,22 @@ export interface SheetChart {
    */
   plotVisOnly?: boolean;
   /**
+   * Whether the chart frame is drawn with rounded corners. Maps to
+   * `<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
+   * `<c:chart>`, not a child). Mirrors Excel's "Format Chart Area →
+   * Border → Rounded corners" toggle.
+   *
+   * Default: `false` — the OOXML schema default and what every fresh
+   * Excel chart emits. Set `true` to soften the chart frame's outer
+   * edge, useful when matching a dashboard whose other charts already
+   * carry the rounded look from a template.
+   *
+   * The writer always emits the element so the rendered intent is
+   * explicit on roundtrip — Excel itself includes it in every reference
+   * serialization.
+   */
+  roundedCorners?: boolean;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -2178,6 +2194,24 @@ export interface Chart {
    * drop to `undefined`.
    */
   plotVisOnly?: boolean;
+  /**
+   * Rounded-corners flag pulled from
+   * `<c:chartSpace><c:roundedCorners val=".."/>`. Reflects Excel's
+   * "Format Chart Area → Border → Rounded corners" toggle, which paints
+   * the chart frame with rounded edges instead of the default square
+   * border.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * the default round-trip identically through {@link cloneChart} —
+   * only an explicit `<c:roundedCorners val="1"/>` surfaces `true`.
+   * The reader accepts the OOXML truthy / falsy spellings (`"1"` /
+   * `"true"` / `"0"` / `"false"`); unknown values and missing `val`
+   * attributes drop to `undefined`.
+   *
+   * Note: `<c:roundedCorners>` lives on `<c:chartSpace>`, not inside
+   * `<c:chart>` — the toggle styles the outer frame, not the plot area.
+   */
+  roundedCorners?: boolean;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -208,6 +208,20 @@ export interface CloneChartOptions {
    */
   plotVisOnly?: boolean | null;
   /**
+   * Override `<c:roundedCorners>` (the chart-frame rounded-edge toggle).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `roundedCorners`. `null` drops the inherited value so the writer
+   * falls back to the OOXML `false` default (square chart frame). A
+   * `boolean` replaces it — useful for matching a dashboard whose
+   * other charts already carry the rounded look from a template, or
+   * for squaring off a clone whose template was rounded.
+   *
+   * The grammar mirrors `plotVisOnly` / `varyColors` so the
+   * chart-frame toggles compose the same way at the call site.
+   */
+  roundedCorners?: boolean | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -426,6 +440,12 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedPlotVisOnly = resolvePlotVisOnly(source.plotVisOnly, options.plotVisOnly);
   if (resolvedPlotVisOnly !== undefined) out.plotVisOnly = resolvedPlotVisOnly;
+
+  const resolvedRoundedCorners = resolveRoundedCorners(
+    source.roundedCorners,
+    options.roundedCorners,
+  );
+  if (resolvedRoundedCorners !== undefined) out.roundedCorners = resolvedRoundedCorners;
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -743,6 +763,26 @@ function resolveVaryColors(
  * toggles compose the same way at the call site.
  */
 function resolvePlotVisOnly(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `roundedCorners` override.
+ *
+ * `undefined` → inherit the source's parsed `roundedCorners`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML `false` default — square chart frame).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `plotVisOnly` / `varyColors` so the chart-frame
+ * toggles compose the same way at the call site.
+ */
+function resolveRoundedCorners(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -205,6 +205,12 @@ export function parseChart(xml: string): Chart | undefined {
   const plotVisOnly = parsePlotVisOnly(chartEl);
   if (plotVisOnly !== undefined) out.plotVisOnly = plotVisOnly;
 
+  // `<c:roundedCorners>` lives on `<c:chartSpace>` (the chart's outer
+  // wrapper), not inside `<c:chart>` — the toggle styles the chart
+  // frame's outer border rather than the plot area.
+  const roundedCorners = parseRoundedCorners(chartSpace);
+  if (roundedCorners !== undefined) out.roundedCorners = roundedCorners;
+
   return out;
 }
 
@@ -1001,6 +1007,42 @@ function parsePlotVisOnly(chartEl: XmlElement): boolean | undefined {
     case "true":
       // OOXML default — collapse to undefined for symmetry with the
       // writer's `plotVisOnly` field.
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+// ── Rounded Corners ───────────────────────────────────────────────
+
+/**
+ * Pull `<c:roundedCorners val=".."/>` off `<c:chartSpace>`. The OOXML
+ * default is `false` (square chart frame), which collapses to
+ * `undefined` so absence and the default round-trip identically through
+ * {@link cloneChart} — only an explicit `<c:roundedCorners val="1"/>`
+ * surfaces `true`.
+ *
+ * Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"`
+ * / `"false"`); unknown values and missing `val` attributes drop to
+ * `undefined` rather than fabricate a flag Excel would not emit.
+ *
+ * Note: `<c:roundedCorners>` sits on `<c:chartSpace>`, not inside
+ * `<c:chart>` — the toggle styles the chart frame's outer border, not
+ * the plot area, and the OOXML schema reflects that with the placement.
+ */
+function parseRoundedCorners(chartSpace: XmlElement): boolean | undefined {
+  const el = findChild(chartSpace, "roundedCorners");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `roundedCorners` field.
       return undefined;
     default:
       return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -86,7 +86,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
       "xmlns:a": NS_A,
       "xmlns:r": NS_R,
     },
-    [xmlSelfClose("c:roundedCorners", { val: 0 }), chartElement],
+    [xmlSelfClose("c:roundedCorners", { val: resolveRoundedCorners(chart) ? 1 : 0 }), chartElement],
   );
 
   // Always emit an empty rels file. Phase 1 charts do not depend on
@@ -1360,6 +1360,27 @@ function resolveDispBlanksAs(chart: SheetChart): ChartDisplayBlanksAs {
 function resolvePlotVisOnly(chart: SheetChart): boolean {
   if (typeof chart.plotVisOnly === "boolean") return chart.plotVisOnly;
   return true;
+}
+
+// ── Rounded Corners ──────────────────────────────────────────────────
+
+/**
+ * Resolve the `<c:roundedCorners>` value emitted on `<c:chartSpace>`.
+ *
+ * Defaults to `false` (the OOXML schema default — square chart frame).
+ * An explicit `chart.roundedCorners === true` flips the toggle to mirror
+ * Excel's "Format Chart Area → Border → Rounded corners" preference.
+ * The writer always emits the element so the file's intent is explicit
+ * even on roundtrip — Excel itself includes it in every reference
+ * serialization.
+ *
+ * `<c:roundedCorners>` is the first child of `<c:chartSpace>` per the
+ * `CT_ChartSpace` sequence, sitting before `<c:chart>` rather than
+ * inside it (the toggle styles the outer frame, not the plot area).
+ */
+function resolveRoundedCorners(chart: SheetChart): boolean {
+  if (typeof chart.roundedCorners === "boolean") return chart.roundedCorners;
+  return false;
 }
 
 // ── Vary Colors ──────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3101,3 +3101,161 @@ describe("cloneChart — plotVisOnly", () => {
     expect(parseChart(written)?.plotVisOnly).toBeUndefined();
   });
 });
+
+// ── cloneChart — roundedCorners ───────────────────────────────────
+
+describe("cloneChart — roundedCorners", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's roundedCorners by default", () => {
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.roundedCorners).toBe(true);
+  });
+
+  it("lets options.roundedCorners override the source's value", () => {
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      roundedCorners: false,
+    });
+    expect(clone.roundedCorners).toBe(false);
+  });
+
+  it("drops the inherited roundedCorners when the override is null", () => {
+    // null collapses to the writer's OOXML default — the field
+    // disappears from the resolved SheetChart so the writer emits the
+    // default `0` (square chart frame).
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      roundedCorners: null,
+    });
+    expect(clone.roundedCorners).toBeUndefined();
+  });
+
+  it("returns undefined roundedCorners when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.roundedCorners).toBeUndefined();
+  });
+
+  it("carries roundedCorners through a flatten (line → column)", () => {
+    // roundedCorners lives on `<c:chartSpace>` and is valid on every
+    // chart family, so a coercion does not drop it.
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.roundedCorners).toBe(true);
+  });
+
+  it("carries roundedCorners through a doughnut flatten (line → doughnut)", () => {
+    // The toggle has no chart-family restriction — even a coercion to
+    // doughnut, which has no axes, must preserve the rounded frame.
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.roundedCorners).toBe(true);
+  });
+
+  it("propagates roundedCorners into the rendered <c:chartSpace> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:roundedCorners val="1"');
+    expect(written).not.toContain('c:roundedCorners val="0"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.roundedCorners).toBe(true);
+  });
+
+  it("emits the OOXML default roundedCorners=0 when both source and override are absent", async () => {
+    // A bare clone with no roundedCorners hint rolls into a SheetChart
+    // whose writer emits the default `0` and re-parses to undefined.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:roundedCorners val="0"');
+    expect(parseChart(written)?.roundedCorners).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins `true`, clone overrides to `false` — the rendered
+    // chart should carry the override and re-parse to undefined (since
+    // `false` is the OOXML default and collapses on read).
+    const clone = cloneChart(source({ roundedCorners: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      roundedCorners: false,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:roundedCorners val="0"');
+    expect(written).not.toContain('c:roundedCorners val="1"');
+    expect(parseChart(written)?.roundedCorners).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2970,3 +2970,92 @@ describe("writeChart — plotVisOnly", () => {
     expect(reparsed?.plotVisOnly).toBeUndefined();
   });
 });
+
+// ── writeChart — roundedCorners ──────────────────────────────────────
+
+describe("writeChart — roundedCorners", () => {
+  it('emits <c:roundedCorners val="0"/> when the field is unset (OOXML default)', () => {
+    // The writer always emits the element so the rendered intent is
+    // explicit on roundtrip — Excel itself includes it in every
+    // reference serialization.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).toContain('c:roundedCorners val="0"');
+    expect(result.chartXml).not.toContain('c:roundedCorners val="1"');
+  });
+
+  it("threads roundedCorners=true through to <c:chartSpace>", () => {
+    // true is the non-default — Excel's "Format Chart Area → Border →
+    // Rounded corners" toggle on.
+    const result = writeChart(makeChart({ roundedCorners: true }), "Sheet1");
+    expect(result.chartXml).toContain('c:roundedCorners val="1"');
+    expect(result.chartXml).not.toContain('c:roundedCorners val="0"');
+  });
+
+  it("threads roundedCorners=false through to <c:chartSpace>", () => {
+    // Setting the OOXML default explicitly produces the same wire
+    // shape as omitting the field — the element is always emitted.
+    const result = writeChart(makeChart({ roundedCorners: false }), "Sheet1");
+    expect(result.chartXml).toContain('c:roundedCorners val="0"');
+  });
+
+  it("places <c:roundedCorners> before <c:chart> inside <c:chartSpace> (OOXML order)", () => {
+    // CT_ChartSpace sequence: ... roundedCorners?, style?, ... chart, ...
+    // — the toggle must precede the chart element so a strict validator
+    // (Excel itself rejects out-of-order children) sees the schema
+    // sequence respected.
+    const result = writeChart(makeChart({ roundedCorners: true }), "Sheet1");
+    expect(result.chartXml.indexOf("c:roundedCorners")).toBeLessThan(
+      result.chartXml.indexOf("<c:chart>"),
+    );
+  });
+
+  it("only emits <c:roundedCorners> once even on a chart that overrides it", () => {
+    // Guard against any regression that would double-emit the element
+    // (e.g. one hardcoded copy plus a dynamic one).
+    const result = writeChart(makeChart({ roundedCorners: true }), "Sheet1");
+    const occurrences = result.chartXml.match(/c:roundedCorners/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads roundedCorners through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, roundedCorners: true }), "Sheet1");
+      expect(result.chartXml).toContain('c:roundedCorners val="1"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        roundedCorners: true,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:roundedCorners val="1"');
+  });
+
+  it("round-trips a non-default roundedCorners value through parseChart", () => {
+    // A chart with roundedCorners=true should re-parse into a Chart
+    // whose `roundedCorners` field is `true` (not collapsed to undefined,
+    // since true is not the OOXML default).
+    const written = writeChart(makeChart({ roundedCorners: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.roundedCorners).toBe(true);
+  });
+
+  it("collapses a defaulted roundedCorners round-trip back to undefined", () => {
+    // A fresh chart (roundedCorners omitted) writes `0` and re-parses to
+    // undefined — absence and the OOXML default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.roundedCorners).toBeUndefined();
+  });
+
+  it("collapses an explicit roundedCorners=false round-trip back to undefined", () => {
+    // Pinning the OOXML default also collapses on read, so a template
+    // that explicitly emits `<c:roundedCorners val="0"/>` is treated the
+    // same as one that omits the field.
+    const written = writeChart(makeChart({ roundedCorners: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.roundedCorners).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3610,3 +3610,125 @@ describe("parseChart — plotVisOnly", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — roundedCorners ───────────────────────────────────
+
+describe("parseChart — roundedCorners", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:roundedCorners val="1"/> on <c:chartSpace> as true (non-default)', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="1"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBe(true);
+  });
+
+  it("collapses the OOXML default false to undefined (writer absence)", () => {
+    // The default carried explicitly by Excel's reference serialization
+    // round-trips identically to absence of the field.
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="0"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBeUndefined();
+  });
+
+  it("returns undefined when the chartSpace has no <c:roundedCorners> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBeUndefined();
+  });
+
+  it("accepts the OOXML true / false spellings on the val attribute", () => {
+    // The OOXML schema for `xsd:boolean` accepts `"true"` / `"false"`
+    // alongside the more common `"1"` / `"0"`. Hucre tolerates both
+    // shapes — a hand-edited template using `true` should round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="true"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBe(true);
+  });
+
+  it("collapses the 'false' spelling to undefined as well", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="false"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBeUndefined();
+  });
+
+  it("drops unknown roundedCorners values rather than fabricate one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="bogus"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:roundedCorners>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.roundedCorners).toBeUndefined();
+  });
+
+  it("surfaces roundedCorners alongside other chart-level toggles", () => {
+    // Co-existing with plotVisOnly / dispBlanksAs / varyColors should
+    // not interfere — roundedCorners parses off <c:chartSpace> while
+    // the others sit on <c:chart>.
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="1"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.roundedCorners).toBe(true);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the `<c:chartSpace><c:roundedCorners val=".."/>` element at the read, write, and clone layers so a template's rounded chart frame survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:roundedCorners>` is the OOXML control behind Excel's "Format Chart Area -> Border -> Rounded corners" toggle. The element sits on `<c:chartSpace>` (a sibling of `<c:chart>`, not a child) because it styles the outer chart frame rather than the plot area. Until now hucre's writer always pinned `val="0"`, so a template that authored a rounded frame flattened back to square corners on every parse -> clone -> write loop. This bridges another chart-frame gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.roundedCorners);  // true when the template pinned val="1",
                                     // undefined when the template used the default val="0"

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      roundedCorners: true,  // soften the chart frame's outer edge
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  roundedCorners: false,  // replace
  // roundedCorners: null  // drop the inherited flag (writer falls back to square val="0")
  // roundedCorners: undefined  // inherit the source's parsed value
});
```

## Model

```ts
interface Chart {
  /* ...existing fields... */
  roundedCorners?: boolean;
}

interface SheetChart {
  /* ...existing fields... */
  roundedCorners?: boolean;
}

interface CloneChartOptions {
  /* ...existing fields... */
  roundedCorners?: boolean | null;
}
```

The read-side `Chart.roundedCorners` mirrors the write-side `SheetChart.roundedCorners` so a parsed value slots straight back into `cloneChart` without transformation. The override grammar mirrors `plotVisOnly` / `varyColors` so the chart-frame toggles compose the same way at the call site.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:chartSpace><c:roundedCorners val=".."/>`. Only `"1"` / `"true"` surface `true`; the OOXML default `"0"` / `"false"` (and unknown tokens, missing `val` attributes, missing `<c:roundedCorners>`) all collapse to `undefined` so absence and the default round-trip identically.
- **Write** — `<c:roundedCorners>` is always emitted because Excel's reference serialization includes it on every chart. The writer pins `val="1"` only when `roundedCorners === true` — a literal `false`, an absent field, or a non-boolean value all collapse to the default `val="0"`. The element is the first child of `<c:chartSpace>` per the `CT_ChartSpace` schema sequence, sitting before `<c:chart>`.
- **Clone** — Each override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `val="0"`) / `boolean` (replace) grammar that mirrors `plotVisOnly` / `varyColors`. The toggle has no chart-family restriction, so the field carries through every coercion (line -> column, line -> doughnut, etc.) — every authored chart family has a `<c:chartSpace>` wrapper.

## Edge cases

- An explicit `roundedCorners: false` collapses to the OOXML default on re-parse (since absence and `val="0"` are indistinguishable on the read side). This matches how `plotVisOnly: true` / `varyColors` collapse on read.
- Unknown / non-boolean values fed to the writer fall back to `val="0"` rather than fabricate an attribute Excel rejects.

## Test plan

- [x] `pnpm test` passes (3014 tests, including 24 new tests across reader, writer, and clone)
- [x] `pnpm build` produces a clean dist
- [x] `parseChart` surfaces `true` only on `<c:roundedCorners val="1"/>` and collapses `val="0"` / absence / unknown / missing attribute to `undefined`
- [x] `writeChart` always emits `<c:roundedCorners>` once on `<c:chartSpace>` before `<c:chart>`, threading the field through every authored family
- [x] `cloneChart` honors inherit / `null` (drop) / value (replace) on the override; carries the value through chart-family coercions; round-trips `true` through `writeXlsx` -> `parseChart`

Refs #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)