### PR TITLE
feat(xlsx): chart data labels number format — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -618,6 +618,22 @@ export interface ChartDataLabels {
    * `" "`, `"; "`, `"\n"` (newline).
    */
   separator?: string;
+  /**
+   * Number format applied to the value rendered inside each data label.
+   * Mirrors Excel's "Format Data Labels -> Number" panel — pinning a
+   * `formatCode` such as `"0.00%"`, `"$#,##0.00"`, or `"#,##0"` lets a
+   * dashboard chart show currency / percent labels without the source
+   * cells carrying the format. Same shape as
+   * {@link ChartAxisNumberFormat} so a single number-format helper can
+   * thread through both the axis and the data-labels code paths.
+   *
+   * Maps to `<c:numFmt formatCode=".." sourceLinked=".."/>` inside
+   * `<c:dLbls>`. The element sits right after `<c:dLbl>` (per the
+   * `CT_DLbls` schema sequence — `dLbl* -> numFmt? -> spPr? -> txPr? ->
+   * dLblPos? -> show*`). Omit to fall back to whatever Excel inherits
+   * from the source cell formatting.
+   */
+  numberFormat?: ChartAxisNumberFormat;
 }
 
 /**
@@ -2332,6 +2348,18 @@ export interface ChartDataLabelsInfo {
   showLegendKey?: boolean;
   position?: ChartDataLabelPosition;
   separator?: string;
+  /**
+   * Mirror of {@link ChartDataLabels.numberFormat}. Surfaces the
+   * `<c:numFmt formatCode=".." sourceLinked=".."/>` parsed from the
+   * source `<c:dLbls>` block — Excel's "Format Data Labels -> Number"
+   * panel pin. Same shape as the axis-side
+   * {@link ChartAxisNumberFormat} so the parsed value can be fed
+   * straight back into {@link cloneChart} or {@link writeXlsx} without
+   * transformation. Absent when the source data-labels block has no
+   * `<c:numFmt>` element or when the parsed `formatCode` is missing /
+   * empty.
+   */
+  numberFormat?: ChartAxisNumberFormat;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -1285,6 +1285,18 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     if (text.length > 0) out.separator = text;
   }
 
+  // `<c:numFmt formatCode=".." sourceLinked=".."/>` mirrors Excel's
+  // "Format Data Labels -> Number" panel — pinning a custom number
+  // format on the rendered label values. Same shape as the axis-side
+  // `<c:numFmt>` so the parsed value can be fed straight back into
+  // {@link cloneChart}. The element sits early in the CT_DLbls
+  // sequence (after the optional `<c:dLbl>` instances), so the lookup
+  // is scoped to direct `<c:dLbls>` children — a `<c:numFmt>` nested
+  // inside a per-point `<c:dLbl>` does not leak into the block-level
+  // record.
+  const numFmt = parseDataLabelsNumberFormat(el);
+  if (numFmt) out.numberFormat = numFmt;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -1293,9 +1305,39 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     !out.showSeriesName &&
     !out.showPercent &&
     !out.showLegendKey &&
