### PR TITLE
feat(xlsx): chart title overlay flag — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,17 @@ missing `val` attributes drop to `undefined`. The flag is dropped
 whenever `Chart.legend` is `false` or the chart omits the legend
 element entirely — there is no overlay slot on a hidden legend, so the
 parsed shape stays minimal.
+`Chart.titleOverlay` surfaces the title-overlay flag pulled from
+`<c:title><c:overlay val=".."/></c:title>` — Excel's "Format Chart
+Title → Show the title without overlapping the chart" toggle (the
+checkbox is the inverse of this flag — checked means `false`, unchecked
+means `true`). The OOXML default `false` collapses to `undefined` so
+absence and `<c:overlay val="0"/>` round-trip identically; only an
+explicit `val="1"` surfaces `true`. The reader accepts the OOXML
+truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
+unknown values and missing `val` attributes drop to `undefined`. The
+flag is dropped whenever the chart omits the `<c:title>` element
+entirely — there is no overlay slot to surface in that case.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -960,6 +971,19 @@ on top of the plot area so the chart series get the full frame
 (`val="1"`). The flag is silently ignored when `legend: false`
 suppresses the entire legend element — there is no overlay slot on a
 hidden legend, so the writer skips emitting any orphaned `<c:overlay>`.
+The chart-level `titleOverlay` field maps to `<c:overlay val=".."/>`
+inside `<c:title>` — Excel's "Format Chart Title → Show the title
+without overlapping the chart" toggle (the checkbox is the inverse of
+this flag — checked means `false`, unchecked means `true`). Absent it,
+the writer emits the OOXML default `val="0"` (the title reserves its
+own slot above the plot area and the plot area shrinks to make room),
+matching Excel's reference serialization. Pin `titleOverlay: true` to
+draw the title on top of the plot area so the chart series get the
+full frame (`val="1"`). The flag is silently ignored when no title is
+emitted (no `title` set or `showTitle: false`) — there is no `<c:title>`
+block to host the overlay child in either case. Independent of
+`legendOverlay`: the legend and title `<c:overlay>` elements live on
+different parents, so the two flags compose freely.
 The `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` fields thin out a
 crowded category axis (`<c:catAx><c:tickLblSkip val=".."/>` and
 `<c:catAx><c:tickMarkSkip val=".."/>`). Pass a positive integer to
@@ -1210,6 +1234,17 @@ from the cloned `SheetChart` whenever the resolved `legend` is `false`
 inherited `true` would carry no on-screen effect. Re-enabling a hidden
 source legend through `legend: "top"` (or any visible position) on the
 override re-opens the slot, and an explicit `legendOverlay: true`
