### PR TITLE
feat(xlsx): chart-level line marker visibility — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,19 @@ model is a plain presence flag at this layer); absence collapses to
 `CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` per the OOXML
 schema; a stray `<c:upDownBars>` on a bar / column / pie / doughnut /
 area / scatter chart is ignored.
+`Chart.showLineMarkers` surfaces the chart-level marker visibility
+flag pulled from `<c:lineChart><c:marker val=".."/></c:lineChart>` —
+Excel's "Line vs. Line with Markers" chart-type distinction. The flag
+gates whether per-series markers paint at all on a line chart;
+per-series `<c:marker>` blocks (CT_Marker, with `<c:symbol>` /
+`<c:size>`) still pick the symbol / size / fill that paints when the
+gate is open. The Excel-default `val="1"` and absence both collapse to
+`undefined` so absence and the default round-trip identically through
+{@link cloneChart} — only an explicit `val="0"` surfaces `false`. The
+chart-level slot lives exclusively on `CT_LineChart` per the OOXML
+schema; `CT_Line3DChart` / `CT_StockChart` and every non-line family
+have no slot for the chart-level CT_Boolean variant, so a stray
+`<c:marker val=".."/>` on those bodies is ignored.
 Sheets that hucre actively regenerates because they
 also carry hucre-managed images currently keep the chart bodies but
 lose the in-drawing chart anchor — merging hucre's drawing output
@@ -1192,6 +1205,21 @@ omits the element on a fresh chart. Pin `upDownBars: true` on a
 every other chart family — `<c:upDownBars>` lives exclusively on
 `CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` per the OOXML
 schema, and the writer never authors the 3D / stock variants.
+The chart-level `showLineMarkers` field maps to `<c:marker val=".."/>`
+inside `<c:lineChart>` — the chart-level CT_Boolean variant that gates
+whether per-series markers paint at all on a line chart (Excel's
+"Line vs. Line with Markers" chart-type distinction). The writer
+always emits the element (Excel's reference behavior — every authored
+line chart includes one), defaulting to `val="1"` when the field is
+unset or `true`. Pin `showLineMarkers: false` to suppress markers
+chart-wide so the line renders as a clean stroke without the
+per-point dots. The flag is silently ignored on every other chart
+family — the OOXML schema places the chart-level `<c:marker>`
+exclusively on `CT_LineChart`, and `CT_Line3DChart` / `CT_StockChart`
+and every non-line family have no slot for it. Independent of any
+per-series marker styling: this gate sits at the chart level and
+decides whether markers paint, while the per-series block picks the
+symbol / size / fill that paints when the gate is open.
 The `axes.{x,y}.dispUnits` field controls the per-value-axis
 display-unit preset (`<c:valAx><c:dispUnits><c:builtInUnit val=".."/></c:dispUnits></c:valAx>`)
 — Excel's "Format Axis -> Display units" dropdown. Each numeric tick
@@ -1565,6 +1593,15 @@ whenever the resolved chart type is anything but `line` — flattening
 a stock or line template into a column / pie / doughnut / area /
 scatter clone therefore never leaks a stale up / down bars block into
 a chart-type element whose schema rejects the element.