-    out.separator === undefined
+    out.separator === undefined &&
+    out.numberFormat === undefined
   ) {
     return undefined;
+  }
+  return out;
+}
+
+/**
+ * Pull `<c:numFmt formatCode=".." sourceLinked=".."/>` off a
+ * `<c:dLbls>` block. Returns `undefined` when the element is absent or
+ * when `formatCode` is missing / empty (the OOXML schema requires the
+ * attribute on every emitted `<c:numFmt>` so a fabricated empty record
+ * cannot round-trip cleanly).
+ *
+ * `sourceLinked` accepts the same OOXML truthy / falsy spellings the
+ * other boolean attributes do (`"1"` / `"true"` / `"0"` / `"false"`);
+ * absence and the OOXML default `"0"` collapse to `undefined` so the
+ * parsed shape stays minimal — only an explicit `"1"` / `"true"`
+ * surfaces `true`. Mirrors how the axis-side numFmt parser shapes its
+ * output.
+ */
+function parseDataLabelsNumberFormat(el: XmlElement): ChartAxisNumberFormat | undefined {
+  const numFmt = findChild(el, "numFmt");
+  if (!numFmt) return undefined;
+  const formatCode = numFmt.attrs.formatCode;
+  if (typeof formatCode !== "string" || formatCode.length === 0) return undefined;
+  const out: ChartAxisNumberFormat = { formatCode };
+  const sourceLinked = numFmt.attrs.sourceLinked;
+  if (typeof sourceLinked === "string") {
+    if (sourceLinked === "1" || sourceLinked.toLowerCase() === "true") {
+      out.sourceLinked = true;
+    }
   }
   return out;
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1991,6 +1991,21 @@ function buildChartLevelDataLabels(chart: SheetChart): string | undefined {
 function buildDataLabelsBody(dl: ChartDataLabels): string {
   const children: string[] = [];
 
+  // `<c:numFmt>` sits at the head of the CT_DLbls sequence (before
+  // `<c:spPr>` / `<c:txPr>` / `<c:dLblPos>` / the show* toggles). The
+  // writer skips emission entirely when the caller leaves `numberFormat`
+  // unset so a fresh chart matches Excel's reference shape (no number
+  // override means Excel inherits from the source cells).
+  const numFmt = resolveDataLabelsNumberFormat(dl.numberFormat);
+  if (numFmt) {
+    children.push(
+      xmlSelfClose("c:numFmt", {
+        formatCode: numFmt.formatCode,
+        sourceLinked: numFmt.sourceLinked === true ? 1 : 0,
+      }),
+    );
+  }
+
   if (dl.position) {
     children.push(xmlSelfClose("c:dLblPos", { val: dl.position }));
   }
@@ -2011,6 +2026,32 @@ function buildDataLabelsBody(dl: ChartDataLabels): string {
   }
 
   return xmlElement("c:dLbls", undefined, children);
+}
+
+/**
+ * Resolve the `<c:numFmt>` value emitted inside `<c:dLbls>`.
+ *
+ * Returns `undefined` when the caller leaves `numberFormat` unset or
+ * when `formatCode` is missing / non-string / empty — the OOXML schema
+ * requires `formatCode` on every emitted `<c:numFmt>` so a malformed
+ * record is dropped rather than fabricate a placeholder Excel rejects.
+ * Mirrors how the axis-side number-format pipeline shapes its output
+ * so a parsed value can flow straight from the read side back into the
+ * write side without transformation.
+ *
+ * `sourceLinked` is normalized to a literal boolean — only `true`
+ * survives, every other shape (`undefined` / `false` / non-boolean)
+ * collapses so the writer's `val` attribute defaults to `0`.
+ */
+function resolveDataLabelsNumberFormat(
+  value: ChartAxisNumberFormat | undefined,
+): ChartAxisNumberFormat | undefined {
+  if (!value) return undefined;
+  const formatCode = value.formatCode;
+  if (typeof formatCode !== "string" || formatCode.length === 0) return undefined;
+  const out: ChartAxisNumberFormat = { formatCode };
+  if (value.sourceLinked === true) out.sourceLinked = true;
+  return out;
 }
 
 // ── Legend ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4839,6 +4839,209 @@ describe("cloneChart — data labels showLegendKey", () => {
   });
 });
 
