### PR TITLE
feat(xlsx): chart pie/doughnut series explosion — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -836,6 +836,22 @@ export interface ChartSeries {
    * the inverted color when the spreadsheet supplies one).
    */
   invertIfNegative?: boolean;
+  /**
+   * Pie / doughnut slice explosion as a percentage of the radius —
+   * the distance the slice is pulled away from the center. Maps to
+   * `<c:explosion val=".."/>` inside the `<c:ser>` element. Only
+   * meaningful for `pie` and `doughnut` charts — the OOXML schema
+   * places `<c:explosion>` exclusively on `CT_PieSer`, so the field
+   * is silently dropped on every other chart family at write time.
+   *
+   * Default: `0` (slices flush against each other). Excel's UI
+   * exposes 0–400% under "Format Data Point → Series Options → Pie
+   * Explosion"; values outside that band are clamped on write so a
+   * round-trip stays inside the range Excel will render. Per-data-point
+   * explosion (one slice pulled away while the rest stay flush) is not
+   * yet supported — the field applies to every slice in the series.
+   */
+  explosion?: number;
 }
 
 /**
@@ -1900,6 +1916,16 @@ export interface ChartSeriesInfo {
    * default and round-trips identically with absence of the field.
    */
   invertIfNegative?: boolean;
+  /**
+   * Slice explosion (in percent of the radius) pulled from
+   * `<c:ser><c:explosion val=".."/>`. Surfaces only on `pie`,
+   * `pie3D`, `doughnut`, and `ofPie` series — the OOXML schema
+   * places `<c:explosion>` exclusively on `CT_PieSer` (which is
+   * shared across the pie family via `EG_PieSer`). The OOXML
+   * default `0` collapses to `undefined` because absence and `0`
+   * round-trip identically through the writer's elision logic.
+   */
+  explosion?: number;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -93,6 +93,16 @@ export interface CloneChartSeriesOverride {
    * resolved chart type is anything else.
    */
   invertIfNegative?: boolean | null;
+  /**
+   * Slice-explosion override (in percent of the radius). `undefined`
+   * (or omitted) inherits the source series' `explosion`; `null` drops
+   * the inherited value (the cloned series falls back to the OOXML
+   * default `0`); a finite `number` replaces it wholesale (clamped to
+   * the 0..400% band Excel's UI exposes; `0` collapses to absence).
+   * Only meaningful for `pie` and `doughnut` clones — silently dropped
+   * from the output when the resolved chart type is anything else.
+   */
+  explosion?: number | null;
 }
 
 /**
@@ -414,6 +424,17 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     }
   }
 
+  // `<c:explosion>` lives exclusively on pie-family series (CT_PieSer,
+  // shared across `<c:pieChart>` / `<c:doughnutChart>` via EG_PieSer);
+  // drop the field from every other resolved type so a pie → bar
+  // flatten (or any other coercion) does not leak the value into a
+  // chart kind whose schema rejects it.
+  if (type !== "pie" && type !== "doughnut") {
+    for (const s of series) {
+      if (s.explosion !== undefined) delete s.explosion;
+    }
+  }
+
   if (series.length === 0) {
     throw new Error(
       "cloneChart: produced 0 series; pass `series` or ensure the source has at least one series with a valuesRef",
@@ -666,6 +687,9 @@ function mergeSeries(
   const invertIfNegative = resolveInvertIfNegative(src?.invertIfNegative, ov?.invertIfNegative);
   if (invertIfNegative !== undefined) out.invertIfNegative = invertIfNegative;
 
+  const explosion = resolveExplosion(src?.explosion, ov?.explosion);
+  if (explosion !== undefined) out.explosion = explosion;
+
   return out;
 }
 
@@ -744,6 +768,36 @@ function resolveInvertIfNegative(
   }
   if (override === null) return undefined;
   return override === true ? true : undefined;
+}
+
+/**
+ * Resolve a per-series slice-explosion override.
+ *
+ * `undefined` → inherit the source series' `explosion`.
+ * `null`      → drop the inherited value (the cloned series renders
+ *               flush against its neighbors).
+ * `number`    → replace.
+ *
+ * Non-finite or non-positive numbers (and the OOXML default `0`)
+ * collapse to `undefined` so absence and the default round-trip
+ * identically through the writer's elision logic. Out-of-band values
+ * (the writer also clamps) are passed through here — the writer
+ * applies the final `0..400` clamp at emit time so a parsed-then-cloned
+ * value remains visible on the resulting `SheetChart` object.
+ */
+function resolveExplosion(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) {
+    if (sourceValue === undefined || !Number.isFinite(sourceValue) || sourceValue <= 0) {
+      return undefined;
+    }
+    return sourceValue;
+  }
+  if (override === null) return undefined;
+  if (!Number.isFinite(override) || override <= 0) return undefined;
+  return override;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -717,6 +717,17 @@ function parseSeries(ser: XmlElement, kind: ChartKind, index: number): ChartSeri
     if (invertIfNegative !== undefined) out.invertIfNegative = invertIfNegative;
   }
 
