### PR TITLE
feat(xlsx): chart 3-D view configuration — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,27 @@ surfaces as an empty `{}`, and absence of the element collapses the
 field to `undefined`. Every chart family carries a slot — the element
 lives on `<c:chartSpace>` (a sibling of `<c:chart>`), not inside
 `<c:plotArea>`, so pie / doughnut still surface the block.
+`Chart.view3D` surfaces the chart-level `<c:chart><c:view3D>` block
+(CT_View3D, ECMA-376 Part 1, §21.2.2.228) — Excel's "3-D Rotation"
+pane on 3D chart families. The reader returns a `ChartView3D` object
+with up to six independently optional fields (`rotX`, `hPercent`,
+`rotY`, `depthPercent`, `rAngAx`, `perspective`); each child is
+independently optional on `CT_View3D`, so the reader only surfaces
+the fields the file actually pinned. Numeric fields are validated
+against the matching OOXML simple-type range
+(`ST_RotX` / `ST_HPercent` / `ST_RotY` / `ST_DepthPercent` /
+`ST_Perspective`) — out-of-range, fractional, and non-numeric `val`
+attributes drop rather than fabricate a clamped value. The boolean
+`<c:rAngAx>` accepts the OOXML truthy / falsy spellings (`"1"` /
+`"true"` / `"0"` / `"false"`); unknown tokens drop to `undefined`.
+The element itself is the gating signal — a `<c:view3D>` block with
+no resolvable children surfaces as an empty `{}`, and absence of the
+element collapses the field to `undefined`. The element lives on
+`<c:chart>` (between `<c:autoTitleDeleted>` and `<c:plotArea>`), so
+the OOXML schema accepts it on every chart family — though it is
+only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`,
+`surface3D`); a stray element on a 2D chart still surfaces here so
+the round-trip through `cloneChart` stays lossless.
 `ChartAxisInfo.tickLblSkip` and `ChartAxisInfo.tickMarkSkip` surface
 the category-axis tick-thinning knobs (`<c:catAx><c:tickLblSkip val=".."/>`
 and `<c:catAx><c:tickMarkSkip val=".."/>`). Both elements live on
@@ -1160,6 +1181,27 @@ doughnut — carries a slot for it. Excel only enforces these flags
 when the host worksheet is itself protected; on an unprotected sheet
 the element round-trips literally but has no observable runtime
 effect.
+The chart-level `view3D` field maps to `<c:chart><c:view3D>` (CT_View3D,
+ECMA-376 Part 1, §21.2.2.228) — Excel's "3-D Rotation" pane on 3D
+chart families. The field accepts a `ChartView3D` object with up to
+six independently optional fields (`rotX`, `hPercent`, `rotY`,
+`depthPercent`, `rAngAx`, `perspective`); pass an object to pin any
+subset of the children, pass `{}` to declare a bare `<c:view3D/>`
+shell (useful for round-trip parity with templates that author the
+empty element), or omit the field to suppress the element entirely so
+the writer skips emission and Excel falls back to the per-family
+default. Each numeric field is clamped against the matching OOXML
+simple-type range (`rotX` -90..90, `hPercent` 5..500, `rotY` 0..360,
+`depthPercent` 20..2000, `perspective` 0..240); out-of-range,
+fractional, and non-finite inputs drop silently rather than emit a
+token Excel's strict validator would reject. The writer emits the
+six children in `CT_View3D` schema order, slots the block between
+`<c:autoTitleDeleted>` and `<c:plotArea>` per `CT_Chart`, and accepts
+the element on every chart family — though it is only meaningful on
+3D families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`); on
+2D families the element round-trips literally but Excel ignores it.
+Useful primarily for round-tripping a 3D template chart through
+`cloneChart`.
 The chart-level `roundedCorners` field maps to
 `<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
 `<c:chart>`, not a child) — Excel's "Format Chart Area → Border →
@@ -1594,6 +1636,20 @@ pin). Unlike `dataTable`, the field lives on `<c:chartSpace>` (not
 inside `<c:plotArea>`), so every chart family — pie / doughnut
 included — carries a slot for it. Coercions between any chart
 families preserve the inherited block.
+The chart-level `view3D` field follows the standard `object | null`
+override grammar: pass `undefined` (or omit it) to inherit the
+source's parsed `ChartView3D` (defensively shallow-copied so a clone
+mutation never leaks back into the parsed `Chart`), `null` to drop
+the inherited block so the writer skips `<c:view3D>` entirely, or a
+`ChartView3D` object to replace the block wholesale (no per-field
+merge with the source — pass every field the cloned 3D view should
+pin). An empty object (`{}`) collapses to a bare `<c:view3D/>` shell
+on emit. Unlike `dataTable`, the field lives on `<c:chart>` (not
+inside `<c:plotArea>`), so every chart family — pie / doughnut
+included — carries a slot for it. Coercions between any chart
+families (line → column, doughnut → pie, etc.) preserve the inherited
+block, mirroring how `protection` composes across the type-coercion
+flow.
 The chart-level `roundedCorners` flag follows the same grammar: pass
 `undefined` to inherit the source's parsed value, `null` to drop it
 back to the writer's OOXML `false` default (square chart frame), or a

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -858,6 +858,77 @@ export interface ChartProtection {
 }
 
 /**
+ * Granular 3D-view configuration for {@link SheetChart.view3D}.
+ *
+ * Maps to the six optional `CT_View3D` children of `<c:chart><c:view3D>`
+ * (ECMA-376 Part 1, §21.2.2.228) — Excel's "3-D Rotation" pane on
+ * 3D chart families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`).
+ * The element itself is optional; each child is independently optional
+ * and Excel falls back to the per-family default for any field the
+ * template leaves unset.
+ *
+ * Every field is independent — pass any subset to override the matching
+ * per-family default. Pin a field to a value at the matching boundary
+ * of the OOXML simple type and the writer round-trips it as the literal
+ * `val` attribute; out-of-range and non-finite numeric inputs drop at
+ * write time rather than emit a token Excel would reject.
+ *
+ * Although `<c:view3D>` is only meaningful on 3D chart families, the
+ * OOXML schema accepts it on every CT_Chart, so the writer pins the
+ * element whenever the caller provides a non-empty configuration —
+ * Excel silently ignores it on 2D families. Useful primarily for
+ * round-tripping a 3D template chart through {@link cloneChart}.
+ */
+export interface ChartView3D {
+  /**
+   * Rotation around the X axis in degrees. Maps to
+   * `<c:rotX val=".."/>` (`ST_RotX`, signed byte). Accepted range:
+   * `-90` – `90`. Excel's default is `15` for most 3D families and
+   * `0` for `pie3D`. Values outside the range drop at write time.
+   */
+  rotX?: number;
+  /**
+   * Height as a percent of the chart width. Maps to
+   * `<c:hPercent val=".."/>` (`ST_HPercent`, percent). Accepted range:
+   * `5` – `500`. Excel's default is `100`. Values outside the range
+   * drop at write time.
+   */
+  hPercent?: number;
+  /**
+   * Rotation around the Y axis in degrees. Maps to
+   * `<c:rotY val=".."/>` (`ST_RotY`, unsigned short). Accepted range:
+   * `0` – `360`. Excel's default is `20` for most 3D families and
+   * `0` for `pie3D` / `bar3D` (column orientation). Values outside the
+   * range drop at write time.
+   */
+  rotY?: number;
+  /**
+   * Depth as a percent of the chart width. Maps to
+   * `<c:depthPercent val=".."/>` (`ST_DepthPercent`, percent). Accepted
+   * range: `20` – `2000`. Excel's default is `100`. Values outside the
+   * range drop at write time.
+   */
+  depthPercent?: number;
+  /**
+   * Right-angle-axes flag. Maps to `<c:rAngAx val=".."/>` (CT_Boolean).
+   * Default: `false` — perspective foreshortening is applied to the
+   * 3D box. Set `true` to draw the chart with axes at right angles
+   * (Excel's "Right angle axes" checkbox), which suppresses perspective
+   * even when {@link perspective} is non-zero.
+   */
+  rAngAx?: boolean;
+  /**
+   * Perspective factor. Maps to `<c:perspective val=".."/>`
+   * (`ST_Perspective`, percent). Accepted range: `0` – `240`. Excel's
+   * default is `30`. Higher values exaggerate the foreshortening; `0`
+   * is the orthographic projection. Silently ignored by Excel when
+   * {@link rAngAx} is `true`. Values outside the range drop at write
+   * time.
+   */
+  perspective?: number;
+}
+
+/**
  * Scatter sub-style applied at the chart level. Maps to the OOXML
  * `ST_ScatterStyle` enum which sits inside `<c:scatterChart>` as
  * `<c:scatterStyle val=".."/>`. Excel exposes the same six presets
@@ -1481,6 +1552,36 @@ export interface SheetChart {
    * {@link ChartProtection}.
    */
   protection?: boolean | ChartProtection;
