### PR TITLE
feat(xlsx): chart-space protection — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,22 @@ collapses the whole field to `undefined`. Only chart families with
 axes (`bar`, `column`, `line`, `area`, `scatter`) carry a slot for the
 element — the OOXML schema places `<c:dTable>` inside `<c:plotArea>`
 alongside the axes, so pie / doughnut surface `undefined`.
+`Chart.protection` surfaces the chart-space-level
+`<c:chartSpace><c:protection>...</c:protection>` block — Excel's
+chart-level lock that pairs with the host worksheet's
+`<sheetProtection>` to decide which interactions remain allowed when
+the parent sheet is protected. The reader returns a `ChartProtection`
+object with up to five independently optional boolean children
+(`chartObject`, `data`, `formatting`, `selection`, `userInterface`);
+each flag is independently optional on `CT_Protection`, so the reader
+only surfaces the flags the file actually pinned. Children with
+missing or unknown `val` attributes drop to `undefined` rather than
+fabricate a flag the file did not pin. The element itself is the
+gating signal — a `<c:protection>` block with no resolvable children
+surfaces as an empty `{}`, and absence of the element collapses the
+field to `undefined`. Every chart family carries a slot — the element
+lives on `<c:chartSpace>` (a sibling of `<c:chart>`), not inside
+`<c:plotArea>`, so pie / doughnut still surface the block.
 `ChartAxisInfo.tickLblSkip` and `ChartAxisInfo.tickMarkSkip` surface
 the category-axis tick-thinning knobs (`<c:catAx><c:tickLblSkip val=".."/>`
 and `<c:catAx><c:tickMarkSkip val=".."/>`). Both elements live on
@@ -1090,6 +1106,25 @@ reference default `true` for any flag the caller leaves unset. The
 field is silently dropped on `pie` / `doughnut` charts because those
 families have no axes and the OOXML schema places no slot for
 `<c:dTable>` on their plot areas.