+  // `<c:explosion>` lives on `CT_PieSer` only — the OOXML schema
+  // shares the type across every pie-family chart (`<c:pieChart>`,
+  // `<c:pie3DChart>`, `<c:doughnutChart>`, `<c:ofPieChart>`) so
+  // surface the value for any of those kinds. A stray element on a
+  // bar / line / area / scatter template is dropped rather than
+  // surfaced — the writer would never emit it back anyway.
+  if (kind === "pie" || kind === "pie3D" || kind === "doughnut" || kind === "ofPie") {
+    const explosion = parseExplosion(ser);
+    if (explosion !== undefined) out.explosion = explosion;
+  }
+
   return out;
 }
 
@@ -748,6 +759,29 @@ function parseInvertIfNegative(ser: XmlElement): boolean | undefined {
   const v = readBoolAttr(el);
   if (v !== true) return undefined;
   return true;
+}
+
+/**
+ * Pull `<c:explosion val=".."/>` off a pie / doughnut series element.
+ * The element's `val` attribute is `xsd:unsignedInt` per the OOXML
+ * schema (CT_UnsignedInt) — the slice is pulled away from the chart
+ * center by `val` percent of the radius. Returns `undefined` when the
+ * attribute is absent, malformed, negative, or carries the OOXML
+ * default `0` — absence and `0` round-trip identically through the
+ * writer's elision logic, so collapsing them keeps the parsed shape
+ * minimal. Non-integer input rounds to the nearest integer for parity
+ * with the writer (Excel's UI accepts integer percentages only).
+ */
+function parseExplosion(ser: XmlElement): number | undefined {
+  const el = findChild(ser, "explosion");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  const rounded = Math.round(n);
+  if (rounded === 0) return undefined;
+  return rounded;
 }
 
 // ── Marker ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -815,6 +815,7 @@ function buildPieChart(chart: SheetChart, sheetName: string): string {
     children.push(
       buildSeries(chart.series[0], 0, sheetName, /* numericCategories */ false, {
         dataLabels: chart.dataLabels,
+        explosion: chart.series[0].explosion,
       }),
     );
   }
@@ -851,6 +852,7 @@ function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
     children.push(
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
         dataLabels: chart.dataLabels,
+        explosion: chart.series[i].explosion,
       }),
     );
   }
@@ -904,6 +906,29 @@ function clampHoleSize(value: number | undefined): number {
   const rounded = Math.round(value);
   if (rounded < DOUGHNUT_HOLE_MIN) return DOUGHNUT_HOLE_MIN;
   if (rounded > DOUGHNUT_HOLE_MAX) return DOUGHNUT_HOLE_MAX;
+  return rounded;
+}
+
+const EXPLOSION_MAX = 400;
+
+/**
+ * Normalize {@link ChartSeries.explosion} for emission inside
+ * `<c:explosion val=".."/>` on a pie / doughnut series.
+ *
+ * The OOXML schema (`CT_UnsignedInt`) accepts any non-negative integer,
+ * but Excel's UI only exposes 0..400% — values outside that band render
+ * but trigger Excel's repair dialog. Clamp to the UI band on the way
+ * out so a round-trip stays inside the range Excel will render.
+ *
+ * Returns `undefined` for the default `0` (and any negative / non-finite
+ * input) so the writer can elide the element entirely; absence and `0`
+ * round-trip identically through the parser's collapse logic.
+ */
+function clampExplosion(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded <= 0) return undefined;
+  if (rounded > EXPLOSION_MAX) return EXPLOSION_MAX;
   return rounded;
 }
 