+// ── cloneChart — data labels numberFormat ───────────────────────────
+
+describe("cloneChart — data labels numberFormat", () => {
+  const sourceWithNumFmt: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    dataLabels: { showValue: true, numberFormat: { formatCode: "0.00%" } },
+  };
+
+  it("inherits chart-level numberFormat from the source by default", () => {
+    const clone = cloneChart(sourceWithNumFmt, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+  });
+
+  it("drops the inherited numberFormat when chart-level dataLabels override is null", () => {
+    const clone = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("replaces the dataLabels block wholesale, dropping the inherited numberFormat", () => {
+    const clone = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showCategoryName: true },
+    });
+    // Wholesale replacement — the inherited numberFormat does not bleed
+    // through the override.
+    expect(clone.dataLabels).toEqual({ showCategoryName: true });
+  });
+
+  it("can pin numberFormat via a chart-level dataLabels override", () => {
+    const noFmt: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, numberFormat: { formatCode: "$#,##0" } },
+    });
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "$#,##0" });
+  });
+
+  it("inherits per-series numberFormat from the source series", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, numberFormat: { formatCode: "0.00" } },
+        },
+      ],
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].dataLabels).toEqual({
+      showValue: true,
+      numberFormat: { formatCode: "0.00" },
+    });
+  });
+
+  it("drops the per-series numberFormat when the override is null", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, numberFormat: { formatCode: "0.00" } },
+        },
+      ],
+    };
+    const clone = cloneChart(src, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ dataLabels: null }],
+    });
+    expect(clone.series[0].dataLabels).toBeUndefined();
+  });
+
+  it("replaces per-series dataLabels via seriesOverrides, dropping the inherited numberFormat", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, numberFormat: { formatCode: "0.00" } },
+        },
+      ],
+    };
+    const clone = cloneChart(src, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ dataLabels: { showCategoryName: true } }],
+    });
+    // Wholesale replacement — the inherited numberFormat does not bleed
+    // through.
+    expect(clone.series[0].dataLabels).toEqual({ showCategoryName: true });
+  });
+
+  it("composes numberFormat alongside other dataLabels fields", () => {
+    const src: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      dataLabels: {
+        showValue: true,
+        showCategoryName: true,
+        position: "outEnd",
+        separator: " | ",
+        numberFormat: { formatCode: "0.00%", sourceLinked: true },
+      },
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toEqual({
+      showValue: true,
+      showCategoryName: true,
+      position: "outEnd",
+      separator: " | ",
+      numberFormat: { formatCode: "0.00%", sourceLinked: true },
+    });
+  });
+
+  it("carries numberFormat through a chart-type coercion (bar -> line)", () => {
+    const lineClone = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(lineClone.type).toBe("line");
+    expect(lineClone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves numberFormat", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00%" sourceLinked="0"/>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const dLbls = written.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:numFmt formatCode="0.00%" sourceLinked="0"/>');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with numberFormat intact", async () => {
+    const clone = cloneChart(sourceWithNumFmt, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const dLbls = written.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:numFmt formatCode="0.00%" sourceLinked="0"/>');
+  });
+});
+
 // ── cloneChart — axis noMultiLvlLbl ─────────────────────────────────
 
 describe("cloneChart — axis noMultiLvlLbl", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4408,6 +4408,243 @@ describe("writeChart — data labels showLegendKey", () => {
   });
 });
 