+The chart-level `protection` field maps to
+`<c:chartSpace><c:protection>...</c:protection>` — Excel's chart-level
+lock that pairs with the host worksheet's `<sheetProtection>` to
+decide which interactions remain allowed when the parent sheet is
+protected. The field accepts a `boolean | ChartProtection`
+discriminated union: pass `true` for the bare `<c:protection>` shell
+with every flag at the OOXML default `false` (action permitted), pass
+an object to opt individual children in (each field maps to the
+matching `<c:protection>` boolean child — `chartObject`, `data`,
+`formatting`, `selection`, `userInterface`), or omit it (or pass
+`false`) to suppress the element entirely. When emitted, the writer
+always serializes all five children in `CT_Protection` schema order,
+falling back to the OOXML default `false` (action permitted) for any
+flag the caller leaves unset. The element sits on `<c:chartSpace>`
+(not inside `<c:plotArea>`), so every chart family — including pie /
+doughnut — carries a slot for it. Excel only enforces these flags
+when the host worksheet is itself protected; on an unprotected sheet
+the element round-trips literally but has no observable runtime
+effect.
 The chart-level `roundedCorners` field maps to
 `<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
 `<c:chart>`, not a child) — Excel's "Format Chart Area → Border →
@@ -1465,6 +1500,18 @@ the resolved chart type is `pie` or `doughnut` — those families have
 no axes and the OOXML schema places no slot for the element on their
 plot areas. Coercions between axis-bearing families (line → column,
 scatter → area, etc.) preserve the inherited block.
+The chart-level `protection` field follows the standard
+`object | boolean | null` override grammar: pass `undefined` (or omit
+it) to inherit the source's parsed `ChartProtection`, `null` (or
+`false`) to drop the inherited block so the writer skips
+`<c:protection>` entirely, `true` to pin every flag to its OOXML
+default `false` (the bare `<c:protection>` shell), or a
+`ChartProtection` object to replace the block wholesale (no per-field
+merge with the source — pass every flag the cloned protection should
+pin). Unlike `dataTable`, the field lives on `<c:chartSpace>` (not
+inside `<c:plotArea>`), so every chart family — pie / doughnut
+included — carries a slot for it. Coercions between any chart
+families preserve the inherited block.
 The chart-level `roundedCorners` flag follows the same grammar: pass
 `undefined` to inherit the source's parsed value, `null` to drop it
 back to the writer's OOXML `false` default (square chart frame), or a

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -783,6 +783,65 @@ export interface ChartDataTable {
 }
 
 /**
+ * Granular chart-protection configuration for {@link SheetChart.protection}.
+ *
+ * Each flag mirrors a `CT_Boolean` child of `<c:chartSpace><c:protection>`
+ * (CT_Protection, ECMA-376 Part 1, §21.2.2.142) — the chart-space-level
+ * lock that pairs with the host worksheet's `<sheetProtection>` to
+ * decide which interactions Excel still allows when the parent sheet is
+ * protected. The element only takes effect when the worksheet that
+ * embeds the chart is itself protected; on an unprotected sheet the
+ * flags are silently ignored by Excel.
+ *
+ * Every field defaults to `false` (the OOXML default Excel itself
+ * emits) — `false` means the action is permitted, `true` means the
+ * action is locked. Each field is independent; pass any combination of
+ * the five flags to lock individual interactions.
+ *
+ * Pass an empty object (`{}`) to declare an empty `<c:protection>`
+ * shell with every flag at the OOXML default — equivalent to passing
+ * `protection: true` and useful for round-trip parity with templates
+ * that author the bare element without pinning any flags.
+ */
+export interface ChartProtection {
+  /**
+   * Lock the chart object (its frame, anchor, and contents) against
+   * direct manipulation. Maps to `<c:chartObject val=".."/>`.
+   * Default: `false` — the chart is movable / resizable on a protected
+   * worksheet. Set `true` to freeze the chart's position and contents.
+   */
+  chartObject?: boolean;
+  /**
+   * Lock the underlying data references the chart points at. Maps to
+   * `<c:data val=".."/>`. Default: `false` — Excel allows the user to
+   * re-pick data ranges via "Select Data Source" even when the parent
+   * sheet is protected. Set `true` to keep the series ranges pinned.
+   */
+  data?: boolean;
+  /**
+   * Lock chart formatting (colors, fills, fonts, layout). Maps to
+   * `<c:formatting val=".."/>`. Default: `false` — the user may still
+   * tweak Format-Chart-Element panes on a protected sheet. Set `true`
+   * to lock down the rendered look.
+   */
+  formatting?: boolean;
+  /**
+   * Lock click-to-select on chart elements. Maps to
+   * `<c:selection val=".."/>`. Default: `false` — the user can still
+   * click into series, legend entries, or labels to inspect them. Set
+   * `true` to disable element selection entirely.
+   */
+  selection?: boolean;
+  /**
+   * Lock chart-level UI affordances such as the floating "+ Chart
+   * Elements" button and the right-click context menu. Maps to
+   * `<c:userInterface val=".."/>`. Default: `false` — Excel still
+   * surfaces the on-canvas affordances. Set `true` to suppress them.
+   */
+  userInterface?: boolean;
+}
+
+/**
  * Scatter sub-style applied at the chart level. Maps to the OOXML
  * `ST_ScatterStyle` enum which sits inside `<c:scatterChart>` as
  * `<c:scatterStyle val=".."/>`. Excel exposes the same six presets
@@ -1295,6 +1354,37 @@ export interface SheetChart {
    * See {@link ChartDataTable}.
    */
   dataTable?: boolean | ChartDataTable;
+  /**
+   * Chart-space protection. Maps to `<c:chartSpace><c:protection>...
+   * </c:protection>` (CT_Protection, ECMA-376 Part 1, §21.2.2.142) —
+   * the chart-level lock that Excel honors when the parent worksheet
+   * is itself protected via `<sheetProtection>`. Each of the five
+   * `CT_Boolean` children (`<c:chartObject>`, `<c:data>`,
+   * `<c:formatting>`, `<c:selection>`, `<c:userInterface>`) toggles a
+   * separate interaction; `false` (the OOXML default) leaves the
+   * action permitted and `true` locks it.
+   *
+   * Pass `true` to declare the bare `<c:protection/>` element with
+   * every flag at its OOXML default `false` — equivalent to passing
+   * `protection: {}`. Pass an object to opt individual flags in. Pass
+   * `false` (or omit the field) to suppress the element entirely so
+   * the writer skips emission.
+   *
+   * Default: omitted — Excel renders no `<c:protection>` element on
+   * a fresh chart.
+   *
+   * Note: Excel only enforces these flags when the host worksheet is
+   * itself protected (the chart inherits the sheet's protection
+   * boundary). On an unprotected sheet the element round-trips
+   * literally but has no observable runtime effect.
+   *
+   * The element sits on every chart family — pie / doughnut / bar /
+   * column / line / area / scatter — because `<c:protection>` lives
+   * on `<c:chartSpace>`, not inside `<c:plotArea>`, so axis-shape
+   * has no bearing on whether the slot exists. See
+   * {@link ChartProtection}.
+   */
+  protection?: boolean | ChartProtection;
   /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
@@ -3223,6 +3313,30 @@ export interface Chart {
    * doughnut have no axes and surface `undefined`.
    */
   dataTable?: ChartDataTable;
+  /**
+   * Chart-space protection pulled from
+   * `<c:chartSpace><c:protection>...</c:protection>`. Reflects the
+   * chart-level lock Excel honors when the parent worksheet is
+   * protected via `<sheetProtection>`.
+   *
+   * Surfaces a {@link ChartProtection} object whenever the source
+   * chart declares the element. Each of the five boolean children
+   * (`<c:chartObject>`, `<c:data>`, `<c:formatting>`, `<c:selection>`,
+   * `<c:userInterface>`) is independently optional on `CT_Protection`,
+   * so the reader only surfaces the flags the file actually pinned.
+   * A child that is missing or carries an unknown `val` attribute drops
+   * to `undefined` for that field rather than fabricate a value the
+   * file did not declare. The element itself is the gating signal — a
+   * `<c:protection>` block with no resolvable children surfaces as an
+   * empty `{}`, mirroring how `dataTable` handles a malformed `<c:dTable>`.
+   *
+   * Surfaces `undefined` when the chart has no `<c:protection>` element
+   * at all. The element lives on `<c:chartSpace>` (a sibling of
+   * `<c:chart>`, between `<c:style>` / `<c:pivotSource>` and
+   * `<c:chart>` per CT_ChartSpace), so every chart family — including
+   * pie / doughnut — can carry it.
+   */
+  protection?: ChartProtection;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,7 @@ export type {
   ChartLineStroke,
   ChartMarker,
   ChartMarkerSymbol,
+  ChartProtection,
   ChartSeriesInfo,
 } from "./_types";
 

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -29,6 +29,7 @@ import type {
   ChartKind,
   ChartLineStroke,
   ChartMarker,
+  ChartProtection,
   ChartScatterStyle,
   ChartSeries,
   ChartSeriesInfo,
@@ -392,6 +393,29 @@ export interface CloneChartOptions {
    * doughnut have no axes and no slot for the element.
    */
   dataTable?: ChartDataTable | boolean | null;
+  /**
+   * Override `<c:chartSpace><c:protection>` (the chart-space
+   * protection block).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * {@link Chart.protection}. `null` drops the inherited block so the
+   * writer skips the element entirely — Excel applies no chart-level
+   * protection. `false` is equivalent to `null` (suppression). `true`
+   * pins every flag to its OOXML default `false` so the writer emits
+   * the bare `<c:protection>` shell. A {@link ChartProtection} object
+   * replaces the block wholesale (no per-field merge; pass every flag
+   * you want preserved). Each unspecified flag inside the object falls
+   * back to `false` at the writer side — `<c:protection>` accepts
+   * every child as optional and Excel treats a missing child as the
+   * unlocked default.
+   *
+   * Applies to every chart family — `<c:protection>` lives on
+   * `<c:chartSpace>` (not inside `<c:plotArea>`), so the element has
+   * a slot on pie / doughnut charts too. The grammar mirrors
+   * {@link CloneChartOptions.dataTable} so the chart-level block
+   * toggles compose the same way at the call site.
+   */
+  protection?: ChartProtection | boolean | null;
   /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
@@ -857,6 +881,15 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     const resolvedDataTable = resolveDataTable(source.dataTable, options.dataTable);
     if (resolvedDataTable !== undefined) out.dataTable = resolvedDataTable;
   }
+
+  // `<c:protection>` lives on `<c:chartSpace>` (not inside
+  // `<c:plotArea>`), so every chart family — including pie / doughnut
+  // — carries a slot for it. Override wins over the source's parsed
+  // value, and the grammar follows the same `object | boolean | null`
+  // shape as `dataTable` so the chart-level block toggles compose
+  // identically at the call site.
+  const resolvedProtection = resolveProtection(source.protection, options.protection);
+  if (resolvedProtection !== undefined) out.protection = resolvedProtection;
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -1400,6 +1433,60 @@ function resolveDataTable(
   // `true` or a {@link ChartDataTable} object — replace the inherited
   // block wholesale. The writer accepts both forms and falls back to
   // the OOXML reference defaults for any field the object leaves unset.
+  return override;
+}
+
+/**
+ * Resolve a `protection` (chart-space protection) override.
+ *
+ * `undefined` → inherit the source's parsed {@link Chart.protection}.
+ * `null`      → drop the inherited block so the writer skips
+ *               `<c:protection>` entirely (no chart-level lock).
+ * `false`     → equivalent to `null` (suppression); kept distinct in
+ *               the API surface so callers can write `protection:
+ *               false` for symmetry with the writer's `boolean |
+ *               object` shape.
+ * `true`      → enable with the OOXML reference defaults (every flag
+ *               `false` — the bare `<c:protection>` shell).
+ * `object`    → replace the inherited block wholesale (no per-field
+ *               merge with the source — pass every flag the cloned
+ *               protection should pin). Each unspecified field falls
+ *               back to `false` at the writer side because every
+ *               `<c:protection>` boolean child is independently
+ *               optional and Excel treats a missing child as
+ *               `false`.
+ *
+ * The grammar mirrors {@link resolveDataTable} so the chart-level
+ * block toggles compose the same way at the call site. Unlike
+ * `dataTable`, `<c:protection>` lives on `<c:chartSpace>` (not inside
+ * `<c:plotArea>`) so the resolver applies to every chart family —
+ * pie / doughnut included.
+ */
+function resolveProtection(
+  sourceValue: ChartProtection | undefined,
+  override: ChartProtection | boolean | null | undefined,
+): ChartProtection | boolean | undefined {
+  if (override === undefined) {
+    // Inherit — pass the source through verbatim. The writer accepts
+    // both the boolean and object shapes, so a parsed
+    // {@link ChartProtection} round-trips directly.
+    return sourceValue;
+  }
+  if (override === null) {
+    // Drop the inherited block. The writer treats `undefined` as
+    // suppression and skips `<c:protection>` entirely.
+    return undefined;
+  }
+  if (override === false) {
+    // Symmetric with `null` — kept distinct in the API surface for
+    // ergonomic alignment with the writer's `boolean | object` shape,
+    // but emits the same on-the-wire result (no `<c:protection>`).
+    return undefined;
+  }
+  // `true` or a {@link ChartProtection} object — replace the inherited
+  // block wholesale. The writer accepts both forms and falls back to
+  // the OOXML reference default `false` for any field the object
+  // leaves unset.
   return override;
 }
 

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -37,6 +37,7 @@ import type {
   ChartLineStroke,
   ChartMarker,
   ChartMarkerSymbol,
+  ChartProtection,
   ChartScatterStyle,
   ChartSeriesInfo,
 } from "../_types";
@@ -312,6 +313,17 @@ export function parseChart(xml: string): Chart | undefined {
   // date interpretation across the whole chart document.
   const date1904 = parseDate1904(chartSpace);
   if (date1904 !== undefined) out.date1904 = date1904;
+
+  // `<c:protection>` (CT_Protection, ECMA-376 Part 1, §21.2.2.142)
+  // sits on `<c:chartSpace>` between `<c:style>` / `<c:pivotSource>`
+  // and `<c:chart>`. The element holds five optional `<xsd:boolean>`
+  // children (`<c:chartObject>`, `<c:data>`, `<c:formatting>`,
+  // `<c:selection>`, `<c:userInterface>`). Unlike `<c:dTable>` (whose
+  // children are required) every protection flag is independently
+  // optional, so the reader only surfaces the ones the file actually
+  // pinned.
+  const protection = parseProtection(chartSpace);
+  if (protection !== undefined) out.protection = protection;
 
   return out;
 }
@@ -1856,6 +1868,70 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
  */
 function parseDataTableFlag(dTable: XmlElement, local: string): boolean | undefined {
   const el = findChild(dTable, local);
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+// ── Protection ────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:protection>...</c:protection>` off `<c:chartSpace>`.
+ * Surfaces a {@link ChartProtection} object whenever the source chart
+ * declares the element; absence collapses to `undefined`.
+ *
+ * Each of the five boolean children (`<c:chartObject>`, `<c:data>`,
+ * `<c:formatting>`, `<c:selection>`, `<c:userInterface>`) is optional
+ * on `CT_Protection`, so the reader only surfaces the flags the file
+ * actually pinned. Children that are missing or carry an unknown
+ * `val` attribute drop to `undefined` rather than fabricate a flag
+ * the file did not pin; the writer falls back to the OOXML default
+ * `false` for any field the object omits, mirroring how Excel's
+ * reader treats a missing child.
+ *
+ * The element itself is the gating signal — a `<c:protection>` block
+ * with no resolvable children surfaces as an empty `{}` rather than
+ * `undefined`, so a chart that authors the bare element (Excel's
+ * "Protect Chart" preset with every flag at the default) round-trips
+ * literally instead of silently disappearing through the parse loop.
+ */
+function parseProtection(chartSpace: XmlElement): ChartProtection | undefined {
+  const el = findChild(chartSpace, "protection");
+  if (!el) return undefined;
+  const out: ChartProtection = {};
+  const chartObject = parseProtectionFlag(el, "chartObject");
+  if (chartObject !== undefined) out.chartObject = chartObject;
+  const data = parseProtectionFlag(el, "data");
+  if (data !== undefined) out.data = data;
+  const formatting = parseProtectionFlag(el, "formatting");
+  if (formatting !== undefined) out.formatting = formatting;
+  const selection = parseProtectionFlag(el, "selection");
+  if (selection !== undefined) out.selection = selection;
+  const userInterface = parseProtectionFlag(el, "userInterface");
+  if (userInterface !== undefined) out.userInterface = userInterface;
+  return out;
+}
+
+/**
+ * Pull a single boolean child off `<c:protection>`. Accepts the OOXML
+ * truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
+ * unknown tokens, missing `val` attributes, and missing elements all
+ * collapse to `undefined` rather than fabricate a flag the file did
+ * not pin. Mirrors {@link parseDataTableFlag} — the same OOXML
+ * `<xsd:boolean>` lexical-space rule.
+ */
+function parseProtectionFlag(protection: XmlElement, local: string): boolean | undefined {
+  const el = findChild(protection, local);
   if (!el) return undefined;
   const raw = el.attrs.val;
   if (typeof raw !== "string") return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -23,6 +23,7 @@ import type {
   ChartLineStroke,
   ChartMarker,
   ChartMarkerSymbol,
+  ChartProtection,
   ChartScatterStyle,
   ChartSeries,
   SheetChart,
@@ -123,6 +124,18 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   const styleVal = resolveStyle(chart);
   if (styleVal !== undefined) {
     chartSpaceChildren.push(xmlSelfClose("c:style", { val: styleVal }));
+  }
+  // `<c:protection>` (CT_Protection, ECMA-376 Part 1, §21.2.2.142)
+  // sits on `<c:chartSpace>` between `<c:style>` / `<c:clrMapOvr>` /
+  // `<c:pivotSource>` and `<c:chart>`. The writer skips the element
+  // when the caller did not opt in (`undefined` / `false`) and emits
+  // it whenever the chart pins `true` or an object — the bare element
+  // round-trips when the override is `true` / `{}` because every
+  // child is `<xsd:boolean>`-typed and absence of a child is itself
+  // valid OOXML (CT_Protection lists every flag as optional).
+  const protection = resolveProtection(chart);
+  if (protection !== undefined) {
+    chartSpaceChildren.push(buildProtection(protection));
   }
   chartSpaceChildren.push(chartElement);
 
@@ -418,6 +431,96 @@ function buildDataTable(table: {
     xmlSelfClose("c:showVertBorder", { val: table.showVertBorder ? 1 : 0 }),
     xmlSelfClose("c:showOutline", { val: table.showOutline ? 1 : 0 }),
     xmlSelfClose("c:showKeys", { val: table.showKeys ? 1 : 0 }),
+  ]);
+}
+
+// ── Protection ───────────────────────────────────────────────────────
+
+/**
+ * Resolve the {@link SheetChart.protection} field into the per-flag
+ * shape `<c:protection>` emits, or `undefined` to signal that the
+ * writer should skip the element entirely.
+ *
+ * Returns `undefined` when the caller did not opt in (`protection` is
+ * `undefined` or `false`).
+ *
+ * Returns the resolved per-flag block when the caller passed `true`
+ * (every flag at the OOXML default `false` — equivalent to a bare
+ * `<c:protection/>` shell) or an object (per-field overrides). Stray
+ * non-boolean inputs collapse to `false` (the OOXML default) rather
+ * than emit a token Excel rejects, mirroring how every other
+ * chart-level boolean writer treats its input.
+ *
+ * Unlike {@link resolveDataTable}, this resolver applies to every
+ * chart family — `<c:protection>` lives on `<c:chartSpace>`, not
+ * inside `<c:plotArea>`, so the element has a slot on pie / doughnut
+ * charts too.
+ */
+function resolveProtection(chart: SheetChart):
+  | {
+      chartObject: boolean;
+      data: boolean;
+      formatting: boolean;
+      selection: boolean;
+      userInterface: boolean;
+    }
+  | undefined {
+  const raw = chart.protection;
+  if (raw === undefined || raw === false) return undefined;
+
+  if (raw === true) {
+    return {
+      chartObject: false,
+      data: false,
+      formatting: false,
+      selection: false,
+      userInterface: false,
+    };
+  }
+
+  // Per-field overrides on top of the `false` defaults. Only literal
+  // `true` flips a flag — anything else (including stray `undefined`,
+  // `null`, or a non-boolean) falls back to the default `false` so the
+  // writer never emits a token the OOXML schema would refuse. The
+  // empty-object case (`{}`) collapses to a bare `<c:protection/>` with
+  // every flag at its default, so Excel still records the chart-level
+  // protection block on roundtrip.
+  return {
+    chartObject: raw.chartObject === true,
+    data: raw.data === true,
+    formatting: raw.formatting === true,
+    selection: raw.selection === true,
+    userInterface: raw.userInterface === true,
+  };
+}
+
+/**
+ * Serialize a resolved protection block into `<c:protection>` with its
+ * five optional boolean children, in the order CT_Protection mandates:
+ * `chartObject`, `data`, `formatting`, `selection`, `userInterface`.
+ *
+ * Unlike `<c:dTable>` (whose four children are required on
+ * CT_DTable), every CT_Protection child is optional — but the writer
+ * always emits all five so the rendered intent is explicit on
+ * roundtrip. Default-valued (`false`) children still surface as
+ * `<c:chartObject val="0"/>` to match the always-emit contract every
+ * other chart-level boolean writer follows (compare `<c:plotVisOnly>`
+ * and `<c:dispBlanksAs>`). Excel's reader treats a missing child as
+ * `false` either way.
+ */
+function buildProtection(protection: {
+  chartObject: boolean;
+  data: boolean;
+  formatting: boolean;
+  selection: boolean;
+  userInterface: boolean;
+}): string {
+  return xmlElement("c:protection", undefined, [
+    xmlSelfClose("c:chartObject", { val: protection.chartObject ? 1 : 0 }),
+    xmlSelfClose("c:data", { val: protection.data ? 1 : 0 }),
+    xmlSelfClose("c:formatting", { val: protection.formatting ? 1 : 0 }),
+    xmlSelfClose("c:selection", { val: protection.selection ? 1 : 0 }),
+    xmlSelfClose("c:userInterface", { val: protection.userInterface ? 1 : 0 }),
   ]);
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -7384,3 +7384,244 @@ describe("cloneChart — data table", () => {
     });
   });
 });
