### PR TITLE
feat(xlsx): chart built-in style preset — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1143,6 +1143,26 @@ export interface SheetChart {
    */
   upDownBars?: boolean;
   /**
+   * Built-in chart style preset. Maps to `<c:style val=".."/>` on
+   * `<c:chartSpace>` (a sibling of `<c:chart>`, not a child). Mirrors
+   * Excel's "Chart Design -> Chart Styles" gallery — each integer
+   * picks one of the 48 numbered presets that cycle a colored
+   * background, gridline density, border, and label styling across
+   * the chart.
+   *
+   * Default: omitted — when the field is absent the writer skips the
+   * element and Excel renders the chart with its application default
+   * look. Set an integer in the OOXML range (1–48) to pin a preset;
+   * out-of-range and non-integer values are silently dropped rather
+   * than emit a token Excel would reject.
+   *
+   * Useful when matching a dashboard whose other charts already
+   * carry a particular preset look from a template — clone-through
+   * preserves the parsed value so a fresh chart and a templated chart
+   * compose side by side without manual re-styling.
+   */
+  style?: number;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -2754,6 +2774,28 @@ export interface Chart {
    * / area / scatter chart-type elements.
    */
   upDownBars?: boolean;
+  /**
+   * Built-in chart style preset pulled from `<c:chartSpace><c:style
+   * val=".."/>`. Reflects Excel's "Chart Design -> Chart Styles"
+   * gallery — each value picks one of the 48 numbered presets that
+   * cycle a colored background, gridline density, border, and label
+   * styling across the chart.
+   *
+   * Surfaces the integer value verbatim when `val` is an integer in
+   * the OOXML range (1–48); absence and out-of-range / non-integer
+   * values drop to `undefined`. The reader does not pin a default —
+   * Excel's reference serialization for a fresh chart emits `<c:style
+   * val="2"/>`, but a chart that omits the element renders identically
+   * (Excel falls back to its application default). Surfacing only the
+   * non-default values keeps the parsed shape minimal and lets a
+   * roundtrip of a templated chart preserve its preset while a fresh
+   * chart stays unmarked.
+   *
+   * Note: `<c:style>` lives on `<c:chartSpace>`, not inside
+   * `<c:chart>` — the preset styles the outer chart space (frame
+   * fill, plot area look, default text font), not just the plot area.
+   */
+  style?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -295,6 +295,23 @@ export interface CloneChartOptions {
    */
   upDownBars?: boolean | null;
   /**
+   * Override `<c:style>` (the built-in chart style preset, 1–48).
+   *
+   * `undefined` (or omitted) inherits the source's parsed `style`.
+   * `null` drops the inherited value so the writer skips the element
+   * entirely — Excel falls back to its application default look. A
+   * number replaces the preset; out-of-range / non-integer values are
+   * dropped at the writer side rather than emit a token Excel would
+   * reject.
+   *
+   * Useful when restyling a cloned chart to a different gallery
+   * preset, or stripping a template's pinned style so the clone picks
+   * up the host workbook's default. The grammar mirrors
+   * `roundedCorners` / `plotVisOnly` so the chart-frame toggles
+   * compose the same way at the call site.
+   */
+  style?: number | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -674,6 +691,9 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     options.roundedCorners,
   );
   if (resolvedRoundedCorners !== undefined) out.roundedCorners = resolvedRoundedCorners;
+
+  const resolvedStyle = resolveStyle(source.style, options.style);
+  if (resolvedStyle !== undefined) out.style = resolvedStyle;
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -1059,6 +1079,30 @@ function resolveRoundedCorners(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `style` (built-in chart preset) override.
+ *
+ * `undefined` → inherit the source's parsed `style`.
+ * `null`      → drop the inherited value (the writer skips `<c:style>`
+ *               so Excel falls back to its application default look).
+ * `number`    → replace. Out-of-range / non-integer values are not
+ *               filtered here — the writer's `resolveStyle` performs
+ *               the same shape check on emit, so a stray value never
+ *               reaches the rendered XML regardless of the path it
+ *               took through clone.
+ *
+ * The grammar mirrors `roundedCorners` / `plotVisOnly` so the chart-
+ * frame toggles compose the same way at the call site.
+ */
+function resolveStyle(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -270,6 +270,13 @@ export function parseChart(xml: string): Chart | undefined {
   const roundedCorners = parseRoundedCorners(chartSpace);
   if (roundedCorners !== undefined) out.roundedCorners = roundedCorners;
 
+  // `<c:style>` also sits on `<c:chartSpace>` — it picks one of the 48
+  // built-in chart-style presets that style the entire chart space
+  // (frame fill, plot area look, default text font), not just the
+  // plot area.
+  const style = parseStyle(chartSpace);
+  if (style !== undefined) out.style = style;
+
   return out;
 }
 
@@ -1510,6 +1517,41 @@ function parseRoundedCorners(chartSpace: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+// ── Chart Style Preset ────────────────────────────────────────────
+
+/**
+ * Pull `<c:style val=".."/>` off `<c:chartSpace>`. Surfaces the
+ * integer value verbatim when `val` parses as an integer in the OOXML
+ * range (1–48); absence and out-of-range / non-integer values drop to
+ * `undefined`.
+ *
+ * The reader does not pin a default — Excel's reference serialization
+ * for a fresh chart emits `<c:style val="2"/>`, but a chart that omits
+ * the element renders identically (Excel falls back to its application
+ * default). Surfacing only the values that round-trip preserves the
+ * minimal-shape contract the rest of {@link Chart} follows.
+ *
+ * Note: `<c:style>` lives on `<c:chartSpace>`, not inside `<c:chart>`
+ * — the preset styles the outer chart space (frame fill, plot area
+ * look, default text font), not just the plot area. Per the
+ * CT_ChartSpace sequence the element sits after `<c:roundedCorners>`
+ * and before `<c:chart>`.
+ */
+function parseStyle(chartSpace: XmlElement): number | undefined {
+  const el = findChild(chartSpace, "style");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  // Strict integer parse — `parseInt` would accept `"3px"` / `"3.5"`,
+  // either of which is outside the `xsd:unsignedByte` shape `<c:style>`
+  // expects per CT_Style.
+  if (!/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  if (n < 1 || n > 48) return undefined;
+  return n;
 }
 
 // ── Vary Colors ────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -81,6 +81,22 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
   const chartElement = xmlElement("c:chart", undefined, chartChildren);
 
+  // `<c:chartSpace>` element ordering per CT_ChartSpace
+  // (ECMA-376 Part 1, §21.2.2.29): date1904?, lang?, roundedCorners?,
+  // AlternateContent?, clrMapOvr?, style?, ... chart, ...
+  // — the `<c:style>` element sits after `<c:roundedCorners>` and
+  // before `<c:chart>`. The writer skips emission entirely when the
+  // chart leaves `style` unset so a fresh chart matches Excel's
+  // implicit default rather than pinning the application's `2` preset.
+  const chartSpaceChildren: string[] = [
+    xmlSelfClose("c:roundedCorners", { val: resolveRoundedCorners(chart) ? 1 : 0 }),
+  ];
+  const styleVal = resolveStyle(chart);
+  if (styleVal !== undefined) {
+    chartSpaceChildren.push(xmlSelfClose("c:style", { val: styleVal }));
+  }
+  chartSpaceChildren.push(chartElement);
+
   const chartXml = xmlDocument(
     "c:chartSpace",
     {
@@ -88,7 +104,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
       "xmlns:a": NS_A,
       "xmlns:r": NS_R,
     },
-    [xmlSelfClose("c:roundedCorners", { val: resolveRoundedCorners(chart) ? 1 : 0 }), chartElement],
+    chartSpaceChildren,
   );
 
   // Always emit an empty rels file. Phase 1 charts do not depend on
@@ -1816,6 +1832,30 @@ function resolvePlotVisOnly(chart: SheetChart): boolean {
 function resolveRoundedCorners(chart: SheetChart): boolean {
   if (typeof chart.roundedCorners === "boolean") return chart.roundedCorners;
   return false;
+}
+
+// ── Chart Style Preset ──────────────────────────────────────────────
+
+/**
+ * Resolve the `<c:style val=".."/>` value emitted on `<c:chartSpace>`.
+ *
+ * Returns `undefined` when the chart leaves `style` unset (the writer
+ * skips the element entirely so a fresh chart matches Excel's implicit
+ * default rather than pinning the application's `2` preset). Out-of-
+ * range and non-integer values also collapse to `undefined` rather
+ * than emit a token Excel would reject — `<c:style>` is `xsd:unsigned
+ * Byte` in the OOXML schema with the gallery range of 1–48.
+ *
+ * `<c:style>` sits on `<c:chartSpace>` (a sibling of `<c:chart>`, not
+ * a child) per CT_ChartSpace. The element follows `<c:roundedCorners>`
+ * and precedes `<c:chart>` in the schema sequence.
+ */
+function resolveStyle(chart: SheetChart): number | undefined {
+  const raw = chart.style;
+  if (typeof raw !== "number") return undefined;
+  if (!Number.isInteger(raw)) return undefined;
+  if (raw < 1 || raw > 48) return undefined;
+  return raw;
 }
 
 // ── Vary Colors ──────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -5997,3 +5997,193 @@ describe("cloneChart — upDownBars", () => {
     expect(parseChart(written)?.upDownBars).toBeUndefined();
   });
 });
+
+// ── cloneChart — chart style preset ──────────────────────────────────
+
+describe("cloneChart — chart style preset", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's style by default", () => {
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.style).toBe(27);
+  });
+
+  it("lets options.style override the source's value", () => {
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      style: 12,
+    });
+    expect(clone.style).toBe(12);
+  });
+
+  it("drops the inherited style when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:style> entirely on emit.
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      style: null,
+    });
+    expect(clone.style).toBeUndefined();
+  });
+
+  it("returns undefined style when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.style).toBeUndefined();
+  });
+
+  it("adds a style hint on a source that lacked one", () => {
+    // The source has no parsed style — the override pins one and the
+    // resolved SheetChart carries the value through.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      style: 18,
+    });
+    expect(clone.style).toBe(18);
+  });
+
+  it("carries style through a flatten (line → column)", () => {
+    // <c:style> lives on <c:chartSpace> and is valid on every chart
+    // family, so a coercion does not drop it.
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.style).toBe(27);
+  });
+
+  it("carries style through a doughnut flatten (line → doughnut)", () => {
+    // The preset has no chart-family restriction — even a coercion to
+    // doughnut, which has no axes, must preserve the pinned value.
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.style).toBe(27);
+  });
+
+  it("propagates style into the rendered <c:chartSpace> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ style: 34 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:style val="34"');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.style).toBe(34);
+  });
+
+  it("emits no <c:style> element when both source and override are absent", async () => {
+    // A bare clone with no style hint rolls into a SheetChart whose
+    // writer skips the element and re-parses to undefined.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:style ");
+    expect(parseChart(written)?.style).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins style 27, clone overrides to null — the rendered
+    // chart should carry no element and re-parse to undefined.
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      style: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:style ");
+    expect(parseChart(written)?.style).toBeUndefined();
+  });
+
+  it("an explicit numeric override replaces a source style through writeXlsx", async () => {
+    const clone = cloneChart(source({ style: 27 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      style: 4,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:style val="4"');
+    expect(written).not.toContain('c:style val="27"');
+    expect(parseChart(written)?.style).toBe(4);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5315,3 +5315,127 @@ describe("writeChart — upDownBars", () => {
     expect(reparsed?.upDownBars).toBe(true);
   });
 });
+
+// ── writeChart — chart style preset ──────────────────────────────────
+
+describe("writeChart — chart style preset", () => {
+  it("skips <c:style> entirely when the field is unset (writer default)", () => {
+    // Excel's reference serialization for a fresh chart pins style 2,
+    // but the writer skips emission so an unstyled chart stays minimal
+    // — Excel falls back to its application default look.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:style ");
+    expect(result.chartXml).not.toContain("<c:style/>");
+  });
+
+  it('emits <c:style val="N"/> on <c:chartSpace> when the field is pinned', () => {
+    const result = writeChart(makeChart({ style: 27 }), "Sheet1");
+    expect(result.chartXml).toContain('c:style val="27"');
+  });
+
+  it("emits the OOXML range bounds (1 and 48)", () => {
+    for (const val of [1, 48]) {
+      const result = writeChart(makeChart({ style: val }), "Sheet1");
+      expect(result.chartXml).toContain(`c:style val="${val}"`);
+    }
+  });
+
+  it("places <c:style> after <c:roundedCorners> and before <c:chart>", () => {
+    // CT_ChartSpace sequence: ... roundedCorners?, AlternateContent?,
+    // clrMapOvr?, style?, ... chart, ... — the preset must follow
+    // <c:roundedCorners> and precede <c:chart> so a strict validator
+    // (Excel itself rejects out-of-order children) sees the schema
+    // sequence respected.
+    const result = writeChart(makeChart({ style: 12, roundedCorners: true }), "Sheet1");
+    const roundedIdx = result.chartXml.indexOf("c:roundedCorners");
+    const styleIdx = result.chartXml.indexOf("c:style ");
+    const chartIdx = result.chartXml.indexOf("<c:chart>");
+    expect(roundedIdx).toBeGreaterThan(-1);
+    expect(styleIdx).toBeGreaterThan(roundedIdx);
+    expect(styleIdx).toBeLessThan(chartIdx);
+  });
+
+  it("only emits <c:style> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ style: 27 }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:style /g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("drops out-of-range style values (0 / 49 / 255) rather than emit them", () => {
+    // CT_Style declares val as xsd:unsignedByte in the gallery range
+    // 1–48. Out-of-range values collapse to absence so the writer
+    // never emits a token Excel would reject.
+    for (const val of [0, 49, 100, 255, -3]) {
+      const result = writeChart(makeChart({ style: val }), "Sheet1");
+      expect(result.chartXml).not.toContain("<c:style ");
+      expect(result.chartXml).not.toContain("<c:style/>");
+    }
+  });
+
+  it("drops non-integer style values (3.5 / NaN / Infinity)", () => {
+    for (const val of [3.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const result = writeChart(makeChart({ style: val }), "Sheet1");
+      expect(result.chartXml).not.toContain("<c:style ");
+    }
+  });
+
+  it("threads style through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, style: 18 }), "Sheet1");
+      expect(result.chartXml).toContain('c:style val="18"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        style: 18,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:style val="18"');
+  });
+
+  it("round-trips a pinned style through parseChart", () => {
+    const written = writeChart(makeChart({ style: 27 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.style).toBe(27);
+  });
+
+  it("collapses an unset style round-trip back to undefined", () => {
+    // A fresh chart writes no element, which re-parses to undefined —
+    // absence and the unstyled default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.style).toBeUndefined();
+  });
+
+  it("threads style end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            style: 34,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('c:style val="34"');
+    // Re-parse the rendered chart to confirm the preset survives the
+    // packaging path.
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.style).toBe(34);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6184,3 +6184,140 @@ describe("parseChart — upDownBars", () => {
     expect(chart?.dispBlanksAs).toBe("zero");
   });
 });
+
+// ── parseChart — chart style preset ────────────────────────────────
+
+describe("parseChart — chart style preset", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:style val="2"/> on <c:chartSpace> as the integer 2', () => {
+    // Excel's reference serialization for a fresh chart pins style 2 —
+    // it surfaces verbatim because the reader does not collapse a
+    // default (a chart that omits the element renders identically).
+    const xml = `<c:chartSpace ${NS}>
+  <c:style val="2"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.style).toBe(2);
+  });
+
+  it("surfaces a templated mid-range preset (style 27)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:style val="27"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.style).toBe(27);
+  });
+
+  it("surfaces the OOXML range bounds (1 and 48)", () => {
+    for (const val of [1, 48]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:style val="${val}"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.style).toBe(val);
+    }
+  });
+
+  it("returns undefined when the chartSpace has no <c:style> element", () => {
+    // Absence is the writer's default — the reader surfaces nothing
+    // so a fresh chart and a chart that omits the element round-trip
+    // identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.style).toBeUndefined();
+  });
+
+  it("drops out-of-range style values (0 / 49)", () => {
+    // CT_Style declares `val` as `xsd:unsignedByte` in the gallery
+    // range 1–48; values outside collapse to undefined rather than
+    // surface a token Excel would not emit.
+    for (const val of ["0", "49", "255"]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:style val="${val}"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.style).toBeUndefined();
+    }
+  });
+
+  it("drops non-integer style values rather than fabricate one", () => {
+    // The OOXML schema forbids fractional / negative / alpha values.
+    for (const val of ["3.5", "-1", "two", "3px"]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:style val="${val}"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.style).toBeUndefined();
+    }
+  });
+
+  it("ignores a missing val attribute on <c:style>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:style/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.style).toBeUndefined();
+  });
+
+  it("surfaces style alongside roundedCorners and other chart-level toggles", () => {
+    // <c:style> sits on <c:chartSpace> (after <c:roundedCorners>) per
+    // the CT_ChartSpace sequence. Co-existing with chart-level toggles
+    // that live on <c:chart> should not interfere.
+    const xml = `<c:chartSpace ${NS}>
+  <c:roundedCorners val="1"/>
+  <c:style val="34"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.style).toBe(34);
+    expect(chart?.roundedCorners).toBe(true);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the chart-space-level `<c:style val=".."/>` element at the read, write, and clone layers so a template's built-in chart-style preset survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch.

`<c:style>` mirrors Excel's "Chart Design -> Chart Styles" gallery — each integer in 1–48 picks one of the numbered presets that cycle a colored background, gridline density, border, and label styling across the chart. The element sits on `<c:chartSpace>` (a sibling of `<c:chart>`, not a child) per `CT_ChartSpace`, after `<c:roundedCorners>` and before `<c:chart>`.

Up until now hucre's writer skipped the element entirely and the reader ignored it, so a templated chart flattened back to the unstyled default on every parse -> clone -> write loop. This bridges another chart-frame gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.style); // 27 when the template pinned <c:style val="27"/>,
                           // undefined when the template omitted the element

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      style: 27, // pin the gallery preset
    }],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  style: 4,        // replace
  // style: null   // drop the inherited preset (writer skips <c:style>)
  // style: undefined // inherit the source's parsed value
});
```

## Model

```ts
interface Chart {
  /* ...existing fields... */
  style?: number;
}