+// ── writeChart — data labels numberFormat ────────────────────────────
+
+describe("writeChart — data labels numberFormat", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("emits <c:numFmt> inside <c:dLbls> when chart-level numberFormat is set", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, numberFormat: { formatCode: "0.00%" } } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:numFmt formatCode="0.00%" sourceLinked="0"/>');
+  });
+
+  it('emits sourceLinked="1" when sourceLinked=true is pinned', () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          numberFormat: { formatCode: "General", sourceLinked: true },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:numFmt formatCode="General" sourceLinked="1"/>');
+  });
+
+  it('defaults sourceLinked to "0" when the field is omitted', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, numberFormat: { formatCode: "$#,##0.00" } } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:numFmt formatCode="$#,##0.00" sourceLinked="0"/>');
+  });
+
+  it("skips emitting <c:numFmt> when numberFormat is unset", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:numFmt");
+  });
+
+  it("skips emitting <c:numFmt> when formatCode is missing or empty", () => {
+    const noCode = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          numberFormat: { formatCode: undefined as unknown as string },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dLblsOf(noCode.chartXml)).not.toContain("<c:numFmt");
+    const empty = writeChart(
+      makeChart({ dataLabels: { showValue: true, numberFormat: { formatCode: "" } } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(empty.chartXml)).not.toContain("<c:numFmt");
+  });
+
+  it("places <c:numFmt> at the head of the CT_DLbls sequence (before <c:dLblPos> and the show* toggles)", () => {
+    // CT_DLbls schema sequence: dLbl* -> numFmt? -> spPr? -> txPr? ->
+    // dLblPos? -> showLegendKey -> showVal -> ...
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          position: "outEnd",
+          showLegendKey: true,
+          numberFormat: { formatCode: "0.00%" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const numFmtIdx = dLbls.indexOf("<c:numFmt");
+    const dLblPosIdx = dLbls.indexOf("<c:dLblPos");
+    const showLegKeyIdx = dLbls.indexOf("<c:showLegendKey");
+    const showValIdx = dLbls.indexOf("<c:showVal");
+    expect(numFmtIdx).toBeGreaterThan(0);
+    expect(numFmtIdx).toBeLessThan(dLblPosIdx);
+    expect(dLblPosIdx).toBeLessThan(showLegKeyIdx);
+    expect(showLegKeyIdx).toBeLessThan(showValIdx);
+  });
+
+  it("threads numberFormat through a series-level <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({
+        series: [
+          {
+            name: "S1",
+            values: "B2:B4",
+            dataLabels: { showValue: true, numberFormat: { formatCode: "0.0" } },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const serStart = xml.indexOf("<c:ser>");
+    const serEnd = xml.indexOf("</c:ser>");
+    const inner = xml.slice(serStart, serEnd);
+    expect(inner).toContain('<c:numFmt formatCode="0.0" sourceLinked="0"/>');
+  });
+
+  it("threads numberFormat through pie / line / scatter chart families", () => {
+    for (const type of ["pie", "line", "scatter"] as const) {
+      const result = writeChart(
+        makeChart({
+          type,
+          dataLabels: { showValue: true, numberFormat: { formatCode: "0.00%" } },
+        }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('<c:numFmt formatCode="0.00%" sourceLinked="0"/>');
+    }
+  });
+
+  it("emits exactly one <c:numFmt> per data-labels block", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, numberFormat: { formatCode: "0.00" } } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect((dLbls.match(/<c:numFmt/g) ?? []).length).toBe(1);
+  });
+
+  it("escapes XML-special characters in the formatCode attribute", () => {
+    // Format codes legitimately contain `<`, `>`, `&`, `"` — e.g.
+    // accounting formats and conditional brackets like
+    // `[<=9999999]###-####;(###) ###-####`. The writer must emit
+    // them through the standard XML attribute escape path.
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          numberFormat: { formatCode: '[<=9999999]"$"#,##0' },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("&lt;");
+    expect(dLbls).toContain("&quot;");
+  });
+
+  it("collapses non-string formatCode inputs to no emission", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          numberFormat: { formatCode: 42 as unknown as string },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:numFmt");
+  });
+
+  it("collapses non-boolean sourceLinked inputs to the default 0", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          numberFormat: {
+            formatCode: "0.00",
+            sourceLinked: "yes" as unknown as boolean,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:numFmt formatCode="0.00" sourceLinked="0"/>');
+  });
+
+  it("round-trips a chart with numberFormat through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, numberFormat: { formatCode: "0.00%" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+    expect(reparsed?.dataLabels?.showValue).toBe(true);
+  });
+
+  it("round-trips numberFormat with sourceLinked=true through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          numberFormat: { formatCode: "General", sourceLinked: true },
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.numberFormat).toEqual({
+      formatCode: "General",
+      sourceLinked: true,
+    });
+  });
+
+  it("end-to-end: writeXlsx packages a chart with numberFormat into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, numberFormat: { formatCode: "$#,##0" } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const dLbls = chartXml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:numFmt formatCode="$#,##0" sourceLinked="0"/>');
+  });
+});
+
 // ── writeChart — axis noMultiLvlLbl ──────────────────────────────────
 
 describe("writeChart — axis noMultiLvlLbl", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5237,6 +5237,257 @@ describe("parseChart — data labels showLegendKey", () => {
   });
 });
 
