### PR TITLE
feat(xlsx): chart category-axis noMultiLvlLbl flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,18 @@ absence, missing `val`, and unknown tokens all collapse to `undefined`
 so absence and the default round-trip identically. The reader accepts
 the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
 `"false"`).
+`ChartAxisInfo.noMultiLvlLbl` surfaces the per-axis
+`<c:noMultiLvlLbl val=".."/>` flag — Excel's "Format Axis ->
+Multi-level Category Labels" checkbox (the checkbox is the inverse:
+checked means tiered labels, i.e. `noMultiLvlLbl: false`). The OOXML
+schema places the element on `CT_CatAx` exclusively (even
+`<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject it), so the parser
+ignores the element on every other axis flavour. Only an explicit
+`val="1"` (multi-tier labels collapsed onto a single line) surfaces
+`true`; the OOXML default `val="0"`, absence, missing `val`, and
+unknown tokens all collapse to `undefined` so absence and the default
+round-trip identically. The reader accepts the OOXML truthy / falsy
+spellings (`"1"` / `"true"` / `"0"` / `"false"`).
 `ChartAxisInfo.reverse` surfaces the per-axis
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
 "Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
@@ -995,6 +1007,21 @@ element because Excel's reference serialization includes
 that default, while only an explicit `true` emits `val="1"`. The flag
 threads through bar / column / line / area / scatter; pie / doughnut
 silently ignore it because OOXML defines no axes for those families.
+The `axes.x.noMultiLvlLbl` flag maps to
+`<c:catAx><c:noMultiLvlLbl val=".."/>` — Excel's "Format Axis ->
+Multi-level Category Labels" checkbox (the checkbox is the inverse:
+checked means tiered labels, i.e. `noMultiLvlLbl: false`). When a
+category range spans multiple columns / rows Excel groups the labels
+into tiers; setting `true` flattens every category onto a single line
+regardless of the source range's shape. The writer always emits the
+element because Excel's reference serialization includes
+`<c:noMultiLvlLbl val="0"/>` on every category axis; `false`, absence,
+and non-boolean inputs all collapse to the default `val="0"`, while
+only an explicit `true` emits `val="1"`. The element lives on
+`CT_CatAx` exclusively (even `<c:dateAx>`, `<c:valAx>`, and
+`<c:serAx>` reject it), so the flag threads through bar / column /
+line / area but is silently dropped on scatter (both axes are value
+axes) and pie / doughnut (no axes at all).
 The `axes.x.reverse` and `axes.y.reverse` flags map to
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` — Excel's
 "Categories / Values in reverse order" toggle. On a category axis,
@@ -1222,6 +1249,18 @@ because OOXML defines no axes for them. An override of `false` is
 equivalent to `null` — the writer treats both as the OOXML default
 `val="0"`, so the cloned `SheetChart` collapses both shapes to
 `undefined`.
+The per-axis `axes.x.noMultiLvlLbl` override follows the same
+`undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar.
+Because `<c:noMultiLvlLbl>` lives exclusively on `CT_CatAx`, the flag
+threads through bar / column / line / area coercions but is dropped
+silently when the resolved clone target is `scatter` (its X axis is a
+value axis, so the element has no slot) or `pie` / `doughnut` (no
+axes at all) — flattening a column template into a scatter clone
+therefore never leaks a stale catAx flag into the output. An override
+of `false` is equivalent to `null` — the writer treats both as the
+OOXML default `val="0"`, so the cloned `SheetChart` collapses both
+shapes to `undefined`. Non-boolean overrides drop rather than fall
+through to the inherited value.
 The per-axis `axes.x.reverse` / `axes.y.reverse` overrides follow the
 same `undefined` (inherit) / `null` (drop) / boolean (replace) grammar
 as the other axis fields. A literal `false` override behaves

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1162,6 +1162,24 @@ export interface SheetChart {
        */
       lblOffset?: number;
       /**
+       * Suppress Excel's automatic multi-level category labels. Maps
+       * to `<c:catAx><c:noMultiLvlLbl val=".."/></c:catAx>`. The OOXML
+       * default `false` (Excel groups labels into tiers when the
+       * category range spans multiple columns / rows); set `true` to
+       * flatten every category into a single line of labels regardless
+       * of the source range's shape. Mirrors Excel's "Format Axis ->
+       * Multi-level Category Labels" checkbox (the checkbox is the
+       * inverse — checked means tiered labels, i.e.
+       * `noMultiLvlLbl: false`).
+       *
+       * Only meaningful for bar / column / line / area charts (whose X
+       * axis is `<c:catAx>`); silently ignored for scatter (both axes
+       * are value axes) and pie / doughnut (no axes at all). The OOXML
+       * schema places the element on `CT_CatAx` only — `CT_ValAx`,
+       * `CT_DateAx`, and `CT_SerAx` reject it.
+       */
+      noMultiLvlLbl?: boolean;
+      /**
        * Horizontal alignment of the tick labels on a category axis —
        * `"ctr"` (center, the OOXML default), `"l"` (left), or `"r"`
        * (right). Maps to `<c:catAx><c:lblAlgn val=".."/></c:catAx>`.
@@ -2185,6 +2203,23 @@ export interface ChartAxisInfo {
    * writer would never emit. See {@link ChartAxisLabelAlign}.
    */
   lblAlgn?: ChartAxisLabelAlign;
+  /**
+   * Multi-level-label suppression flag pulled from
+   * `<c:noMultiLvlLbl val=".."/>`. Surfaces `true` only when the axis
+   * pinned `val="1"` (Excel's "Multi-level Category Labels" checkbox
+   * unchecked — every category collapses onto one line). The OOXML
+   * default `val="0"` (and absence of the element) collapse to
+   * `undefined` so absence and the default round-trip identically
+   * through {@link cloneChart}.
+   *
+   * Surfaces only on category axes (`<c:catAx>`) — the OOXML schema
+   * places the element on `CT_CatAx` exclusively (it has no slot on
+   * `CT_ValAx`, `CT_DateAx`, or `CT_SerAx`). The reader accepts the
+   * OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
+   * `"false"`); unknown values and missing `val` attributes drop to
+   * `undefined`.
+   */
+  noMultiLvlLbl?: boolean;
   /**
    * Axis hidden flag pulled from `<c:delete val=".."/>`. Surfaces
    * `true` when the axis pinned `val="1"` (Excel's "Format Axis ->

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -331,6 +331,16 @@ export interface CloneChartOptions {
        */
       lblAlgn?: ChartAxisLabelAlign | null;
       /**
+       * Override `SheetChart.axes.x.noMultiLvlLbl`. `undefined` (or
+       * omitted) inherits the source axis's flag; `null` drops the
+       * inherited value (the writer falls back to the OOXML `false`
+       * default — multi-level labels enabled); a `boolean` replaces
+       * it. Only meaningful for resolved chart types whose X axis is
+       * `<c:catAx>` (bar / column / line / area); silently dropped on
+       * scatter and pie / doughnut.
+       */
+      noMultiLvlLbl?: boolean | null;
+      /**
        * Override `SheetChart.axes.x.hidden`. `undefined` (or omitted)
        * inherits the source axis's flag; `null` drops the inherited
        * value (the writer falls back to the OOXML `false` default —
@@ -1038,6 +1048,13 @@ function resolveAxes(
   const xLblAlgn = isCatAxisX
     ? applyLblAlgnOverride(sourceAxes?.x?.lblAlgn, overrides?.x?.lblAlgn)
     : undefined;
+  // `noMultiLvlLbl` is even tighter — `CT_CatAx` only (no `<c:dateAx>`
+  // slot per ECMA-376 §21.2.2). Reuse the catAx scope rule above; the
+  // resolved chart type still funnels through `<c:catAx>` for every
+  // bar / column / line / area family the writer supports.
+  const xNoMultiLvlLbl = isCatAxisX
+    ? applyNoMultiLvlLblOverride(sourceAxes?.x?.noMultiLvlLbl, overrides?.x?.noMultiLvlLbl)
+    : undefined;
   // `<c:delete>` lives on every axis flavour — both `<c:catAx>` and
   // `<c:valAx>` accept it — so the hidden flag carries through every
   // chart family that has axes. Pie / doughnut have no axes at all
@@ -1059,6 +1076,7 @@ function resolveAxes(
     xTickMarkSkip !== undefined ||
     xLblOffset !== undefined ||
     xLblAlgn !== undefined ||
+    xNoMultiLvlLbl !== undefined ||
     xHidden !== undefined
   ) {
     out.x = {};
@@ -1074,6 +1092,7 @@ function resolveAxes(
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
     if (xLblOffset !== undefined) out.x.lblOffset = xLblOffset;
     if (xLblAlgn !== undefined) out.x.lblAlgn = xLblAlgn;
+    if (xNoMultiLvlLbl !== undefined) out.x.noMultiLvlLbl = xNoMultiLvlLbl;
     if (xHidden !== undefined) out.x.hidden = xHidden;
   }
   if (
@@ -1172,6 +1191,26 @@ function applyLblAlgnOverride(
   if (override === null) return undefined;
   if (override !== "l" && override !== "r" && override !== "ctr") return undefined;
   return override === "ctr" ? undefined : override;
+}
+
+/**
+ * Resolve a `noMultiLvlLbl` override using the same `undefined`
+ * (inherit) / `null` (drop) / `boolean` (replace) grammar as the
+ * other axis helpers. Only `true` surfaces (the writer treats `false`
+ * and absence identically — both produce `<c:noMultiLvlLbl val="0"/>`),
+ * so an override of `false` collapses to `undefined` to keep the
+ * cloned `SheetChart` shape minimal. Non-boolean inputs fall through
+ * the type guard to `undefined`.
+ */
+function applyNoMultiLvlLblOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    return source === true ? true : undefined;
+  }
+  if (override === null) return undefined;
+  return override === true ? true : undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -309,6 +309,12 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   // §21.2.2 — the OOXML `ST_LblAlgn` schema places the element on
   // `CT_CatAx` / `CT_DateAx` only. Same scope rule as `lblOffset`.
   const lblAlgn = isCategoryAxis ? parseAxisLblAlgn(axis) : undefined;
+  // `<c:noMultiLvlLbl>` lives exclusively on `CT_CatAx` per ECMA-376
+  // Part 1, §21.2.2 — even `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>`
+  // reject the element. Skip the parse on every other axis flavour so
+  // a corrupt template carrying a stray flag does not surface a value
+  // the writer would never emit anyway.
+  const noMultiLvlLbl = axis.local === "catAx" ? parseAxisNoMultiLvlLbl(axis) : undefined;
   // `<c:delete>` sits on every axis flavour (CT_CatAx / CT_ValAx /
   // CT_DateAx / CT_SerAx) per ECMA-376 Part 1, §21.2.2. The OOXML
   // default `val="0"` (axis visible) collapses to `undefined` so
@@ -327,6 +333,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     tickMarkSkip === undefined &&
     lblOffset === undefined &&
     lblAlgn === undefined &&
+    noMultiLvlLbl === undefined &&
     hidden === undefined
   ) {
     return undefined;
@@ -344,6 +351,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
   if (lblOffset !== undefined) out.lblOffset = lblOffset;
   if (lblAlgn !== undefined) out.lblAlgn = lblAlgn;
+  if (noMultiLvlLbl !== undefined) out.noMultiLvlLbl = noMultiLvlLbl;
   if (hidden !== undefined) out.hidden = hidden;
   return out;
 }
@@ -509,6 +517,37 @@ function parseAxisLblAlgn(axis: XmlElement): ChartAxisLabelAlign | undefined {
   const value = raw.trim() as ChartAxisLabelAlign;
   if (!VALID_LBL_ALIGNS.has(value)) return undefined;
   return value === "ctr" ? undefined : value;
+}
+
+/**
+ * Pull `<c:noMultiLvlLbl val=".."/>` off a category axis element.
+ * Returns `true` only when the axis pinned `val="1"` / `val="true"`
+ * (Excel's "Multi-level Category Labels" checkbox unchecked, i.e.
+ * tiered category labels collapsed onto a single line). The OOXML
+ * default `val="0"` / `val="false"`, absence, missing `val`, and
+ * unknown tokens all collapse to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart}.
+ *
+ * Mirrors the truthy / falsy parsing in {@link parseAxisHidden} —
+ * the OOXML schema (`xsd:boolean`) accepts `0` / `1` / `false` /
+ * `true` for `<c:noMultiLvlLbl>` just as it does for every other
+ * Boolean-valued chart attribute.
+ */
+function parseAxisNoMultiLvlLbl(axis: XmlElement): boolean | undefined {
+  const el = findChild(axis, "noMultiLvlLbl");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw.trim()) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -172,6 +172,11 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // scope rule as `lblOffset`; the catAx builder is the sole
     // consumer.
     xLblAlgn: normalizeAxisLblAlgn(chart.axes?.x?.lblAlgn),
+    // `noMultiLvlLbl` lives exclusively on `CT_CatAx` per ECMA-376
+    // Part 1, §21.2.2 — even `<c:dateAx>` rejects the element. Same
+    // catAx-only scope rule as the surrounding category-axis knobs;
+    // the catAx builder is the sole consumer.
+    xNoMultiLvlLbl: chart.axes?.x?.noMultiLvlLbl === true,
     // `<c:delete>` lives on every axis flavour (CT_CatAx / CT_ValAx /
     // CT_DateAx / CT_SerAx). The writer always emits the element —
     // Excel's reference serialization includes `<c:delete val="0"/>`
@@ -263,6 +268,15 @@ interface AxisRenderOptions {
    * writer falls back to the OOXML default `"ctr"`).
    */
   xLblAlgn: ChartAxisLabelAlign | undefined;
+  /**
+   * Whether the X axis should pin `<c:noMultiLvlLbl val="1"/>`
+   * (multi-level category labels suppressed). Always defined — `false`
+   * keeps Excel's reference `val="0"` while `true` collapses multi-tier
+   * category labels onto a single line. Only meaningful for the catAx
+   * builder; scatter has no category axis, so the value is silently
+   * dropped at the per-chart-type branch.
+   */
+  xNoMultiLvlLbl: boolean;
   /**
    * Whether the X axis should render its `<c:delete>` element with
    * `val="1"` (axis hidden). Always defined — `false` keeps Excel's
@@ -760,7 +774,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     // so a fresh chart matches Excel's reference serialization (the
     // default `1` is omitted and Excel renders every tick).
     ...buildAxisSkips(opts.xTickLblSkip, opts.xTickMarkSkip),
-    xmlSelfClose("c:noMultiLvlLbl", { val: 0 }),
+    // `<c:noMultiLvlLbl>` is always emitted because Excel's reference
+    // serialization includes it on every category axis. The writer
+    // pins the caller's override when `true`; absence and an explicit
+    // `false` both produce `val="0"` so untouched charts match Excel's
+    // output byte-for-byte.
+    xmlSelfClose("c:noMultiLvlLbl", { val: opts.xNoMultiLvlLbl ? 1 : 0 }),
   );
 
   const valAxChildren: string[] = [

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4315,3 +4315,191 @@ describe("cloneChart — axis lblAlgn", () => {
     expect(written).toContain('c:lblAlgn val="l"');
   });
 });
+
+// ── cloneChart — axis noMultiLvlLbl ─────────────────────────────────
+
+describe("cloneChart — axis noMultiLvlLbl", () => {
+  const sourceWithFlag: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { noMultiLvlLbl: true } },
+  };
+
+  it("inherits axes.x.noMultiLvlLbl=true from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithFlag, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("drops the inherited flag when override is null", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { noMultiLvlLbl: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the inherited flag when override is false", () => {
+    // `false` collapses to undefined the same way `null` does because the
+    // writer treats both shapes identically (val="0" is the default).
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { noMultiLvlLbl: false } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited true with override true (no-op)", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { noMultiLvlLbl: true } },
+    });
+    expect(clone.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("adds noMultiLvlLbl=true to a source axis that did not declare it", () => {
+    const noFlag: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { noMultiLvlLbl: true } },
+    });
+    expect(clone.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("collapses non-boolean overrides to undefined", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { noMultiLvlLbl: 1 as unknown as boolean } },
+    });
+    // The non-boolean override drops, falling back to undefined (not the
+    // inherited true) since the override was non-undefined.
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { noMultiLvlLbl: true } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { noMultiLvlLbl: true } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is scatter", () => {
+    // Scatter uses two value axes, so the X axis is no longer a category
+    // axis. Drop inherited noMultiLvlLbl so the cloned model accurately
+    // reflects what the chart will paint — the schema rejects the
+    // element on every value-axis flavour.
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the flag through a chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("composes the flag alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Region",
+          gridlines: { major: true },
+          tickLblSkip: 3,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Region");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.tickLblSkip).toBe(3);
+    expect(clone.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the flag", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:noMultiLvlLbl val="1"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.noMultiLvlLbl).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.noMultiLvlLbl).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const catAxBlock = written.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:noMultiLvlLbl val="1"');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the flag intact", async () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:noMultiLvlLbl val="1"');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3957,3 +3957,153 @@ describe("writeChart — legendOverlay", () => {
     expect(legend).toContain('c:overlay val="1"');
   });
 });
+
+// ── writeChart — axis noMultiLvlLbl ──────────────────────────────────
+
+describe("writeChart — axis noMultiLvlLbl", () => {
+  it('emits <c:noMultiLvlLbl val="1"/> on the category axis when the override is true', () => {
+    const result = writeChart(makeChart({ axes: { x: { noMultiLvlLbl: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:noMultiLvlLbl val="1"');
+    expect(catAxBlock).not.toContain('c:noMultiLvlLbl val="0"');
+  });
+
+  it('emits the OOXML default <c:noMultiLvlLbl val="0"/> when the field is unset', () => {
+    // Excel's reference serialization always emits `<c:noMultiLvlLbl val="0"/>`,
+    // so the writer keeps that contract on a stock chart even though the
+    // parser collapses `0` to undefined on the read side.
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:noMultiLvlLbl val="0"');
+  });
+
+  it("emits the default when the override is explicitly false", () => {
+    // Pinning the default has the same wire effect as omitting the
+    // field — the OOXML default `false` round-trips identically with
+    // absence.
+    const result = writeChart(makeChart({ axes: { x: { noMultiLvlLbl: false } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:noMultiLvlLbl val="0"');
+  });
+
+  it("emits exactly one <c:noMultiLvlLbl> element per category axis", () => {
+    const result = writeChart(makeChart({ axes: { x: { noMultiLvlLbl: true } } }), "Sheet1");
+    expect((result.chartXml.match(/c:noMultiLvlLbl/g) ?? []).length).toBe(1);
+  });
+
+  it("threads the override through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { noMultiLvlLbl: true } } }),
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('c:noMultiLvlLbl val="1"');
+    }
+  });
+
+  it("ignores the override on scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { noMultiLvlLbl: true } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:noMultiLvlLbl");
+  });
+
+  it("ignores the override on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(
+      makeChart({ type: "pie", axes: { x: { noMultiLvlLbl: true } } }),
+      "Sheet1",
+    );
+    expect(pie.chartXml).not.toContain("c:noMultiLvlLbl");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { noMultiLvlLbl: true } } }),
+      "Sheet1",
+    );
+    expect(dough.chartXml).not.toContain("c:noMultiLvlLbl");
+  });
+
+  it("does not emit noMultiLvlLbl on the value axis", () => {
+    // The model surfaces the flag only on `axes.x`; setting it via
+    // `axes.y` is impossible at the type level. This test pins the
+    // negative case for the writer: a valAx never carries the element.
+    const result = writeChart(makeChart({ axes: { x: { noMultiLvlLbl: true } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).not.toContain("c:noMultiLvlLbl");
+  });
+
+  it("places noMultiLvlLbl after lblOffset / tickLblSkip / tickMarkSkip per the OOXML schema", () => {
+    // CT_CatAx: ... lblOffset -> tickLblSkip? -> tickMarkSkip? -> noMultiLvlLbl.
+    const result = writeChart(
+      makeChart({
+        axes: { x: { tickLblSkip: 3, tickMarkSkip: 5, noMultiLvlLbl: true } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const lblOffsetIdx = catAxBlock.indexOf("c:lblOffset");
+    const tickLblSkipIdx = catAxBlock.indexOf("c:tickLblSkip");
+    const tickMarkSkipIdx = catAxBlock.indexOf("c:tickMarkSkip");
+    const noMultiLvlLblIdx = catAxBlock.indexOf("c:noMultiLvlLbl");
+    expect(lblOffsetIdx).toBeGreaterThan(0);
+    expect(tickLblSkipIdx).toBeGreaterThan(lblOffsetIdx);
+    expect(tickMarkSkipIdx).toBeGreaterThan(tickLblSkipIdx);
+    expect(noMultiLvlLblIdx).toBeGreaterThan(tickMarkSkipIdx);
+  });
+
+  it("ignores non-boolean noMultiLvlLbl values (falls back to default 0)", () => {
+    // Match how `legendOverlay` / `roundedCorners` / axis `hidden` treat
+    // their inputs: only literal `true` produces the non-default. A
+    // stray non-boolean collapses to the default.
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { noMultiLvlLbl: "yes" as any } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:noMultiLvlLbl val="0"');
+  });
+
+  it("round-trips a non-default noMultiLvlLbl through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { noMultiLvlLbl: true } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it("collapses a defaulted noMultiLvlLbl round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the flag into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { noMultiLvlLbl: true } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('c:noMultiLvlLbl val="1"');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -4717,3 +4717,187 @@ describe("parseChart — legendOverlay", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — axis noMultiLvlLbl ────────────────────────────────
+
+describe("parseChart — axis noMultiLvlLbl", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces noMultiLvlLbl=true on the category axis when val="1"', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:noMultiLvlLbl val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.noMultiLvlLbl).toBe(true);
+    expect(chart?.axes?.y?.noMultiLvlLbl).toBeUndefined();
+  });
+
+  it('collapses the OOXML default val="0" to undefined', () => {
+    // Excel's reference serialization emits `<c:noMultiLvlLbl val="0"/>`
+    // on every category axis even though the schema default is `false`.
+    // The parser collapses the default so absence and the default
+    // round-trip identically through the writer's elision logic.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:noMultiLvlLbl val="0"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses absence of <c:noMultiLvlLbl> to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it('accepts the OOXML truthy spelling val="true"', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:noMultiLvlLbl val="true"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.noMultiLvlLbl).toBe(true);
+  });
+
+  it('accepts the OOXML falsy spelling val="false" and collapses to undefined', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:noMultiLvlLbl val="false"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:noMultiLvlLbl> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:noMultiLvlLbl/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined for unknown val tokens", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:noMultiLvlLbl val="yes"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface noMultiLvlLbl on a value axis", () => {
+    // The OOXML schema places `<c:noMultiLvlLbl>` on CT_CatAx exclusively
+    // — `<c:valAx>` rejects it entirely. A corrupt template carrying a
+    // stray flag on a value axis should not surface a field the writer
+    // would never emit anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:noMultiLvlLbl val="1"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.noMultiLvlLbl).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface noMultiLvlLbl on a scatter chart's value axes", () => {
+    // Scatter has two valAx — the schema rejects `<c:noMultiLvlLbl>` on
+    // both, so a stray flag on either axis must not bleed through into
+    // the parsed shape.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:noMultiLvlLbl val="1"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:noMultiLvlLbl val="1"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.noMultiLvlLbl).toBeUndefined();
+    expect(chart?.axes?.y?.noMultiLvlLbl).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces noMultiLvlLbl alongside title, gridlines, and other catAx fields", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:majorGridlines/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:lblOffset val="200"/>
+      <c:tickLblSkip val="3"/>
+      <c:noMultiLvlLbl val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Region",
+      gridlines: { major: true },
+      lblOffset: 200,
+      tickLblSkip: 3,
+      noMultiLvlLbl: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:noMultiLvlLbl>` element at the read, write, and clone layers so a template's multi-level-label suppression survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:noMultiLvlLbl>` lives exclusively on `CT_CatAx` in OOXML — even `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject it. It mirrors Excel's "Format Axis -> Multi-level Category Labels" checkbox (the checkbox is the inverse — checked means tiered labels, i.e. `noMultiLvlLbl: false`). When a category range spans multiple columns / rows Excel groups the labels into tiers; setting `noMultiLvlLbl: true` flattens every category onto a single line regardless of the source range's shape. Up until now hucre's writer always pinned `val="0"`, so a template that pinned `val="1"` flattened back to the default on every parse -> clone -> write loop. This bridges another category-axis-configuration gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.noMultiLvlLbl); // true (template flattened multi-tier labels)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ values: "B2:B10", categories: "A2:B10" }], // 2-column range -> Excel would tier
      axes: { x: { noMultiLvlLbl: true } },                  // flatten back to one line
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    x: { noMultiLvlLbl: true },     // override the inherited value
    // x: { noMultiLvlLbl: null },  // drop the inherited value (writer falls back to false)
    // x: { noMultiLvlLbl: undefined } // inherit the source's parsed value
  },
});
```

## Model

```ts
export interface SheetChart {
  // ...existing fields...
  axes?: {
    x?: {
      // ...existing fields...
      noMultiLvlLbl?: boolean;
    };
    y?: { /* ... */ };
  };
}

