### PR TITLE
feat(xlsx): chart line up/down bars — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,19 @@ series (the OOXML schema places `<c:invertIfNegative>` exclusively on
 `CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
 `val="0"` both collapse to `undefined`, so only an explicit
 `<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
+`Chart.upDownBars` surfaces the line-chart up / down bars flag pulled
+from `<c:lineChart><c:upDownBars>...</c:upDownBars></c:lineChart>` —
+Excel's "Add Chart Element -> Up/Down Bars" toggle. The element
+paints a vertical bar at each category whose top tracks the higher
+series value and bottom tracks the lower one (typically used to
+visualize open / close differences on a line-style stock chart).
+Surfaces `true` whenever the element is present (with or without the
+optional `<c:gapWidth>` / `<c:upBars>` / `<c:downBars>` children — the
+model is a plain presence flag at this layer); absence collapses to
+`undefined`. Only line-flavored chart-type bodies surface the field —
+`CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` per the OOXML
+schema; a stray `<c:upDownBars>` on a bar / column / pie / doughnut /
+area / scatter chart is ignored.
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
@@ -1006,6 +1019,18 @@ emitted (no `title` set or `showTitle: false`) — there is no `<c:title>`
 block to host the overlay child in either case. Independent of
 `legendOverlay`: the legend and title `<c:overlay>` elements live on
 different parents, so the two flags compose freely.
+The chart-level `upDownBars` field maps to `<c:upDownBars>` inside
+`<c:lineChart>` — Excel's "Add Chart Element -> Up/Down Bars" toggle
+on a line chart. The element paints a vertical bar at each category
+whose top tracks the higher series value and bottom tracks the lower
+one (typically used to visualize open / close differences on a
+line-style stock chart). The OOXML default is absence, so the writer
+omits the element on a fresh chart. Pin `upDownBars: true` on a
+`type: "line"` chart to emit the element with Excel's reference
+`<c:gapWidth val="150"/>` child. The flag is silently ignored on
+every other chart family — `<c:upDownBars>` lives exclusively on
+`CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` per the OOXML
+schema, and the writer never authors the 3D / stock variants.
 The `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` fields thin out a
 crowded category axis (`<c:catAx><c:tickLblSkip val=".."/>` and
 `<c:catAx><c:tickMarkSkip val=".."/>`). Pass a positive integer to
@@ -1283,6 +1308,15 @@ is no `<c:title>` block to host the overlay flag in either case.
 Re-introducing a missing source title through an explicit `title:
 "..."` override re-opens the slot, and an explicit `titleOverlay: true`
 override threads through.
+The chart-level `upDownBars` flag follows the same grammar: pass
+`undefined` to inherit the source's parsed value, `null` to drop it
+back to the writer's OOXML default (no `<c:upDownBars>` element), or a
+`boolean` to replace it. The element renders inside `<c:lineChart>`
+so the field is silently dropped from the cloned `SheetChart`
+whenever the resolved chart type is anything but `line` — flattening
+a stock or line template into a column / pie / doughnut / area /
+scatter clone therefore never leaks a stale up / down bars block into
+a chart-type element whose schema rejects the element.
 The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
 follow the same `undefined` (inherit) / `null` (drop) / number
 (replace) grammar as `gridlines` / `scale` / `numberFormat`. The

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1086,6 +1086,28 @@ export interface SheetChart {
    */
   roundedCorners?: boolean;
   /**
+   * Whether to render up / down bars between paired series on a line
+   * chart. Maps to `<c:lineChart><c:upDownBars/></c:lineChart>` —
+   * Excel's "Add Chart Element -> Up/Down Bars" toggle. The element
+   * paints a vertical bar at each category whose top tracks the higher
+   * series value and bottom tracks the lower one (typically used to
+   * highlight open / close differences on a line-style stock chart).
+   *
+   * Only meaningful for `line` charts — the OOXML schema places
+   * `<c:upDownBars>` on `CT_LineChart`, `CT_Line3DChart`, and
+   * `CT_StockChart`; the writer never emits it on bar / column / pie /
+   * doughnut / area / scatter, so the field is silently dropped on
+   * those families. Default: `false` (no up / down bars; Excel's
+   * reference serialization for a fresh line chart omits the element).
+   *
+   * The writer emits a default `<c:gapWidth val="150"/>` child to
+   * mirror Excel's reference serialization — `150` is the OOXML
+   * default for `CT_UpDownBars/gapWidth`. Custom gap widths are not
+   * exposed at this layer; pass a richer model in a follow-up if a
+   * caller needs to thin or widen the bars.
+   */
+  upDownBars?: boolean;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -2653,6 +2675,23 @@ export interface Chart {
    * `<c:chart>` — the toggle styles the outer frame, not the plot area.
    */
   roundedCorners?: boolean;
+  /**
+   * Up / down bars flag pulled from the first `<c:lineChart>` element's
+   * `<c:upDownBars>` child. Reflects Excel's "Add Chart Element ->
+   * Up/Down Bars" toggle on a line chart — vertical bars connecting
+   * paired series at each category, typically used to visualize open /
+   * close differences on a line-style stock chart.
+   *
+   * Surfaces `true` whenever the element is present (with or without
+   * the optional `<c:gapWidth>` / `<c:upBars>` / `<c:downBars>`
+   * children — the model is a plain presence flag at this layer).
+   * Absence collapses to `undefined`. Only line-flavored chart types
+   * surface the field; the OOXML schema places `<c:upDownBars>` on
+   * `CT_LineChart`, `CT_Line3DChart`, and `CT_StockChart`, so the
+   * reader ignores any stray element on bar / column / pie / doughnut
+   * / area / scatter chart-type elements.
+   */
+  upDownBars?: boolean;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -260,6 +260,24 @@ export interface CloneChartOptions {
    */
   roundedCorners?: boolean | null;
   /**
+   * Override `<c:upDownBars>` (the line-chart up / down bars toggle).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `upDownBars`. `null` drops the inherited value so the writer
+   * falls back to the OOXML default (no up / down bars). A `boolean`
+   * replaces it — useful for adding the bars to a dashboard line clone
+   * whose template did not carry them, or stripping them from a
+   * template-supplied stock-style line chart.
+   *
+   * Only meaningful when the resolved chart type is `line` — the OOXML
+   * schema places `<c:upDownBars>` on `CT_LineChart` /
+   * `CT_Line3DChart` / `CT_StockChart`. The field is silently dropped
+   * when the clone targets any other family (so a line-template
+   * up/down-bars hint never leaks into a column / pie / doughnut /
+   * area / scatter clone).
+   */
+  upDownBars?: boolean | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -626,6 +644,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     if (resolvedScatterStyle !== undefined) out.scatterStyle = resolvedScatterStyle;
   }
 
+  // `<c:upDownBars>` only renders inside `<c:lineChart>` (the writer
+  // never authors `<c:line3DChart>` or `<c:stockChart>`). Drop the
+  // flag on every other resolved type so a line-template up/down-bars
+  // hint never leaks into a column / pie / doughnut / area / scatter
+  // clone — the OOXML schema places the element exclusively on the
+  // line-flavored chart-type elements. Override wins over the source's
+  // parsed value.
+  if (type === "line") {
+    const resolvedUpDownBars = resolveUpDownBars(source.upDownBars, options.upDownBars);
+    if (resolvedUpDownBars !== undefined) out.upDownBars = resolvedUpDownBars;
+  }
+
   // Pie and doughnut have no axes, so silently skip carrying over axis
   // titles even when the source declared them or the caller passed an
   // override.
@@ -986,6 +1016,31 @@ function resolvePlotVisOnly(
  * toggles compose the same way at the call site.
  */
 function resolveRoundedCorners(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve an `upDownBars` override.
+ *
+ * `undefined` → inherit the source's parsed `upDownBars`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML default — no `<c:upDownBars>` element emitted).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `roundedCorners` / `plotVisOnly` so the chart-
+ * level line-only toggle composes the same way at the call site.
+ * `false` collapses to absence on the writer side because the writer
+ * only emits `<c:upDownBars>` when the flag is literally `true`; the
+ * `false` value still surfaces in the cloned `SheetChart` for
+ * symmetry with other resolve helpers, leaving the renderer to drop
+ * it during emit.
+ */
+function resolveUpDownBars(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -103,6 +103,7 @@ export function parseChart(xml: string): Chart | undefined {
     let firstSliceAng: number | undefined;
     let varyColors: boolean | undefined;
     let scatterStyle: ChartScatterStyle | undefined;
+    let upDownBars: boolean | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
@@ -170,6 +171,20 @@ export function parseChart(xml: string): Chart | undefined {
       if (scatterStyle === undefined && kind === "scatter") {
         scatterStyle = parseScatterStyle(child);
       }
+      // `<c:upDownBars>` lives on `CT_LineChart`, `CT_Line3DChart`, and
+      // `CT_StockChart` per the OOXML schema. Surface the flag from the
+      // first line-flavored chart-type element that carries one — the
+      // schema places the element on the chart-type element itself, not
+      // the per-series body, so this is a chart-level toggle. The
+      // model is a plain presence flag at this layer; richer details
+      // (per-bar styling, custom gap width) can layer on later.
+      if (
+        upDownBars === undefined &&
+        (kind === "line" || kind === "line3D" || kind === "stock") &&
+        findChild(child, "upDownBars") !== undefined
+      ) {
+        upDownBars = true;
+      }
       let localIndex = 0;
       for (const ser of childElements(child)) {
         if (ser.local !== "ser") continue;
@@ -201,6 +216,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (firstSliceAng !== undefined) out.firstSliceAng = firstSliceAng;
     if (varyColors !== undefined) out.varyColors = varyColors;
     if (scatterStyle !== undefined) out.scatterStyle = scatterStyle;
+    if (upDownBars !== undefined) out.upDownBars = upDownBars;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -944,11 +944,40 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
   const chartLevelDLbls = buildChartLevelDataLabels(chart);
   if (chartLevelDLbls) children.push(chartLevelDLbls);
 
+  // CT_LineChart child order: grouping, varyColors?, ser*, dLbls?,
+  // dropLines?, hiLowLines?, upDownBars?, marker?, axId+. The
+  // up/down-bars block sits before `<c:marker>` so the schema
+  // sequence is respected even on a chart that pins both flags.
+  if (chart.upDownBars === true) {
+    children.push(buildUpDownBars());
+  }
+
   children.push(xmlSelfClose("c:marker", { val: 1 }));
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_CAT }));
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_VAL }));
 
   return xmlElement("c:lineChart", undefined, children);
+}
+
+/**
+ * Build a default `<c:upDownBars>` block for {@link buildLineChart}.
+ *
+ * The OOXML schema (`CT_UpDownBars`) allows three optional children —
+ * `<c:gapWidth>`, `<c:upBars>`, and `<c:downBars>` — but the up / down
+ * bars themselves are painted by the mere presence of the parent
+ * element. The writer emits a default `<c:gapWidth val="150"/>` to
+ * mirror Excel's reference serialization for a freshly-toggled
+ * "Add Chart Element -> Up/Down Bars" — `150` is the OOXML default for
+ * `CT_UpDownBars/gapWidth` and the value Excel itself emits.
+ *
+ * `<c:upBars>` / `<c:downBars>` are intentionally omitted: each is a
+ * `CT_UpDownBar` (only `<c:spPr>` inside) and their absence makes
+ * Excel paint the default white-up / black-down bars Excel uses on a
+ * fresh toggle. A richer model — explicit gap widths or per-bar
+ * styling — can layer on top in a follow-up if needed.
+ */
+function buildUpDownBars(): string {
+  return xmlElement("c:upDownBars", undefined, [xmlSelfClose("c:gapWidth", { val: 150 })]);
 }
 
 // ── Area ─────────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -5390,3 +5390,220 @@ describe("cloneChart — axis crosses / crossesAt", () => {
     expect(written).toContain('c:crossesAt val="42"');
   });
 });