+// ── parseChart — data labels numberFormat ──────────────────────────
+
+describe("parseChart — data labels numberFormat", () => {
+  const NS_NF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces numberFormat from a chart-level <c:dLbls><c:numFmt>", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="0.00%" sourceLinked="0"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+  });
+
+  it("surfaces sourceLinked=true when the OOXML attribute is pinned to 1", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="General" sourceLinked="1"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toEqual({
+      formatCode: "General",
+      sourceLinked: true,
+    });
+  });
+
+  it('accepts the OOXML truthy spelling sourceLinked="true"', () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="0.0" sourceLinked="true"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toEqual({
+      formatCode: "0.0",
+      sourceLinked: true,
+    });
+  });
+
+  it('collapses the OOXML default sourceLinked="0" to undefined', () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="$#,##0.00" sourceLinked="0"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "$#,##0.00" });
+  });
+
+  it("collapses absence of <c:numFmt> to undefined", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toBeUndefined();
+  });
+
+  it("returns undefined when <c:numFmt> is missing the formatCode attribute", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt sourceLinked="0"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toBeUndefined();
+  });
+
+  it("returns undefined for empty formatCode strings", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="" sourceLinked="0"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toBeUndefined();
+  });
+
+  it("makes numberFormat alone enough to surface a dataLabels record", () => {
+    // The number format pin is meaningful even without any show* toggle —
+    // Excel still applies it to a per-series label override that turns
+    // the labels on. The reader must not collapse the block to undefined
+    // when the only pinned field is the numFmt.
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="0.00%" sourceLinked="0"/>
+        <c:showLegendKey val="0"/>
+        <c:showVal val="0"/>
+        <c:showCatName val="0"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="0"/>
+        <c:showBubbleSize val="0"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({ numberFormat: { formatCode: "0.00%" } });
+  });
+
+  it("surfaces numberFormat on a series-level <c:dLbls>", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:tx><c:v>Revenue</c:v></c:tx>
+        <c:dLbls>
+          <c:numFmt formatCode="$#,##0" sourceLinked="0"/>
+          <c:dLblPos val="ctr"/>
+          <c:showVal val="1"/>
+        </c:dLbls>
+        <c:val><c:numRef><c:f>S!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].dataLabels).toEqual({
+      position: "ctr",
+      showValue: true,
+      numberFormat: { formatCode: "$#,##0" },
+    });
+  });
+
+  it("co-surfaces numberFormat alongside other dataLabels fields", () => {
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="0.00%" sourceLinked="0"/>
+        <c:dLblPos val="bestFit"/>
+        <c:showLegendKey val="1"/>
+        <c:showVal val="0"/>
+        <c:showCatName val="1"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="1"/>
+        <c:showBubbleSize val="0"/>
+        <c:separator>; </c:separator>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({
+      position: "bestFit",
+      showLegendKey: true,
+      showCategoryName: true,
+      showPercent: true,
+      separator: "; ",
+      numberFormat: { formatCode: "0.00%" },
+    });
+  });
+
+  it("does not leak a per-point <c:dLbl><c:numFmt> into the block-level record", () => {
+    // The CT_DLbls schema allows a `<c:numFmt>` to live inside a
+    // per-point `<c:dLbl>` as well as at the block level. The reader
+    // scopes its lookup to direct `<c:dLbls>` children so only the
+    // block-level pin surfaces — a per-point override on a single data
+    // point cannot pollute the chart-level record.
+    const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:dLbl>
+          <c:idx val="0"/>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:showVal val="1"/>
+        </c:dLbl>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.numberFormat).toBeUndefined();
+  });
+
+  it("threads numberFormat through line / pie / scatter chart families", () => {
+    const families = [
+      ["lineChart", "line"],
+      ["pieChart", "pie"],
+      ["scatterChart", "scatter"],
+    ] as const;
+    for (const [tag] of families) {
+      const xml = `<c:chartSpace ${NS_NF}>
+  <c:chart><c:plotArea>
+    <c:${tag}>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="0.00%" sourceLinked="0"/>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:${tag}>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      const chart = parseChart(xml);
+      expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00%" });
+    }
+  });
+});
+
 // ── parseChart — axis noMultiLvlLbl ────────────────────────────────
 
 describe("parseChart — axis noMultiLvlLbl", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:numFmt formatCode=".." sourceLinked=".."/>` at the read, write, and clone layers so a template's data-label number format survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:numFmt>` inside `<c:dLbls>` mirrors Excel's "Format Data Labels -> Number" panel — pinning a custom format string (`"0.00%"`, `"$#,##0.00"`, `"#,##0"`, etc.) on the rendered label values. Until now hucre's writer skipped the element entirely and the reader ignored it, so a dashboard template that pinned currency / percent labels lost the format on every parse -> clone -> write loop.

Reuses the existing `ChartAxisNumberFormat` shape so a single number-format helper can thread through both the axis and the data-labels code paths — the write-side `ChartDataLabels.numberFormat` and the read-side `ChartDataLabelsInfo.numberFormat` share field semantics with `ChartAxisInfo.numberFormat`, so a parsed value flows straight back into the writer / clone without transformation. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.dataLabels?.numberFormat);
// { formatCode: "0.00%" }   ← when the template pinned a percent format

// Per-series override surfaces on ChartSeriesInfo.dataLabels:
console.log(source.series?.[0].dataLabels?.numberFormat);
// { formatCode: "$#,##0", sourceLinked: false }

// ── Write side — chart-level ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      {
        type: "column",
        series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        dataLabels: {
          showValue: true,
          numberFormat: { formatCode: "$#,##0" },
        },
      },
    ],
  }],
});

