### PR TITLE
feat(xlsx): chart data table — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,20 @@ non-default that strips labels off any point whose value exceeds the
 pinned `<c:max>`). The reader accepts the OOXML truthy / falsy
 spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and
 missing `val` attributes drop to `undefined`.
+`Chart.dataTable` surfaces the chart-level
+`<c:plotArea><c:dTable>...</c:dTable></c:plotArea>` block — Excel's
+"Add Chart Element → Data Table" toggle (the small grid of underlying
+series values painted beneath the plot area). The reader returns a
+`ChartDataTable` object with up to four boolean children
+(`showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`); each
+flag round-trips literally because all four are required on
+`CT_DTable` and Excel always emits every one. Children with missing or
+unknown `val` attributes drop to `undefined` rather than fabricate a
+flag the file did not pin, and absence of the `<c:dTable>` element
+collapses the whole field to `undefined`. Only chart families with
+axes (`bar`, `column`, `line`, `area`, `scatter`) carry a slot for the
+element — the OOXML schema places `<c:dTable>` inside `<c:plotArea>`
+alongside the axes, so pie / doughnut surface `undefined`.
 `ChartAxisInfo.tickLblSkip` and `ChartAxisInfo.tickMarkSkip` surface
 the category-axis tick-thinning knobs (`<c:catAx><c:tickLblSkip val=".."/>`
 and `<c:catAx><c:tickMarkSkip val=".."/>`). Both elements live on
@@ -1061,6 +1075,21 @@ to strip labels off any point whose value exceeds the pinned `<c:max>`
 intent is explicit on roundtrip — no chart family is special-cased,
 since the toggle lives on `<c:chart>` and is valid on every chart
 family.
