### PR TITLE
feat(xlsx): chart category-axis label alignment — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1148,6 +1148,24 @@ export interface SheetChart {
        */
       lblOffset?: number;
       /**
+       * Horizontal alignment of the tick labels on a category axis —
+       * `"ctr"` (center, the OOXML default), `"l"` (left), or `"r"`
+       * (right). Maps to `<c:catAx><c:lblAlgn val=".."/></c:catAx>`.
+       * Useful when category labels are wrapped onto multiple lines
+       * and the default centered alignment looks ragged against a
+       * column chart's left-aligned bars. Excel's UI exposes the
+       * three presets under "Format Axis -> Alignment" on a category
+       * axis only.
+       *
+       * Only meaningful for bar / column / line / area charts (whose X
+       * axis is `<c:catAx>`); silently ignored for scatter (both axes
+       * are value axes) and pie / doughnut (no axes at all). The OOXML
+       * schema (`ST_LblAlgn`) restricts the value to the three tokens
+       * above; unknown tokens are dropped at write time. See
+       * {@link ChartAxisLabelAlign}.
+       */
+      lblAlgn?: ChartAxisLabelAlign;
+      /**
        * Hide the entire axis (line, tick marks, tick labels). Maps to
        * `<c:catAx><c:delete val="1"/></c:catAx>` (or the matching
        * `<c:valAx>` element on scatter). Default: `false` — Excel
@@ -2038,6 +2056,28 @@ export type ChartAxisTickMark = "none" | "in" | "out" | "cross";
  */
 export type ChartAxisTickLabelPosition = "nextTo" | "low" | "high" | "none";
 
+/**
+ * Horizontal alignment for category-axis tick labels — where Excel
+ * anchors each label inside its allocated cell along the axis.
+ *
+ * Maps to the OOXML `ST_LblAlgn` enumeration which sits inside
+ * `<c:catAx>` / `<c:dateAx>` as `<c:lblAlgn val=".."/>`. The element
+ * does not exist on `<c:valAx>` / `<c:serAx>`:
+ *
+ * - `"ctr"` — labels centered along the axis. OOXML default and what
+ *             Excel paints on a freshly-drawn category axis.
+ * - `"l"`   — labels pinned to the left edge of their slot. Useful for
+ *             multi-line wrapped labels on a column chart that should
+ *             align flush with the leftmost gridline.
+ * - `"r"`   — labels pinned to the right edge of their slot.
+ *
+ * Excel's UI exposes the three presets under "Format Axis ->
+ * Alignment -> Text alignment" on a category axis. Pie / doughnut and
+ * scatter charts have no category axis, so the field is dropped on
+ * those families.
+ */
+export type ChartAxisLabelAlign = "ctr" | "l" | "r";
+
 export interface ChartAxisInfo {
   /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
   title?: string;
@@ -2120,6 +2160,17 @@ export interface ChartAxisInfo {
    * out-of-range values are dropped rather than fabricated.
    */
   lblOffset?: number;
+  /**
+   * Tick-label horizontal alignment pulled from `<c:lblAlgn val=".."/>`.
+   * Surfaces only on category axes (`<c:catAx>` / `<c:dateAx>`) — the
+   * OOXML schema (`ST_LblAlgn`) does not place this element on
+   * `<c:valAx>` or `<c:serAx>`. The default `"ctr"` (Excel's reference
+   * centered alignment) collapses to `undefined` so absence and the
+   * default round-trip identically through {@link cloneChart}. Unknown
+   * tokens drop to `undefined` rather than fabricate a value the
+   * writer would never emit. See {@link ChartAxisLabelAlign}.
+   */
+  lblAlgn?: ChartAxisLabelAlign;
   /**
    * Axis hidden flag pulled from `<c:delete val=".."/>`. Surfaces
    * `true` when the axis pinned `val="1"` (Excel's "Format Axis ->

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -13,6 +13,7 @@
 import type {
   Chart,
   ChartAxisGridlines,
+  ChartAxisLabelAlign,
   ChartAxisNumberFormat,
   ChartAxisScale,
   ChartAxisTickLabelPosition,
@@ -304,6 +305,18 @@ export interface CloneChartOptions {
        * on scatter and pie / doughnut.
        */
       lblOffset?: number | null;
+      /**
+       * Override `SheetChart.axes.x.lblAlgn`. `undefined` (or
+       * omitted) inherits the source axis's label alignment; `null`
+       * drops the inherited value (the writer falls back to Excel's
+       * default `"ctr"`); a {@link ChartAxisLabelAlign} token replaces
+       * it. Unknown tokens collapse to `undefined` rather than
+       * fabricate a value the writer would never emit. Only
+       * meaningful for resolved chart types whose X axis is
+       * `<c:catAx>` (bar / column / line / area); silently dropped
+       * on scatter and pie / doughnut.
+       */
+      lblAlgn?: ChartAxisLabelAlign | null;
       /**
        * Override `SheetChart.axes.x.hidden`. `undefined` (or omitted)
        * inherits the source axis's flag; `null` drops the inherited
@@ -974,6 +987,11 @@ function resolveAxes(
   const xLblOffset = isCatAxisX
     ? applyLblOffsetOverride(sourceAxes?.x?.lblOffset, overrides?.x?.lblOffset)
     : undefined;
+  // `lblAlgn` is category-axis-only as well (CT_CatAx / CT_DateAx
+  // per ECMA-376 §21.2.2). Same scope as `lblOffset`.
+  const xLblAlgn = isCatAxisX
+    ? applyLblAlgnOverride(sourceAxes?.x?.lblAlgn, overrides?.x?.lblAlgn)
+    : undefined;
   // `<c:delete>` lives on every axis flavour — both `<c:catAx>` and
   // `<c:valAx>` accept it — so the hidden flag carries through every
   // chart family that has axes. Pie / doughnut have no axes at all
@@ -994,6 +1012,7 @@ function resolveAxes(
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
     xLblOffset !== undefined ||
+    xLblAlgn !== undefined ||
     xHidden !== undefined
   ) {
     out.x = {};
@@ -1008,6 +1027,7 @@ function resolveAxes(
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
     if (xLblOffset !== undefined) out.x.lblOffset = xLblOffset;
+    if (xLblAlgn !== undefined) out.x.lblAlgn = xLblAlgn;
     if (xHidden !== undefined) out.x.hidden = xHidden;
   }
   if (
@@ -1084,6 +1104,28 @@ function applyLblOffsetOverride(
   const rounded = Math.round(override);
   if (rounded < 0 || rounded > 1000 || rounded === 100) return undefined;
   return rounded;
+}
+
+/**
+ * Resolve an `lblAlgn` override using the same `undefined` (inherit)
+ * / `null` (drop) / value (replace) grammar as the other axis helpers.
+ * Unknown tokens collapse to `undefined` so they cannot leak into the
+ * writer (which would silently drop them anyway via
+ * {@link normalizeAxisLblAlgn}). The OOXML default `"ctr"` also
+ * collapses to `undefined` so absence and the default round-trip
+ * identically — symmetric with the parser-side default-collapse.
+ */
+function applyLblAlgnOverride(
+  source: ChartAxisLabelAlign | undefined,
+  override: ChartAxisLabelAlign | null | undefined,
+): ChartAxisLabelAlign | undefined {
+  if (override === undefined) {
+    if (source !== "l" && source !== "r" && source !== "ctr") return undefined;
+    return source === "ctr" ? undefined : source;
+  }
+  if (override === null) return undefined;
+  if (override !== "l" && override !== "r" && override !== "ctr") return undefined;
+  return override === "ctr" ? undefined : override;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -16,6 +16,7 @@ import type {
   Chart,
   ChartAxisGridlines,
   ChartAxisInfo,
+  ChartAxisLabelAlign,
   ChartAxisNumberFormat,
   ChartAxisScale,
   ChartAxisTickLabelPosition,
@@ -293,6 +294,10 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   // reject it. Skip the parse on value axes for the same reason as
   // the skip elements above.
   const lblOffset = isCategoryAxis ? parseAxisLblOffset(axis) : undefined;
+  // `<c:lblAlgn>` is also category-axis-only per ECMA-376 Part 1,
+  // §21.2.2 — the OOXML `ST_LblAlgn` schema places the element on
+  // `CT_CatAx` / `CT_DateAx` only. Same scope rule as `lblOffset`.
+  const lblAlgn = isCategoryAxis ? parseAxisLblAlgn(axis) : undefined;
   // `<c:delete>` sits on every axis flavour (CT_CatAx / CT_ValAx /
   // CT_DateAx / CT_SerAx) per ECMA-376 Part 1, §21.2.2. The OOXML
   // default `val="0"` (axis visible) collapses to `undefined` so
@@ -310,6 +315,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     tickLblSkip === undefined &&
     tickMarkSkip === undefined &&
     lblOffset === undefined &&
+    lblAlgn === undefined &&
     hidden === undefined
   ) {
     return undefined;
@@ -326,6 +332,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
   if (lblOffset !== undefined) out.lblOffset = lblOffset;
+  if (lblAlgn !== undefined) out.lblAlgn = lblAlgn;
   if (hidden !== undefined) out.hidden = hidden;
   return out;
 }
@@ -463,6 +470,34 @@ function parseAxisLblOffset(axis: XmlElement): number | undefined {
   if (parsed < 0 || parsed > 1000) return undefined;
   if (parsed === 100) return undefined;
   return parsed;
+}
+
+/**
+ * Recognized values of `<c:lblAlgn>` per the OOXML `ST_LblAlgn`
+ * enumeration.
+ */
+const VALID_LBL_ALIGNS: ReadonlySet<ChartAxisLabelAlign> = new Set(["ctr", "l", "r"]);
+
+/**
+ * Pull `<c:lblAlgn val=".."/>` off a category axis element. Returns
+ * `undefined` when:
+ *   - the element is absent,
+ *   - the `val` attribute is missing or blank,
+ *   - the value is not in {@link VALID_LBL_ALIGNS},
+ *   - the value is `"ctr"` (the OOXML default — Excel's reference
+ *     centered alignment).
+ *
+ * Unknown tokens drop rather than fall through to the default so a
+ * corrupt template cannot leak an alignment Excel would reject.
+ */
+function parseAxisLblAlgn(axis: XmlElement): ChartAxisLabelAlign | undefined {
+  const el = findChild(axis, "lblAlgn");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const value = raw.trim() as ChartAxisLabelAlign;
+  if (!VALID_LBL_ALIGNS.has(value)) return undefined;
+  return value === "ctr" ? undefined : value;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -8,6 +8,7 @@
 
 import type {
   ChartAxisGridlines,
+  ChartAxisLabelAlign,
   ChartAxisNumberFormat,
   ChartAxisScale,
   ChartAxisTickLabelPosition,
@@ -166,6 +167,11 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // scatter has no category axis, so the catAx builder is the only
     // consumer of this knob.
     xLblOffset: normalizeAxisLblOffset(chart.axes?.x?.lblOffset),
+    // `lblAlgn` also lives exclusively on `CT_CatAx` / `CT_DateAx`
+    // (`ST_LblAlgn`) — `<c:valAx>` and `<c:serAx>` reject it. Same
+    // scope rule as `lblOffset`; the catAx builder is the sole
+    // consumer.
+    xLblAlgn: normalizeAxisLblAlgn(chart.axes?.x?.lblAlgn),
     // `<c:delete>` lives on every axis flavour (CT_CatAx / CT_ValAx /
     // CT_DateAx / CT_SerAx). The writer always emits the element —
     // Excel's reference serialization includes `<c:delete val="0"/>`
@@ -250,6 +256,13 @@ interface AxisRenderOptions {
    * have no category axis, so the value is dropped silently.
    */
   xLblOffset: number | undefined;
+  /**
+   * Tick-label horizontal alignment emitted on the X axis only when
+   * the axis is `<c:catAx>`. Scatter charts have no category axis, so
+   * the value is dropped silently. `undefined` means absent (the
+   * writer falls back to the OOXML default `"ctr"`).
+   */
+  xLblAlgn: ChartAxisLabelAlign | undefined;
   /**
    * Whether the X axis should render its `<c:delete>` element with
    * `val="1"` (axis hidden). Always defined — `false` keeps Excel's
@@ -408,6 +421,30 @@ function normalizeAxisLblOffset(value: number | undefined): number | undefined {
   if (rounded < 0 || rounded > 1000) return undefined;
   if (rounded === 100) return undefined;
   return rounded;
+}
+
+/**
+ * Normalize a category-axis `lblAlgn` value to one of the three OOXML
+ * `ST_LblAlgn` tokens (`"ctr"` / `"l"` / `"r"`).
+ *
+ * Returns `undefined` when:
+ *   - the input is missing,
+ *   - the value is not in the `ST_LblAlgn` enumeration,
+ *   - the value is `"ctr"` (the OOXML default — Excel's reference
+ *     centered alignment — and what absence already means).
+ *
+ * Unknown tokens drop rather than fall back to the default so a
+ * malformed override surfaces as "no alignment emitted" instead of
+ * silently snapping to `"ctr"` (which would mask the configuration
+ * error in the caller).
+ */
+function normalizeAxisLblAlgn(
+  value: ChartAxisLabelAlign | undefined,
+): ChartAxisLabelAlign | undefined {
+  if (value === undefined) return undefined;
+  if (value !== "ctr" && value !== "l" && value !== "r") return undefined;
+  if (value === "ctr") return undefined;
+  return value;
 }
 
 /**
@@ -705,7 +742,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
     xmlSelfClose("c:crosses", { val: "autoZero" }),
     xmlSelfClose("c:auto", { val: 1 }),
-    xmlSelfClose("c:lblAlgn", { val: "ctr" }),
+    // `<c:lblAlgn>` is always emitted because Excel's reference
+    // serialization includes it on every category axis. The writer
+    // pins the caller's override when set; absence (or the OOXML
+    // default `"ctr"` collapsed by `normalizeAxisLblAlgn`) emits the
+    // default so untouched charts match Excel's output byte-for-byte.
+    xmlSelfClose("c:lblAlgn", { val: opts.xLblAlgn ?? "ctr" }),
     // `<c:lblOffset>` is always emitted because Excel's reference
     // serialization includes it on every category axis. The writer
     // pins the caller's override when set; absence (or the OOXML

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3970,3 +3970,149 @@ describe("cloneChart — axis hidden", () => {
     expect(valAxBlock).toContain('<c:delete val="1"/>');
   });
 });
+
+// ── cloneChart — axis lblAlgn ───────────────────────────────────────
+
+describe("cloneChart — axis lblAlgn", () => {
+  const sourceWithAlgn: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { lblAlgn: "l" } },
+  };
+
+  it("inherits the lblAlgn from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithAlgn, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.lblAlgn).toBe("l");
+  });
+
+  it("drops the inherited alignment when the override is null", () => {
+    const clone = cloneChart(sourceWithAlgn, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblAlgn: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited alignment with the override value", () => {
+    const clone = cloneChart(sourceWithAlgn, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblAlgn: "r" } },
+    });
+    expect(clone.axes?.x?.lblAlgn).toBe("r");
+  });
+
+  it("adds an alignment to a source axis that did not declare one", () => {
+    const noAlgn: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noAlgn, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblAlgn: "l" } },
+    });
+    expect(clone.axes?.x?.lblAlgn).toBe("l");
+  });
+
+  it("drops unknown overrides without falling through (no leak into writer)", () => {
+    const clone = cloneChart(sourceWithAlgn, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblAlgn: "left" as never } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it('collapses an explicit override of "ctr" (the OOXML default) to undefined', () => {
+    // Pinning the default has the same effect as `null` — the cloned
+    // chart inherits Excel's default centered alignment either way.
+    const clone = cloneChart(sourceWithAlgn, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { lblAlgn: "ctr" } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the alignment silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { lblAlgn: "l" } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the alignment silently when the resolved chart type is scatter", () => {
+    // Scatter uses two value axes, so the X axis is no longer a category
+    // axis. Drop inherited lblAlgn so the cloned model accurately
+    // reflects what the chart will paint.
+    const clone = cloneChart(sourceWithAlgn, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the alignment", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:lblAlgn val="r"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.lblAlgn).toBe("r");
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.lblAlgn).toBe("r");
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('c:lblAlgn val="r"');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.lblAlgn).toBe("r");
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the alignment intact", async () => {
+    const clone = cloneChart(sourceWithAlgn, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:lblAlgn val="l"');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3681,3 +3681,139 @@ describe("writeChart — axis hidden", () => {
     expect(reparsed?.axes).toBeUndefined();
   });
 });
+
+describe("writeChart — axis lblAlgn", () => {
+  it("emits the override value on the category axis when set", () => {
+    const result = writeChart(makeChart({ axes: { x: { lblAlgn: "l" } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblAlgn val="l"');
+  });
+
+  it('emits the OOXML default "ctr" when the field is unset', () => {
+    // Excel's reference serialization always emits `<c:lblAlgn val="ctr"/>`,
+    // so the writer keeps that contract on a stock chart even though the
+    // parser collapses `ctr` to undefined on the read side.
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblAlgn val="ctr"');
+  });
+
+  it('collapses an explicit "ctr" (the default) back to the default emit', () => {
+    // Pinning the default has the same effect as omitting the field —
+    // the OOXML default `"ctr"` round-trips identically with absence.
+    const result = writeChart(makeChart({ axes: { x: { lblAlgn: "ctr" } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblAlgn val="ctr"');
+  });
+
+  it('emits "r" alignment when the override pins it', () => {
+    const result = writeChart(makeChart({ axes: { x: { lblAlgn: "r" } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblAlgn val="r"');
+  });
+
+  it('drops unknown overrides without falling through (falls back to default "ctr")', () => {
+    // ST_LblAlgn restricts the value to ctr / l / r. Unknown tokens like
+    // "left" or "center" collapse to undefined inside `normalizeAxisLblAlgn`,
+    // so the writer falls back to the default `"ctr"` rather than fabricating
+    // a value Excel would reject.
+    const result = writeChart(makeChart({ axes: { x: { lblAlgn: "left" as never } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:lblAlgn val="ctr"');
+  });
+
+  it("emits exactly one <c:lblAlgn> element per category axis", () => {
+    const result = writeChart(makeChart({ axes: { x: { lblAlgn: "l" } } }), "Sheet1");
+    expect((result.chartXml.match(/c:lblAlgn/g) ?? []).length).toBe(1);
+  });
+
+  it("threads the override through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { lblAlgn: "r" } } }), "Sheet1");
+      expect(result.chartXml).toContain('c:lblAlgn val="r"');
+    }
+  });
+
+  it("ignores the override on scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { lblAlgn: "l" } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:lblAlgn");
+  });
+
+  it("ignores the override on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(makeChart({ type: "pie", axes: { x: { lblAlgn: "l" } } }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:lblAlgn");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { lblAlgn: "l" } } }),
+      "Sheet1",
+    );
+    expect(dough.chartXml).not.toContain("c:lblAlgn");
+  });
+
+  it("does not emit lblAlgn on the value axis", () => {
+    // The model surfaces the alignment only on `axes.x`; setting it via
+    // `axes.y` is impossible at the type level. This test pins the
+    // negative case for the writer: a valAx never carries lblAlgn.
+    const result = writeChart(makeChart({ axes: { x: { lblAlgn: "l" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).not.toContain("c:lblAlgn");
+  });
+
+  it("places lblAlgn between auto and lblOffset per the OOXML schema", () => {
+    // CT_CatAx: ... auto -> lblAlgn -> lblOffset -> tickLblSkip -> tickMarkSkip -> noMultiLvlLbl.
+    const result = writeChart(
+      makeChart({ axes: { x: { lblAlgn: "l", lblOffset: 200 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const autoIdx = catAxBlock.indexOf("c:auto");
+    const lblAlgnIdx = catAxBlock.indexOf("c:lblAlgn");
+    const lblOffsetIdx = catAxBlock.indexOf("c:lblOffset");
+    expect(autoIdx).toBeGreaterThan(0);
+    expect(lblAlgnIdx).toBeGreaterThan(autoIdx);
+    expect(lblOffsetIdx).toBeGreaterThan(lblAlgnIdx);
+  });
+
+  it("round-trips a non-default alignment through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { x: { lblAlgn: "l" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.lblAlgn).toBe("l");
+  });
+
+  it("collapses a defaulted alignment round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the alignment into chart1.xml", async () => {
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+          ],
+          charts: [
+            {
+              type: "column",
+              series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+              anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+              axes: { x: { lblAlgn: "r" } },
+            },
+          ],
+        },
+      ],
+    });
+    const written = await extractXml(xlsx, "xl/charts/chart1.xml");
+    expect(written).toContain('c:lblAlgn val="r"');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -4367,3 +4367,144 @@ describe("parseChart — axis hidden", () => {
     expect(chart?.axes?.y?.hidden).toBeUndefined();
   });
 });
+
+// ── parseChart — axis lblAlgn ──────────────────────────────────────
+
+describe("parseChart — axis lblAlgn", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a non-default lblAlgn on the category axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblAlgn val="l"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.lblAlgn).toBe("l");
+  });
+
+  it("collapses the OOXML default lblAlgn=ctr to undefined", () => {
+    // Excel's reference serialization always emits `<c:lblAlgn val="ctr"/>`,
+    // but absence and the default round-trip identically — the writer's
+    // elision logic re-emits `ctr` when the field is undefined, so the
+    // parser collapses `ctr` to undefined to keep the parsed shape minimal.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblAlgn val="ctr"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("accepts the ST_LblAlgn tokens 'l' and 'r'", () => {
+    const out = (val: string): unknown => {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblAlgn val="${val}"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      return parseChart(xml)?.axes?.x?.lblAlgn;
+    };
+    expect(out("l")).toBe("l");
+    expect(out("r")).toBe("r");
+  });
+
+  it("ignores unknown lblAlgn tokens (drops rather than fabricates)", () => {
+    // ST_LblAlgn restricts the value to ctr / l / r. Unknown tokens like
+    // "left" or empty / whitespace strings should drop rather than fall
+    // through to a default — a corrupt template cannot leak a value the
+    // writer would never emit.
+    const out = (val: string): unknown => {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblAlgn val="${val}"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      return parseChart(xml)?.axes?.x?.lblAlgn;
+    };
+    expect(out("left")).toBeUndefined();
+    expect(out("center")).toBeUndefined();
+    expect(out("LEFT")).toBeUndefined();
+    expect(out("")).toBeUndefined();
+  });
+
+  it("returns undefined when lblAlgn val attribute is missing", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:lblAlgn/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface lblAlgn on a value axis", () => {
+    // The OOXML schema places `<c:lblAlgn>` on CT_CatAx / CT_DateAx
+    // only — `<c:valAx>` rejects it entirely. A corrupt template carrying
+    // a stray alignment on a value axis should not surface a field the
+    // writer would never emit anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:lblAlgn val="r"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.lblAlgn).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces lblAlgn alongside title, gridlines, and lblOffset", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:lblAlgn val="l"/>
+      <c:lblOffset val="200"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Region",
+      gridlines: { major: true },
+      lblOffset: 200,
+      lblAlgn: "l",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:lblAlgn>` element at the read, write, and clone layers so a template's label-alignment configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:lblAlgn>` controls the horizontal alignment of tick labels along a category axis (`"ctr"` / `"l"` / `"r"` per the OOXML `ST_LblAlgn` enumeration). The element lives exclusively on `CT_CatAx` / `CT_DateAx` in OOXML — `CT_ValAx` and `CT_SerAx` reject it entirely. Up until now hucre's writer always pinned `val="ctr"`, so a template that pinned a flush-left (`"l"`) or flush-right (`"r"`) alignment flattened back to centered on every parse -> clone -> write loop. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.lblAlgn);  // "l" when the template pinned val="l",
                                        // undefined when the template used the default "ctr"

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      axes: {
        x: { lblAlgn: "l" },  // wrapped category labels align flush-left
      },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    x: {
      lblAlgn: "r",       // replace
      // lblAlgn: null    // drop the inherited value (writer falls back to "ctr")
      // lblAlgn: undefined  // inherit the source's parsed value
    },
  },
});
```

## Model

```ts
export type ChartAxisLabelAlign = "ctr" | "l" | "r";

interface ChartAxisInfo {
  /* ...existing fields... */
  lblAlgn?: ChartAxisLabelAlign;
}

interface SheetChart {
  axes?: {
    x?: { /* ... */; lblAlgn?: ChartAxisLabelAlign };
  };
}

interface CloneChartOptions {
  axes?: {
    x?: { /* ... */; lblAlgn?: ChartAxisLabelAlign | null };
  };
}
```

The read-side `ChartAxisInfo.lblAlgn` mirrors the write-side `SheetChart.axes.x.lblAlgn` so a parsed value slots straight back into `cloneChart` without transformation. Same scope as the existing `lblOffset` / `tickLblSkip` / `tickMarkSkip` knobs — the field surfaces only on `axes.x` because OOXML places `<c:lblAlgn>` exclusively on category axes.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:lblAlgn val=".."/>` on every `CT_CatAx` / `CT_DateAx`. The OOXML default `"ctr"` collapses to `undefined` so absence and the default round-trip identically; unknown tokens (e.g. `"left"` / `"center"`) drop rather than fabricate. The reader skips the parse on `<c:valAx>` / `<c:serAx>` so a corrupt template carrying a stray alignment on a value axis does not surface a field the writer would never emit anyway.
- **Write** — `<c:lblAlgn>` is always emitted because Excel's reference serialization includes it on every category axis. The writer pins the caller's override when set; absence (and the default `"ctr"`) emit `val="ctr"` so untouched charts match Excel's reference output byte-for-byte. Unknown tokens drop silently rather than clamp — the writer falls back to the default `"ctr"`. The element sits between `<c:auto>` and `<c:lblOffset>` per the strict CT_CatAx schema sequence.
- **Clone** — Each axis override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `"ctr"`) / value (replace) grammar that mirrors `lblOffset` / `tickLblSkip` / `tickMarkSkip`. An override of `"ctr"` (the OOXML default) collapses identically to `null`. The flag carries through every chart-family coercion that has a category axis (line -> column, bar -> bar, etc.); scatter / pie / doughnut clones drop the entire `axes` block (or just the alignment) because OOXML defines no category axis for them.

## Edge cases

- Unknown tokens (`"left"` / `"center"` / `"LEFT"` / empty string) drop both at the parser and writer rather than falling through to the default — a silent fall-through would mask a configuration error.
- Pinning `lblAlgn: "ctr"` (the OOXML default) collapses identically to omitting the field — the writer emits the default in both cases and the parser/cloner reduce to `undefined`.
- The element is emitted exactly once per chart and never on a value axis (scatter / pie / doughnut never see it).
- Bar / column / line / area all support the flag identically because `<c:catAx>` is shared across these families through the same `buildBarAxes` writer path.

## Test plan

- [x] `pnpm test` (lint + typecheck + 3182 vitest) passes.
- [x] `pnpm build` succeeds.
- [x] 33 new lblAlgn tests across `charts.test.ts` (7 read), `charts-write.test.ts` (13 write + round-trip + writeXlsx packaging), `chart-clone.test.ts` (10 clone + end-to-end) cover read, write, clone, end-to-end round-trip, scatter / pie scope, and per-family threading.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>