### PR TITLE
feat(xlsx): chart date system (date1904) — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1188,6 +1188,36 @@ export interface SheetChart {
    */
   lang?: string;
   /**
+   * Date-system hint. Maps to `<c:date1904 val=".."/>` on
+   * `<c:chartSpace>` (a sibling of `<c:chart>`, not a child). The flag
+   * mirrors the host workbook's `<workbookPr date1904="1"/>` toggle —
+   * `true` means the chart's date-axis values are interpreted under
+   * the 1904 base (Excel for Mac's legacy epoch where day 0 falls on
+   * 1904-01-01); `false` (the OOXML default) is the 1900 base.
+   *
+   * Default: omitted — when the field is absent the writer skips the
+   * element entirely and Excel falls back to the workbook's date
+   * system. Excel itself emits `<c:date1904 val="0"/>` on every
+   * authored chart even under the 1900 base; the writer does not pin
+   * that default so an unmarked chart re-parses to `undefined` (the
+   * minimal-shape contract every other chart-space toggle follows).
+   *
+   * Useful when restamping a chart from a 1904-based template into a
+   * 1900-based workbook (or vice versa) — pinning the field keeps the
+   * chart's date references anchored to the source's epoch even after
+   * the host changes. The value is emitted as `<c:date1904 val="1"/>`
+   * for `true` and skipped (rather than `val="0"`) for `false` so the
+   * writer's behavior matches absence — a re-parse drops the default
+   * back to `undefined` either way.
+   *
+   * Note: `<c:date1904>` lives on `<c:chartSpace>` (per CT_ChartSpace
+   * the element sits at the head of the sequence, before `<c:lang>`
+   * and `<c:roundedCorners>`), not inside `<c:chart>` — the toggle
+   * governs date interpretation across the whole chart document, not
+   * just the plot area.
+   */
+  date1904?: boolean;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -2971,6 +3001,39 @@ export interface Chart {
    * document, not just the plot area.
    */
   lang?: string;
+  /**
+   * Date-system flag pulled from `<c:chartSpace><c:date1904 val=".."/>`.
+   * Mirrors the host workbook's `<workbookPr date1904="1"/>` toggle —
+   * `true` signals that date-axis values inside the chart are
+   * interpreted under the 1904 base (Excel for Mac's legacy epoch
+   * where day 0 falls on 1904-01-01); the OOXML default `false` is
+   * the 1900 base.
+   *
+   * Surfaces `true` only when the chart pinned `<c:date1904 val="1"/>`
+   * (the non-default state). The default `val="0"` and absence both
+   * collapse to `undefined` so absence and the default round-trip
+   * identically through {@link cloneChart}. The reader accepts the
+   * OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
+   * `"false"`); unknown values and missing `val` attributes drop to
+   * `undefined`.
+   *
+   * Useful when copying a chart authored on Excel for Mac (or any
+   * 1904-based template) into a 1900-based workbook — pinning the
+   * flag keeps the chart's date references anchored to the source's
+   * epoch instead of silently shifting by 1462 days when the host
+   * date system flips. Excel's reference serialization for a fresh
+   * chart authored on a 1900-based workbook emits `<c:date1904
+   * val="0"/>`, but a chart that omits the element renders identically;
+   * surfacing only the non-default value preserves the minimal-shape
+   * contract the rest of {@link Chart} follows.
+   *
+   * Note: `<c:date1904>` lives on `<c:chartSpace>` (per CT_ChartSpace
+   * the element sits at the head of the sequence, before `<c:lang>`
+   * and `<c:roundedCorners>`), not inside `<c:chart>` — the toggle
+   * governs date interpretation across the whole chart document, not
+   * just the plot area.
+   */
+  date1904?: boolean;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -333,6 +333,26 @@ export interface CloneChartOptions {
    */
   lang?: string | null;
   /**
+   * Override `<c:date1904>` (the chart-space date-system toggle).
+   *
+   * `undefined` (or omitted) inherits the source's parsed `date1904`.
+   * `null` drops the inherited value so the writer skips the element
+   * entirely — Excel falls back to the host workbook's date system.
+   * `true` pins the chart to the 1904 base (Excel for Mac's legacy
+   * epoch) and `false` collapses to absence on the writer side
+   * because `<c:date1904 val="0"/>` is the OOXML default and the
+   * writer follows the minimal-shape contract every other chart-space
+   * toggle uses.
+   *
+   * Useful when restamping a chart from a 1904-based template into a
+   * 1900-based workbook (or vice versa) — pinning the field keeps the
+   * chart's date references anchored to the source's epoch even after
+   * the host changes. The grammar mirrors `roundedCorners` /
+   * `plotVisOnly` so the chart-space toggles compose the same way at
+   * the call site.
+   */
+  date1904?: boolean | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -747,6 +767,9 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedLang = resolveLang(source.lang, options.lang);
   if (resolvedLang !== undefined) out.lang = resolvedLang;
+
+  const resolvedDate1904 = resolveDate1904(source.date1904, options.date1904);
+  if (resolvedDate1904 !== undefined) out.date1904 = resolvedDate1904;
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -1184,6 +1207,39 @@ function resolveLang(
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;
+}
+
+/**
+ * Resolve a `date1904` (chart-space date-system) override.
+ *
+ * `undefined` → inherit the source's parsed `date1904`.
+ * `null`      → drop the inherited value (the writer skips
+ *               `<c:date1904>` so Excel falls back to the host
+ *               workbook's date system).
+ * `boolean`   → replace. `false` collapses to absence on the writer
+ *               side because `<c:date1904 val="0"/>` is the OOXML
+ *               default and the writer follows the minimal-shape
+ *               contract every other chart-space toggle uses.
+ *
+ * The grammar mirrors `roundedCorners` / `plotVisOnly` so the
+ * chart-space toggles compose the same way at the call site. `false`
+ * here means "explicitly pin the 1900 base" — but because absence
+ * and `val="0"` round-trip identically the resolved value still
+ * collapses to `undefined` (the writer would emit nothing either
+ * way).
+ */
+function resolveDate1904(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  const merged = override === undefined ? sourceValue : override === null ? undefined : override;
+  if (merged === true) return true;
+  // `false` and `undefined` both collapse to `undefined` — absence
+  // and the OOXML default `<c:date1904 val="0"/>` round-trip the
+  // same way through parseChart -> cloneChart -> writeChart, so the
+  // resolved chart drops the field rather than carry a value the
+  // writer would skip on emit anyway.
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -287,6 +287,14 @@ export function parseChart(xml: string): Chart | undefined {
   const lang = parseLang(chartSpace);
   if (lang !== undefined) out.lang = lang;
 
+  // `<c:date1904>` mirrors the host workbook's date-system toggle for
+  // chart date-axis interpretation. It sits at the head of
+  // `<c:chartSpace>` (per CT_ChartSpace, before `<c:lang>` and
+  // `<c:roundedCorners>`), not inside `<c:chart>` — the toggle governs
+  // date interpretation across the whole chart document.
+  const date1904 = parseDate1904(chartSpace);
+  if (date1904 !== undefined) out.date1904 = date1904;
+
   return out;
 }
 
@@ -1653,6 +1661,46 @@ function parseLang(chartSpace: XmlElement): string | undefined {
   // raw garbage like `"english"` or `"en US"`.
   if (!/^[A-Za-z]{2,3}(-[A-Za-z0-9]{2,8})*$/.test(raw)) return undefined;
   return raw;
+}
+
+// ── Date System ────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:date1904 val=".."/>` off `<c:chartSpace>`. Surfaces `true`
+ * only when the chart pinned `<c:date1904 val="1"/>` (the non-default
+ * state — date-axis values inside the chart use the 1904 base, Excel
+ * for Mac's legacy epoch where day 0 falls on 1904-01-01). The OOXML
+ * default `val="0"` and absence both collapse to `undefined` so
+ * absence and the default round-trip identically through
+ * {@link cloneChart}.
+ *
+ * Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` /
+ * `"0"` / `"false"`); unknown values and missing `val` attributes drop
+ * to `undefined` rather than fabricate a flag Excel would not emit.
+ *
+ * Note: `<c:date1904>` lives on `<c:chartSpace>` (per CT_ChartSpace
+ * the element sits at the head of the sequence, before `<c:lang>`
+ * and `<c:roundedCorners>`), not inside `<c:chart>` — the toggle
+ * governs date interpretation across the whole chart document, not
+ * just the plot area.
+ */
+function parseDate1904(chartSpace: XmlElement): boolean | undefined {
+  const el = findChild(chartSpace, "date1904");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `date1904` field.
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 // ── Vary Colors ────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -86,13 +86,23 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   // `<c:chartSpace>` element ordering per CT_ChartSpace
   // (ECMA-376 Part 1, §21.2.2.29): date1904?, lang?, roundedCorners?,
   // AlternateContent?, clrMapOvr?, style?, ... chart, ...
-  // — `<c:lang>` sits between `<c:date1904>` and `<c:roundedCorners>`,
-  // and `<c:style>` sits after `<c:roundedCorners>` and before
-  // `<c:chart>`. The writer skips emission for any element the chart
-  // leaves unset so a fresh chart stays minimal; Excel itself falls
-  // back to the workbook's editing language and the application's
-  // default look respectively.
+  // — `<c:date1904>` sits at the head of the sequence, `<c:lang>` next
+  // (between `<c:date1904>` and `<c:roundedCorners>`), and `<c:style>`
+  // after `<c:roundedCorners>` and before `<c:chart>`. The writer
+  // skips emission for any element the chart leaves unset so a fresh
+  // chart stays minimal; Excel itself falls back to the workbook's
+  // date system / editing language / application default look
+  // respectively.
   const chartSpaceChildren: string[] = [];
+  if (resolveDate1904(chart)) {
+    // `<c:date1904 val="0"/>` is the OOXML default — skip emission so
+    // the rendered shape matches absence (every other chart-space
+    // toggle follows the same minimal-emission contract). Only the
+    // non-default `val="1"` surfaces so a re-parse of the writer's
+    // output collapses back to the same `undefined` an unmarked
+    // chart parses to.
+    chartSpaceChildren.push(xmlSelfClose("c:date1904", { val: 1 }));
+  }
   const langVal = resolveLang(chart);
   if (langVal !== undefined) {
     chartSpaceChildren.push(xmlSelfClose("c:lang", { val: langVal }));
@@ -1967,6 +1977,34 @@ function resolveStyle(chart: SheetChart): number | undefined {
   if (!Number.isInteger(raw)) return undefined;
   if (raw < 1 || raw > 48) return undefined;
   return raw;
+}
+
+// ── Date System ──────────────────────────────────────────────────────
+
+/**
+ * Resolve the `<c:date1904 val=".."/>` value emitted on
+ * `<c:chartSpace>`.
+ *
+ * Returns `true` when the chart pins `date1904: true` (the
+ * non-default state), `false` otherwise. The caller decides whether
+ * to emit the element — the writer skips it whenever the resolved
+ * value is `false` so absence and the OOXML default `val="0"`
+ * round-trip identically through {@link parseChart}. Non-boolean
+ * values collapse to `false` so a stray runtime value never reaches
+ * the rendered XML.
+ *
+ * `<c:date1904>` mirrors the host workbook's
+ * `<workbookPr date1904="1"/>` toggle — `true` interprets date-axis
+ * values under the 1904 base (Excel for Mac's legacy epoch where day
+ * 0 falls on 1904-01-01) and `false` under the 1900 base. The
+ * element governs the whole chart document, not just the plot area.
+ *
+ * `<c:date1904>` sits at the head of `<c:chartSpace>` per
+ * CT_ChartSpace — before `<c:lang>` and `<c:roundedCorners>` — so
+ * the writer threads it first when the chart pins it.
+ */
+function resolveDate1904(chart: SheetChart): boolean {
+  return chart.date1904 === true;
 }
 
 // ── Editing Locale ──────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6562,3 +6562,240 @@ describe("cloneChart — chart editing locale", () => {
     expect(reparsed?.style).toBe(34);
   });
 });
+
+// ── cloneChart — chart date system (date1904) ────────────────────────
+
+describe("cloneChart — chart date system", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's date1904 by default", () => {
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.date1904).toBe(true);
+  });
+
+  it("lets options.date1904 override the source's value", () => {
+    // Source has no flag, override pins true — the clone carries the
+    // override.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      date1904: true,
+    });
+    expect(clone.date1904).toBe(true);
+  });
+
+  it("drops the inherited date1904 when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:date1904> entirely on emit and
+    // Excel falls back to the host workbook's date system.
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      date1904: null,
+    });
+    expect(clone.date1904).toBeUndefined();
+  });
+
+  it("collapses an explicit false override to absence", () => {
+    // `<c:date1904 val="0"/>` is the OOXML default — the writer
+    // would skip it on emit anyway, so the clone layer collapses
+    // false back to undefined to keep the resolved shape minimal.
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      date1904: false,
+    });
+    expect(clone.date1904).toBeUndefined();
+  });
+
+  it("returns undefined date1904 when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.date1904).toBeUndefined();
+  });
+
+  it("carries date1904 through a flatten (line → column)", () => {
+    // <c:date1904> lives on <c:chartSpace> and is valid on every
+    // chart family, so a coercion does not drop it.
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.date1904).toBe(true);
+  });
+
+  it("carries date1904 through a doughnut flatten (line → doughnut)", () => {
+    // The date-system flag has no chart-family restriction — even a
+    // coercion to doughnut, which has no axes, must preserve the
+    // pinned value because chart-space children sit above the plot
+    // area.
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.date1904).toBe(true);
+  });
+
+  it("propagates date1904 into the rendered <c:chartSpace> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:date1904 val="1"');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.date1904).toBe(true);
+  });
+
+  it("emits no <c:date1904> when both source and override are absent", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:date1904 ");
+    expect(parseChart(written)?.date1904).toBeUndefined();
+  });
+
+  it("an explicit null override beats the source value through writeXlsx", async () => {
+    // Source pins date1904 true, clone overrides to null — the
+    // rendered chart should carry no element and re-parse to
+    // undefined.
+    const clone = cloneChart(source({ date1904: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      date1904: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:date1904 ");
+    expect(parseChart(written)?.date1904).toBeUndefined();
+  });
+
+  it("composes date1904 with other chart-space toggles through writeXlsx", async () => {
+    // date1904 / lang / roundedCorners / style all live on
+    // <c:chartSpace> and must round-trip together without interfering
+    // with each other.
+    const clone = cloneChart(
+      source({ date1904: true, lang: "tr-TR", roundedCorners: true, style: 34 }),
+      {
+        anchor: { from: { row: 5, col: 0 } },
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:date1904 val="1"');
+    expect(written).toContain('c:lang val="tr-TR"');
+    expect(written).toContain('c:roundedCorners val="1"');
+    expect(written).toContain('c:style val="34"');
+    const reparsed = parseChart(written);
+    expect(reparsed?.date1904).toBe(true);
+    expect(reparsed?.lang).toBe("tr-TR");
+    expect(reparsed?.roundedCorners).toBe(true);
+    expect(reparsed?.style).toBe(34);
+  });
+
+  it("places <c:date1904> ahead of <c:lang> and <c:roundedCorners> in the rendered chart-space", async () => {
+    // Verify the schema sequence end-to-end through writeXlsx —
+    // CT_ChartSpace expects date1904? / lang? / roundedCorners? /
+    // style? in that order.
+    const clone = cloneChart(source({ date1904: true, lang: "en-US", roundedCorners: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const dateIdx = written.indexOf("c:date1904 ");
+    const langIdx = written.indexOf("c:lang ");
+    const roundedIdx = written.indexOf("c:roundedCorners");
+    expect(dateIdx).toBeGreaterThan(-1);
+    expect(langIdx).toBeGreaterThan(dateIdx);
+    expect(roundedIdx).toBeGreaterThan(langIdx);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5771,3 +5771,140 @@ describe("writeChart — chart editing locale", () => {
     expect(reparsed?.lang).toBe("tr-TR");
   });
 });
+
+// ── writeChart — chart date system (date1904) ────────────────────────
+
+describe("writeChart — chart date system", () => {
+  it("skips <c:date1904> entirely when the field is unset (writer default)", () => {
+    // Excel's reference serialization always emits <c:date1904 val="0"/>,
+    // but the writer skips emission when the chart leaves `date1904`
+    // unset so the file does not silently fabricate a flag Excel
+    // falls back to anyway. Absence and the OOXML default round-trip
+    // identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:date1904 ");
+    expect(result.chartXml).not.toContain("<c:date1904/>");
+  });
+
+  it("skips <c:date1904> when date1904 is false (matches OOXML default)", () => {
+    // `false` and absence both map to the default `val="0"` — the
+    // writer skips the element so re-parse collapses back to the
+    // same `undefined` that absence would produce.
+    const result = writeChart(makeChart({ date1904: false }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:date1904 ");
+    expect(result.chartXml).not.toContain("<c:date1904/>");
+  });
+
+  it('emits <c:date1904 val="1"/> when the chart pins date1904: true', () => {
+    const result = writeChart(makeChart({ date1904: true }), "Sheet1");
+    expect(result.chartXml).toContain('c:date1904 val="1"');
+  });
+
+  it("places <c:date1904> before <c:roundedCorners> on <c:chartSpace>", () => {
+    // CT_ChartSpace sequence: date1904?, lang?, roundedCorners?, ...
+    // — the date-system flag must precede <c:roundedCorners> so a
+    // strict validator (Excel itself rejects out-of-order children)
+    // sees the schema sequence respected.
+    const result = writeChart(makeChart({ date1904: true }), "Sheet1");
+    const dateIdx = result.chartXml.indexOf("c:date1904 ");
+    const roundedIdx = result.chartXml.indexOf("c:roundedCorners");
+    const chartIdx = result.chartXml.indexOf("<c:chart>");
+    expect(dateIdx).toBeGreaterThan(-1);
+    expect(roundedIdx).toBeGreaterThan(dateIdx);
+    expect(chartIdx).toBeGreaterThan(roundedIdx);
+  });
+
+  it("places <c:date1904> before <c:lang> when both are pinned", () => {
+    // <c:date1904> sits at the head of CT_ChartSpace, before <c:lang>
+    // which sits before <c:roundedCorners> which sits before
+    // <c:style> — the writer threads all four in the right order so
+    // a validator never sees them transposed.
+    const result = writeChart(
+      makeChart({ date1904: true, lang: "tr-TR", style: 27, roundedCorners: true }),
+      "Sheet1",
+    );
+    const dateIdx = result.chartXml.indexOf("c:date1904 ");
+    const langIdx = result.chartXml.indexOf("c:lang ");
+    const roundedIdx = result.chartXml.indexOf("c:roundedCorners");
+    const styleIdx = result.chartXml.indexOf("c:style ");
+    expect(dateIdx).toBeGreaterThan(-1);
+    expect(langIdx).toBeGreaterThan(dateIdx);
+    expect(roundedIdx).toBeGreaterThan(langIdx);
+    expect(styleIdx).toBeGreaterThan(roundedIdx);
+  });
+
+  it("only emits <c:date1904> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ date1904: true }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:date1904 /g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads date1904 through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, date1904: true }), "Sheet1");
+      expect(result.chartXml).toContain('c:date1904 val="1"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        date1904: true,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:date1904 val="1"');
+  });
+
+  it("round-trips a pinned date1904 through parseChart", () => {
+    const written = writeChart(makeChart({ date1904: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.date1904).toBe(true);
+  });
+
+  it("collapses an unset date1904 round-trip back to undefined", () => {
+    // A fresh chart writes no element, which re-parses to undefined —
+    // absence and the unset default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.date1904).toBeUndefined();
+  });
+
+  it("collapses date1904: false round-trip back to undefined", () => {
+    // `false` writes nothing (matches OOXML default), so re-parse
+    // also returns undefined — there is no asymmetry between the
+    // pinned-default and unset states.
+    const written = writeChart(makeChart({ date1904: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.date1904).toBeUndefined();
+  });
+
+  it("threads date1904 end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            date1904: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('c:date1904 val="1"');
+    // Re-parse the rendered chart to confirm the date-system flag
+    // survives the packaging path.
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.date1904).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6589,3 +6589,152 @@ describe("parseChart — chart editing locale", () => {
     expect(chart?.varyColors).toBe(true);
   });
 });
+
+// ── parseChart — chart date system (date1904) ──────────────────────
+
+describe("parseChart — chart date system", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:date1904 val="1"/> as true', () => {
+    // The non-default state — chart date references use the 1904 base
+    // (Excel for Mac's legacy epoch). Surfaces verbatim because a
+    // chart that pinned the flag carries the override Excel would
+    // otherwise inherit from the host workbook.
+    const xml = `<c:chartSpace ${NS}>
+  <c:date1904 val="1"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.date1904).toBe(true);
+  });
+
+  it('surfaces <c:date1904 val="true"/> as true', () => {
+    // OOXML accepts the textual `xsd:boolean` spellings.
+    const xml = `<c:chartSpace ${NS}>
+  <c:date1904 val="true"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.date1904).toBe(true);
+  });
+
+  it('collapses <c:date1904 val="0"/> to undefined (OOXML default)', () => {
+    // The OOXML default — chart uses the 1900 base. Absence and the
+    // default round-trip identically through cloneChart, so the
+    // reader collapses the explicit default to undefined for symmetry
+    // with every other chart-space toggle.
+    const xml = `<c:chartSpace ${NS}>
+  <c:date1904 val="0"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.date1904).toBeUndefined();
+  });
+
+  it('collapses <c:date1904 val="false"/> to undefined', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:date1904 val="false"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.date1904).toBeUndefined();
+  });
+
+  it("returns undefined when the chartSpace has no <c:date1904>", () => {
+    // Absence is the writer's default — the reader surfaces nothing
+    // so a fresh chart and a chart that omits the element round-trip
+    // identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.date1904).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:date1904>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:date1904/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.date1904).toBeUndefined();
+  });
+
+  it("drops unknown val tokens rather than fabricate a flag", () => {
+    // <c:date1904> is xsd:boolean per CT_Boolean. Anything outside
+    // `1` / `true` / `0` / `false` collapses to undefined so the
+    // parsed chart never carries a token Excel itself would not emit.
+    for (const bad of ["yes", "no", "2", "T", "F", " ", ""]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:date1904 val="${bad}"/>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.date1904).toBeUndefined();
+    }
+  });
+
+  it("surfaces date1904 alongside lang and other chart-space toggles", () => {
+    // <c:date1904> sits at the head of the CT_ChartSpace sequence,
+    // before <c:lang> and <c:roundedCorners> — co-existing chart-
+    // space children should not interfere with each other's parsing.
+    const xml = `<c:chartSpace ${NS}>
+  <c:date1904 val="1"/>
+  <c:lang val="en-US"/>
+  <c:roundedCorners val="1"/>
+  <c:style val="34"/>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.date1904).toBe(true);
+    expect(chart?.lang).toBe("en-US");
+    expect(chart?.roundedCorners).toBe(true);
+    expect(chart?.style).toBe(34);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the `<c:chartSpace><c:date1904>` element at the read, write, and clone layers so a template's chart-level date-system toggle survives `parseChart -> cloneChart -> writeXlsx` and can be authored from scratch.

`<c:date1904>` mirrors the host workbook's `<workbookPr date1904="1"/>` flag for chart date-axis interpretation — `true` anchors dates inside the chart to the 1904 base (Excel for Mac's legacy epoch where day 0 falls on 1904-01-01); `false` (the OOXML default) is the 1900 base. The element sits at the head of `<c:chartSpace>` per CT_ChartSpace (ECMA-376 Part 1, §21.2.2.29), before `<c:lang>` and `<c:roundedCorners>`. Until now hucre's writer skipped the element entirely and the reader ignored it, so a chart copied from a 1904-based template silently shifted by 1462 days when the host workbook used a different date system on every parse -> clone -> write loop.

The model is a plain boolean (`date1904?: boolean`); the writer emits `<c:date1904 val="1"/>` only when the chart pins `true` and skips emission for `false` / unset because `val="0"` is the OOXML default and absence renders identically. The reader collapses both the default value and absence to `undefined` so a fresh chart and a chart that pinned the default round-trip identically. The clone layer follows the same `boolean | null | boolean` override grammar as `roundedCorners` / `plotVisOnly` so the chart-space toggles compose the same way at the call site.

This bridges another chart-space gap for the dashboard composition flow tracked in #136 and closes the trio of chart-space siblings (`date1904` / `lang` / `roundedCorners`) that sit ahead of `<c:style>` in the schema sequence.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.date1904);
// true when the template pinned <c:date1904 val="1"/>; undefined when
// the template inherited the default (the OOXML `val="0"` collapses
// to undefined alongside absence so absence and the default round-
// trip identically).

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "line",
      series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
      anchor: { from: { row: 6, col: 0 } },
      // Anchor the chart's date references to the 1904 base even
      // though the host workbook uses 1900.
      date1904: true,
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  // date1904: undefined  -> inherit the source's parsed value
  // date1904: null       -> drop the inherited value (writer skips
  //                          the element; Excel falls back to the
  //                          host workbook's date system)
  // date1904: true       -> pin the 1904 base
  // date1904: false      -> collapses to absence (the writer would
  //                          skip val="0" anyway because it matches
  //                          the OOXML default)
  date1904: true,
});
```

## Model

```ts
// Read side
export interface Chart {
  // ...existing fields...
  date1904?: boolean;
}

// Write side
export interface SheetChart {
  // ...existing fields...
  date1904?: boolean;
}

// Clone side
export interface CloneChartOptions {
  // ...existing fields...
  date1904?: boolean | null;
}
```

## Scope rules

- The OOXML schema places `<c:date1904>` exclusively on `<c:chartSpace>` (a sibling of `<c:chart>`). The writer threads the element at the head of the chartSpace children, before `<c:lang>` / `<c:roundedCorners>` / `<c:style>` per the CT_ChartSpace sequence so a strict validator never sees the children transposed.
- The writer emits `<c:date1904 val="1"/>` only when the chart pins `true`. `false` and unset both collapse to absence because the OOXML default is `val="0"` and a re-parse of either renders identically — the minimal-emission contract every other chart-space toggle (`roundedCorners`, `style`, `lang`) follows.
- The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing `val` attributes drop to `undefined` rather than fabricate a flag Excel would not emit.
- `<c:date1904>` is family-agnostic — the toggle governs date interpretation across the whole chart document, so the clone layer carries the value through every flatten (line -> column / doughnut / scatter) without dropping it.

## Test plan

- [x] `pnpm test` (lint + typecheck + vitest under `--dir=test`, all 3625 tests passing — 31 new tests covering reader / writer / clone)
- [x] `pnpm build`
- [x] `parseChart` covers `val="1"` / `val="true"` surfacing, `val="0"` / `val="false"` default-collapse, absence, missing `val`, unknown-token drop, co-existence with `<c:lang>` / `<c:roundedCorners>` / `<c:style>`.
- [x] `writeChart` covers absence default, `false` default-collapse, `<c:date1904 val="1"/>` emission, CT_ChartSpace ordering (before `<c:lang>` and `<c:roundedCorners>`), single-emit guard, every chart family (bar / column / line / pie / doughnut / area / scatter), parseChart round-trip, end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace, `false` collapse-to-absence, addition on a source that lacked the field, scope retention through flatten (line -> column / doughnut), composition with `lang` / `roundedCorners` / `style` without dropping unrelated state, end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`, schema-sequence ordering verification on the rendered chartSpace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)