+The chart-level `dataTable` field maps to
+`<c:plotArea><c:dTable>...</c:dTable></c:plotArea>` — Excel's "Add
+Chart Element → Data Table" toggle. The field accepts a
+`boolean | ChartDataTable` discriminated union: pass `true` for
+Excel's reference defaults (every border drawn, the outline frame on,
+and the legend keys shown next to each series row), pass an object to
+opt individual children in or out (each field maps to the matching
+`<c:dTable>` boolean child — `showHorzBorder`, `showVertBorder`,
+`showOutline`, `showKeys`), or omit it (or pass `false`) to suppress
+the element entirely. When emitted, the writer always serializes all
+four children in `CT_DTable` schema order, falling back to the OOXML
+reference default `true` for any flag the caller leaves unset. The
+field is silently dropped on `pie` / `doughnut` charts because those
+families have no axes and the OOXML schema places no slot for
+`<c:dTable>` on their plot areas.
 The chart-level `roundedCorners` field maps to
 `<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
 `<c:chart>`, not a child) — Excel's "Format Chart Area → Border →
@@ -1422,6 +1451,20 @@ point regardless of axis ceiling), or a `boolean` to replace it. Like
 `plotVisOnly` / `dispBlanksAs`, the field lives on `<c:chart>` and is
 valid on every chart family, so a coercion (line → column, doughnut →
 pie, etc.) preserves the inherited value rather than dropping it.
+The chart-level `dataTable` field follows the standard
+`object | boolean | null` override grammar: pass `undefined` (or omit
+it) to inherit the source's parsed `ChartDataTable`, `null` (or
+`false`) to drop the inherited block so the writer skips `<c:dTable>`
+entirely, `true` to pin every flag to its OOXML default `true`, or a
+`ChartDataTable` object to replace the block wholesale (no per-field
+merge with the source — pass every flag the cloned table should
+render). Unlike the chart-level toggles that live on `<c:chart>`, the
+data-table block lives inside `<c:plotArea>` alongside the axes, so
+the field is silently dropped from the cloned `SheetChart` whenever
+the resolved chart type is `pie` or `doughnut` — those families have
+no axes and the OOXML schema places no slot for the element on their
+plot areas. Coercions between axis-bearing families (line → column,
+scatter → area, etc.) preserve the inherited block.
 The chart-level `roundedCorners` flag follows the same grammar: pass
 `undefined` to inherit the source's parsed value, `null` to drop it
 back to the writer's OOXML `false` default (square chart frame), or a

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -750,6 +750,39 @@ export interface ChartMarker {
 export type ChartDisplayBlanksAs = "gap" | "zero" | "span";
 
 /**
+ * Granular data-table configuration for {@link SheetChart.dataTable}.
+ * Maps to the four boolean children of `<c:plotArea><c:dTable>`:
+ * `<c:showHorzBorder>`, `<c:showVertBorder>`, `<c:showOutline>`, and
+ * `<c:showKeys>`. Each toggle flips one of Excel's "Format Data Table"
+ * checkboxes:
+ *
+ * - {@link showHorzBorder} — paint the horizontal lines between table
+ *   rows. Default: `true` (Excel's reference serialization).
+ * - {@link showVertBorder} — paint the vertical lines between category
+ *   columns. Default: `true`.
+ * - {@link showOutline}    — paint the outer border around the table.
+ *   Default: `true`.
+ * - {@link showKeys}       — render the legend swatch next to each
+ *   series row so the table doubles as the chart legend. Default:
+ *   `true`.
+ *
+ * The writer always emits all four children — the OOXML schema marks
+ * them required on `CT_DTable` — falling back to the per-field defaults
+ * for any field the caller leaves unset. Pass an empty object (`{}`) to
+ * accept every default, equivalent to `dataTable: true`.
+ */
+export interface ChartDataTable {
+  /** Paint horizontal lines between rows. Default: `true`. */
+  showHorzBorder?: boolean;
+  /** Paint vertical lines between category columns. Default: `true`. */
+  showVertBorder?: boolean;
+  /** Paint the outer border around the table. Default: `true`. */
+  showOutline?: boolean;
+  /** Render the legend swatch next to each series row. Default: `true`. */
+  showKeys?: boolean;
+}
+
+/**
  * Scatter sub-style applied at the chart level. Maps to the OOXML
  * `ST_ScatterStyle` enum which sits inside `<c:scatterChart>` as
  * `<c:scatterStyle val=".."/>`. Excel exposes the same six presets
@@ -1217,6 +1250,29 @@ export interface SheetChart {
    * just the plot area.
    */
   date1904?: boolean;
+  /**
+   * Whether the chart paints a data table beneath the plot area. Maps
+   * to `<c:plotArea><c:dTable>...</c:dTable></c:plotArea>` — Excel's
+   * "Add Chart Element -> Data Table" toggle, which renders a small
+   * table of the underlying series values alongside the plotted shape
+   * for a quick read of the numbers behind the picture.
+   *
+   * Pass `true` to enable the table with Excel's reference defaults
+   * (every border drawn, the outline frame on, and the legend keys
+   * shown next to each series row). Pass an object to opt individual
+   * children in or out — each field maps to the matching `<c:dTable>`
+   * boolean child. Pass `false` (or omit the field) to suppress the
+   * element entirely so the writer skips emission.
+   *
+   * Default: omitted — Excel renders no data table on a fresh chart.
+   *
+   * Only meaningful for chart families that have axes — `bar`, `column`,
+   * `line`, `area`, and `scatter`. The OOXML schema places `<c:dTable>`
+   * inside `<c:plotArea>` after the axes, and pie / doughnut have no
+   * axes at all, so the field is silently dropped on those families.
+   * See {@link ChartDataTable}.
+   */
+  dataTable?: boolean | ChartDataTable;
   /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
@@ -3100,6 +3156,28 @@ export interface Chart {
    * just the plot area.
    */
   date1904?: boolean;
+  /**
+   * Data-table configuration pulled from
+   * `<c:plotArea><c:dTable>...</c:dTable></c:plotArea>`. Reflects
+   * Excel's "Add Chart Element -> Data Table" toggle, which paints a
+   * small table of the underlying series values beneath the plot area.
+   *
+   * Surfaces a {@link ChartDataTable} object whenever the source chart
+   * declares the element. Each of the four boolean children
+   * (`<c:showHorzBorder>`, `<c:showVertBorder>`, `<c:showOutline>`,
+   * `<c:showKeys>`) round-trips literally — the reader does not collapse
+   * any per-field default because every field is required on
+   * `CT_DTable` and Excel always emits all four. Absent / unknown
+   * `val` attributes drop the matching field to `undefined` rather than
+   * fabricate a flag the file did not pin.
+   *
+   * Surfaces `undefined` when the chart has no `<c:dTable>` element at
+   * all. Only chart families with axes (`bar`, `column`, `line`,
+   * `area`, `scatter`) carry a data table because the OOXML schema
+   * places `<c:dTable>` inside `<c:plotArea>` after the axes — pie /
+   * doughnut have no axes and surface `undefined`.
+   */
+  dataTable?: ChartDataTable;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,7 @@ export type {
   ChartDataLabelPosition,
   ChartDataLabels,
   ChartDataLabelsInfo,
+  ChartDataTable,
   ChartDisplayBlanksAs,
   ChartKind,
   ChartLegendPosition,

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -24,6 +24,7 @@ import type {
   ChartAxisTickMark,
   ChartDataLabels,
   ChartDataLabelsInfo,
+  ChartDataTable,
   ChartDisplayBlanksAs,
   ChartKind,
   ChartLineStroke,
@@ -353,6 +354,28 @@ export interface CloneChartOptions {
    * the call site.
    */
   date1904?: boolean | null;
+  /**
+   * Override `<c:plotArea><c:dTable>` (the data-table beneath the plot
+   * area).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * {@link Chart.dataTable}. `null` drops the inherited block so the
+   * writer skips the element entirely — Excel renders no data table.
+   * `false` is equivalent to `null` (suppression). `true` pins every
+   * border / outline / key flag to its OOXML default `true`. A
+   * {@link ChartDataTable} object replaces the block wholesale (no
+   * per-field merge; pass every flag you want preserved). Each
+   * unspecified flag inside the object falls back to `true` at the
+   * writer side because every `<c:dTable>` boolean child is required
+   * on `CT_DTable` and Excel emits all four.
+   *
+   * Only meaningful when the resolved chart type has axes — `bar`,
+   * `column`, `line`, `area`, `scatter`. The field is silently dropped
+   * when the clone targets `pie` / `doughnut` because the OOXML schema
+   * places `<c:dTable>` inside `<c:plotArea>` alongside the axes; pie /
+   * doughnut have no axes and no slot for the element.
+   */
+  dataTable?: ChartDataTable | boolean | null;
   /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
@@ -800,6 +823,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
 
   const resolvedDate1904 = resolveDate1904(source.date1904, options.date1904);
   if (resolvedDate1904 !== undefined) out.date1904 = resolvedDate1904;
+
+  // `<c:dTable>` only renders inside `<c:plotArea>` alongside the axes
+  // — pie / doughnut have no axes at all, so the OOXML schema places no
+  // slot for the element on those families. Drop the field on those
+  // resolved types so a templated bar / line / scatter chart with a
+  // pinned data table does not leak the element into a doughnut clone
+  // whose schema rejects it. Override wins over the source's parsed
+  // value.
+  if (type !== "pie" && type !== "doughnut") {
+    const resolvedDataTable = resolveDataTable(source.dataTable, options.dataTable);
+    if (resolvedDataTable !== undefined) out.dataTable = resolvedDataTable;
+  }
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -1270,6 +1305,59 @@ function resolveDate1904(
   // resolved chart drops the field rather than carry a value the
   // writer would skip on emit anyway.
   return undefined;
+}
+
+/**
+ * Resolve a `dataTable` (plot-area data-table) override.
+ *
+ * `undefined` → inherit the source's parsed {@link Chart.dataTable}.
+ * `null`      → drop the inherited block so the writer skips
+ *               `<c:dTable>` entirely (no data table rendered).
+ * `false`     → equivalent to `null` (suppression); kept distinct in
+ *               the API surface so callers can write `dataTable: false`
+ *               for symmetry with the writer's `boolean | object` shape.
+ * `true`      → enable with the OOXML reference defaults (every flag
+ *               `true`).
+ * `object`    → replace the inherited block wholesale (no per-field
+ *               merge with the source — pass every flag the cloned
+ *               table should render). Each unspecified field falls back
+ *               to `true` at the writer side because every `<c:dTable>`
+ *               boolean child is required on `CT_DTable` and Excel
+ *               always emits all four.
+ *
+ * The grammar mirrors {@link CloneChartSeriesOverride.marker} (and the
+ * other `object | null` / wholesale-replace patterns) so the
+ * chart-level block toggles compose the same way at the call site.
+ *
+ * The caller already short-circuits this for pie / doughnut clones
+ * because the OOXML schema places `<c:dTable>` inside `<c:plotArea>`
+ * alongside the axes, and pie / doughnut have no axes at all.
+ */
+function resolveDataTable(
+  sourceValue: ChartDataTable | undefined,
+  override: ChartDataTable | boolean | null | undefined,
+): ChartDataTable | boolean | undefined {
+  if (override === undefined) {
+    // Inherit — pass the source through verbatim. The writer accepts
+    // both the boolean and object shapes, so a parsed `ChartDataTable`
+    // round-trips directly.
+    return sourceValue;
+  }
+  if (override === null) {
+    // Drop the inherited block. The writer treats `undefined` as
+    // suppression and skips `<c:dTable>` entirely.
+    return undefined;
+  }
+  if (override === false) {
+    // Symmetric with `null` — kept distinct in the API surface for
+    // ergonomic alignment with the writer's `boolean | object` shape,
+    // but emits the same on-the-wire result (no `<c:dTable>`).
+    return undefined;
+  }
+  // `true` or a {@link ChartDataTable} object — replace the inherited
+  // block wholesale. The writer accepts both forms and falls back to
+  // the OOXML reference defaults for any field the object leaves unset.
+  return override;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -28,6 +28,7 @@ import type {
   ChartBarGrouping,
   ChartDataLabelPosition,
   ChartDataLabelsInfo,
+  ChartDataTable,
   ChartDisplayBlanksAs,
   ChartKind,
   ChartLegendPosition,
@@ -245,6 +246,14 @@ export function parseChart(xml: string): Chart | undefined {
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
+
+    // `<c:dTable>` lives inside `<c:plotArea>` after the axes per
+    // CT_PlotArea — the data table renders the underlying series values
+    // as a small grid beneath the plot. Only chart families with axes
+    // (bar / column / line / area / scatter / surface / stock) carry
+    // a slot for it; pie / doughnut have no axes at all.
+    const dataTable = parseDataTable(plotArea);
+    if (dataTable !== undefined) out.dataTable = dataTable;
   }
 
   const legend = parseLegend(chartEl);
@@ -1756,6 +1765,61 @@ function parseDate1904(chartSpace: XmlElement): boolean | undefined {
       // OOXML default — collapse to undefined for symmetry with the
       // writer's `date1904` field.
       return undefined;
+    default:
+      return undefined;
+  }
+}
+
+// ── Data Table ─────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:dTable>...</c:dTable>` off `<c:plotArea>`. Surfaces a
+ * {@link ChartDataTable} whenever the source chart declares the
+ * element; absence collapses to `undefined`.
+ *
+ * Each of the four boolean children (`<c:showHorzBorder>`,
+ * `<c:showVertBorder>`, `<c:showOutline>`, `<c:showKeys>`) round-trips
+ * literally — the reader does not collapse any per-field default
+ * because all four are required on `CT_DTable` and Excel always emits
+ * every one. Children that are missing or carry an unknown `val`
+ * attribute drop to `undefined` rather than fabricate a flag the file
+ * did not pin; the writer falls back to the OOXML reference defaults
+ * (`true` for every child) on round-trip.
+ */
+function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
+  const el = findChild(plotArea, "dTable");
+  if (!el) return undefined;
+  const out: ChartDataTable = {};
+  const showHorzBorder = parseDataTableFlag(el, "showHorzBorder");
+  if (showHorzBorder !== undefined) out.showHorzBorder = showHorzBorder;
+  const showVertBorder = parseDataTableFlag(el, "showVertBorder");
+  if (showVertBorder !== undefined) out.showVertBorder = showVertBorder;
+  const showOutline = parseDataTableFlag(el, "showOutline");
+  if (showOutline !== undefined) out.showOutline = showOutline;
+  const showKeys = parseDataTableFlag(el, "showKeys");
+  if (showKeys !== undefined) out.showKeys = showKeys;
+  return out;
+}
+
+/**
+ * Pull a single boolean child off `<c:dTable>`. Accepts the OOXML
+ * truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
+ * unknown tokens, missing `val` attributes, and missing elements all
+ * collapse to `undefined` rather than fabricate a flag the file did
+ * not pin.
+ */
+function parseDataTableFlag(dTable: XmlElement, local: string): boolean | undefined {
+  const el = findChild(dTable, local);
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      return false;
     default:
       return undefined;
   }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -315,7 +315,101 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     }
   }
 
