### PR TITLE
feat(xlsx): chart axis crosses / crossesAt — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,19 @@ collapse to `undefined` so absence and the default round-trip
 identically through `cloneChart`. Reverse can fire on either or both
 axes independently — bar / column / line / area / scatter all support
 it; pie / doughnut never report it because they have no axes.
+`ChartAxisInfo.crosses` and `ChartAxisInfo.crossesAt` surface the
+per-axis crossing pin — where the perpendicular axis crosses this axis
+along its own range. `crosses` mirrors the OOXML `ST_Crosses`
+enumeration (`"autoZero"` / `"min"` / `"max"`) on `<c:crosses>`;
+`crossesAt` carries the literal numeric pin from `<c:crossesAt>`. The
+two elements live in an XSD choice (only one may legally appear at a
+time), and the reader honours that schema by preferring `crossesAt`
+when both surface on a malformed template — mirroring the writer's
+emit order. The OOXML default `crosses: "autoZero"` collapses to
+`undefined`, but `crossesAt: 0` is preserved (a numeric pin at zero is
+distinct from the `"autoZero"` default which defers to Excel's
+auto-placement). Unknown semantic tokens and non-numeric `val`
+attributes drop rather than fabricate values the writer would reject.
 `Chart.roundedCorners` surfaces the chart-frame
 `<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
 Chart Area → Border → Rounded corners" toggle. The element sits on
@@ -856,7 +869,7 @@ charts; `lineGrouping` and `areaGrouping` accept
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
 attributes for screen readers.
-`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse } }`
+`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt } }`
 attaches per-axis labels, gridlines, numeric scaling, the tick-label
 number format and the tick-rendering trio — `x` lands inside
 `<c:catAx>` (or the X value axis for scatter), `y` inside the value
@@ -1044,6 +1057,21 @@ collapse to the forward `"minMax"` default. Each axis carries its own
 flag so reversing X never propagates to Y. Bar / column / line / area /
 scatter all honour both axes; pie / doughnut silently ignore the entire
 `axes` block since OOXML defines no axes for them.
+The `axes.x.crosses` / `axes.x.crossesAt` (and the matching `axes.y.*`)
+fields control where the perpendicular axis crosses this axis along its
+own range. `crosses` accepts the OOXML `ST_Crosses` tokens
+(`"autoZero"` / `"min"` / `"max"`) — Excel's "Format Axis -> Vertical
+axis crosses" toggle — and `crossesAt` accepts a literal numeric pin
+(useful when the perpendicular axis should cross at a specific value
+like `crossesAt: 100`). The two fields share an XSD choice in the
+schema (only `<c:crosses>` or `<c:crossesAt>` may legally appear at a
+time), so the writer favours `crossesAt` whenever it is set to a
+finite number — including `crossesAt: 0`, which pins the crossing
+point to the numeric value zero, distinct from the `"autoZero"`
+default. Non-finite numeric inputs and unknown semantic tokens drop
+silently to the `"autoZero"` default. The pin threads through bar /
+column / line / area / scatter; pie / doughnut silently ignore it
+because OOXML defines no axes for those families.
 For line and scatter charts, each `series[i].smooth` flag toggles
 Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
 Line series always emit the element — `smooth: true` writes `val="1"`,
@@ -1278,6 +1306,20 @@ identically to `null` because the OOXML default and an explicit
 The inherited flag is dropped silently when the resolved clone target
 is `pie` or `doughnut` so flattening a bar template into a pie clone
 never leaks a stale orientation into the output.
+The per-axis `axes.x.crosses` / `axes.x.crossesAt` (and the matching
+`axes.y.*`) overrides follow the same `undefined` (inherit) / `null`
+(drop) / value (replace) grammar as the other axis fields, applied
+independently to each side of the XSD choice between `<c:crosses>` and
+`<c:crossesAt>`. The writer enforces the schema's mutual exclusion
+downstream by preferring the numeric pin when both fields are set —
+inheriting `crosses: "max"` and overriding only `crossesAt: 50`
+therefore leaves the numeric pin in the cloned shape and surfaces the
+inherited semantic value alongside it; the writer picks `crossesAt`,
+matching how the parser handles the same pair on a malformed input.
+Drop only one side by passing `null`; the other side then inherits
+normally. The inherited pin is dropped silently when the resolved
+clone target is `pie` or `doughnut` because OOXML defines no axes for
+those families.
 
 #### Walking and adding charts with `getCharts` / `addChart`
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1242,6 +1242,37 @@ export interface SheetChart {
        * because the OOXML schema places no axes on those families.
        */
       hidden?: boolean;
+      /**
+       * Where the perpendicular axis crosses this axis along its own
+       * range. Maps to `<c:catAx><c:crosses val=".."/></c:catAx>` (or
+       * `<c:valAx>` for scatter). Default: `"autoZero"` — Excel's
+       * reference serialization, the perpendicular axis crosses at zero
+       * on a value axis or at the first category on a category axis.
+       *
+       * Set `"min"` / `"max"` to pin the perpendicular axis to the low
+       * / high end of this axis (Excel's "Format Axis -> Axis Options
+       * -> Vertical axis crosses" toggle). Mutually exclusive with
+       * {@link crossesAt} — when both are set the writer favours
+       * `crossesAt`. Silently ignored on `pie` / `doughnut` charts
+       * because the OOXML schema places no axes on those families. See
+       * {@link ChartAxisCrosses}.
+       */
+      crosses?: ChartAxisCrosses;
+      /**
+       * Numeric crossing position. Maps to
+       * `<c:catAx><c:crossesAt val=".."/></c:catAx>` (or `<c:valAx>` for
+       * scatter). When set, takes precedence over {@link crosses}
+       * because the OOXML schema (`CT_CatAx` / `CT_ValAx`) places the
+       * two elements in an XSD choice — only one may appear at a time.
+       *
+       * The literal value is preserved (including `0`, which is
+       * distinct from the `"autoZero"` default — `crossesAt: 0` pins
+       * the crossing point to the numeric value zero, while `crosses:
+       * "autoZero"` defers to Excel's auto-placement). Non-finite
+       * inputs (`NaN`, `Infinity`) drop at write time. Silently ignored
+       * on `pie` / `doughnut` charts.
+       */
+      crossesAt?: number;
     };
     /** Value axis. */
     y?: {
@@ -1284,6 +1315,22 @@ export interface SheetChart {
        * at the origin and the minimum at the far end.
        */
       reverse?: boolean;
+      /**
+       * Where the perpendicular axis crosses the value axis along its
+       * own range. Maps to `<c:valAx><c:crosses val=".."/></c:valAx>`.
+       * Default: `"autoZero"`. Mirrors
+       * {@link SheetChart.axes.x.crosses} for the value axis. Mutually
+       * exclusive with {@link crossesAt} — when both are set the writer
+       * favours `crossesAt`. See {@link ChartAxisCrosses}.
+       */
+      crosses?: ChartAxisCrosses;
+      /**
+       * Numeric crossing position for the value axis. Maps to
+       * `<c:valAx><c:crossesAt val=".."/></c:valAx>`. Mirrors
+       * {@link SheetChart.axes.x.crossesAt} — when set, takes
+       * precedence over {@link crosses}.
+       */
+      crossesAt?: number;
     };
   };
 }
@@ -2155,6 +2202,28 @@ export type ChartAxisTickLabelPosition = "nextTo" | "low" | "high" | "none";
  */
 export type ChartAxisLabelAlign = "ctr" | "l" | "r";
 
+/**
+ * Axis crossing position — where the perpendicular axis crosses this
+ * axis along its own range. Maps to the OOXML `ST_Crosses` enumeration
+ * which sits inside `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` /
+ * `<c:serAx>` as `<c:crosses val=".."/>`:
+ *
+ * - `"autoZero"` — the perpendicular axis crosses at zero on a value
+ *                  axis (or at the first category on a category axis).
+ *                  OOXML default and Excel's reference serialization on
+ *                  every freshly-drawn axis.
+ * - `"min"`      — the perpendicular axis crosses at the low end of
+ *                  this axis (Excel's "Format Axis -> Vertical axis
+ *                  crosses -> Automatic / At minimum value" toggle).
+ * - `"max"`      — the perpendicular axis crosses at the high end.
+ *
+ * `<c:crosses>` and `<c:crossesAt>` are mutually exclusive in the OOXML
+ * schema (CT_Crosses sits in an XSD choice with CT_Double). The writer
+ * favours `crossesAt` whenever the caller pins it; `crosses` is the
+ * fallback when only the semantic toggle is set.
+ */
+export type ChartAxisCrosses = "autoZero" | "min" | "max";
+
 export interface ChartAxisInfo {
   /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
   title?: string;
@@ -2276,6 +2345,33 @@ export interface ChartAxisInfo {
    * drop to `undefined`.
    */
   hidden?: boolean;
+  /**
+   * Semantic crossing position pulled from `<c:crosses val=".."/>`.
+   * Surfaces only when the axis pinned a non-default token — the OOXML
+   * default `"autoZero"` collapses to `undefined` so absence and the
+   * default round-trip identically through {@link cloneChart}. Unknown
+   * tokens drop rather than fabricate a value the writer would never
+   * emit. See {@link ChartAxisCrosses}.
+   *
+   * Mutually exclusive with {@link crossesAt} in the OOXML schema —
+   * when both elements appear on the same axis (a malformed template),
+   * the reader keeps `crossesAt` and drops `crosses` to mirror the
+   * writer's preference.
+   */
+  crosses?: ChartAxisCrosses;
+  /**
+   * Numeric crossing position pulled from `<c:crossesAt val=".."/>`.
+   * Surfaces the literal value Excel paints — `0` is preserved (it is a
+   * valid pin, distinct from the `"autoZero"` default). Non-numeric
+   * `val` attributes drop to `undefined` rather than fabricate a value
+   * the writer would never emit.
+   *
+   * Mutually exclusive with {@link crosses} in the OOXML schema (CT_Double
+   * sits in an XSD choice with CT_Crosses). When both elements appear on
+   * the same axis (a malformed template) the reader keeps `crossesAt`
+   * and drops `crosses` to mirror the writer's preference.
+   */
+  crossesAt?: number;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -12,6 +12,7 @@
 
 import type {
   Chart,
+  ChartAxisCrosses,
   ChartAxisGridlines,
   ChartAxisLabelAlign,
   ChartAxisNumberFormat,
@@ -362,6 +363,32 @@ export interface CloneChartOptions {
        * `doughnut` since neither has axes.
        */
       hidden?: boolean | null;
+      /**
+       * Override `SheetChart.axes.x.crosses`. `undefined` (or omitted)
+       * inherits the source axis's semantic crossing pin; `null` drops
+       * the inherited value (the writer falls back to the OOXML default
+       * `"autoZero"`); a {@link ChartAxisCrosses} token replaces it.
+       *
+       * Mutually exclusive with {@link crossesAt} — when both are set
+       * (here or on the source chart) the writer favours `crossesAt`,
+       * mirroring how the OOXML schema places the two elements in an
+       * XSD choice. Silently dropped on `pie` / `doughnut` charts since
+       * neither has axes.
+       */
+      crosses?: ChartAxisCrosses | null;
+      /**
+       * Override `SheetChart.axes.x.crossesAt`. `undefined` (or omitted)
+       * inherits the source axis's numeric crossing pin; `null` drops
+       * the inherited value (the writer falls back to the semantic
+       * crossing pin from {@link crosses}, or to the OOXML default
+       * `"autoZero"`); a finite number replaces it. `0` is preserved —
+       * it is a valid pin, distinct from the `"autoZero"` default.
+       *
+       * When set, takes precedence over {@link crosses} because the
+       * OOXML schema places `<c:crosses>` and `<c:crossesAt>` in an XSD
+       * choice — only one may legally appear at a time.
+       */
+      crossesAt?: number | null;
     };
     y?: {
       title?: string | null;
@@ -378,6 +405,10 @@ export interface CloneChartOptions {
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
       reverse?: boolean | null;
+      /** See {@link CloneChartOptions.axes.x.crosses}. */
+      crosses?: ChartAxisCrosses | null;
+      /** See {@link CloneChartOptions.axes.x.crossesAt}. */
+      crossesAt?: number | null;
     };
   };
 }
@@ -1115,6 +1146,19 @@ function resolveAxes(
   // and the caller already short-circuited those above.
   const xHidden = applyHiddenOverride(sourceAxes?.x?.hidden, overrides?.x?.hidden);
   const yHidden = applyHiddenOverride(sourceAxes?.y?.hidden, overrides?.y?.hidden);
+  // `<c:crosses>` and `<c:crossesAt>` live in an XSD choice on every
+  // axis flavour. Resolve the pair together so the precedence rule
+  // (numeric pin wins over semantic token) survives the inherit / null
+  // / replace grammar — a `crossesAt` override of `null` falls through
+  // to the (possibly inherited) semantic `crosses`, and vice versa.
+  const xCrossesPair = applyCrossesOverride(
+    { crosses: sourceAxes?.x?.crosses, crossesAt: sourceAxes?.x?.crossesAt },
+    { crosses: overrides?.x?.crosses, crossesAt: overrides?.x?.crossesAt },
+  );
+  const yCrossesPair = applyCrossesOverride(
+    { crosses: sourceAxes?.y?.crosses, crossesAt: sourceAxes?.y?.crossesAt },
+    { crosses: overrides?.y?.crosses, crossesAt: overrides?.y?.crossesAt },
+  );
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -1131,7 +1175,9 @@ function resolveAxes(
     xLblOffset !== undefined ||
     xLblAlgn !== undefined ||
     xNoMultiLvlLbl !== undefined ||
-    xHidden !== undefined
+    xHidden !== undefined ||
+    xCrossesPair.crosses !== undefined ||
+    xCrossesPair.crossesAt !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
@@ -1148,6 +1194,8 @@ function resolveAxes(
     if (xLblAlgn !== undefined) out.x.lblAlgn = xLblAlgn;
     if (xNoMultiLvlLbl !== undefined) out.x.noMultiLvlLbl = xNoMultiLvlLbl;
     if (xHidden !== undefined) out.x.hidden = xHidden;
+    if (xCrossesPair.crosses !== undefined) out.x.crosses = xCrossesPair.crosses;
+    if (xCrossesPair.crossesAt !== undefined) out.x.crossesAt = xCrossesPair.crossesAt;
   }
   if (
     yTitle !== undefined ||
@@ -1158,7 +1206,9 @@ function resolveAxes(
     yMinorTickMark !== undefined ||
     yTickLblPos !== undefined ||
     yHidden !== undefined ||
-    yReverse !== undefined
+    yReverse !== undefined ||
+    yCrossesPair.crosses !== undefined ||
+    yCrossesPair.crossesAt !== undefined
   ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
@@ -1170,6 +1220,8 @@ function resolveAxes(
     if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
+    if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
+    if (yCrossesPair.crossesAt !== undefined) out.y.crossesAt = yCrossesPair.crossesAt;
   }
 
   return out.x || out.y ? out : undefined;
@@ -1455,4 +1507,73 @@ function applyReverseOverride(
   }
   if (override === null) return undefined;
   return override === true ? true : undefined;
+}
+
+/** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */
+const VALID_CROSSES_VALUES: ReadonlySet<ChartAxisCrosses> = new Set(["autoZero", "min", "max"]);
+
+interface CrossesPairSource {
+  crosses?: ChartAxisCrosses;
+  crossesAt?: number;
+}
+
+interface CrossesPairOverride {
+  crosses?: ChartAxisCrosses | null;
+  crossesAt?: number | null;
+}
+
+interface CrossesPair {
+  crosses?: ChartAxisCrosses;
+  crossesAt?: number;
+}
+
+/**
+ * Resolve the `crosses` / `crossesAt` pair using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers — but applied to the XSD choice between `<c:crosses>`
+ * and `<c:crossesAt>`. The two fields are resolved independently
+ * (each follows the standard inherit / null / replace contract); the
+ * writer's normalizer enforces the choice rule downstream by
+ * preferring the numeric pin when both are set.
+ *
+ * The OOXML default `crosses: "autoZero"` collapses to `undefined` so
+ * the cloned shape stays minimal. `crossesAt: 0` is preserved (it is
+ * a valid pin, distinct from the `"autoZero"` default). Non-finite
+ * inputs and unknown semantic tokens drop to `undefined` so they
+ * cannot leak into the writer.
+ */
+function applyCrossesOverride(
+  source: CrossesPairSource,
+  override: CrossesPairOverride,
+): CrossesPair {
+  const out: CrossesPair = {};
+
+  if (override.crosses !== undefined) {
+    if (override.crosses !== null) {
+      const value = override.crosses;
+      if (VALID_CROSSES_VALUES.has(value) && value !== "autoZero") {
+        out.crosses = value;
+      }
+    }
+    // override.crosses === null drops the field entirely.
+  } else if (source.crosses !== undefined) {
+    if (VALID_CROSSES_VALUES.has(source.crosses) && source.crosses !== "autoZero") {
+      out.crosses = source.crosses;
+    }
+  }
+
+  if (override.crossesAt !== undefined) {
+    if (
+      override.crossesAt !== null &&
+      typeof override.crossesAt === "number" &&
+      Number.isFinite(override.crossesAt)
+    ) {
+      out.crossesAt = override.crossesAt;
+    }
+    // override.crossesAt === null drops the field entirely.
+  } else if (typeof source.crossesAt === "number" && Number.isFinite(source.crossesAt)) {
+    out.crossesAt = source.crossesAt;
+  }
+
+  return out;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -14,6 +14,7 @@
 
 import type {
   Chart,
+  ChartAxisCrosses,
   ChartAxisGridlines,
   ChartAxisInfo,
   ChartAxisLabelAlign,
@@ -320,6 +321,16 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   // default `val="0"` (axis visible) collapses to `undefined` so
   // absence and the default round-trip identically.
   const hidden = parseAxisHidden(axis);
+  // `<c:crosses>` and `<c:crossesAt>` sit on every axis flavour and live
+  // in an XSD choice (CT_Crosses ⊕ CT_Double) — only one may legally
+  // appear at a time per ECMA-376 Part 1, §21.2.2. The reader honours
+  // the schema by preferring `crossesAt` when both elements show up
+  // together (a malformed template); the writer mirrors that order so a
+  // round-trip surfaces the numeric pin and drops the redundant
+  // semantic toggle.
+  const crossesPair = parseAxisCrosses(axis);
+  const crosses = crossesPair.crosses;
+  const crossesAt = crossesPair.crossesAt;
   if (
     title === undefined &&
     gridlines === undefined &&
@@ -334,7 +345,9 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     lblOffset === undefined &&
     lblAlgn === undefined &&
     noMultiLvlLbl === undefined &&
-    hidden === undefined
+    hidden === undefined &&
+    crosses === undefined &&
+    crossesAt === undefined
   ) {
     return undefined;
   }
@@ -353,6 +366,8 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (lblAlgn !== undefined) out.lblAlgn = lblAlgn;
   if (noMultiLvlLbl !== undefined) out.noMultiLvlLbl = noMultiLvlLbl;
   if (hidden !== undefined) out.hidden = hidden;
+  if (crosses !== undefined) out.crosses = crosses;
+  if (crossesAt !== undefined) out.crossesAt = crossesAt;
   return out;
 }
 
@@ -579,6 +594,58 @@ function parseAxisHidden(axis: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+/** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */
+const VALID_CROSSES: ReadonlySet<ChartAxisCrosses> = new Set(["autoZero", "min", "max"]);
+
+/**
+ * Pull the axis crossing pin off `<c:crosses>` / `<c:crossesAt>`. The
+ * OOXML schema (`CT_CatAx`, `CT_ValAx`, `CT_DateAx`, `CT_SerAx`) places
+ * the two elements in an XSD choice — only one may legally appear at a
+ * time per ECMA-376 Part 1, §21.2.2. The reader still handles both
+ * appearing on the same axis (a malformed template) by preferring
+ * `crossesAt` and dropping the redundant `crosses` value, mirroring the
+ * writer's emit order.
+ *
+ * Returns:
+ *   - `crosses`   — set when only `<c:crosses>` is present and the value
+ *                   is a non-default token. The OOXML default `"autoZero"`
+ *                   collapses to `undefined` so absence and the default
+ *                   round-trip identically. Unknown tokens drop rather
+ *                   than fabricate a value the writer would never emit.
+ *   - `crossesAt` — set when `<c:crossesAt>` is present with a
+ *                   parseable numeric `val`. Non-numeric / missing
+ *                   `val` attributes drop to `undefined`. `0` is
+ *                   preserved (it is a valid pin, distinct from the
+ *                   `"autoZero"` default).
+ */
+function parseAxisCrosses(axis: XmlElement): {
+  crosses?: ChartAxisCrosses;
+  crossesAt?: number;
+} {
+  const crossesAtEl = findChild(axis, "crossesAt");
+  if (crossesAtEl) {
+    const raw = crossesAtEl.attrs.val;
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (trimmed.length > 0) {
+        const parsed = Number.parseFloat(trimmed);
+        if (Number.isFinite(parsed)) {
+          return { crossesAt: parsed };
+        }
+      }
+    }
+  }
+
+  const crossesEl = findChild(axis, "crosses");
+  if (!crossesEl) return {};
+  const raw = crossesEl.attrs.val;
+  if (typeof raw !== "string") return {};
+  const value = raw.trim() as ChartAxisCrosses;
+  if (!VALID_CROSSES.has(value)) return {};
+  if (value === "autoZero") return {};
+  return { crosses: value };
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -7,6 +7,7 @@
 // referenced from a drawing part via a `chart` relationship.
 
 import type {
+  ChartAxisCrosses,
   ChartAxisGridlines,
   ChartAxisLabelAlign,
   ChartAxisNumberFormat,
@@ -185,6 +186,14 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // collapse to `false` to keep the on-the-wire output stable.
     xHidden: normalizeAxisHidden(chart.axes?.x?.hidden),
     yHidden: normalizeAxisHidden(chart.axes?.y?.hidden),
+    // `<c:crosses>` and `<c:crossesAt>` sit on every axis flavour
+    // (CT_CatAx / CT_ValAx / CT_DateAx / CT_SerAx) but live in an XSD
+    // choice — only one of them may appear at a time. The normalizer
+    // resolves that choice once here so the per-family axis builders
+    // can emit whichever element the caller pinned without duplicating
+    // the precedence rule.
+    xCrosses: normalizeAxisCrosses(chart.axes?.x?.crosses, chart.axes?.x?.crossesAt),
+    yCrosses: normalizeAxisCrosses(chart.axes?.y?.crosses, chart.axes?.y?.crossesAt),
   };
 
   switch (chart.type) {
@@ -286,7 +295,31 @@ interface AxisRenderOptions {
   xHidden: boolean;
   /** Whether the Y axis should render hidden. Same shape as {@link xHidden}. */
   yHidden: boolean;
+  /**
+   * Resolved axis-crosses pin for the X axis. The XSD choice between
+   * `<c:crosses>` and `<c:crossesAt>` is collapsed to a single tagged
+   * union: `kind: "default"` emits the OOXML default `<c:crosses
+   * val="autoZero"/>`, `kind: "semantic"` emits the resolved
+   * {@link ChartAxisCrosses} token, and `kind: "numeric"` emits
+   * `<c:crossesAt>` with the literal value the caller pinned.
+   */
+  xCrosses: ResolvedAxisCrosses;
+  /** Resolved axis-crosses pin for the Y axis. Same shape as {@link xCrosses}. */
+  yCrosses: ResolvedAxisCrosses;
 }
+
+/**
+ * Resolved per-axis crossing pin. The OOXML schema places `<c:crosses>`
+ * and `<c:crossesAt>` in an XSD choice — only one may appear at a time.
+ * `normalizeAxisCrosses` collapses the writer's two input fields
+ * (`crosses` and `crossesAt`) into this tagged union so the per-family
+ * axis builders can emit the right element without re-implementing the
+ * precedence rule.
+ */
+type ResolvedAxisCrosses =
+  | { kind: "default" }
+  | { kind: "semantic"; value: ChartAxisCrosses }
+  | { kind: "numeric"; value: number };
 
 /**
  * Normalize an axis title input to either a non-empty trimmed string
@@ -471,6 +504,61 @@ function normalizeAxisLblAlgn(
  */
 function normalizeAxisHidden(value: boolean | undefined): boolean {
   return value === true;
+}
+
+/** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */
+const VALID_AXIS_CROSSES: ReadonlySet<ChartAxisCrosses> = new Set(["autoZero", "min", "max"]);
+
+/**
+ * Resolve the writer's `axes.x.crosses` / `axes.x.crossesAt` pair into
+ * the {@link ResolvedAxisCrosses} tagged union the per-family axis
+ * builders emit. The OOXML schema places `<c:crosses>` and
+ * `<c:crossesAt>` in an XSD choice — only one may legally appear at a
+ * time per ECMA-376 Part 1, §21.2.2 — so the normalizer collapses the
+ * caller's two fields to a single resolved shape:
+ *
+ *   - A finite numeric `crossesAt` always wins, mirroring how Excel
+ *     treats the choice (the explicit numeric pin overrides the
+ *     semantic default). Non-finite inputs (NaN / Infinity) drop so the
+ *     writer never emits an attribute Excel would reject.
+ *   - When only `crosses` is set, the resolved kind is `"semantic"` for
+ *     `"min"` / `"max"`. The OOXML default `"autoZero"` collapses to
+ *     `kind: "default"` so absence and the default emit the same
+ *     `<c:crosses val="autoZero"/>` byte-for-byte. Unknown tokens drop
+ *     to `kind: "default"` for the same reason.
+ *   - When neither is set, the resolved kind is `"default"` (the writer
+ *     still emits `<c:crosses val="autoZero"/>` to match Excel's
+ *     reference serialization on every freshly-drawn axis).
+ */
+function normalizeAxisCrosses(
+  semantic: ChartAxisCrosses | undefined,
+  numeric: number | undefined,
+): ResolvedAxisCrosses {
+  if (typeof numeric === "number" && Number.isFinite(numeric)) {
+    return { kind: "numeric", value: numeric };
+  }
+  if (semantic !== undefined && VALID_AXIS_CROSSES.has(semantic) && semantic !== "autoZero") {
+    return { kind: "semantic", value: semantic };
+  }
+  return { kind: "default" };
+}
+
+/**
+ * Render the resolved axis crossing pin as the matching child element.
+ * `kind: "numeric"` emits `<c:crossesAt val=".."/>`; every other kind
+ * emits `<c:crosses val=".."/>` so Excel's reference serialization
+ * (which always pins `<c:crosses val="autoZero"/>` on every axis) is
+ * preserved on freshly-drawn charts.
+ */
+function buildAxisCrosses(resolved: ResolvedAxisCrosses): string {
+  switch (resolved.kind) {
+    case "numeric":
+      return xmlSelfClose("c:crossesAt", { val: resolved.value });
+    case "semantic":
+      return xmlSelfClose("c:crosses", { val: resolved.value });
+    case "default":
+      return xmlSelfClose("c:crosses", { val: "autoZero" });
+  }
 }
 
 /**
@@ -754,7 +842,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
-    xmlSelfClose("c:crosses", { val: "autoZero" }),
+    buildAxisCrosses(opts.xCrosses),
     xmlSelfClose("c:auto", { val: 1 }),
     // `<c:lblAlgn>` is always emitted because Excel's reference
     // serialization includes it on every category axis. The writer
@@ -794,7 +882,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
-    xmlSelfClose("c:crosses", { val: "autoZero" }),
+    buildAxisCrosses(opts.yCrosses),
     xmlSelfClose("c:crossBetween", { val: "between" }),
     ...buildAxisTickUnits(opts.yScale),
   );
@@ -1037,7 +1125,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
-    xmlSelfClose("c:crosses", { val: "autoZero" }),
+    buildAxisCrosses(opts.xCrosses),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
     ...buildAxisTickUnits(opts.xScale),
   );
@@ -1054,7 +1142,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),
-    xmlSelfClose("c:crosses", { val: "autoZero" }),
+    buildAxisCrosses(opts.yCrosses),
     xmlSelfClose("c:crossBetween", { val: "midCat" }),
     ...buildAxisTickUnits(opts.yScale),
   );

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4895,3 +4895,276 @@ describe("cloneChart — axis noMultiLvlLbl", () => {
     expect(written).toContain('c:noMultiLvlLbl val="1"');
   });
 });
+
+// ── cloneChart — axis crosses / crossesAt ───────────────────────────
+
+describe("cloneChart — axis crosses / crossesAt", () => {
+  const sourceWithSemantic: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { y: { crosses: "max" } },
+  };
+
+  const sourceWithNumeric: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { y: { crossesAt: 42 } },
+  };
+
+  it("inherits axes.y.crosses from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithSemantic, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.crosses).toBe("max");
+    expect(clone.axes?.y?.crossesAt).toBeUndefined();
+  });
+
+  it("inherits axes.y.crossesAt from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithNumeric, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.crossesAt).toBe(42);
+    expect(clone.axes?.y?.crosses).toBeUndefined();
+  });
+
+  it("preserves crossesAt=0 through inherit (distinct from autoZero default)", () => {
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { crossesAt: 0 } },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.crossesAt).toBe(0);
+  });
+
+  it("drops the inherited semantic crosses when override is null", () => {
+    const clone = cloneChart(sourceWithSemantic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crosses: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the inherited numeric crossesAt when override is null", () => {
+    const clone = cloneChart(sourceWithNumeric, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossesAt: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited semantic crosses with a new value", () => {
+    const clone = cloneChart(sourceWithSemantic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crosses: "min" } },
+    });
+    expect(clone.axes?.y?.crosses).toBe("min");
+  });
+
+  it("replaces the inherited numeric crossesAt with a new value", () => {
+    const clone = cloneChart(sourceWithNumeric, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossesAt: -7.5 } },
+    });
+    expect(clone.axes?.y?.crossesAt).toBe(-7.5);
+  });
+
+  it("collapses an autoZero override to undefined (the OOXML default)", () => {
+    const clone = cloneChart(sourceWithSemantic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crosses: "autoZero" } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("collapses non-finite numeric overrides to undefined", () => {
+    const clone = cloneChart(sourceWithNumeric, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossesAt: Number.POSITIVE_INFINITY } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("collapses unknown semantic tokens to undefined", () => {
+    const clone = cloneChart(sourceWithSemantic, {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { y: { crosses: "middle" as any } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("inherits crosses on a source that did not declare crossesAt (and vice versa)", () => {
+    // Override with one shape leaves the inherited shape on the other
+    // field unaffected — the two are resolved independently.
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { crosses: "min", crossesAt: 5 } },
+    };
+    // Drop only the numeric pin — the semantic should still surface.
+    const clone = cloneChart(source, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossesAt: null } },
+    });
+    expect(clone.axes?.y?.crosses).toBe("min");
+    expect(clone.axes?.y?.crossesAt).toBeUndefined();
+  });
+
+  it("strips the pin silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { crosses: "max" } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the pin silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { crossesAt: 5 } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the pin through scatter (both axes are valAx)", () => {
+    const scatterSource: Chart = {
+      kinds: ["scatter"],
+      seriesCount: 1,
+      series: [{ kind: "scatter", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { crossesAt: 1.5 }, y: { crosses: "min" } },
+    };
+    const clone = cloneChart(scatterSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes?.x?.crossesAt).toBe(1.5);
+    expect(clone.axes?.y?.crosses).toBe("min");
+  });
+
+  it("carries the pin through a chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithSemantic, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.y?.crosses).toBe("max");
+  });
+
+  it("composes the pin alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithNumeric, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        y: {
+          title: "Revenue",
+          gridlines: { major: true },
+        },
+      },
+    });
+    expect(clone.axes?.y?.title).toBe("Revenue");
+    expect(clone.axes?.y?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.y?.crossesAt).toBe(42);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves a semantic pin", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:crosses val="max"/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.y?.crosses).toBe("max");
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.y?.crosses).toBe("max");
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const valAxBlock = written.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crosses val="max"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.crosses).toBe("max");
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves a numeric pin", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:crossesAt val="-12.25"/>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.y?.crossesAt).toBe(-12.25);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.y?.crossesAt).toBe(-12.25);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const valAxBlock = written.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crossesAt val="-12.25"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.crossesAt).toBe(-12.25);
+  });
+
+  it("end-to-end: writeXlsx packages a cloned chart with the pin intact", async () => {
+    const clone = cloneChart(sourceWithNumeric, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:crossesAt val="42"');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4472,3 +4472,211 @@ describe("writeChart — axis noMultiLvlLbl", () => {
     expect(chartXml).toContain('c:noMultiLvlLbl val="1"');
   });
 });
+
+// ── writeChart — axis crosses / crossesAt ────────────────────────────
+
+describe("writeChart — axis crosses / crossesAt", () => {
+  it('emits the OOXML default <c:crosses val="autoZero"/> on every axis when unset', () => {
+    // Excel's reference serialization always pins `<c:crosses val="autoZero"/>`
+    // on every axis, so the writer keeps that contract on a stock chart even
+    // though the parser collapses the default to undefined on read.
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('c:crosses val="autoZero"');
+    expect(valAxBlock).toContain('c:crosses val="autoZero"');
+    expect(catAxBlock).not.toContain("c:crossesAt");
+    expect(valAxBlock).not.toContain("c:crossesAt");
+  });
+
+  it('emits a non-default semantic crosses="min" on the category axis', () => {
+    const result = writeChart(makeChart({ axes: { x: { crosses: "min" } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:crosses val="min"');
+    expect(catAxBlock).not.toContain('c:crosses val="autoZero"');
+  });
+
+  it('emits semantic crosses="max" on the value axis', () => {
+    const result = writeChart(makeChart({ axes: { y: { crosses: "max" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crosses val="max"');
+  });
+
+  it('falls back to the default when crosses="autoZero" is set explicitly', () => {
+    // Pinning the default has the same wire effect as omitting the field.
+    const result = writeChart(makeChart({ axes: { x: { crosses: "autoZero" } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:crosses val="autoZero"');
+  });
+
+  it("emits <c:crossesAt> in place of <c:crosses> when the numeric pin is set", () => {
+    const result = writeChart(makeChart({ axes: { y: { crossesAt: 50 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crossesAt val="50"');
+    expect(valAxBlock).not.toContain("c:crosses ");
+    expect(valAxBlock).not.toContain("<c:crosses/>");
+  });
+
+  it("preserves crossesAt=0 (distinct from the autoZero default)", () => {
+    // `crossesAt: 0` pins the crossing point to the numeric value zero,
+    // distinct from `crosses: "autoZero"` which defers to Excel's
+    // auto-placement. The writer must emit `<c:crossesAt val="0"/>`,
+    // not collapse to the semantic default.
+    const result = writeChart(makeChart({ axes: { y: { crossesAt: 0 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crossesAt val="0"');
+    expect(valAxBlock).not.toContain("c:crosses ");
+  });
+
+  it("emits a negative crossesAt verbatim", () => {
+    const result = writeChart(makeChart({ axes: { y: { crossesAt: -25.5 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crossesAt val="-25.5"');
+  });
+
+  it("prefers crossesAt over crosses when both are set (XSD choice)", () => {
+    // The OOXML schema places <c:crosses> and <c:crossesAt> in an XSD
+    // choice — only one may legally appear. The writer favours the
+    // numeric pin, mirroring the reader's preference on malformed input.
+    const result = writeChart(
+      makeChart({ axes: { y: { crosses: "max", crossesAt: 7 } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crossesAt val="7"');
+    expect(valAxBlock).not.toContain("c:crosses ");
+    expect(valAxBlock).not.toContain('c:crosses val="max"');
+  });
+
+  it("falls back to crosses when crossesAt is non-finite", () => {
+    // NaN / Infinity inputs drop through to the semantic crosses
+    // (or to the autoZero default when crosses is also unset).
+    const result = writeChart(
+      makeChart({
+        axes: { y: { crosses: "min", crossesAt: Number.NaN } },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crosses val="min"');
+    expect(valAxBlock).not.toContain("c:crossesAt");
+  });
+
+  it("ignores unknown semantic tokens (falls back to autoZero default)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { y: { crosses: "middle" as any } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('c:crosses val="autoZero"');
+  });
+
+  it("emits exactly one crosses-or-crossesAt element per axis", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { crosses: "min" }, y: { crossesAt: 10 } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect((catAxBlock.match(/c:crosses\b/g) ?? []).length).toBe(1);
+    expect((catAxBlock.match(/c:crossesAt\b/g) ?? []).length).toBe(0);
+    expect((valAxBlock.match(/c:crosses\b/g) ?? []).length).toBe(0);
+    expect((valAxBlock.match(/c:crossesAt\b/g) ?? []).length).toBe(1);
+  });
+
+  it("threads the override through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { y: { crosses: "max" } } }), "Sheet1");
+      expect(result.chartXml).toContain('c:crosses val="max"');
+    }
+  });
+
+  it("threads the override through scatter charts (both axes are valAx)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { crossesAt: 3.14 }, y: { crosses: "min" } },
+      }),
+      "Sheet1",
+    );
+    // Scatter emits two <c:valAx> elements — first is the X axis, second
+    // is the Y axis.
+    const valAxes = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxes).toHaveLength(2);
+    expect(valAxes[0]).toContain('c:crossesAt val="3.14"');
+    expect(valAxes[1]).toContain('c:crosses val="min"');
+  });
+
+  it("ignores the override on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(makeChart({ type: "pie", axes: { y: { crosses: "min" } } }), "Sheet1");
+    expect(pie.chartXml).not.toContain("c:crosses");
+    expect(pie.chartXml).not.toContain("c:crossesAt");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { y: { crossesAt: 5 } } }),
+      "Sheet1",
+    );
+    expect(dough.chartXml).not.toContain("c:crosses");
+    expect(dough.chartXml).not.toContain("c:crossesAt");
+  });
+
+  it("places crosses after crossAx per the OOXML schema (CT_CatAx / CT_ValAx)", () => {
+    // OOXML CT_CatAx / CT_ValAx: ... → tickLblPos → crossAx → (crosses
+    // | crossesAt) → ... The writer's emit order pins crossAx first.
+    const result = writeChart(makeChart({ axes: { y: { crossesAt: 42 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const crossAxIdx = valAxBlock.indexOf("c:crossAx");
+    const crossesAtIdx = valAxBlock.indexOf("c:crossesAt");
+    expect(crossAxIdx).toBeGreaterThan(0);
+    expect(crossesAtIdx).toBeGreaterThan(crossAxIdx);
+  });
+
+  it("round-trips a non-default semantic crosses through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { y: { crosses: "max" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.crosses).toBe("max");
+    expect(reparsed?.axes?.y?.crossesAt).toBeUndefined();
+  });
+
+  it("round-trips a numeric crossesAt through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { y: { crossesAt: -3.5 } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.crossesAt).toBe(-3.5);
+    expect(reparsed?.axes?.y?.crosses).toBeUndefined();
+  });
+
+  it("collapses a defaulted crosses round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the crosses pin into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { crosses: "min" }, y: { crossesAt: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('c:crosses val="min"');
+    expect(chartXml).toContain('c:crossesAt val="0"');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5299,3 +5299,267 @@ describe("parseChart — axis noMultiLvlLbl", () => {
     });
   });
 });
+
+// ── parseChart — axis crosses / crossesAt ──────────────────────────
+
+describe("parseChart — axis crosses / crossesAt", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces crosses="min" on the category axis', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crosses val="min"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crosses).toBe("min");
+    expect(chart?.axes?.x?.crossesAt).toBeUndefined();
+    expect(chart?.axes?.y?.crosses).toBeUndefined();
+  });
+
+  it('surfaces crosses="max" on the value axis', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crosses val="max"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crosses).toBeUndefined();
+    expect(chart?.axes?.y?.crosses).toBe("max");
+  });
+
+  it('collapses the OOXML default crosses="autoZero" to undefined', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crosses val="autoZero"/>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crosses val="autoZero"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses absence of <c:crosses> to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined for unknown crosses tokens", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crosses val="middle"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:crosses> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crosses/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("surfaces a positive crossesAt on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossesAt val="50"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossesAt).toBe(50);
+    expect(chart?.axes?.y?.crosses).toBeUndefined();
+  });
+
+  it("surfaces a negative crossesAt", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossesAt val="-25.5"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossesAt).toBe(-25.5);
+  });
+
+  it("preserves crossesAt=0 (distinct from autoZero)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossesAt val="0"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossesAt).toBe(0);
+    expect(chart?.axes?.y?.crosses).toBeUndefined();
+  });
+
+  it("returns undefined when <c:crossesAt> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossesAt/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:crossesAt val> is non-numeric", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossesAt val="middle"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("prefers crossesAt over crosses when both are present (XSD choice)", () => {
+    // The OOXML schema places <c:crosses> and <c:crossesAt> in an XSD
+    // choice — only one may legally appear. The reader handles
+    // malformed templates that emit both by keeping the numeric pin
+    // (mirroring the writer's emit order).
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crosses val="max"/>
+      <c:crossesAt val="42"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crosses).toBeUndefined();
+    expect(chart?.axes?.x?.crossesAt).toBe(42);
+  });
+
+  it("falls back to crosses when crossesAt is unparseable", () => {
+    // Same malformed-template guard, the other direction: when
+    // crossesAt is present but unparseable, the semantic crosses still
+    // surfaces.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crosses val="min"/>
+      <c:crossesAt/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crosses).toBe("min");
+    expect(chart?.axes?.x?.crossesAt).toBeUndefined();
+  });
+
+  it("surfaces crosses on a scatter chart's value-axis pair", () => {
+    // Scatter has two valAx — the first (axPos="b") is the X axis, the
+    // second (axPos="l") is the Y axis. The reader maps them back to
+    // axes.x / axes.y the same way it does for the rest of the
+    // metadata.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:crossesAt val="3.14"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:crosses val="max"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crossesAt).toBe(3.14);
+    expect(chart?.axes?.y?.crosses).toBe("max");
+  });
+
+  it("co-surfaces crosses alongside title and tick rendering", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+      <c:crosses val="min"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Region",
+      tickLblPos: "low",
+      crosses: "min",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-axis `<c:crosses val=\"..\"/>` and `<c:crossesAt val=\"..\"/>` elements at the read, write, and clone layers so a template's axis-crossing pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:crosses>` and `<c:crossesAt>` mirror Excel's "Format Axis -> Axis Options -> Vertical/Horizontal axis crosses" toggle. `crosses` accepts the OOXML `ST_Crosses` tokens (`\"autoZero\"` / `\"min\"` / `\"max\"`) and `crossesAt` accepts a literal numeric pin (e.g. `crossesAt: 100` to put the perpendicular axis at value 100). The two elements live in an XSD choice in `CT_CatAx` / `CT_ValAx` / `CT_DateAx` / `CT_SerAx` — only one may legally appear at a time — so the writer favours `crossesAt` when both are set, mirroring how the reader handles the same pair on a malformed template. `crossesAt: 0` is preserved (a numeric pin at zero, distinct from the `\"autoZero\"` default which defers to Excel's auto-placement).

