### PR TITLE
feat(xlsx): chart legend overlay flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,18 @@ round-trip identically; only an explicit `val="1"` surfaces `true`.
 The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"`
 / `"0"` / `"false"`); unknown values and missing `val` attributes drop
 to `undefined`.
+`Chart.legendOverlay` surfaces the legend-overlay flag pulled from
+`<c:legend><c:overlay val=".."/></c:legend>` — Excel's "Format Legend →
+Show the legend without overlapping the chart" toggle (the checkbox is
+the inverse of this flag — checked means `false`, unchecked means
+`true`). The OOXML default `false` collapses to `undefined` so absence
+and `<c:overlay val="0"/>` round-trip identically; only an explicit
+`val="1"` surfaces `true`. The reader accepts the OOXML truthy / falsy
+spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and
+missing `val` attributes drop to `undefined`. The flag is dropped
+whenever `Chart.legend` is `false` or the chart omits the legend
+element entirely — there is no overlay slot on a hidden legend, so the
+parsed shape stays minimal.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -908,6 +920,17 @@ outer edge (`val="1"`). The writer always emits the element so the
 rendered intent is explicit on roundtrip — no chart family is
 special-cased, since the toggle styles the outer wrapper rather than
 any chart-family-specific markup.
+The chart-level `legendOverlay` field maps to `<c:overlay val=".."/>`
+inside `<c:legend>` — Excel's "Format Legend → Show the legend without
+overlapping the chart" toggle (the checkbox is the inverse of this
+flag — checked means `false`, unchecked means `true`). Absent it, the
+writer emits the OOXML default `val="0"` (the legend reserves its own
+slot and the plot area shrinks to make room), matching Excel's
+reference serialization. Pin `legendOverlay: true` to draw the legend
+on top of the plot area so the chart series get the full frame
+(`val="1"`). The flag is silently ignored when `legend: false`
+suppresses the entire legend element — there is no overlay slot on a
+hidden legend, so the writer skips emitting any orphaned `<c:overlay>`.
 The `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` fields thin out a
 crowded category axis (`<c:catAx><c:tickLblSkip val=".."/>` and
 `<c:catAx><c:tickMarkSkip val=".."/>`). Pass a positive integer to
@@ -1107,6 +1130,17 @@ back to the writer's OOXML `false` default (square chart frame), or a
 lives on `<c:chartSpace>` and is valid on every chart family, so a
 coercion (line → column, doughnut → pie, etc.) preserves the
 inherited value rather than dropping it.