+override threads through.
+The chart-level `titleOverlay` flag follows the same grammar: pass
+`undefined` to inherit the source's parsed value, `null` to drop it
+back to the writer's OOXML `false` default (no overlap with the plot
+area), or a `boolean` to replace it. The flag lives on `<c:title>` so
+the field is valid on every chart family, but it is silently dropped
+from the cloned `SheetChart` whenever the resolved chart renders no
+title (`title` resolved to `undefined` or `showTitle: false`) — there
+is no `<c:title>` block to host the overlay flag in either case.
+Re-introducing a missing source title through an explicit `title:
+"..."` override re-opens the slot, and an explicit `titleOverlay: true`
 override threads through.
 The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
 follow the same `undefined` (inherit) / `null` (drop) / number

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -960,6 +960,23 @@ export interface SheetChart {
   legendOverlay?: boolean;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
+  /**
+   * Whether the chart title overlaps the plot area. Maps to
+   * `<c:title><c:overlay val=".."/></c:title>` — Excel's "Format Chart
+   * Title -> Show the title without overlapping the chart" toggle (the
+   * checkbox is the inverse of this flag — checked means `false`,
+   * unchecked means `true`). Default: `false` (the OOXML default Excel
+   * itself emits) — the title reserves its own slot above the plot area
+   * and the plot area shrinks to accommodate it. Set `true` to draw the
+   * title on top of the plot area so the chart series get the full frame.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false` or
+   * `title` is absent) — there is no `<c:title>` element to host the
+   * overlay flag in either case. Independent of {@link legendOverlay}:
+   * the legend's `<c:overlay>` lives on `<c:legend>`, while this one
+   * lives on `<c:title>`, so the two flags compose freely.
+   */
+  titleOverlay?: boolean;
   /** Alternative text for screen readers (lands in xdr:cNvPr/@descr). */
   altText?: string;
   /** Caption for the chart frame (lands in xdr:cNvPr/@title). */
@@ -2347,6 +2364,23 @@ export interface Chart {
    * overlay flag to surface in either case.
    */
   legendOverlay?: boolean;
+  /**
+   * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
+   * Reflects Excel's "Format Chart Title -> Show the title without
+   * overlapping the chart" toggle (the checkbox is the inverse — checked
+   * means `false`, unchecked means `true`).
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<c:overlay val="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<c:overlay val="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings (`"1"`
+   * / `"true"` / `"0"` / `"false"`); unknown values and missing `val`
+   * attributes drop to `undefined`.
+   *
+   * Reported as `undefined` whenever the source chart has no `<c:title>`
+   * element at all — there is no overlay flag to surface in that case.
+   */
+  titleOverlay?: boolean;
   /**
    * Grouping pulled from the first `<c:barChart>` element, when the
    * chart has one. Surfaces only the stacked variants — the OOXML

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -187,6 +187,19 @@ export interface CloneChartOptions {
   firstSliceAng?: number;
   /** Override `SheetChart.showTitle`. */
   showTitle?: boolean;
+  /**
+   * Override the chart-level title-overlay flag. `undefined` (or
+   * omitted) inherits the source's parsed value; `null` drops the
+   * inherited value (the writer falls back to the OOXML `false` default
+   * — the title reserves its own slot above the plot area, no overlap);
+   * a `boolean` replaces it.
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved chart renders no title (`title` resolved to `undefined`
+   * or `showTitle === false`) — there is no `<c:title>` block to host
+   * the overlay flag in either case.
+   */
+  titleOverlay?: boolean | null;
   /** Override `SheetChart.altText`. */
   altText?: string;
   /** Override `SheetChart.frameTitle`. */
@@ -542,6 +555,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (options.showTitle !== undefined) out.showTitle = options.showTitle;
   if (options.altText !== undefined) out.altText = options.altText;
   if (options.frameTitle !== undefined) out.frameTitle = options.frameTitle;
+
+  // `titleOverlay` only renders inside `<c:title>`, so a clone that
+  // omits the title (resolved title is undefined or `showTitle === false`)
+  // drops the inherited overlay flag — there is no `<c:overlay>` slot on
+  // a missing title for the writer to populate. The override wins over
+  // the source's parsed value; absence inherits, `null` drops, a `boolean`
+  // replaces. Mirrors the legendOverlay scoping rule.
+  const titleRendered = (out.showTitle ?? Boolean(out.title)) && out.title !== undefined;
+  if (titleRendered) {
+    const resolvedTitleOverlay = resolveTitleOverlay(source.titleOverlay, options.titleOverlay);
+    if (resolvedTitleOverlay !== undefined) out.titleOverlay = resolvedTitleOverlay;
+  }
 
   const resolvedDataLabels = resolveChartDataLabels(source.dataLabels, options.dataLabels);
   if (resolvedDataLabels !== undefined) out.dataLabels = resolvedDataLabels;
@@ -953,6 +978,29 @@ function resolveRoundedCorners(
  * is emitted, the overlay flag has no slot in the rendered chart.
  */
 function resolveLegendOverlay(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `titleOverlay` override.
+ *
+ * `undefined` → inherit the source's parsed `titleOverlay`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML `false` default — the title reserves its own slot
+ *               above the plot area, no overlap with it).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `legendOverlay` / `roundedCorners` so the chart-
+ * level overlay toggles compose the same way at the call site. Callers
+ * should gate the result on the resolved title visibility — when no
+ * title is emitted, the overlay flag has no slot in the rendered chart.
+ */
+function resolveTitleOverlay(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -80,6 +80,14 @@ export function parseChart(xml: string): Chart | undefined {
   const title = parseTitle(chartEl);
   if (title !== undefined) out.title = title;
 
+  // `<c:overlay>` is a child of `<c:title>`, so a chart that omits the
+  // title element has no overlay flag to surface — pulling the value
+  // off a `<c:title>` that is not part of the chart's render would leak
+  // a toggle that has no effect. Only attempt the parse when the chart
+  // declares a title element.
+  const titleOverlay = parseTitleOverlay(chartEl);
+  if (titleOverlay !== undefined) out.titleOverlay = titleOverlay;
+
   const plotArea = findChild(chartEl, "plotArea");
   if (plotArea) {
     let seriesCount = 0;
@@ -1247,6 +1255,44 @@ function parseLegendOverlay(chartEl: XmlElement): boolean | undefined {
     case "false":
       // OOXML default — collapse to undefined for symmetry with the
       // writer's `legendOverlay` field.
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pull `<c:title><c:overlay val=".."/></c:title>` off the chart. The
+ * OOXML default `false` (the title reserves its own slot above the plot
+ * area, no overlap) collapses to `undefined` so absence and
+ * `<c:overlay val="0"/>` round-trip identically through
+ * {@link cloneChart} — only an explicit `<c:overlay val="1"/>` surfaces
+ * `true`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` element
+ * — there is no overlay slot to surface in that case. The element is a
+ * sibling of `<c:tx>` inside `<c:title>` per the CT_Title schema, so the
+ * lookup is scoped to direct title children.
+ *
+ * Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"`
+ * / `"false"`); unknown values and missing `val` attributes drop to
+ * `undefined` rather than fabricate a flag Excel would not emit.
+ */
+function parseTitleOverlay(chartEl: XmlElement): boolean | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const overlay = findChild(title, "overlay");
+  if (!overlay) return undefined;
+  const raw = overlay.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `titleOverlay` field.
       return undefined;
     default:
       return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -61,7 +61,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
   // ── Title ──
   if (showTitle && chart.title) {
-    chartChildren.push(buildTitle(chart.title));
+    chartChildren.push(buildTitle(chart.title, resolveTitleOverlay(chart)));
     chartChildren.push(xmlSelfClose("c:autoTitleDeleted", { val: 0 }));
   } else {
     chartChildren.push(xmlSelfClose("c:autoTitleDeleted", { val: 1 }));
@@ -101,7 +101,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
 // ── Title ────────────────────────────────────────────────────────────
 
-function buildTitle(title: string): string {
+function buildTitle(title: string, overlay: boolean): string {
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -127,8 +127,34 @@ function buildTitle(title: string): string {
         ]),
       ]),
     ]),
-    xmlSelfClose("c:overlay", { val: 0 }),
+    xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }),
   ]);