@@ -1051,6 +1076,15 @@ interface SeriesOptions {
    * identically.
    */
   invertIfNegative?: boolean;
+  /**
+   * Per-series slice explosion (percentage of the radius). Only
+   * meaningful for pie / doughnut series — every other family ignores
+   * the field. The OOXML schema places `<c:explosion>` between
+   * `<c:spPr>` and `<c:dPt>` / `<c:dLbls>` on `CT_PieSer`. The element
+   * is only emitted when the resolved value is `> 0` — `0` is the OOXML
+   * default and absence round-trips identically.
+   */
+  explosion?: number;
 }
 
 function buildSeries(
@@ -1099,6 +1133,18 @@ function buildSeries(
   // matches the OOXML default and absence round-trips identically.
   if (options?.invertIfNegative === true) {
     children.push(xmlSelfClose("c:invertIfNegative", { val: 1 }));
+  }
+
+  // `<c:explosion>` — only pie / doughnut (CT_PieSer, shared across
+  // the pie family via `EG_PieSer`) series carry the element per the
+  // OOXML schema. It sits between `<c:spPr>` and `<c:dPt>` / `<c:dLbls>`.
+  // Non-pie callers leave `options.explosion` undefined so the field
+  // is silently dropped on every other chart family. Emit only when
+  // the resolved value is non-zero — `0` matches the OOXML default and
+  // absence round-trips identically.
+  const explosion = clampExplosion(options?.explosion);
+  if (explosion !== undefined) {
+    children.push(xmlSelfClose("c:explosion", { val: explosion }));
   }
 
   // Data labels — series-level override always wins over the chart-level

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -2404,6 +2404,193 @@ describe("cloneChart — series invertIfNegative flag", () => {
   });
 });
 