+  // `<c:dTable>` sits inside `<c:plotArea>` after the axes per
+  // CT_PlotArea (ECMA-376 Part 1, §21.2.2.145) — between the last
+  // `<c:valAx>` / `<c:catAx>` and the optional `<c:spPr>` that the
+  // writer never emits. Pie / doughnut have no axes at all, so the
+  // OOXML schema places no slot for `<c:dTable>` on those families;
+  // `resolveDataTable` short-circuits them by returning `undefined`.
+  const dTable = resolveDataTable(chart);
+  if (dTable !== undefined) {
+    children.push(buildDataTable(dTable));
+  }
+
   return xmlElement("c:plotArea", undefined, children);
+}
+
+// ── Data Table ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the {@link SheetChart.dataTable} field into the four boolean
+ * children `<c:dTable>` requires, or `undefined` to signal that the
+ * writer should skip emission of the element.
+ *
+ * Returns `undefined` when:
+ *  - The chart's family has no axes (pie / doughnut). The OOXML schema
+ *    places `<c:dTable>` inside `<c:plotArea>` alongside the axes, so
+ *    no axes means no slot to host the element.
+ *  - The caller did not opt in (`dataTable` is `undefined` or `false`).
+ *
+ * Returns the four resolved booleans when the caller passed `true`
+ * (every default `true`) or an object (per-field overrides on top of the
+ * `true` defaults). Stray non-boolean inputs collapse to the matching
+ * default rather than emit a token Excel rejects, mirroring how every
+ * other chart-level boolean writer treats its input.
+ */
+function resolveDataTable(chart: SheetChart):
+  | {
+      showHorzBorder: boolean;
+      showVertBorder: boolean;
+      showOutline: boolean;
+      showKeys: boolean;
+    }
+  | undefined {
+  // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
+  // alongside `<c:catAx>` / `<c:valAx>`, so there is no slot for it on
+  // those families. Drop the field silently rather than emit an element
+  // Excel's strict validator would reject.
+  if (chart.type === "pie" || chart.type === "doughnut") return undefined;
+
+  const raw = chart.dataTable;
+  if (raw === undefined || raw === false) return undefined;
+
+  if (raw === true) {
+    return {
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+    };
+  }
+
+  // Per-field overrides on top of the `true` defaults. Only literal
+  // `false` flips a flag — anything else (including stray `undefined`,
+  // `null`, or a non-boolean) falls back to the default `true` so the
+  // writer never emits a value the OOXML schema would refuse.
+  return {
+    showHorzBorder: raw.showHorzBorder !== false,
+    showVertBorder: raw.showVertBorder !== false,
+    showOutline: raw.showOutline !== false,
+    showKeys: raw.showKeys !== false,
+  };
+}
+
+/**
+ * Serialize a resolved data-table into `<c:dTable>` with its four
+ * required boolean children, in the order CT_DTable mandates:
+ * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`.
+ *
+ * The writer always emits all four children — the OOXML schema marks
+ * them required on `CT_DTable`, and Excel's reference serialization
+ * includes every one even when the caller leaves it at the default. The
+ * optional `<c:spPr>` / `<c:txPr>` / `<c:extLst>` children are skipped
+ * because hucre's data-table model does not surface fill / text styling
+ * yet.
+ */
+function buildDataTable(table: {
+  showHorzBorder: boolean;
+  showVertBorder: boolean;
+  showOutline: boolean;
+  showKeys: boolean;
+}): string {
+  return xmlElement("c:dTable", undefined, [
+    xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
+    xmlSelfClose("c:showVertBorder", { val: table.showVertBorder ? 1 : 0 }),
+    xmlSelfClose("c:showOutline", { val: table.showOutline ? 1 : 0 }),
+    xmlSelfClose("c:showKeys", { val: table.showKeys ? 1 : 0 }),
+  ]);
 }
 
 interface AxisRenderOptions {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6951,3 +6951,305 @@ describe("cloneChart — axis crossBetween", () => {
     expect(parseChart(written)?.axes?.y?.crossBetween).toBe("midCat");
   });
 });
