### PR TITLE
feat(xlsx): chart data-labels showLegendKey flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,10 +562,11 @@ for (const sheet of wb.sheets) {
     // }
 
     // chart.dataLabels surfaces the chart-type-level <c:dLbls> block.
-    // showValue / showCategoryName / showSeriesName / showPercent and
-    // position / separator round-trip through cloneChart unchanged.
+    // showValue / showCategoryName / showSeriesName / showPercent /
+    // showLegendKey and position / separator round-trip through
+    // cloneChart unchanged.
     console.log(chart.dataLabels);
-    // e.g. { showValue: true, position: "outEnd" }
+    // e.g. { showValue: true, showLegendKey: true, position: "outEnd" }
 
     for (const s of chart.series ?? []) {
       console.log(s.kind, s.index, s.name, s.valuesRef, s.categoriesRef, s.color);
@@ -630,10 +631,15 @@ never report one.
 `Chart.dataLabels` mirrors the writer-side `SheetChart.dataLabels`
 and surfaces the toggles Excel carries inside `<c:dLbls>`
 (`showValue`, `showCategoryName`, `showSeriesName`, `showPercent`,
-plus `position` and `separator`). Series-level overrides land on
-`ChartSeriesInfo.dataLabels`; a `<c:dLbls>` block that only contains
-`<c:delete val="1"/>` (Excel's "labels off" idiom) collapses to
-`undefined` rather than a record so callers see the absence cleanly.
+`showLegendKey`, plus `position` and `separator`). Series-level
+overrides land on `ChartSeriesInfo.dataLabels`; a `<c:dLbls>` block
+that only contains `<c:delete val="1"/>` (Excel's "labels off" idiom)
+collapses to `undefined` rather than a record so callers see the
+absence cleanly. `showLegendKey` mirrors Excel's "Format Data Labels
+-> Legend Key" checkbox: pin it `true` to paint the legend's color
+swatch beside every label. The OOXML default `false` collapses to
+`undefined` on the read side so absence and `<c:showLegendKey val="0"/>`
+round-trip identically through `cloneChart`.
 `Chart.holeSize` surfaces `<c:doughnutChart><c:holeSize val=".."/>`
 on doughnut charts so a parsed template can round-trip its hole back
 through `cloneChart`; non-doughnut charts (and doughnut charts that
@@ -870,11 +876,14 @@ the chart edge when the value axis crosses elsewhere
 dropped silently so the writer never emits a token Excel rejects.
 Pie / doughnut charts ignore the entire `axes` field because OOXML
 defines no axes for them.
-`dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, position, separator }`
+`dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, showLegendKey, position, separator }`
 attaches Excel's small in-chart annotations: set at the chart level
 to label every series, or set on a single `series[i].dataLabels` to
 override (passing `false` suppresses labels for that series alone
-even when the chart-level default has them on). For doughnut charts,
+even when the chart-level default has them on). `showLegendKey` repeats
+the legend's color swatch inside each label slot (Excel's "Format
+Data Labels -> Legend Key" checkbox); the OOXML default is `false`
+so omit the field for the standard label shape. For doughnut charts,
 `holeSize` (10 – 90, Excel's UI band; default 50) controls the
 diameter of the inner hole — values outside the band are clamped to
 the closest end and non-doughnut kinds silently ignore the field.

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -596,6 +596,16 @@ export interface ChartDataLabels {
   /** Show the value as a percent of total. Pie / doughnut only. */
   showPercent?: boolean;
   /**
+   * Render the legend's color swatch (the small marker / bar Excel
+   * paints in the chart legend) inline with each data label. Mirrors
+   * Excel's "Format Data Labels -> Legend Key" checkbox.
+   *
+   * Maps to `<c:showLegendKey val=".."/>` inside `<c:dLbls>`. The OOXML
+   * default is `false` (no legend key); set to `true` to repeat the
+   * legend swatch alongside every label.
+   */
+  showLegendKey?: boolean;
+  /**
    * Where the label sits relative to its point. See
    * {@link ChartDataLabelPosition} for the valid set per chart kind.
    * Omit to let Excel pick a default (`outEnd` for bar/column,
@@ -1957,6 +1967,15 @@ export interface ChartDataLabelsInfo {
   showCategoryName?: boolean;
   showSeriesName?: boolean;
   showPercent?: boolean;
+  /**
+   * Mirror of {@link ChartDataLabels.showLegendKey}. Surfaces `true`
+   * only when the source `<c:dLbls>` block pinned
+   * `<c:showLegendKey val="1"/>` (Excel's "Format Data Labels ->
+   * Legend Key" checkbox). The OOXML default `false` collapses to
+   * `undefined` so absence and the default round-trip identically
+   * through {@link cloneChart}.
+   */
+  showLegendKey?: boolean;
   position?: ChartDataLabelPosition;
   separator?: string;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -951,6 +951,15 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     }
   }
 
+  // `<c:showLegendKey val=".."/>` mirrors Excel's "Format Data Labels
+  // -> Legend Key" checkbox. The OOXML default is `false`, so absence
+  // and an explicit `val="0"` collapse to `undefined` — only an
+  // explicit `val="1"` (or `"true"`) surfaces `true`. Same shape as the
+  // other `show*` toggles so the parsed record can be fed straight back
+  // into {@link cloneChart}.
+  const showLeg = findChild(el, "showLegendKey");
+  if (showLeg && readBoolAttr(showLeg) === true) out.showLegendKey = true;
+
   const showVal = findChild(el, "showVal");
   if (showVal && readBoolAttr(showVal) === true) out.showValue = true;
 
@@ -976,6 +985,7 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     !out.showCategoryName &&
     !out.showSeriesName &&
     !out.showPercent &&
+    !out.showLegendKey &&
     out.separator === undefined
   ) {
     return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1512,7 +1512,9 @@ function buildDataLabelsBody(dl: ChartDataLabels): string {
 
   // OOXML requires showLegendKey to appear first when any toggle is set.
   // Always emit it explicitly so the rendered XML is deterministic.
-  children.push(xmlSelfClose("c:showLegendKey", { val: 0 }));
+  // Non-boolean inputs collapse to `false` to keep the on-the-wire output
+  // stable, mirroring how the other `show*` toggles treat their inputs.
+  children.push(xmlSelfClose("c:showLegendKey", { val: dl.showLegendKey === true ? 1 : 0 }));
   children.push(xmlSelfClose("c:showVal", { val: dl.showValue ? 1 : 0 }));
   children.push(xmlSelfClose("c:showCatName", { val: dl.showCategoryName ? 1 : 0 }));
   children.push(xmlSelfClose("c:showSerName", { val: dl.showSeriesName ? 1 : 0 }));

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4502,3 +4502,208 @@ describe("cloneChart — axis lblAlgn", () => {
     expect(written).toContain('c:lblAlgn val="l"');
   });
 });
+
+// ── cloneChart — data labels showLegendKey ──────────────────────────
+
+describe("cloneChart — data labels showLegendKey", () => {
+  const sourceWithLegendKey: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    dataLabels: { showValue: true, showLegendKey: true },
+  };
+
+  it("inherits chart-level showLegendKey from the source by default", () => {
+    const clone = cloneChart(sourceWithLegendKey, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels?.showLegendKey).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+  });
+
+  it("drops the inherited showLegendKey when chart-level dataLabels override is null", () => {
+    const clone = cloneChart(sourceWithLegendKey, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("replaces the dataLabels block wholesale, dropping the inherited showLegendKey", () => {
+    const clone = cloneChart(sourceWithLegendKey, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showCategoryName: true },
+    });
+    // The override is wholesale — the inherited showLegendKey does not
+    // bleed through.
+    expect(clone.dataLabels).toEqual({ showCategoryName: true });
+  });
+
+  it("can pin showLegendKey via a chart-level dataLabels override", () => {
+    const noLegendKey: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      dataLabels: { showValue: true },
+    };
+    const clone = cloneChart(noLegendKey, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, showLegendKey: true },
+    });
+    expect(clone.dataLabels).toEqual({ showValue: true, showLegendKey: true });
+  });
+
+  it("inherits showLegendKey on per-series dataLabels by default", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, showLegendKey: true, position: "ctr" },
+        },
+      ],
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].dataLabels).toEqual({
+      showValue: true,
+      showLegendKey: true,
+      position: "ctr",
+    });
+  });
+
+  it("drops the per-series showLegendKey when the override is null", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, showLegendKey: true },
+        },
+      ],
+    };
+    const clone = cloneChart(src, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ dataLabels: null }],
+    });
+    expect(clone.series[0].dataLabels).toBeUndefined();
+  });
+
+  it("replaces per-series dataLabels via seriesOverrides, dropping the inherited showLegendKey", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, showLegendKey: true },
+        },
+      ],
+    };
+    const clone = cloneChart(src, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ dataLabels: { showCategoryName: true } }],
+    });
+    // Wholesale replacement — the inherited showLegendKey does not bleed
+    // through.
+    expect(clone.series[0].dataLabels).toEqual({ showCategoryName: true });
+  });
+
+  it("composes showLegendKey alongside other show* toggles and a position", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      dataLabels: {
+        showValue: true,
+        showCategoryName: true,
+        showLegendKey: true,
+        position: "outEnd",
+        separator: " | ",
+      },
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toEqual({
+      showValue: true,
+      showCategoryName: true,
+      showLegendKey: true,
+      position: "outEnd",
+      separator: " | ",
+    });
+  });
+
+  it("carries showLegendKey through a chart-type coercion (bar -> line)", () => {
+    const lineClone = cloneChart(sourceWithLegendKey, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(lineClone.type).toBe("line");
+    expect(lineClone.dataLabels?.showLegendKey).toBe(true);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves showLegendKey", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:dLbls>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="1"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.dataLabels?.showLegendKey).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.dataLabels?.showLegendKey).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const dLbls = written.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:showLegendKey val="1"/>');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.showLegendKey).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with showLegendKey intact", async () => {
+    const clone = cloneChart(sourceWithLegendKey, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const dLbls = written.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:showLegendKey val="1"/>');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4167,3 +4167,158 @@ describe("writeChart — legendOverlay", () => {
     expect(legend).toContain('c:overlay val="1"');
   });
 });
+
+// ── writeChart — data labels showLegendKey ──────────────────────────
+
+describe("writeChart — data labels showLegendKey", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it('emits <c:showLegendKey val="0"/> by default when chart-level dataLabels is set', () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:showLegendKey val="0"/>');
+  });
+
+  it('emits <c:showLegendKey val="1"/> when chart-level showLegendKey=true', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, showLegendKey: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:showLegendKey val="1"/>');
+  });
+
+  it('treats showLegendKey=false the same as omitting the field (val="0")', () => {
+    const explicit = writeChart(
+      makeChart({ dataLabels: { showValue: true, showLegendKey: false } }),
+      "Sheet1",
+    ).chartXml;
+    const implicit = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(explicit).toEqual(implicit);
+  });
+
+  it('collapses non-boolean inputs to the default val="0"', () => {
+    // A stray non-boolean leaking past the type guard (e.g. 1 / "true" /
+    // null) must collapse to the default rather than emit something Excel
+    // would reject.
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, showLegendKey: 1 as unknown as boolean },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:showLegendKey val="0"/>');
+  });
+
+  it("emits showLegendKey first among the show* toggles (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, showLegendKey: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const idxLk = dLbls.indexOf("<c:showLegendKey");
+    const idxVal = dLbls.indexOf("<c:showVal");
+    const idxCat = dLbls.indexOf("<c:showCatName");
+    const idxSer = dLbls.indexOf("<c:showSerName");
+    const idxPct = dLbls.indexOf("<c:showPercent");
+    const idxBub = dLbls.indexOf("<c:showBubbleSize");
+    expect(idxLk).toBeGreaterThan(0);
+    expect(idxLk).toBeLessThan(idxVal);
+    expect(idxVal).toBeLessThan(idxCat);
+    expect(idxCat).toBeLessThan(idxSer);
+    expect(idxSer).toBeLessThan(idxPct);
+    expect(idxPct).toBeLessThan(idxBub);
+  });
+
+  it("emits exactly one <c:showLegendKey> per <c:dLbls> block", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, showLegendKey: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect((dLbls.match(/<c:showLegendKey /g) ?? []).length).toBe(1);
+  });
+
+  it("places <c:showLegendKey> after <c:dLblPos> when the position is set", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, position: "outEnd", showLegendKey: true },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("<c:dLblPos")).toBeLessThan(dLbls.indexOf("<c:showLegendKey"));
+  });
+
+  it("threads showLegendKey through a series-level <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({
+        series: [
+          {
+            name: "S1",
+            values: "B2:B4",
+            dataLabels: { showValue: true, showLegendKey: true },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const serStart = xml.indexOf("<c:ser>");
+    const serEnd = xml.indexOf("</c:ser>");
+    const inner = xml.slice(serStart, serEnd);
+    expect(inner).toContain('<c:showLegendKey val="1"/>');
+  });
+
+  it("threads showLegendKey through pie / line / scatter chart families", () => {
+    for (const type of ["pie", "line", "scatter"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, showLegendKey: true } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('<c:showLegendKey val="1"/>');
+    }
+  });
+
+  it("round-trips a chart with showLegendKey=true through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, showLegendKey: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.showLegendKey).toBe(true);
+    expect(reparsed?.dataLabels?.showValue).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages a chart with showLegendKey=true", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, showLegendKey: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const dLbls = chartXml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:showLegendKey val="1"/>');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -4910,3 +4910,208 @@ describe("parseChart — legendOverlay", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — data labels showLegendKey ──────────────────────────
+
+describe("parseChart — data labels showLegendKey", () => {
+  const NS_LK = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces showLegendKey=true on chart-level dLbls when val="1"', () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:dLblPos val="outEnd"/>
+        <c:showLegendKey val="1"/>
+        <c:showVal val="1"/>
+        <c:showCatName val="0"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="0"/>
+        <c:showBubbleSize val="0"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({
+      position: "outEnd",
+      showLegendKey: true,
+      showValue: true,
+    });
+  });
+
+  it('collapses the OOXML default val="0" to undefined', () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="0"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLegendKey).toBeUndefined();
+    expect(chart?.dataLabels?.showValue).toBe(true);
+  });
+
+  it("collapses absence of <c:showLegendKey> to undefined", () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLegendKey).toBeUndefined();
+  });
+
+  it('accepts the OOXML truthy spelling val="true"', () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="true"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLegendKey).toBe(true);
+  });
+
+  it('accepts the OOXML falsy spelling val="false" and collapses to undefined', () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="false"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLegendKey).toBeUndefined();
+  });
+
+  it("ignores unknown val tokens", () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="yes"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLegendKey).toBeUndefined();
+  });
+
+  it("returns undefined when <c:showLegendKey> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLegendKey).toBeUndefined();
+  });
+
+  it("makes showLegendKey alone enough to surface a dataLabels record", () => {
+    // Even when no value/category/series/percent toggle is on, a pinned
+    // showLegendKey=true is still meaningful — Excel renders the legend
+    // swatch beside each (otherwise empty) label slot. The reader must
+    // not collapse the block to undefined in that case.
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="1"/>
+        <c:showVal val="0"/>
+        <c:showCatName val="0"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="0"/>
+        <c:showBubbleSize val="0"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({ showLegendKey: true });
+  });
+
+  it("surfaces showLegendKey on a series-level <c:dLbls>", () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:tx><c:v>Revenue</c:v></c:tx>
+        <c:dLbls>
+          <c:dLblPos val="ctr"/>
+          <c:showLegendKey val="1"/>
+          <c:showVal val="1"/>
+        </c:dLbls>
+        <c:val><c:numRef><c:f>S!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].dataLabels).toEqual({
+      position: "ctr",
+      showLegendKey: true,
+      showValue: true,
+    });
+  });
+
+  it("co-surfaces showLegendKey alongside other show toggles and separator", () => {
+    const xml = `<c:chartSpace ${NS_LK}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:dLblPos val="bestFit"/>
+        <c:showLegendKey val="1"/>
+        <c:showVal val="1"/>
+        <c:showCatName val="1"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="1"/>
+        <c:showBubbleSize val="0"/>
+        <c:separator>; </c:separator>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({
+      position: "bestFit",
+      showLegendKey: true,
+      showValue: true,
+      showCategoryName: true,
+      showPercent: true,
+      separator: "; ",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the `<c:showLegendKey>` element on `<c:dLbls>` at the read, write, and clone layers so a template's `showLegendKey` toggle survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:showLegendKey>` mirrors Excel's "Format Data Labels -> Legend Key" checkbox — when on, Excel paints the legend's color swatch (the small marker / bar shown in the chart legend) inline with every data label. The element lives on `CT_DLbls`, which appears at both the chart-type level (`<c:barChart><c:dLbls>` etc.) and the per-series level (`<c:ser><c:dLbls>`), so the flag threads through every chart family that supports data labels (bar / column / line / area / pie / doughnut / scatter).

Up until now hucre's writer always pinned `val="0"`, so a template that pinned `val="1"` flattened back to the default on every parse -> clone -> write loop. This bridges another data-label-configuration gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.dataLabels?.showLegendKey); // true (template pinned val="1")

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ values: "B2:B10", categories: "A2:A10" }],
      dataLabels: {
        showValue: true,
        showLegendKey: true, // paint the legend swatch beside every label
        position: "outEnd",
      },
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  // dataLabels: undefined  -> inherit (showLegendKey: true carries through)
  // dataLabels: null       -> drop the inherited block entirely
  // dataLabels: { ... }    -> wholesale replace (no per-field merge)
});
```

## Model

```ts
export interface ChartDataLabels {
  // ...existing fields...
  showLegendKey?: boolean;
}

