### PR TITLE
feat(xlsx): chart category-axis label offset — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,63 +704,62 @@ tick skips above — `CT_CatAx` / `CT_DateAx` only — and the same
 default-collapse semantics: the OOXML default `100` (Excel's
 reference label spacing) collapses to `undefined` so absence and the
 default round-trip identically; out-of-range values (negative or
-
-> 1000. drop rather than clamp.
->       `ChartAxisInfo.reverse` surfaces the per-axis
->       `<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
->       "Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
->       `true`; the OOXML default `"minMax"` (and unknown tokens, missing `val`
->       attributes, missing `<c:orientation>` / `<c:scaling>` elements) all
->       collapse to `undefined` so absence and the default round-trip
->       identically through `cloneChart`. Reverse can fire on either or both
->       axes independently — bar / column / line / area / scatter all support
->       it; pie / doughnut never report it because they have no axes.
->       `Chart.roundedCorners` surfaces the chart-frame
->       `<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
->       Chart Area → Border → Rounded corners" toggle. The element sits on
->       `<c:chartSpace>` (a sibling of `<c:chart>`) because it styles the
->       outer frame rather than the plot area. The OOXML default `false`
->       collapses to `undefined` so absence and `<c:roundedCorners val="0"/>`
->       round-trip identically; only an explicit `val="1"` surfaces `true`.
->       The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"`
->       / `"0"` / `"false"`); unknown values and missing `val` attributes drop
->       to `undefined`.
->       `ChartSeriesInfo.smooth` surfaces the per-series
->       `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
->       Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
->       series (the OOXML schema places `<c:smooth>` exclusively on
->       `CT_LineSer` and `CT_ScatterSer`). Absence and the OOXML default
->       `val="0"` both collapse to `undefined`, so only an explicit
->       `<c:smooth val="1"/>` round-trips as `smooth: true`.
->       `ChartSeriesInfo.marker` surfaces the per-series `<c:ser><c:marker>`
->       glyph configuration on `line` / `line3D` / `scatter` series (the
->       schema places `<c:marker>` only on `CT_LineSer` and `CT_ScatterSer`).
->       The reader pulls `symbol` (`circle` / `square` / `diamond` /
->       `triangle` / `x` / `star` / `dot` / `dash` / `plus` / `auto` /
->       `none`), `size` (clamped to the OOXML 2..72 band), and the marker's
->       fill / outline colors out of `<c:spPr><a:solidFill>` and
->       `<c:spPr><a:ln><a:solidFill>` — empty `<c:marker/>` elements collapse
->       to `undefined` so absence and a bare element round-trip identically.
->       `ChartSeriesInfo.stroke` surfaces the per-series
->       `<c:ser><c:spPr><a:ln>` line styling on the same `line` / `line3D` /
->       `scatter` series — `dash` mirrors the OOXML `ST_PresetLineDashVal`
->       enum (`solid`, `dot`, `dash`, `lgDash`, `dashDot`, `lgDashDot`,
->       `lgDashDotDot`, `sysDash`, `sysDot`, `sysDashDot`, `sysDashDotDot`)
->       and `width` is reported in points after converting from EMU and
->       clamping to Excel's 0.25 – 13.5 pt UI band. Empty `<a:ln/>` blocks,
->       unknown dash tokens, and out-of-band widths collapse to `undefined`
->       so the parsed shape stays minimal.
->       `ChartSeriesInfo.invertIfNegative` surfaces the per-series
->       `<c:ser><c:invertIfNegative val=".."/>` flag — Excel's "Format Data
->       Series → Fill → Invert if negative" toggle — only on `bar` / `bar3D`
->       series (the OOXML schema places `<c:invertIfNegative>` exclusively on
->       `CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
->       `val="0"` both collapse to `undefined`, so only an explicit
->       `<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
->       Sheets that hucre actively regenerates because they
->       also carry hucre-managed images currently keep the chart bodies but
->       lose the in-drawing chart anchor — merging hucre's drawing output
->       with the original chart graphicFrames is a follow-up.
+greater than 1000) drop rather than clamp.
+`ChartAxisInfo.reverse` surfaces the per-axis
+`<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
+"Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
+`true`; the OOXML default `"minMax"` (and unknown tokens, missing `val`
+attributes, missing `<c:orientation>` / `<c:scaling>` elements) all
+collapse to `undefined` so absence and the default round-trip
+identically through `cloneChart`. Reverse can fire on either or both
+axes independently — bar / column / line / area / scatter all support
+it; pie / doughnut never report it because they have no axes.
+`Chart.roundedCorners` surfaces the chart-frame
+`<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
+Chart Area → Border → Rounded corners" toggle. The element sits on
+`<c:chartSpace>` (a sibling of `<c:chart>`) because it styles the
+outer frame rather than the plot area. The OOXML default `false`
+collapses to `undefined` so absence and `<c:roundedCorners val="0"/>`
+round-trip identically; only an explicit `val="1"` surfaces `true`.
+The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"`
+/ `"0"` / `"false"`); unknown values and missing `val` attributes drop
+to `undefined`.
+`ChartSeriesInfo.smooth` surfaces the per-series
+`<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
+Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
+series (the OOXML schema places `<c:smooth>` exclusively on
+`CT_LineSer` and `CT_ScatterSer`). Absence and the OOXML default
+`val="0"` both collapse to `undefined`, so only an explicit
+`<c:smooth val="1"/>` round-trips as `smooth: true`.
+`ChartSeriesInfo.marker` surfaces the per-series `<c:ser><c:marker>`
+glyph configuration on `line` / `line3D` / `scatter` series (the
+schema places `<c:marker>` only on `CT_LineSer` and `CT_ScatterSer`).
+The reader pulls `symbol` (`circle` / `square` / `diamond` /
+`triangle` / `x` / `star` / `dot` / `dash` / `plus` / `auto` /
+`none`), `size` (clamped to the OOXML 2..72 band), and the marker's
+fill / outline colors out of `<c:spPr><a:solidFill>` and
+`<c:spPr><a:ln><a:solidFill>` — empty `<c:marker/>` elements collapse
+to `undefined` so absence and a bare element round-trip identically.
+`ChartSeriesInfo.stroke` surfaces the per-series
+`<c:ser><c:spPr><a:ln>` line styling on the same `line` / `line3D` /
+`scatter` series — `dash` mirrors the OOXML `ST_PresetLineDashVal`
+enum (`solid`, `dot`, `dash`, `lgDash`, `dashDot`, `lgDashDot`,
+`lgDashDotDot`, `sysDash`, `sysDot`, `sysDashDot`, `sysDashDotDot`)
+and `width` is reported in points after converting from EMU and
+clamping to Excel's 0.25 – 13.5 pt UI band. Empty `<a:ln/>` blocks,
+unknown dash tokens, and out-of-band widths collapse to `undefined`
+so the parsed shape stays minimal.
+`ChartSeriesInfo.invertIfNegative` surfaces the per-series
+`<c:ser><c:invertIfNegative val=".."/>` flag — Excel's "Format Data
+Series → Fill → Invert if negative" toggle — only on `bar` / `bar3D`
+series (the OOXML schema places `<c:invertIfNegative>` exclusively on
+`CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
+`val="0"` both collapse to `undefined`, so only an explicit
+`<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
+Sheets that hucre actively regenerates because they
+also carry hucre-managed images currently keep the chart bodies but
+lose the in-drawing chart anchor — merging hucre's drawing output
+with the original chart graphicFrames is a follow-up.
 
 #### Authoring charts with `writeXlsx`
 

--- a/README.md
+++ b/README.md
@@ -698,61 +698,69 @@ axis does not surface a field the writer would never emit anyway. The
 OOXML default `1` (show every label / mark) collapses to `undefined`;
 out-of-range values (non-positive or > 32767) drop rather than clamp
 so a malformed input cannot leak into the writer.
-`ChartAxisInfo.reverse` surfaces the per-axis
-`<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
-"Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
-`true`; the OOXML default `"minMax"` (and unknown tokens, missing `val`
-attributes, missing `<c:orientation>` / `<c:scaling>` elements) all
-collapse to `undefined` so absence and the default round-trip
-identically through `cloneChart`. Reverse can fire on either or both
-axes independently — bar / column / line / area / scatter all support
-it; pie / doughnut never report it because they have no axes.
-`Chart.roundedCorners` surfaces the chart-frame
-`<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
-Chart Area → Border → Rounded corners" toggle. The element sits on
-`<c:chartSpace>` (a sibling of `<c:chart>`) because it styles the
-outer frame rather than the plot area. The OOXML default `false`
-collapses to `undefined` so absence and `<c:roundedCorners val="0"/>`
-round-trip identically; only an explicit `val="1"` surfaces `true`.
-The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"`
-/ `"0"` / `"false"`); unknown values and missing `val` attributes drop
-to `undefined`.
-`ChartSeriesInfo.smooth` surfaces the per-series
-`<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
-Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
-series (the OOXML schema places `<c:smooth>` exclusively on
-`CT_LineSer` and `CT_ScatterSer`). Absence and the OOXML default
-`val="0"` both collapse to `undefined`, so only an explicit
-`<c:smooth val="1"/>` round-trips as `smooth: true`.
-`ChartSeriesInfo.marker` surfaces the per-series `<c:ser><c:marker>`
-glyph configuration on `line` / `line3D` / `scatter` series (the
-schema places `<c:marker>` only on `CT_LineSer` and `CT_ScatterSer`).
-The reader pulls `symbol` (`circle` / `square` / `diamond` /
-`triangle` / `x` / `star` / `dot` / `dash` / `plus` / `auto` /
-`none`), `size` (clamped to the OOXML 2..72 band), and the marker's
-fill / outline colors out of `<c:spPr><a:solidFill>` and
-`<c:spPr><a:ln><a:solidFill>` — empty `<c:marker/>` elements collapse
-to `undefined` so absence and a bare element round-trip identically.
-`ChartSeriesInfo.stroke` surfaces the per-series
-`<c:ser><c:spPr><a:ln>` line styling on the same `line` / `line3D` /
-`scatter` series — `dash` mirrors the OOXML `ST_PresetLineDashVal`
-enum (`solid`, `dot`, `dash`, `lgDash`, `dashDot`, `lgDashDot`,
-`lgDashDotDot`, `sysDash`, `sysDot`, `sysDashDot`, `sysDashDotDot`)
-and `width` is reported in points after converting from EMU and
-clamping to Excel's 0.25 – 13.5 pt UI band. Empty `<a:ln/>` blocks,
-unknown dash tokens, and out-of-band widths collapse to `undefined`
-so the parsed shape stays minimal.
-`ChartSeriesInfo.invertIfNegative` surfaces the per-series
-`<c:ser><c:invertIfNegative val=".."/>` flag — Excel's "Format Data
-Series → Fill → Invert if negative" toggle — only on `bar` / `bar3D`
-series (the OOXML schema places `<c:invertIfNegative>` exclusively on
-`CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
-`val="0"` both collapse to `undefined`, so only an explicit
-`<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
-Sheets that hucre actively regenerates because they
-also carry hucre-managed images currently keep the chart bodies but
-lose the in-drawing chart anchor — merging hucre's drawing output
-with the original chart graphicFrames is a follow-up.
+`ChartAxisInfo.lblOffset` surfaces the category-axis label-offset
+percentage (`<c:catAx><c:lblOffset val=".."/>`). Same scope as the
+tick skips above — `CT_CatAx` / `CT_DateAx` only — and the same
+default-collapse semantics: the OOXML default `100` (Excel's
+reference label spacing) collapses to `undefined` so absence and the
+default round-trip identically; out-of-range values (negative or
+
+> 1000. drop rather than clamp.
+>       `ChartAxisInfo.reverse` surfaces the per-axis
+>       `<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
+>       "Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
+>       `true`; the OOXML default `"minMax"` (and unknown tokens, missing `val`
+>       attributes, missing `<c:orientation>` / `<c:scaling>` elements) all
+>       collapse to `undefined` so absence and the default round-trip
+>       identically through `cloneChart`. Reverse can fire on either or both
+>       axes independently — bar / column / line / area / scatter all support
+>       it; pie / doughnut never report it because they have no axes.
+>       `Chart.roundedCorners` surfaces the chart-frame
+>       `<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
+>       Chart Area → Border → Rounded corners" toggle. The element sits on
+>       `<c:chartSpace>` (a sibling of `<c:chart>`) because it styles the
+>       outer frame rather than the plot area. The OOXML default `false`
+>       collapses to `undefined` so absence and `<c:roundedCorners val="0"/>`
+>       round-trip identically; only an explicit `val="1"` surfaces `true`.
+>       The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"`
+>       / `"0"` / `"false"`); unknown values and missing `val` attributes drop
+>       to `undefined`.
+>       `ChartSeriesInfo.smooth` surfaces the per-series
+>       `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
+>       Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
+>       series (the OOXML schema places `<c:smooth>` exclusively on
+>       `CT_LineSer` and `CT_ScatterSer`). Absence and the OOXML default
+>       `val="0"` both collapse to `undefined`, so only an explicit
+>       `<c:smooth val="1"/>` round-trips as `smooth: true`.
+>       `ChartSeriesInfo.marker` surfaces the per-series `<c:ser><c:marker>`
+>       glyph configuration on `line` / `line3D` / `scatter` series (the
+>       schema places `<c:marker>` only on `CT_LineSer` and `CT_ScatterSer`).
+>       The reader pulls `symbol` (`circle` / `square` / `diamond` /
+>       `triangle` / `x` / `star` / `dot` / `dash` / `plus` / `auto` /
+>       `none`), `size` (clamped to the OOXML 2..72 band), and the marker's
+>       fill / outline colors out of `<c:spPr><a:solidFill>` and
+>       `<c:spPr><a:ln><a:solidFill>` — empty `<c:marker/>` elements collapse
+>       to `undefined` so absence and a bare element round-trip identically.
+>       `ChartSeriesInfo.stroke` surfaces the per-series
+>       `<c:ser><c:spPr><a:ln>` line styling on the same `line` / `line3D` /
+>       `scatter` series — `dash` mirrors the OOXML `ST_PresetLineDashVal`
+>       enum (`solid`, `dot`, `dash`, `lgDash`, `dashDot`, `lgDashDot`,
+>       `lgDashDotDot`, `sysDash`, `sysDot`, `sysDashDot`, `sysDashDotDot`)
+>       and `width` is reported in points after converting from EMU and
+>       clamping to Excel's 0.25 – 13.5 pt UI band. Empty `<a:ln/>` blocks,
+>       unknown dash tokens, and out-of-band widths collapse to `undefined`
+>       so the parsed shape stays minimal.
+>       `ChartSeriesInfo.invertIfNegative` surfaces the per-series
+>       `<c:ser><c:invertIfNegative val=".."/>` flag — Excel's "Format Data
+>       Series → Fill → Invert if negative" toggle — only on `bar` / `bar3D`
+>       series (the OOXML schema places `<c:invertIfNegative>` exclusively on
+>       `CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
+>       `val="0"` both collapse to `undefined`, so only an explicit
+>       `<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
+>       Sheets that hucre actively regenerates because they
+>       also carry hucre-managed images currently keep the chart bodies but
+>       lose the in-drawing chart anchor — merging hucre's drawing output
+>       with the original chart graphicFrames is a follow-up.
 
 #### Authoring charts with `writeXlsx`
 
@@ -912,6 +920,19 @@ fields live on category axes only — bar / column / line / area
 honour them; scatter (whose two axes are value axes) and pie /
 doughnut (no axes at all) silently ignore them. Non-integer inputs
 round to the nearest integer.
+The `axes.x.lblOffset` field controls the distance between the tick
+labels and the axis line on a category axis (`<c:catAx><c:lblOffset
+val=".."/>`), expressed as a percentage of Excel's default spacing.
+Pass a value in the `0..1000` band to pull labels in towards the axis
+or push them out. The writer always emits `<c:lblOffset>` because
+Excel's reference serialization includes it on every category axis;
+absence (and the OOXML default `100`) emit `val="100"` so untouched
+charts match the reference output byte-for-byte. Out-of-range values
+(negative or > 1000) drop silently rather than clamp — the writer
+falls back to the default `100`. Same scope as the tick skips above:
+bar / column / line / area honour the override; scatter and pie /
+doughnut silently ignore it. Non-integer inputs round to the nearest
+integer.
 The `axes.x.reverse` and `axes.y.reverse` flags map to
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` — Excel's
 "Categories / Values in reverse order" toggle. On a category axis,