+
+// ── cloneChart — data table ──────────────────────────────────────────
+
+describe("cloneChart — data table", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's dataTable by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+
+  it("lets options.dataTable: true replace the inherited block wholesale", () => {
+    // Source has a partial table, override pins every flag to default true.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, showOutline: false },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: true,
+      },
+    );
+    expect(clone.dataTable).toBe(true);
+  });
+
+  it("lets options.dataTable: object replace the inherited block wholesale", () => {
+    // No per-field merge — the override block replaces the source's.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, showOutline: false },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited dataTable when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:dTable> entirely on emit.
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: null,
+      },
+    );
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops the inherited dataTable when the override is false", () => {
+    // `false` is the suppression alias — symmetric with null on the
+    // on-the-wire result (no <c:dTable> emitted).
+    const clone = cloneChart(
+      source({
+        dataTable: { showHorzBorder: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: false,
+      },
+    );
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("returns undefined dataTable when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("carries dataTable through a flatten (line → column)", () => {
+    // <c:dTable> lives inside <c:plotArea> alongside the axes — both
+    // bar / column and line have axes, so a coercion preserves the
+    // pinned table.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "column",
+      },
+    );
+    expect(clone.type).toBe("column");
+    expect(clone.dataTable).toEqual({ showKeys: false });
+  });
+
+  it("drops dataTable when flattening into a doughnut clone (no axes, no slot)", () => {
+    // Pie / doughnut have no axes — the OOXML schema places no slot
+    // for <c:dTable> inside their plot areas, so the clone layer
+    // strips the inherited block.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops dataTable when flattening into a pie clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showHorzBorder: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "pie",
+      },
+    );
+    expect(clone.type).toBe("pie");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<c:showHorzBorder val="1"/>');
+    expect(written).toContain('<c:showVertBorder val="0"/>');
+    expect(written).toContain('<c:showOutline val="1"/>');
+    expect(written).toContain('<c:showKeys val="0"/>');
+
+    // Re-parsing the rendered chart returns the same shape — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+
+  it("emits no <c:dTable> when both source and override are absent", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dTable");
+    expect(parseChart(written)?.dataTable).toBeUndefined();
+  });
+
+  it("an explicit null override beats the source value through writeXlsx", async () => {
+    // Source pins a data table, clone overrides to null — the
+    // rendered chart should carry no element and re-parse to undefined.
+    const clone = cloneChart(
+      source({
+        dataTable: { showHorzBorder: true },
+      }),
+      {
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: null,
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dTable");
+    expect(parseChart(written)?.dataTable).toBeUndefined();
+  });
+
+  it("a parsed dataTable round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    // Build a source by writing a chart with a partial dataTable, then
+    // parse it back to a Chart, then clone-through, then write again.
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, showOutline: false },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: false,
+      showKeys: false,
+    });
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: false,
+      showKeys: false,
+    });
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -6099,3 +6099,236 @@ describe("writeChart — axis crossBetween", () => {
     expect(reparsed?.axes?.y?.crossBetween).toBe("midCat");
   });
 });
