### PR TITLE
feat(xlsx): chart editing locale (lang) — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1163,6 +1163,31 @@ export interface SheetChart {
    */
   style?: number;
   /**
+   * Editing-locale hint. Maps to `<c:lang val=".."/>` on
+   * `<c:chartSpace>` (a sibling of `<c:chart>`, not a child). The
+   * value is an RFC-1766 / IETF BCP-47 culture name such as `en-US`,
+   * `tr-TR`, or `de-DE` — Excel uses it to drive locale-sensitive
+   * defaults within the chart (decimal / group separators on
+   * unformatted axis ticks, default text font fallback, and the
+   * locale recorded for any in-chart text runs).
+   *
+   * Default: omitted — when the field is absent the writer skips the
+   * element and Excel falls back to the workbook's editing language.
+   * Excel's reference serialization for a fresh chart authored on an
+   * English locale emits `<c:lang val="en-US"/>`; the writer does
+   * not pin a default so an unmarked chart and an `en-US` chart do
+   * not silently diverge on roundtrip.
+   *
+   * Useful when restamping a templated chart for a different locale,
+   * or carrying a translated dashboard's `tr-TR` / `de-DE` hint
+   * through the parse → clone → write loop. Only well-formed culture
+   * names are emitted — unrecognized shapes are silently dropped
+   * rather than emit a token Excel would reject. The token has to
+   * match `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*` (the IETF language tag
+   * subset `<c:lang>` accepts under `xsd:language`).
+   */
+  lang?: string;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -2796,6 +2821,28 @@ export interface Chart {
    * fill, plot area look, default text font), not just the plot area.
    */
   style?: number;
+  /**
+   * Editing-locale hint pulled from `<c:chartSpace><c:lang val=".."/>`.
+   * The value is an IETF BCP-47 culture name such as `en-US`, `tr-TR`,
+   * or `de-DE` — Excel records the editing locale on every authored
+   * chart and uses it to drive locale-sensitive defaults (decimal /
+   * group separators on unformatted axis ticks, default text font
+   * fallback, and the locale recorded for any in-chart text runs).
+   *
+   * Surfaces the value verbatim when `val` matches the IETF subset
+   * Excel emits (`[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`); absence and
+   * malformed tokens drop to `undefined` rather than fabricate a
+   * default. Excel's reference serialization for a fresh chart
+   * authored on an English locale emits `<c:lang val="en-US"/>`,
+   * but the reader does not pin that — only the value the file
+   * actually carries surfaces, so the round-trip stays minimal.
+   *
+   * Note: `<c:lang>` lives on `<c:chartSpace>` (per CT_ChartSpace
+   * the element sits between `<c:date1904>` and `<c:roundedCorners>`),
+   * not inside `<c:chart>` — the locale governs the entire chart
+   * document, not just the plot area.
+   */
+  lang?: string;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -312,6 +312,25 @@ export interface CloneChartOptions {
    */
   style?: number | null;
   /**
+   * Override `<c:lang>` (the chart-space editing-locale hint).
+   *
+   * `undefined` (or omitted) inherits the source's parsed `lang`.
+   * `null` drops the inherited value so the writer skips the element
+   * entirely — Excel falls back to the host workbook's editing
+   * language. A string replaces the locale; malformed culture names
+   * are dropped at the writer side rather than emit a token Excel
+   * would reject (`<c:lang>` is `xsd:language` per the OOXML schema,
+   * the BCP-47 shape `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`, e.g.
+   * `en-US`, `tr-TR`, `zh-Hant-TW`).
+   *
+   * Useful when restamping a templated chart for a different locale,
+   * or stripping a template's pinned `en-US` so a translated
+   * dashboard inherits the host workbook's locale. The grammar
+   * mirrors `style` so the chart-space toggles compose the same way
+   * at the call site.
+   */
+  lang?: string | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -694,6 +713,9 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedStyle = resolveStyle(source.style, options.style);
   if (resolvedStyle !== undefined) out.style = resolvedStyle;
+
+  const resolvedLang = resolveLang(source.lang, options.lang);
+  if (resolvedLang !== undefined) out.lang = resolvedLang;
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -1103,6 +1125,31 @@ function resolveStyle(
   sourceValue: number | undefined,
   override: number | null | undefined,
 ): number | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `lang` (chart-space editing-locale hint) override.
+ *
+ * `undefined` → inherit the source's parsed `lang`.
+ * `null`      → drop the inherited value (the writer skips `<c:lang>`
+ *               so Excel falls back to the host workbook's editing
+ *               language).
+ * `string`    → replace. Malformed culture names are not filtered
+ *               here — the writer's `resolveLang` performs the same
+ *               BCP-47 shape check on emit, so a stray value never
+ *               reaches the rendered XML regardless of the path it
+ *               took through clone.
+ *
+ * The grammar mirrors `style` / `roundedCorners` / `plotVisOnly` so
+ * the chart-space toggles compose the same way at the call site.
+ */
+function resolveLang(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -277,6 +277,14 @@ export function parseChart(xml: string): Chart | undefined {
   const style = parseStyle(chartSpace);
   if (style !== undefined) out.style = style;
 
+  // `<c:lang>` records the editing locale Excel used to author the
+  // chart. It also sits on `<c:chartSpace>` (per CT_ChartSpace, between
+  // `<c:date1904>` and `<c:roundedCorners>`), not inside `<c:chart>` —
+  // the value drives locale-sensitive defaults across the entire chart
+  // document.
+  const lang = parseLang(chartSpace);
+  if (lang !== undefined) out.lang = lang;
+
   return out;
 }
 
@@ -1552,6 +1560,42 @@ function parseStyle(chartSpace: XmlElement): number | undefined {
   if (!Number.isInteger(n)) return undefined;
   if (n < 1 || n > 48) return undefined;
   return n;
+}
+
+// ── Editing Locale ────────────────────────────────────────────────
+
+/**
+ * Pull `<c:lang val=".."/>` off `<c:chartSpace>`. Surfaces the
+ * culture-name verbatim when `val` matches the IETF BCP-47 subset
+ * Excel emits (`[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*`, e.g. `en-US`,
+ * `tr-TR`, `zh-Hant-TW`); absence and malformed tokens drop to
+ * `undefined`.
+ *
+ * The reader does not pin a default — Excel's reference serialization
+ * for a fresh chart authored on an English locale emits `<c:lang
+ * val="en-US"/>`, but a chart that omits the element renders
+ * identically (Excel falls back to the workbook's editing language).
+ * Surfacing only the values that round-trip preserves the minimal-
+ * shape contract the rest of {@link Chart} follows.
+ *
+ * Note: `<c:lang>` lives on `<c:chartSpace>` (per the CT_ChartSpace
+ * sequence the element sits between `<c:date1904>` and
+ * `<c:roundedCorners>`), not inside `<c:chart>` — the locale governs
+ * the entire chart document, not just the plot area.
+ */
+function parseLang(chartSpace: XmlElement): string | undefined {
+  const el = findChild(chartSpace, "lang");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  // Strict shape check — Excel's `<c:lang>` is `xsd:language`
+  // (RFC-1766 / BCP-47 culture name). The pattern matches a primary
+  // 2- / 3-letter language tag plus zero or more `-`-separated 2–8
+  // alphanumeric subtags, which covers everything Excel emits
+  // (`en-US`, `tr-TR`, `pt-BR`, `zh-Hans-CN`, …) without admitting
+  // raw garbage like `"english"` or `"en US"`.
+  if (!/^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(raw)) return undefined;
+  return raw;
 }
 
 // ── Vary Colors ────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -84,13 +84,20 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   // `<c:chartSpace>` element ordering per CT_ChartSpace
   // (ECMA-376 Part 1, §21.2.2.29): date1904?, lang?, roundedCorners?,
   // AlternateContent?, clrMapOvr?, style?, ... chart, ...
-  // — the `<c:style>` element sits after `<c:roundedCorners>` and
-  // before `<c:chart>`. The writer skips emission entirely when the
-  // chart leaves `style` unset so a fresh chart matches Excel's
-  // implicit default rather than pinning the application's `2` preset.
-  const chartSpaceChildren: string[] = [
+  // — `<c:lang>` sits between `<c:date1904>` and `<c:roundedCorners>`,
+  // and `<c:style>` sits after `<c:roundedCorners>` and before
+  // `<c:chart>`. The writer skips emission for any element the chart
+  // leaves unset so a fresh chart stays minimal; Excel itself falls
+  // back to the workbook's editing language and the application's
+  // default look respectively.
+  const chartSpaceChildren: string[] = [];
+  const langVal = resolveLang(chart);
+  if (langVal !== undefined) {
+    chartSpaceChildren.push(xmlSelfClose("c:lang", { val: langVal }));
+  }
+  chartSpaceChildren.push(
     xmlSelfClose("c:roundedCorners", { val: resolveRoundedCorners(chart) ? 1 : 0 }),
-  ];
+  );
   const styleVal = resolveStyle(chart);
   if (styleVal !== undefined) {
     chartSpaceChildren.push(xmlSelfClose("c:style", { val: styleVal }));
@@ -1855,6 +1862,34 @@ function resolveStyle(chart: SheetChart): number | undefined {
   if (typeof raw !== "number") return undefined;
   if (!Number.isInteger(raw)) return undefined;
   if (raw < 1 || raw > 48) return undefined;
+  return raw;
+}
+
+// ── Editing Locale ──────────────────────────────────────────────────
+
+/**
+ * Resolve the `<c:lang val=".."/>` value emitted on `<c:chartSpace>`.
+ *
+ * Returns `undefined` when the chart leaves `lang` unset (the writer
+ * skips the element entirely so a fresh chart falls back to Excel's
+ * workbook-level editing language rather than fabricating a token
+ * neither the caller nor a re-parse would carry). Malformed and
+ * non-string values also collapse to `undefined` — `<c:lang>` is
+ * `xsd:language` in the OOXML schema, the IETF BCP-47 culture-name
+ * shape `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*` (e.g. `en-US`, `tr-TR`,
+ * `zh-Hant-TW`).
+ *
+ * `<c:lang>` sits on `<c:chartSpace>` (a sibling of `<c:chart>`, not
+ * a child) per CT_ChartSpace. The element follows `<c:date1904>` and
+ * precedes `<c:roundedCorners>` in the schema sequence — the locale
+ * governs the entire chart document (locale-sensitive separators on
+ * unformatted axis ticks, default text font fallback, the locale
+ * recorded for in-chart text runs), not just the plot area.
+ */
+function resolveLang(chart: SheetChart): string | undefined {
+  const raw = chart.lang;
+  if (typeof raw !== "string") return undefined;
+  if (!/^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(raw)) return undefined;
   return raw;
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6187,3 +6187,224 @@ describe("cloneChart — chart style preset", () => {
     expect(parseChart(written)?.style).toBe(4);
   });
 });
+
+// ── cloneChart — chart editing locale (lang) ─────────────────────────
+
+describe("cloneChart — chart editing locale", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's lang by default", () => {
+    const clone = cloneChart(source({ lang: "en-US" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.lang).toBe("en-US");
+  });
+
+  it("lets options.lang override the source's value", () => {
+    const clone = cloneChart(source({ lang: "en-US" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      lang: "tr-TR",
+    });
+    expect(clone.lang).toBe("tr-TR");
+  });
+
+  it("drops the inherited lang when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:lang> entirely on emit.
+    const clone = cloneChart(source({ lang: "en-US" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      lang: null,
+    });
+    expect(clone.lang).toBeUndefined();
+  });
+
+  it("returns undefined lang when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.lang).toBeUndefined();
+  });
+
+  it("adds a lang hint on a source that lacked one", () => {
+    // The source has no parsed lang — the override pins one and the
+    // resolved SheetChart carries the value through.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      lang: "de-DE",
+    });
+    expect(clone.lang).toBe("de-DE");
+  });
+
+  it("carries lang through a flatten (line → column)", () => {
+    // <c:lang> lives on <c:chartSpace> and is valid on every chart
+    // family, so a coercion does not drop it.
+    const clone = cloneChart(source({ lang: "tr-TR" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.lang).toBe("tr-TR");
+  });
+
+  it("carries lang through a doughnut flatten (line → doughnut)", () => {
+    // The locale has no chart-family restriction — even a coercion to
+    // doughnut, which has no axes, must preserve the pinned value.
+    const clone = cloneChart(source({ lang: "tr-TR" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.lang).toBe("tr-TR");
+  });
+
+  it("propagates lang into the rendered <c:chartSpace> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ lang: "tr-TR" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:lang val="tr-TR"');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.lang).toBe("tr-TR");
+  });
+
+  it("emits no <c:lang> element when both source and override are absent", async () => {
+    // A bare clone with no lang hint rolls into a SheetChart whose
+    // writer skips the element and re-parses to undefined.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:lang ");
+    expect(parseChart(written)?.lang).toBeUndefined();
+  });
+
+  it("an explicit null override beats the source value through writeXlsx", async () => {
+    // Source pins lang en-US, clone overrides to null — the rendered
+    // chart should carry no element and re-parse to undefined.
+    const clone = cloneChart(source({ lang: "en-US" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      lang: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:lang ");
+    expect(parseChart(written)?.lang).toBeUndefined();
+  });
+
+  it("an explicit string override replaces a source lang through writeXlsx", async () => {
+    const clone = cloneChart(source({ lang: "en-US" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      lang: "de-DE",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:lang val="de-DE"');
+    expect(written).not.toContain('c:lang val="en-US"');
+    expect(parseChart(written)?.lang).toBe("de-DE");
+  });
+
+  it("composes lang with other chart-space toggles through writeXlsx", async () => {
+    // lang / roundedCorners / style all live on <c:chartSpace> and
+    // must round-trip together without interfering with each other.
+    const clone = cloneChart(source({ lang: "tr-TR", roundedCorners: true, style: 34 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:lang val="tr-TR"');
+    expect(written).toContain('c:roundedCorners val="1"');
+    expect(written).toContain('c:style val="34"');
+    const reparsed = parseChart(written);
+    expect(reparsed?.lang).toBe("tr-TR");
+    expect(reparsed?.roundedCorners).toBe(true);
+    expect(reparsed?.style).toBe(34);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5439,3 +5439,158 @@ describe("writeChart — chart style preset", () => {
     expect(reparsed?.style).toBe(34);
   });
 });
+
+// ── writeChart — chart editing locale (lang) ─────────────────────────
+
+describe("writeChart — chart editing locale", () => {
+  it("skips <c:lang> entirely when the field is unset (writer default)", () => {
+    // Excel's reference serialization for a fresh chart authored on
+    // an English locale pins <c:lang val="en-US"/>, but the writer
+    // skips emission when the chart leaves `lang` unset so the file
+    // does not silently fabricate a locale Excel falls back to anyway.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:lang ");
+    expect(result.chartXml).not.toContain("<c:lang/>");
+  });
+
+  it('emits <c:lang val=".."/> on <c:chartSpace> when the field is pinned', () => {
+    const result = writeChart(makeChart({ lang: "en-US" }), "Sheet1");
+    expect(result.chartXml).toContain('c:lang val="en-US"');
+  });
+
+  it("emits a non-English locale verbatim", () => {
+    for (const tag of ["tr-TR", "de-DE", "pt-BR", "zh-Hans-CN", "fr"]) {
+      const result = writeChart(makeChart({ lang: tag }), "Sheet1");
+      expect(result.chartXml).toContain(`c:lang val="${tag}"`);
+    }
+  });
+
+  it("places <c:lang> before <c:roundedCorners> on <c:chartSpace>", () => {
+    // CT_ChartSpace sequence: date1904?, lang?, roundedCorners?, ...
+    // — the locale must precede <c:roundedCorners> so a strict
+    // validator (Excel itself rejects out-of-order children) sees the
+    // schema sequence respected.
+    const result = writeChart(makeChart({ lang: "en-US" }), "Sheet1");
+    const langIdx = result.chartXml.indexOf("c:lang ");
+    const roundedIdx = result.chartXml.indexOf("c:roundedCorners");
+    const chartIdx = result.chartXml.indexOf("<c:chart>");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(roundedIdx).toBeGreaterThan(langIdx);
+    expect(chartIdx).toBeGreaterThan(roundedIdx);
+  });
+
+  it("places <c:lang> before <c:style> when both are pinned", () => {
+    // <c:lang> precedes <c:roundedCorners> which precedes <c:style>
+    // per CT_ChartSpace; the writer threads all three in the right
+    // order so a validator never sees them transposed.
+    const result = writeChart(
+      makeChart({ lang: "tr-TR", style: 27, roundedCorners: true }),
+      "Sheet1",
+    );
+    const langIdx = result.chartXml.indexOf("c:lang ");
+    const roundedIdx = result.chartXml.indexOf("c:roundedCorners");
+    const styleIdx = result.chartXml.indexOf("c:style ");
+    expect(langIdx).toBeGreaterThan(-1);
+    expect(roundedIdx).toBeGreaterThan(langIdx);
+    expect(styleIdx).toBeGreaterThan(roundedIdx);
+  });
+
+  it("only emits <c:lang> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ lang: "en-US" }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:lang /g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("drops malformed locale tokens rather than emit them", () => {
+    // <c:lang> is xsd:language in the OOXML schema (BCP-47 culture
+    // names). Tokens that don't match the alphabet / length shape
+    // collapse to absence so the writer never emits a value Excel
+    // would reject.
+    for (const bad of [
+      "english",
+      "en US",
+      "en_US",
+      "1234",
+      "",
+      " ",
+      "a-bad-very-long-tag-segment",
+      "en-",
+      "-US",
+    ]) {
+      const result = writeChart(makeChart({ lang: bad }), "Sheet1");
+      expect(result.chartXml).not.toContain("<c:lang ");
+      expect(result.chartXml).not.toContain("<c:lang/>");
+    }
+  });
+
+  it("drops non-string lang values rather than fabricate one", () => {
+    for (const val of [42, true, null, undefined, {}, []]) {
+      const result = writeChart(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        makeChart({ lang: val as any }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("<c:lang ");
+    }
+  });
+
+  it("threads lang through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, lang: "tr-TR" }), "Sheet1");
+      expect(result.chartXml).toContain('c:lang val="tr-TR"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        lang: "tr-TR",
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:lang val="tr-TR"');
+  });
+
+  it("round-trips a pinned lang through parseChart", () => {
+    const written = writeChart(makeChart({ lang: "en-US" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.lang).toBe("en-US");
+  });
+
+  it("collapses an unset lang round-trip back to undefined", () => {
+    // A fresh chart writes no element, which re-parses to undefined —
+    // absence and the unset default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.lang).toBeUndefined();
+  });
+
+  it("threads lang end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            lang: "tr-TR",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('c:lang val="tr-TR"');
+    // Re-parse the rendered chart to confirm the locale survives the
+    // packaging path.
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.lang).toBe("tr-TR");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6321,3 +6321,129 @@ describe("parseChart — chart style preset", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — chart editing locale (lang) ───────────────────────
+
+describe("parseChart — chart editing locale", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:lang val="en-US"/> on <c:chartSpace> as the string "en-US"', () => {
+    // Excel's reference serialization for a fresh chart authored on
+    // an English locale pins lang en-US — it surfaces verbatim
+    // because the reader does not collapse a default (a chart that
+    // omits the element renders identically).
+    const xml = `<c:chartSpace ${NS}>
+  <c:lang val="en-US"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.lang).toBe("en-US");
+  });
+
+  it("surfaces a templated non-English locale (tr-TR)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:lang val="tr-TR"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.lang).toBe("tr-TR");
+  });
+
+  it("surfaces locale shapes Excel actually emits", () => {
+    // Sample of the BCP-47 forms <c:lang> accepts under xsd:language.
+    for (const tag of ["en-US", "tr-TR", "de-DE", "pt-BR", "zh-Hans-CN", "fr"]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:lang val="${tag}"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.lang).toBe(tag);
+    }
+  });
+
+  it("returns undefined when the chartSpace has no <c:lang> element", () => {
+    // Absence is the writer's default — the reader surfaces nothing
+    // so a fresh chart and a chart that omits the element round-trip
+    // identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.lang).toBeUndefined();
+  });
+
+  it("drops malformed locale tokens rather than surface them", () => {
+    // <c:lang> is xsd:language (BCP-47 culture name). Garbage values
+    // collapse to undefined so the parsed chart never carries a token
+    // Excel itself would not emit.
+    for (const bad of ["english", "en US", "en_US", "1234", "en-", "-US", " ", ""]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:lang val="${bad}"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.lang).toBeUndefined();
+    }
+  });
+
+  it("ignores a missing val attribute on <c:lang>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:lang/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.lang).toBeUndefined();
+  });
+
+  it("surfaces lang alongside other chart-space toggles", () => {
+    // <c:lang> sits before <c:roundedCorners> per CT_ChartSpace and
+    // <c:style> sits after — co-existing chart-space children should
+    // not interfere with each other's parsing.
+    const xml = `<c:chartSpace ${NS}>
+  <c:lang val="tr-TR"/>
+  <c:roundedCorners val="1"/>
+  <c:style val="34"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.lang).toBe("tr-TR");
+    expect(chart?.roundedCorners).toBe(true);
+    expect(chart?.style).toBe(34);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the chart-space `<c:lang>` element at the read, write, and clone layers so a template's editing-locale hint survives `parseChart -> cloneChart -> writeXlsx` and can be authored from scratch on a fresh chart.

`<c:lang val=".."/>` is the IETF BCP-47 culture name Excel records on every authored chart (e.g. `en-US`, `tr-TR`, `zh-Hans-CN`). Excel uses the value to drive locale-sensitive defaults inside the chart — decimal / group separators on unformatted axis ticks, default text-font fallback, and the locale recorded for in-chart text runs. The element sits on `<c:chartSpace>` (a sibling of `<c:chart>`, not a child) per `CT_ChartSpace` in ECMA-376 §21.2.2.29, between `<c:date1904>` and `<c:roundedCorners>`.

Up until now hucre's writer had no slot for the element, so a template that pinned `tr-TR` flattened back to the host workbook's editing language on every parse -> clone -> write loop. Excel's reference serialization for a fresh chart authored on an English locale emits `<c:lang val="en-US"/>` — the writer here intentionally does not pin a default so an unmarked chart and an `en-US` chart do not silently diverge on roundtrip.

The model is a plain string (`lang?: string`); the writer emits the element when the value matches the BCP-47 shape `[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*` Excel itself emits, dropping malformed / non-string values rather than emit a token Excel would reject (`<c:lang>` is `xsd:language` in the schema). The reader applies the same shape check, so absence and malformed tokens both round-trip to `undefined` identically. The clone layer follows the same `string | null | undefined` override grammar as `style` / `roundedCorners` so the chart-space toggles compose the same way at the call site.

This bridges another chart-space gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.lang);
// "tr-TR" when the template pinned it; undefined when the template
// omitted <c:lang> entirely.

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      lang: "tr-TR",
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  // lang: undefined  -> inherit
  // lang: null       -> drop (no element emitted; Excel falls back to
  //                            workbook editing language)
  // lang: "de-DE"    -> replace
});
```

## Test plan

- [x] `pnpm test` (lint + typecheck + 3563 vitest tests, all passing)
- [x] `pnpm build`
- [x] New unit tests cover: writer emission + ordering, reader shape filter, clone inherit / null / replace / flatten, end-to-end packaging round-trip, and composition with the existing `roundedCorners` / `style` chart-space toggles