### PR TITLE
feat(xlsx): chart axis hidden flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,13 @@ axis does not surface a field the writer would never emit anyway. The
 OOXML default `1` (show every label / mark) collapses to `undefined`;
 out-of-range values (non-positive or > 32767) drop rather than clamp
 so a malformed input cannot leak into the writer.
+`ChartAxisInfo.hidden` surfaces the per-axis `<c:delete val=".."/>`
+flag — Excel's "Format Axis -> Show axis" toggle. Only an explicit
+`val="1"` (axis hidden) surfaces `true`; the OOXML default `val="0"`,
+absence, missing `val`, and unknown tokens all collapse to `undefined`
+so absence and the default round-trip identically. The reader accepts
+the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
+`"false"`).
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -883,6 +890,16 @@ fields live on category axes only — bar / column / line / area
 honour them; scatter (whose two axes are value axes) and pie /
 doughnut (no axes at all) silently ignore them. Non-integer inputs
 round to the nearest integer.
+The per-axis `axes.x.hidden` and `axes.y.hidden` flags toggle
+`<c:catAx><c:delete val=".."/>` / `<c:valAx><c:delete val=".."/>` —
+Excel's "Format Axis -> Show axis" toggle. Set `true` to collapse the
+axis line, tick marks, and tick labels off the rendered chart (handy
+for sparkline-style dashboard tiles). The writer always emits the
+element because Excel's reference serialization includes
+`<c:delete val="0"/>` on every axis; `false` and absence both produce
+that default, while only an explicit `true` emits `val="1"`. The flag
+threads through bar / column / line / area / scatter; pie / doughnut
+silently ignore it because OOXML defines no axes for those families.
 For line and scatter charts, each `series[i].smooth` flag toggles
 Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
 Line series always emit the element — `smooth: true` writes `val="1"`,
@@ -1050,6 +1067,15 @@ slot in the rendered chart) and when the target is `pie` or
 `doughnut` (no axes at all) — flattening a column template into a
 scatter clone therefore never leaks a stale catAx skip into the
 output.
+The per-axis `axes.x.hidden` and `axes.y.hidden` overrides follow the
+same `undefined` (inherit) / `null` (drop) / `boolean` (replace)
+grammar. Because `<c:delete>` lives on every axis flavour, the flag
+threads through every coercion that has axes (bar / column / line /
+area / scatter); pie / doughnut clones drop the entire `axes` block
+because OOXML defines no axes for them. An override of `false` is
+equivalent to `null` — the writer treats both as the OOXML default
+`val="0"`, so the cloned `SheetChart` collapses both shapes to
+`undefined`.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1045,6 +1045,13 @@ export interface SheetChart {
    * `<c:tickMarkSkip>` on `CT_CatAx` / `CT_DateAx`); they have no slot
    * on `<c:valAx>` and are silently ignored on the value axis or on
    * scatter charts (whose two axes are both value axes).
+   *
+   * `hidden` collapses the axis line, tick marks, and tick labels off
+   * the rendered chart by emitting `<c:delete val="1"/>`. Maps to
+   * Excel's "Format Axis -> Axis Options -> Labels -> Show axis" toggle
+   * (and the matching context-menu "Delete" action). Useful for
+   * minimal "sparkline-style" dashboard tiles where only the data
+   * series should remain visible.
    */
   axes?: {
     /** Category axis (bar/column/line/area) or X value axis (scatter). */
@@ -1095,6 +1102,25 @@ export interface SheetChart {
        * scope-restriction as `tickLblSkip` — category axes only.
        */
       tickMarkSkip?: number;
+      /**
+       * Hide the entire axis (line, tick marks, tick labels). Maps to
+       * `<c:catAx><c:delete val="1"/></c:catAx>` (or the matching
+       * `<c:valAx>` element on scatter). Default: `false` — Excel
+       * paints the axis. Set `true` to collapse a noisy axis off a
+       * sparkline-style dashboard tile.
+       *
+       * Excel still reserves the layout slot the axis would have
+       * occupied, so a hidden category axis on a column chart leaves a
+       * thin gap at the bottom of the plot area where the labels would
+       * have rendered — pair with `<c:layout>` overrides on the parent
+       * `<c:plotArea>` if you need to reclaim that space (hucre does
+       * not surface a layout knob today; the writer falls back to
+       * Excel's auto-layout in either case).
+       *
+       * The flag is silently ignored on `pie` / `doughnut` charts
+       * because the OOXML schema places no axes on those families.
+       */
+      hidden?: boolean;
     };
     /** Value axis. */
     y?: {
@@ -1120,6 +1146,13 @@ export interface SheetChart {
        * `"nextTo"`. See {@link ChartAxisTickLabelPosition}.
        */
       tickLblPos?: ChartAxisTickLabelPosition;
+      /**
+       * Hide the entire value axis (line, tick marks, tick labels).
+       * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
+       * `false`. See {@link SheetChart.axes.x.hidden} for the full
+       * semantics — the value-axis flag mirrors the X-axis flag.
+       */
+      hidden?: boolean;
     };
   };
 }