+}
+
+/**
+ * Resolve `<c:title><c:overlay val=".."/></c:title>` from
+ * {@link SheetChart.titleOverlay}.
+ *
+ * Defaults to `false` (the OOXML default Excel itself emits — the title
+ * reserves its own slot above the plot area and the plot area shrinks
+ * to make room). Anything other than literal `true` collapses to `false`
+ * so a stray non-boolean leaking through the type guard (e.g. `0` / `1` /
+ * `"true"` / `null`) never produces `<c:overlay val="1"/>`. This matches
+ * how `legendOverlay` / `roundedCorners` / `plotVisOnly` / axis `hidden`
+ * treat their inputs: a literal boolean is the only path to a non-default
+ * value.
+ *
+ * The writer always emits `<c:overlay>` inside `<c:title>` because Excel's
+ * reference serialization includes the element on every visible title;
+ * only the `val` flips when the caller pins `titleOverlay: true`.
+ *
+ * The flag is only meaningful when the chart actually emits a title — the
+ * caller is expected to gate the call on `showTitle && chart.title`. A
+ * chart whose title is suppressed has no `<c:title>` block to host the
+ * overlay element.
+ */
+function resolveTitleOverlay(chart: SheetChart): boolean {
+  return chart.titleOverlay === true;
 }
 
 // ── Plot Area ────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4690,3 +4690,225 @@ describe("cloneChart — axis noMultiLvlLbl", () => {
     expect(written).toContain('c:noMultiLvlLbl val="1"');
   });
 });