+
+// ── writeChart — data table ──────────────────────────────────────────
+
+describe("writeChart — data table", () => {
+  it("skips <c:dTable> entirely when the field is unset (writer default)", () => {
+    // Excel renders no data table on a fresh chart — the writer skips
+    // the element so the file stays minimal. Absence and the unset
+    // default round-trip identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:dTable");
+  });
+
+  it("skips <c:dTable> when dataTable is false", () => {
+    // `false` mirrors the unset default — the writer skips the element.
+    const result = writeChart(makeChart({ dataTable: false }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:dTable");
+  });
+
+  it("emits a fully-defaulted <c:dTable> when dataTable is true", () => {
+    // `true` enables the table with Excel's reference defaults — every
+    // border drawn, the outline frame on, and the legend keys shown.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    expect(result.chartXml).toContain("<c:dTable>");
+    expect(result.chartXml).toContain('<c:showHorzBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="1"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+  });
+
+  it("emits a fully-defaulted <c:dTable> when dataTable is an empty object", () => {
+    // An empty override accepts every default — equivalent to passing
+    // `dataTable: true`. Each unspecified field falls back to the OOXML
+    // reference value `true`.
+    const result = writeChart(makeChart({ dataTable: {} }), "Sheet1");
+    expect(result.chartXml).toContain("<c:dTable>");
+    expect(result.chartXml).toContain('<c:showHorzBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="1"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+  });
+
+  it("honours per-field overrides (false for showKeys)", () => {
+    // A common pattern — paint the table grid but hide the legend
+    // swatches because the chart already carries a separate legend.
+    const result = writeChart(makeChart({ dataTable: { showKeys: false } }), "Sheet1");
+    expect(result.chartXml).toContain('<c:showHorzBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="1"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="0"/>');
+  });
+
+  it("flips every flag false when the caller pins each false", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: false,
+          showOutline: false,
+          showKeys: false,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="0"/>');
+  });
+
+  it("emits the four <c:dTable> children in CT_DTable schema order", () => {
+    // CT_DTable: showHorzBorder?, showVertBorder?, showOutline?, showKeys?,
+    // spPr?, txPr?, extLst? — though all four boolean children are
+    // always emitted, the order matters for strict validators (Excel
+    // itself rejects out-of-order children).
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const horzIdx = result.chartXml.indexOf("c:showHorzBorder");
+    const vertIdx = result.chartXml.indexOf("c:showVertBorder");
+    const outlineIdx = result.chartXml.indexOf("c:showOutline");
+    const keysIdx = result.chartXml.indexOf("c:showKeys");
+    expect(horzIdx).toBeGreaterThan(-1);
+    expect(vertIdx).toBeGreaterThan(horzIdx);
+    expect(outlineIdx).toBeGreaterThan(vertIdx);
+    expect(keysIdx).toBeGreaterThan(outlineIdx);
+  });
+
+  it("places <c:dTable> after the axes inside <c:plotArea>", () => {
+    // CT_PlotArea sequence: layout?, [chart-types], catAx*/valAx*/dateAx*/
+    // serAx*, dTable?, spPr? — the table sits after the axes.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const lastValAxClose = result.chartXml.lastIndexOf("</c:valAx>");
+    const dTableIdx = result.chartXml.indexOf("<c:dTable>");
+    const plotAreaCloseIdx = result.chartXml.indexOf("</c:plotArea>");
+    expect(lastValAxClose).toBeGreaterThan(-1);
+    expect(dTableIdx).toBeGreaterThan(lastValAxClose);
+    expect(plotAreaCloseIdx).toBeGreaterThan(dTableIdx);
+  });
+
+  it("only emits <c:dTable> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:dTable>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads dataTable through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: true }), "Sheet1");
+      expect(result.chartXml).toContain("<c:dTable>");
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: true,
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain("<c:dTable>");
+  });
+
+  it("silently drops dataTable on pie charts (no axes, no slot for the element)", () => {
+    // The OOXML schema places <c:dTable> inside <c:plotArea> alongside
+    // the axes, but pie charts have no axes at all. The writer drops
+    // the field rather than emit an element Excel's strict validator
+    // would reject.
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: true,
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+  });
+
+  it("silently drops dataTable on doughnut charts (no axes either)", () => {
+    const result = writeChart(
+      {
+        type: "doughnut",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: true,
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+  });
+
+  it("round-trips a pinned dataTable through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+
+  it("round-trips dataTable: true as the fully-defaulted shape", () => {
+    // The writer emits all four flags as `true` — a re-parse surfaces
+    // every one literally because every child is required on
+    // CT_DTable.
+    const written = writeChart(makeChart({ dataTable: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+    });
+  });
+
+  it("collapses an unset dataTable round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toBeUndefined();
+  });
+
+  it("collapses dataTable: false round-trip back to undefined", () => {
+    // `false` writes nothing (matches the unset default), so re-parse
+    // also returns undefined.
+    const written = writeChart(makeChart({ dataTable: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toBeUndefined();
+  });
+
+  it("threads dataTable end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: false },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<c:showKeys val="0"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6896,3 +6896,252 @@ describe("parseChart — axis crossBetween", () => {
     expect(chart?.axes?.y?.crossBetween).toBeUndefined();
   });
 });
+
+// ── parseChart — data table ──────────────────────────────────────────
+
+describe("parseChart — data table", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a fully-defaulted <c:dTable> with every flag true", () => {
+    // Excel's reference serialization for a freshly-enabled data table
+    // pins all four boolean children to `1`. The reader surfaces every
+    // field literally — `<c:dTable>` is required-children-only on
+    // CT_DTable so a clone can replay the exact shape the file carried.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+    });
+  });
+
+  it("surfaces non-default false flags literally", () => {
+    // Each boolean child round-trips literally — `false` is just as
+    // important as `true` because the writer always emits all four
+    // children and a clone must preserve the exact pattern.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="0"/>
+      <c:showVertBorder val="0"/>
+      <c:showOutline val="0"/>
+      <c:showKeys val="0"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: false,
+      showVertBorder: false,
+      showOutline: false,
+      showKeys: false,
+    });
+  });
+
+  it("surfaces a mixed shape (keys hidden, borders shown)", () => {
+    // A common pattern — paint the table grid but hide the legend
+    // swatches because the chart already has a separate legend.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="0"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+
+  it("accepts the OOXML textual <xsd:boolean> spellings", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="true"/>
+      <c:showVertBorder val="false"/>
+      <c:showOutline val="true"/>
+      <c:showKeys val="false"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+
+  it("returns undefined when the plot area has no <c:dTable> element", () => {
+    // Absence is the writer's default — Excel renders no data table.
+    // The reader surfaces nothing so a fresh chart and a chart that
+    // omits the element round-trip identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toBeUndefined();
+  });
+
+  it("drops a missing val attribute on a <c:dTable> child rather than fabricate a flag", () => {
+    // A child without `val` is malformed per CT_Boolean; the reader
+    // drops the field rather than fabricate a value the file did not
+    // pin. The other children still round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showOutline: true,
+      showKeys: true,
+    });
+  });
+
+  it("drops unknown val tokens rather than fabricate flags", () => {
+    // Anything outside the OOXML truthy / falsy spellings collapses
+    // to undefined for that field. The other children still surface.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="yes"/>
+      <c:showVertBorder val="2"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="0"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showOutline: true,
+      showKeys: false,
+    });
+  });
+
+  it("surfaces an empty object when <c:dTable> is present but every child is malformed", () => {
+    // The element itself is the gating signal — when it appears, the
+    // chart is requesting a data table even if every child carries a
+    // malformed `val`. The shape stays minimal (an empty object) so a
+    // round-trip through the writer falls back to the OOXML defaults
+    // (every flag `true`) which Excel would render anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder/>
+      <c:showVertBorder/>
+      <c:showOutline/>
+      <c:showKeys/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({});
+  });
+
+  it("surfaces dataTable on a column chart", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+    });
+  });
+
+  it("surfaces dataTable on a scatter chart (both axes are valAx)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:scatterChart>
+    <c:valAx><c:axId val="1"/></c:valAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="0"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="0"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: false,
+      showVertBorder: true,
+      showOutline: false,
+      showKeys: true,
+    });
+  });
+
+  it("returns undefined when the chart has no plotArea", () => {
+    // Defensive — a chart with no plotArea has no slot for <c:dTable>
+    // either. Surfaces nothing so the parsed shape stays minimal.
+    const xml = `<c:chartSpace ${NS}><c:chart></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the chart-level `<c:plotArea><c:dTable>...</c:dTable></c:plotArea>` element (Excel's "Add Chart Element -> Data Table" toggle) at the read, write, and clone layers so a template's data-table configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:dTable>` paints a small table of the underlying series values beneath the plot area for a quick read of the numbers behind the picture — the same surface Excel exposes under "Format Data Table" with four boolean checkboxes for the borders, outline, and legend keys. The OOXML schema (`CT_DTable`) requires those four children: `<c:showHorzBorder>`, `<c:showVertBorder>`, `<c:showOutline>`, and `<c:showKeys>`. The element sits inside `<c:plotArea>` after the axes per `CT_PlotArea` (ECMA-376 Part 1, §21.2.2.145), so only chart families that have axes (bar / column / line / area / scatter) carry a slot for it; pie / doughnut have no axes at all and reject the element.

Until now hucre's writer skipped the element entirely and the reader ignored it, so a template that pinned a data table beneath the chart silently lost it on every parse → clone → write loop. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.dataTable);
// { showHorzBorder: true, showVertBorder: true, showOutline: true, showKeys: false }

// ── Write side — boolean shorthand (every flag true) ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      {
        type: "column",
        series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        dataTable: true,
      },
    ],
  }],
});