+// ── cloneChart — series explosion (pie / doughnut) ────────────────
+
+describe("cloneChart — series explosion", () => {
+  function pieSource(explosion: number | undefined): Chart {
+    return {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "pie",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+          ...(explosion !== undefined ? { explosion } : {}),
+        },
+      ],
+    };
+  }
+
+  it("inherits explosion=25 from a pie series source", () => {
+    const clone = cloneChart(pieSource(25), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.series[0].explosion).toBe(25);
+  });
+
+  it("does not surface explosion when the source series did not declare it", () => {
+    const clone = cloneChart(pieSource(undefined), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].explosion).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].explosion override a source missing the value", () => {
+    const clone = cloneChart(pieSource(undefined), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ explosion: 50 }],
+    });
+    expect(clone.series[0].explosion).toBe(50);
+  });
+
+  it("lets seriesOverrides[i].explosion=null drop an inherited value", () => {
+    const clone = cloneChart(pieSource(25), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ explosion: null }],
+    });
+    expect(clone.series[0].explosion).toBeUndefined();
+  });
+
+  it("lets seriesOverrides[i].explosion=0 drop an inherited value", () => {
+    // `0` collapses to undefined for symmetry with the OOXML default —
+    // unexploded slices and absence round-trip identically.
+    const clone = cloneChart(pieSource(25), {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ explosion: 0 }],
+    });
+    expect(clone.series[0].explosion).toBeUndefined();
+  });
+
+  it("carries explosion through when flattening doughnut to pie", () => {
+    const doughnut: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "doughnut",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          explosion: 40,
+        },
+      ],
+    };
+    const clone = cloneChart(doughnut, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.series[0].explosion).toBe(40);
+  });
+
+  it("drops inherited explosion when the resolved type is not pie/doughnut", () => {
+    // A pie template flattened to bar / column / line / area / scatter
+    // must not leak <c:explosion> — the OOXML schema rejects it on
+    // every other chart family.
+    for (const type of ["bar", "column", "line", "area", "scatter"] as const) {
+      const clone = cloneChart(pieSource(50), {
+        anchor: { from: { row: 0, col: 0 } },
+        type,
+        seriesOverrides: [{ values: "Sheet1!$B$2:$B$5" }],
+      });
+      expect(clone.type).toBe(type);
+      expect(clone.series[0].explosion).toBeUndefined();
+    }
+  });
+
+  it("drops explosion from explicit options.series when the resolved type is not pie/doughnut", () => {
+    // Replacing the entire series array via options.series still goes
+    // through the post-build explosion-strip, so a stray field does not
+    // leak into a non-pie/doughnut target.
+    const clone = cloneChart(pieSource(50), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      series: [{ values: "Sheet1!$B$2:$B$5", explosion: 25 }],
+    });
+    expect(clone.series[0].explosion).toBeUndefined();
+  });
+
+  it("propagates explosion across a multi-series doughnut clone", () => {
+    const multi: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 3,
+      series: [
+        { kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5", explosion: 25 },
+        { kind: "doughnut", index: 1, valuesRef: "Tpl!$C$2:$C$5" },
+        { kind: "doughnut", index: 2, valuesRef: "Tpl!$D$2:$D$5", explosion: 75 },
+      ],
+    };
+    const clone = cloneChart(multi, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].explosion).toBe(25);
+    expect(clone.series[1].explosion).toBeUndefined();
+    expect(clone.series[2].explosion).toBe(75);
+  });
+
+  it("round-trips explosion through parseChart → cloneChart → writeXlsx → parseChart", async () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:doughnutChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Exploded</c:v></c:tx>
+          <c:explosion val="35"/>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:tx><c:v>Default</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$C$2:$C$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:firstSliceAng val="0"/>
+        <c:holeSize val="50"/>
+      </c:doughnutChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const source = parseChart(sourceXml)!;
+    expect(source.series?.[0].explosion).toBe(35);
+    expect(source.series?.[1].explosion).toBeUndefined();
+
+    const sheetChart: SheetChart = cloneChart(source, {
+      anchor: { from: { row: 14, col: 0 } },
+      seriesOverrides: [{ values: "Dashboard!$B$2:$B$5" }, { values: "Dashboard!$C$2:$C$5" }],
+    });
+    expect(sheetChart.type).toBe("doughnut");
+    expect(sheetChart.series[0].explosion).toBe(35);
+    expect(sheetChart.series[1].explosion).toBeUndefined();
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [
+            ["A", "B", "C"],
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [10, 11, 12],
+          ],
+          charts: [sheetChart],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // Only the exploded series carries <c:explosion>; the second
+    // falls back to the OOXML default (absence of the element).
+    const matches = written.match(/c:explosion val="\d+"/g) ?? [];
+    expect(matches).toEqual(['c:explosion val="35"']);
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.series?.[0].explosion).toBe(35);
+    expect(reparsed?.series?.[1].explosion).toBeUndefined();
+  });
+});
+
 // ── cloneChart — dispBlanksAs ─────────────────────────────────────
 
 describe("cloneChart — dispBlanksAs", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -2370,6 +2370,216 @@ describe("writeChart — series invertIfNegative flag", () => {
   });
 });
 