+The chart-level `legendOverlay` flag follows the same grammar: pass
+`undefined` to inherit the source's parsed value, `null` to drop it
+back to the writer's OOXML `false` default (no overlap with the plot
+area), or a `boolean` to replace it. The flag lives on `<c:legend>` so
+the field is valid on every chart family, but it is silently dropped
+from the cloned `SheetChart` whenever the resolved `legend` is `false`
+— a hidden legend has no overlay slot in the rendered chart, so an
+inherited `true` would carry no on-screen effect. Re-enabling a hidden
+source legend through `legend: "top"` (or any visible position) on the
+override re-opens the slot, and an explicit `legendOverlay: true`
+override threads through.
 The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
 follow the same `undefined` (inherit) / `null` (drop) / number
 (replace) grammar as `gridlines` / `scale` / `numberFormat`. The

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -928,6 +928,20 @@ export interface SheetChart {
    * to hide the legend.
    */
   legend?: false | "top" | "bottom" | "left" | "right" | "topRight";
+  /**
+   * Whether the legend overlaps the plot area. Maps to
+   * `<c:legend><c:overlay val=".."/></c:legend>` — Excel's "Format
+   * Legend -> Show the legend without overlapping the chart" toggle
+   * (the checkbox is the inverse of this flag — checked means `false`,
+   * unchecked means `true`). Default: `false` (the OOXML default Excel
+   * itself emits) — the legend reserves its own slot and the plot area
+   * shrinks to accommodate it. Set `true` to draw the legend on top of
+   * the plot area so the chart series get the full frame.
+   *
+   * Silently ignored when `legend === false` (no legend element is
+   * emitted) — there is no overlay flag to set on a hidden legend.
+   */
+  legendOverlay?: boolean;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /** Alternative text for screen readers (lands in xdr:cNvPr/@descr). */
@@ -2178,6 +2192,24 @@ export interface Chart {
    * placement in that case.
    */
   legend?: false | ChartLegendPosition;
+  /**
+   * Legend-overlay flag pulled from `<c:legend><c:overlay val=".."/>`.
+   * Reflects Excel's "Format Legend -> Show the legend without
+   * overlapping the chart" toggle (the checkbox is the inverse — checked
+   * means `false`, unchecked means `true`).
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<c:overlay val="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<c:overlay val="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings (`"1"`
+   * / `"true"` / `"0"` / `"false"`); unknown values and missing `val`
+   * attributes drop to `undefined`.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * overlay flag to surface in either case.
+   */
+  legendOverlay?: boolean;
   /**
    * Grouping pulled from the first `<c:barChart>` element, when the
    * chart has one. Surfaces only the stacked variants — the OOXML

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -127,6 +127,19 @@ export interface CloneChartOptions {
   seriesOverrides?: ReadonlyArray<CloneChartSeriesOverride | undefined>;
   /** Override `SheetChart.legend`. */
   legend?: SheetChart["legend"];
+  /**
+   * Override the chart-level legend-overlay flag. `undefined` (or
+   * omitted) inherits the source's parsed value; `null` drops the
+   * inherited value (the writer falls back to the OOXML `false` default
+   * — the legend reserves its own slot, no overlap with the plot area);
+   * a `boolean` replaces it.
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved legend is `false` (no legend element will be emitted)
+   * — there is no overlay flag to set on a hidden legend, so leaking
+   * the value into the output would carry a toggle Excel never reads.
+   */
+  legendOverlay?: boolean | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -411,6 +424,16 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   // writer, so we drop the inherited value to keep the model honest.
   const legend = options.legend !== undefined ? options.legend : source.legend;
   if (legend !== undefined) out.legend = legend;
+
+  // `legendOverlay` only renders inside `<c:legend>`, so a clone whose
+  // resolved legend is `false` (legend hidden) drops the inherited
+  // overlay flag — there is no `<c:overlay>` slot on a hidden legend
+  // for the writer to populate. The override wins over the source's
+  // parsed value; absence inherits, `null` drops, a `boolean` replaces.
+  if (legend !== false) {
+    const resolvedLegendOverlay = resolveLegendOverlay(source.legendOverlay, options.legendOverlay);
+    if (resolvedLegendOverlay !== undefined) out.legendOverlay = resolvedLegendOverlay;
+  }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
   if (barGrouping !== undefined && (type === "bar" || type === "column")) {
@@ -820,6 +843,29 @@ function resolvePlotVisOnly(
  * toggles compose the same way at the call site.
  */
 function resolveRoundedCorners(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `legendOverlay` override.
+ *
+ * `undefined` → inherit the source's parsed `legendOverlay`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML `false` default — the legend reserves its own
+ *               slot, no overlap with the plot area).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `plotVisOnly` / `roundedCorners` so the chart-
+ * level toggles compose the same way at the call site. Callers should
+ * gate the result on the resolved legend visibility — when no legend
+ * is emitted, the overlay flag has no slot in the rendered chart.
+ */
+function resolveLegendOverlay(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -199,6 +199,17 @@ export function parseChart(xml: string): Chart | undefined {
   const legend = parseLegend(chartEl);
   if (legend !== undefined) out.legend = legend;
 
+  // `<c:overlay>` is a child of `<c:legend>`, so a chart that hides the
+  // legend (legend === false) or omits the element entirely (legend ===
+  // undefined) has no overlay flag to surface — pulling the value off a
+  // `<c:legend>` that is not part of the chart's render would leak a
+  // toggle that has no effect. Only attempt the parse when the chart
+  // declares a visible legend.
+  if (legend !== undefined && legend !== false) {
+    const legendOverlay = parseLegendOverlay(chartEl);
+    if (legendOverlay !== undefined) out.legendOverlay = legendOverlay;
+  }
+
   const dispBlanksAs = parseDispBlanksAs(chartEl);
   if (dispBlanksAs !== undefined) out.dispBlanksAs = dispBlanksAs;
 
@@ -1058,6 +1069,44 @@ function parseLegend(chartEl: XmlElement): false | ChartLegendPosition | undefin
       return "topRight";
     default:
       // Unknown legendPos values are dropped rather than fabricated.
+      return undefined;
+  }
+}
+
+/**
+ * Pull `<c:legend><c:overlay val=".."/></c:legend>` off the chart. The
+ * OOXML default `false` (the legend reserves its own slot, no overlap
+ * with the plot area) collapses to `undefined` so absence and
+ * `<c:overlay val="0"/>` round-trip identically through
+ * {@link cloneChart} — only an explicit `<c:overlay val="1"/>` surfaces
+ * `true`.
+ *
+ * The caller is expected to confirm a visible legend exists before
+ * invoking this — `<c:overlay>` only renders when the legend is part of
+ * the chart, so reading it from a chart that hides or omits the legend
+ * would surface a flag with no on-screen effect.
+ *
+ * Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"`
+ * / `"false"`); unknown values and missing `val` attributes drop to
+ * `undefined` rather than fabricate a flag Excel would not emit.
+ */
+function parseLegendOverlay(chartEl: XmlElement): boolean | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const overlay = findChild(legend, "overlay");
+  if (!overlay) return undefined;
+  const raw = overlay.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `legendOverlay` field.
+      return undefined;
+    default:
       return undefined;
   }
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -71,7 +71,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
   // ── Legend ──
   if (legendPos) {
-    chartChildren.push(buildLegend(legendPos));
+    chartChildren.push(buildLegend(legendPos, resolveLegendOverlay(chart)));
   }
 
   chartChildren.push(xmlSelfClose("c:plotVisOnly", { val: resolvePlotVisOnly(chart) ? 1 : 0 }));
@@ -1423,11 +1423,31 @@ function resolveLegendPosition(chart: SheetChart): LegendPos | null {
   }
 }
 
-function buildLegend(pos: LegendPos): string {
+function buildLegend(pos: LegendPos, overlay: boolean): string {
   return xmlElement("c:legend", undefined, [
     xmlSelfClose("c:legendPos", { val: pos }),
-    xmlSelfClose("c:overlay", { val: 0 }),
+    xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }),
   ]);
+}
+
+/**
+ * Resolve `<c:legend><c:overlay val=".."/></c:legend>` from
+ * {@link SheetChart.legendOverlay}.
+ *
+ * Defaults to `false` (the OOXML default Excel itself emits — the
+ * legend reserves its own slot and the plot area shrinks to make room).
+ * Anything other than literal `true` collapses to `false` so a stray
+ * non-boolean leaking through the type guard (e.g. `0` / `1` / `"true"`
+ * / `null`) never produces `<c:overlay val="1"/>`. This matches how
+ * `roundedCorners` / `plotVisOnly` / axis `hidden` treat their inputs:
+ * a literal boolean is the only path to a non-default value.
+ *
+ * The writer always emits `<c:overlay>` because Excel's reference
+ * serialization includes the element on every visible legend; only the
+ * `val` flips when the caller pins `legendOverlay: true`.
+ */
+function resolveLegendOverlay(chart: SheetChart): boolean {
+  return chart.legendOverlay === true;
 }
 
 // ── Display Blanks As ────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3824,3 +3824,202 @@ describe("cloneChart — axis hidden", () => {
     expect(valAxBlock).toContain('<c:delete val="1"/>');
   });
 });