export interface ChartAxisInfo {
  // ...existing fields...
  noMultiLvlLbl?: boolean;
}

export interface CloneChartOptions {
  // ...existing fields...
  axes?: {
    x?: {
      // ...existing fields...
      noMultiLvlLbl?: boolean | null;
    };
    y?: { /* ... */ };
  };
}
```

## Scope rules

- Only meaningful for bar / column / line / area charts (whose X axis is `<c:catAx>`).
- Silently dropped on scatter (both axes are value axes) and pie / doughnut (no axes at all).
- Default `false` (multi-level labels enabled) collapses to `undefined` on read so absence and the default round-trip identically.
- Non-boolean inputs collapse to `false` to keep the on-the-wire output stable, mirroring how `legendOverlay` / `roundedCorners` / axis `hidden` treat their inputs.

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest) — 3253 tests passing.
- [x] `pnpm build` — obuild succeeds.
- [x] `parseChart` covers truthy / falsy spellings, default collapse, missing `val`, value-axis rejection, scatter-chart rejection, and co-surfacing alongside title / gridlines / tick skips.
- [x] `writeChart` covers default emit, non-boolean fallback, exactly-one-emit guard, OOXML element ordering, scatter / pie / doughnut suppression, value-axis suppression, and end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers inherit / null / false / true grammar, non-boolean fallback, chart-type coercion (bar -> column carries, bar -> scatter strips), composition with other axis overrides, and end-to-end through `parseChart -> cloneChart -> writeChart`.