Up until now hucre's writer always pinned `<c:crosses val=\"autoZero\"/>`, so a template with a non-default crossing pin flattened back to the default on every parse -> clone -> write loop. This bridges another axis-configuration gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.y?.crosses);   // \"max\" when the template pinned val=\"max\"
console.log(source.axes?.y?.crossesAt); // 50 when the template pinned <c:crossesAt val=\"50\"/>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [...],
    charts: [{
      type: \"column\",
      series: [{ values: \"B2:B10\", categories: \"A2:A10\" }],
      axes: {
        x: { crosses: \"min\" },     // category axis crosses at the low end
        y: { crossesAt: 0 },        // value axis crosses at zero (numeric pin)
      },
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    y: {
      // crosses: undefined  -> inherit semantic crosses (e.g. \"max\")
      // crosses: null       -> drop inherited crosses
      // crosses: \"min\"      -> replace inherited crosses
      // crossesAt: undefined -> inherit numeric pin
      // crossesAt: null     -> drop numeric pin (falls back to crosses)
      // crossesAt: 7        -> replace numeric pin (wins over crosses)
    },
  },
});
```

## Model

```ts
export type ChartAxisCrosses = \"autoZero\" | \"min\" | \"max\";

// Read side
export interface ChartAxisInfo {
  // ...existing fields...
  crosses?: ChartAxisCrosses;
  crossesAt?: number;
}

// Write side
export interface SheetChart {
  axes?: {
    x?: { /* ...existing fields..., */ crosses?: ChartAxisCrosses; crossesAt?: number };
    y?: { /* ...existing fields..., */ crosses?: ChartAxisCrosses; crossesAt?: number };
  };
}
```

## Scope rules

- The XSD choice between `<c:crosses>` and `<c:crossesAt>` is collapsed into a single resolved tagged union (`{ kind: \"default\" | \"semantic\" | \"numeric\" }`) so the per-family axis builders emit exactly one of the two elements per axis.
- `crossesAt` always wins over `crosses` when both are set (numeric pin > semantic token), mirroring how Excel resolves the schema choice. `crossesAt: 0` is preserved verbatim because it is a valid numeric pin distinct from the `\"autoZero\"` default.
- Default `\"autoZero\"` collapses to `undefined` on read so absence and the default round-trip identically; the writer still emits `<c:crosses val=\"autoZero\"/>` on freshly-drawn charts to match Excel's reference serialization byte-for-byte.
- Non-finite numeric inputs (`NaN` / `Infinity`) drop on the writer side; unknown semantic tokens drop on both sides.
- The pin threads through bar / column / line / area / scatter; pie / doughnut silently ignore it because OOXML defines no axes for those families.
- Element ordering inside `<c:catAx>` / `<c:valAx>` follows CT_CatAx / CT_ValAx: `crossAx` before the resolved `crosses` / `crossesAt` element.

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest) — 3370 tests passing.
- [x] `pnpm build` — obuild succeeds.
- [x] `parseChart` covers `\"min\"` / `\"max\"` surfacing, default collapse, missing `val`, unknown tokens, numeric `crossesAt` (positive / negative / zero), non-numeric `val` drop, the XSD-choice precedence (numeric wins over semantic on a malformed template), the fallback to semantic when `crossesAt` is unparseable, scatter axis mapping, and co-surfacing with title / tickLblPos.
- [x] `writeChart` covers default `<c:crosses val=\"autoZero\"/>` emit on every axis, semantic `\"min\"` / `\"max\"` emit, autoZero-equals-omit, numeric `crossesAt` emit (including `0` and negatives), the XSD-choice precedence (numeric wins over semantic), the fallback when `crossesAt` is non-finite, unknown-token drop, exactly-one-emit guard per axis, multi-family threading (bar / column / line / area / scatter), pie / doughnut drop, OOXML element ordering (after `crossAx`), parseChart round-trip, and end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace for both `crosses` and `crossesAt`, the independent resolution of the two fields under the XSD choice, `crossesAt: 0` preservation, non-finite / unknown-token drop, scatter / pie / doughnut scope rules, chart-type coercion (bar -> column) carry, composition with other axis overrides, and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)