@@ -2010,6 +2043,17 @@ export interface ChartAxisInfo {
    * {@link tickLblSkip}.
    */
   tickMarkSkip?: number;
+  /**
+   * Axis hidden flag pulled from `<c:delete val=".."/>`. Surfaces
+   * `true` when the axis pinned `val="1"` (Excel's "Format Axis ->
+   * Show axis = off" toggle). The OOXML default `val="0"` (and absence
+   * of the element) collapse to `undefined` so absence and the default
+   * round-trip identically through {@link cloneChart}. The reader
+   * accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` /
+   * `"0"` / `"false"`); unknown values and missing `val` attributes
+   * drop to `undefined`.
+   */
+  hidden?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -273,6 +273,18 @@ export interface CloneChartOptions {
        * scope rules as {@link tickLblSkip}.
        */
       tickMarkSkip?: number | null;
+      /**
+       * Override `SheetChart.axes.x.hidden`. `undefined` (or omitted)
+       * inherits the source axis's flag; `null` drops the inherited
+       * value (the writer falls back to the OOXML `false` default —
+       * axis visible); a `boolean` replaces it. Useful when porting a
+       * "hide axis" template to a chart that should reveal its axis,
+       * or vice versa.
+       *
+       * Silently dropped when the resolved chart type is `pie` /
+       * `doughnut` since neither has axes.
+       */
+      hidden?: boolean | null;
     };
     y?: {
       title?: string | null;
@@ -285,6 +297,8 @@ export interface CloneChartOptions {
       minorTickMark?: ChartAxisTickMark | null;
       /** See {@link CloneChartOptions.axes.x.tickLblPos}. */
       tickLblPos?: ChartAxisTickLabelPosition | null;
+      /** See {@link CloneChartOptions.axes.x.hidden}. */
+      hidden?: boolean | null;
     };
   };
 }