+  /**
+   * 3-D view configuration. Maps to `<c:chart><c:view3D>` (CT_View3D,
+   * ECMA-376 Part 1, §21.2.2.228) — Excel's "3-D Rotation" pane,
+   * which controls the X / Y rotation, height and depth percentages,
+   * the right-angle-axes flag, and the perspective foreshortening
+   * factor on 3D chart families.
+   *
+   * Pass an object to pin one or more of the six `CT_View3D` children;
+   * each unspecified field falls back to Excel's per-family default
+   * (the writer skips emission of any child the object leaves unset
+   * so the rendered shape matches absence). Pass an empty object
+   * (`{}`) to declare a bare `<c:view3D>` shell, useful for
+   * round-trip parity with templates that author the element with no
+   * children pinned. Omit the field to suppress the element entirely
+   * so the writer skips emission.
+   *
+   * Default: omitted — Excel renders no `<c:view3D>` element on a
+   * fresh chart and falls back to the per-family default rotation /
+   * perspective.
+   *
+   * Although `<c:view3D>` is only meaningful on 3D chart families
+   * (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`) and hucre's
+   * writer authors only 2D families, the OOXML schema accepts the
+   * element on every CT_Chart, so the writer pins it whenever the
+   * caller provides a non-empty configuration — Excel silently
+   * ignores it on 2D families. Useful primarily for round-tripping a
+   * 3D template chart through {@link cloneChart}. See
+   * {@link ChartView3D}.
+   */
+  view3D?: ChartView3D;
   /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
@@ -3511,6 +3612,35 @@ export interface Chart {
    * pie / doughnut — can carry it.
    */
   protection?: ChartProtection;
+  /**
+   * 3-D view configuration pulled from `<c:chart><c:view3D>` (CT_View3D,
+   * ECMA-376 Part 1, §21.2.2.228). Reflects Excel's "3-D Rotation"
+   * pane on 3D chart families — the X / Y rotation, height and depth
+   * percentages, the right-angle-axes flag, and the perspective
+   * foreshortening factor.
+   *
+   * Surfaces a {@link ChartView3D} object whenever the source chart
+   * declares the element. Each of the six children (`<c:rotX>`,
+   * `<c:hPercent>`, `<c:rotY>`, `<c:depthPercent>`, `<c:rAngAx>`,
+   * `<c:perspective>`) is independently optional on CT_View3D, so the
+   * reader only surfaces the fields the file actually pinned. A child
+   * that is missing or carries an out-of-range / unparseable `val`
+   * attribute drops to `undefined` for that field rather than fabricate
+   * a value the file did not declare. The element itself is the gating
+   * signal — a `<c:view3D>` block with no resolvable children surfaces
+   * as an empty `{}`, mirroring how `dataTable` / `protection` handle
+   * a malformed inner block.
+   *
+   * Surfaces `undefined` when the chart has no `<c:view3D>` element at
+   * all. The element lives on `<c:chart>` (between `<c:autoTitleDeleted>`
+   * / `<c:pivotFmts>` and `<c:floor>` / `<c:plotArea>` per CT_Chart),
+   * so the OOXML schema accepts it on every chart family — though it
+   * is only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`,
+   * `area3D`, `surface3D`); a stray element on a 2D chart still
+   * surfaces here so the round-trip through {@link cloneChart} stays
+   * lossless.
+   */
+  view3D?: ChartView3D;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,7 @@ export type {
   ChartMarkerSymbol,
   ChartProtection,
   ChartSeriesInfo,
+  ChartView3D,
 } from "./_types";
 
 // ── Date Utilities ─────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -33,6 +33,7 @@ import type {
   ChartScatterStyle,
   ChartSeries,
   ChartSeriesInfo,
+  ChartView3D,
   SheetChart,
   WriteChartKind,
 } from "../_types";