// ── Write side — sourceLinked=true (Excel inherits the source cell format) ──
dataLabels: {
  showValue: true,
  numberFormat: { formatCode: "General", sourceLinked: true },
}

// ── Write side — per-series override ──
series: [
  {
    name: "Margin",
    values: "B2:B6",
    dataLabels: {
      showValue: true,
      numberFormat: { formatCode: "0.00%" },
    },
  },
],

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  // dataLabels: undefined            // inherit the parsed numberFormat
  // dataLabels: null                 // drop the inherited block (and its numFmt)
  // dataLabels: { showValue: true,
  //   numberFormat: { formatCode: "0.00%" } }  // wholesale replace
});
```

## Model

```ts
interface ChartDataLabels {
  // ...existing fields...
  numberFormat?: ChartAxisNumberFormat;
}

interface ChartDataLabelsInfo {
  // ...existing fields...
  numberFormat?: ChartAxisNumberFormat;
}
```

The read-side `ChartDataLabelsInfo.numberFormat` mirrors the write-side `ChartDataLabels.numberFormat` so a parsed value slots straight back into `cloneChart` without transformation. Same shape as the existing axis-side `ChartAxisInfo.numberFormat` — the writer / parser / clone all reuse the existing `ChartAxisNumberFormat` interface (`{ formatCode: string; sourceLinked?: boolean }`).

## Behavior

- **Read** — `parseChart` pulls the value off `<c:dLbls><c:numFmt formatCode=".." sourceLinked=".."/>`. `formatCode` is required; absence of the element, missing / non-string / empty `formatCode` all collapse to `undefined` so a malformed pin cannot fabricate a record. `sourceLinked` accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); absence and the OOXML default `"0"` collapse to `undefined` so absence and the default round-trip identically. The lookup is scoped to direct `<c:dLbls>` children — a `<c:numFmt>` nested inside a per-point `<c:dLbl>` does not leak into the block-level record. The `numberFormat` field alone is enough to surface a `dataLabels` record (Excel still applies the format pin even when no `show*` toggle is on, since a series-level override can flip the labels on without restating the format).
- **Write** — `<c:numFmt>` sits at the head of the CT_DLbls sequence (before `<c:dLblPos>` and the show* toggles). The writer skips emission entirely when `numberFormat` is unset / `formatCode` is missing / non-string / empty, so a fresh chart matches Excel's reference shape (no override means Excel inherits from the source cells). `sourceLinked` is normalized to a literal boolean — only `true` survives, every other shape (`undefined` / `false` / non-boolean) defaults to `val="0"`. Format codes are emitted through the standard XML attribute escape path so accounting / conditional formats containing `<`, `>`, `&`, `"` round-trip cleanly.
- **Clone** — Lives inside the existing `dataLabels` clone grammar (chart-level: `undefined` inherits / `null` drops / object replaces wholesale; per-series: `undefined` inherits / `null` drops / `false` suppresses / object replaces wholesale). The inherited block carries `numberFormat` through automatically because `ChartDataLabelsInfo` and `ChartDataLabels` share the same field semantics — no separate helper needed.

