### PR TITLE
feat(xlsx): chart axis crossBetween — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,22 @@ schema accepts the nine `ST_BuiltInUnit` tokens (`"hundreds"`,
 `"tenMillions"`, `"hundredMillions"`, `"billions"`, `"trillions"`);
 unknown tokens drop to `undefined` rather than fabricate a value the
 writer would never emit.
+`ChartAxisInfo.crossBetween` surfaces the per-value-axis cross-between
+mode pulled from `<c:valAx><c:crossBetween val=".."/></c:valAx>` — the
+OOXML `ST_CrossBetween` enum (`"between"` / `"midCat"`) that controls
+whether the perpendicular axis crosses BETWEEN data points (a half-
+category gap on each end of the plot area) or AT the midpoint of each
+category (data points sit ON the perpendicular-axis ticks). The element
+is required on every `<c:valAx>` and Excel emits a per-family default
+on every freshly-drawn chart — `"between"` on bar / column / line /
+area Y axes; `"midCat"` on both scatter axes — so the reader collapses
+the family-default value to `undefined` and only surfaces a non-default
+override (e.g. a template that pinned `"midCat"` on a line chart's Y
+axis to land the first / last data point flush with the value-axis
+line). The OOXML schema places the element exclusively on `CT_ValAx`,
+so `crossBetween` only surfaces on value-axis sides; category axes
+(`<c:catAx>`) and pie / doughnut never carry one. Unknown tokens drop
+to `undefined`.
 `Chart.roundedCorners` surfaces the chart-frame
 `<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
 Chart Area → Border → Rounded corners" toggle. The element sits on
@@ -932,7 +948,7 @@ charts; `lineGrouping` and `areaGrouping` accept
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
 attributes for screen readers.
-`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt, dispUnits }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt, dispUnits } }`
+`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt, dispUnits, crossBetween }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt, dispUnits, crossBetween } }`
 attaches per-axis labels, gridlines, numeric scaling, the tick-label
 number format and the tick-rendering trio — `x` lands inside
 `<c:catAx>` (or the X value axis for scatter), `y` inside the value
@@ -1112,6 +1128,24 @@ and pie / doughnut have no axes at all. Unknown tokens drop silently
 rather than fabricate a value the OOXML `ST_BuiltInUnit` enum would
 reject. The custom-divisor variant (`<c:custUnit>`) and rich-text
 `<c:dispUnitsLbl>` body are intentionally not surfaced.
+The `axes.{x,y}.crossBetween` field controls the per-value-axis
+cross-between mode (`<c:valAx><c:crossBetween val=".."/></c:valAx>`) —
+the OOXML `ST_CrossBetween` enum that picks between `"between"` (the
+perpendicular axis crosses BETWEEN data points, leaving a half-category
+gap on each end of the plot area; Excel's default on bar / column /
+line / area Y axes) and `"midCat"` (the perpendicular axis crosses AT
+the midpoint of each category, so data points sit ON the
+perpendicular-axis ticks; Excel's default on both scatter axes). The
+writer pins the per-family default when no override is set so untouched
+charts match Excel's reference serialization byte-for-byte; pass
+`crossBetween: "midCat"` on a line / area Y axis to land the first /
+last data point flush with the value-axis line, or `crossBetween:
+"between"` on a scatter axis to leave a margin around the outermost
+points. The OOXML schema places `<c:crossBetween>` exclusively on
+`CT_ValAx`, so category axes (`<c:catAx>`) silently drop the field and
+pie / doughnut have no axes at all. Unknown tokens drop silently rather
+than fabricate a value the enum would reject — the writer falls back to
+the family default in that case.
 The `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` fields thin out a
 crowded category axis (`<c:catAx><c:tickLblSkip val=".."/>` and
 `<c:catAx><c:tickMarkSkip val=".."/>`). Pass a positive integer to

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1385,6 +1385,19 @@ export interface SheetChart {
        * {@link ChartAxisDispUnit} for the accepted preset tokens.
        */
       dispUnits?: ChartAxisDispUnits | ChartAxisDispUnit;
+      /**
+       * Cross-between mode for the X axis. Maps to
+       * `<c:valAx><c:crossBetween val=".."/></c:valAx>`.
+       *
+       * Only meaningful for `scatter` charts — both axes there are
+       * value axes (`<c:valAx>`), so `<c:crossBetween>` slots onto the
+       * X axis as well. The OOXML schema places the element exclusively
+       * on `CT_ValAx`, so the writer drops the field on every other
+       * family (the X axis on bar / column / line / area is a category
+       * axis, which rejects `<c:crossBetween>`; pie / doughnut have no
+       * axes at all). See {@link ChartAxisCrossBetween}.
+       */
+      crossBetween?: ChartAxisCrossBetween;
     };
     /** Value axis. */
     y?: {
@@ -1463,6 +1476,17 @@ export interface SheetChart {
        * {@link ChartAxisDispUnit} for the accepted preset tokens.
        */
       dispUnits?: ChartAxisDispUnits | ChartAxisDispUnit;
+      /**
+       * Cross-between mode for the value axis. Maps to
+       * `<c:valAx><c:crossBetween val=".."/></c:valAx>`.
+       *
+       * The Y axis is a value axis on every chart family that has axes —
+       * bar / column / line / area / scatter — so the override always
+       * takes effect on those families. Pie / doughnut have no axes at
+       * all, so the field is silently dropped on those families. See
+       * {@link ChartAxisCrossBetween}.
+       */
+      crossBetween?: ChartAxisCrossBetween;
     };
   };
 }
@@ -2357,6 +2381,37 @@ export type ChartAxisLabelAlign = "ctr" | "l" | "r";
 export type ChartAxisCrosses = "autoZero" | "min" | "max";
 
 /**
+ * Whether the perpendicular axis crosses BETWEEN data points or AT the
+ * midpoint of each category on a value axis. Maps to the OOXML
+ * `ST_CrossBetween` enumeration which sits inside `<c:valAx>` as
+ * `<c:crossBetween val=".."/>`. The element is value-axis-only — the
+ * OOXML schema places `<c:crossBetween>` exclusively on `CT_ValAx`, so
+ * `<c:catAx>` / `<c:dateAx>` / `<c:serAx>` reject it:
+ *
+ * - `"between"` — the perpendicular axis crosses between data points,
+ *                 leaving a half-category gap on each end of the plot
+ *                 area. Excel's reference serialization on bar / column
+ *                 charts (so bars sit inside their category slot rather
+ *                 than straddling the value-axis line) and the writer's
+ *                 default on bar / column / line / area today.
+ * - `"midCat"`  — the perpendicular axis crosses at the midpoint of
+ *                 each category, so data points (line markers / area
+ *                 fill anchors / scatter points) sit ON the
+ *                 perpendicular-axis ticks rather than between them.
+ *                 Excel's reference serialization on scatter charts —
+ *                 useful when porting line / area templates whose first
+ *                 / last data point should land flush with the value
+ *                 axis instead of inside the plot area.
+ *
+ * Excel's UI does not expose the toggle as a checkbox — Excel computes
+ * it from the chart family on insertion — but Excel preserves the
+ * element on round-trip, and a template that pins a non-default value
+ * should round-trip through `parseChart -> cloneChart -> writeXlsx`
+ * without flattening.
+ */
+export type ChartAxisCrossBetween = "between" | "midCat";
+
+/**
  * Built-in display-unit preset on a value axis — Excel's "Format Axis ->
  * Display units" dropdown. Every numeric tick label is divided by the
  * preset's scale before being rendered, so a chart whose source range
@@ -2594,6 +2649,17 @@ export interface ChartAxisInfo {
    * round-trip leaves Excel's default "no display unit" state untouched.
    */
   dispUnits?: ChartAxisDispUnits;
+  /**
+   * Cross-between mode pulled from `<c:crossBetween val=".."/>`.
+   * Surfaces only on value axes — the OOXML schema places the element
+   * exclusively on `CT_ValAx`, so `<c:catAx>` / `<c:dateAx>` /
+   * `<c:serAx>` never carry one. Unknown / typo'd tokens drop to
+   * `undefined` rather than fabricate a value the writer would never
+   * emit; absence likewise collapses to `undefined` so a chart that
+   * inherited Excel's default still round-trips minimally through
+   * {@link cloneChart}. See {@link ChartAxisCrossBetween}.
+   */
+  crossBetween?: ChartAxisCrossBetween;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -12,6 +12,7 @@
 
 import type {
   Chart,
+  ChartAxisCrossBetween,
   ChartAxisCrosses,
   ChartAxisDispUnit,
   ChartAxisDispUnits,
@@ -473,6 +474,23 @@ export interface CloneChartOptions {
        * have no axes at all.
        */
       dispUnits?: ChartAxisDispUnits | ChartAxisDispUnit | null;
+      /**
+       * Override `SheetChart.axes.x.crossBetween`. `undefined` (or
+       * omitted) inherits the source axis's parsed cross-between mode;
+       * `null` drops the inherited value (the writer falls back to the
+       * per-family default each axis builder pins today); a
+       * {@link ChartAxisCrossBetween} token replaces it.
+       *
+       * `<c:crossBetween>` lives exclusively on `<c:valAx>` per the
+       * OOXML schema, so the override only takes effect when the
+       * resolved chart type routes the X axis through `<c:valAx>` —
+       * that is the scatter family. Bar / column / line / area route
+       * the X axis through `<c:catAx>` (which rejects
+       * `<c:crossBetween>`); the resolver collapses the field to
+       * `undefined` on those families so a stale hint never leaks into
+       * the writer. Pie / doughnut have no axes at all.
+       */
+      crossBetween?: ChartAxisCrossBetween | null;
     };
     y?: {
       title?: string | null;
@@ -505,6 +523,18 @@ export interface CloneChartOptions {
        * on those types.
        */
       dispUnits?: ChartAxisDispUnits | ChartAxisDispUnit | null;
+      /**
+       * Override `SheetChart.axes.y.crossBetween`. Same `undefined`
+       * (inherit) / `null` (drop) / replace grammar as
+       * {@link CloneChartOptions.axes.x.crossBetween}.
+       *
+       * The Y axis is a value axis on every chart family that has axes
+       * — bar / column / line / area / scatter — so the override always
+       * takes effect on those families. Pie / doughnut have no axes at
+       * all and the resolver collapses the field to `undefined` on
+       * those types.
+       */
+      crossBetween?: ChartAxisCrossBetween | null;
     };
   };
 }
@@ -1432,6 +1462,20 @@ function resolveAxes(
       ? applyDispUnitsOverride(sourceAxes?.x?.dispUnits, overrides?.x?.dispUnits)
       : undefined;
   const yDispUnits = applyDispUnitsOverride(sourceAxes?.y?.dispUnits, overrides?.y?.dispUnits);
+  // `<c:crossBetween>` is also value-axis-only per ECMA-376 §21.2.2.10
+  // (CT_ValAx → CT_CrossBetween). Same scope rule as `dispUnits` — the
+  // X-axis override is only honoured on scatter (both axes are value
+  // axes); bar / column / line / area route X through `<c:catAx>` which
+  // rejects `<c:crossBetween>`. The Y axis is a value axis on every
+  // family that has axes, so the Y override always carries through.
+  const xCrossBetween =
+    type === "scatter"
+      ? applyCrossBetweenOverride(sourceAxes?.x?.crossBetween, overrides?.x?.crossBetween)
+      : undefined;
+  const yCrossBetween = applyCrossBetweenOverride(
+    sourceAxes?.y?.crossBetween,
+    overrides?.y?.crossBetween,
+  );
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -1451,7 +1495,8 @@ function resolveAxes(
     xHidden !== undefined ||
     xCrossesPair.crosses !== undefined ||
     xCrossesPair.crossesAt !== undefined ||
-    xDispUnits !== undefined
+    xDispUnits !== undefined ||
+    xCrossBetween !== undefined
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
@@ -1471,6 +1516,7 @@ function resolveAxes(
     if (xCrossesPair.crosses !== undefined) out.x.crosses = xCrossesPair.crosses;
     if (xCrossesPair.crossesAt !== undefined) out.x.crossesAt = xCrossesPair.crossesAt;
     if (xDispUnits !== undefined) out.x.dispUnits = xDispUnits;
+    if (xCrossBetween !== undefined) out.x.crossBetween = xCrossBetween;
   }
   if (
     yTitle !== undefined ||
@@ -1484,7 +1530,8 @@ function resolveAxes(
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
     yCrossesPair.crossesAt !== undefined ||
-    yDispUnits !== undefined
+    yDispUnits !== undefined ||
+    yCrossBetween !== undefined
   ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
@@ -1499,6 +1546,7 @@ function resolveAxes(
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
     if (yCrossesPair.crossesAt !== undefined) out.y.crossesAt = yCrossesPair.crossesAt;
     if (yDispUnits !== undefined) out.y.dispUnits = yDispUnits;
+    if (yCrossBetween !== undefined) out.y.crossBetween = yCrossBetween;
   }
 
   return out.x || out.y ? out : undefined;
@@ -1910,4 +1958,32 @@ function applyDispUnitsOverride(
   if (override === undefined) return normalizeDispUnits(source);
   if (override === null) return undefined;
   return normalizeDispUnits(override);
+}
+
+/** Recognized values of `<c:crossBetween>` per the OOXML `ST_CrossBetween` enum. */
+const VALID_CROSS_BETWEEN_VALUES: ReadonlySet<ChartAxisCrossBetween> = new Set([
+  "between",
+  "midCat",
+]);
+
+/**
+ * Resolve a `crossBetween` override using the standard `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar. Unknown / typo'd
+ * tokens collapse to `undefined` rather than fabricate a value the
+ * writer would never emit — the writer's per-family default
+ * (`"between"` on bar / column / line / area Y axes; `"midCat"` on
+ * scatter axes) takes over instead. The reader and writer mirror this
+ * normalizer so a parsed source value slots straight back into a clone
+ * target without transformation.
+ */
+function applyCrossBetweenOverride(
+  source: ChartAxisCrossBetween | undefined,
+  override: ChartAxisCrossBetween | null | undefined,
+): ChartAxisCrossBetween | undefined {
+  if (override === undefined) {
+    if (source === undefined) return undefined;
+    return VALID_CROSS_BETWEEN_VALUES.has(source) ? source : undefined;
+  }
+  if (override === null) return undefined;
+  return VALID_CROSS_BETWEEN_VALUES.has(override) ? override : undefined;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -14,6 +14,7 @@
 
 import type {
   Chart,
+  ChartAxisCrossBetween,
   ChartAxisCrosses,
   ChartAxisDispUnit,
   ChartAxisDispUnits,
@@ -318,8 +319,19 @@ function parseAxes(plotArea: XmlElement): { x?: ChartAxisInfo; y?: ChartAxisInfo
     yAxis = valAxes[1];
   }
 
-  const x = xAxis ? parseAxisInfo(xAxis) : undefined;
-  const y = yAxis ? parseAxisInfo(yAxis) : undefined;
+  // `<c:crossBetween>` is required on every `<c:valAx>` — Excel always
+  // emits the element — so the reader needs a per-family default to
+  // collapse against. The catAx-anchored families (bar / column / line
+  // / area) emit `"between"` on the value axis; scatter (catAx-less,
+  // both axes are valAx) emits `"midCat"` on both axes. Pass the
+  // expected default to `parseAxisInfo` so a chart that inherited the
+  // default round-trips identically through {@link cloneChart} —
+  // absence on the parsed shape and the writer-emitted default produce
+  // the same `<c:crossBetween val=".."/>` byte-for-byte.
+  const familyDefaultCrossBetween: ChartAxisCrossBetween = catAx ? "between" : "midCat";
+
+  const x = xAxis ? parseAxisInfo(xAxis, familyDefaultCrossBetween) : undefined;
+  const y = yAxis ? parseAxisInfo(yAxis, familyDefaultCrossBetween) : undefined;
 
   if (!x && !y) return undefined;
   const out: { x?: ChartAxisInfo; y?: ChartAxisInfo } = {};
@@ -328,7 +340,10 @@ function parseAxes(plotArea: XmlElement): { x?: ChartAxisInfo; y?: ChartAxisInfo
   return out;
 }
 
-function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
+function parseAxisInfo(
+  axis: XmlElement,
+  familyDefaultCrossBetween: ChartAxisCrossBetween,
+): ChartAxisInfo | undefined {
   const title = parseAxisTitle(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
@@ -391,6 +406,17 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   // axis flavour so a corrupt template carrying a stray element does
   // not surface a value the writer would never emit anyway.
   const dispUnits = axis.local === "valAx" ? parseAxisDispUnits(axis) : undefined;
+  // `<c:crossBetween>` is also value-axis-only per ECMA-376 Part 1,
+  // §21.2.2.10 (CT_ValAx → CT_CrossBetween). The OOXML schema rejects
+  // the element on `<c:catAx>` / `<c:dateAx>` / `<c:serAx>`, so the
+  // reader skips the parse on every other axis flavour to mirror the
+  // writer's scope rule. The element is required on every `<c:valAx>`
+  // and Excel always emits the family default — collapse the parsed
+  // value when it matches the family default so absence and the
+  // default round-trip identically through {@link cloneChart}.
+  const parsedCrossBetween = axis.local === "valAx" ? parseAxisCrossBetween(axis) : undefined;
+  const crossBetween =
+    parsedCrossBetween === familyDefaultCrossBetween ? undefined : parsedCrossBetween;
   if (
     title === undefined &&
     gridlines === undefined &&
@@ -408,7 +434,8 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
     hidden === undefined &&
     crosses === undefined &&
     crossesAt === undefined &&
-    dispUnits === undefined
+    dispUnits === undefined &&
+    crossBetween === undefined
   ) {
     return undefined;
   }
@@ -430,6 +457,7 @@ function parseAxisInfo(axis: XmlElement): ChartAxisInfo | undefined {
   if (crosses !== undefined) out.crosses = crosses;
   if (crossesAt !== undefined) out.crossesAt = crossesAt;
   if (dispUnits !== undefined) out.dispUnits = dispUnits;
+  if (crossBetween !== undefined) out.crossBetween = crossBetween;
   return out;
 }
 
@@ -756,6 +784,36 @@ function parseAxisDispUnits(axis: XmlElement): ChartAxisDispUnits | undefined {
     out.showLabel = true;
   }
   return out;
+}
+
+/** Recognized values of `<c:crossBetween>` per the OOXML `ST_CrossBetween` enum. */
+const VALID_CROSS_BETWEEN: ReadonlySet<ChartAxisCrossBetween> = new Set(["between", "midCat"]);
+
+/**
+ * Read a value axis's `<c:crossBetween val=".."/>`. The OOXML schema
+ * places the element exclusively on `CT_ValAx` per ECMA-376 Part 1,
+ * §21.2.2.10 — `<c:catAx>`, `<c:dateAx>`, and `<c:serAx>` reject it —
+ * so the caller is expected to gate the parse on `axis.local === "valAx"`
+ * before calling this helper.
+ *
+ * Returns `undefined` when:
+ *   - the axis declares no `<c:crossBetween>` at all,
+ *   - the `val` attribute is missing, empty, or not a string,
+ *   - the `val` attribute is not one of the OOXML `ST_CrossBetween`
+ *     tokens (`"between"` / `"midCat"`).
+ *
+ * Unknown tokens drop rather than fabricate a value the writer would
+ * never emit — the caller cannot tell absence from a corrupt template
+ * without the parser's help.
+ */
+function parseAxisCrossBetween(axis: XmlElement): ChartAxisCrossBetween | undefined {
+  const el = findChild(axis, "crossBetween");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim() as ChartAxisCrossBetween;
+  if (!VALID_CROSS_BETWEEN.has(trimmed)) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -7,6 +7,7 @@
 // referenced from a drawing part via a `chart` relationship.
 
 import type {
+  ChartAxisCrossBetween,
   ChartAxisCrosses,
   ChartAxisDispUnit,
   ChartAxisDispUnits,
@@ -248,6 +249,16 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // refuse.
     xDispUnits: normalizeAxisDispUnits(chart.axes?.x?.dispUnits),
     yDispUnits: normalizeAxisDispUnits(chart.axes?.y?.dispUnits),
+    // `<c:crossBetween>` is value-axis-only per ECMA-376 §21.2.2.10
+    // (CT_ValAx → CT_CrossBetween). The category-axis builder ignores
+    // `xCrossBetween`; only the scatter X-axis (a value axis) and every
+    // Y axis pick the field up. The normalizer rejects unknown tokens
+    // so the writer never emits a value the OOXML `ST_CrossBetween`
+    // enum would refuse — absence falls back to the per-family default
+    // each axis builder pins today (`"between"` on bar / column / line
+    // / area Y axes; `"midCat"` on both scatter axes).
+    xCrossBetween: normalizeAxisCrossBetween(chart.axes?.x?.crossBetween),
+    yCrossBetween: normalizeAxisCrossBetween(chart.axes?.y?.crossBetween),
   };
 
   switch (chart.type) {
@@ -376,6 +387,23 @@ interface AxisRenderOptions {
    * short-circuits those branches.
    */
   yDispUnits: ChartAxisDispUnits | undefined;
+  /**
+   * Cross-between override for the X axis. Only honoured on scatter
+   * (the X axis is a value axis there); the catAx builder ignores it
+   * because `<c:crossBetween>` is value-axis-only per ECMA-376
+   * §21.2.2.10. `undefined` falls back to the per-family default each
+   * axis builder pins today.
+   */
+  xCrossBetween: ChartAxisCrossBetween | undefined;
+  /**
+   * Cross-between override for the value axis. The catAx builder (bar
+   * / column / line / area) routes the Y axis through `<c:valAx>`, and
+   * the scatter builder routes both axes through `<c:valAx>` — so this
+   * field surfaces on every chart family that has a value axis. Pie /
+   * doughnut have no axes at all and the caller already short-circuits
+   * those branches.
+   */
+  yCrossBetween: ChartAxisCrossBetween | undefined;
 }
 
 /**
@@ -752,6 +780,30 @@ function buildAxisDispUnits(dispUnits: ChartAxisDispUnits | undefined): string[]
   return [xmlElement("c:dispUnits", undefined, children)];
 }
 
+/** Recognized values of `<c:crossBetween>` per the OOXML `ST_CrossBetween` enum. */
+const VALID_CROSS_BETWEEN: ReadonlySet<ChartAxisCrossBetween> = new Set(["between", "midCat"]);
+
+/**
+ * Normalize the {@link SheetChart.axes.x.crossBetween} /
+ * {@link SheetChart.axes.y.crossBetween} input. Unknown / typo'd tokens
+ * collapse to `undefined` so the writer never emits a value the OOXML
+ * `ST_CrossBetween` enum rejects — the caller's per-family default
+ * (`"between"` on bar / column / line / area Y axes; `"midCat"` on
+ * scatter axes) takes over instead.
+ *
+ * Non-string inputs (e.g. `null`, numbers, arrays) likewise collapse to
+ * `undefined` so a stray runtime value leaking through the type guard
+ * cannot poison the output.
+ */
+function normalizeAxisCrossBetween(
+  value: ChartAxisCrossBetween | undefined,
+): ChartAxisCrossBetween | undefined {
+  if (typeof value !== "string") return undefined;
+  return VALID_CROSS_BETWEEN.has(value as ChartAxisCrossBetween)
+    ? (value as ChartAxisCrossBetween)
+    : undefined;
+}
+
 /**
  * Build the axis tick-label `<c:numFmt formatCode=".." sourceLinked=".."/>`.
  * Returns an empty array when the axis declares no number format — the
@@ -1016,7 +1068,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
     buildAxisCrosses(opts.yCrosses),
-    xmlSelfClose("c:crossBetween", { val: "between" }),
+    // `<c:crossBetween>` sits between `<c:crosses>`/`<c:crossesAt>` and
+    // `<c:majorUnit>` per CT_ValAx (ECMA-376 §21.2.2.32). The default
+    // for bar / column / line / area is `"between"` — the writer
+    // honours an override when the caller pinned `"midCat"` and falls
+    // back to the family default otherwise.
+    xmlSelfClose("c:crossBetween", { val: opts.yCrossBetween ?? "between" }),
     ...buildAxisTickUnits(opts.yScale),
     // `<c:dispUnits>` is the last child slot on `<c:valAx>` per
     // CT_ValAx (after `<c:minorUnit>`). Bar / column / line / area
@@ -1313,7 +1370,11 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
     buildAxisCrosses(opts.xCrosses),
-    xmlSelfClose("c:crossBetween", { val: "midCat" }),
+    // Scatter charts default to `"midCat"` (data points sit ON the
+    // perpendicular-axis ticks rather than between them). The writer
+    // honours an override when the caller pinned `"between"` and falls
+    // back to the family default otherwise.
+    xmlSelfClose("c:crossBetween", { val: opts.xCrossBetween ?? "midCat" }),
     ...buildAxisTickUnits(opts.xScale),
     // `<c:dispUnits>` slots onto `<c:valAx>` per CT_ValAx (after
     // `<c:minorUnit>`). Scatter charts route both axes through
@@ -1334,7 +1395,9 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),
     buildAxisCrosses(opts.yCrosses),
-    xmlSelfClose("c:crossBetween", { val: "midCat" }),
+    // Scatter Y axis defaults to `"midCat"`. Same override grammar as
+    // the X axis above.
+    xmlSelfClose("c:crossBetween", { val: opts.yCrossBetween ?? "midCat" }),
     ...buildAxisTickUnits(opts.yScale),
     // `<c:dispUnits>` on the Y axis. Scatter Y is also a value axis,
     // so the same builder applies. See `buildBarAxes` for the broader

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6341,3 +6341,155 @@ describe("cloneChart — chart style preset", () => {
     expect(parseChart(written)?.style).toBe(4);
   });
 });
+
+// ── cloneChart — axis crossBetween ───────────────────────────────────
+
+describe("cloneChart — axis crossBetween", () => {
+  const sourceWithMidCat: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { y: { crossBetween: "midCat" } },
+  };
+
+  it("inherits axes.y.crossBetween from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithMidCat, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.crossBetween).toBe("midCat");
+  });
+
+  it("drops the inherited mode when the override is null", () => {
+    const clone = cloneChart(sourceWithMidCat, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossBetween: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited mode with a new value", () => {
+    const clone = cloneChart(sourceWithMidCat, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossBetween: "between" } },
+    });
+    expect(clone.axes?.y?.crossBetween).toBe("between");
+  });
+
+  it("adds crossBetween to a source that lacked the field", () => {
+    const bare: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(bare, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossBetween: "midCat" } },
+    });
+    expect(clone.axes?.y?.crossBetween).toBe("midCat");
+  });
+
+  it("collapses unknown ST_CrossBetween tokens to undefined", () => {
+    const clone = cloneChart(sourceWithMidCat, {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { y: { crossBetween: "diagonal" as any } },
+    });
+    expect(clone.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it("drops the inherited crossBetween when flattening to pie (no axes)", () => {
+    // Pie / doughnut have no axes at all in the OOXML schema — the
+    // resolver short-circuits on those families so crossBetween cannot
+    // leak into the writer.
+    const clone = cloneChart(sourceWithMidCat, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the inherited X-axis crossBetween when flattening to bar (catAx X)", () => {
+    // The X axis on bar / column / line / area is a category axis,
+    // which rejects <c:crossBetween>. A clone from scatter (where both
+    // axes are valAx) into a column chart should drop the X-axis
+    // mode so the writer never sees it.
+    const scatterSource: Chart = {
+      kinds: ["scatter"],
+      seriesCount: 1,
+      series: [{ kind: "scatter", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { crossBetween: "between" }, y: { crossBetween: "between" } },
+    };
+    const clone = cloneChart(scatterSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.axes?.x?.crossBetween).toBeUndefined();
+    // Y axis is valAx on column too — the inherited mode survives.
+    expect(clone.axes?.y?.crossBetween).toBe("between");
+  });
+
+  it("carries the X-axis crossBetween through a scatter -> scatter clone", () => {
+    const scatterSource: Chart = {
+      kinds: ["scatter"],
+      seriesCount: 1,
+      series: [{ kind: "scatter", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { crossBetween: "between" }, y: { crossBetween: "between" } },
+    };
+    const clone = cloneChart(scatterSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.crossBetween).toBe("between");
+    expect(clone.axes?.y?.crossBetween).toBe("between");
+  });
+
+  it("composes with other axis overrides without dropping unrelated state", () => {
+    // The resolver bundles every axis field into a single `out.y`
+    // object — make sure adding crossBetween next to crosses / crossesAt
+    // / dispUnits doesn't accidentally drop the other fields.
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        y: {
+          crossBetween: "midCat",
+          crosses: "max",
+          dispUnits: { unit: "millions" },
+        },
+      },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.crossBetween).toBe("midCat");
+    expect(clone.axes?.y?.crosses).toBe("max");
+    expect(clone.axes?.y?.dispUnits).toEqual({ unit: "millions" });
+  });
+
+  it("round-trips through parseChart -> cloneChart -> writeChart", async () => {
+    const source: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { crossBetween: "midCat" } },
+    };
+    const xml = writeChart(source, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    expect(clone.axes?.y?.crossBetween).toBe("midCat");
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:crossBetween val="midCat"/>');
+    expect(parseChart(written)?.axes?.y?.crossBetween).toBe("midCat");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5616,3 +5616,194 @@ describe("writeChart — chart style preset", () => {
     expect(reparsed?.style).toBe(34);
   });
 });
+
+// ── writeChart — axis crossBetween ───────────────────────────────────
+
+describe("writeChart — axis crossBetween", () => {
+  it('emits the family default <c:crossBetween val="between"/> on a column chart with no override', () => {
+    // The writer always emits `<c:crossBetween>` on the value axis
+    // because the OOXML schema requires it. The default for bar /
+    // column / line / area is `"between"` — Excel's reference
+    // serialization on every freshly-drawn column chart pins exactly
+    // that value.
+    const result = writeChart(makeChart(), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:crossBetween val="between"/>');
+  });
+
+  it("honours a value-axis override on a column chart", () => {
+    const result = writeChart(makeChart({ axes: { y: { crossBetween: "midCat" } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:crossBetween val="midCat"/>');
+  });
+
+  it('emits the family default <c:crossBetween val="midCat"/> on both scatter axes', () => {
+    // Scatter charts route both axes through `<c:valAx>`; the writer
+    // pins `"midCat"` on each by default to mirror Excel's reference
+    // serialization on a freshly-drawn scatter chart.
+    const scatter: SheetChart = {
+      type: "scatter",
+      series: [{ name: "S1", values: "B2:B5", categories: "A2:A5" }],
+      anchor: { from: { row: 0, col: 0 } },
+    };
+    const result = writeChart(scatter, "Sheet1");
+    const valAxBlocks = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxBlocks).toHaveLength(2);
+    expect(valAxBlocks[0]).toContain('<c:crossBetween val="midCat"/>');
+    expect(valAxBlocks[1]).toContain('<c:crossBetween val="midCat"/>');
+  });
+
+  it("honours independent overrides on both scatter axes", () => {
+    const scatter: SheetChart = {
+      type: "scatter",
+      series: [{ name: "S1", values: "B2:B5", categories: "A2:A5" }],
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: { crossBetween: "between" },
+        y: { crossBetween: "between" },
+      },
+    };
+    const result = writeChart(scatter, "Sheet1");
+    const valAxBlocks = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxBlocks).toHaveLength(2);
+    expect(valAxBlocks[0]).toContain('<c:crossBetween val="between"/>');
+    expect(valAxBlocks[1]).toContain('<c:crossBetween val="between"/>');
+  });
+
+  it("drops an unknown ST_CrossBetween token rather than fabricating a value", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { y: { crossBetween: "diagonal" as never } },
+      }),
+      "Sheet1",
+    );
+    // Falls back to the family default rather than emitting the bad token.
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:crossBetween val="between"/>');
+    expect(result.chartXml).not.toContain('val="diagonal"');
+  });
+
+  it("does not emit <c:crossBetween> on the X axis of a column chart (catAx rejects it)", () => {
+    // The OOXML schema places <c:crossBetween> exclusively on CT_ValAx,
+    // so even though the user pinned a value on the X axis, the catAx
+    // builder should silently drop the field.
+    const result = writeChart(
+      makeChart({ type: "column", axes: { x: { crossBetween: "midCat" } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("c:crossBetween");
+  });
+
+  it("does not emit <c:crossBetween> on a pie chart (no axes at all)", () => {
+    // The writer never builds <c:valAx> for pie / doughnut, so even
+    // when the caller pins a value the element should not surface.
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        axes: { y: { crossBetween: "midCat" } },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:crossBetween");
+  });
+
+  it("places <c:crossBetween> after <c:crosses> inside <c:valAx> (CT_ValAx order)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            crosses: "max",
+            crossBetween: "midCat",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const crossesIdx = valAxBlock.indexOf("c:crosses");
+    const crossBetweenIdx = valAxBlock.indexOf("c:crossBetween");
+    expect(crossesIdx).toBeGreaterThan(-1);
+    expect(crossBetweenIdx).toBeGreaterThan(crossesIdx);
+  });
+
+  it("places <c:crossBetween> before <c:majorUnit> inside <c:valAx> (CT_ValAx order)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            scale: { min: 0, max: 100, majorUnit: 25 },
+            crossBetween: "midCat",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    const crossBetweenIdx = valAxBlock.indexOf("c:crossBetween");
+    const majorUnitIdx = valAxBlock.indexOf("c:majorUnit");
+    expect(crossBetweenIdx).toBeGreaterThan(-1);
+    expect(majorUnitIdx).toBeGreaterThan(crossBetweenIdx);
+  });
+
+  it("only emits <c:crossBetween> once on the value axis", () => {
+    const result = writeChart(makeChart({ axes: { y: { crossBetween: "midCat" } } }), "Sheet1");
+    const occurrences = result.chartXml.match(/c:crossBetween/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("survives a parseChart round-trip on the value axis", () => {
+    const result = writeChart(makeChart({ axes: { y: { crossBetween: "midCat" } } }), "Sheet1");
+    const reparsed = parseChart(result.chartXml);
+    expect(reparsed?.axes?.y?.crossBetween).toBe("midCat");
+  });
+
+  it("survives a parseChart round-trip on a scatter chart with an X-axis override", () => {
+    const scatter: SheetChart = {
+      type: "scatter",
+      series: [{ name: "S1", values: "B2:B5", categories: "A2:A5" }],
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { crossBetween: "between" } },
+    };
+    const result = writeChart(scatter, "Sheet1");
+    const reparsed = parseChart(result.chartXml);
+    expect(reparsed?.axes?.x?.crossBetween).toBe("between");
+    // Y axis stayed at the scatter family default — collapses on read.
+    expect(reparsed?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it("collapses a defaulted crossBetween round-trip back to undefined", () => {
+    // A chart that left crossBetween unset emits the family default,
+    // and the reader should collapse that default back to undefined.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it("packages the chart end-to-end through writeXlsx", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 100],
+          ["Q2", 200],
+          ["Q3", 150],
+        ],
+        charts: [
+          {
+            type: "line",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { y: { crossBetween: "midCat" } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<c:crossBetween val="midCat"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.y?.crossBetween).toBe("midCat");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6463,3 +6463,161 @@ describe("parseChart — chart style preset", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — axis crossBetween ───────────────────────────────────
+
+describe("parseChart — axis crossBetween", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces a non-default <c:crossBetween val="midCat"/> on the value axis of a column chart', () => {
+    // Bar / column / line / area's family default is `"between"`; pinning
+    // `"midCat"` is a non-default override and the reader should surface it.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossBetween val="midCat"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossBetween).toBe("midCat");
+    expect(chart?.axes?.x?.crossBetween).toBeUndefined();
+  });
+
+  it('collapses the family-default <c:crossBetween val="between"/> on a column chart to undefined', () => {
+    // Excel always emits `<c:crossBetween>` on every `<c:valAx>` because
+    // the element is required by the schema. The reader must collapse the
+    // value when it matches the family default so absence and the default
+    // round-trip identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossBetween val="between"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it('collapses the family-default <c:crossBetween val="midCat"/> on a scatter chart to undefined', () => {
+    // Scatter's family default is `"midCat"` because both axes are value
+    // axes and Excel emits `<c:crossBetween val="midCat"/>` on each of
+    // them. The reader collapses the default so a clone of an untouched
+    // scatter chart stays minimal.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:crossBetween val="midCat"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:crossBetween val="midCat"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crossBetween).toBeUndefined();
+    expect(chart?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it('surfaces a non-default <c:crossBetween val="between"/> on a scatter chart', () => {
+    // Scatter's family default is `"midCat"`; pinning `"between"` is a
+    // non-default override and the reader surfaces it on whichever axis
+    // it was pinned.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:crossBetween val="between"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crossBetween).toBe("between");
+    expect(chart?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it("collapses crossBetween to undefined on a category axis (catAx rejects the element)", () => {
+    // The OOXML schema places <c:crossBetween> exclusively on CT_ValAx,
+    // so a stray element on <c:catAx> from a corrupt template should
+    // never surface — the reader explicitly skips the parse on every
+    // non-valAx flavour.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:crossBetween val="midCat"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.crossBetween).toBeUndefined();
+  });
+
+  it("drops an unknown ST_CrossBetween token rather than fabricating a value", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossBetween val="diagonal"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it("drops a missing val attribute rather than fabricating a value", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:crossBetween/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossBetween).toBeUndefined();
+  });
+
+  it("collapses crossBetween to undefined when the chart has no <c:crossBetween>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.crossBetween).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the per-value-axis `<c:crossBetween>` element at the read, write, and clone layers so a template's cross-between mode survives `parseChart -> cloneChart -> writeXlsx` and can be authored from scratch on a fresh chart.

`<c:crossBetween>` is the OOXML `ST_CrossBetween` toggle (`"between"` / `"midCat"`) that controls whether the perpendicular axis crosses BETWEEN data points (a half-category gap on each end of the plot area) or AT the midpoint of each category (data points sit ON the perpendicular-axis ticks rather than between them). The element is value-axis-only per ECMA-376 Part 1, §21.2.2.10 (CT_ValAx → CT_CrossBetween) — `<c:catAx>` / `<c:dateAx>` / `<c:serAx>` reject it.

Excel emits a per-family default on every freshly-drawn chart: `"between"` on bar / column / line / area Y axes and `"midCat"` on both scatter axes. The reader collapses the family-default value to `undefined` so absence and the default round-trip identically through `cloneChart`; only a non-default override (e.g. a template that pinned `"midCat"` on a line chart's Y axis to land the first / last data point flush with the value-axis line) surfaces. The writer pins the family default when the caller leaves `crossBetween` unset so untouched charts still match Excel's reference serialization byte-for-byte.

This bridges another axis-rendering gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.y?.crossBetween);
// "midCat" when the template pinned a non-default value on the value
// axis; undefined when the template inherited the family default.

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "line",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      // Land the first / last data point flush with the value-axis line.
      axes: { y: { crossBetween: "midCat" } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  axes: {
    y: {
      // crossBetween: undefined  -> inherit
      // crossBetween: null       -> drop (writer falls back to the
      //                                   per-family default)
      // crossBetween: "between"  -> replace
      crossBetween: "between",
    },
  },
});
```

## Model

```ts
export type ChartAxisCrossBetween = "between" | "midCat";

// Read side
export interface ChartAxisInfo {
  // ...existing fields...
  crossBetween?: ChartAxisCrossBetween;
}

// Write side
export interface SheetChart {
  axes?: {
    x?: { /* ...existing... */ crossBetween?: ChartAxisCrossBetween };
    y?: { /* ...existing... */ crossBetween?: ChartAxisCrossBetween };
  };
}

// Clone side
export interface CloneChartOptions {
  axes?: {
    x?: { /* ...existing... */ crossBetween?: ChartAxisCrossBetween | null };
    y?: { /* ...existing... */ crossBetween?: ChartAxisCrossBetween | null };
  };
}
```

## Scope rules

- The OOXML schema places `<c:crossBetween>` exclusively on `CT_ValAx`. The reader skips the parse on every other axis flavour (catAx / dateAx / serAx); a stray element on a corrupt template never surfaces. The writer drops the field on category axes (the X axis on bar / column / line / area) and on pie / doughnut (no axes at all); the value-axis side of bar / column / line / area (the Y axis) and both axes on scatter (both are value axes) honour the field.
- Element ordering inside `<c:valAx>` follows CT_ValAx: `<c:crossBetween>` lands after `<c:crosses>`/`<c:crossesAt>` and before `<c:majorUnit>`.
- The OOXML accepts the two `ST_CrossBetween` tokens (`"between"`, `"midCat"`); unknown tokens drop to the per-family default rather than fabricate a value the schema would reject.
- The writer always emits the element because Excel's reference serialization requires it on every `<c:valAx>`. The per-family default (`"between"` on bar / column / line / area Y axes; `"midCat"` on scatter axes) keeps untouched charts byte-for-byte identical to Excel's output.
- The reader's family-default collapse mirrors the writer so a chart that inherited Excel's default round-trips minimally through `cloneChart`. The clone layer drops the X-axis override on a flatten to anything other than scatter (e.g. scatter -> column flattens drop the X-axis pin because catAx rejects the element).

## Test plan

- [x] `pnpm test` (lint + typecheck + 3595 vitest tests, all passing — 32 new tests)
- [x] `pnpm build`
- [x] `parseChart` covers default-collapse on column (`"between"`) and scatter (`"midCat"`), non-default override surfacing on both families, scope drop on catAx, unknown ST_CrossBetween token rejection, missing val attribute, absence default.
- [x] `writeChart` covers absence default per family, single-token override, OOXML element ordering (after `<c:crosses>`, before `<c:majorUnit>`), category-axis scope drop, pie / doughnut scope drop, both scatter axes, parseChart round-trip including default-collapse, single-emit guard, end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace, addition on a source that lacked the field, unknown-token drop, scope drops on flatten to pie / column from scatter, scatter -> scatter carry-through, composition with other axis fields (crosses, dispUnits) without dropping unrelated state, end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)