@@ -894,6 +908,12 @@ function resolveAxes(
   const xTickMarkSkip = isCatAxisX
     ? applySkipOverride(sourceAxes?.x?.tickMarkSkip, overrides?.x?.tickMarkSkip)
     : undefined;
+  // `<c:delete>` lives on every axis flavour — both `<c:catAx>` and
+  // `<c:valAx>` accept it — so the hidden flag carries through every
+  // chart family that has axes. Pie / doughnut have no axes at all
+  // and the caller already short-circuited those above.
+  const xHidden = applyHiddenOverride(sourceAxes?.x?.hidden, overrides?.x?.hidden);
+  const yHidden = applyHiddenOverride(sourceAxes?.y?.hidden, overrides?.y?.hidden);
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -905,7 +925,8 @@ function resolveAxes(
     xMinorTickMark !== undefined ||
     xTickLblPos !== undefined ||
     xTickLblSkip !== undefined ||
-    xTickMarkSkip !== undefined
+    xTickMarkSkip !== undefined ||
+    xHidden !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
@@ -917,6 +938,7 @@ function resolveAxes(
     if (xTickLblPos !== undefined) out.x.tickLblPos = xTickLblPos;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
+    if (xHidden !== undefined) out.x.hidden = xHidden;
   }
   if (
     yTitle !== undefined ||
@@ -925,7 +947,8 @@ function resolveAxes(
     yNumFmt !== undefined ||
     yMajorTickMark !== undefined ||
     yMinorTickMark !== undefined ||
-    yTickLblPos !== undefined
+    yTickLblPos !== undefined ||
+    yHidden !== undefined
   ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
@@ -935,6 +958,7 @@ function resolveAxes(
     if (yMajorTickMark !== undefined) out.y.majorTickMark = yMajorTickMark;
     if (yMinorTickMark !== undefined) out.y.minorTickMark = yMinorTickMark;
     if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
+    if (yHidden !== undefined) out.y.hidden = yHidden;
   }
 
   return out.x || out.y ? out : undefined;
@@ -962,6 +986,26 @@ function applySkipOverride(
   const rounded = Math.round(override);
   if (rounded < 1 || rounded > 32767 || rounded === 1) return undefined;
   return rounded;
+}
+
+/**
+ * Resolve an axis `hidden` override using the same `undefined`
+ * (inherit) / `null` (drop) / `boolean` (replace) grammar as the
+ * other axis helpers. Only `true` surfaces (the writer treats `false`
+ * and absence identically — both produce `<c:delete val="0"/>`), so
+ * an override of `false` collapses to `undefined` to keep the cloned
+ * `SheetChart` shape minimal. Non-boolean inputs fall through the
+ * type guard to `undefined`.
+ */
+function applyHiddenOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    return source === true ? true : undefined;
+  }
+  if (override === null) return undefined;
+  return override === true ? true : undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -277,6 +277,11 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const isCategoryAxis = axis.local === "catAx" || axis.local === "dateAx";
   const tickLblSkip = isCategoryAxis ? parseAxisSkip(axis, "tickLblSkip") : undefined;
   const tickMarkSkip = isCategoryAxis ? parseAxisSkip(axis, "tickMarkSkip") : undefined;
+  // `<c:delete>` sits on every axis flavour (CT_CatAx / CT_ValAx /
+  // CT_DateAx / CT_SerAx) per ECMA-376 Part 1, §21.2.2. The OOXML
+  // default `val="0"` (axis visible) collapses to `undefined` so
+  // absence and the default round-trip identically.
+  const hidden = parseAxisHidden(axis);
   if (
     title === undefined &&
     gridlines === undefined &&
@@ -286,7 +291,8 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     minorTickMark === undefined &&
     tickLblPos === undefined &&
     tickLblSkip === undefined &&
-    tickMarkSkip === undefined
+    tickMarkSkip === undefined &&
+    hidden === undefined
   ) {
     return undefined;
   }
@@ -300,6 +306,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (tickLblPos !== undefined) out.tickLblPos = tickLblPos;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
+  if (hidden !== undefined) out.hidden = hidden;
   return out;
 }
 
@@ -387,6 +394,37 @@ function parseAxisSkip(
   if (parsed < 1 || parsed > 32767) return undefined;
   if (parsed === 1) return undefined;
   return parsed;
+}
+
+/**
+ * Pull `<c:delete val=".."/>` off an axis element. Returns `true`
+ * only when the axis pinned `val="1"` / `val="true"` (Excel's "hide
+ * axis" toggle). The OOXML default `val="0"` / `val="false"`,
+ * absence, missing `val`, and unknown tokens all collapse to
+ * `undefined` so absence and the default round-trip identically.
+ *
+ * Mirrors the truthy / falsy parsing in {@link parsePlotVisOnly} —
+ * the OOXML schema (`xsd:boolean`) accepts `0` / `1` / `false` /
+ * `true` for `<c:delete>` just as it does for every other Boolean-
+ * valued chart attribute.
+ */
+function parseAxisHidden(axis: XmlElement): boolean | undefined {
+  const el = findChild(axis, "delete");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw.trim()) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      // OOXML default — collapse to undefined so absence and the
+      // default round-trip identically.
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -159,6 +159,14 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // catAx builder is the only consumer of these knobs.
     xTickLblSkip: normalizeAxisSkip(chart.axes?.x?.tickLblSkip),
     xTickMarkSkip: normalizeAxisSkip(chart.axes?.x?.tickMarkSkip),
+    // `<c:delete>` lives on every axis flavour (CT_CatAx / CT_ValAx /
+    // CT_DateAx / CT_SerAx). The writer always emits the element —
+    // Excel's reference serialization includes `<c:delete val="0"/>`
+    // on every axis — so the axis builders read these flags directly
+    // rather than skipping the element on `false`. Non-boolean inputs
+    // collapse to `false` to keep the on-the-wire output stable.
+    xHidden: normalizeAxisHidden(chart.axes?.x?.hidden),
+    yHidden: normalizeAxisHidden(chart.axes?.y?.hidden),
   };
 
   switch (chart.type) {
@@ -227,6 +235,15 @@ interface AxisRenderOptions {
    * is `<c:catAx>`. Same scope rule as {@link xTickLblSkip}.
    */
   xTickMarkSkip: number | undefined;
+  /**
+   * Whether the X axis should render its `<c:delete>` element with
+   * `val="1"` (axis hidden). Always defined — `false` keeps Excel's
+   * reference `val="0"` while `true` collapses the axis line, ticks,
+   * and labels off the rendered chart.
+   */
+  xHidden: boolean;
+  /** Whether the Y axis should render hidden. Same shape as {@link xHidden}. */
+  yHidden: boolean;
 }
 
 /**
@@ -353,6 +370,18 @@ function normalizeAxisSkip(value: number | undefined): number | undefined {
   if (rounded < 1 || rounded > 32767) return undefined;
   if (rounded === 1) return undefined;
   return rounded;
+}
+
+/**
+ * Normalize an axis `hidden` flag to a strict boolean. Anything other
+ * than literal `true` collapses to `false` so the writer never emits
+ * `<c:delete val="1"/>` from a stray non-boolean leaking through the
+ * type guard (e.g. `0` / `1` / `"true"` / `null`). This matches how
+ * `roundedCorners` / `plotVisOnly` / `varyColors` treat their inputs:
+ * a literal boolean is the only path to a non-default value.
+ */
+function normalizeAxisHidden(value: boolean | undefined): boolean {
+  return value === true;
 }
 
 /**
@@ -625,7 +654,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   const catAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_CAT }),
     buildAxisScaling(opts.xScale),
-    xmlSelfClose("c:delete", { val: 0 }),
+    xmlSelfClose("c:delete", { val: opts.xHidden ? 1 : 0 }),
     xmlSelfClose("c:axPos", { val: catPos }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
@@ -650,7 +679,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   const valAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL }),
     buildAxisScaling(opts.yScale),
-    xmlSelfClose("c:delete", { val: 0 }),
+    xmlSelfClose("c:delete", { val: opts.yHidden ? 1 : 0 }),
     xmlSelfClose("c:axPos", { val: valPos }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
@@ -868,7 +897,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   const xAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_X }),
     buildAxisScaling(opts.xScale),
-    xmlSelfClose("c:delete", { val: 0 }),
+    xmlSelfClose("c:delete", { val: opts.xHidden ? 1 : 0 }),
     xmlSelfClose("c:axPos", { val: "b" }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
@@ -885,7 +914,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   const yAxChildren: string[] = [
     xmlSelfClose("c:axId", { val: AXIS_ID_VAL_Y }),
     buildAxisScaling(opts.yScale),
-    xmlSelfClose("c:delete", { val: 0 }),
+    xmlSelfClose("c:delete", { val: opts.yHidden ? 1 : 0 }),
     xmlSelfClose("c:axPos", { val: "l" }),
     ...buildAxisGridlines(opts.yGridlines),
   ];

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3264,3 +3264,235 @@ describe("cloneChart — axis tickLblSkip / tickMarkSkip", () => {
     expect(written).toContain('c:tickMarkSkip val="5"');
   });
 });
+
+// ── cloneChart — axis hidden flag ───────────────────────────────────
+
+describe("cloneChart — axis hidden", () => {
+  const sourceWithHiddenX: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { hidden: true } },
+  };
+
+  it("inherits axes.x.hidden=true from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithHiddenX, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.hidden).toBe(true);
+    expect(clone.axes?.y?.hidden).toBeUndefined();
+  });
+
+  it("inherits axes.y.hidden=true from the source when no override is given", () => {
+    const sourceWithHiddenY: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { hidden: true } },
+    };
+    const clone = cloneChart(sourceWithHiddenY, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.hidden).toBe(true);
+    expect(clone.axes?.x?.hidden).toBeUndefined();
+  });
+
+  it("drops the inherited flag when override is null", () => {
+    const clone = cloneChart(sourceWithHiddenX, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { hidden: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the inherited flag when override is false", () => {
+    // `false` collapses to undefined the same way `null` does because the
+    // writer treats both shapes identically (val="0" is the default).
+    const clone = cloneChart(sourceWithHiddenX, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { hidden: false } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces an inherited true with override true (no-op)", () => {
+    const clone = cloneChart(sourceWithHiddenX, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { hidden: true } },
+    });
+    expect(clone.axes?.x?.hidden).toBe(true);
+  });
+
+  it("adds hidden=true to a source that did not declare it", () => {
+    const noHidden: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noHidden, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { hidden: true } },
+    });
+    expect(clone.axes?.y?.hidden).toBe(true);
+    expect(clone.axes?.x?.hidden).toBeUndefined();
+  });
+
+  it("inherits one axis while letting the override drop the other", () => {
+    const sourceBoth: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { hidden: true }, y: { hidden: true } },
+    };
+    const clone = cloneChart(sourceBoth, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { hidden: null } },
+    });
+    expect(clone.axes?.x?.hidden).toBe(true);
+    expect(clone.axes?.y?.hidden).toBeUndefined();
+  });
+
+  it("collapses non-boolean overrides to undefined", () => {
+    const clone = cloneChart(sourceWithHiddenX, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { hidden: 1 as unknown as boolean } },
+    });
+    // The non-boolean override drops, falling back to undefined (not the
+    // inherited true) since the override was non-undefined.
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips hidden silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { hidden: true } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips hidden silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { hidden: true } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries hidden through a chart-type coercion (line -> column)", () => {
+    const lineSource: Chart = {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { hidden: true } },
+    };
+    const clone = cloneChart(lineSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.y?.hidden).toBe(true);
+  });
+
+  it("carries hidden through a chart-type coercion (bar -> scatter)", () => {
+    // Scatter has two value axes — the hidden flag still applies because
+    // <c:delete> is a member of every axis flavour.
+    const clone = cloneChart(sourceWithHiddenX, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes?.x?.hidden).toBe(true);
+  });
+
+  it("composes hidden alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithHiddenX, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Region",
+          gridlines: { major: true },
+        },
+        y: {
+          hidden: true,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Region");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.hidden).toBe(true);
+    expect(clone.axes?.y?.hidden).toBe(true);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves hidden", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:delete val="1"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.hidden).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.hidden).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const catAxBlock = written.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="1"/>');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.hidden).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with hidden axes intact", async () => {
+    const sourceBoth: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { hidden: true }, y: { hidden: true } },
+    };
+    const clone = cloneChart(sourceBoth, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const catAxBlock = written.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = written.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="1"/>');
+    expect(valAxBlock).toContain('<c:delete val="1"/>');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3149,3 +3149,176 @@ describe("writeChart — axis tickLblSkip / tickMarkSkip", () => {
     expect(idx("c:tickMarkSkip")).toBeLessThan(idx("c:noMultiLvlLbl"));
   });
 });
+
+// ── writeChart — axis hidden flag (<c:delete>) ──────────────────────
+
+describe("writeChart — axis hidden", () => {
+  it('emits <c:delete val="0"/> on both axes by default (Excel reference shape)', () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="0"/>');
+    expect(valAxBlock).toContain('<c:delete val="0"/>');
+  });
+
+  it('emits <c:delete val="1"/> on the category axis when axes.x.hidden=true', () => {
+    const result = writeChart(makeChart({ axes: { x: { hidden: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="1"/>');
+    // The Y axis stays visible — the flag is per-axis.
+    expect(valAxBlock).toContain('<c:delete val="0"/>');
+  });
+
+  it('emits <c:delete val="1"/> on the value axis when axes.y.hidden=true', () => {
+    const result = writeChart(makeChart({ axes: { y: { hidden: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="0"/>');
+    expect(valAxBlock).toContain('<c:delete val="1"/>');
+  });
+
+  it("hides both axes when axes.x.hidden and axes.y.hidden are both true", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { hidden: true }, y: { hidden: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="1"/>');
+    expect(valAxBlock).toContain('<c:delete val="1"/>');
+  });
+
+  it("treats axes.x.hidden=false the same as omitting the field", () => {
+    const explicit = writeChart(makeChart({ axes: { x: { hidden: false } } }), "Sheet1").chartXml;
+    const implicit = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(explicit).toEqual(implicit);
+  });
+
+  it('collapses non-boolean inputs to the default val="0"', () => {
+    // A stray non-boolean leaking past the type guard (e.g. `0` / `1` /
+    // `"true"` / `null`) must collapse to the default rather than emit
+    // an attribute Excel would reject.
+    const result = writeChart(
+      makeChart({ axes: { x: { hidden: 1 as unknown as boolean } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<c:delete val="0"/>');
+  });
+
+  it("threads the flag through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { hidden: true } } }), "Sheet1");
+      const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+      expect(catAxBlock).toContain('<c:delete val="1"/>');
+    }
+  });
+
+  it("emits the flag on scatter X (axPos=b) and Y (axPos=l) value axes", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { hidden: true } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlocks = [...result.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)].map(
+      (m) => m[0],
+    );
+    // First valAx is the X axis (axPos="b"), second is Y (axPos="l").
+    expect(valAxBlocks[0]).toContain('c:axPos val="b"');
+    expect(valAxBlocks[0]).toContain('<c:delete val="1"/>');
+    expect(valAxBlocks[1]).toContain('c:axPos val="l"');
+    expect(valAxBlocks[1]).toContain('<c:delete val="0"/>');
+  });
+
+  it("ignores the flag on pie charts (no axes at all)", () => {
+    const result = writeChart(makeChart({ type: "pie", axes: { x: { hidden: true } } }), "Sheet1");
+    // Pie chart emits no <c:catAx> / <c:valAx> at all, so there is no
+    // <c:delete> to find. The flag must not leak elsewhere.
+    expect(result.chartXml).not.toContain("c:catAx");
+    expect(result.chartXml).not.toContain("c:valAx");
+  });
+
+  it("ignores the flag on doughnut charts (no axes at all)", () => {
+    const result = writeChart(
+      makeChart({ type: "doughnut", axes: { y: { hidden: true } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:catAx");
+    expect(result.chartXml).not.toContain("c:valAx");
+  });
+
+  it("places <c:delete> after <c:scaling> and before <c:axPos> (OOXML order)", () => {
+    const result = writeChart(makeChart({ axes: { x: { hidden: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const scalingIdx = catAxBlock.indexOf("<c:scaling");
+    const deleteIdx = catAxBlock.indexOf("<c:delete");
+    const axPosIdx = catAxBlock.indexOf("<c:axPos");
+    expect(scalingIdx).toBeGreaterThan(0);
+    expect(deleteIdx).toBeGreaterThan(scalingIdx);
+    expect(axPosIdx).toBeGreaterThan(deleteIdx);
+  });
+
+  it("emits exactly one <c:delete> per axis", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { hidden: true }, y: { hidden: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect((catAxBlock.match(/<c:delete /g) ?? []).length).toBe(1);
+    expect((valAxBlock.match(/<c:delete /g) ?? []).length).toBe(1);
+  });
+
+  it("composes alongside other axis fields without breaking spec ordering", () => {
+    // Combine title, gridlines, scale, number format, tick rendering and
+    // hidden on the X axis to verify the catAx still renders in spec order.
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Region",
+            gridlines: { major: true },
+            numberFormat: { formatCode: "@" },
+            majorTickMark: "cross",
+            tickLblPos: "low",
+            hidden: true,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const idx = (needle: string): number => catAxBlock.indexOf(needle);
+    expect(idx("c:axId")).toBeLessThan(idx("c:scaling"));
+    expect(idx("c:scaling")).toBeLessThan(idx("c:delete"));
+    expect(idx("c:delete")).toBeLessThan(idx("c:axPos"));
+    expect(idx("c:axPos")).toBeLessThan(idx("c:majorGridlines"));
+    expect(idx("c:majorGridlines")).toBeLessThan(idx("c:title"));
+    expect(idx("c:title")).toBeLessThan(idx("c:numFmt"));
+    expect(idx("c:numFmt")).toBeLessThan(idx("c:majorTickMark"));
+    expect(idx("c:majorTickMark")).toBeLessThan(idx("c:tickLblPos"));
+    expect(idx("c:tickLblPos")).toBeLessThan(idx("c:crossAx"));
+    expect(catAxBlock).toContain('<c:delete val="1"/>');
+  });
+
+  it("round-trips axes.x.hidden=true through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { x: { hidden: true } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.hidden).toBe(true);
+    // The Y axis pinned val="0" so it collapses to undefined.
+    expect(reparsed?.axes?.y?.hidden).toBeUndefined();
+  });
+
+  it('collapses a default round-trip back to undefined axes (val="0" alone is the default)', () => {
+    // No axis fields set at all → the writer still emits <c:delete val="0"/>
+    // on every axis but the reader collapses both axes to no info, leaving
+    // `axes` undefined.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3771,3 +3771,198 @@ describe("parseChart — axis tickLblSkip / tickMarkSkip", () => {
     });
   });
 });
+
+// ── parseChart — axis hidden flag (<c:delete>) ──────────────────────
+
+describe("parseChart — axis hidden", () => {
+  const NS_HIDDEN = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces hidden=true on the category axis when val="1"', () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.hidden).toBe(true);
+    expect(chart?.axes?.y?.hidden).toBeUndefined();
+  });
+
+  it('surfaces hidden=true on the value axis when val="1"', () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:delete val="1"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.hidden).toBeUndefined();
+    expect(chart?.axes?.y?.hidden).toBe(true);
+  });
+
+  it('surfaces hidden=true on both axes when both pin val="1"', () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="1"/>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:delete val="1"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.hidden).toBe(true);
+    expect(chart?.axes?.y?.hidden).toBe(true);
+  });
+
+  it('collapses the OOXML default val="0" to undefined', () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="0"/>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:delete val="0"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses absence of <c:delete> to undefined", () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it('accepts the OOXML truthy spelling val="true"', () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="true"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.hidden).toBe(true);
+  });
+
+  it('accepts the OOXML falsy spelling val="false" and collapses to undefined', () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="false"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:delete> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined for unknown val tokens", () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="yes"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces hidden alongside title, gridlines, and tick rendering", () => {
+    const xml = `<c:chartSpace ${NS_HIDDEN}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:delete val="1"/>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Region",
+      gridlines: { major: true },
+      tickLblPos: "low",
+      hidden: true,
+    });
+  });
+
+  it("surfaces hidden on a scatter chart's value-axis pair", () => {
+    // Scatter has two valAx — the first (axPos="b") is the X axis, the
+    // second (axPos="l") is the Y axis. The reader should map them back
+    // to axes.x / axes.y the same way it does for the rest of the
+    // metadata.
+    const xml = `<c:chartSpace ${NS_HIDDEN}>
+  <c:chart><c:plotArea>
+    <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:delete val="1"/>
+      <c:axPos val="b"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.hidden).toBe(true);
+    expect(chart?.axes?.y?.hidden).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:delete val=".."/>` element at the read, write, and clone layers so a template's hidden-axis configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:delete>` is the OOXML control behind Excel's "Format Axis -> Axis Options -> Labels -> Show axis" toggle (and the matching "Delete" context-menu action). When pinned to `val="1"` it collapses the axis line, tick marks, and tick labels off the rendered chart — handy for sparkline-style dashboard tiles where only the data series should remain visible. Up until now hucre's writer always pinned `val="0"`, so a template that hid its value axis flattened back to a visible axis on every parse -> clone -> write loop. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.hidden);  // true when the template pinned val="1",
                                      // undefined when the template used the default val="0"

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      axes: {
        x: { hidden: true },  // hide the category axis (sparkline look)
        y: { hidden: true },  // hide the value axis too
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    x: {
      hidden: true,    // replace
      // hidden: null   // drop the inherited flag (writer falls back to val="0")
      // hidden: false  // identical to null — both collapse to the OOXML default
      // hidden: undefined  // inherit the source's parsed value
    },
  },
});
```

## Model

```ts
interface ChartAxisInfo {
  /* ...existing fields... */
  hidden?: boolean;
}

interface SheetChart {
  axes?: {
    x?: { /* ... */; hidden?: boolean };
    y?: { /* ... */; hidden?: boolean };
  };
}

interface CloneChartOptions {
  axes?: {
    x?: { /* ... */; hidden?: boolean | null };
    y?: { /* ... */; hidden?: boolean | null };
  };
}
```

The read-side `ChartAxisInfo.hidden` mirrors the write-side `SheetChart.axes.[x|y].hidden` so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:delete val=".."/>` on every `CT_CatAx` / `CT_ValAx` / `CT_DateAx` / `CT_SerAx`. Only `"1"` / `"true"` surface `true`; the OOXML default `"0"` / `"false"` (and unknown tokens, missing `val` attributes, missing `<c:delete>`) all collapse to `undefined` so absence and the default round-trip identically.
- **Write** — `<c:delete>` is always emitted because Excel's reference serialization includes it on every axis. The writer pins `val="1"` only when `hidden === true` — a literal `false`, an absent field, or a non-boolean value all collapse to the default `val="0"`. The element sits between `<c:scaling>` and `<c:axPos>` per the strict CT_CatAx / CT_ValAx schema sequence.
- **Clone** — Each axis override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `val="0"`) / `boolean` (replace) grammar that mirrors `gridlines` / `scale` / `numberFormat`. An override of `false` collapses identically to `null` because the writer treats both as the OOXML default. The flag carries through every chart-family coercion that has axes (line -> column, bar -> scatter, etc.); pie / doughnut clones drop the entire `axes` block because OOXML defines no axes for them.

## Edge cases

- An explicit `hidden: false` round-trips to `undefined` (since absence and `val="0"` are indistinguishable on the read side). This matches how `plotVisOnly: true` / `varyColors` collapse on read.
- Non-boolean inputs fed to the writer fall back to `val="0"` rather than fabricate an attribute Excel rejects.
- Each axis carries its own flag, so hiding X never propagates to Y (and vice versa).
- Bar / column / line / area / scatter all support the flag on both axes; pie / doughnut silently drop the entire `axes` block since OOXML defines no axes for them.

Refs #136

## Test plan

- [x] `pnpm test` passes (3064 tests, including 50 new tests across reader, writer, and clone for the hidden flag)
- [x] `pnpm build` produces a clean dist
- [x] Reader, writer, and clone tests cover: defaults, `val="1"` / `val="true"` / `val="0"` / `val="false"`, missing `<c:delete>` / `val`, unknown tokens, OOXML element ordering inside the axis, single-axis isolation (X hidden does not propagate to Y), every chart family, scatter axis layout (axPos="b" / "l"), pie / doughnut drop-through, chart-family coercions (line -> column, bar -> scatter), and a full `parseChart -> cloneChart -> writeChart -> parseChart` round-trip with a `writeXlsx` end-to-end check.