+
+// ── cloneChart — legendOverlay ───────────────────────────────────────
+
+describe("cloneChart — legendOverlay", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendOverlay by default", () => {
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendOverlay).toBe(true);
+  });
+
+  it("lets options.legendOverlay override the source's value", () => {
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendOverlay: false,
+    });
+    expect(clone.legendOverlay).toBe(false);
+  });
+
+  it("drops the inherited legendOverlay when the override is null", () => {
+    // null collapses to the writer's OOXML default — the field
+    // disappears from the resolved SheetChart so the writer emits the
+    // default `0` (no overlap with the plot area).
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendOverlay: null,
+    });
+    expect(clone.legendOverlay).toBeUndefined();
+  });
+
+  it("returns undefined legendOverlay when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendOverlay).toBeUndefined();
+  });
+
+  it("carries legendOverlay through a flatten (line → column)", () => {
+    // legendOverlay lives on `<c:legend>` and is valid on every chart
+    // family, so a coercion does not drop it.
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendOverlay).toBe(true);
+  });
+
+  it("carries legendOverlay through a doughnut flatten (line → doughnut)", () => {
+    // The flag has no chart-family restriction — even a coercion to
+    // doughnut, which has no axes, must preserve the legend overlay.
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendOverlay).toBe(true);
+  });
+
+  it("drops the inherited legendOverlay when the resolved legend is hidden", () => {
+    // legend === false suppresses the entire <c:legend> element on the
+    // writer side, so an inherited overlay flag would never render.
+    // The clone collapses the field to keep the SheetChart honest.
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendOverlay).toBeUndefined();
+  });
+
+  it("drops the legendOverlay override when the resolved legend is hidden", () => {
+    // Same guard, this time on the override path — pinning legend:false
+    // wins over an explicit overlay override too.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendOverlay: true,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendOverlay).toBeUndefined();
+  });
+
+  it("retains the legendOverlay override when the override re-enables a hidden source legend", () => {
+    // Source pinned legend:false (so legendOverlay would normally be
+    // undefined), but the override re-enables a visible legend — the
+    // overlay flag the override carries must thread through.
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendOverlay: true,
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendOverlay).toBe(true);
+  });
+
+  it("propagates legendOverlay into the rendered <c:legend> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).not.toContain('c:overlay val="0"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendOverlay).toBe(true);
+  });
+
+  it("emits the OOXML default legendOverlay=0 when both source and override are absent", async () => {
+    // A bare clone with no overlay hint rolls into a SheetChart whose
+    // writer emits the default `0` and re-parses to undefined.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="0"');
+    expect(parseChart(written)?.legendOverlay).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins `true`, clone overrides to `false` — the rendered
+    // chart should carry the override and re-parse to undefined (since
+    // `false` is the OOXML default and collapses on read).
+    const clone = cloneChart(source({ legendOverlay: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendOverlay: false,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="0"');
+    expect(legend).not.toContain('c:overlay val="1"');
+    expect(parseChart(written)?.legendOverlay).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3560,3 +3560,143 @@ describe("writeChart — axis hidden", () => {
     expect(reparsed?.axes).toBeUndefined();
   });
 });
+
+// ── writeChart — legend overlay ──────────────────────────────────────
+
+describe("writeChart — legendOverlay", () => {
+  it('emits <c:overlay val="0"/> when the field is unset (OOXML default)', () => {
+    // The writer always emits the element so the rendered intent is
+    // explicit on roundtrip — Excel itself includes it in every
+    // reference legend serialization.
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="0"');
+    expect(legend).not.toContain('c:overlay val="1"');
+  });
+
+  it("threads legendOverlay=true through to <c:legend>", () => {
+    // true is the non-default — Excel's "Show the legend without
+    // overlapping the chart" toggle off (the legend is drawn on top of
+    // the plot area).
+    const result = writeChart(makeChart({ legendOverlay: true }), "Sheet1");
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).not.toContain('c:overlay val="0"');
+  });
+
+  it("threads legendOverlay=false through to <c:legend>", () => {
+    // Setting the OOXML default explicitly produces the same wire shape
+    // as omitting the field — the element is always emitted.
+    const result = writeChart(makeChart({ legendOverlay: false }), "Sheet1");
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="0"');
+  });
+
+  it("places <c:overlay> after <c:legendPos> inside <c:legend> (OOXML order)", () => {
+    // CT_Legend sequence: legendPos?, legendEntry*, layout?, overlay?, ...
+    const result = writeChart(makeChart({ legendOverlay: true }), "Sheet1");
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:overlay"));
+  });
+
+  it("only emits <c:overlay> once inside <c:legend> even on a chart that overrides it", () => {
+    // Guard against any regression that would double-emit the element
+    // (e.g. one hardcoded copy plus a dynamic one). The title also
+    // carries its own `<c:overlay>` so we scope the count to the legend.
+    const result = writeChart(makeChart({ legendOverlay: true }), "Sheet1");
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    const occurrences = legend.match(/c:overlay/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false", () => {
+    // A hidden legend has no slot for an overlay flag — the writer
+    // suppresses the entire legend element rather than emit a stray
+    // overlay child Excel would never read.
+    const result = writeChart(makeChart({ legend: false, legendOverlay: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+    // The title still carries its own <c:overlay>; ensure no legend
+    // element exists so we know no legend-overlay snuck in.
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendOverlay through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendOverlay: true }), "Sheet1");
+      const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+      expect(legend).toContain('c:overlay val="1"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const legend = scatter.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="1"');
+  });
+
+  it("round-trips a non-default legendOverlay value through parseChart", () => {
+    // A chart with legendOverlay=true should re-parse into a Chart whose
+    // `legendOverlay` field is `true` (not collapsed to undefined since
+    // true is not the OOXML default).
+    const written = writeChart(makeChart({ legendOverlay: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendOverlay).toBe(true);
+  });
+
+  it("collapses a defaulted legendOverlay round-trip back to undefined", () => {
+    // A fresh chart (legendOverlay omitted) writes `0` and re-parses to
+    // undefined — absence and the OOXML default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendOverlay).toBeUndefined();
+  });
+
+  it("collapses an explicit legendOverlay=false round-trip back to undefined", () => {
+    // Pinning the OOXML default also collapses on read, so a template
+    // that explicitly emits `<c:overlay val="0"/>` is treated the same
+    // as one that omits the field.
+    const written = writeChart(makeChart({ legendOverlay: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendOverlay).toBeUndefined();
+  });
+
+  it("ignores non-boolean legendOverlay values", () => {
+    // Match how `roundedCorners` / `plotVisOnly` / axis hidden treat
+    // their inputs: only literal `true` produces the non-default. A
+    // stray non-boolean (e.g. truthy string) collapses to the default.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendOverlay: "yes" as any }), "Sheet1");
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="0"');
+  });
+
+  it("survives a writeXlsx round trip — legendOverlay lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendOverlay: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const legend = chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('c:overlay val="1"');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -4243,3 +4243,212 @@ describe("parseChart — axis hidden", () => {
     expect(chart?.axes?.y?.hidden).toBeUndefined();
   });
 });
+
+// ── parseChart — legend overlay ──────────────────────────────────────
+
+describe("parseChart — legendOverlay", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:legend><c:overlay val="1"/></c:legend> as true (non-default)', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="1"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("right");
+    expect(chart?.legendOverlay).toBe(true);
+  });
+
+  it("collapses the OOXML default false to undefined (writer absence)", () => {
+    // The default carried explicitly by Excel's reference serialization
+    // round-trips identically to absence of the field.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("bottom");
+    expect(chart?.legendOverlay).toBeUndefined();
+  });
+
+  it("returns undefined when the legend element omits <c:overlay>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="t"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("top");
+    expect(chart?.legendOverlay).toBeUndefined();
+  });
+
+  it("accepts the OOXML true / false spellings on the val attribute", () => {
+    // The OOXML schema for `xsd:boolean` accepts `"true"` / `"false"`
+    // alongside `"1"` / `"0"`. Hucre tolerates both shapes — a hand-
+    // edited template using `true` should round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="l"/>
+      <c:overlay val="true"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendOverlay).toBe(true);
+  });
+
+  it("collapses the 'false' spelling to undefined as well", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="false"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendOverlay).toBeUndefined();
+  });
+
+  it("drops unknown overlay values rather than fabricate one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="bogus"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendOverlay).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:overlay>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendOverlay).toBeUndefined();
+  });
+
+  it('drops the overlay flag when the legend is hidden via <c:delete val="1"/>', () => {
+    // A hidden legend (legend === false) has no <c:overlay> slot in the
+    // rendered chart, so the reader does not surface a flag that would
+    // carry no on-screen effect through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendOverlay).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBeUndefined();
+    expect(chart?.legendOverlay).toBeUndefined();
+  });
+
+  it("surfaces overlay on every chart family that emits a legend", () => {
+    // The element lives on <c:legend>, which is a sibling of
+    // <c:plotArea> on every chart-family <c:chart>; the toggle should
+    // round-trip identically across families. Pie / doughnut / line /
+    // bar all emit legends by default.
+    for (const kind of ["lineChart", "barChart", "pieChart", "doughnutChart"]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:${kind}><c:ser><c:idx val="0"/></c:ser></c:${kind}>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:overlay val="1"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+      const chart = parseChart(xml);
+      expect(chart?.legendOverlay).toBe(true);
+    }
+  });
+
+  it("co-exists with other chart-level toggles", () => {
+    // The legend overlay flag should not interfere with sibling chart-
+    // level fields parsed off <c:chart> (plotVisOnly, dispBlanksAs,
+    // varyColors).
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="1"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="t"/>
+      <c:overlay val="1"/>
+    </c:legend>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("top");
+    expect(chart?.legendOverlay).toBe(true);
+    expect(chart?.roundedCorners).toBe(true);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the legend-overlay element at the read, write, and clone layers so a template's overlay configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:legend><c:overlay val=".."/></c:legend>` is the OOXML control behind Excel's "Format Legend -> Show the legend without overlapping the chart" toggle (the checkbox is the inverse of the flag — checked means `val=0`, unchecked means `val=1`). `val=1` draws the legend on top of the plot area so the chart series get the full frame; `val=0` reserves a slot for the legend and shrinks the plot area to make room.

Until now hucre's writer always pinned `val=0`, so a template that overlapped its legend flattened back to a side-anchored legend on every parse -> clone -> write loop. This bridges another chart-level gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.legendOverlay);  // true when the template pinned val="1",
                                    // undefined when the template used the default 0

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      legend: "right",
      legendOverlay: true,  // legend draws on top of the plot area
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  legendOverlay: true,    // replace
  // legendOverlay: null  // drop the inherited overlay (writer falls back to 0)
  // legendOverlay: undefined // inherit the source's parsed value
});
```

## Model

```ts
interface SheetChart {
  /* ...existing fields... */
  legendOverlay?: boolean;
}