+
+// ── cloneChart — chart-space protection ──────────────────────────────
+
+describe("cloneChart — chart-space protection", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's protection by default", () => {
+    const clone = cloneChart(
+      source({
+        protection: {
+          chartObject: true,
+          data: false,
+          formatting: true,
+          selection: false,
+          userInterface: true,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.protection).toEqual({
+      chartObject: true,
+      data: false,
+      formatting: true,
+      selection: false,
+      userInterface: true,
+    });
+  });
+
+  it("lets options.protection: true replace the inherited block wholesale", () => {
+    // Source has a partial protection, override pins every flag to default false.
+    const clone = cloneChart(
+      source({
+        protection: { formatting: true, selection: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        protection: true,
+      },
+    );
+    expect(clone.protection).toBe(true);
+  });
+
+  it("lets options.protection: object replace the inherited block wholesale", () => {
+    // No per-field merge — the override block replaces the source's.
+    const clone = cloneChart(
+      source({
+        protection: { formatting: true, selection: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        protection: { data: true },
+      },
+    );
+    expect(clone.protection).toEqual({ data: true });
+  });
+
+  it("drops the inherited protection when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:protection> entirely on emit.
+    const clone = cloneChart(
+      source({
+        protection: {
+          chartObject: true,
+          data: true,
+          formatting: true,
+          selection: true,
+          userInterface: true,
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        protection: null,
+      },
+    );
+    expect(clone.protection).toBeUndefined();
+  });
+
+  it("drops the inherited protection when the override is false", () => {
+    // `false` is the suppression alias — symmetric with null on the
+    // on-the-wire result (no <c:protection> emitted).
+    const clone = cloneChart(
+      source({
+        protection: { formatting: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        protection: false,
+      },
+    );
+    expect(clone.protection).toBeUndefined();
+  });
+
+  it("returns undefined protection when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.protection).toBeUndefined();
+  });
+
+  it("carries protection through a flatten (line → column)", () => {
+    // <c:protection> lives on <c:chartSpace>, so a chart-type
+    // coercion preserves the pinned block — the element has no axis
+    // dependency.
+    const clone = cloneChart(
+      source({
+        protection: { selection: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "column",
+      },
+    );
+    expect(clone.type).toBe("column");
+    expect(clone.protection).toEqual({ selection: true });
+  });
+
+  it("preserves protection when flattening into a doughnut clone", () => {
+    // Unlike <c:dTable>, <c:protection> has no axis dependency — it
+    // lives on <c:chartSpace> so pie / doughnut still carry the slot.
+    // The clone layer keeps the inherited block on those families.
+    const clone = cloneChart(
+      source({
+        protection: { selection: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.protection).toEqual({ selection: true });
+  });
+
+  it("preserves protection when flattening into a pie clone", () => {
+    const clone = cloneChart(
+      source({
+        protection: { formatting: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "pie",
+      },
+    );
+    expect(clone.type).toBe("pie");
+    expect(clone.protection).toEqual({ formatting: true });
+  });
+
+  it("propagates protection into the rendered <c:protection> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        protection: {
+          chartObject: true,
+          data: false,
+          formatting: true,
+          selection: false,
+          userInterface: true,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:protection>");
+    expect(written).toContain('<c:chartObject val="1"/>');
+    expect(written).toContain('<c:data val="0"/>');
+    expect(written).toContain('<c:formatting val="1"/>');
+    expect(written).toContain('<c:selection val="0"/>');
+    expect(written).toContain('<c:userInterface val="1"/>');
+
+    // Re-parsing the rendered chart returns the same shape — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.protection).toEqual({
+      chartObject: true,
+      data: false,
+      formatting: true,
+      selection: false,
+      userInterface: true,
+    });
+  });
+
+  it("propagates protection: true into a fully-defaulted block on roundtrip", async () => {
+    // `protection: true` declares the bare element with every flag at
+    // its OOXML default `false`. The writer emits all five children
+    // (always-emit contract) so a re-parse surfaces the literal shape.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+      protection: true,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.protection).toEqual({
+      chartObject: false,
+      data: false,
+      formatting: false,
+      selection: false,
+      userInterface: false,
+    });
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -6417,3 +6417,260 @@ describe("writeChart — data table", () => {
     });
   });
 });
+
+// ── writeChart — chart-space protection ──────────────────────────────
+
+describe("writeChart — chart-space protection", () => {
+  it("skips <c:protection> entirely when the field is unset (writer default)", () => {
+    // Excel applies no chart-level protection on a fresh chart — the
+    // writer skips the element so the file stays minimal. Absence and
+    // the unset default round-trip identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:protection");
+  });
+
+  it("skips <c:protection> when protection is false", () => {
+    // `false` mirrors the unset default — the writer skips the element.
+    const result = writeChart(makeChart({ protection: false }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:protection");
+  });
+
+  it("emits a fully-defaulted <c:protection> when protection is true", () => {
+    // `true` declares the bare <c:protection> shell with every flag at
+    // its OOXML default `false` — useful for round-trip parity with
+    // templates that pin the bare element without locking any flag.
+    const result = writeChart(makeChart({ protection: true }), "Sheet1");
+    expect(result.chartXml).toContain("<c:protection>");
+    expect(result.chartXml).toContain('<c:chartObject val="0"/>');
+    expect(result.chartXml).toContain('<c:data val="0"/>');
+    expect(result.chartXml).toContain('<c:formatting val="0"/>');
+    expect(result.chartXml).toContain('<c:selection val="0"/>');
+    expect(result.chartXml).toContain('<c:userInterface val="0"/>');
+  });
+
+  it("emits a fully-defaulted <c:protection> when protection is an empty object", () => {
+    // An empty override accepts every default — equivalent to passing
+    // `protection: true`. Each unspecified field falls back to the
+    // OOXML reference value `false`.
+    const result = writeChart(makeChart({ protection: {} }), "Sheet1");
+    expect(result.chartXml).toContain("<c:protection>");
+    expect(result.chartXml).toContain('<c:chartObject val="0"/>');
+    expect(result.chartXml).toContain('<c:data val="0"/>');
+    expect(result.chartXml).toContain('<c:formatting val="0"/>');
+    expect(result.chartXml).toContain('<c:selection val="0"/>');
+    expect(result.chartXml).toContain('<c:userInterface val="0"/>');
+  });
+
+  it("honours per-field overrides (true for formatting + selection)", () => {
+    // A common pattern — lock the look (formatting + selection) but
+    // leave the underlying data references and the on-canvas UI
+    // affordances unlocked.
+    const result = writeChart(
+      makeChart({
+        protection: { formatting: true, selection: true },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:chartObject val="0"/>');
+    expect(result.chartXml).toContain('<c:data val="0"/>');
+    expect(result.chartXml).toContain('<c:formatting val="1"/>');
+    expect(result.chartXml).toContain('<c:selection val="1"/>');
+    expect(result.chartXml).toContain('<c:userInterface val="0"/>');
+  });
+
+  it("flips every flag true when the caller pins each true", () => {
+    const result = writeChart(
+      makeChart({
+        protection: {
+          chartObject: true,
+          data: true,
+          formatting: true,
+          selection: true,
+          userInterface: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:chartObject val="1"/>');
+    expect(result.chartXml).toContain('<c:data val="1"/>');
+    expect(result.chartXml).toContain('<c:formatting val="1"/>');
+    expect(result.chartXml).toContain('<c:selection val="1"/>');
+    expect(result.chartXml).toContain('<c:userInterface val="1"/>');
+  });
+
+  it("emits the five <c:protection> children in CT_Protection schema order", () => {
+    // CT_Protection: chartObject?, data?, formatting?, selection?,
+    // userInterface? — order matters for strict validators (Excel
+    // itself rejects out-of-order children).
+    const result = writeChart(makeChart({ protection: true }), "Sheet1");
+    const chartObjectIdx = result.chartXml.indexOf("c:chartObject");
+    const dataIdx = result.chartXml.indexOf("c:data ");
+    const formattingIdx = result.chartXml.indexOf("c:formatting");
+    const selectionIdx = result.chartXml.indexOf("c:selection");
+    const userInterfaceIdx = result.chartXml.indexOf("c:userInterface");
+    expect(chartObjectIdx).toBeGreaterThan(-1);
+    expect(dataIdx).toBeGreaterThan(chartObjectIdx);
+    expect(formattingIdx).toBeGreaterThan(dataIdx);
+    expect(selectionIdx).toBeGreaterThan(formattingIdx);
+    expect(userInterfaceIdx).toBeGreaterThan(selectionIdx);
+  });
+
+  it("places <c:protection> after <c:style> and before <c:chart> on <c:chartSpace>", () => {
+    // CT_ChartSpace sequence: date1904?, lang?, roundedCorners?,
+    // AlternateContent?, style?, clrMapOvr?, pivotSource?, protection?,
+    // chart, ... — protection sits after style and before the visible
+    // <c:chart>.
+    const result = writeChart(makeChart({ style: 12, protection: true }), "Sheet1");
+    const styleIdx = result.chartXml.indexOf("<c:style");
+    const protectionIdx = result.chartXml.indexOf("<c:protection>");
+    const chartIdx = result.chartXml.indexOf("<c:chart>");
+    expect(styleIdx).toBeGreaterThan(-1);
+    expect(protectionIdx).toBeGreaterThan(styleIdx);
+    expect(chartIdx).toBeGreaterThan(protectionIdx);
+  });
+
+  it("places <c:protection> before <c:chart> even without a <c:style>", () => {
+    // The element should still slot directly before <c:chart> when
+    // no style preset is set — the writer must not require a sibling
+    // to anchor the position.
+    const result = writeChart(makeChart({ protection: true }), "Sheet1");
+    const protectionIdx = result.chartXml.indexOf("<c:protection>");
+    const chartIdx = result.chartXml.indexOf("<c:chart>");
+    expect(protectionIdx).toBeGreaterThan(-1);
+    expect(chartIdx).toBeGreaterThan(protectionIdx);
+  });
+
+  it("only emits <c:protection> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ protection: true }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:protection>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads protection through every chart family", () => {
+    // <c:protection> lives on <c:chartSpace>, not inside <c:plotArea>
+    // — every chart family carries a slot, including pie / doughnut.
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, protection: { formatting: true } }), "Sheet1");
+      expect(result.chartXml).toContain("<c:protection>");
+      expect(result.chartXml).toContain('<c:formatting val="1"/>');
+    }
+    for (const type of ["pie", "doughnut"] as const) {
+      const result = writeChart(
+        {
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4" }],
+          anchor: { from: { row: 5, col: 0 } },
+          protection: { formatting: true },
+        },
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain("<c:protection>");
+      expect(result.chartXml).toContain('<c:formatting val="1"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        protection: { formatting: true },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain("<c:protection>");
+  });
+
+  it("ignores stray non-boolean overrides rather than emit invalid tokens", () => {
+    // A non-boolean leaking through the type guard collapses to the
+    // OOXML default `false` rather than emit a token Excel rejects.
+    const result = writeChart(
+      makeChart({
+        protection: {
+          // @ts-expect-error — defensive: stray non-boolean leaking through
+          chartObject: 1,
+          // @ts-expect-error — defensive: stray non-boolean leaking through
+          data: "true",
+          formatting: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:chartObject val="0"/>');
+    expect(result.chartXml).toContain('<c:data val="0"/>');
+    expect(result.chartXml).toContain('<c:formatting val="1"/>');
+  });
+
+  it("round-trips a pinned protection through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        protection: {
+          chartObject: true,
+          data: false,
+          formatting: true,
+          selection: false,
+          userInterface: true,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.protection).toEqual({
+      chartObject: true,
+      data: false,
+      formatting: true,
+      selection: false,
+      userInterface: true,
+    });
+  });
+
+  it("round-trips protection: true as the fully-defaulted shape", () => {
+    // The writer emits all five flags as `false` — a re-parse surfaces
+    // the same shape (every flag literal `false`) so the cloned
+    // protection is byte-for-byte stable.
+    const written = writeChart(makeChart({ protection: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.protection).toEqual({
+      chartObject: false,
+      data: false,
+      formatting: false,
+      selection: false,
+      userInterface: false,
+    });
+  });
+
+  it("threads protection through writeXlsx into xl/charts/chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Month", "Revenue"],
+          ["Jan", 100],
+          ["Feb", 200],
+          ["Mar", 300],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Quarterly",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            protection: { formatting: true, selection: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:protection>");
+    expect(chartXml).toContain('<c:formatting val="1"/>');
+    expect(chartXml).toContain('<c:selection val="1"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.protection).toEqual({
+      chartObject: false,
+      data: false,
+      formatting: true,
+      selection: true,
+      userInterface: false,
+    });
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -7266,3 +7266,231 @@ describe("parseChart — data table", () => {
     expect(parseChart(xml)?.dataTable).toBeUndefined();
   });
 });
+
+// ── parseChart — chart-space protection ──────────────────────────────
+
+describe("parseChart — chart-space protection", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces every flag a fully-pinned <c:protection> declares", () => {
+    // CT_Protection lists every child as optional, but a "lock
+    // everything" preset emits all five. The reader surfaces every
+    // pinned flag literally so a clone can replay the exact shape.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:chartObject val="1"/>
+    <c:data val="1"/>
+    <c:formatting val="1"/>
+    <c:selection val="1"/>
+    <c:userInterface val="1"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.protection).toEqual({
+      chartObject: true,
+      data: true,
+      formatting: true,
+      selection: true,
+      userInterface: true,
+    });
+  });
+
+  it("surfaces non-default false flags literally", () => {
+    // Each boolean child round-trips literally — `false` is just as
+    // important as `true` because the writer always emits all five
+    // children and a clone must preserve the exact pattern.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:chartObject val="0"/>
+    <c:data val="0"/>
+    <c:formatting val="0"/>
+    <c:selection val="0"/>
+    <c:userInterface val="0"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({
+      chartObject: false,
+      data: false,
+      formatting: false,
+      selection: false,
+      userInterface: false,
+    });
+  });
+
+  it("surfaces a partial shape with only the flags the file pinned", () => {
+    // Common pattern — lock data and selection but leave the rest
+    // unpinned. CT_Protection lists every child as optional so the
+    // parser surfaces only the present flags rather than fabricate
+    // defaults the file did not declare.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:data val="1"/>
+    <c:selection val="1"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({
+      data: true,
+      selection: true,
+    });
+  });
+
+  it("accepts the OOXML textual <xsd:boolean> spellings", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:chartObject val="true"/>
+    <c:data val="false"/>
+    <c:formatting val="true"/>
+    <c:selection val="false"/>
+    <c:userInterface val="true"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({
+      chartObject: true,
+      data: false,
+      formatting: true,
+      selection: false,
+      userInterface: true,
+    });
+  });
+
+  it("returns undefined when the chart has no <c:protection> element", () => {
+    // Absence is the writer's default — Excel applies no chart-level
+    // protection. The reader surfaces nothing so a fresh chart and a
+    // chart that omits the element round-trip identically through
+    // cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toBeUndefined();
+  });
+
+  it("drops a missing val attribute on a <c:protection> child rather than fabricate a flag", () => {
+    // A child without `val` is malformed per CT_Boolean; the reader
+    // drops the field rather than fabricate a value the file did not
+    // pin. The other children still round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:chartObject val="1"/>
+    <c:data/>
+    <c:formatting val="1"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({
+      chartObject: true,
+      formatting: true,
+    });
+  });
+
+  it("drops unknown val tokens rather than fabricate flags", () => {
+    // Anything outside the OOXML truthy / falsy spellings collapses
+    // to undefined for that field. The other children still surface.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:chartObject val="yes"/>
+    <c:data val="2"/>
+    <c:selection val="1"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({
+      selection: true,
+    });
+  });
+
+  it("surfaces an empty object when <c:protection> is present but every child is malformed", () => {
+    // The element itself is the gating signal — when it appears, the
+    // chart is requesting protection even if every child carries a
+    // malformed `val`. The shape stays minimal (an empty object) so a
+    // round-trip through the writer falls back to the OOXML defaults
+    // (every flag `false`) which Excel would apply anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:chartObject/>
+    <c:data/>
+    <c:formatting/>
+    <c:selection/>
+    <c:userInterface/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({});
+  });
+
+  it("surfaces an empty object on a bare <c:protection/> element", () => {
+    // A self-closing element with no children — same minimal-shape
+    // result as a malformed-children block. Round-trips through the
+    // writer which falls back to every-flag `false` for emit.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection/>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({});
+  });
+
+  it("surfaces protection on a pie chart (no axes, but the element lives on chartSpace)", () => {
+    // <c:protection> lives on <c:chartSpace>, not inside <c:plotArea>,
+    // so axis-shape has no bearing on whether the slot exists. Pie /
+    // doughnut still carry the element when the file pins it.
+    const xml = `<c:chartSpace ${NS}>
+  <c:protection>
+    <c:formatting val="1"/>
+  </c:protection>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:varyColors val="1"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.protection).toEqual({
+      formatting: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:chartSpace><c:protection>...</c:protection>` (CT_Protection, ECMA-376 Part 1, §21.2.2.142) at the read, write, and clone layers so a template's chart-level lock survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:protection>` declares which interactions Excel still permits when the host worksheet is itself protected via `<sheetProtection>` — the chart inherits the sheet's protection boundary, and these flags decide whether the user can still move the frame, re-pick data ranges, retheme the look, click into chart elements, or use the floating "+ Chart Elements" / right-click affordances. The OOXML schema lists five independently optional `CT_Boolean` children: `<c:chartObject>`, `<c:data>`, `<c:formatting>`, `<c:selection>`, `<c:userInterface>`. Every flag defaults to `false` (action permitted); `true` locks the action.

The element sits on `<c:chartSpace>` between `<c:style>` / `<c:pivotSource>` and `<c:chart>` per CT_ChartSpace, so every chart family — pie / doughnut / bar / column / line / area / scatter — can carry it (the slot has no axis dependency, unlike `<c:dTable>`). Until now hucre's writer skipped the element entirely and the reader ignored it, so a chart copied from a locked-down template silently lost its protection on every parse → clone → write loop. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.protection);
// { formatting: true, selection: true }   ← only the flags the file pinned

// ── Write side — boolean shorthand (bare <c:protection> shell) ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      {
        type: "column",
        series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        protection: true,
      },
    ],
  }],
});

// ── Write side — object form with per-flag overrides ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      {
        type: "line",
        series: [...],
        anchor: { from: { row: 6, col: 0 } },
        // Lock the look (formatting + selection) but leave the data
        // references and on-canvas affordances untouched.
        protection: { formatting: true, selection: true },
      },
    ],
  }],
});

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  protection: { chartObject: true, data: true }, // replace wholesale
  // protection: true,                            // pin the bare shell (all flags false)
  // protection: null,                            // drop the inherited block
  // protection: false,                           // alias for null
  // protection: undefined,                       // inherit the source's parsed value
});
```

## Model

```ts
interface ChartProtection {
  chartObject?: boolean;
  data?: boolean;
  formatting?: boolean;
  selection?: boolean;
  userInterface?: boolean;
}

interface SheetChart {
  /** ...existing fields... */
  protection?: boolean | ChartProtection;
}

interface Chart {
  /** ...existing fields... */
  protection?: ChartProtection;
}

interface CloneChartOptions {
  /** ...existing fields... */
  protection?: ChartProtection | boolean | null;
}
```

The read-side `Chart.protection` always surfaces the object shape so a parsed value slots straight back into `cloneChart` without transformation. The write-side `SheetChart.protection` accepts the boolean shorthand for ergonomics — `protection: true` is equivalent to `protection: {}` and yields the same on-the-wire output (the bare `<c:protection>` shell with every flag at the OOXML default `false`).

## Behavior

- **Read** — `parseChart` pulls `<c:protection>` off `<c:chartSpace>`. Each of the five boolean children is independently optional on `CT_Protection`, so the reader only surfaces the flags the file actually pinned (mirroring how every CT_Protection child is optional). Children that are missing or carry an unknown `val` attribute drop to `undefined` for that field rather than fabricate a flag the file did not pin. The element itself is the gating signal — a `<c:protection>` block with no resolvable children surfaces as `{}` (mirroring how `dataTable` handles a malformed `<c:dTable>`), so a chart that authors the bare element round-trips literally.
- **Write** — The writer emits `<c:protection>` only when the chart pins a non-suppression value (`true` or an object); `undefined` and `false` skip the element. When emitted, all five boolean children are serialized in `CT_Protection` schema order (`chartObject`, `data`, `formatting`, `selection`, `userInterface`), each falling back to `false` for any unspecified field — the always-emit contract matches `<c:plotVisOnly>` / `<c:dispBlanksAs>` so the rendered intent is explicit on roundtrip. Stray non-boolean inputs leaking through the type guard collapse to the OOXML default `false` rather than emit a token Excel rejects.
- **Clone** — `options.protection` accepts `undefined` (inherit) / `null` (drop) / `false` (drop, alias for `null`) / `true` (pin the bare shell with every flag `false`) / object (replace wholesale, no per-field merge). Unlike `dataTable`, the resolver applies to every chart family — `<c:protection>` lives on `<c:chartSpace>` (not inside `<c:plotArea>`), so pie / doughnut clones still carry the inherited block instead of stripping it.

## Notes

Excel only enforces these flags when the host worksheet is itself protected (the chart inherits the sheet's protection boundary). On an unprotected sheet the element round-trips literally but has no observable runtime effect — it sits dormant until `<sheetProtection>` activates the lock.

Refs #136

## Test plan

- [x] `pnpm test` (lint + typecheck + vitest, 88 files, 3759 tests, all passing)
- [x] `pnpm build` (obuild, 183 files, 1.17 MB)
- [x] New `parseChart — chart-space protection` describe (10 tests) covering the fully-pinned shape, partial overrides, missing / malformed `val` attributes, the bare `<c:protection/>` element, and pie-chart roundtrip
- [x] New `writeChart — chart-space protection` describe (15 tests) covering suppression, the boolean shorthand, per-field overrides, schema-order emission, the chartSpace placement, every chart family, and writeXlsx integration
- [x] New `cloneChart — chart-space protection` describe (10 tests) covering inherit / replace / drop / coerce-into-doughnut grammar plus a full template → clone → write → re-parse loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)