+
+// ── cloneChart — upDownBars ──────────────────────────────────────────
+
+describe("cloneChart — upDownBars", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 2,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "High",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+        {
+          kind: "line",
+          index: 1,
+          name: "Low",
+          valuesRef: "Tpl!$C$2:$C$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's upDownBars by default", () => {
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.upDownBars).toBe(true);
+  });
+
+  it("lets options.upDownBars override the source's value", () => {
+    // Source pins the flag, clone strips it back to false (which the
+    // writer collapses to absence — the default).
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBars: false,
+    });
+    expect(clone.upDownBars).toBe(false);
+  });
+
+  it("drops the inherited upDownBars when the override is null", () => {
+    // null collapses to the writer's OOXML default — the field
+    // disappears from the resolved SheetChart so the writer emits no
+    // <c:upDownBars> element.
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBars: null,
+    });
+    expect(clone.upDownBars).toBeUndefined();
+  });
+
+  it("returns undefined upDownBars when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.upDownBars).toBeUndefined();
+  });
+
+  it("lets the caller add upDownBars to a source that did not carry one", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBars: true,
+    });
+    expect(clone.upDownBars).toBe(true);
+  });
+
+  it("drops upDownBars on a flatten to a non-line family (line → column)", () => {
+    // <c:upDownBars> only renders inside <c:lineChart>. A column clone
+    // must not surface a flag whose target chart-type element rejects
+    // it — the writer would otherwise refuse to compile.
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.upDownBars).toBeUndefined();
+  });
+
+  it("drops upDownBars on a flatten to area (CT_AreaChart rejects the element)", () => {
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "area",
+    });
+    expect(clone.type).toBe("area");
+    expect(clone.upDownBars).toBeUndefined();
+  });
+
+  it("drops upDownBars on a flatten to pie (CT_PieChart rejects the element)", () => {
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.upDownBars).toBeUndefined();
+  });
+
+  it("drops upDownBars on a flatten to scatter (CT_ScatterChart rejects the element)", () => {
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      // scatter expects a numeric x/y range, override the series shape.
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.upDownBars).toBeUndefined();
+  });
+
+  it("carries upDownBars through a stock-template flatten (stock → line)", () => {
+    // Stock charts are read-only on the writer side, but a stock
+    // template's upDownBars flag should survive a flatten to line —
+    // CT_LineChart hosts the same element.
+    const stockSource: Chart = {
+      kinds: ["stock"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "stock",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+        },
+      ],
+      upDownBars: true,
+    };
+    const clone = cloneChart(stockSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      // The stock series shape doesn't carry a categories range; pass
+      // a fresh series for the line clone.
+      series: [{ values: "Tpl!$B$2:$B$5", categories: "Tpl!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.upDownBars).toBe(true);
+  });
+
+  it("propagates upDownBars into the rendered <c:lineChart> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B", "C"],
+            [1, 10, 5],
+            [2, 12, 6],
+            [3, 15, 8],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:upDownBars>");
+    expect(written).toContain('c:gapWidth val="150"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBars).toBe(true);
+  });
+
+  it("emits no <c:upDownBars> when both source and override are absent", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B", "C"],
+            [1, 10, 5],
+            [2, 12, 6],
+            [3, 15, 8],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("c:upDownBars");
+    expect(parseChart(written)?.upDownBars).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins `true`, clone overrides to `null` — the rendered
+    // chart should carry no element and re-parse to undefined.
+    const clone = cloneChart(source({ upDownBars: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      upDownBars: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B", "C"],
+            [1, 10, 5],
+            [2, 12, 6],
+            [3, 15, 8],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("c:upDownBars");
+    expect(parseChart(written)?.upDownBars).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4839,3 +4839,132 @@ describe("writeChart — axis crosses / crossesAt", () => {
     expect(chartXml).toContain('c:crossesAt val="0"');
   });
 });
+
+// ── writeChart — upDownBars ──────────────────────────────────────────
+
+describe("writeChart — upDownBars", () => {
+  it("omits <c:upDownBars> when the field is unset (OOXML default)", () => {
+    // The OOXML default for <c:upDownBars> on CT_LineChart is absence —
+    // Excel's reference serialization for a fresh line chart does not
+    // emit the element. The writer mirrors that default by only
+    // emitting on an explicit `true`.
+    const result = writeChart(makeChart({ type: "line" }), "Sheet1");
+    expect(result.chartXml).not.toContain("c:upDownBars");
+  });
+
+  it('emits <c:upDownBars> with default <c:gapWidth val="150"/> when upDownBars=true', () => {
+    // The schema default for CT_UpDownBars/gapWidth is 150 — Excel's
+    // reference serialization emits the element with that gap width.
+    const result = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1");
+    expect(result.chartXml).toContain("<c:upDownBars>");
+    expect(result.chartXml).toContain("</c:upDownBars>");
+    expect(result.chartXml).toContain('c:gapWidth val="150"');
+  });
+
+  it("treats upDownBars=false as absence (no element emitted)", () => {
+    // The writer only emits on a literal `true`; `false` collapses to
+    // the OOXML default (no element) so a stray `false` from clone
+    // resolution does not fabricate an empty up/down bars block.
+    const result = writeChart(makeChart({ type: "line", upDownBars: false }), "Sheet1");
+    expect(result.chartXml).not.toContain("c:upDownBars");
+  });
+
+  it("places <c:upDownBars> before <c:marker> inside <c:lineChart> (OOXML order)", () => {
+    // CT_LineChart sequence: ... ser*, dLbls?, dropLines?, hiLowLines?,
+    // upDownBars?, marker?, axId+. The schema rejects an out-of-order
+    // <c:upDownBars> after <c:marker>, so the writer must place it
+    // first.
+    const result = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1");
+    const upDownBarsIdx = result.chartXml.indexOf("c:upDownBars");
+    const markerIdx = result.chartXml.indexOf('c:marker val="1"');
+    expect(upDownBarsIdx).toBeGreaterThan(0);
+    expect(markerIdx).toBeGreaterThan(0);
+    expect(upDownBarsIdx).toBeLessThan(markerIdx);
+  });
+
+  it("places <c:upDownBars> before <c:axId> inside <c:lineChart> (OOXML order)", () => {
+    // The axId pair sits at the tail of CT_LineChart — every optional
+    // chart-level child must precede them.
+    const result = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1");
+    const upDownBarsIdx = result.chartXml.indexOf("c:upDownBars");
+    const firstAxIdIdx = result.chartXml.indexOf("c:axId");
+    expect(upDownBarsIdx).toBeLessThan(firstAxIdIdx);
+  });
+
+  it("only emits <c:upDownBars> once even on a chart that pins the flag", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:upDownBars\b/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("ignores upDownBars on bar / column / pie / doughnut / area / scatter chart kinds", () => {
+    // The OOXML schema places <c:upDownBars> exclusively on CT_LineChart
+    // / CT_Line3DChart / CT_StockChart. The writer never authors the
+    // 3D / stock variants, so only `type: "line"` should emit. Every
+    // other family must drop the flag silently.
+    for (const type of ["bar", "column", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, upDownBars: true }), "Sheet1");
+      expect(result.chartXml).not.toContain("c:upDownBars");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        upDownBars: true,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).not.toContain("c:upDownBars");
+  });
+
+  it("round-trips upDownBars=true through parseChart", () => {
+    // A line chart with upDownBars=true should re-parse into a Chart
+    // whose `upDownBars` field is `true`.
+    const written = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBars).toBe(true);
+  });
+
+  it("collapses an unset upDownBars round-trip back to undefined", () => {
+    // A fresh line chart (upDownBars omitted) writes no element and
+    // re-parses to undefined — absence and the OOXML default round-trip
+    // identically.
+    const written = writeChart(makeChart({ type: "line" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBars).toBeUndefined();
+  });
+
+  it("threads upDownBars through writeXlsx end-to-end packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["High", "Low"],
+          [10, 5],
+          [12, 6],
+          [15, 8],
+        ],
+        charts: [
+          {
+            type: "line",
+            series: [
+              { name: "High", values: "A2:A4" },
+              { name: "Low", values: "B2:B4" },
+            ],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            upDownBars: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:upDownBars>");
+    expect(chartXml).toContain('c:gapWidth val="150"');
+    // Re-parse the rendered chart to confirm the flag survives the
+    // packaging path.
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.upDownBars).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5771,3 +5771,230 @@ describe("parseChart — axis crosses / crossesAt", () => {
     });
   });
 });
+
+// ── parseChart — upDownBars ────────────────────────────────────────
+
+describe("parseChart — upDownBars", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces upDownBars=true on a line chart with the bare element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+  });
+
+  it("surfaces upDownBars=true when the element carries the optional gapWidth child", () => {
+    // Excel's reference serialization includes <c:gapWidth val="150"/>
+    // inside <c:upDownBars>. The model is a presence flag at this
+    // layer, so the child should not change the surfaced value.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars>
+        <c:gapWidth val="150"/>
+      </c:upDownBars>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+  });
+
+  it("surfaces upDownBars=true when the element carries upBars / downBars children", () => {
+    // <c:upBars> and <c:downBars> are CT_UpDownBar — each with an
+    // optional <c:spPr>. Their presence does not change the bare
+    // toggle exposed at this layer.
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars>
+        <c:gapWidth val="200"/>
+        <c:upBars>
+          <c:spPr>
+            <a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill>
+          </c:spPr>
+        </c:upBars>
+        <c:downBars>
+          <c:spPr>
+            <a:solidFill><a:srgbClr val="000000"/></a:solidFill>
+          </c:spPr>
+        </c:downBars>
+      </c:upDownBars>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+  });
+
+  it("collapses absence of <c:upDownBars> to undefined on a line chart", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBeUndefined();
+  });
+
+  it("ignores <c:upDownBars> on a bar chart (CT_BarChart rejects the element)", () => {
+    // The OOXML schema places <c:upDownBars> on CT_LineChart /
+    // CT_Line3DChart / CT_StockChart only. A stray element on a bar
+    // / column chart is not surfaced — the writer would never emit
+    // it there.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:grouping val="clustered"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBeUndefined();
+  });
+
+  it("ignores <c:upDownBars> on an area chart (CT_AreaChart rejects the element)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:areaChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:areaChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBeUndefined();
+  });
+
+  it("ignores <c:upDownBars> on a scatter chart (CT_ScatterChart rejects the element)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:scatterChart>
+    <c:valAx><c:axId val="1"/></c:valAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBeUndefined();
+  });
+
+  it("surfaces upDownBars on a stock chart (CT_StockChart accepts the element)", () => {
+    // CT_StockChart is where Excel typically paints up/down bars in the
+    // wild (open / close). The reader accepts the element on any
+    // line-flavored chart-type body.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:stockChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:stockChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+  });
+
+  it("surfaces upDownBars on a 3D line chart (CT_Line3DChart accepts the element)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:line3DChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+      <c:axId val="3"/>
+    </c:line3DChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:serAx><c:axId val="3"/></c:serAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+  });
+
+  it("co-surfaces upDownBars alongside other chart-level fields", () => {
+    // upDownBars sits inside the chart-type element (line/stock) and
+    // should not interfere with chart-level toggles like dispBlanksAs
+    // / plotVisOnly that live on <c:chart> itself.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="standard"/>
+        <c:varyColors val="0"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:upDownBars>
+          <c:gapWidth val="150"/>
+        </c:upDownBars>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the chart-type-level `<c:upDownBars>` element at the read, write, and clone layers so a template's up / down bars configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh line chart.

`<c:upDownBars>` mirrors Excel's "Add Chart Element -> Up/Down Bars" toggle on a line chart — vertical bars at each category that connect a paired series, where the bar's top tracks the higher value and bottom tracks the lower one. The element is the visualization Excel paints natively on line-style stock charts (open / close differences on a price series). The model at this layer is a plain presence flag (`upDownBars: boolean`); the writer emits the element with Excel's reference `<c:gapWidth val="150"/>` child whenever the flag is `true` on a line chart.

Up until now hucre's writer had no slot for the element, so a template that pinned up / down bars flattened back to no bars on every parse -> clone -> write loop. This bridges another visualization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.upDownBars); // true when the template pinned <c:upDownBars/>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Stock",
    rows: [...],
    charts: [{
      type: "line",
      series: [
        { name: "High", values: "B2:B10", categories: "A2:A10" },
        { name: "Low",  values: "C2:C10", categories: "A2:A10" },
      ],
      upDownBars: true, // vertical bars connecting High / Low at each category
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  // upDownBars: undefined -> inherit
  // upDownBars: null      -> drop inherited flag (no element emitted)
  // upDownBars: true      -> pin
  // upDownBars: false     -> equivalent to absence (writer collapses to default)
});
```

## Model

```ts
// Read side
export interface Chart {
  // ...existing fields...
  upDownBars?: boolean;
}

// Write side
export interface SheetChart {
  // ...existing fields...
  upDownBars?: boolean;
}

// Clone side
export interface CloneChartOptions {
  // ...existing fields...
  upDownBars?: boolean | null;
}
```

## Scope rules

- The OOXML schema places `<c:upDownBars>` on `CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` exclusively. The writer only authors `<c:lineChart>`, so the flag emits only when `type: "line"`; bar / column / pie / doughnut / area / scatter silently drop it.
- The reader surfaces the flag from any line-flavored chart-type body (line / line3D / stock); a stray `<c:upDownBars>` on bar / column / pie / doughnut / area / scatter chart-type elements is ignored.
- Element ordering inside `<c:lineChart>` follows CT_LineChart: `<c:upDownBars>` lands before `<c:marker>` and `<c:axId>`.
- The writer emits a default `<c:gapWidth val="150"/>` child to mirror Excel's reference serialization. `<c:upBars>` / `<c:downBars>` are intentionally omitted — Excel paints the default white-up / black-down bars on a fresh toggle. A richer model (custom gap widths, per-bar styling) can layer on later if needed.
- The clone layer drops the flag on a flatten to anything but `line` (line -> column flattens drop the element) so a stale up/down-bars hint never leaks into a chart-type element whose schema rejects it.

## Test plan

- [x] `pnpm exec vitest run --dir test` — 3443 tests passing.
- [x] `pnpm typecheck` — tsgo clean.
- [x] `pnpm exec oxlint src test` — 0 errors.
- [x] `pnpm exec oxfmt --check src test` — clean.
- [x] `pnpm build` — obuild succeeds.
- [x] `parseChart` covers bare element, element with `<c:gapWidth>` child, element with `<c:upBars>` / `<c:downBars>` children, absence collapse, scope drops on bar / area / scatter, surfacing on stock + line3D bodies, and co-existence with chart-level toggles.
- [x] `writeChart` covers absence default, `true` emit with default gapWidth=150, `false` collapse to absence, OOXML element ordering (before `<c:marker>` / `<c:axId>`), single-emit guard, drop on every non-line chart family, parseChart round-trip, and end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace, addition on a source that lacked the flag, drops on flatten to column / area / pie / scatter, carry through stock -> line flatten, and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.