interface Chart {
  /* ...existing fields... */
  legendOverlay?: boolean;
}

interface CloneChartOptions {
  /* ...existing fields... */
  legendOverlay?: boolean | null;
}
```

The read-side `Chart.legendOverlay` mirrors the write-side `SheetChart.legendOverlay` so a parsed value slots straight back into `cloneChart` without transformation. Same shape as the existing `roundedCorners` / `plotVisOnly` toggles.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:legend><c:overlay val=".."/></c:legend>`. The OOXML default `false` (`val="0"`) collapses to `undefined` so absence and the default round-trip identically; only an explicit `val="1"` surfaces `true`. Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing `val` attributes drop to `undefined`. The flag is dropped whenever the chart hides the legend (`<c:delete val="1"/>`) or omits the `<c:legend>` element entirely — there is no overlay slot to surface in either case.
- **Write** — `<c:overlay>` is always emitted inside `<c:legend>` because Excel's reference serialization includes it on every visible legend. The writer pins the caller's override when set; absence (and the default `false`) emit `val="0"` so untouched charts match Excel's reference output byte-for-byte. Non-boolean inputs collapse to `false` to keep the on-the-wire output stable. The element sits between `<c:legendPos>` and the rest of the legend's children per the strict CT_Legend schema sequence. When `legend === false` the writer skips the entire `<c:legend>` element so no orphan overlay can leak through.
- **Clone** — Each override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `0`) / `boolean` (replace) grammar that mirrors `roundedCorners` / `plotVisOnly`. The inherited value is silently dropped from the cloned `SheetChart` whenever the resolved `legend` is `false` — a hidden legend has no overlay slot, so leaking the value would carry no on-screen effect. Re-enabling a hidden source legend through `legend: "top"` (or any visible position) on the override re-opens the slot, and an explicit `legendOverlay: true` override threads through.

## Edge cases

- A hidden source legend with `<c:overlay val="1"/>` parses to `legendOverlay: undefined` (since the overlay has no rendering effect on a deleted legend).
- An explicit `legendOverlay: true` override with `legend: false` collapses to `undefined` on the cloned `SheetChart`.
- Non-boolean `legendOverlay` inputs (e.g. truthy strings) collapse to the OOXML `false` default rather than fabricate a flag.
- The element is emitted exactly once per chart (the chart title also carries its own `<c:overlay>` element, scoped to the title block — they do not collide).
- Pie / doughnut / line / bar / column / area / scatter all support the flag identically because `<c:legend>` is a chart-level sibling of `<c:plotArea>`.

## Test plan

- [x] `pnpm test` (lint + typecheck + 3156 vitest) passes.
- [x] `pnpm build` succeeds.
- [x] 35 new legendOverlay tests across `charts.test.ts` (11 read), `charts-write.test.ts` (12 write + round-trip + writeXlsx packaging), `chart-clone.test.ts` (12 clone) cover read, write, clone, end-to-end round-trip, hidden-legend interaction, and per-family threading.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>