## Edge cases

- A chart with no `<c:numFmt>` element parses to `numberFormat: undefined`.
- Empty / missing `formatCode` collapses to no emission rather than fabricate an attribute Excel rejects.
- A per-point `<c:dLbl><c:numFmt>` does not leak into the block-level record — the lookup is scoped to direct `<c:dLbls>` children.
- Non-string `formatCode` and non-boolean `sourceLinked` inputs collapse safely (no emission / `val="0"` default).
- The element is emitted exactly once per `<c:dLbls>` block — both chart-level and series-level can carry their own pin independently.
- All chart families (bar / column / line / pie / doughnut / area / scatter) support the field identically because `<c:dLbls>` is shared across every chart-type element.
- Format codes containing XML-special characters (e.g. `[<=9999999]"$"#,##0`) are escaped through the standard XML attribute path.
- Clone-through respects the wholesale `dataLabels` override — pinning a new `dataLabels` block on the clone drops the inherited `numberFormat` along with the rest of the parsed shape, matching how the existing `showLegendKey` / `position` / `separator` fields handle the override.

## Test plan

- [x] `pnpm vitest run --dir=test` (88 files / 3761 tests in worktree) passes.
- [x] `pnpm lint` and `pnpm typecheck` pass with no new errors.
- [x] `pnpm build` succeeds.
- [x] 11 new `parseChart` tests cover the truthy / falsy `sourceLinked` spellings, default collapse, missing `formatCode`, missing element, empty `formatCode`, surfacing-as-only-field guard, series-level threading, multi-family threading (line / pie / scatter), composition with other dLbls fields, and per-point `<c:dLbl>` scoping.
- [x] 14 new `writeChart` tests cover the default emit, `sourceLinked` true / false threading, OOXML element ordering (`numFmt` before `dLblPos` / show*), exactly-one-emit guard, missing-numberFormat / empty-formatCode / non-string-formatCode suppression, multi-family threading (pie / line / scatter), series-level threading, XML escaping for format codes with special characters, non-boolean `sourceLinked` fallback, parse-side round-trip (with and without `sourceLinked`), and end-to-end packaging via `writeXlsx`.
- [x] 11 new `cloneChart` tests cover inherit / null / wholesale-replace grammar at chart and series scope, override-pins-on-source-without-numberFormat, chart-type coercion (bar -> line), composition alongside other dLbls fields, and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)