// ── Write side — object form with per-flag overrides ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      {
        type: "line",
        series: [...],
        anchor: { from: { row: 6, col: 0 } },
        // Paint the table grid but hide the legend swatches because
        // the chart already carries a separate legend.
        dataTable: { showKeys: false },
      },
    ],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  dataTable: { showKeys: false, showOutline: false }, // replace wholesale
  // dataTable: true,                                  // pin every flag true
  // dataTable: null,                                  // drop the inherited block
  // dataTable: false,                                 // alias for null
  // dataTable: undefined,                             // inherit the source's parsed value
});
```

## Model

```ts
interface ChartDataTable {
  showHorzBorder?: boolean;
  showVertBorder?: boolean;
  showOutline?: boolean;
  showKeys?: boolean;
}

interface SheetChart {
  /** ...existing fields... */
  dataTable?: boolean | ChartDataTable;
}

interface Chart {
  /** ...existing fields... */
  dataTable?: ChartDataTable;
}

interface CloneChartOptions {
  /** ...existing fields... */
  dataTable?: ChartDataTable | boolean | null;
}
```

The read-side `Chart.dataTable` always surfaces the object shape so a parsed value slots straight back into `cloneChart` without transformation. The write-side `SheetChart.dataTable` accepts the boolean shorthand for ergonomics — `dataTable: true` is equivalent to `dataTable: {}` and yields the same on-the-wire output (every flag `true`).

## Behavior

- **Read** — `parseChart` pulls `<c:dTable>` off `<c:plotArea>`. Each of the four boolean children round-trips literally because all four are required on `CT_DTable` and Excel always emits them; the reader does not collapse any per-field default. Children that are missing or carry an unknown `val` attribute drop to `undefined` rather than fabricate a flag the file did not pin (the writer falls back to the OOXML reference defaults — every flag `true` — on round-trip). Absence of the `<c:dTable>` element collapses the whole `dataTable` field to `undefined`.
- **Write** — The writer emits `<c:dTable>` only when the chart pins a non-suppression value (`true` or an object); `undefined` and `false` skip the element. When emitted, all four boolean children are serialized in `CT_DTable` schema order (`showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`), each falling back to `true` for any unspecified field. The element is silently dropped on `pie` / `doughnut` charts because those families have no axes and the OOXML schema places no slot for `<c:dTable>` on their plot areas.
- **Clone** — `options.dataTable` accepts `undefined` (inherit) / `null` (drop) / `false` (drop, alias for `null`) / `true` (pin every flag default `true`) / object (replace wholesale, no per-field merge). The clone layer drops the field on pie / doughnut targets so a templated bar / line / scatter chart with a pinned data table does not leak the element into a doughnut clone whose schema rejects it.

## Edge cases

- A chart with `dataTable: { showHorzBorder: true, showVertBorder: true, showOutline: true, showKeys: true }` round-trips identically to a chart that uses `dataTable: true` — the writer emits the same XML and the reader surfaces the same shape.
- `dataTable: false` and `dataTable: null` (in the clone API) both collapse to absence on the writer side. The two are kept distinct in the API surface for ergonomic alignment with the `boolean | object` shape but produce the same XML.
- An empty object (`dataTable: {}`) accepts every default — equivalent to `dataTable: true`.
- A `<c:dTable>` element with every boolean child malformed (no `val` attribute) parses as an empty `ChartDataTable` (`{}`), preserving the gating intent — the file is requesting a data table even if every flag is malformed.
- The element is placed in the spec-required slot inside `<c:plotArea>` — after the last axis (`</c:catAx>` / `</c:valAx>`) and before the optional `<c:spPr>` — so Excel's strict validator accepts the file.
- Coercing a line / column source with a pinned data table to a `pie` or `doughnut` clone drops the table because pie / doughnut have no axes; the clone layer handles the coercion silently rather than emit XML Excel would refuse.

Refs #136

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm build` produces a clean dist
- [x] `pnpm vitest run --dir=test` (3698 tests passing including 35 new `dataTable` tests across reader, writer, and clone)
- [x] Reader, writer, and clone tests cover: defaults, the four-flags-`true` shape, mixed (per-flag) shapes, all-flags-`false`, the `"true"` / `"false"` spellings, missing `val`, unknown tokens, OOXML element ordering inside `<c:plotArea>`, single-emission guard, every chart family (with the pie / doughnut drop), pie / doughnut coercion drops, and a full `parseChart -> cloneChart -> writeXlsx -> parseChart` round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)