### PR TITLE
feat(xlsx): chart series lines — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,6 +890,16 @@ presence surfaces `true`, absence collapses to `undefined`. The
 element has no slot on `<c:areaChart>` / `<c:area3DChart>` per the
 OOXML schema, so the reader ignores it on those parents and on every
 non-line / non-stock family.
+`Chart.serLines` surfaces the chart-type-level `<c:serLines/>` flag on
+the first `<c:barChart>` / `<c:ofPieChart>` element — Excel's "Add
+Chart Element → Lines → Series Lines" toggle (connector lines drawn
+between paired data points across consecutive series in a stacked bar
+/ column chart). Same bare-element shape as `dropLines` / `hiLowLines`:
+presence surfaces `true`, absence collapses to `undefined`. The reader
+does not surface `serLines` for chart families whose OOXML schema
+rejects the element (line / pie / doughnut / area / scatter / stock /
+radar / surface / bubble) — a stray element on those parents is
+ignored.
 `ChartSeriesInfo.smooth` surfaces the per-series
 `<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
 Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
@@ -1180,6 +1190,21 @@ schema, so the area writer ignores `hiLowLines` entirely; same for
 bar / column / pie / doughnut / scatter. The two flags compose freely
 on a line chart and the writer pins `<c:dropLines>` before
 `<c:hiLowLines>` to honour the CT_LineChart sequence.
+The chart-level `serLines` field maps to a bare `<c:serLines/>` inside
+`<c:barChart>` — Excel's "Add Chart Element → Lines → Series Lines"
+toggle (connector lines between paired data points across consecutive
+series in a stacked bar / column chart). Same default and emit grammar
+as `dropLines` / `hiLowLines`: only literal `true` emits the element;
+`false`, absence, and non-boolean inputs all drop to the default. The
+flag is silently ignored on chart families whose schema rejects
+`<c:serLines>` (line / pie / doughnut / area / scatter). Excel only
+renders the connectors on the `stacked` / `percentStacked` groupings,
+but the writer honours the toggle on a clustered chart too — the
+element pins, the renderer paints nothing (matches Excel's own
+behavior when the toggle is flipped on a clustered chart). The writer
+slots `<c:serLines>` after `<c:overlap>` (when emitted on a stacked
+chart) and before the first `<c:axId>` to honour the CT_BarChart
+sequence.
 The chart-level `upDownBars` field maps to `<c:upDownBars>` inside
 `<c:lineChart>` — Excel's "Add Chart Element -> Up/Down Bars" toggle
 on a line chart. The element paints a vertical bar at each category
@@ -1565,6 +1590,17 @@ whenever the resolved chart type is anything but `line` — flattening
 a stock or line template into a column / pie / doughnut / area /
 scatter clone therefore never leaks a stale up / down bars block into
 a chart-type element whose schema rejects the element.
+The chart-level `serLines` flag follows the same `undefined` (inherit)
+/ `null` (drop) / `boolean` (replace) grammar as the other connector-
+line toggles. An override of `false` is equivalent to `null` — the
+writer treats both as the OOXML default of no element. The element
+renders inside `<c:barChart>` so the field is silently dropped from
+the cloned `SheetChart` whenever the resolved chart type is anything
+other than `bar` / `column` — flattening a stacked-bar template into a
+line / area / pie / doughnut / scatter clone therefore never leaks the
+series-line connectors into a chart-type element whose schema rejects
+the element. The flag does carry through the bar ↔ column coercion
+unchanged (both write to `<c:barChart>` with a different `barDir`).
 The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
 follow the same `undefined` (inherit) / `null` (drop) / number
 (replace) grammar as `gridlines` / `scale` / `numberFormat`. The

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1073,6 +1073,28 @@ export interface SheetChart {
    */
   hiLowLines?: boolean;
   /**
+   * Whether the chart paints `<c:serLines>` — connector lines drawn
+   * between paired data points across consecutive series in a stacked
+   * bar / column chart. Mirrors Excel's "Add Chart Element -> Lines ->
+   * Series Lines" toggle (visible only on stacked / 100% stacked bar
+   * and column charts).
+   *
+   * Default: `false` (no series lines, Excel's reference serialization).
+   * Set `true` to emit `<c:serLines/>` on the chart-type element so
+   * Excel paints the connectors.
+   *
+   * The OOXML schema places `<c:serLines>` exclusively on
+   * `<c:barChart>` and `<c:ofPieChart>`. Hucre's writer authors
+   * `<c:barChart>` only, so the flag is silently ignored on every
+   * other chart kind (`line` / `pie` / `doughnut` / `area` /
+   * `scatter`). Excel only renders the connectors on the
+   * `stacked` / `percentStacked` groupings — a clustered chart with
+   * `serLines: true` still pins the element but Excel paints nothing
+   * (matches Excel's own behavior when the toggle is flipped on a
+   * clustered chart).
+   */
+  serLines?: boolean;
+  /**
    * Doughnut hole size as a percentage of the outer radius. Accepted
    * range: 10 – 90 (Excel's UI clamps values outside this band).
    * Default: `50` — the Excel default. Ignored for non-doughnut chart
@@ -3068,6 +3090,21 @@ export interface Chart {
    * `undefined` on every other chart family.
    */
   hiLowLines?: boolean;
+  /**
+   * Series-lines flag pulled from the first `<c:barChart>` /
+   * `<c:ofPieChart>` element's `<c:serLines/>` child. Reflects Excel's
+   * "Add Chart Element -> Lines -> Series Lines" toggle — connector
+   * lines drawn between paired data points across consecutive series in
+   * a stacked bar / column chart. Like `<c:dropLines>` /
+   * `<c:hiLowLines>`, the element is bare — its mere presence paints
+   * the connectors, so this field surfaces `true` when the element is
+   * present and `undefined` when it is absent.
+   *
+   * The OOXML schema places `<c:serLines>` exclusively on
+   * `<c:barChart>` and `<c:ofPieChart>`. Surfaces `undefined` on every
+   * other chart family.
+   */
+  serLines?: boolean;
   /**
    * Chart-level data label defaults parsed from the first chart-type
    * element's `<c:dLbls>` block. Series-level overrides on

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -194,6 +194,16 @@ export interface CloneChartOptions {
    */
   hiLowLines?: boolean | null;
   /**
+   * Override `SheetChart.serLines`. `undefined` (or omitted) inherits
+   * the source's parsed flag; `null` drops the inherited value (the
+   * writer falls back to the OOXML default of no `<c:serLines>`); a
+   * `boolean` replaces it. Only meaningful when the resolved chart type
+   * is `bar` or `column`; silently dropped on every other family
+   * (`<c:serLines>` has no slot on `<c:lineChart>` / `<c:areaChart>` /
+   * `<c:pieChart>` / `<c:scatterChart>` per OOXML).
+   */
+  serLines?: boolean | null;
+  /**
    * Override `SheetChart.holeSize` (only meaningful for `doughnut`).
    * When the resolved chart type is not `doughnut`, the field is
    * dropped from the output so it does not leak into a cloned pie or
@@ -798,6 +808,19 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (type === "line") {
     const hiLowLines = resolveHiLowLines(source.hiLowLines, options.hiLowLines);
     if (hiLowLines !== undefined) out.hiLowLines = hiLowLines;
+  }
+
+  // `<c:serLines>` lives on `<c:barChart>` / `<c:ofPieChart>` per the
+  // OOXML schema. Hucre's writer authors `<c:barChart>` only (`bar` /
+  // `column` from the public `SheetChart.type` enum both resolve to
+  // `<c:barChart>`), so the flag carries through bar / column
+  // resolutions and is dropped on every other family — coercing a
+  // stacked-bar template into a line / pie / area clone therefore
+  // never leaks the connector lines into a chart kind whose schema
+  // rejects the element.
+  if (type === "bar" || type === "column") {
+    const serLines = resolveSerLines(source.serLines, options.serLines);
+    if (serLines !== undefined) out.serLines = serLines;
   }
 
   // Doughnut hole size only makes sense when the resolved type is
@@ -1594,6 +1617,24 @@ function resolveDropLines(
  * no slot on `<c:areaChart>`.
  */
 function resolveHiLowLines(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    return sourceValue === true ? true : undefined;
+  }
+  if (override === null) return undefined;
+  return override === true ? true : undefined;
+}
+
+/**
+ * Resolve a `serLines` override. Mirrors {@link resolveDropLines} /
+ * {@link resolveHiLowLines}; the only difference is the per-family
+ * scope — `<c:serLines>` has no slot on `<c:lineChart>` /
+ * `<c:areaChart>` / `<c:pieChart>` / `<c:doughnutChart>` /
+ * `<c:scatterChart>`.
+ */
+function resolveSerLines(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -110,6 +110,7 @@ export function parseChart(xml: string): Chart | undefined {
     let scatterStyle: ChartScatterStyle | undefined;
     let dropLines: boolean | undefined;
     let hiLowLines: boolean | undefined;
+    let serLines: boolean | undefined;
     let upDownBars: boolean | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
@@ -196,6 +197,14 @@ export function parseChart(xml: string): Chart | undefined {
       if (hiLowLines === undefined && (kind === "line" || kind === "line3D" || kind === "stock")) {
         hiLowLines = parseHiLowLines(child);
       }
+      // `<c:serLines>` lives on `<c:barChart>` / `<c:ofPieChart>` per
+      // the OOXML schema. Hucre's writer authors `<c:barChart>` only,
+      // but a parsed of-pie template carrying the element should
+      // round-trip the flag too. Same bare-element shape as
+      // `<c:dropLines>` / `<c:hiLowLines>`.
+      if (serLines === undefined && (kind === "bar" || kind === "ofPie")) {
+        serLines = parseSerLines(child);
+      }
       // `<c:upDownBars>` lives on `CT_LineChart`, `CT_Line3DChart`, and
       // `CT_StockChart` per the OOXML schema. Surface the flag from the
       // first line-flavored chart-type element that carries one — the
@@ -243,6 +252,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (scatterStyle !== undefined) out.scatterStyle = scatterStyle;
     if (dropLines !== undefined) out.dropLines = dropLines;
     if (hiLowLines !== undefined) out.hiLowLines = hiLowLines;
+    if (serLines !== undefined) out.serLines = serLines;
     if (upDownBars !== undefined) out.upDownBars = upDownBars;
 
     const axes = parseAxes(plotArea);
@@ -2114,6 +2124,23 @@ function parseDropLines(chartTypeEl: XmlElement): boolean | undefined {
  */
 function parseHiLowLines(chartTypeEl: XmlElement): boolean | undefined {
   return findChild(chartTypeEl, "hiLowLines") ? true : undefined;
+}
+
+/**
+ * Pull `<c:serLines/>` off a `<c:barChart>` / `<c:ofPieChart>` element.
+ * Same on/off shape as {@link parseDropLines} / {@link parseHiLowLines};
+ * the element is bare so its mere presence surfaces `true`, absence
+ * collapses to `undefined`.
+ *
+ * `<c:serLines>` is structurally a `CT_ChartLines` and may carry a
+ * nested `<c:spPr>` for stroke styling, but hucre's reader only
+ * surfaces the on/off bit at this layer (mirrors how `parseDropLines`
+ * handles the same shape on its hosts). Even when the nested `<c:spPr>`
+ * is the only child, the presence flag still survives, which is what
+ * {@link cloneChart} needs.
+ */
+function parseSerLines(chartTypeEl: XmlElement): boolean | undefined {
+  return findChild(chartTypeEl, "serLines") ? true : undefined;
 }
 
 // ── Bar Grouping ──────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1179,6 +1179,20 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
     children.push(xmlSelfClose("c:overlap", { val: emitOverlap }));
   }
 
+  // CT_BarChart sequence places `<c:serLines>` between `<c:overlap>`
+  // and `<c:axId>`. The element is bare — its mere presence paints the
+  // connectors between paired data points across consecutive series on
+  // a stacked bar / column chart — so we only emit when the caller
+  // explicitly opted in. Absence and an explicit `false` both collapse
+  // to no element so untouched bar charts match Excel's reference
+  // serialization. Excel only renders the connectors on stacked /
+  // percentStacked groupings, but the writer still honours the toggle
+  // on a clustered chart (matches Excel's own behavior — the element
+  // pins, the renderer paints nothing).
+  if (chart.serLines === true) {
+    children.push(xmlElement("c:serLines", undefined, []));
+  }
+
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_CAT }));
   children.push(xmlSelfClose("c:axId", { val: AXIS_ID_VAL }));
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6115,6 +6115,241 @@ describe("cloneChart — hiLowLines", () => {
   });
 });
 
+// ── cloneChart — series lines ────────────────────────────────────────
+
+describe("cloneChart — serLines", () => {
+  function barSource(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 2,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Q1",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+        {
+          kind: "bar",
+          index: 1,
+          name: "Q2",
+          valuesRef: "Tpl!$C$2:$C$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+      ],
+      barGrouping: "clustered",
+      ...extra,
+    };
+  }
+
+  it("inherits serLines=true from a bar source by default", () => {
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.serLines).toBe(true);
+  });
+
+  it("inherits serLines=true on the default bar -> column coercion (no type override)", () => {
+    // Read-side `bar` covers both `<c:barChart barDir="bar">` and
+    // `<c:barChart barDir="col">`; the default coercion lands on
+    // `column` (the more common vertical orientation). The flag must
+    // still carry through because both `bar` and `column` route to
+    // `<c:barChart>` on the writer side.
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.serLines).toBe(true);
+  });
+
+  it("returns undefined serLines when neither source nor override sets it", () => {
+    const clone = cloneChart(barSource(), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("drops the inherited serLines when the override is null", () => {
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      serLines: null,
+    });
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("drops the inherited serLines when the override is false", () => {
+    // `false` collapses to undefined just like `null` because the writer
+    // treats absence and `false` identically (no element emitted).
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      serLines: false,
+    });
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("lets the override pin serLines=true when the source did not declare it", () => {
+    const clone = cloneChart(barSource(), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      serLines: true,
+    });
+    expect(clone.serLines).toBe(true);
+  });
+
+  it("collapses non-boolean overrides to undefined", () => {
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      serLines: 1 as unknown as boolean,
+    });
+    // The non-boolean override drops, falling back to undefined (not the
+    // inherited true) because the override path treats non-boolean as
+    // "explicitly unset".
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("strips the flag when the resolved chart type is line", () => {
+    // CT_LineChart has no `<c:serLines>` slot. Coercing into line must
+    // drop the inherited flag so the writer never tries to emit an
+    // element on a host that rejects it.
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("strips the flag when the resolved chart type is area", () => {
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "area",
+    });
+    expect(clone.type).toBe("area");
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("strips the flag when the resolved chart type is pie / doughnut", () => {
+    const pie = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(pie.serLines).toBeUndefined();
+
+    const doughnut = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(doughnut.serLines).toBeUndefined();
+  });
+
+  it("strips the flag when the resolved chart type is scatter", () => {
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.serLines).toBeUndefined();
+  });
+
+  it("carries the flag across the bar <-> column coercion (both map to <c:barChart>)", () => {
+    const barToColumn = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(barToColumn.type).toBe("column");
+    expect(barToColumn.serLines).toBe(true);
+  });
+
+  it("composes serLines alongside barGrouping / dataLabels overrides", () => {
+    const clone = cloneChart(barSource({ serLines: true, barGrouping: "stacked" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+      dataLabels: { showValue: true },
+    });
+    expect(clone.serLines).toBe(true);
+    expect(clone.barGrouping).toBe("stacked");
+    expect(clone.dataLabels).toEqual({ showValue: true });
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the flag", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="stacked"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:ser>
+          <c:idx val="1"/>
+          <c:val><c:numRef><c:f>Tpl!$C$2:$C$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:overlap val="100"/>
+        <c:serLines/>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.serLines).toBe(true);
+    expect(parsed?.barGrouping).toBe("stacked");
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(sheetChart.serLines).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const barBlock = written.match(/<c:barChart>[\s\S]*?<\/c:barChart>/)![0];
+    expect(barBlock).toContain("<c:serLines/>");
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.serLines).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the flag intact", async () => {
+    const clone = cloneChart(barSource({ serLines: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      type: "column",
+      barGrouping: "stacked",
+      series: [
+        { name: "Q1", values: "Sheet1!$B$2:$B$3", categories: "Sheet1!$A$2:$A$3" },
+        { name: "Q2", values: "Sheet1!$C$2:$C$3", categories: "Sheet1!$A$2:$A$3" },
+      ],
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Region", "Q1", "Q2"],
+            ["North", 100, 120],
+            ["South", 200, 180],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:serLines/>");
+  });
+});
+
 // ── cloneChart — upDownBars ──────────────────────────────────────────
 
 describe("cloneChart — upDownBars", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5509,6 +5509,285 @@ describe("writeChart — high-low lines", () => {
     expect(parsed?.hiLowLines).toBe(true);
   });
 });
+
+// ── writeChart — series lines ────────────────────────────────────────
+
+describe("writeChart — series lines", () => {
+  it("omits <c:serLines> on a column chart with serLines unset (default)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:serLines");
+  });
+
+  it("omits <c:serLines> on a column chart when serLines is explicitly false", () => {
+    // The writer treats absence and `false` identically — both produce
+    // no element, matching Excel's reference serialization.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: false,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:serLines");
+  });
+
+  it("emits <c:serLines/> on a stacked column chart when serLines is true", () => {
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain("<c:serLines/>");
+  });
+
+  it("emits <c:serLines/> on a stacked bar chart when serLines is true", () => {
+    const result = writeChart(
+      makeChart({
+        type: "bar",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain("<c:serLines/>");
+  });
+
+  it("emits <c:serLines/> on a percentStacked bar chart when serLines is true", () => {
+    const result = writeChart(
+      makeChart({
+        type: "bar",
+        barGrouping: "percentStacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain("<c:serLines/>");
+  });
+
+  it("emits <c:serLines/> on a clustered bar chart when serLines is true", () => {
+    // The OOXML element pins regardless of grouping; Excel only renders
+    // the connectors on stacked groupings, but the writer honours the
+    // toggle on a clustered chart (matches Excel's own behavior — the
+    // element pins, the renderer paints nothing).
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain("<c:serLines/>");
+  });
+
+  it("ignores serLines on chart kinds whose schema rejects the element", () => {
+    // CT_LineChart / CT_AreaChart / CT_PieChart / CT_DoughnutChart /
+    // CT_ScatterChart all reject `<c:serLines>` per OOXML. Setting the
+    // flag on these families must not leak the element into the output.
+    const cases: Array<["line" | "area" | "pie" | "doughnut" | "scatter"]> = [
+      ["line"],
+      ["area"],
+      ["pie"],
+      ["doughnut"],
+      ["scatter"],
+    ];
+    for (const [type] of cases) {
+      const result = writeChart(
+        makeChart({
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4" }],
+          serLines: true,
+        }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("c:serLines");
+    }
+  });
+
+  it("non-boolean serLines values collapse to absence (only literal true emits)", () => {
+    // Mirrors the dropLines / hiLowLines writers — the resolver does
+    // not coerce its inputs. Truthy strings, numbers, etc. drop to the
+    // default of no element.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        serLines: 1 as any,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:serLines");
+  });
+
+  it("places <c:serLines> after <c:overlap> and before <c:axId> inside <c:barChart>", () => {
+    // CT_BarChart sequence: barDir, grouping, varyColors?, ser*,
+    // dLbls?, gapWidth?, overlap?, serLines*, axId+. The
+    // `<c:serLines>` slot lands after `<c:overlap>` (when emitted on a
+    // stacked chart) and before the first `<c:axId>`.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    const barBlock = result.chartXml.match(/<c:barChart>[\s\S]*?<\/c:barChart>/)![0];
+    const overlapIdx = barBlock.indexOf("<c:overlap ");
+    const serIdx = barBlock.indexOf("<c:serLines/>");
+    const axIdx = barBlock.indexOf("<c:axId ");
+    expect(overlapIdx).toBeGreaterThan(-1);
+    expect(serIdx).toBeGreaterThan(overlapIdx);
+    expect(axIdx).toBeGreaterThan(serIdx);
+  });
+
+  it("places <c:serLines> after <c:gapWidth> on a clustered bar chart", () => {
+    // On a clustered bar / column chart, the writer emits
+    // `<c:gapWidth val="150"/>` and skips `<c:overlap>`; `<c:serLines>`
+    // must still land after `<c:gapWidth>` and before the first
+    // `<c:axId>`.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    const barBlock = result.chartXml.match(/<c:barChart>[\s\S]*?<\/c:barChart>/)![0];
+    const gapWidthIdx = barBlock.indexOf("<c:gapWidth ");
+    const serIdx = barBlock.indexOf("<c:serLines/>");
+    const axIdx = barBlock.indexOf("<c:axId ");
+    expect(gapWidthIdx).toBeGreaterThan(-1);
+    expect(serIdx).toBeGreaterThan(gapWidthIdx);
+    expect(axIdx).toBeGreaterThan(serIdx);
+  });
+
+  it("emits <c:serLines/> exactly once even when called repeatedly", () => {
+    // Sanity check that the writer does not duplicate the element on a
+    // chart with multiple series.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+          { values: "D2:D4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml.match(/<c:serLines\/>/g)?.length).toBe(1);
+  });
+
+  it("round-trips serLines through parseChart (column)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(parseChart(result.chartXml)?.serLines).toBe(true);
+  });
+
+  it("round-trips serLines through parseChart (bar)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "bar",
+        barGrouping: "stacked",
+        series: [
+          { values: "B2:B4", categories: "A2:A4" },
+          { values: "C2:C4", categories: "A2:A4" },
+        ],
+        serLines: true,
+      }),
+      "Sheet1",
+    );
+    expect(parseChart(result.chartXml)?.serLines).toBe(true);
+  });
+
+  it("survives a writeXlsx round trip — serLines lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Q1", "Q2"],
+          ["North", 100, 120],
+          ["South", 200, 180],
+        ],
+        charts: [
+          {
+            type: "column",
+            barGrouping: "stacked",
+            series: [
+              { name: "Q1", values: "B2:B3", categories: "A2:A3" },
+              { name: "Q2", values: "C2:C3", categories: "A2:A3" },
+            ],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            serLines: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:serLines/>");
+  });
+});
+
 // ── writeChart — upDownBars ──────────────────────────────────────────
 
 describe("writeChart — upDownBars", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6330,6 +6330,155 @@ describe("parseChart — high-low lines", () => {
     expect(parseChart(xml)?.hiLowLines).toBe(true);
   });
 });
+
+// ── parseChart — series lines ──────────────────────────────────────
+
+describe("parseChart — series lines", () => {
+  function barChartWithExtras(extras: string): string {
+    return `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:ser><c:idx val="1"/></c:ser>
+        ${extras}
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces serLines=true on a bar chart that declares <c:serLines/>", () => {
+    const xml = barChartWithExtras("<c:serLines/>");
+    expect(parseChart(xml)?.serLines).toBe(true);
+  });
+
+  it("surfaces serLines=true on a bar chart that declares <c:serLines> with a nested <c:spPr>", () => {
+    // CT_ChartLines may carry `<c:spPr>` for stroke styling. The
+    // reader only surfaces the on/off bit — the shape properties are
+    // not modelled in this phase but the presence of the element still
+    // surfaces `true` so the clone bridge can carry the intent.
+    const xml = barChartWithExtras(
+      `<c:serLines><c:spPr><a:ln w="9525"><a:solidFill><a:srgbClr val="808080"/></a:solidFill></a:ln></c:spPr></c:serLines>`,
+    );
+    expect(parseChart(xml)?.serLines).toBe(true);
+  });
+
+  it("returns undefined when the bar chart omits <c:serLines>", () => {
+    const xml = barChartWithExtras("");
+    expect(parseChart(xml)?.serLines).toBeUndefined();
+  });
+
+  it("does not surface serLines for chart kinds that have no <c:serLines> slot (line)", () => {
+    // The reader only inspects bar / ofPie children; a stray
+    // `<c:serLines>` on a line chart (which the OOXML schema rejects)
+    // must not surface a value.
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:lineChart>
+        <c:grouping val="standard"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:serLines/>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.serLines).toBeUndefined();
+  });
+
+  it("does not surface serLines for chart kinds that have no slot (pie)", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:pieChart>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:serLines/>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.serLines).toBeUndefined();
+  });
+
+  it("does not surface serLines for chart kinds that have no slot (area)", () => {
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:areaChart>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:serLines/>
+      </c:areaChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.serLines).toBeUndefined();
+  });
+
+  it("surfaces serLines on an ofPieChart (the second OOXML host for the element)", () => {
+    // hucre's writer never authors `<c:ofPieChart>`, but a parsed
+    // ofPie template carrying the element should round-trip the flag
+    // so a downstream tool that introspects it gets the right answer.
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:ofPieChart>
+        <c:ofPieType val="pie"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:serLines/>
+      </c:ofPieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.serLines).toBe(true);
+  });
+
+  it("surfaces serLines on the first bar/ofPie chart-type element only (combo workbook)", () => {
+    // Combo charts (multi-kind plot area) surface the first matching
+    // value just like the existing connector-line helpers.
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="stacked"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:serLines/>
+      </c:barChart>
+      <c:lineChart>
+        <c:grouping val="standard"/>
+        <c:ser><c:idx val="1"/></c:ser>
+      </c:lineChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.serLines).toBe(true);
+  });
+
+  it("surfaces serLines on a clustered bar chart even though Excel paints nothing", () => {
+    // The OOXML element pins regardless of the grouping; Excel only
+    // renders the connectors on stacked groupings, but the model is a
+    // plain presence flag so the reader should not gate on grouping.
+    const xml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:serLines/>
+      </c:barChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.serLines).toBe(true);
+  });
+});
+
 // ── parseChart — upDownBars ────────────────────────────────────────
 
 describe("parseChart — upDownBars", () => {


### PR DESCRIPTION
## Summary

Surfaces the chart-type-level `<c:serLines/>` element at the read, write, and clone layers so a template's series-lines configuration survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:serLines>` mirrors Excel's "Add Chart Element -> Lines -> Series Lines" toggle — connector lines drawn between paired data points across consecutive series in a stacked bar / column chart (visible only on `stacked` / `percentStacked` groupings; Excel disables the toggle on a clustered chart). Up until now hucre's writer had no slot for the element, so a stacked-bar template that pinned the connectors flattened back to no series lines on every parse -> clone -> write loop. This bridges another visualization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.serLines); // true when the template pinned <c:serLines/>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [...],
    charts: [{
      type: "column",
      barGrouping: "stacked",
      series: [
        { name: "Q1", values: "B2:B6", categories: "A2:A6" },
        { name: "Q2", values: "C2:C6", categories: "A2:A6" },
      ],
      serLines: true, // connector lines between same-category data points
      anchor: { from: { row: 6, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 14, col: 0 } },
  type: "column",
  // serLines: undefined -> inherit
  // serLines: null      -> drop inherited flag
  // serLines: true      -> pin
  // serLines: false     -> equivalent to null (writer treats both as default)
});
```

## Model

```ts
// Read side
export interface Chart {
  // ...existing fields...
  serLines?: boolean; // <c:barChart> / <c:ofPieChart>
}

// Write side
export interface SheetChart {
  // ...existing fields...
  serLines?: boolean; // emitted on type === "bar" | "column"
}

// Clone-through
export interface CloneChartOptions {
  // ...existing fields...
  serLines?: boolean | null;
}
```

## Scope rules

- The element is bare (no `val` attribute), so the reader surfaces `true` on presence and `undefined` on absence; the writer emits the element only when the field is literally `true` (`false`, absence, and non-boolean inputs all collapse to no element).
- `<c:serLines>` is read off the first `<c:barChart>` / `<c:ofPieChart>` in the plot area. Stray elements on chart families whose schema rejects them (line / area / pie / doughnut / scatter / stock) are ignored.
- The bar writer pins `<c:serLines>` between `<c:overlap>` and the first `<c:axId>` to honour the CT_BarChart sequence (barDir, grouping, varyColors?, ser*, dLbls?, gapWidth?, overlap?, serLines*, axId+). The element pins regardless of grouping — Excel only renders the connectors on stacked / percentStacked but the writer honours the toggle on a clustered chart too (matches Excel's own behavior when the toggle is flipped on a clustered chart).
- The clone-through carries `serLines` across the bar ↔ column coercion (both map to `<c:barChart>` with a different `barDir`) and drops it on every other type-coercion. Non-boolean overrides drop rather than fall through to the inherited value, mirroring the existing `dropLines` / `hiLowLines` / `upDownBars` resolvers.

## Test plan

- [x] `pnpm test` (oxlint + oxfmt + tsgo + vitest) — 3835 tests passing (+39).
- [x] `pnpm build` — obuild succeeds.
- [x] `parseChart` covers presence / absence on `<c:barChart>` (with and without nested `<c:spPr>`), the schema-scope gate (stray elements on line / pie / area drop), `<c:ofPieChart>` (the second OOXML host), combo-workbook surfacing, and a clustered bar chart pinning the element.
- [x] `writeChart` covers absence / explicit-`false` / explicit-`true` emit on column / bar / stacked / percentStacked / clustered, the per-family scope gate (line / area / pie / doughnut / scatter all drop), non-boolean drop, OOXML element ordering (after `<c:overlap>` / `<c:gapWidth>`, before `<c:axId>`), the exactly-once emit guard, `parseChart` round-trip on bar and column, and end-to-end packaging via `writeXlsx`.
- [x] `cloneChart` covers chart-level inherit / null / wholesale-replace, the bar-only default coercion (read-side `bar` flattens to write-side `column` so the flag still threads through), the bar ↔ column coercion carry, the per-family drop on line / area / pie / doughnut / scatter, composition with other chart-level overrides (barGrouping / dataLabels), and end-to-end through `parseChart -> cloneChart -> writeChart` plus packaging via `writeXlsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)