### PR TITLE
feat(xlsx): chart showDLblsOverMax — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,6 +695,16 @@ non-default that keeps hidden cells in the chart). The reader accepts
 the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
 `"false"`); unknown values and missing `val` attributes drop to
 `undefined`.
+`Chart.showDLblsOverMax` surfaces the chart-level
+`<c:chart><c:showDLblsOverMax val=".."/>` flag — Excel's "Format Axis
+→ Labels → Show data labels for values over maximum scale" checkbox.
+The OOXML default `true` (labels render for every point) collapses to
+`undefined` so absence and `<c:showDLblsOverMax val="1"/>` round-trip
+identically; only an explicit `val="0"` surfaces `false` (the
+non-default that strips labels off any point whose value exceeds the
+pinned `<c:max>`). The reader accepts the OOXML truthy / falsy
+spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and
+missing `val` attributes drop to `undefined`.
 `ChartAxisInfo.tickLblSkip` and `ChartAxisInfo.tickMarkSkip` surface
 the category-axis tick-thinning knobs (`<c:catAx><c:tickLblSkip val=".."/>`
 and `<c:catAx><c:tickMarkSkip val=".."/>`). Both elements live on
@@ -1040,6 +1050,17 @@ the chart), matching Excel's reference serialization. Pin
 chart (`val="0"`). The writer always emits the element so the
 rendered intent is explicit on roundtrip — no chart family is special-
 cased.
+The chart-level `showDLblsOverMax` field maps to
+`<c:showDLblsOverMax val=".."/>` on `<c:chart>` — Excel's "Format
+Axis → Labels → Show data labels for values over maximum scale"
+checkbox. Absent it, the writer emits the OOXML default `val="1"`
+(labels render for every point regardless of the axis ceiling),
+matching Excel's reference serialization. Pin `showDLblsOverMax: false`
+to strip labels off any point whose value exceeds the pinned `<c:max>`
+(`val="0"`). The writer always emits the element so the rendered
+intent is explicit on roundtrip — no chart family is special-cased,
+since the toggle lives on `<c:chart>` and is valid on every chart
+family.
 The chart-level `roundedCorners` field maps to
 `<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
 `<c:chart>`, not a child) — Excel's "Format Chart Area → Border →
@@ -1394,6 +1415,13 @@ a `boolean` to replace it. Like `dispBlanksAs` and `varyColors`, the
 field lives on `<c:chart>` and is valid on every chart family, so a
 coercion (line → column, doughnut → pie, etc.) preserves the
 inherited value rather than dropping it.
+The chart-level `showDLblsOverMax` flag follows the same grammar:
+pass `undefined` to inherit the source's parsed value, `null` to drop
+it back to the writer's OOXML `true` default (labels render for every
+point regardless of axis ceiling), or a `boolean` to replace it. Like
+`plotVisOnly` / `dispBlanksAs`, the field lives on `<c:chart>` and is
+valid on every chart family, so a coercion (line → column, doughnut →
+pie, etc.) preserves the inherited value rather than dropping it.
 The chart-level `roundedCorners` flag follows the same grammar: pass
 `undefined` to inherit the source's parsed value, `null` to drop it
 back to the writer's OOXML `false` default (square chart frame), or a

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1105,6 +1105,28 @@ export interface SheetChart {
    */
   plotVisOnly?: boolean;
   /**
+   * Whether data labels are shown for points whose values exceed the
+   * chart's maximum axis bound. Maps to `<c:showDLblsOverMax val=".."/>`
+   * on `<c:chart>`. The element sits at the tail of CT_Chart (after
+   * `<c:dispBlanksAs>` and before `<c:extLst>`).
+   *
+   * Default: `true` — the OOXML schema default. When the value axis
+   * is auto-scaled the flag has no observable effect because no point
+   * exceeds the max; the toggle only matters when the caller pinned a
+   * tight `<c:max>` via {@link ChartAxisScale.max} and a series carries
+   * values above it. Setting `false` matches Excel's "Format Axis →
+   * Labels → Show data labels for values over maximum scale" checkbox
+   * unchecked — the labels for the over-max points disappear while the
+   * connector / line still draws above the plot area.
+   *
+   * The writer always emits the element so the rendered intent is
+   * explicit on roundtrip — Excel itself includes it in every reference
+   * serialization. Mirrors {@link plotVisOnly} / {@link dispBlanksAs}
+   * (the other always-emitted chart-level toggles); a value pinned by
+   * the caller round-trips identically through {@link cloneChart}.
+   */
+  showDLblsOverMax?: boolean;
+  /**
    * Whether the chart frame is drawn with rounded corners. Maps to
    * `<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
    * `<c:chart>`, not a child). Mirrors Excel's "Format Chart Area →