+The chart-level `showLineMarkers` flag follows the same grammar:
+`undefined` inherits, `null` drops the inherited value (the writer
+falls back to Excel's default `<c:marker val="1"/>`), and a `boolean`
+replaces it. Like `upDownBars`, the element renders exclusively
+inside `<c:lineChart>` per the OOXML schema, so the field is silently
+dropped from the cloned `SheetChart` whenever the resolved chart
+type is anything but `line` — flattening a line template into a
+column / pie / doughnut / area / scatter clone never leaks the
+chart-level marker gate into a host that cannot carry it.
 The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
 follow the same `undefined` (inherit) / `null` (drop) / number
 (replace) grammar as `gridlines` / `scale` / `numberFormat`. The

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1257,6 +1257,37 @@ export interface SheetChart {
    */
   upDownBars?: boolean;
   /**
+   * Whether the line chart paints markers at each data point. Maps to
+   * `<c:lineChart><c:marker val=".."/></c:lineChart>` — Excel's
+   * "Line vs. Line with Markers" chart-type distinction at the
+   * chart level. The flag is the chart-level visibility gate; per-
+   * series {@link ChartSeries.marker} still picks the symbol / size /
+   * color when this gate lets markers render.
+   *
+   * Default: `true` (the Excel reference behavior — every authored
+   * line chart emits `<c:marker val="1"/>`, and hucre's writer mirrors
+   * that for back-compat with existing renders). Set `false` to
+   * suppress markers chart-wide (the "Line" preset look) — useful when
+   * a templated dashboard line chart should render as a clean stroke
+   * without the per-point dots.
+   *
+   * Only meaningful for `line` charts — the OOXML schema places
+   * `<c:marker>` (the chart-level CT_Boolean variant) exclusively on
+   * `CT_LineChart`. The `line3D` and `stock` chart-type elements have
+   * no slot for it; the writer never authors those families, so the
+   * field is silently dropped on every other chart kind (`bar` /
+   * `column` / `pie` / `doughnut` / `area` / `scatter`).
+   *
+   * The writer always emits the element so the rendered intent is
+   * explicit on roundtrip — Excel's reference serialization includes
+   * `<c:marker>` on every line chart, and matching that contract keeps
+   * the rendered shape stable. The reader collapses the default
+   * `val="1"` (and absence) to `undefined` so a fresh chart and a
+   * marker-on chart round-trip identically through {@link cloneChart};
+   * only an explicit `val="0"` surfaces `false`.
+   */
+  showLineMarkers?: boolean;
+  /**
    * Built-in chart style preset. Maps to `<c:style val=".."/>` on
    * `<c:chartSpace>` (a sibling of `<c:chart>`, not a child). Mirrors
    * Excel's "Chart Design -> Chart Styles" gallery — each integer
@@ -3214,6 +3245,33 @@ export interface Chart {
    * / area / scatter chart-type elements.
    */
   upDownBars?: boolean;
+  /**
+   * Chart-level marker visibility flag pulled from
+   * `<c:lineChart><c:marker val=".."/></c:lineChart>`. Reflects Excel's
+   * "Line vs. Line with Markers" chart-type distinction — the flag
+   * gates whether per-series markers paint at all on a line chart.
+   *
+   * Surfaces `false` only when the chart pinned `<c:marker val="0"/>`
+   * (the non-default state — the "Line" preset, no per-point dots).
+   * The Excel-default `val="1"` and absence both collapse to
+   * `undefined` so absence and the default round-trip identically
+   * through {@link cloneChart}. The reader accepts the OOXML truthy /
+   * falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown
+   * values and missing `val` attributes drop to `undefined`.
+   *
+   * Only line-flavored chart types surface the field — the OOXML
+   * schema places the chart-level `<c:marker>` (CT_Boolean) exclusively
+   * on `CT_LineChart`. `CT_Line3DChart` / `CT_StockChart` have no
+   * slot for it, and a stray `<c:marker>` on bar / column / pie /
+   * doughnut / area / scatter chart-type elements is ignored — the
+   * reader only inspects the line-flavored body.
+   *
+   * Note: this flag is independent of per-series
+   * {@link ChartSeriesInfo.marker} — the chart-level toggle gates
+   * marker rendering across every series, while the per-series block
+   * picks the symbol / size / fill that paints when the gate is open.
+   */
+  showLineMarkers?: boolean;
   /**
    * Built-in chart style preset pulled from `<c:chartSpace><c:style
    * val=".."/>`. Reflects Excel's "Chart Design -> Chart Styles"

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -316,6 +316,30 @@ export interface CloneChartOptions {
    */
   upDownBars?: boolean | null;
   /**
+   * Override `<c:lineChart><c:marker val=".."/>` (the chart-level
+   * line-marker visibility toggle).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `showLineMarkers`. `null` drops the inherited value so the writer
+   * falls back to the Excel default (`<c:marker val="1"/>` — markers
+   * shown). A `boolean` replaces it — `true` keeps markers on (matches
+   * the default), `false` flips the chart-level gate off and emits
+   * `<c:marker val="0"/>` so per-series marker definitions stop
+   * rendering chart-wide.
+   *
+   * Only meaningful when the resolved chart type is `line` — the OOXML
+   * schema places the chart-level `<c:marker>` (CT_Boolean) exclusively
+   * on `CT_LineChart`. The field is silently dropped when the clone
+   * targets any other family (so a line-template marker-off hint never
+   * leaks into a column / pie / doughnut / area / scatter clone).
+   *
+   * Independent of any per-series marker overrides — this gate sits at
+   * the chart level and decides whether markers paint at all; the
+   * per-series block then picks the symbol / size / fill that paints
+   * when the gate is open.
+   */
+  showLineMarkers?: boolean | null;
+  /**
    * Override `<c:style>` (the built-in chart style preset, 1–48).
    *
    * `undefined` (or omitted) inherits the source's parsed `style`.
@@ -910,6 +934,19 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (type === "line") {
     const resolvedUpDownBars = resolveUpDownBars(source.upDownBars, options.upDownBars);
     if (resolvedUpDownBars !== undefined) out.upDownBars = resolvedUpDownBars;
+  }
+
+  // `<c:marker>` (the chart-level CT_Boolean variant) lives exclusively
+  // on `<c:lineChart>` per the OOXML schema. Drop the flag on every
+  // other resolved type so a line-template marker-off hint never leaks
+  // into a column / pie / doughnut / area / scatter clone. Override
+  // wins over the source's parsed value.
+  if (type === "line") {
+    const resolvedShowLineMarkers = resolveShowLineMarkers(
+      source.showLineMarkers,
+      options.showLineMarkers,
+    );
+    if (resolvedShowLineMarkers !== undefined) out.showLineMarkers = resolvedShowLineMarkers;
   }
 
   // Pie and doughnut have no axes, so silently skip carrying over axis
@@ -1507,6 +1544,30 @@ function resolveProtection(
  * it during emit.
  */
 function resolveUpDownBars(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `showLineMarkers` override.
+ *
+ * `undefined` → inherit the source's parsed `showLineMarkers`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               Excel default — `<c:marker val="1"/>`, markers shown).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `upDownBars` / `dropLines` / `hiLowLines` so the
+ * chart-level line-only toggles compose the same way at the call site.
+ * `true` collapses to `undefined` on the writer side because the writer
+ * already emits `val="1"` by default; the `true` value still surfaces
+ * in the cloned `SheetChart` for symmetry with other resolve helpers,
+ * leaving the renderer to fold it back into the default during emit.
+ */
+function resolveShowLineMarkers(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -111,6 +111,7 @@ export function parseChart(xml: string): Chart | undefined {
     let dropLines: boolean | undefined;
     let hiLowLines: boolean | undefined;
     let upDownBars: boolean | undefined;
+    let showLineMarkers: boolean | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
       if (!kind) continue;
@@ -210,6 +211,18 @@ export function parseChart(xml: string): Chart | undefined {
       ) {
         upDownBars = true;
       }
+      // `<c:marker>` (the chart-level CT_Boolean variant) lives on
+      // `CT_LineChart` only — `CT_Line3DChart` and `CT_StockChart` have
+      // no slot for it per the OOXML schema. Surface the value from the
+      // first `<c:lineChart>` element so a combo chart that mixes line
+      // with another family still carries the line side's flag. The
+      // OOXML / Excel default `val="1"` collapses to `undefined` so
+      // absence and the default round-trip identically through
+      // {@link cloneChart} — only an explicit `val="0"` surfaces
+      // `false`.
+      if (showLineMarkers === undefined && kind === "line") {
+        showLineMarkers = parseShowLineMarkers(child);
+      }
       let localIndex = 0;
       for (const ser of childElements(child)) {
         if (ser.local !== "ser") continue;
@@ -244,6 +257,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (dropLines !== undefined) out.dropLines = dropLines;
     if (hiLowLines !== undefined) out.hiLowLines = hiLowLines;
     if (upDownBars !== undefined) out.upDownBars = upDownBars;
+    if (showLineMarkers !== undefined) out.showLineMarkers = showLineMarkers;
 
     const axes = parseAxes(plotArea);
     if (axes !== undefined) out.axes = axes;
@@ -2072,6 +2086,47 @@ function parseDropLines(chartTypeEl: XmlElement): boolean | undefined {
  */
 function parseHiLowLines(chartTypeEl: XmlElement): boolean | undefined {
   return findChild(chartTypeEl, "hiLowLines") ? true : undefined;
+}
+
+// ── Chart-level Marker Visibility ─────────────────────────────────
+
+/**
+ * Pull `<c:marker val=".."/>` off a `<c:lineChart>` element. This is
+ * the chart-level CT_Boolean variant of `<c:marker>` — distinct from
+ * the per-series `<c:marker>` (CT_Marker, with style / size / fill).
+ * The element gates whether per-series markers paint at all on the
+ * line chart.
+ *
+ * The OOXML / Excel default `val="1"` (markers shown) collapses to
+ * `undefined` so absence and the default round-trip identically
+ * through {@link cloneChart}; only an explicit `val="0"` surfaces
+ * `false`. Accepts the OOXML truthy / falsy spellings (`"1"` /
+ * `"true"` / `"0"` / `"false"`); unknown values, missing `val`
+ * attributes, and a missing element all drop to `undefined`.
+ *
+ * The chart-level slot lives exclusively on `CT_LineChart` per the
+ * OOXML schema — `CT_Line3DChart` and `CT_StockChart` have no
+ * chart-level marker toggle. Caller is expected to gate the lookup
+ * on the matching chart-type kind.
+ */
+function parseShowLineMarkers(lineChart: XmlElement): boolean | undefined {
+  const el = findChild(lineChart, "marker");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "0":
+    case "false":
+      return false;
+    case "1":
+    case "true":
+      // OOXML / Excel default — collapse to undefined for symmetry
+      // with the writer's `showLineMarkers` field, so a fresh chart
+      // and a marker-on chart round-trip identically.
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 // ── Bar Grouping ──────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1355,7 +1355,17 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
     children.push(buildUpDownBars());
   }
 
-  children.push(xmlSelfClose("c:marker", { val: 1 }));
+  // `<c:marker>` (the chart-level CT_Boolean variant) gates per-series
+  // marker rendering across the entire line chart. Excel's reference
+  // serialization always emits the element on every authored line chart
+  // — `val="1"` for the default "Line with Markers" look, `val="0"`
+  // for the bare "Line" preset. The writer mirrors that always-emit
+  // contract so a roundtrip preserves Excel's reference shape; only an
+  // explicit `showLineMarkers: false` flips the value to `0` to suppress
+  // the per-point dots chart-wide. `undefined` and `true` both emit
+  // `val="1"` so a fresh chart matches Excel's default render and a
+  // back-compat caller that never set the flag keeps the same output.
+  children.push(xmlSelfClose("c:marker", { val: chart.showLineMarkers === false ? 0 : 1 }));
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_CAT }));
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_VAL }));
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -7625,3 +7625,262 @@ describe("cloneChart — chart-space protection", () => {
     });
   });
 });