+// ── explosion (per-series, pie / doughnut only) ─────────────────────
+
+describe("writeChart — series explosion", () => {
+  it("omits <c:explosion> on a pie series with the field left unset", () => {
+    // Absence of <c:explosion> matches the OOXML default
+    // (`val="0"`); the writer keeps untouched series byte-clean.
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:explosion");
+  });
+
+  it('emits <c:explosion val="25"/> on a pie series when explosion is set', () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4", explosion: 25 }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:explosion val="25"');
+  });
+
+  it('emits <c:explosion val="50"/> on a doughnut series when explosion is set', () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        series: [{ values: "B2:B4", categories: "A2:A4", explosion: 50 }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:explosion val="50"');
+  });
+
+  it("renders explosion per-series independently across a multi-series doughnut chart", () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        series: [
+          { name: "Exploded", values: "B2:B4", explosion: 30 },
+          { name: "Default", values: "C2:C4" },
+          { name: "Zero", values: "D2:D4", explosion: 0 },
+        ],
+      }),
+      "Sheet1",
+    );
+    // Only the first series carries <c:explosion>. Series with the
+    // value explicitly 0 collapse to absence (the OOXML default).
+    const matches = result.chartXml.match(/c:explosion val="\d+"/g) ?? [];
+    expect(matches).toEqual(['c:explosion val="30"']);
+  });
+
+  it("ignores explosion on chart kinds whose schema rejects <c:explosion>", () => {
+    // The OOXML schema places <c:explosion> only on CT_PieSer (and
+    // its EG_PieSer-sharing siblings). Setting the field on a bar /
+    // column / line / area / scatter series must not leak the element.
+    const cases: Array<["bar" | "column" | "line" | "area" | "scatter"]> = [
+      ["bar"],
+      ["column"],
+      ["line"],
+      ["area"],
+      ["scatter"],
+    ];
+    for (const [type] of cases) {
+      const result = writeChart(
+        makeChart({
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4", explosion: 25 }],
+        }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("c:explosion");
+    }
+  });
+
+  it("places <c:explosion> between <c:spPr> and <c:cat>/<c:val> (OOXML order)", () => {
+    // CT_PieSer puts <c:explosion> after <c:spPr> and before
+    // <c:dPt> / <c:dLbls> / <c:cat> / <c:val>. The element must land
+    // between the styling block and the data references so Excel's
+    // strict validator does not reject the file.
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [
+          {
+            name: "Exploded",
+            values: "B2:B4",
+            categories: "A2:A4",
+            color: "FF0000",
+            explosion: 30,
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const serBlock = result.chartXml.match(/<c:ser>[\s\S]*?<\/c:ser>/)![0];
+    const spPrIdx = serBlock.indexOf("c:spPr");
+    const explosionIdx = serBlock.indexOf("c:explosion");
+    const catIdx = serBlock.indexOf("c:cat");
+    const valIdx = serBlock.indexOf("c:val");
+    expect(spPrIdx).toBeLessThan(explosionIdx);
+    expect(explosionIdx).toBeLessThan(catIdx);
+    expect(explosionIdx).toBeLessThan(valIdx);
+  });
+
+  it("clamps an explosion value above 400 down to 400", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4", explosion: 9999 }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:explosion val="400"');
+  });
+
+  it("rounds non-integer explosion values to the nearest integer", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4", explosion: 33.6 }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:explosion val="34"');
+  });
+
+  it("collapses negative or non-finite explosion values to absence (OOXML default)", () => {
+    const cases = [-50, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+    for (const value of cases) {
+      const result = writeChart(
+        makeChart({
+          type: "pie",
+          series: [{ values: "B2:B4", categories: "A2:A4", explosion: value }],
+        }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("c:explosion");
+    }
+  });
+
+  it("emits <c:explosion> alongside the pie-only <c:firstSliceAng> without disturbing it", () => {
+    // The pieChart-level <c:firstSliceAng> is independent of the
+    // per-series <c:explosion>. Both must emit cleanly without
+    // interfering and the chart must still parse back.
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        firstSliceAng: 90,
+        series: [{ values: "B2:B4", categories: "A2:A4", explosion: 25 }],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:explosion val="25"');
+    expect(result.chartXml).toContain('c:firstSliceAng val="90"');
+  });
+
+  it("survives a parseChart round-trip with explosion preserved", async () => {
+    // writeChart → parseChart pulls the value straight back. Confirms
+    // the reader and writer agree on the element and that the value is
+    // surfaced on the resulting ChartSeriesInfo.
+    const written = writeChart(
+      makeChart({
+        type: "doughnut",
+        series: [
+          { name: "Exploded", values: "B2:B4", explosion: 30 },
+          { name: "Default", values: "C2:C4" },
+        ],
+      }),
+      "Sheet1",
+    );
+    const parsed = parseChart(written.chartXml);
+    expect(parsed?.series).toHaveLength(2);
+    expect(parsed?.series?.[0].explosion).toBe(30);
+    expect(parsed?.series?.[1].explosion).toBeUndefined();
+  });
+
+  it("threads explosion through an end-to-end writeXlsx round-trip", async () => {
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Dashboard",
+          rows: [
+            ["Region", "Revenue"],
+            ["North", 100],
+            ["South", 200],
+            ["East", 150],
+            ["West", 175],
+          ],
+          charts: [
+            {
+              type: "pie",
+              series: [{ values: "B2:B5", categories: "A2:A5", explosion: 40 }],
+              anchor: { from: { row: 6, col: 0 } },
+            },
+          ],
+        },
+      ],
+    });
+    const written = await extractXml(xlsx, "xl/charts/chart1.xml");
+    expect(written).toContain('c:explosion val="40"');
+    const reparsed = parseChart(written);
+    expect(reparsed?.series?.[0].explosion).toBe(40);
+  });
+});
+
 // ── Display blanks as ────────────────────────────────────────────────
 
 describe("writeChart — dispBlanksAs", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3277,6 +3277,199 @@ describe("parseChart — series invertIfNegative flag", () => {
   });
 });
 