@@ -2958,6 +2980,29 @@ export interface Chart {
    * drop to `undefined`.
    */
   plotVisOnly?: boolean;
+  /**
+   * Show-data-labels-over-max flag pulled from
+   * `<c:chart><c:showDLblsOverMax val=".."/>`. Reflects Excel's "Format
+   * Axis → Labels → Show data labels for values over maximum scale"
+   * checkbox — when the box is unchecked, labels are suppressed for any
+   * point whose value exceeds the pinned `<c:max>` axis bound and the
+   * field surfaces `false`.
+   *
+   * The OOXML default `true` collapses to `undefined` so absence and
+   * the default round-trip identically through {@link cloneChart} —
+   * only an explicit `<c:showDLblsOverMax val="0"/>` surfaces `false`.
+   * The reader accepts the OOXML truthy / falsy spellings (`"1"` /
+   * `"true"` / `"0"` / `"false"`); unknown values and missing `val`
+   * attributes drop to `undefined`. Mirrors the parsing semantics of
+   * {@link plotVisOnly}.
+   *
+   * `<c:showDLblsOverMax>` lives on `<c:chart>` at the tail of CT_Chart
+   * (after `<c:dispBlanksAs>` and before `<c:extLst>`). The toggle has
+   * no observable effect on a chart whose value axis auto-scales (no
+   * point exceeds the auto-computed max); it only matters when the
+   * caller pinned a tighter axis ceiling.
+   */
+  showDLblsOverMax?: boolean;
   /**
    * Rounded-corners flag pulled from
    * `<c:chartSpace><c:roundedCorners val=".."/>`. Reflects Excel's

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -266,6 +266,22 @@ export interface CloneChartOptions {
    */
   plotVisOnly?: boolean | null;
   /**
+   * Override `<c:showDLblsOverMax>` (the "show data labels for values
+   * over maximum scale" toggle).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `showDLblsOverMax`. `null` drops the inherited value so the writer
+   * falls back to the OOXML `true` default (labels render for every
+   * point regardless of the axis ceiling). A `boolean` replaces it —
+   * useful for stripping labels off over-max points on a clone whose
+   * value axis pins a tight `<c:max>` (`false`), or for restoring the
+   * default behavior on a clone whose template overrode it (`true`).
+   *
+   * The grammar mirrors `plotVisOnly` / `dispBlanksAs` so the
+   * chart-level toggles compose the same way at the call site.
+   */
+  showDLblsOverMax?: boolean | null;
+  /**
    * Override `<c:roundedCorners>` (the chart-frame rounded-edge toggle).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -766,6 +782,12 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   const resolvedPlotVisOnly = resolvePlotVisOnly(source.plotVisOnly, options.plotVisOnly);
   if (resolvedPlotVisOnly !== undefined) out.plotVisOnly = resolvedPlotVisOnly;
 
+  const resolvedShowDLblsOverMax = resolveShowDLblsOverMax(
+    source.showDLblsOverMax,
+    options.showDLblsOverMax,
+  );
+  if (resolvedShowDLblsOverMax !== undefined) out.showDLblsOverMax = resolvedShowDLblsOverMax;
+
   const resolvedRoundedCorners = resolveRoundedCorners(
     source.roundedCorners,
     options.roundedCorners,
@@ -1139,6 +1161,27 @@ function resolveVaryColors(
  * toggles compose the same way at the call site.
  */
 function resolvePlotVisOnly(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `showDLblsOverMax` override.
+ *
+ * `undefined` → inherit the source's parsed `showDLblsOverMax`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML `true` default — labels render for every point
+ *               regardless of the pinned axis ceiling).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `plotVisOnly` / `dispBlanksAs` so the chart-level
+ * toggles compose the same way at the call site.
+ */
+function resolveShowDLblsOverMax(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -267,6 +267,14 @@ export function parseChart(xml: string): Chart | undefined {
   const plotVisOnly = parsePlotVisOnly(chartEl);
   if (plotVisOnly !== undefined) out.plotVisOnly = plotVisOnly;
 
+  // `<c:showDLblsOverMax>` sits at the tail of CT_Chart (after
+  // `<c:dispBlanksAs>` and before `<c:extLst>`). Mirrors the writer
+  // side, which always emits the element — only the non-default
+  // `val="0"` surfaces here (`true` collapses to `undefined` for the
+  // standard minimal-shape contract).
+  const showDLblsOverMax = parseShowDLblsOverMax(chartEl);
+  if (showDLblsOverMax !== undefined) out.showDLblsOverMax = showDLblsOverMax;
+
   // `<c:roundedCorners>` lives on `<c:chartSpace>` (the chart's outer
   // wrapper), not inside `<c:chart>` — the toggle styles the chart
   // frame's outer border rather than the plot area.
@@ -1600,6 +1608,44 @@ function parsePlotVisOnly(chartEl: XmlElement): boolean | undefined {
     case "true":
       // OOXML default — collapse to undefined for symmetry with the
       // writer's `plotVisOnly` field.
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+// ── Show Data Labels Over Max ─────────────────────────────────────
+
+/**
+ * Pull `<c:showDLblsOverMax val=".."/>` off `<c:chart>`. The OOXML
+ * default is `true` (data labels render for every point regardless of
+ * whether the value exceeds the pinned axis ceiling), which collapses
+ * to `undefined` so absence and the default round-trip identically
+ * through {@link cloneChart} — only an explicit `<c:showDLblsOverMax val="0"/>`
+ * surfaces `false`.
+ *
+ * Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` /
+ * `"0"` / `"false"`); unknown values and missing `val` attributes drop
+ * to `undefined` rather than fabricate a flag Excel would not emit.
+ *
+ * `<c:showDLblsOverMax>` sits at the tail of CT_Chart (after
+ * `<c:dispBlanksAs>` and before `<c:extLst>`); the parser pulls it off
+ * `<c:chart>` directly, so the toggle's order relative to its sibling
+ * elements does not matter.
+ */
+function parseShowDLblsOverMax(chartEl: XmlElement): boolean | undefined {
+  const el = findChild(chartEl, "showDLblsOverMax");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "0":
+    case "false":
+      return false;
+    case "1":
+    case "true":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `showDLblsOverMax` field.
       return undefined;
     default:
       return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -81,6 +81,15 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
   chartChildren.push(xmlSelfClose("c:plotVisOnly", { val: resolvePlotVisOnly(chart) ? 1 : 0 }));
   chartChildren.push(xmlSelfClose("c:dispBlanksAs", { val: resolveDispBlanksAs(chart) }));
+  // `<c:showDLblsOverMax>` sits at the tail of CT_Chart per ECMA-376
+  // Part 1, §21.2.2.29 (after `<c:dispBlanksAs>` and before
+  // `<c:extLst>`). The writer always emits the element so the rendered
+  // intent is explicit on roundtrip — Excel itself includes it in every
+  // reference serialization. Mirrors the always-emit contract `<c:plotVisOnly>`
+  // and `<c:dispBlanksAs>` follow.
+  chartChildren.push(
+    xmlSelfClose("c:showDLblsOverMax", { val: resolveShowDLblsOverMax(chart) ? 1 : 0 }),
+  );
 
   const chartElement = xmlElement("c:chart", undefined, chartChildren);
 
@@ -1984,6 +1993,29 @@ function resolveDispBlanksAs(chart: SheetChart): ChartDisplayBlanksAs {
  */
 function resolvePlotVisOnly(chart: SheetChart): boolean {
   if (typeof chart.plotVisOnly === "boolean") return chart.plotVisOnly;
+  return true;
+}
+
+// ── Show Data Labels Over Max ────────────────────────────────────────
+
+/**
+ * Resolve the `<c:showDLblsOverMax>` value emitted on `<c:chart>`.
+ *
+ * Defaults to `true` (the OOXML schema default — labels render for
+ * every data point regardless of whether the value exceeds the pinned
+ * axis maximum). An explicit `chart.showDLblsOverMax === false` flips
+ * the toggle to mirror Excel's "Format Axis → Labels → Show data labels
+ * for values over maximum scale" checkbox unchecked. The writer always
+ * emits the element so the file's intent is explicit even on roundtrip
+ * — Excel itself includes it in every reference serialization.
+ *
+ * `<c:showDLblsOverMax>` sits at the tail of CT_Chart per ECMA-376
+ * Part 1, §21.2.2.29 (after `<c:dispBlanksAs>` and before `<c:extLst>`).
+ * Mirrors the always-emit contract of {@link resolvePlotVisOnly} and
+ * {@link resolveDispBlanksAs}.
+ */
+function resolveShowDLblsOverMax(chart: SheetChart): boolean {
+  if (typeof chart.showDLblsOverMax === "boolean") return chart.showDLblsOverMax;
   return true;
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -3289,6 +3289,137 @@ describe("cloneChart — plotVisOnly", () => {
   });
 });
 
+// ── cloneChart — showDLblsOverMax ─────────────────────────────────
+
+describe("cloneChart — showDLblsOverMax", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's showDLblsOverMax by default", () => {
+    const clone = cloneChart(source({ showDLblsOverMax: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.showDLblsOverMax).toBe(false);
+  });
+
+  it("lets options.showDLblsOverMax override the source's value", () => {
+    const clone = cloneChart(source({ showDLblsOverMax: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showDLblsOverMax: true,
+    });
+    expect(clone.showDLblsOverMax).toBe(true);
+  });
+
+  it("drops the inherited showDLblsOverMax when the override is null", () => {
+    // null collapses to the writer's OOXML default — the field
+    // disappears from the resolved SheetChart so the writer emits the
+    // default `1` (labels render for every point regardless of axis
+    // ceiling).
+    const clone = cloneChart(source({ showDLblsOverMax: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showDLblsOverMax: null,
+    });
+    expect(clone.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("returns undefined showDLblsOverMax when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("carries showDLblsOverMax through a flatten (line → column)", () => {
+    // showDLblsOverMax lives on `<c:chart>` and is valid on every chart
+    // family, so a coercion does not drop it.
+    const clone = cloneChart(source({ showDLblsOverMax: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.showDLblsOverMax).toBe(false);
+  });
+
+  it("carries showDLblsOverMax through a doughnut flatten (line → doughnut)", () => {
+    // The toggle has no chart-family restriction in the OOXML schema —
+    // even a coercion to doughnut, which has no axes, must preserve
+    // the pinned value.
+    const clone = cloneChart(source({ showDLblsOverMax: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.showDLblsOverMax).toBe(false);
+  });
+
+  it("propagates showDLblsOverMax into the rendered <c:chart> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ showDLblsOverMax: false }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:showDLblsOverMax val="0"');
+    expect(written).not.toContain('c:showDLblsOverMax val="1"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.showDLblsOverMax).toBe(false);
+  });
+
+  it("emits the OOXML default showDLblsOverMax=1 when both source and override are absent", async () => {
+    // A bare clone with no showDLblsOverMax hint rolls into a SheetChart
+    // whose writer emits the default `1` and re-parses to undefined.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:showDLblsOverMax val="1"');
+    expect(parseChart(written)?.showDLblsOverMax).toBeUndefined();
+  });
+});
+
 // ── cloneChart — roundedCorners ───────────────────────────────────
 
 describe("cloneChart — roundedCorners", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -3181,6 +3181,91 @@ describe("writeChart — plotVisOnly", () => {
   });
 });
 
+// ── writeChart — showDLblsOverMax ────────────────────────────────────
+
+describe("writeChart — showDLblsOverMax", () => {
+  it('emits <c:showDLblsOverMax val="1"/> when the field is unset (OOXML default)', () => {
+    // The writer always emits the element so the rendered intent is
+    // explicit on roundtrip — mirrors the always-emit contract that
+    // <c:plotVisOnly> and <c:dispBlanksAs> follow.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).toContain('c:showDLblsOverMax val="1"');
+    expect(result.chartXml).not.toContain('c:showDLblsOverMax val="0"');
+  });
+
+  it("threads showDLblsOverMax=false through to <c:chart>", () => {
+    // false is the non-default — Excel's "Format Axis -> Labels ->
+    // Show data labels for values over maximum scale" checkbox unchecked.
+    const result = writeChart(makeChart({ showDLblsOverMax: false }), "Sheet1");
+    expect(result.chartXml).toContain('c:showDLblsOverMax val="0"');
+    expect(result.chartXml).not.toContain('c:showDLblsOverMax val="1"');
+  });
+
+  it("threads showDLblsOverMax=true through to <c:chart>", () => {
+    // Setting the OOXML default explicitly produces the same wire
+    // shape as omitting the field — the element is always emitted.
+    const result = writeChart(makeChart({ showDLblsOverMax: true }), "Sheet1");
+    expect(result.chartXml).toContain('c:showDLblsOverMax val="1"');
+  });
+
+  it("places <c:showDLblsOverMax> after <c:dispBlanksAs> inside <c:chart> (OOXML order)", () => {
+    // CT_Chart sequence: ... plotArea, legend?, plotVisOnly?, dispBlanksAs?,
+    // showDLblsOverMax?, extLst? — the new toggle sits at the tail.
+    const result = writeChart(makeChart({ showDLblsOverMax: false }), "Sheet1");
+    expect(result.chartXml.indexOf("c:dispBlanksAs")).toBeLessThan(
+      result.chartXml.indexOf("c:showDLblsOverMax"),
+    );
+  });
+
+  it("only emits <c:showDLblsOverMax> once even on a chart that overrides it", () => {
+    const result = writeChart(makeChart({ showDLblsOverMax: false }), "Sheet1");
+    const occurrences = result.chartXml.match(/c:showDLblsOverMax/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads showDLblsOverMax through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, showDLblsOverMax: false }), "Sheet1");
+      expect(result.chartXml).toContain('c:showDLblsOverMax val="0"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        showDLblsOverMax: false,
+      }),
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('c:showDLblsOverMax val="0"');
+  });
+
+  it("round-trips a non-default showDLblsOverMax value through parseChart", () => {
+    // A chart with showDLblsOverMax=false should re-parse into a Chart
+    // whose `showDLblsOverMax` field is `false` (not collapsed to undefined,
+    // since false is not the OOXML default).
+    const written = writeChart(makeChart({ showDLblsOverMax: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.showDLblsOverMax).toBe(false);
+  });
+
+  it("collapses a defaulted showDLblsOverMax round-trip back to undefined", () => {
+    // A fresh chart (showDLblsOverMax omitted) writes `1` and re-parses to
+    // undefined — absence and the OOXML default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("collapses an explicit showDLblsOverMax=true round-trip back to undefined", () => {
+    // Pinning the OOXML default also collapses on read, so a template
+    // that explicitly emits `<c:showDLblsOverMax val="1"/>` is treated the
+    // same as one that omits the field.
+    const written = writeChart(makeChart({ showDLblsOverMax: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.showDLblsOverMax).toBeUndefined();
+  });
+});
+
 // ── writeChart — roundedCorners ──────────────────────────────────────
 
 describe("writeChart — roundedCorners", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -3804,6 +3804,127 @@ describe("parseChart — plotVisOnly", () => {
   });
 });
 
+// ── parseChart — showDLblsOverMax ─────────────────────────────────
+
+describe("parseChart — showDLblsOverMax", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces <c:showDLblsOverMax val="0"/> on <c:chart> as false (non-default)', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+    <c:showDLblsOverMax val="0"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBe(false);
+  });
+
+  it("collapses the OOXML default true to undefined (writer absence)", () => {
+    // The default carried explicitly by the writer's reference shape
+    // round-trips identically to absence of the field.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:showDLblsOverMax val="1"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:showDLblsOverMax> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("accepts the OOXML true / false spellings on the val attribute", () => {
+    // The OOXML schema for `xsd:boolean` accepts `"true"` / `"false"`
+    // alongside the more common `"1"` / `"0"`. Hucre tolerates both
+    // shapes — a hand-edited template using `false` should round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:showDLblsOverMax val="false"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBe(false);
+  });
+
+  it("collapses the 'true' spelling to undefined as well", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:showDLblsOverMax val="true"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("drops unknown showDLblsOverMax values rather than fabricate one", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:showDLblsOverMax val="bogus"/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("ignores a missing val attribute on <c:showDLblsOverMax>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    </c:plotArea>
+    <c:showDLblsOverMax/>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showDLblsOverMax).toBeUndefined();
+  });
+
+  it("surfaces showDLblsOverMax alongside other chart-level toggles", () => {
+    // Co-existing with plotVisOnly / dispBlanksAs / varyColors should
+    // not interfere — each toggle parses independently off <c:chart>.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+    <c:showDLblsOverMax val="0"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showDLblsOverMax).toBe(false);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+    expect(chart?.varyColors).toBe(true);
+  });
+});
+
 // ── parseChart — roundedCorners ───────────────────────────────────
 
 describe("parseChart — roundedCorners", () => {


### PR DESCRIPTION
## Summary

Surfaces the chart-level `<c:showDLblsOverMax>` element at the read, write, and clone layers so a template's "Show data labels for values over maximum scale" toggle survives `parseChart` → `cloneChart` → `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:showDLblsOverMax>` is the OOXML element behind Excel's "Format Axis → Labels → Show data labels for values over maximum scale" checkbox. When the box is unchecked, data labels are suppressed for any point whose value exceeds the value axis's pinned `<c:max>` and the field surfaces `false`. The element sits at the tail of `CT_Chart` (after `<c:dispBlanksAs>` and before `<c:extLst>`) per ECMA-376 Part 1, §21.2.2.29. Until now hucre's writer skipped the element entirely and `parseChart` did not surface the value, so a template that pinned a tight axis ceiling and stripped over-max labels could not round-trip through clone. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.showDLblsOverMax); // false on a chart that strips over-max labels,
                                       // undefined when the template uses the OOXML default

// ── Write side ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      // Strip data labels off any point whose value exceeds the pinned axis max.
      {
        type: "column",
        series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        axes: { y: { scale: { max: 100 } } },
        showDLblsOverMax: false,
      },
    ],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  showDLblsOverMax: false,            // replace
  // showDLblsOverMax: null,          // drop the inherited flag (writer falls back to OOXML default true)
  // showDLblsOverMax: undefined,     // inherit the source's parsed value
});
```

## Model

```ts
interface SheetChart {
  /** ...existing fields... */
  showDLblsOverMax?: boolean;
}

interface Chart {
  /** ...existing fields... */
  showDLblsOverMax?: boolean;
}

interface CloneChartOptions {
  /** ...existing fields... */
  showDLblsOverMax?: boolean | null;
}
```

The read-side `Chart.showDLblsOverMax` mirrors the same shape so a parsed value slots straight back into `cloneChart` without transformation.

## Behavior

- **Read** — `parseChart` pulls `<c:showDLblsOverMax val=".."/>` off `<c:chart>`. The OOXML default `true` collapses to `undefined` so absence and the default round-trip identically; only an explicit `val="0"` surfaces `false`. The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing `val` attributes drop to `undefined`.
- **Write** — The writer always emits `<c:showDLblsOverMax>` on `<c:chart>` (matching the always-emit contract `<c:plotVisOnly>` and `<c:dispBlanksAs>` follow). Absent `showDLblsOverMax`, the writer emits `val="1"` (the OOXML schema default). An explicit `chart.showDLblsOverMax === false` flips it to `val="0"`.
- **Clone** — `options.showDLblsOverMax` accepts the standard `undefined` (inherit) / `null` (drop the inherited flag, falling back to the writer's default `true`) / `boolean` (replace) grammar that mirrors `plotVisOnly` / `dispBlanksAs`. The inherited value carries through every coercion (column → pie, doughnut → line, etc.) since the element lives on `<c:chart>` and is valid on every chart family.

## Edge cases

- A chart with `showDLblsOverMax: true` round-trips identically to a chart that omits the field — the writer emits `val="1"` and the reader collapses both shapes to `undefined`.
- A chart with `showDLblsOverMax: false` round-trips as `false` because that is the non-default value.
- A `<c:showDLblsOverMax/>` element with no `val` attribute reads as `undefined` rather than fabricate a flag Excel would not emit.
- The element is placed in the spec-required slot inside `<c:chart>` — after `<c:dispBlanksAs>` and before `<c:extLst>` — so Excel's strict validator accepts the file.
- The toggle has no observable effect on a chart whose value axis auto-scales (no point exceeds the auto-computed max); it only matters when the caller pinned a tighter axis ceiling via `axes.y.scale.max`.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm test` (lint + typecheck + vitest, all 3651 tests passing including 25 new `showDLblsOverMax` tests across reader, writer, and clone)
- [x] Reader, writer, and clone tests cover: defaults, true / false / absent, the `"true"` / `"false"` spellings, missing `val`, unknown tokens, OOXML element ordering inside `<c:chart>`, single-emission guard, every chart family, and a full `parseChart -> cloneChart -> writeXlsx -> parseChart` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)