+
+// ── cloneChart — chart-level line marker visibility ─────────────────
+
+describe("cloneChart — showLineMarkers", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's showLineMarkers by default", () => {
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.showLineMarkers).toBe(false);
+  });
+
+  it("lets options.showLineMarkers override the source's value", () => {
+    // Source pins markers off; clone restores them with an explicit
+    // `true` (which the writer collapses to the default <c:marker val="1"/>).
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showLineMarkers: true,
+    });
+    expect(clone.showLineMarkers).toBe(true);
+  });
+
+  it("drops the inherited showLineMarkers when the override is null", () => {
+    // null collapses to the writer's default — the field disappears
+    // from the resolved SheetChart so the writer falls back to
+    // <c:marker val="1"/>.
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showLineMarkers: null,
+    });
+    expect(clone.showLineMarkers).toBeUndefined();
+  });
+
+  it("returns undefined showLineMarkers when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.showLineMarkers).toBeUndefined();
+  });
+
+  it("lets the caller flip markers off on a source that did not carry the flag", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      showLineMarkers: false,
+    });
+    expect(clone.showLineMarkers).toBe(false);
+  });
+
+  it("drops showLineMarkers on a flatten to a non-line family (line → column)", () => {
+    // The chart-level <c:marker> (CT_Boolean) only renders inside
+    // <c:lineChart>. A column clone must not surface the flag so the
+    // writer does not author it on a chart-type element whose schema
+    // rejects it.
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.showLineMarkers).toBeUndefined();
+  });
+
+  it("drops showLineMarkers on a flatten to area (CT_AreaChart has no slot)", () => {
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "area",
+    });
+    expect(clone.type).toBe("area");
+    expect(clone.showLineMarkers).toBeUndefined();
+  });
+
+  it("drops showLineMarkers on a flatten to pie / doughnut / scatter", () => {
+    const pie = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(pie.showLineMarkers).toBeUndefined();
+
+    const doughnut = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(doughnut.showLineMarkers).toBeUndefined();
+
+    const scatter = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      // scatter expects numeric ranges; pin a fresh series shape.
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(scatter.showLineMarkers).toBeUndefined();
+  });
+
+  it("ignores a stock template's stray showLineMarkers on flatten to line (read-side already drops it)", () => {
+    // The reader scopes the lookup to <c:lineChart>, so a stock
+    // template never surfaces a `showLineMarkers` field. Even if a
+    // caller fabricates one on the parsed Chart, the resolver still
+    // honours it on a line clone — confirm the line scope accepts it.
+    const stockSource: Chart = {
+      kinds: ["stock"],
+      seriesCount: 1,
+      series: [{ kind: "stock", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      // Synthetic — the reader would never emit this on a stock chart,
+      // but the resolver's contract is to honour the field on the
+      // resolved write-side family.
+      showLineMarkers: false,
+    };
+    const clone = cloneChart(stockSource, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+      series: [{ values: "Tpl!$B$2:$B$5", categories: "Tpl!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.showLineMarkers).toBe(false);
+  });
+
+  it("composes alongside other line-only chart-level toggles", () => {
+    const clone = cloneChart(
+      source({
+        dropLines: true,
+        hiLowLines: true,
+        upDownBars: true,
+        showLineMarkers: false,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dropLines).toBe(true);
+    expect(clone.hiLowLines).toBe(true);
+    expect(clone.upDownBars).toBe(true);
+    expect(clone.showLineMarkers).toBe(false);
+  });
+
+  it("propagates showLineMarkers=false into the rendered <c:lineChart> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Quarter", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+            ["Q3", 150],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:marker val="0"/>');
+
+    // Re-parsing closes the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.showLineMarkers).toBe(false);
+  });
+
+  it('emits the default <c:marker val="1"/> when both source and override are absent', async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Quarter", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:marker val="1"/>');
+    // Re-parse collapses the default back to undefined for symmetry.
+    expect(parseChart(written)?.showLineMarkers).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    // Source pins `false` (markers off); clone overrides to `null` —
+    // the rendered chart should fall back to <c:marker val="1"/> and
+    // re-parse to undefined.
+    const clone = cloneChart(source({ showLineMarkers: false }), {
+      anchor: { from: { row: 5, col: 0 } },
+      showLineMarkers: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Quarter", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:marker val="1"/>');
+    expect(written).not.toContain('<c:marker val="0"/>');
+    expect(parseChart(written)?.showLineMarkers).toBeUndefined();
+  });
+
+  it("round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const sourceWrite: SheetChart = {
+      type: "line",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      showLineMarkers: false,
+    };
+    const xml = writeChart(sourceWrite, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.showLineMarkers).toBe(false);
+
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    expect(clone.showLineMarkers).toBe(false);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Quarter", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:marker val="0"/>');
+    expect(parseChart(written)?.showLineMarkers).toBe(false);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -6674,3 +6674,255 @@ describe("writeChart — chart-space protection", () => {
     });
   });
 });
+
+// ── writeChart — chart-level line marker visibility ───────────────────
+
+describe("writeChart — showLineMarkers", () => {
+  it('emits <c:marker val="1"/> by default on a line chart (Excel reference)', () => {
+    // Excel's reference serialization for every authored line chart
+    // emits <c:marker val="1"/> — markers shown at each data point.
+    // The writer mirrors that on `showLineMarkers` undefined so a
+    // back-compat caller that never set the field keeps the same output.
+    const result = writeChart(makeChart({ type: "line" }), "Sheet1");
+    expect(result.chartXml).toContain('<c:marker val="1"/>');
+  });
+
+  it('emits <c:marker val="1"/> when showLineMarkers=true', () => {
+    const result = writeChart(makeChart({ type: "line", showLineMarkers: true }), "Sheet1");
+    expect(result.chartXml).toContain('<c:marker val="1"/>');
+  });
+
+  it('emits <c:marker val="0"/> when showLineMarkers=false', () => {
+    // The non-default state — flips the chart-level gate off so
+    // per-series marker definitions stop rendering chart-wide.
+    const result = writeChart(makeChart({ type: "line", showLineMarkers: false }), "Sheet1");
+    expect(result.chartXml).toContain('<c:marker val="0"/>');
+  });
+
+  it("emits <c:marker> exactly once on a line chart", () => {
+    // Guard against any regression that would double-emit the element.
+    // The chart-level <c:marker> sits in CT_LineChart, not CT_LineSer —
+    // per-series <c:marker> blocks (line / scatter) live elsewhere.
+    const result = writeChart(makeChart({ type: "line", showLineMarkers: false }), "Sheet1");
+    // Filter to the chart-level <c:marker val=".."/> shape — per-series
+    // <c:marker> blocks are never authored without a child element.
+    const occurrences = result.chartXml.match(/<c:marker val="[01]"\s*\/>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("places <c:marker> after <c:upDownBars> inside <c:lineChart> (OOXML order)", () => {
+    // CT_LineChart sequence: ... ser*, dLbls?, dropLines?, hiLowLines?,
+    // upDownBars?, marker?, axId+. The schema rejects an out-of-order
+    // <c:marker> before <c:upDownBars>, so the writer must place
+    // <c:marker> after the up/down bars block when both are present.
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, showLineMarkers: false }),
+      "Sheet1",
+    );
+    const upDownBarsIdx = result.chartXml.indexOf("c:upDownBars");
+    const markerIdx = result.chartXml.indexOf('c:marker val="0"');
+    expect(upDownBarsIdx).toBeGreaterThan(0);
+    expect(markerIdx).toBeGreaterThan(0);
+    expect(upDownBarsIdx).toBeLessThan(markerIdx);
+  });
+
+  it("places <c:marker> before <c:axId> inside <c:lineChart> (OOXML order)", () => {
+    // The axId pair sits at the tail of CT_LineChart — every optional
+    // chart-level child must precede them.
+    const result = writeChart(makeChart({ type: "line", showLineMarkers: false }), "Sheet1");
+    const markerIdx = result.chartXml.indexOf('c:marker val="0"');
+    const firstAxIdIdx = result.chartXml.indexOf("c:axId");
+    expect(markerIdx).toBeLessThan(firstAxIdIdx);
+  });
+
+  it("places <c:marker> after <c:dropLines> / <c:hiLowLines> inside <c:lineChart>", () => {
+    // CT_LineChart: ... dLbls?, dropLines?, hiLowLines?, upDownBars?,
+    // marker?, axId+. <c:marker> must sit after every line-only
+    // optional block.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        dropLines: true,
+        hiLowLines: true,
+        showLineMarkers: false,
+      }),
+      "Sheet1",
+    );
+    const dropLinesIdx = result.chartXml.indexOf("c:dropLines");
+    const hiLowLinesIdx = result.chartXml.indexOf("c:hiLowLines");
+    const markerIdx = result.chartXml.indexOf('c:marker val="0"');
+    expect(dropLinesIdx).toBeLessThan(markerIdx);
+    expect(hiLowLinesIdx).toBeLessThan(markerIdx);
+  });
+
+  it("ignores showLineMarkers on bar / column / pie / doughnut / area / scatter chart kinds", () => {
+    // The OOXML schema places the chart-level <c:marker> (CT_Boolean)
+    // exclusively on CT_LineChart. Every other family must drop the
+    // flag silently — the writer never authors a <c:marker> child on
+    // <c:barChart> / <c:pieChart> / <c:doughnutChart> / <c:areaChart>
+    // / <c:scatterChart> regardless of the flag.
+    for (const type of ["bar", "column", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, showLineMarkers: false }), "Sheet1");
+      // Only per-series <c:marker> (with style/size children, used on
+      // scatter) should ever appear on these families — and column /
+      // bar / pie / doughnut / area never emit <c:marker> at all. Confirm
+      // the chart-level <c:marker val="0"/> shape never leaks here.
+      expect(result.chartXml).not.toContain('<c:marker val="0"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        showLineMarkers: false,
+      }),
+      "Sheet1",
+    );
+    // Scatter charts emit per-series <c:marker> blocks (CT_Marker with
+    // child elements), but never the chart-level CT_Boolean variant.
+    expect(scatter.chartXml).not.toContain('<c:marker val="0"/>');
+    expect(scatter.chartXml).not.toContain('<c:marker val="1"/>');
+  });
+
+  it("collapses non-boolean showLineMarkers values to the default", () => {
+    // A stray non-boolean leaking through the type guard should fall
+    // back to the default <c:marker val="1"/> rather than emit a token
+    // Excel rejects.
+    const result = writeChart(
+      makeChart({ type: "line", showLineMarkers: "off" as never }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:marker val="1"/>');
+    expect(result.chartXml).not.toContain('<c:marker val="0"/>');
+  });
+
+  it("round-trips showLineMarkers=false through parseChart", () => {
+    const written = writeChart(
+      makeChart({ type: "line", showLineMarkers: false }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.showLineMarkers).toBe(false);
+  });
+
+  it("collapses an unset showLineMarkers round-trip back to undefined", () => {
+    // A fresh line chart writes <c:marker val="1"/> (the Excel default)
+    // and re-parses to undefined — absence and the default round-trip
+    // identically per the asymmetric collapse contract.
+    const written = writeChart(makeChart({ type: "line" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.showLineMarkers).toBeUndefined();
+  });
+
+  it("collapses showLineMarkers=true round-trip back to undefined (default-state)", () => {
+    // An explicit `true` writes the same <c:marker val="1"/> the
+    // default emits, so the re-parsed value collapses to undefined for
+    // symmetry — only the non-default `false` survives the round-trip.
+    const written = writeChart(
+      makeChart({ type: "line", showLineMarkers: true }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.showLineMarkers).toBeUndefined();
+  });
+
+  it("composes with per-series marker blocks (gate vs. styling)", () => {
+    // Chart-level <c:marker val="0"/> gates rendering across every
+    // series; per-series <c:marker> still picks the symbol / size /
+    // fill. Both blocks should coexist in the output — the chart-level
+    // gate sits inside <c:lineChart>, per-series markers sit inside
+    // <c:ser>.
+    const result = writeChart(
+      makeChart({
+        type: "line",
+        series: [
+          {
+            name: "Revenue",
+            values: "B2:B4",
+            categories: "A2:A4",
+            marker: { symbol: "circle", size: 6 },
+          },
+        ],
+        showLineMarkers: false,
+      }),
+      "Sheet1",
+    );
+    // Chart-level gate.
+    expect(result.chartXml).toContain('<c:marker val="0"/>');
+    // Per-series marker block (CT_Marker with children, not CT_Boolean).
+    expect(result.chartXml).toContain('<c:symbol val="circle"/>');
+    expect(result.chartXml).toContain('<c:size val="6"/>');
+  });
+
+  it("threads showLineMarkers=false through writeXlsx end-to-end packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 100],
+          ["Q2", 200],
+          ["Q3", 150],
+        ],
+        charts: [
+          {
+            type: "line",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            showLineMarkers: false,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<c:marker val="0"/>');
+    // Re-parse the rendered chart to confirm the flag survives the
+    // packaging path.
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.showLineMarkers).toBe(false);
+  });
+
+  it("threads showLineMarkers alongside upDownBars / dropLines / hiLowLines", async () => {
+    // Compose every line-only optional block on the same chart to
+    // guard the schema-order contract end-to-end (writer → re-parse).
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Day", "High", "Low"],
+          ["Mon", 12, 5],
+          ["Tue", 14, 6],
+          ["Wed", 10, 4],
+        ],
+        charts: [
+          {
+            type: "line",
+            series: [
+              { name: "High", values: "B2:B4", categories: "A2:A4" },
+              { name: "Low", values: "C2:C4", categories: "A2:A4" },
+            ],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dropLines: true,
+            hiLowLines: true,
+            upDownBars: true,
+            showLineMarkers: false,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    // <c:dropLines> / <c:hiLowLines> are emitted bare (self-closing
+    // when XML serialization collapses an empty element); accept both
+    // shapes via a regex that does not pin the closing token.
+    expect(chartXml).toMatch(/<c:dropLines\s*\/>|<c:dropLines>/);
+    expect(chartXml).toMatch(/<c:hiLowLines\s*\/>|<c:hiLowLines>/);
+    expect(chartXml).toContain("<c:upDownBars>");
+    expect(chartXml).toContain('<c:marker val="0"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dropLines).toBe(true);
+    expect(reparsed?.hiLowLines).toBe(true);
+    expect(reparsed?.upDownBars).toBe(true);
+    expect(reparsed?.showLineMarkers).toBe(false);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -7494,3 +7494,253 @@ describe("parseChart — chart-space protection", () => {
     });
   });
 });
+
+// ── parseChart — chart-level line marker visibility ────────────────
+
+describe("parseChart — showLineMarkers", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces showLineMarkers=false when the line chart pins <c:marker val="0"/>', () => {
+    // The non-default state — flips the chart-level gate off so
+    // per-series marker definitions stop rendering chart-wide.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="0"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBe(false);
+  });
+
+  it('collapses <c:marker val="1"/> (the Excel / OOXML default) to undefined', () => {
+    // Excel's reference serialization for every authored line chart
+    // emits <c:marker val="1"/>. Surfacing only the non-default value
+    // keeps the parsed shape minimal — a fresh chart and a marker-on
+    // chart round-trip identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="1"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBeUndefined();
+  });
+
+  it("collapses absence of <c:marker> to undefined on a line chart", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBeUndefined();
+  });
+
+  it('accepts the OOXML truthy / falsy spellings ("true" / "false")', () => {
+    const xmlFalse = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="false"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xmlFalse)?.showLineMarkers).toBe(false);
+
+    const xmlTrue = xmlFalse.replace('val="false"', 'val="true"');
+    expect(parseChart(xmlTrue)?.showLineMarkers).toBeUndefined();
+  });
+
+  it("drops a missing val attribute (CT_Boolean default would be true)", () => {
+    // A bare <c:marker/> carries no `val`; per CT_Boolean the schema
+    // default would be true, but the reader collapses ambiguous shapes
+    // to undefined rather than fabricate the default state — the
+    // writer's always-emit contract means a real chart never emits a
+    // bare element.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBeUndefined();
+  });
+
+  it("drops an unknown val token rather than fabricating a value", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="maybe"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBeUndefined();
+  });
+
+  it("ignores chart-level <c:marker> on a 3D line chart (CT_Line3DChart has no slot)", () => {
+    // The OOXML schema places the chart-level <c:marker> (CT_Boolean)
+    // exclusively on CT_LineChart — CT_Line3DChart has no slot. A
+    // stray element on a 3D line chart-type body should not surface
+    // through `showLineMarkers`.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:line3DChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="0"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+      <c:axId val="3"/>
+    </c:line3DChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:serAx><c:axId val="3"/></c:serAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBeUndefined();
+  });
+
+  it("ignores chart-level <c:marker> on a stock chart (CT_StockChart has no slot)", () => {
+    // CT_StockChart has hiLowLines / upDownBars but no chart-level
+    // marker per the OOXML schema. A stray element should not surface.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:stockChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="0"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:stockChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBeUndefined();
+  });
+
+  it("ignores <c:marker> on bar / column / pie / doughnut / area / scatter charts", () => {
+    // The chart-level <c:marker> (CT_Boolean) only lives on
+    // CT_LineChart. The reader scopes the lookup to the matching kind
+    // — every other family falls through. Note that scatter has its
+    // own per-series <c:marker> (CT_Marker) handling, but no
+    // chart-level CT_Boolean variant.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:grouping val="clustered"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:marker val="0"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.showLineMarkers).toBeUndefined();
+  });
+
+  it("does not confuse the chart-level <c:marker> with the per-series <c:marker> block", () => {
+    // The per-series <c:marker> sits inside <c:ser> and carries
+    // CT_Marker children (<c:symbol>, <c:size>, ...). The chart-level
+    // gate sits as a sibling of <c:ser> and carries CT_Boolean's `val`
+    // attribute. The reader must not surface a per-series marker as
+    // `showLineMarkers`.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:marker><c:symbol val="circle"/><c:size val="6"/></c:marker>
+      </c:ser>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    // No chart-level <c:marker> is present — only the per-series
+    // block — so showLineMarkers must be undefined.
+    expect(chart?.showLineMarkers).toBeUndefined();
+    // Per-series marker still surfaces on the series side.
+    expect(chart?.series?.[0].marker).toMatchObject({ symbol: "circle", size: 6 });
+  });
+
+  it("co-surfaces showLineMarkers alongside other line-only chart-level fields", () => {
+    // The chart-level <c:marker> sits at the tail of CT_LineChart
+    // (after dropLines / hiLowLines / upDownBars, before axId+).
+    // Composing every line-only block on the same chart should not
+    // disturb the surfaced marker flag.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:varyColors val="0"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dropLines/>
+      <c:hiLowLines/>
+      <c:upDownBars><c:gapWidth val="150"/></c:upDownBars>
+      <c:marker val="0"/>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.showLineMarkers).toBe(false);
+    expect(chart?.dropLines).toBe(true);
+    expect(chart?.hiLowLines).toBe(true);
+    expect(chart?.upDownBars).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:lineChart><c:marker val=".."/>` (the chart-level CT_Boolean variant of CT_LineChart `<c:marker>`, ECMA-376 Part 1 §21.2.2.103) at the read, write, and clone layers so a template's "Line vs. Line with Markers" choice survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The chart-level `<c:marker>` element gates whether per-series markers paint at all on a line chart — flipping `val="0"` collapses the chart to the bare "Line" preset look, while `val="1"` (Excel's reference for every authored line chart) lets per-series CT_Marker blocks render their symbol / size / fill. Until now hucre's writer hard-coded `val="1"` and the reader ignored the element entirely, so a templated dashboard line chart that pinned `val="0"` silently re-painted markers on every parse -> clone -> write loop. This bridges another chart-level configuration gap for the dashboard composition flow tracked in #136.

Distinct from the per-series `<c:marker>` (CT_Marker, with `<c:symbol>` / `<c:size>` / `<c:spPr>` children) hucre already supports — the chart-level gate decides whether markers paint, while the per-series block picks the symbol / size / fill that paints when the gate is open.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// ── Read side ──
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.showLineMarkers);
// false   ← when the template pinned <c:marker val="0"/>
// undefined ← when the template emits the default <c:marker val="1"/> (or absence)

// ── Write side — suppress markers chart-wide ──
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [
      {
        type: "line",
        series: [{ name: "Revenue", values: "B2:B6", categories: "A2:A6" }],
        anchor: { from: { row: 6, col: 0 } },
        showLineMarkers: false,   // emits <c:marker val="0"/>
      },
    ],
  }],
});

// ── Write side — explicit on (matches Excel default behavior) ──
showLineMarkers: true            // emits <c:marker val="1"/>

// ── Write side — undefined / omitted ──
// (no field set)                 // emits <c:marker val="1"/> — back-compat
//                                // with every line chart hucre wrote before

// ── Clone-through ──
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  // showLineMarkers: undefined            // inherit the parsed value
  // showLineMarkers: null                 // drop the inherited value
  //                                       // (writer falls back to <c:marker val="1"/>)
  // showLineMarkers: false                // wholesale replace — gate off
  // showLineMarkers: true                 // explicit gate on (collapses to default on emit)
});
```

## Model

```ts
interface SheetChart {
  // ...existing fields...
  showLineMarkers?: boolean;
}

interface Chart {
  // ...existing fields...
  showLineMarkers?: boolean;
}

interface CloneChartOptions {
  // ...existing fields...
  showLineMarkers?: boolean | null;
}
```

The read-side `Chart.showLineMarkers` and write-side `SheetChart.showLineMarkers` share field semantics so a parsed value slots straight back into `cloneChart` without transformation. The clone option mirrors `upDownBars` / `dropLines` / `hiLowLines` grammar — `undefined` inherits, `null` drops the inherited value (writer falls back to default), and a `boolean` replaces.

## Behavior

- **Read** — `parseChart` pulls the value off the first `<c:lineChart>` element's `<c:marker>` child. The OOXML / Excel default `val="1"` and absence both collapse to `undefined` so absence and the default round-trip identically through `cloneChart` — only an explicit `val="0"` surfaces `false`. Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values, missing `val` attributes, and a missing element all drop to `undefined`. The lookup is scoped to `<c:lineChart>` only — `CT_Line3DChart` / `CT_StockChart` and every non-line family have no slot for the chart-level CT_Boolean variant per the OOXML schema, so a stray `<c:marker val=".."/>` on those bodies is ignored. Per-series `<c:marker>` (CT_Marker, sibling of `<c:idx>`) still surfaces through `ChartSeriesInfo.marker` — the chart-level gate and the per-series styling carry separately.
- **Write** — The writer always emits `<c:marker val="0|1"/>` inside `<c:lineChart>` (Excel's reference behavior — every authored line chart includes the element). Defaults to `val="1"` when `showLineMarkers` is unset, `true`, or any non-boolean leaking through the type guard; flips to `val="0"` only on a literal `false`. The element sits in CT_LineChart schema position — after `<c:dLbls>` / `<c:dropLines>` / `<c:hiLowLines>` / `<c:upDownBars>`, before `<c:axId>`. Silently dropped on every other chart family — the writer's `<c:barChart>` / `<c:areaChart>` / `<c:pieChart>` / `<c:doughnutChart>` / `<c:scatterChart>` builders never author the chart-level `<c:marker>` block.
- **Clone** — Lives inside the existing line-only chart-level grammar (mirrors `upDownBars` / `dropLines` / `hiLowLines`): `undefined` inherits / `null` drops / `boolean` replaces. The resolver gates the carry on the resolved write-side family — flattening a line template into a column / pie / doughnut / area / scatter clone drops the inherited flag silently so a host that cannot carry `<c:marker>` never picks one up.

## Edge cases

- A line chart with no `<c:marker>` parses to `showLineMarkers: undefined`.
- The Excel default `<c:marker val="1"/>` collapses to `undefined` so absence and the default round-trip identically; only the non-default `val="0"` survives.
- A bare `<c:marker/>` (no `val`) collapses to `undefined` — the writer always emits the attribute, so a real chart never emits the bare shape.
- Non-boolean `showLineMarkers` inputs (e.g. a stray `"off"` leaking through the type guard) collapse to the default `val="1"`.
- The chart-level `<c:marker>` (CT_Boolean) and per-series `<c:marker>` (CT_Marker, with `<c:symbol>` / `<c:size>` children) compose freely — both surface independently on parse, both emit independently on write.
- Stray `<c:marker val=".."/>` on `<c:line3DChart>` / `<c:stockChart>` / `<c:barChart>` / `<c:areaChart>` / `<c:pieChart>` / `<c:doughnutChart>` / `<c:scatterChart>` does not surface — the reader scopes the lookup to `<c:lineChart>` per the OOXML schema.
- Composes alongside other line-only chart-level toggles (`dropLines` / `hiLowLines` / `upDownBars`) — the writer respects the CT_LineChart schema sequence (`<c:marker>` sits at the tail before `<c:axId>`).

## Test plan

- [x] `pnpm vitest run --dir=test` (88 files / 3799 tests in worktree) passes.
- [x] `pnpm lint` and `pnpm typecheck` pass with no new errors.
- [x] `pnpm build` succeeds (1.18 MB / 183 files).
- [x] 11 new `parseChart` tests cover the non-default `val="0"` surface, default `val="1"` collapse, absence, OOXML truthy / falsy spellings, missing-attr / unknown-token drops, line3D / stock / bar / column / pie / doughnut / area / scatter no-slot guards, per-series-marker scope guard, and composition with other line-only chart-level fields.
- [x] 13 new `writeChart` tests cover the default emit, explicit `true` / `false` threading, exactly-one-emit guard, OOXML schema-order placement (`<c:marker>` after `<c:upDownBars>` / `<c:dropLines>` / `<c:hiLowLines>`, before `<c:axId>`), bar / column / pie / doughnut / area / scatter no-emit guards, non-boolean fallback, parse-side round-trip (false / undefined / true), per-series marker composition, and end-to-end packaging via `writeXlsx` (alone and alongside every line-only optional block).
- [x] 13 new `cloneChart` tests cover inherit / null / wholesale-replace grammar, override-on-source-without-flag, line → column / area / pie / doughnut / scatter flatten guards, stock → line carry, composition with other line-only toggles, and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)