@@ -472,6 +473,32 @@ export interface CloneChartOptions {
    * toggles compose the same way at the call site.
    */
   protection?: ChartProtection | boolean | null;
+  /**
+   * Override `<c:chart><c:view3D>` (the 3-D rotation / perspective
+   * block).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * {@link Chart.view3D}. `null` drops the inherited block so the
+   * writer skips the element entirely — Excel falls back to its
+   * per-family default rotation / perspective. A {@link ChartView3D}
+   * object replaces the inherited block wholesale (no per-field merge;
+   * pass every field you want preserved). Pass an empty object (`{}`)
+   * to declare a bare `<c:view3D/>` shell — useful for round-trip
+   * parity with templates that author the element with no children
+   * pinned. Each unspecified field falls back to absence at the writer
+   * side because every CT_View3D child is independently optional and
+   * Excel treats a missing child as the per-family default.
+   *
+   * Applies to every chart family — `<c:view3D>` lives on `<c:chart>`
+   * (between `<c:autoTitleDeleted>` and `<c:plotArea>`), so the OOXML
+   * schema accepts the element on both 2D and 3D families. The toggle
+   * is only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`,
+   * `area3D`, `surface3D`), but the writer carries a templated value
+   * through every clone so a 3D template chart round-trips losslessly.
+   * The grammar mirrors {@link CloneChartOptions.protection} so the
+   * chart-level block toggles compose the same way at the call site.
+   */
+  view3D?: ChartView3D | null;
   /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
@@ -973,6 +1000,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   // identically at the call site.
   const resolvedProtection = resolveProtection(source.protection, options.protection);
   if (resolvedProtection !== undefined) out.protection = resolvedProtection;
+
+  // `<c:view3D>` lives on `<c:chart>` directly, so the OOXML schema
+  // accepts it on every chart family — both 2D and 3D. The toggle is
+  // only meaningful on 3D families, but the resolver applies to every
+  // type so a 3D template chart round-trips losslessly through a clone
+  // (and a 2D clone of a 3D template that happens to inherit the
+  // value silently keeps the element — Excel ignores it on 2D).
+  // Override wins over the source's parsed value, and the grammar
+  // follows the standard `object | null` shape so the chart-level
+  // block toggles compose the same way at the call site.
+  const resolvedView3D = resolveView3D(source.view3D, options.view3D);
+  if (resolvedView3D !== undefined) out.view3D = resolvedView3D;
 
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
@@ -1584,6 +1623,49 @@ function resolveProtection(
   // the OOXML reference default `false` for any field the object
   // leaves unset.
   return override;
+}
+
+/**
+ * Resolve a `view3D` override.
+ *
+ * `undefined` → inherit the source's parsed {@link Chart.view3D}. The
+ *               source's parsed object is defensively shallow-copied
+ *               so a downstream mutation to the cloned SheetChart
+ *               never leaks back into the parsed Chart.
+ * `null`      → drop the inherited block so the writer skips
+ *               `<c:view3D>` entirely (no chart-level 3D pin).
+ * `object`    → replace the inherited block wholesale (no per-field
+ *               merge with the source — pass every field the cloned
+ *               view3D should pin). An empty object emits a bare
+ *               `<c:view3D/>` shell at the writer side.
+ *
+ * The grammar mirrors {@link resolveProtection} / {@link resolveDataTable}
+ * so the chart-level block toggles compose the same way at the call
+ * site. Unlike `dataTable`, `<c:view3D>` lives on `<c:chart>` (not
+ * inside `<c:plotArea>`) so the resolver applies to every chart family
+ * — pie / doughnut included.
+ */
+function resolveView3D(
+  sourceValue: ChartView3D | undefined,
+  override: ChartView3D | null | undefined,
+): ChartView3D | undefined {
+  if (override === undefined) {
+    // Inherit — defensively shallow-copy the source so a downstream
+    // mutation to the cloned SheetChart never leaks back into the
+    // parsed Chart. The CT_View3D children are all scalars (numbers
+    // and a boolean), so a single-level spread is enough.
+    if (sourceValue === undefined) return undefined;
+    return { ...sourceValue };
+  }
+  if (override === null) {
+    // Drop the inherited block. The writer treats `undefined` as
+    // suppression and skips `<c:view3D>` entirely.
+    return undefined;
+  }
+  // Replace the inherited block wholesale. The writer accepts the
+  // empty-object shape and emits a bare `<c:view3D/>` shell, mirroring
+  // how `resolveProtection` handles the `true` / `{}` forms.
+  return { ...override };
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -40,6 +40,7 @@ import type {
   ChartProtection,
   ChartScatterStyle,
   ChartSeriesInfo,
+  ChartView3D,
 } from "../_types";
 import { parseXml } from "../xml/parser";
 import type { XmlElement } from "../xml/parser";
@@ -359,6 +360,19 @@ export function parseChart(xml: string): Chart | undefined {
   // pinned.
   const protection = parseProtection(chartSpace);
   if (protection !== undefined) out.protection = protection;
+
+  // `<c:view3D>` (CT_View3D, ECMA-376 Part 1, §21.2.2.228) sits on
+  // `<c:chart>` between `<c:autoTitleDeleted>` / `<c:pivotFmts>` and
+  // `<c:floor>` / `<c:plotArea>`. The element holds six independently
+  // optional children (`<c:rotX>`, `<c:hPercent>`, `<c:rotY>`,
+  // `<c:depthPercent>`, `<c:rAngAx>`, `<c:perspective>`); the reader
+  // surfaces only the fields the file actually pinned. The element is
+  // only meaningful on 3D chart families but the OOXML schema accepts
+  // it on every CT_Chart, so the reader looks for it on every chart —
+  // a stray element on a 2D chart still surfaces here so the round-
+  // trip through cloneChart stays lossless.
+  const view3D = parseView3D(chartEl);
+  if (view3D !== undefined) out.view3D = view3D;
 
   return out;
 }
@@ -2053,6 +2067,117 @@ function parseProtection(chartSpace: XmlElement): ChartProtection | undefined {
  */
 function parseProtectionFlag(protection: XmlElement, local: string): boolean | undefined {
   const el = findChild(protection, local);
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+// ── 3-D View ──────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:view3D>` (CT_View3D) off `<c:chart>`. Surfaces a
+ * {@link ChartView3D} object whenever the source chart declares the
+ * element. Each of the six children (`<c:rotX>`, `<c:hPercent>`,
+ * `<c:rotY>`, `<c:depthPercent>`, `<c:rAngAx>`, `<c:perspective>`)
+ * is independently optional on CT_View3D, so the reader only surfaces
+ * the fields the file actually pinned. A child that is missing or
+ * carries an out-of-range / unparseable `val` attribute drops to
+ * `undefined` for that field rather than fabricate a value the file
+ * did not declare.
+ *
+ * The element itself is the gating signal — a `<c:view3D>` block with
+ * no resolvable children surfaces as an empty `{}`, mirroring how
+ * `dataTable` / `protection` handle a malformed inner block. This
+ * keeps a chart that authors the bare element (Excel's "default 3D
+ * view" preset) from silently disappearing through the parse loop.
+ *
+ * Note: `<c:view3D>` lives on `<c:chart>` (between `<c:autoTitleDeleted>`
+ * / `<c:pivotFmts>` and `<c:floor>` / `<c:plotArea>` per CT_Chart
+ * §21.2.2.4), not on `<c:chartSpace>` — the toggle governs the 3D
+ * projection of the rendered chart, not the outer chart frame.
+ */
+function parseView3D(chartEl: XmlElement): ChartView3D | undefined {
+  const el = findChild(chartEl, "view3D");
+  if (!el) return undefined;
+  const out: ChartView3D = {};
+  // `<c:rotX>` (CT_RotX, ST_RotX) is a signed byte in the range
+  // -90..90. Out-of-range values drop rather than emit a token Excel
+  // would clamp at parse time.
+  const rotX = parseView3DInt(el, "rotX", -90, 90);
+  if (rotX !== undefined) out.rotX = rotX;
+  // `<c:hPercent>` (CT_HPercent, ST_HPercent) is a percent value in
+  // the range 5..500. Same drop-on-out-of-range rule.
+  const hPercent = parseView3DInt(el, "hPercent", 5, 500);
+  if (hPercent !== undefined) out.hPercent = hPercent;
+  // `<c:rotY>` (CT_RotY, ST_RotY) is an unsigned short in the range
+  // 0..360.
+  const rotY = parseView3DInt(el, "rotY", 0, 360);
+  if (rotY !== undefined) out.rotY = rotY;
+  // `<c:depthPercent>` (CT_DepthPercent, ST_DepthPercent) is a percent
+  // value in the range 20..2000.
+  const depthPercent = parseView3DInt(el, "depthPercent", 20, 2000);
+  if (depthPercent !== undefined) out.depthPercent = depthPercent;
+  // `<c:rAngAx>` (CT_Boolean) — accepts the OOXML truthy / falsy
+  // spellings; unknown values and missing `val` attributes drop to
+  // `undefined`. Mirrors the parsing semantics of the chartSpace-level
+  // `<c:protection>` boolean children.
+  const rAngAx = parseView3DBoolean(el, "rAngAx");
+  if (rAngAx !== undefined) out.rAngAx = rAngAx;
+  // `<c:perspective>` (CT_Perspective, ST_Perspective) is a percent
+  // value in the range 0..240.
+  const perspective = parseView3DInt(el, "perspective", 0, 240);
+  if (perspective !== undefined) out.perspective = perspective;
+  return out;
+}
+
+/**
+ * Pull a single integer child off `<c:view3D>`. Surfaces the value
+ * only when `val` parses as an integer inside the matching OOXML
+ * simple-type range; absence and out-of-range / non-integer values
+ * collapse to `undefined`.
+ *
+ * Accepts an optional leading `-` so signed types (`<c:rotX>`) round-
+ * trip cleanly. The strict integer regex rejects fractional values
+ * (`"15.5"`) and non-numeric tokens (`"15px"`) — `parseInt` would
+ * coerce both into a number Excel never emits.
+ */
+function parseView3DInt(
+  view3D: XmlElement,
+  local: string,
+  min: number,
+  max: number,
+): number | undefined {
+  const el = findChild(view3D, local);
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  if (!/^-?\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  if (n < min || n > max) return undefined;
+  return n;
+}
+
+/**
+ * Pull a single boolean child off `<c:view3D>`. Accepts the OOXML
+ * truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
+ * unknown tokens, missing `val` attributes, and missing elements all
+ * collapse to `undefined` rather than fabricate a flag the file did
+ * not pin. Mirrors {@link parseProtectionFlag} — the same OOXML
+ * `<xsd:boolean>` lexical-space rule.
+ */
+function parseView3DBoolean(view3D: XmlElement, local: string): boolean | undefined {
+  const el = findChild(view3D, local);
   if (!el) return undefined;
   const raw = el.attrs.val;
   if (typeof raw !== "string") return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -26,6 +26,7 @@ import type {
   ChartProtection,
   ChartScatterStyle,
   ChartSeries,
+  ChartView3D,
   SheetChart,
   WriteChartKind,
 } from "../_types";
@@ -89,6 +90,21 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   chartChildren.push(
     xmlSelfClose("c:autoTitleDeleted", { val: resolveAutoTitleDeleted(chart) ? 1 : 0 }),
   );
+
+  // `<c:view3D>` (CT_View3D, ECMA-376 Part 1, §21.2.2.228) sits on
+  // `<c:chart>` between `<c:autoTitleDeleted>` / `<c:pivotFmts>` and
+  // `<c:floor>` / `<c:plotArea>`. The element is only meaningful on
+  // 3D chart families but the OOXML schema accepts it on every
+  // CT_Chart, so the writer emits it whenever the caller pins a
+  // non-empty configuration — Excel silently ignores it on 2D
+  // families. Useful primarily for round-tripping a 3D template chart
+  // through cloneChart. The writer skips emission entirely when the
+  // caller leaves `view3D` unset so a fresh chart matches Excel's
+  // reference serialization byte-for-byte.
+  const view3DXml = buildView3D(chart.view3D);
+  if (view3DXml !== undefined) {
+    chartChildren.push(view3DXml);
+  }
 
   // ── Plot Area ──
   chartChildren.push(buildPlotArea(chart, sheetName));
@@ -574,6 +590,82 @@ function buildProtection(protection: {
     xmlSelfClose("c:selection", { val: protection.selection ? 1 : 0 }),
     xmlSelfClose("c:userInterface", { val: protection.userInterface ? 1 : 0 }),
   ]);
+}
+
+// ── 3-D View ─────────────────────────────────────────────────────────
+
+/**
+ * Serialize a {@link ChartView3D} into `<c:view3D>` with one self-
+ * closing child per pinned field, in the order CT_View3D mandates:
+ * `<c:rotX>`, `<c:hPercent>`, `<c:rotY>`, `<c:depthPercent>`,
+ * `<c:rAngAx>`, `<c:perspective>`. Returns `undefined` when the
+ * caller did not opt in (`view3D` is `undefined`) so the writer can
+ * skip the element entirely; returns the bare `<c:view3D/>` shell
+ * when an empty object is passed (round-trips a template that
+ * authored the element with no children pinned).
+ *
+ * Each numeric field is clamped against the matching OOXML simple-
+ * type range — out-of-range and non-finite inputs drop silently
+ * rather than emit a token Excel's strict validator would reject.
+ * The boolean field surfaces only as a literal `0` / `1` `val`
+ * attribute; non-boolean inputs collapse to `false` (the OOXML
+ * default), mirroring how every other chart-level boolean writer
+ * treats its input.
+ */
+function buildView3D(view3D: ChartView3D | undefined): string | undefined {
+  if (view3D === undefined) return undefined;
+  const children: string[] = [];
+  // CT_View3D children sequence per ECMA-376 §21.2.2.228:
+  // rotX?, hPercent?, rotY?, depthPercent?, rAngAx?, perspective?,
+  // extLst?
+  const rotX = clampView3DInt(view3D.rotX, -90, 90);
+  if (rotX !== undefined) children.push(xmlSelfClose("c:rotX", { val: rotX }));
+  const hPercent = clampView3DInt(view3D.hPercent, 5, 500);
+  if (hPercent !== undefined) {
+    // `<c:hPercent>` accepts the bare integer per ST_HPercent — Excel
+    // emits a plain percent value with no `%` suffix.
+    children.push(xmlSelfClose("c:hPercent", { val: hPercent }));
+  }
+  const rotY = clampView3DInt(view3D.rotY, 0, 360);
+  if (rotY !== undefined) children.push(xmlSelfClose("c:rotY", { val: rotY }));
+  const depthPercent = clampView3DInt(view3D.depthPercent, 20, 2000);
+  if (depthPercent !== undefined) {
+    children.push(xmlSelfClose("c:depthPercent", { val: depthPercent }));
+  }
+  if (view3D.rAngAx === true) {
+    children.push(xmlSelfClose("c:rAngAx", { val: 1 }));
+  } else if (view3D.rAngAx === false) {
+    // Explicit `false` round-trips as `<c:rAngAx val="0"/>` so the
+    // caller can pin the OOXML default literally — useful for parity
+    // with templates that author the explicit value.
+    children.push(xmlSelfClose("c:rAngAx", { val: 0 }));
+  }
+  const perspective = clampView3DInt(view3D.perspective, 0, 240);
+  if (perspective !== undefined) {
+    children.push(xmlSelfClose("c:perspective", { val: perspective }));
+  }
+  // Empty object (`{}`) collapses to a bare `<c:view3D/>` shell —
+  // `xmlElement` with an empty child array emits the self-closing form.
+  return xmlElement("c:view3D", undefined, children);
+}
+
+/**
+ * Clamp a `<c:view3D>` numeric field against the matching OOXML
+ * simple-type range. Returns `undefined` when the input is non-finite,
+ * non-integer, or out-of-range — the writer drops the matching child
+ * rather than emit a token Excel's strict validator would reject.
+ *
+ * The strict integer check rejects fractional inputs (`15.5`) so the
+ * round-trip stays lossless — `parseView3DInt` on the reader side
+ * also rejects fractional `val` attributes, and a fractional input
+ * here would silently mismatch on the next parse.
+ */
+function clampView3DInt(value: number | undefined, min: number, max: number): number | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  if (!Number.isInteger(value)) return undefined;
+  if (value < min || value > max) return undefined;
+  return value;
 }
 
 interface AxisRenderOptions {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4,7 +4,7 @@ import { parseChart } from "../src/xlsx/chart-reader";
 import { writeChart } from "../src/xlsx/chart-writer";
 import { writeXlsx } from "../src/xlsx/writer";
 import { ZipReader } from "../src/zip/reader";
-import type { Chart, ChartLineStroke, ChartMarker, SheetChart } from "../src/_types";
+import type { Chart, ChartLineStroke, ChartMarker, ChartView3D, SheetChart } from "../src/_types";
 
 const decoder = new TextDecoder("utf-8");
 
@@ -8546,5 +8546,231 @@ describe("cloneChart — autoTitleDeleted", () => {
     expect(written).not.toContain("<c:title>");
     expect(written).toContain('<c:autoTitleDeleted val="0"/>');
     expect(parseChart(written)?.autoTitleDeleted).toBeUndefined();
+  });
+});
+
+// ── cloneChart — view3D ──────────────────────────────────────────────
+
+describe("cloneChart — view3D", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's view3D by default", () => {
+    const view: ChartView3D = {
+      rotX: 15,
+      hPercent: 100,
+      rotY: 20,
+      depthPercent: 100,
+      rAngAx: true,
+      perspective: 30,
+    };
+    const clone = cloneChart(source({ view3D: view }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.view3D).toEqual(view);
+  });
+
+  it("defensively copies the inherited view3D so a clone mutation does not leak back", () => {
+    // The resolver shallow-copies the source so a downstream
+    // mutation to the cloned SheetChart never leaks back into the
+    // parsed Chart. Mirrors how `legendEntries` defensively copies
+    // its inherited array.
+    const sourceChart = source({ view3D: { rotX: 15, rotY: 20 } });
+    const clone = cloneChart(sourceChart, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    clone.view3D!.rotX = 90;
+    expect(sourceChart.view3D).toEqual({ rotX: 15, rotY: 20 });
+  });
+
+  it("lets options.view3D replace the inherited block wholesale", () => {
+    // No per-field merge — the override block replaces the source's.
+    const clone = cloneChart(source({ view3D: { rotX: 15, rotY: 20, perspective: 30 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      view3D: { rotX: 45 },
+    });
+    expect(clone.view3D).toEqual({ rotX: 45 });
+  });
+
+  it("lets options.view3D: {} declare a bare <c:view3D/> shell", () => {
+    // An empty override accepts every per-family default — useful for
+    // round-trip parity with a templated bare element.
+    const clone = cloneChart(source({ view3D: { rotX: 15 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      view3D: {},
+    });
+    expect(clone.view3D).toEqual({});
+  });
+
+  it("drops the inherited view3D when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:view3D> entirely on emit.
+    const clone = cloneChart(
+      source({
+        view3D: { rotX: 15, rotY: 20, perspective: 30 },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        view3D: null,
+      },
+    );
+    expect(clone.view3D).toBeUndefined();
+  });
+
+  it("returns undefined view3D when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.view3D).toBeUndefined();
+  });
+
+  it("carries view3D through a flatten (line → column)", () => {
+    // <c:view3D> lives on <c:chart>, so a chart-type coercion
+    // preserves the pinned block — the element has no axis dependency.
+    const clone = cloneChart(source({ view3D: { rotX: 25 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.view3D).toEqual({ rotX: 25 });
+  });
+
+  it("preserves view3D when flattening into a doughnut clone", () => {
+    // Unlike <c:dTable>, <c:view3D> has no axis dependency — it lives
+    // on <c:chart> so pie / doughnut still carry the slot.
+    const clone = cloneChart(source({ view3D: { rotY: 60 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.view3D).toEqual({ rotY: 60 });
+  });
+
+  it("preserves view3D when flattening into a pie clone", () => {
+    const clone = cloneChart(source({ view3D: { perspective: 45 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.view3D).toEqual({ perspective: 45 });
+  });
+
+  it("propagates view3D into the rendered <c:view3D> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        view3D: {
+          rotX: 15,
+          hPercent: 100,
+          rotY: 20,
+          depthPercent: 100,
+          rAngAx: true,
+          perspective: 30,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:view3D>");
+    expect(written).toContain('<c:rotX val="15"/>');
+    expect(written).toContain('<c:hPercent val="100"/>');
+    expect(written).toContain('<c:rotY val="20"/>');
+    expect(written).toContain('<c:depthPercent val="100"/>');
+    expect(written).toContain('<c:rAngAx val="1"/>');
+    expect(written).toContain('<c:perspective val="30"/>');
+
+    // Re-parsing the rendered chart returns the same shape — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({
+      rotX: 15,
+      hPercent: 100,
+      rotY: 20,
+      depthPercent: 100,
+      rAngAx: true,
+      perspective: 30,
+    });
+  });
+
+  it("propagates an empty view3D into a bare <c:view3D/> shell on roundtrip", async () => {
+    // The empty-object input collapses to the bare self-closing
+    // element on emit, and the reader surfaces it as an empty object
+    // — closes the round-trip loop on the gating-element shape.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+      view3D: {},
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:view3D/>");
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({});
+  });
+
+  it("propagates the override-drop (null) into absence on roundtrip", async () => {
+    // null on the override drops the inherited block so the writer
+    // skips the element entirely — Excel falls back to its per-family
+    // default rotation / perspective. The round-trip closes with no
+    // <c:view3D> present in the rendered file.
+    const clone = cloneChart(source({ view3D: { rotX: 15, perspective: 30 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      view3D: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:view3D");
+    expect(parseChart(written)?.view3D).toBeUndefined();
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -7623,3 +7623,324 @@ describe("writeChart — autoTitleDeleted", () => {
     expect(reparsed?.autoTitleDeleted).toBe(true);
   });
 });
+
+// ── writeChart — view3D ──────────────────────────────────────────────
+
+describe("writeChart — view3D", () => {
+  it("skips <c:view3D> entirely when the field is unset (writer default)", () => {
+    // Excel falls back to the per-family default rotation / perspective
+    // on a fresh chart — the writer skips the element so the file
+    // stays minimal. Absence and the unset default round-trip
+    // identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:view3D");
+  });
+
+  it("emits a bare <c:view3D/> shell when view3D is an empty object", () => {
+    // An empty override accepts every per-family default — useful for
+    // round-trip parity with templates that author the bare element
+    // without pinning any field. The writer emits a self-closing
+    // shell so the bytes stay minimal.
+    const result = writeChart(makeChart({ view3D: {} }), "Sheet1");
+    expect(result.chartXml).toContain("<c:view3D/>");
+  });
+
+  it("emits every pinned field as a self-closing child", () => {
+    const result = writeChart(
+      makeChart({
+        view3D: {
+          rotX: 15,
+          hPercent: 100,
+          rotY: 20,
+          depthPercent: 100,
+          rAngAx: true,
+          perspective: 30,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:rotX val="15"/>');
+    expect(result.chartXml).toContain('<c:hPercent val="100"/>');
+    expect(result.chartXml).toContain('<c:rotY val="20"/>');
+    expect(result.chartXml).toContain('<c:depthPercent val="100"/>');
+    expect(result.chartXml).toContain('<c:rAngAx val="1"/>');
+    expect(result.chartXml).toContain('<c:perspective val="30"/>');
+  });
+
+  it("emits signed rotX values literally (ST_RotX accepts -90..90)", () => {
+    // Negative tilts must round-trip — ST_RotX is a signed byte so
+    // Excel emits the leading `-` and the writer must too.
+    const result = writeChart(makeChart({ view3D: { rotX: -45 } }), "Sheet1");
+    expect(result.chartXml).toContain('<c:rotX val="-45"/>');
+  });
+
+  it("emits the boundary values of every range (min and max)", () => {
+    const min = writeChart(
+      makeChart({
+        view3D: {
+          rotX: -90,
+          hPercent: 5,
+          rotY: 0,
+          depthPercent: 20,
+          perspective: 0,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(min.chartXml).toContain('<c:rotX val="-90"/>');
+    expect(min.chartXml).toContain('<c:hPercent val="5"/>');
+    expect(min.chartXml).toContain('<c:rotY val="0"/>');
+    expect(min.chartXml).toContain('<c:depthPercent val="20"/>');
+    expect(min.chartXml).toContain('<c:perspective val="0"/>');
+
+    const max = writeChart(
+      makeChart({
+        view3D: {
+          rotX: 90,
+          hPercent: 500,
+          rotY: 360,
+          depthPercent: 2000,
+          perspective: 240,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(max.chartXml).toContain('<c:rotX val="90"/>');
+    expect(max.chartXml).toContain('<c:hPercent val="500"/>');
+    expect(max.chartXml).toContain('<c:rotY val="360"/>');
+    expect(max.chartXml).toContain('<c:depthPercent val="2000"/>');
+    expect(max.chartXml).toContain('<c:perspective val="240"/>');
+  });
+
+  it("drops out-of-range numeric fields rather than emit a token Excel rejects", () => {
+    // Each numeric field is bound by an OOXML simple type. Out-of-
+    // range inputs drop silently rather than emit a token Excel's
+    // strict validator would reject. The other pinned fields still
+    // emit.
+    const result = writeChart(
+      makeChart({
+        view3D: {
+          rotX: 180,
+          hPercent: 3,
+          rotY: 400,
+          depthPercent: 10,
+          perspective: 500,
+          rAngAx: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:rotX");
+    expect(result.chartXml).not.toContain("<c:hPercent");
+    expect(result.chartXml).not.toContain("<c:rotY");
+    expect(result.chartXml).not.toContain("<c:depthPercent");
+    expect(result.chartXml).not.toContain("<c:perspective");
+    // rAngAx still emits — only the numeric children dropped.
+    expect(result.chartXml).toContain('<c:rAngAx val="1"/>');
+  });
+
+  it("drops fractional values rather than truncate", () => {
+    // Every CT_View3D numeric child is an integer simple type. A
+    // fractional input drops rather than silently truncate — `parseInt`
+    // would coerce 15.5 → 15 and the round-trip would silently lose
+    // the fractional value the caller passed.
+    const result = writeChart(makeChart({ view3D: { rotX: 15.5, hPercent: 100 } }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:rotX");
+    expect(result.chartXml).toContain('<c:hPercent val="100"/>');
+  });
+
+  it("drops non-finite values (NaN, Infinity, -Infinity)", () => {
+    const result = writeChart(
+      makeChart({
+        view3D: {
+          rotX: NaN,
+          hPercent: Infinity,
+          rotY: -Infinity,
+          depthPercent: 100,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:rotX");
+    expect(result.chartXml).not.toContain("<c:hPercent");
+    expect(result.chartXml).not.toContain("<c:rotY");
+    expect(result.chartXml).toContain('<c:depthPercent val="100"/>');
+  });
+
+  it('emits rAngAx=false literally (val="0") for round-trip parity', () => {
+    // Explicit `false` round-trips as `<c:rAngAx val="0"/>` so the
+    // caller can pin the OOXML default literally — useful for parity
+    // with templates that author the explicit value.
+    const result = writeChart(makeChart({ view3D: { rAngAx: false } }), "Sheet1");
+    expect(result.chartXml).toContain('<c:rAngAx val="0"/>');
+  });
+
+  it("ignores a non-boolean rAngAx (drops the child rather than emit invalid token)", () => {
+    // A non-boolean leaking through the type guard drops the child —
+    // mirrors how every other chart-level boolean writer treats its
+    // input.
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ view3D: { rAngAx: 1 as any, rotX: 15 } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:rAngAx");
+    expect(result.chartXml).toContain('<c:rotX val="15"/>');
+  });
+
+  it("emits the six CT_View3D children in schema order", () => {
+    // CT_View3D sequence per ECMA-376 Part 1, §21.2.2.228:
+    //   rotX?, hPercent?, rotY?, depthPercent?, rAngAx?, perspective?
+    const result = writeChart(
+      makeChart({
+        view3D: {
+          rotX: 15,
+          hPercent: 100,
+          rotY: 20,
+          depthPercent: 100,
+          rAngAx: true,
+          perspective: 30,
+        },
+      }),
+      "Sheet1",
+    );
+    const rotXIdx = result.chartXml.indexOf("<c:rotX");
+    const hPercentIdx = result.chartXml.indexOf("<c:hPercent");
+    const rotYIdx = result.chartXml.indexOf("<c:rotY");
+    const depthPercentIdx = result.chartXml.indexOf("<c:depthPercent");
+    const rAngAxIdx = result.chartXml.indexOf("<c:rAngAx");
+    const perspectiveIdx = result.chartXml.indexOf("<c:perspective");
+    expect(rotXIdx).toBeGreaterThan(-1);
+    expect(hPercentIdx).toBeGreaterThan(rotXIdx);
+    expect(rotYIdx).toBeGreaterThan(hPercentIdx);
+    expect(depthPercentIdx).toBeGreaterThan(rotYIdx);
+    expect(rAngAxIdx).toBeGreaterThan(depthPercentIdx);
+    expect(perspectiveIdx).toBeGreaterThan(rAngAxIdx);
+  });
+
+  it("places <c:view3D> after <c:autoTitleDeleted> and before <c:plotArea> per CT_Chart", () => {
+    // CT_Chart sequence (ECMA-376 Part 1, §21.2.2.4):
+    //   title?, autoTitleDeleted?, pivotFmts?, view3D?, ..., plotArea, ...
+    const result = writeChart(makeChart({ view3D: { rotX: 15 } }), "Sheet1");
+    const autoIdx = result.chartXml.indexOf("<c:autoTitleDeleted");
+    const view3DIdx = result.chartXml.indexOf("<c:view3D");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(autoIdx).toBeGreaterThan(-1);
+    expect(view3DIdx).toBeGreaterThan(autoIdx);
+    expect(view3DIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("only emits <c:view3D> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ view3D: { rotX: 15 } }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:view3D[\s/>]/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads view3D through every chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:view3D> is only meaningful on 3D families but the OOXML
+    // schema accepts it on every CT_Chart. The writer emits it on
+    // every family the caller pins it on — Excel silently ignores it
+    // on 2D families.
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, view3D: { rotX: 10 } }), "Sheet1");
+      expect(result.chartXml).toContain('<c:rotX val="10"/>');
+    }
+    for (const type of ["pie", "doughnut"] as const) {
+      const result = writeChart(
+        {
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4" }],
+          anchor: { from: { row: 5, col: 0 } },
+          view3D: { rotX: 10 },
+        },
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('<c:rotX val="10"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        view3D: { rotX: 10 },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<c:rotX val="10"/>');
+  });
+
+  it("round-trips a fully-pinned view3D through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        view3D: {
+          rotX: 15,
+          hPercent: 100,
+          rotY: 20,
+          depthPercent: 100,
+          rAngAx: true,
+          perspective: 30,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({
+      rotX: 15,
+      hPercent: 100,
+      rotY: 20,
+      depthPercent: 100,
+      rAngAx: true,
+      perspective: 30,
+    });
+  });
+
+  it("round-trips a partial view3D (only rotation pinned)", () => {
+    // Common pattern — pin the rotation only, leave height / depth /
+    // perspective at the per-family default. The reader surfaces the
+    // exact partial shape the writer emitted.
+    const written = writeChart(makeChart({ view3D: { rotX: 20, rotY: 40 } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 20, rotY: 40 });
+  });
+
+  it("round-trips a bare <c:view3D/> shell as an empty object", () => {
+    // The empty-object input collapses to the bare self-closing
+    // element on emit, and the reader surfaces it as an empty object
+    // — closes the round-trip loop on the gating-element shape.
+    const written = writeChart(makeChart({ view3D: {} }), "Sheet1").chartXml;
+    expect(written).toContain("<c:view3D/>");
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({});
+  });
+
+  it("threads view3D through writeXlsx into xl/charts/chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "3D Look",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            view3D: { rotX: 15, rotY: 20, perspective: 30 },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:view3D>");
+    expect(chartXml).toContain('<c:rotX val="15"/>');
+    expect(chartXml).toContain('<c:rotY val="20"/>');
+    expect(chartXml).toContain('<c:perspective val="30"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.view3D).toEqual({ rotX: 15, rotY: 20, perspective: 30 });
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -8298,3 +8298,372 @@ describe("parseChart — showLineMarkers", () => {
     expect(chart?.upDownBars).toBe(true);
   });
 });
+
+// ── parseChart — view3D ────────────────────────────────────────────
+
+describe("parseChart — view3D", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces every CT_View3D field a fully-pinned <c:view3D> declares", () => {
+    // Excel's "3-D Rotation" pane writes every field on a fresh 3D
+    // chart. The reader surfaces every pinned value literally so a
+    // clone can replay the exact rotation / perspective shape.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="15"/>
+      <c:hPercent val="100"/>
+      <c:rotY val="20"/>
+      <c:depthPercent val="100"/>
+      <c:rAngAx val="1"/>
+      <c:perspective val="30"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.view3D).toEqual({
+      rotX: 15,
+      hPercent: 100,
+      rotY: 20,
+      depthPercent: 100,
+      rAngAx: true,
+      perspective: 30,
+    });
+  });
+
+  it("surfaces a partial shape with only the fields the file pinned", () => {
+    // Common pattern — pin rotation only, leave height / depth /
+    // perspective at the per-family default. CT_View3D lists every
+    // child as optional so the parser surfaces only the present
+    // fields rather than fabricate defaults the file did not declare.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="20"/>
+      <c:rotY val="40"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:line3DChart><c:ser><c:idx val="0"/></c:ser></c:line3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({ rotX: 20, rotY: 40 });
+  });
+
+  it("surfaces signed rotX values (the OOXML ST_RotX type accepts -90..90)", () => {
+    // ST_RotX is a signed byte — Excel writes negative values for
+    // back-tilts. The parser must accept the leading `-` so a tilted
+    // template round-trips.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="-30"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({ rotX: -30 });
+  });
+
+  it("surfaces the boundary values of every range (min and max)", () => {
+    // Verify the inclusive bounds of every child's simple type.
+    const xmlMin = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="-90"/>
+      <c:hPercent val="5"/>
+      <c:rotY val="0"/>
+      <c:depthPercent val="20"/>
+      <c:perspective val="0"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xmlMin)?.view3D).toEqual({
+      rotX: -90,
+      hPercent: 5,
+      rotY: 0,
+      depthPercent: 20,
+      perspective: 0,
+    });
+
+    const xmlMax = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="90"/>
+      <c:hPercent val="500"/>
+      <c:rotY val="360"/>
+      <c:depthPercent val="2000"/>
+      <c:perspective val="240"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xmlMax)?.view3D).toEqual({
+      rotX: 90,
+      hPercent: 500,
+      rotY: 360,
+      depthPercent: 2000,
+      perspective: 240,
+    });
+  });
+
+  it("drops out-of-range numeric fields rather than fabricate clamped values", () => {
+    // Each numeric field is bound by an OOXML simple type (ST_RotX,
+    // ST_HPercent, ...). Out-of-range values drop silently rather
+    // than silently clamp — Excel itself would reject the token.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="180"/>
+      <c:hPercent val="3"/>
+      <c:rotY val="-10"/>
+      <c:depthPercent val="10"/>
+      <c:perspective val="500"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    // Every field is out of its simple-type range — nothing surfaces,
+    // but the empty `<c:view3D>` shell still gates the field as `{}`.
+    expect(parseChart(xml)?.view3D).toEqual({});
+  });
+
+  it("drops fractional / non-integer values rather than fabricate floats", () => {
+    // Every CT_View3D numeric child is an integer simple type.
+    // `parseInt` would coerce "15.5" → 15, but Excel never emits the
+    // fractional spelling. Drop the field so a hand-edited file with
+    // a fractional `val` stays unrecognised rather than silently
+    // round-trip a value Excel would not author.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="15.5"/>
+      <c:hPercent val="100abc"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({});
+  });
+
+  it("accepts the OOXML textual <xsd:boolean> spellings on rAngAx", () => {
+    // CT_Boolean accepts "1" / "true" / "0" / "false".
+    const xmlTrue = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D><c:rAngAx val="true"/></c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xmlTrue)?.view3D).toEqual({ rAngAx: true });
+
+    const xmlFalse = xmlTrue.replace('val="true"', 'val="false"');
+    expect(parseChart(xmlFalse)?.view3D).toEqual({ rAngAx: false });
+  });
+
+  it("drops a missing val attribute on a <c:view3D> child rather than fabricate a value", () => {
+    // A child without `val` is malformed per its CT type; the reader
+    // drops the field rather than fabricate a value the file did not
+    // pin. The other children still round-trip.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX/>
+      <c:rotY val="20"/>
+      <c:rAngAx/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({ rotY: 20 });
+  });
+
+  it("drops unknown rAngAx tokens rather than fabricate flags", () => {
+    // Anything outside the OOXML truthy / falsy spellings collapses
+    // to undefined for the rAngAx field. Other fields still surface.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="15"/>
+      <c:rAngAx val="yes"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({ rotX: 15 });
+  });
+
+  it("surfaces an empty object when <c:view3D> is present but every child is malformed", () => {
+    // The element itself is the gating signal — when it appears, the
+    // chart is requesting a 3D view even if every child carries a
+    // malformed `val`. The shape stays minimal (an empty object) so
+    // a round-trip through the writer falls back to absence.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX/>
+      <c:hPercent/>
+      <c:rotY/>
+      <c:depthPercent/>
+      <c:rAngAx/>
+      <c:perspective/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({});
+  });
+
+  it("surfaces an empty object on a bare <c:view3D/> element", () => {
+    // A self-closing element with no children — same minimal-shape
+    // result as a malformed-children block.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D/>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({});
+  });
+
+  it("returns undefined when the chart has no <c:view3D> element", () => {
+    // Absence is the writer's default — Excel falls back to the
+    // per-family default rotation / perspective. The reader surfaces
+    // nothing so a fresh chart and a chart that omits the element
+    // round-trip identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toBeUndefined();
+  });
+
+  it("surfaces view3D on a 2D chart family (the OOXML schema accepts it on every CT_Chart)", () => {
+    // <c:view3D> is only meaningful on 3D families but the schema
+    // accepts it on every CT_Chart. A stray element on a 2D chart
+    // surfaces here so the round-trip through cloneChart stays
+    // lossless even when the template authors a no-op.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotX val="15"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({ rotX: 15 });
+  });
+
+  it("surfaces view3D on a pie chart (no axes, but the element lives on <c:chart>)", () => {
+    // <c:view3D> lives on <c:chart>, not inside <c:plotArea>, so
+    // axis-shape has no bearing on whether the slot exists. Pie /
+    // doughnut still carry the element when the file pins it.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:view3D>
+      <c:rotY val="180"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:pieChart>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.view3D).toEqual({ rotY: 180 });
+  });
+
+  it("co-exists with sibling chart-level toggles", () => {
+    // The view3D reader should not interfere with sibling fields
+    // parsed off <c:chart> / <c:chartSpace>.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:autoTitleDeleted val="1"/>
+    <c:view3D>
+      <c:rotX val="20"/>
+      <c:rotY val="30"/>
+    </c:view3D>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.autoTitleDeleted).toBe(true);
+    expect(chart?.view3D).toEqual({ rotX: 20, rotY: 30 });
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:chart><c:view3D>` (CT_View3D, ECMA-376 Part 1, §21.2.2.228) at the read, write, and clone layers so a template's 3-D rotation / perspective shape survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:view3D>` mirrors Excel's "3-D Rotation" pane on 3D chart families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`). The element holds six independently optional CT_View3D children — `<c:rotX>` (X rotation, signed -90..90), `<c:hPercent>` (height percent, 5..500), `<c:rotY>` (Y rotation, 0..360), `<c:depthPercent>` (depth percent, 20..2000), `<c:rAngAx>` (right-angle-axes flag), and `<c:perspective>` (foreshortening factor, 0..240). Until now hucre's writer had no slot for the element, and the reader ignored it entirely, so a templated 3D dashboard chart silently lost its rotation and perspective settings on every parse -> clone -> write loop. Bridges another rotation-customization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.view3D);
// { rotX: 15, hPercent: 100, rotY: 20, depthPercent: 100, rAngAx: true, perspective: 30 }
//   ← when the template authored the bar3D chart with Excel's defaults
// undefined
//   ← when the template emits no `<c:view3D>` element

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Region", "Sales"],
      ["North", 100],
      ["South", 200],
    ],
    charts: [{
      type: "column",
      title: "Sales (3D look)",
      series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
      // Pin a custom rotation / perspective. Each numeric field is
      // clamped against its OOXML simple-type range; out-of-range and
      // fractional inputs drop silently.
      view3D: { rotX: 20, rotY: 30, perspective: 45 },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed view3D unchanged (defensively copied).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  view3D: null,
});
//   → drops the inherited block (writer skips `<c:view3D>` entirely).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  view3D: { rotX: 45 },
});
//   → replaces the inherited block wholesale (no per-field merge).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  view3D: {},
});
//   → empty object collapses to a bare `<c:view3D/>` shell on emit.
```

## Implementation notes

- **Reader**: `parseView3D` walks `<c:view3D>` and surfaces only the children whose `val` parses inside the matching OOXML simple-type range. Each numeric field is validated with a strict integer regex (rejects `15.5`, `15px`); out-of-range values drop rather than fabricate a clamped result. Boolean `<c:rAngAx>` accepts the OOXML truthy / falsy spellings; unknown tokens drop. The element itself is the gating signal — a `<c:view3D>` with no resolvable children surfaces as `{}`, mirroring how `dataTable` / `protection` handle a malformed inner block. The lookup runs on every chart family (the schema accepts the element on every CT_Chart) so a stray element on a 2D chart still surfaces for lossless round-trip.
- **Writer**: `buildView3D` returns `undefined` when the field is unset (writer skips emission), a bare `<c:view3D/>` shell when the input is `{}`, or the populated element with one self-closing child per pinned field. Children emit in CT_View3D schema order (`rotX`, `hPercent`, `rotY`, `depthPercent`, `rAngAx`, `perspective`). Each numeric child is clamped via `clampView3DInt` against its OOXML range; out-of-range, fractional, and non-finite inputs drop silently. The boolean child emits `val="0"` literally on `false` for round-trip parity with templates that author the explicit OOXML default. The block slots between `<c:autoTitleDeleted>` and `<c:plotArea>` per the CT_Chart sequence.
- **Clone**: `resolveView3D` follows the standard `undefined` (inherit) / `null` (drop) / `object` (replace) grammar. Inherited values are defensively shallow-copied so a downstream mutation to the cloned `SheetChart` never leaks back into the parsed `Chart`. Unlike `dataTable`, the field has no axis dependency — `<c:view3D>` lives on `<c:chart>`, so the resolver applies to every chart family (pie / doughnut included). The grammar mirrors `protection` / `dataTable` so the chart-level block toggles compose the same way at the call site.
- **Validation**: Numeric fields outside the matching OOXML range (`rotX` -90..90, `hPercent` 5..500, `rotY` 0..360, `depthPercent` 20..2000, `perspective` 0..240) drop at write time rather than emit a token Excel's strict validator would reject. Fractional and non-finite inputs (`NaN`, `Infinity`) drop at the same boundary.

## Test plan

- [x] `parseChart — view3D` (14 tests) — fully-pinned shape, partial shape, signed rotX, boundary values, out-of-range drop, fractional drop, OOXML truthy / falsy spellings, missing val drop, unknown rAngAx tokens, malformed children gating, bare element gating, absence, every chart family scope, sibling toggle co-existence.
- [x] `writeChart — view3D` (16 tests) — unset omission, empty-object bare shell, fully-pinned children, signed rotX, boundary values, out-of-range drop, fractional drop, non-finite drop, explicit `false` rAngAx, non-boolean rAngAx drop, CT_View3D schema order, CT_Chart placement, single-emit guard, every chart family scope, full round-trip via parse / write, full `writeXlsx` package round-trip.
- [x] `cloneChart — view3D` (12 tests) — inherit / replace / drop / empty-object semantics, defensive copy, every flatten (line → column / doughnut / pie), end-to-end parse -> clone -> write -> reparse for fully-pinned, empty-shell, and dropped overrides.
- [x] `pnpm test` — all 3959 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)