+// ── parseChart — series explosion (pie / doughnut) ────────────────
+
+describe("parseChart — series explosion", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces explosion=25 on a <c:pieChart> series with <c:explosion val="25"/>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="25"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].explosion).toBe(25);
+  });
+
+  it('surfaces explosion on a <c:doughnutChart> series with <c:explosion val="50"/>', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="50"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:holeSize val="50"/>
+    </c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].explosion).toBe(50);
+  });
+
+  it("collapses the OOXML default explosion=0 to undefined", () => {
+    // Absence of <c:explosion> and `<c:explosion val="0"/>` round-trip
+    // identically through the writer's elision logic, so the parser
+    // collapses both to undefined to keep the read-side shape minimal.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="0"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].explosion).toBeUndefined();
+  });
+
+  it("returns explosion undefined when <c:explosion> is absent", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].explosion).toBeUndefined();
+  });
+
+  it("rounds non-integer explosion values to the nearest integer", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="33.6"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].explosion).toBe(34);
+  });
+
+  it("rejects malformed or negative explosion values", () => {
+    const cases = ["bogus", "-50", "NaN", "Infinity", ""];
+    for (const val of cases) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="${val}"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.series?.[0].explosion).toBeUndefined();
+    }
+  });
+
+  it("returns explosion undefined when val attribute is missing", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].explosion).toBeUndefined();
+  });
+
+  it("ignores <c:explosion> on chart families whose schema rejects the element", () => {
+    // The OOXML schema places <c:explosion> only on CT_PieSer (shared
+    // across the pie family). A bar/line/area/scatter template carrying
+    // a stray explosion element should not surface a value the writer
+    // would never emit anyway.
+    const cases = ["barChart", "lineChart", "areaChart", "scatterChart"] as const;
+    for (const tag of cases) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:${tag}>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="50"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:${tag}>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.series?.[0].explosion).toBeUndefined();
+    }
+  });
+
+  it("surfaces explosion per-series independently across multi-series doughnut charts", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="25"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="1"/>
+        <c:val><c:numRef><c:f>Sheet1!$C$2:$C$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:ser>
+        <c:idx val="2"/>
+        <c:explosion val="75"/>
+        <c:val><c:numRef><c:f>Sheet1!$D$2:$D$5</c:f></c:numRef></c:val>
+      </c:ser>
+      <c:holeSize val="50"/>
+    </c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series).toHaveLength(3);
+    expect(chart?.series?.[0].explosion).toBe(25);
+    expect(chart?.series?.[1].explosion).toBeUndefined();
+    expect(chart?.series?.[2].explosion).toBe(75);
+  });
+
+  it("surfaces explosion on <c:pie3DChart> and <c:ofPieChart> series", () => {
+    // CT_Pie3DSer / CT_OfPieSer share CT_PieSer through EG_PieSer, so
+    // the parser should accept <c:explosion> on both flavors.
+    for (const tag of ["pie3DChart", "ofPieChart"] as const) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:${tag}>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:explosion val="40"/>
+        <c:val><c:numRef><c:f>Sheet1!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:${tag}>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.series?.[0].explosion).toBe(40);
+    }
+  });
+});
+
 // ── parseChart — axis tick marks and tick label position ──────────
 
 describe("parseChart — axis tick marks and tick label position", () => {


### PR DESCRIPTION
## Summary

Surfaces the per-series `<c:explosion>` element at the read, write, and clone layers so a template's pie / doughnut slice-explosion configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:explosion>` controls how far each slice is pulled away from the chart center, expressed as a percentage of the radius. The element lives only on `CT_PieSer` (shared across `<c:pieChart>` / `<c:doughnutChart>` / `<c:pie3DChart>` / `<c:ofPieChart>` via `EG_PieSer`); every other chart family rejects it. Up until now hucre's writer never emitted the element and the parser ignored it, so a template's slice explosion flattened to zero on every parse -> clone -> write loop. This bridges another series-level gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.series?.[0].explosion); // 25  (template pulled the slice 25% out)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "pie",
      series: [{
        values: "B2:B6",
        categories: "A2:A6",
        explosion: 25,   // pull every slice 25% from the center
      }],
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  seriesOverrides: [
    { explosion: 50 },     // replace the inherited value
    // { explosion: null }   // drop the inherited value (writer falls back to 0)
    // { explosion: undefined } // inherit the source's parsed value
  ],
});
```

## Model

```ts
export interface ChartSeries {
  /* ...existing fields... */
  explosion?: number;
}