@@ -1099,6 +1120,15 @@ slot in the rendered chart) and when the target is `pie` or
 `doughnut` (no axes at all) — flattening a column template into a
 scatter clone therefore never leaks a stale catAx skip into the
 output.
+The per-axis `axes.x.lblOffset` override follows the same `undefined`
+(inherit) / `null` (drop) / number (replace) grammar. An explicit
+override of `100` (the OOXML default) collapses to `undefined` so it
+behaves identically to `null` — both leave the cloned chart with
+Excel's default label spacing. Same scope-restriction as the tick
+skips: the inherited offset is dropped silently when the resolved
+clone target is `scatter` or `pie` / `doughnut`, so flattening a
+column template into a scatter clone never leaks a stale catAx offset
+into the output.
 The per-axis `axes.x.reverse` / `axes.y.reverse` overrides follow the
 same `undefined` (inherit) / `null` (drop) / boolean (replace) grammar
 as the other axis fields. A literal `false` override behaves

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1126,6 +1126,20 @@ export interface SheetChart {
        * scope-restriction as `tickLblSkip` — category axes only.
        */
       tickMarkSkip?: number;
+      /**
+       * Distance between the tick labels and the axis line on a
+       * category axis, expressed as a percentage of the default
+       * spacing. `100` (the OOXML default) renders Excel's reference
+       * spacing; lower values pull the labels in towards the axis,
+       * higher values push them out. Maps to
+       * `<c:catAx><c:lblOffset val="N"/></c:catAx>`. Only meaningful
+       * for bar / column / line / area charts (whose X axis is
+       * `<c:catAx>`); silently ignored for scatter (both axes are
+       * value axes) and pie / doughnut (no axes at all). Accepted
+       * range: `0..1000` (the OOXML `ST_LblOffsetPercent` schema).
+       * Values outside the range are dropped at write time.
+       */
+      lblOffset?: number;
     };
     /** Value axis. */
     y?: {
@@ -2062,6 +2076,17 @@ export interface ChartAxisInfo {
    * {@link tickLblSkip}.
    */
   tickMarkSkip?: number;
+  /**
+   * Label offset pulled from `<c:lblOffset val=".."/>`, expressed as a
+   * percentage of the default axis-label spacing. Surfaces only on
+   * category axes (`<c:catAx>` / `<c:dateAx>`) — the OOXML schema
+   * (`ST_LblOffsetPercent`) does not place this element on `<c:valAx>`
+   * or `<c:serAx>`. The default `100` (Excel's reference spacing)
+   * collapses to `undefined` so absence and the default round-trip
+   * identically through {@link cloneChart}. Accepted range is `0..1000`;
+   * out-of-range values are dropped rather than fabricated.
+   */
+  lblOffset?: number;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -294,6 +294,16 @@ export interface CloneChartOptions {
        * scope rules as {@link tickLblSkip}.
        */
       tickMarkSkip?: number | null;
+      /**
+       * Override `SheetChart.axes.x.lblOffset`. `undefined` (or
+       * omitted) inherits the source axis's label offset; `null`
+       * drops the inherited value (the writer falls back to Excel's
+       * default `100`); a number in the `0..1000` band replaces it.
+       * Only meaningful for resolved chart types whose X axis is
+       * `<c:catAx>` (bar / column / line / area); silently dropped
+       * on scatter and pie / doughnut.
+       */
+      lblOffset?: number | null;
     };
     y?: {
       title?: string | null;
@@ -945,6 +955,11 @@ function resolveAxes(
   const xTickMarkSkip = isCatAxisX
     ? applySkipOverride(sourceAxes?.x?.tickMarkSkip, overrides?.x?.tickMarkSkip)
     : undefined;
+  // `lblOffset` is also category-axis-only (CT_CatAx / CT_DateAx) per
+  // the OOXML schema. Same scope rule as the skip elements above.
+  const xLblOffset = isCatAxisX
+    ? applyLblOffsetOverride(sourceAxes?.x?.lblOffset, overrides?.x?.lblOffset)
+    : undefined;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -957,7 +972,8 @@ function resolveAxes(
     xTickLblPos !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
-    xTickMarkSkip !== undefined
+    xTickMarkSkip !== undefined ||
+    xLblOffset !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
@@ -970,6 +986,7 @@ function resolveAxes(
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
+    if (xLblOffset !== undefined) out.x.lblOffset = xLblOffset;
   }
   if (
     yTitle !== undefined ||
@@ -1016,6 +1033,32 @@ function applySkipOverride(
   if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
   const rounded = Math.round(override);
   if (rounded < 1 || rounded > 32767 || rounded === 1) return undefined;
+  return rounded;
+}
+
+/**
+ * Resolve an `lblOffset` override using the same `undefined` (inherit)
+ * / `null` (drop) / value (replace) grammar as the other axis helpers.
+ * Out-of-range / non-numeric values collapse to `undefined` so they
+ * cannot leak into the writer (which would silently drop them anyway
+ * via {@link normalizeAxisLblOffset}). The OOXML default `100` also
+ * collapses to `undefined` so absence and the default round-trip
+ * identically — symmetric with the parser-side default-collapse.
+ */
+function applyLblOffsetOverride(
+  source: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) {
+    if (typeof source !== "number" || !Number.isFinite(source)) return undefined;
+    const rounded = Math.round(source);
+    if (rounded < 0 || rounded > 1000 || rounded === 100) return undefined;
+    return rounded;
+  }
+  if (override === null) return undefined;
+  if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
+  const rounded = Math.round(override);
+  if (rounded < 0 || rounded > 1000 || rounded === 100) return undefined;
   return rounded;
 }
 

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -288,6 +288,11 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   const isCategoryAxis = axis.local === "catAx" || axis.local === "dateAx";
   const tickLblSkip = isCategoryAxis ? parseAxisSkip(axis, "tickLblSkip") : undefined;
   const tickMarkSkip = isCategoryAxis ? parseAxisSkip(axis, "tickMarkSkip") : undefined;
+  // `<c:lblOffset>` lives exclusively on `CT_CatAx` / `CT_DateAx` per
+  // ECMA-376 Part 1, §21.2.2 — the `<c:valAx>` and `<c:serAx>` schemas
+  // reject it. Skip the parse on value axes for the same reason as
+  // the skip elements above.
+  const lblOffset = isCategoryAxis ? parseAxisLblOffset(axis) : undefined;
   if (
     title === undefined &&
     gridlines === undefined &&
@@ -298,7 +303,8 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     tickLblPos === undefined &&
     reverse === undefined &&
     tickLblSkip === undefined &&
-    tickMarkSkip === undefined
+    tickMarkSkip === undefined &&
+    lblOffset === undefined
   ) {
     return undefined;
   }
@@ -313,6 +319,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (reverse !== undefined) out.reverse = reverse;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
+  if (lblOffset !== undefined) out.lblOffset = lblOffset;
   return out;
 }
 
@@ -421,6 +428,33 @@ function parseAxisSkip(
   if (!Number.isFinite(parsed)) return undefined;
   if (parsed < 1 || parsed > 32767) return undefined;
   if (parsed === 1) return undefined;
+  return parsed;
+}
+
+/**
+ * Pull `<c:lblOffset val=".."/>` off a category axis element. Returns
+ * `undefined` when:
+ *   - the element is absent,
+ *   - the `val` attribute is missing or non-numeric,
+ *   - the parsed value is `100` (the OOXML default — Excel's
+ *     reference label spacing),
+ *   - the parsed value falls outside the OOXML
+ *     `ST_LblOffsetPercent` range (`0..1000`).
+ *
+ * Out-of-range / non-numeric inputs are dropped rather than clamped
+ * so a corrupt template cannot leak an offset Excel would reject.
+ */
+function parseAxisLblOffset(axis: XmlElement): number | undefined {
+  const el = findChild(axis, "lblOffset");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 0 || parsed > 1000) return undefined;
+  if (parsed === 100) return undefined;
   return parsed;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -161,6 +161,11 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // catAx builder is the only consumer of these knobs.
     xTickLblSkip: normalizeAxisSkip(chart.axes?.x?.tickLblSkip),
     xTickMarkSkip: normalizeAxisSkip(chart.axes?.x?.tickMarkSkip),
+    // `lblOffset` lives exclusively on `CT_CatAx` / `CT_DateAx` per
+    // the OOXML schema. Same scope rule as the skip elements above —
+    // scatter has no category axis, so the catAx builder is the only
+    // consumer of this knob.
+    xLblOffset: normalizeAxisLblOffset(chart.axes?.x?.lblOffset),
   };
 
   switch (chart.type) {
@@ -231,6 +236,12 @@ interface AxisRenderOptions {
    * is `<c:catAx>`. Same scope rule as {@link xTickLblSkip}.
    */
   xTickMarkSkip: number | undefined;
+  /**
+   * Label offset percentage emitted on the X axis only when the axis
+   * is `<c:catAx>` (i.e. bar / column / line / area). Scatter charts
+   * have no category axis, so the value is dropped silently.
+   */
+  xLblOffset: number | undefined;
 }
 
 /**
@@ -356,6 +367,29 @@ function normalizeAxisSkip(value: number | undefined): number | undefined {
   const rounded = Math.round(value);
   if (rounded < 1 || rounded > 32767) return undefined;
   if (rounded === 1) return undefined;
+  return rounded;
+}
+
+/**
+ * Normalize a category-axis `lblOffset` percentage to an integer in
+ * the OOXML `ST_LblOffsetPercent` band (`0..1000`).
+ *
+ * Returns `undefined` when:
+ *   - the input is missing or non-finite,
+ *   - the rounded value is `100` (the OOXML default — Excel's
+ *     reference label spacing — and what absence already means),
+ *   - the rounded value falls outside the `0..1000` range.
+ *
+ * Out-of-range values drop rather than clamp so a malformed override
+ * surfaces as "no offset emitted" instead of silently snapping to the
+ * extreme — a clamp from `9999` to `1000` would mask a programming
+ * error in the caller.
+ */
+function normalizeAxisLblOffset(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < 0 || rounded > 1000) return undefined;
+  if (rounded === 100) return undefined;
   return rounded;
 }
 
@@ -643,7 +677,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:auto", { val: 1 }),
     xmlSelfClose("c:lblAlgn", { val: "ctr" }),
-    xmlSelfClose("c:lblOffset", { val: 100 }),
+    // `<c:lblOffset>` is always emitted because Excel's reference
+    // serialization includes it on every category axis. The writer
+    // pins the caller's override when set; absence (or the OOXML
+    // default `100` collapsed by `normalizeAxisLblOffset`) emits the
+    // default so untouched charts match Excel's output byte-for-byte.
+    xmlSelfClose("c:lblOffset", { val: opts.xLblOffset ?? 100 }),
     // OOXML CT_CatAx places `<c:tickLblSkip>` / `<c:tickMarkSkip>`
     // after `<c:lblOffset>` and before `<c:noMultiLvlLbl>`. Only
     // emit each element when the caller pinned a non-default value

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3592,3 +3592,149 @@ describe("cloneChart — axis tickLblSkip / tickMarkSkip", () => {
     expect(written).toContain('c:tickMarkSkip val="5"');
   });
 });
+
+// ── cloneChart — axis lblOffset ─────────────────────────────────────
+
+describe("cloneChart — axis lblOffset", () => {
+  const sourceWithOffset: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { lblOffset: 250 } },
+  };
+
+  it("inherits the lblOffset from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithOffset, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.lblOffset).toBe(250);
+  });
+
+  it("drops the inherited offset when the override is null", () => {
+    const clone = cloneChart(sourceWithOffset, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblOffset: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited offset with the override value", () => {
+    const clone = cloneChart(sourceWithOffset, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblOffset: 400 } },
+    });
+    expect(clone.axes?.x?.lblOffset).toBe(400);
+  });
+
+  it("adds an offset to a source axis that did not declare one", () => {
+    const noOffset: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noOffset, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblOffset: 200 } },
+    });
+    expect(clone.axes?.x?.lblOffset).toBe(200);
+  });
+
+  it("drops out-of-range overrides without clamping", () => {
+    const clone = cloneChart(sourceWithOffset, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblOffset: 9999 } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("collapses an explicit override of 100 (the OOXML default) to undefined", () => {
+    // Pinning the default has the same effect as `null` — the cloned
+    // chart inherits Excel's default label spacing either way.
+    const clone = cloneChart(sourceWithOffset, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblOffset: 100 } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the offset silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { lblOffset: 250 } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the offset silently when the resolved chart type is scatter", () => {
+    // Scatter uses two value axes, so the X axis is no longer a category
+    // axis. Drop inherited lblOffset so the cloned model accurately
+    // reflects what the chart will paint.
+    const clone = cloneChart(sourceWithOffset, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the offset", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:lblOffset val="300"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.lblOffset).toBe(300);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.lblOffset).toBe(300);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('c:lblOffset val="300"');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.lblOffset).toBe(300);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the offset intact", async () => {
+    const clone = cloneChart(sourceWithOffset, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:lblOffset val="250"');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3387,3 +3387,124 @@ describe("writeChart — axis tickLblSkip / tickMarkSkip", () => {
     expect(idx("c:tickMarkSkip")).toBeLessThan(idx("c:noMultiLvlLbl"));
   });
 });
+
+describe("writeChart — axis lblOffset", () => {
+  it("emits the override value on the category axis when set", () => {
+    const result = writeChart(makeChart({ axes: { x: { lblOffset: 250 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblOffset val="250"');
+  });
+
+  it("emits the OOXML default 100 when the field is unset", () => {
+    // Excel's reference serialization always emits `<c:lblOffset val="100"/>`,
+    // so the writer keeps that contract on a stock chart even though the
+    // parser collapses `100` to undefined on the read side.
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblOffset val="100"');
+  });
+
+  it("collapses an explicit 100 (the default) back to the default emit", () => {
+    // Pinning the default has the same effect as omitting the field —
+    // the OOXML default `100` round-trips identically with absence.
+    const result = writeChart(makeChart({ axes: { x: { lblOffset: 100 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblOffset val="100"');
+  });
+
+  it("drops out-of-range overrides without clamping (falls back to default 100)", () => {
+    // ST_LblOffsetPercent restricts the value to 0..1000. Passing -5 or
+    // 9999 collapses to undefined inside `normalizeAxisLblOffset`, so the
+    // writer falls back to the default `100` rather than clamping.
+    const lo = writeChart(makeChart({ axes: { x: { lblOffset: -5 } } }), "Sheet1");
+    const loCatAx = lo.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(loCatAx).toContain('c:lblOffset val="100"');
+
+    const hi = writeChart(makeChart({ axes: { x: { lblOffset: 9999 } } }), "Sheet1");
+    const hiCatAx = hi.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(hiCatAx).toContain('c:lblOffset val="100"');
+  });
+
+  it("rounds non-integer values to the nearest integer", () => {
+    const result = writeChart(makeChart({ axes: { x: { lblOffset: 247.6 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblOffset val="248"');
+  });
+
+  it("accepts the schema boundaries 0 and 1000", () => {
+    const lo = writeChart(makeChart({ axes: { x: { lblOffset: 0 } } }), "Sheet1");
+    expect(lo.chartXml).toContain('c:lblOffset val="0"');
+    const hi = writeChart(makeChart({ axes: { x: { lblOffset: 1000 } } }), "Sheet1");
+    expect(hi.chartXml).toContain('c:lblOffset val="1000"');
+  });
+
+  it("emits exactly one <c:lblOffset> element per category axis", () => {
+    const result = writeChart(makeChart({ axes: { x: { lblOffset: 250 } } }), "Sheet1");
+    expect((result.chartXml.match(/c:lblOffset/g) ?? []).length).toBe(1);
+  });
+
+  it("threads the override through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { lblOffset: 200 } } }), "Sheet1");
+      expect(result.chartXml).toContain('c:lblOffset val="200"');
+    }
+  });
+
+  it("ignores the override on scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { lblOffset: 250 } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:lblOffset");
+  });
+
+  it("ignores the override on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(makeChart({ type: "pie", axes: { x: { lblOffset: 250 } } }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:lblOffset");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { lblOffset: 250 } } }),
+      "Sheet1",
+    );
+    expect(dough.chartXml).not.toContain("c:lblOffset");
+  });
+
+  it("does not emit lblOffset on the value axis", () => {
+    // The model surfaces the offset only on `axes.x`; setting it via
+    // `axes.y` is impossible at the type level. This test pins the
+    // negative case for the writer: a valAx never carries lblOffset.
+    const result = writeChart(makeChart({ axes: { x: { lblOffset: 250 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).not.toContain("c:lblOffset");
+  });
+
+  it("places lblOffset between lblAlgn and tickLblSkip per the OOXML schema", () => {
+    // CT_CatAx: ... lblAlgn → lblOffset → tickLblSkip → tickMarkSkip → noMultiLvlLbl.
+    const result = writeChart(
+      makeChart({ axes: { x: { lblOffset: 250, tickLblSkip: 3 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const lblAlgnIdx = catAxBlock.indexOf("c:lblAlgn");
+    const lblOffsetIdx = catAxBlock.indexOf("c:lblOffset");
+    const tickLblSkipIdx = catAxBlock.indexOf("c:tickLblSkip");
+    expect(lblAlgnIdx).toBeGreaterThan(0);
+    expect(lblOffsetIdx).toBeGreaterThan(lblAlgnIdx);
+    expect(tickLblSkipIdx).toBeGreaterThan(lblOffsetIdx);
+  });
+
+  it("round-trips a non-default offset through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { x: { lblOffset: 200 } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.lblOffset).toBe(200);
+  });
+
+  it("collapses a defaulted offset round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -4048,3 +4048,127 @@ describe("parseChart — axis tickLblSkip / tickMarkSkip", () => {
     });
   });
 });
+
+// ── parseChart — axis lblOffset ────────────────────────────────────
+
+describe("parseChart — axis lblOffset", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a non-default lblOffset on the category axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblOffset val="250"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.lblOffset).toBe(250);
+  });
+
+  it("collapses the OOXML default lblOffset=100 to undefined", () => {
+    // Excel's reference serialization always emits `<c:lblOffset val="100"/>`,
+    // but absence and the default round-trip identically — the writer's
+    // elision logic re-emits `100` when the field is undefined, so the
+    // parser collapses `100` to undefined to keep the parsed shape minimal.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblOffset val="100"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("ignores out-of-range lblOffset values (drops rather than clamps)", () => {
+    // ST_LblOffsetPercent restricts the value to 0..1000. Out-of-range
+    // values like -5, 9999 should drop rather than clamp because a silent
+    // clamp would mask a configuration error in the source template.
+    const out = (val: string): unknown => {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblOffset val="${val}"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      return parseChart(xml)?.axes?.x?.lblOffset;
+    };
+    expect(out("-5")).toBeUndefined();
+    expect(out("9999")).toBeUndefined();
+    expect(out("not-a-number")).toBeUndefined();
+    // Boundaries 0 and 1000 are accepted.
+    expect(out("0")).toBe(0);
+    expect(out("1000")).toBe(1000);
+  });
+
+  it("returns undefined when lblOffset val attribute is missing", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblOffset/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface lblOffset on a value axis", () => {
+    // The OOXML schema places `<c:lblOffset>` on CT_CatAx / CT_DateAx
+    // only — `<c:valAx>` rejects it entirely. A corrupt template carrying
+    // a stray offset on a value axis should not surface a field the writer
+    // would never emit anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:lblOffset val="250"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.lblOffset).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces lblOffset alongside title, gridlines, and tick skips", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:lblOffset val="200"/>
+      <c:tickLblSkip val="3"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Region",
+      gridlines: { major: true },
+      lblOffset: 200,
+      tickLblSkip: 3,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:lblOffset>` element at the read, write, and clone layers so a template's label-offset configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:lblOffset>` controls the distance between the tick labels and the axis line on a category axis, expressed as a percentage (0..1000) of Excel's default spacing. Up until now hucre's writer always pinned `val="100"`, so a template that pinned a wider gap (e.g. `val="250"`) flattened back to the default on every parse -> clone -> write loop. The element lives exclusively on `CT_CatAx` / `CT_DateAx` in OOXML — it has no slot on `CT_ValAx` or `CT_SerAx`. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.lblOffset);  // 250 when the template pinned val="250",
                                         // undefined when the template used the default 100

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      axes: {
        x: { lblOffset: 250 },  // push category labels twice as far from the axis
      },
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    x: {
      lblOffset: 200,    // replace
      // lblOffset: null   // drop the inherited offset (writer falls back to 100)
      // lblOffset: undefined  // inherit the source's parsed value
    },
  },
});
```

## Model

```ts
interface ChartAxisInfo {
  /* ...existing fields... */
  lblOffset?: number;
}

interface SheetChart {
  axes?: {
    x?: { /* ... */; lblOffset?: number };
  };
}

interface CloneChartOptions {
  axes?: {
    x?: { /* ... */; lblOffset?: number | null };
  };
}
```

The read-side `ChartAxisInfo.lblOffset` mirrors the write-side `SheetChart.axes.x.lblOffset` so a parsed value slots straight back into `cloneChart` without transformation. Same scope as the existing `tickLblSkip` / `tickMarkSkip` knobs — the field surfaces only on `axes.x` because OOXML places `<c:lblOffset>` exclusively on category axes.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:lblOffset val=".."/>` on every `CT_CatAx` / `CT_DateAx`. The OOXML default `100` collapses to `undefined` so absence and the default round-trip identically; out-of-range values (negative or > 1000) drop rather than fabricate. The reader skips the parse on `<c:valAx>` so a corrupt template carrying a stray offset on a value axis does not surface a field the writer would never emit anyway.
- **Write** — `<c:lblOffset>` is always emitted because Excel's reference serialization includes it on every category axis. The writer pins the caller's override when set; absence (and the default `100`) emit `val="100"` so untouched charts match Excel's reference output byte-for-byte. Out-of-range values drop silently rather than clamp — the writer falls back to the default `100`. The element sits between `<c:lblAlgn>` and `<c:tickLblSkip>` per the strict CT_CatAx schema sequence.
- **Clone** — Each axis override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `100`) / `number` (replace) grammar that mirrors `tickLblSkip` / `tickMarkSkip`. An override of `100` (the OOXML default) collapses identically to `null`. The flag carries through every chart-family coercion that has a category axis (line -> column, bar -> bar, etc.); scatter / pie / doughnut clones drop the entire `axes` block (or just the offset) because OOXML defines no category axis for them.

## Edge cases

- Out-of-range inputs (`-5`, `9999`, `NaN`) drop both at the parser and writer rather than clamping — a silent clamp would mask a configuration error.
- Non-integer values round to the nearest integer.
- The schema boundaries `0` and `1000` are accepted.
- The element is emitted exactly once per category axis, threaded through bar / column / line / area chart families.
- A scatter or pie / doughnut clone target silently drops an inherited `lblOffset` (its X axis is not a category axis), so flattening a column template into a scatter clone never leaks a stale catAx offset.

Closes Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + 3110 vitest) passes.
- [x] `pnpm build` succeeds.
- [x] 30 new lblOffset tests across `charts.test.ts`, `charts-write.test.ts`, `chart-clone.test.ts` cover read, write, clone, end-to-end round-trip, and writeXlsx packaging.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>