export interface ChartDataLabelsInfo {
  // ...existing fields...
  showLegendKey?: boolean;
}
```

## Scope rules

- Element appears at both the chart-type-level and per-series `<c:dLbls>`. The flag follows the existing `dataLabels` resolution path on both layers (chart-level + series overrides via `seriesOverrides[i].dataLabels`).
- Default `false` (no legend swatch) collapses to `undefined` on read so absence and the OOXML default round-trip identically.
- Non-boolean inputs collapse to `false` on the writer side to keep the on-the-wire output stable, mirroring how the other `show*` toggles (showValue / showCategoryName / showSeriesName / showPercent) treat their inputs.
- A `<c:dLbls>` block whose only meaningful flag is `showLegendKey: true` (every other show toggle off, no position, no separator) still surfaces on the read side — Excel renders the swatch beside otherwise-empty label slots.
- Element ordering inside `<c:dLbls>` follows CT_DLbls: `dLblPos` (when set) before `showLegendKey` before `showVal` / `showCatName` / `showSerName` / `showPercent` / `showBubbleSize` before `separator`.

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest) — 3281 tests passing.
- [x] `pnpm build` — obuild succeeds.
- [x] `parseChart` covers truthy / falsy spellings, default collapse, missing `val`, unknown tokens, the showLegendKey-alone-surfaces case, series-level surfacing, and co-surfacing with other show toggles + separator.
- [x] `writeChart` covers default `val="0"` emit, true emit, false-equals-omit, non-boolean fallback, exactly-one-emit guard, OOXML element ordering, series-level threading, multi-family threading (pie / line / scatter), and end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace, per-series inherit / null / wholesale-replace, composition with other show toggles + position + separator, chart-type coercion (bar -> line) carry, and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.