+
+// ── cloneChart — titleOverlay ────────────────────────────────────────
+
+describe("cloneChart — titleOverlay", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleOverlay by default", () => {
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("lets options.titleOverlay override the source's value", () => {
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleOverlay: false,
+    });
+    expect(clone.titleOverlay).toBe(false);
+  });
+
+  it("drops the inherited titleOverlay when the override is null", () => {
+    // null collapses to the writer's OOXML default — the field
+    // disappears from the resolved SheetChart so the writer emits the
+    // default `0` (no overlap with the plot area).
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleOverlay: null,
+    });
+    expect(clone.titleOverlay).toBeUndefined();
+  });
+
+  it("returns undefined titleOverlay when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleOverlay).toBeUndefined();
+  });
+
+  it("carries titleOverlay through a flatten (line → column)", () => {
+    // titleOverlay lives on `<c:title>` and is valid on every chart
+    // family that emits a title, so a coercion does not drop it.
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("carries titleOverlay through a doughnut flatten (line → doughnut)", () => {
+    // Pie / doughnut both render the chart-level title block, so the
+    // overlay flag must survive coercion into either family.
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("drops the inherited titleOverlay when the resolved title is dropped", () => {
+    // `title: null` on the override flattens the inherited title — no
+    // `<c:title>` element will be emitted, so the inherited overlay
+    // flag has no slot in the rendered chart and the clone collapses it.
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleOverlay).toBeUndefined();
+  });
+
+  it("drops the inherited titleOverlay when showTitle is set to false", () => {
+    // `showTitle: false` suppresses the title block on the writer side,
+    // so the inherited overlay flag would never render. The clone
+    // collapses the field to keep the SheetChart honest.
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.showTitle).toBe(false);
+    expect(clone.titleOverlay).toBeUndefined();
+  });
+
+  it("drops the titleOverlay override when the resolved chart has no title", () => {
+    // Same guard, this time on the override path — pinning title:null
+    // wins over an explicit overlay override too.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+      titleOverlay: true,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleOverlay).toBeUndefined();
+  });
+
+  it("retains the titleOverlay override when the override re-introduces a missing source title", () => {
+    // Source had no title (so titleOverlay would normally be undefined),
+    // but the override pins a title — the overlay flag the override
+    // carries must thread through.
+    const clone = cloneChart(source({ title: undefined }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "New Title",
+      titleOverlay: true,
+    });
+    expect(clone.title).toBe("New Title");
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("composes independently with the legendOverlay clone-through", () => {
+    // The two overlay flags live on different parents and must not
+    // collide on the clone-through.
+    const clone = cloneChart(
+      source({ titleOverlay: true, legend: "right", legendOverlay: false }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleOverlay).toBe(true);
+    expect(clone.legendOverlay).toBe(false);
+  });
+
+  it("propagates titleOverlay into the rendered <c:title> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const title = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="1"');
+    expect(title).not.toContain('c:overlay val="0"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleOverlay).toBe(true);
+  });
+
+  it("emits the OOXML default titleOverlay=0 when both source and override are absent", async () => {
+    // A bare clone with no overlay hint rolls into a SheetChart whose
+    // writer emits the default `0` and re-parses to undefined.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const title = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="0"');
+    expect(parseChart(written)?.titleOverlay).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins `true`, clone overrides to `false` — the rendered
+    // chart should carry the override and re-parse to undefined (since
+    // `false` is the OOXML default and collapses on read).
+    const clone = cloneChart(source({ titleOverlay: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      titleOverlay: false,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const title = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="0"');
+    expect(title).not.toContain('c:overlay val="1"');
+    expect(parseChart(written)?.titleOverlay).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4317,3 +4317,162 @@ describe("writeChart — axis noMultiLvlLbl", () => {
     expect(chartXml).toContain('c:noMultiLvlLbl val="1"');
   });
 });
+
+// ── writeChart — title overlay ───────────────────────────────────────
+
+describe("writeChart — titleOverlay", () => {
+  it('emits <c:overlay val="0"/> inside <c:title> when the field is unset (OOXML default)', () => {
+    // The writer always emits the element so the rendered intent is
+    // explicit on roundtrip — Excel itself includes it in every
+    // reference title serialization.
+    const result = writeChart(makeChart(), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="0"');
+    expect(title).not.toContain('c:overlay val="1"');
+  });
+
+  it("threads titleOverlay=true through to <c:title>", () => {
+    // true is the non-default — Excel's "Show the title without
+    // overlapping the chart" toggle off (the title is drawn on top of
+    // the plot area).
+    const result = writeChart(makeChart({ titleOverlay: true }), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="1"');
+    expect(title).not.toContain('c:overlay val="0"');
+  });
+
+  it("threads titleOverlay=false through to <c:title>", () => {
+    // Setting the OOXML default explicitly produces the same wire shape
+    // as omitting the field — the element is always emitted.
+    const result = writeChart(makeChart({ titleOverlay: false }), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="0"');
+  });
+
+  it("places <c:overlay> after <c:tx> inside <c:title> (CT_Title order)", () => {
+    // CT_Title sequence: tx?, layout?, overlay?, ...
+    const result = writeChart(makeChart({ titleOverlay: true }), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title.indexOf("c:tx")).toBeLessThan(title.indexOf("c:overlay"));
+  });
+
+  it("only emits <c:overlay> once inside <c:title> even on a chart that overrides it", () => {
+    // Guard against any regression that would double-emit the element
+    // (e.g. one hardcoded copy plus a dynamic one). Scope the count to
+    // the title — the legend also carries its own `<c:overlay>`.
+    const result = writeChart(makeChart({ titleOverlay: true }), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    const occurrences = title.match(/c:overlay/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:title> when the chart has no title", () => {
+    // No title means no title block to host the overlay flag — the
+    // writer suppresses the entire `<c:title>` element. The chart still
+    // emits `<c:autoTitleDeleted val="1"/>` so the picker shows blank.
+    const result = writeChart(makeChart({ title: undefined, titleOverlay: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+    // The legend still carries its own `<c:overlay>`; the chart-level
+    // title block has none.
+    expect(result.chartXml).toContain('c:autoTitleDeleted val="1"');
+  });
+
+  it("does not emit any <c:title> when showTitle=false even with titleOverlay", () => {
+    // `showTitle: false` suppresses the title block entirely — the
+    // writer drops the inherited overlay flag rather than emit a stray
+    // overlay child Excel would never read.
+    const result = writeChart(makeChart({ showTitle: false, titleOverlay: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+    expect(result.chartXml).toContain('c:autoTitleDeleted val="1"');
+  });
+
+  it("threads titleOverlay through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, titleOverlay: true }), "Sheet1");
+      const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+      expect(title).toContain('c:overlay val="1"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        titleOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const title = scatter.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="1"');
+  });
+
+  it("composes independently with legendOverlay", () => {
+    // The two flags live on different parents (`<c:title>` vs
+    // `<c:legend>`); pinning one must not change the other.
+    const result = writeChart(makeChart({ titleOverlay: true, legendOverlay: false }), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(title).toContain('c:overlay val="1"');
+    expect(legend).toContain('c:overlay val="0"');
+  });
+
+  it("round-trips a non-default titleOverlay value through parseChart", () => {
+    // A chart with titleOverlay=true should re-parse into a Chart whose
+    // `titleOverlay` field is `true` (not collapsed to undefined since
+    // true is not the OOXML default).
+    const written = writeChart(makeChart({ titleOverlay: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleOverlay).toBe(true);
+  });
+
+  it("collapses a defaulted titleOverlay round-trip back to undefined", () => {
+    // A fresh chart (titleOverlay omitted) writes `0` and re-parses to
+    // undefined — absence and the OOXML default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleOverlay).toBeUndefined();
+  });
+
+  it("collapses an explicit titleOverlay=false round-trip back to undefined", () => {
+    // Pinning the OOXML default also collapses on read, so a template
+    // that explicitly emits `<c:overlay val="0"/>` is treated the same
+    // as one that omits the field.
+    const written = writeChart(makeChart({ titleOverlay: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleOverlay).toBeUndefined();
+  });
+
+  it("ignores non-boolean titleOverlay values", () => {
+    // Match how `legendOverlay` / `roundedCorners` / axis hidden treat
+    // their inputs: only literal `true` produces the non-default. A
+    // stray non-boolean (e.g. truthy string) collapses to the default.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ titleOverlay: "yes" as any }), "Sheet1");
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="0"');
+  });
+
+  it("survives a writeXlsx round trip — titleOverlay lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            titleOverlay: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const title = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain('c:overlay val="1"');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5094,3 +5094,211 @@ describe("parseChart — axis noMultiLvlLbl", () => {
     });
   });
 });
+
+// ── parseChart — titleOverlay ───────────────────────────────────────
+
+describe("parseChart — titleOverlay", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitle(overlay?: string): string {
+    const overlayElement = overlay === undefined ? "" : `<c:overlay val="${overlay}"/>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      ${overlayElement}
+    </c:title>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces <c:title><c:overlay val="1"/></c:title> as true (non-default)', () => {
+    const chart = parseChart(withTitle("1"));
+    expect(chart?.title).toBe("Sales");
+    expect(chart?.titleOverlay).toBe(true);
+  });
+
+  it("collapses the OOXML default false to undefined (writer absence)", () => {
+    // The default carried explicitly by Excel's reference serialization
+    // round-trips identically to absence of the field.
+    const chart = parseChart(withTitle("0"));
+    expect(chart?.title).toBe("Sales");
+    expect(chart?.titleOverlay).toBeUndefined();
+  });
+
+  it("returns undefined when the title element omits <c:overlay>", () => {
+    const chart = parseChart(withTitle());
+    expect(chart?.title).toBe("Sales");
+    expect(chart?.titleOverlay).toBeUndefined();
+  });
+
+  it("accepts the OOXML true / false spellings on the val attribute", () => {
+    // The OOXML schema for `xsd:boolean` accepts `"true"` / `"false"`
+    // alongside `"1"` / `"0"`. Hucre tolerates both shapes — a hand-
+    // edited template using `true` should round-trip.
+    expect(parseChart(withTitle("true"))?.titleOverlay).toBe(true);
+  });
+
+  it("collapses the 'false' spelling to undefined as well", () => {
+    expect(parseChart(withTitle("false"))?.titleOverlay).toBeUndefined();
+  });
+
+  it("drops unknown overlay values rather than fabricate one", () => {
+    expect(parseChart(withTitle("bogus"))?.titleOverlay).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:overlay>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      <c:overlay/>
+    </c:title>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleOverlay).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element at all", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBeUndefined();
+    expect(chart?.titleOverlay).toBeUndefined();
+  });
+
+  it("surfaces the overlay flag on every chart family that emits a title", () => {
+    // The element lives on <c:title>, a chart-level sibling of
+    // <c:plotArea>, so it round-trips identically across families. Pie
+    // / doughnut / line / bar all support the title block identically.
+    for (const kind of ["lineChart", "barChart", "pieChart", "doughnutChart"]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:r><a:t>Header</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:${kind}><c:ser><c:idx val="0"/></c:ser></c:${kind}>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      const chart = parseChart(xml);
+      expect(chart?.titleOverlay).toBe(true);
+    }
+  });
+
+  it("co-exists independently with the legend overlay flag", () => {
+    // The chart-title `<c:overlay>` lives on `<c:title>`, while the
+    // legend `<c:overlay>` lives on `<c:legend>`; the two flags must
+    // surface independently from the same chart even though they share
+    // a local element name.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleOverlay).toBe(true);
+    expect(chart?.legendOverlay).toBeUndefined();
+  });
+
+  it("co-exists with other chart-level toggles", () => {
+    // The title overlay flag should not interfere with sibling chart-
+    // level fields parsed off <c:chart> / <c:chartSpace>.
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="1"/>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Sales");
+    expect(chart?.titleOverlay).toBe(true);
+    expect(chart?.roundedCorners).toBe(true);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+
+  it("does not pull <c:overlay> from a sibling element by mistake", () => {
+    // The reader must scope the lookup to direct `<c:title>` children
+    // — if the title omits an `<c:overlay>` but the legend has one,
+    // the title flag must not pick up the legend's value.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="1"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleOverlay).toBeUndefined();
+    expect(chart?.legendOverlay).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:overlay val=".."/></c:title>` at the read, write, and clone layers so a template's chart-title overlay survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:title><c:overlay>` mirrors Excel's "Format Chart Title -> Show the title without overlapping the chart" toggle (the checkbox is the inverse of the flag — checked means `false`, unchecked means `true`). `val=1` draws the title on top of the plot area so the chart series get the full frame; `val=0` reserves a slot for the title above the plot area and shrinks the plot area to make room.

Up until now hucre's writer always pinned `val=0`, so a template that overlapped its title flattened back to a vertically-stacked title on every parse -> clone -> write loop. Sibling of the existing `legendOverlay` flag — both elements share a local name but live on different parents (`<c:title>` vs `<c:legend>`), so the two compose freely. This bridges another chart-level gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleOverlay); // true when the template pinned val="1",
                                  // undefined when the template used the default 0

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      title: "Revenue",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      titleOverlay: true,  // title draws on top of the plot area
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  titleOverlay: true,    // replace
  // titleOverlay: null  // drop the inherited overlay (writer falls back to 0)
  // titleOverlay: undefined // inherit the source's parsed value
});
```

## Model

```ts
interface SheetChart {
  // ...existing fields...
  titleOverlay?: boolean;
}

interface Chart {
  // ...existing fields...
  titleOverlay?: boolean;
}

interface CloneChartOptions {
  // ...existing fields...
  titleOverlay?: boolean | null;
}
```

The read-side `Chart.titleOverlay` mirrors the write-side `SheetChart.titleOverlay` so a parsed value slots straight back into `cloneChart` without transformation. Same shape as the existing `legendOverlay` / `roundedCorners` / `plotVisOnly` toggles.

## Behavior

- **Read** — `parseChart` pulls the value off `<c:title><c:overlay val=".."/></c:title>`. The OOXML default `false` (`val="0"`) collapses to `undefined` so absence and the default round-trip identically; only an explicit `val="1"` surfaces `true`. Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing `val` attributes drop to `undefined`. The flag is dropped whenever the chart omits the `<c:title>` element entirely. The lookup is scoped to direct `<c:title>` children, so a sibling's `<c:overlay>` (e.g. the legend's) cannot leak into the title flag.
- **Write** — `<c:overlay>` is always emitted inside `<c:title>` because Excel's reference serialization includes it on every visible title. The writer pins the caller's override when set; absence (and the default `false`) emit `val="0"` so untouched charts match Excel's reference output byte-for-byte. Non-boolean inputs collapse to `false`. The element sits after `<c:tx>` per the strict CT_Title schema sequence. When the chart renders no title (no `title` set or `showTitle: false`) the writer skips the entire `<c:title>` element so no orphan overlay can leak through.
- **Clone** — Each override accepts the standard `undefined` (inherit) / `null` (drop, writer falls back to `0`) / `boolean` (replace) grammar that mirrors `legendOverlay` / `roundedCorners`. The inherited value is silently dropped from the cloned `SheetChart` whenever the resolved chart renders no title (resolved `title` is `undefined` or `showTitle === false`) — a missing title has no overlay slot. Re-introducing a missing source title through `title: "..."` on the override re-opens the slot, and an explicit `titleOverlay: true` override threads through.

## Edge cases

- A chart with no `<c:title>` element parses to `titleOverlay: undefined`.
- An explicit `titleOverlay: true` override with `title: null` (or `showTitle: false`) collapses to `undefined` on the cloned `SheetChart`.
- Non-boolean `titleOverlay` inputs collapse to the OOXML `false` default rather than fabricate a flag.
- The element is emitted exactly once per title (the legend also carries its own `<c:overlay>` element, scoped to the legend block — they do not collide). The reader scopes its lookup to direct `<c:title>` children so a sibling's `<c:overlay>` cannot leak in.
- Pie / doughnut / line / bar / column / area / scatter all support the flag identically because `<c:title>` is a chart-level sibling of `<c:plotArea>`.
- Composes independently with `legendOverlay`: pinning one does not change the other on either the writer or the clone path.

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest) passes — 3325 vitest tests.
- [x] `pnpm build` succeeds.
- [x] 13 new `parseChart` tests cover the truthy / falsy spellings, default collapse, missing val, missing element, missing title, multi-family threading (line / bar / pie / doughnut), independence from legend overlay, sibling-element scoping, and co-surfacing alongside other chart-level toggles.
- [x] 14 new `writeChart` tests cover the default emit, true / false threading, OOXML element ordering, exactly-one-emit guard, missing-title and `showTitle: false` suppression, multi-family threading, independent composition with legend overlay, non-boolean fallback, parse-side round-trip (true / default / explicit-false), and end-to-end packaging via `writeXlsx`.
- [x] 15 new `cloneChart` tests cover inherit / null / replace grammar, chart-type coercion (line -> column / doughnut), missing-title / `showTitle: false` drop guards, override-wins-when-re-introducing-title, independent composition with `legendOverlay` clone-through, and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.