export interface ChartSeriesInfo {
  /* ...existing fields... */
  explosion?: number;
}

export interface CloneChartSeriesOverride {
  /* ...existing fields... */
  explosion?: number | null;
}
```

The read-side `ChartSeriesInfo.explosion` mirrors the write-side `ChartSeries.explosion` so a parsed value slots straight into `cloneChart` without transformation. Same scope as the existing `invertIfNegative` (#209) / `smooth` (#205) per-series knobs — the field surfaces only on pie-family series because OOXML places `<c:explosion>` exclusively on `CT_PieSer`.

## Behavior

- **Read** — `parseExplosion` pulls the value off `<c:ser><c:explosion val=".."/>` on every pie-family series (`pie`, `pie3D`, `doughnut`, `ofPie`). The OOXML default `0` collapses to `undefined` so absence and `0` round-trip identically; negative or non-finite values drop rather than fabricate. Non-integer input rounds for parity with the writer (Excel's UI accepts integer percentages only). The parser ignores stray `<c:explosion>` elements on bar / line / area / scatter templates so a corrupt source does not surface a value the writer would never emit anyway.
- **Write** — `<c:explosion>` is only emitted when the resolved value is `> 0` — `0` matches the OOXML default and absence round-trips identically. A new `clampExplosion` helper rounds non-integer input, drops negatives and non-finites, and clamps the upper bound to 400% (Excel's UI band). The element sits between `<c:spPr>` and `<c:dPt>` / `<c:dLbls>` per the strict CT_PieSer schema sequence. Non-pie / non-doughnut writers never thread the field, so a stray `explosion` on a bar / line / area / scatter series is silently dropped.
- **Clone** — Each series override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `0`) / `number` (replace) grammar that mirrors `invertIfNegative` / `smooth`. An override of `0` (the OOXML default) collapses identically to `null`. The field carries through pie -> doughnut and doughnut -> pie flattens (the element lives on both kinds, so the explosion survives); coercion into any other family (`bar`, `column`, `line`, `area`, `scatter`) drops the inherited value silently because OOXML defines no `<c:explosion>` slot for them.

## Edge cases

- `<c:explosion val="0"/>` collapses to `undefined` on read.
- Negative, non-finite, or malformed explosion values drop both at the parser and writer rather than silently substituting `0` — a fall-through would mask a configuration error.
- Pinning `explosion: 0` collapses identically to omitting the field — the writer elides the element in both cases.
- The element is emitted exactly once per series and never on a non-pie / non-doughnut chart family.
- Out-of-band values clamp on write (`9999` -> `400`); the writer's upper bound matches Excel's UI ceiling so a round-trip stays inside the range Excel will render.
- Non-integer input rounds (`33.6` -> `34`) for parity between the parser and writer.
- `pie3DChart` and `ofPieChart` series surface explosion at parse time (CT_Pie3DSer / CT_OfPieSer share CT_PieSer through EG_PieSer); the writer maps both kinds onto the 2D `pie` writer so the element survives the round-trip.
- A doughnut template flattened to pie keeps its explosion (and vice versa); coercion into a non-pie family drops it.

## Test plan

- [x] `pnpm test` (lint + typecheck + 3218 vitest) passes.
- [x] `pnpm build` succeeds.
- [x] 31 new explosion tests across `charts.test.ts` (9 read), `charts-write.test.ts` (12 write + round-trip + writeXlsx packaging), `chart-clone.test.ts` (10 clone + end-to-end) cover read, write, clone, end-to-end round-trip, multi-series independence, doughnut <-> pie flatten, and per-family scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)