interface SheetChart {
  /* ...existing fields... */
  style?: number;
}

interface CloneChartOptions {
  /* ...existing fields... */
  style?: number | null;
}
```

The read-side `Chart.style` mirrors the write-side `SheetChart.style` so a parsed value slots straight back into `cloneChart` without transformation. The override grammar mirrors `roundedCorners` / `plotVisOnly` so the chart-frame toggles compose the same way at the call site.

## Scope rules

- The OOXML schema declares `<c:style>` `val` as `xsd:unsignedByte` in the gallery range 1–48. Out-of-range / non-integer / missing values drop to absence on both read and write — the reader collapses them to `undefined` and the writer skips emission rather than emit a token Excel would reject.
- Element ordering inside `<c:chartSpace>` follows the `CT_ChartSpace` sequence: `<c:style>` lands after `<c:roundedCorners>` and before `<c:chart>`. The chart-frame helper applies on every chart family — the writer threads `style` through bar / column / line / pie / doughnut / area / scatter identically, since the preset has no chart-family restriction.
- Unlike `roundedCorners` (always emitted with the explicit default `0`), the writer skips the element entirely when `style` is unset so a fresh chart matches Excel's implicit default look. Excel's reference serialization for a fresh chart pins style 2, but a chart that omits the element renders identically — collapsing absence to absence keeps the parsed shape minimal so a roundtrip of an unstyled chart returns no `style` field.
- The clone layer carries `style` through every chart-type flatten (line -> column / doughnut / pie / area / scatter) because `<c:style>` lives on `<c:chartSpace>` and is valid on every chart family.

## Test plan

- [x] `pnpm test` — 3532 tests passing (47 new), 0 lint errors, 0 type errors, oxfmt clean.
- [x] `pnpm build` — obuild succeeds.
- [x] `parseChart` covers default-shape (val="2"), templated mid-range (val="27"), range bounds (1 / 48), absence, out-of-range (0 / 49 / 255), non-integer (3.5 / -1 / "two" / "3px"), missing val attribute, and co-existence with `roundedCorners` / `plotVisOnly` / `dispBlanksAs` / `varyColors`.
- [x] `writeChart` covers absence skip, `style: 27` emit, range bounds emit, OOXML element ordering (after `<c:roundedCorners>`, before `<c:chart>`), single-emit guard, out-of-range drop (0 / 49 / 100 / 255 / -3), non-integer drop (3.5 / NaN / Infinity), every chart family (bar / column / line / pie / doughnut / area / scatter), `parseChart` round-trip, and end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace, addition on a source that lacked the field, carry through every flatten (line -> column / doughnut), and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)