### PR TITLE
feat(xlsx): chart axis custom display unit divisor — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,25 +803,32 @@ distinct from the `"autoZero"` default which defers to Excel's
 auto-placement). Unknown semantic tokens and non-numeric `val`
 attributes drop rather than fabricate values the writer would reject.
 `ChartAxisInfo.dispUnits` surfaces the per-value-axis display-unit
-preset pulled from `<c:valAx><c:dispUnits><c:builtInUnit val=".."/></c:dispUnits></c:valAx>`
+configuration pulled from `<c:valAx><c:dispUnits>...</c:dispUnits></c:valAx>`
 — Excel's "Format Axis -> Display units" dropdown. The element rescales
-the numeric tick labels by the chosen preset (e.g. `"millions"` divides
+the numeric tick labels by the chosen divisor (e.g. `"millions"` divides
 every label by 1e6) so a chart whose source range stores raw amounts
 can show compact tick labels without modifying the underlying cells.
 The OOXML schema places the element exclusively on `CT_ValAx`, so
 `dispUnits` only surfaces on the value-axis side of bar / column / line
 / area charts (the Y axis) and on both axes of scatter charts (both are
 value axes); category axes (`<c:catAx>`) and pie / doughnut never
-surface the field. The reader keeps the parsed `unit` token and the
-presence of `<c:dispUnitsLbl>` (`showLabel: true` when Excel paints its
-automatic annotation alongside the axis); the alternative
-`<c:custUnit val=".."/>` (custom numeric divisor) and any rich-text
-`<c:dispUnitsLbl>` body are intentionally not surfaced. The OOXML
+surface the field. The reader keeps both choices the OOXML schema
+allows: the named `unit` token from `<c:builtInUnit val=".."/>` and the
+arbitrary numeric divisor from `<c:custUnit val=".."/>` (Excel's
+"Display units → Other" path — e.g. `86400` to convert seconds to
+days). The OOXML schema places the two children in an `xsd:choice`
+(exactly one may appear); on emit hucre prefers `custUnit` when both
+fields are pinned so a clone can layer a custom divisor on top of an
+inherited preset without manually pruning the original. The
+`showLabel: true` flag tracks the presence of `<c:dispUnitsLbl>`
+(Excel paints its automatic annotation alongside the axis); the rich-
+text `<c:dispUnitsLbl>` body is intentionally not surfaced. The OOXML
 schema accepts the nine `ST_BuiltInUnit` tokens (`"hundreds"`,
 `"thousands"`, `"tenThousands"`, `"hundredThousands"`, `"millions"`,
 `"tenMillions"`, `"hundredMillions"`, `"billions"`, `"trillions"`);
 unknown tokens drop to `undefined` rather than fabricate a value the
-writer would never emit.
+writer would never emit. Non-positive / non-finite `custUnit` values
+drop at the same boundary.
 `ChartAxisInfo.crossBetween` surfaces the per-value-axis cross-between
 mode pulled from `<c:valAx><c:crossBetween val=".."/></c:valAx>` — the
 OOXML `ST_CrossBetween` enum (`"between"` / `"midCat"`) that controls
@@ -1302,26 +1309,33 @@ per-series marker styling: this gate sits at the chart level and
 decides whether markers paint, while the per-series block picks the
 symbol / size / fill that paints when the gate is open.
 The `axes.{x,y}.dispUnits` field controls the per-value-axis
-display-unit preset (`<c:valAx><c:dispUnits><c:builtInUnit val=".."/></c:dispUnits></c:valAx>`)
+display-unit configuration (`<c:valAx><c:dispUnits>...</c:dispUnits></c:valAx>`)
 — Excel's "Format Axis -> Display units" dropdown. Each numeric tick
-label is divided by the chosen preset before rendering, so a chart
+label is divided by the chosen divisor before rendering, so a chart
 whose source range stores raw amounts (e.g. `1_500_000`) can show
 compact tick labels (`1.5` with an optional "Millions" annotation)
 without modifying the underlying cells. Pass a `ChartAxisDispUnit`
-shorthand (e.g. `"millions"`) or a `{ unit, showLabel? }` object to
-opt into the automatic unit annotation by setting `showLabel: true`
-(the writer emits a bare `<c:dispUnitsLbl/>` so Excel paints its
-default label alongside the axis). Accepted unit tokens: `"hundreds"`,
-`"thousands"`, `"tenThousands"`, `"hundredThousands"`, `"millions"`,
-`"tenMillions"`, `"hundredMillions"`, `"billions"`, `"trillions"`. The
-OOXML schema places `<c:dispUnits>` exclusively on `CT_ValAx`, so the
-field only takes effect on the value-axis side of bar / column / line
-/ area charts (the Y axis) and on both axes of scatter charts (both
-are value axes); category axes (`<c:catAx>`) silently drop the field
-and pie / doughnut have no axes at all. Unknown tokens drop silently
-rather than fabricate a value the OOXML `ST_BuiltInUnit` enum would
-reject. The custom-divisor variant (`<c:custUnit>`) and rich-text
-`<c:dispUnitsLbl>` body are intentionally not surfaced.
+shorthand (e.g. `"millions"`) or a `{ unit?, custUnit?, showLabel? }`
+object: pin `unit` for one of the named OOXML presets, or pin
+`custUnit` for an arbitrary positive divisor (Excel's "Display units →
+Other" path — e.g. `86400` to convert seconds to days). The two
+fields are mutually exclusive in the OOXML schema's `xsd:choice`; when
+both are set, `custUnit` wins on emit so a clone can layer a custom
+divisor on top of an inherited preset without manually pruning the
+original. Set `showLabel: true` to opt into the automatic unit
+annotation (the writer emits a bare `<c:dispUnitsLbl/>` so Excel
+paints its default label alongside the axis). Accepted unit tokens:
+`"hundreds"`, `"thousands"`, `"tenThousands"`, `"hundredThousands"`,
+`"millions"`, `"tenMillions"`, `"hundredMillions"`, `"billions"`,
+`"trillions"`. The OOXML schema places `<c:dispUnits>` exclusively on
+`CT_ValAx`, so the field only takes effect on the value-axis side of
+bar / column / line / area charts (the Y axis) and on both axes of
+scatter charts (both are value axes); category axes (`<c:catAx>`)
+silently drop the field and pie / doughnut have no axes at all.
+Unknown tokens drop silently rather than fabricate a value the OOXML
+`ST_BuiltInUnit` enum would reject; non-positive / non-finite
+`custUnit` values drop at the same boundary. The rich-text
+`<c:dispUnitsLbl>` body is intentionally not surfaced.
 The `axes.{x,y}.crossBetween` field controls the per-value-axis
 cross-between mode (`<c:valAx><c:crossBetween val=".."/></c:valAx>`) —
 the OOXML `ST_CrossBetween` enum that picks between `"between"` (the

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2856,10 +2856,16 @@ export type ChartAxisDispUnit =
  * labels by the chosen preset (e.g. `"millions"` divides every label by
  * 1e6) and optionally prints the unit annotation on the chart.
  *
- * The reader and writer model only the built-in preset path
- * (`<c:builtInUnit val=".."/>`); the alternative `<c:custUnit
- * val=".."/>` (custom numeric divisor) is intentionally out of scope —
- * pass a {@link ChartAxisDispUnit} preset instead.
+ * The OOXML schema places `<c:builtInUnit>` and `<c:custUnit>` in an
+ * `xsd:choice` — exactly one of the two may appear inside `<c:dispUnits>`.
+ * Hucre exposes both: pin {@link unit} to pick one of the named OOXML
+ * presets (the common path — Excel's "Display units → Hundreds /
+ * Thousands / ..." dropdown), or pin {@link custUnit} to declare an
+ * arbitrary numeric divisor (Excel's "Display units → Other" path).
+ * When both fields are pinned, `custUnit` wins on emit because the
+ * OOXML schema forbids emitting both children — the more specific
+ * numeric divisor takes precedence so a caller can append a custom unit
+ * to a cloned source without manually pruning the inherited preset.
  *
  * `<c:dispUnitsLbl>` is also intentionally minimal: when `showLabel` is
  * `true` the writer emits a bare `<c:dispUnitsLbl/>` so Excel paints its
@@ -2869,8 +2875,29 @@ export type ChartAxisDispUnit =
  * string can layer it on later.
  */
 export interface ChartAxisDispUnits {
-  /** OOXML `ST_BuiltInUnit` token — the preset divisor. */
-  unit: ChartAxisDispUnit;
+  /**
+   * OOXML `ST_BuiltInUnit` token — the preset divisor. Maps to
+   * `<c:dispUnits><c:builtInUnit val=".."/></c:dispUnits>`. Mutually
+   * exclusive with {@link custUnit} per the OOXML schema; when both are
+   * pinned, `custUnit` wins on emit. Required when `custUnit` is
+   * absent — a `ChartAxisDispUnits` object with neither field pinned
+   * collapses to no element on emit.
+   */
+  unit?: ChartAxisDispUnit;
+  /**
+   * Custom numeric divisor — Excel's "Display units → Other" path.
+   * Maps to `<c:dispUnits><c:custUnit val=".."/></c:dispUnits>` (CT_Double
+   * per the OOXML schema). The divisor rescales every tick label by the
+   * given factor (e.g. `1000` divides labels by 1 000, the same as the
+   * `"thousands"` preset; `86400` converts seconds to days).
+   *
+   * Mutually exclusive with {@link unit} per the OOXML `xsd:choice` —
+   * when both are pinned, `custUnit` wins on emit. Must be a finite
+   * positive number; `0`, negative, non-finite (`NaN`, `Infinity`), and
+   * non-number inputs drop silently rather than emit a token Excel
+   * would refuse.
+   */
+  custUnit?: number;
   /**
    * Whether to print Excel's automatic display-unit annotation
    * alongside the axis (e.g. "Millions" for `unit: "millions"`). Maps

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -2474,6 +2474,16 @@ const VALID_DISP_UNIT_VALUES: ReadonlySet<ChartAxisDispUnit> = new Set([
  * can hand back to the writer-side `SheetChart.axes.{x,y}.dispUnits`
  * field. Unknown / typo'd tokens collapse to `undefined` so they cannot
  * leak past the clone layer.
+ *
+ * Both `unit` (built-in preset) and `custUnit` (custom numeric divisor)
+ * pass through when valid. The OOXML schema's `xsd:choice` between
+ * `<c:builtInUnit>` and `<c:custUnit>` is enforced at emit time by the
+ * writer (which prefers `custUnit` when both are pinned); the
+ * normalizer keeps both fields so the clone layer can append a
+ * `custUnit` override to a source whose parsed value pinned `unit`
+ * without manually pruning the inherited preset. Returns `undefined`
+ * when neither field resolves to a valid value — a stray
+ * `ChartAxisDispUnits` with no usable child has nothing to emit.
  */
 function normalizeDispUnits(
   value: ChartAxisDispUnits | ChartAxisDispUnit | undefined,
@@ -2485,11 +2495,16 @@ function normalizeDispUnits(
       : undefined;
   }
   if (typeof value !== "object" || value === null) return undefined;
+  const out: ChartAxisDispUnits = {};
   const unit = value.unit;
-  if (typeof unit !== "string" || !VALID_DISP_UNIT_VALUES.has(unit as ChartAxisDispUnit)) {
-    return undefined;
+  if (typeof unit === "string" && VALID_DISP_UNIT_VALUES.has(unit as ChartAxisDispUnit)) {
+    out.unit = unit as ChartAxisDispUnit;
   }
-  const out: ChartAxisDispUnits = { unit: unit as ChartAxisDispUnit };
+  const custUnit = value.custUnit;
+  if (typeof custUnit === "number" && Number.isFinite(custUnit) && custUnit > 0) {
+    out.custUnit = custUnit;
+  }
+  if (out.unit === undefined && out.custUnit === undefined) return undefined;
   if (value.showLabel === true) out.showLabel = true;
   return out;
 }

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -842,18 +842,21 @@ const VALID_DISP_UNITS: ReadonlySet<ChartAxisDispUnit> = new Set([
 ]);
 
 /**
- * Read a value axis's `<c:dispUnits>` block. The element holds a choice
- * between `<c:builtInUnit val=".."/>` and `<c:custUnit val=".."/>`,
- * optionally followed by `<c:dispUnitsLbl>`. The reader only surfaces
- * the built-in path — the `<c:custUnit>` variant (custom numeric
- * divisor) and any rich-text `<c:dispUnitsLbl>` body are ignored.
+ * Read a value axis's `<c:dispUnits>` block. The element holds an
+ * `xsd:choice` between `<c:builtInUnit val=".."/>` and
+ * `<c:custUnit val=".."/>`, optionally followed by `<c:dispUnitsLbl>`.
+ * The reader surfaces both: a recognized `<c:builtInUnit>` token lands
+ * in `unit`, and a finite positive `<c:custUnit>` value lands in
+ * `custUnit`. When both children are present (a malformed template,
+ * since the schema's choice forbids it), `custUnit` wins and `unit`
+ * drops — the writer applies the same precedence on emit, so the parsed
+ * shape round-trips identically through {@link cloneChart}.
  *
  * Returns `undefined` when:
  *   - the axis declares no `<c:dispUnits>` at all,
- *   - `<c:dispUnits>` is present but has no `<c:builtInUnit>` child
- *     (the schema also tolerates `<c:custUnit>` but we don't surface it),
- *   - `<c:builtInUnit val>` is missing, malformed, or not in
- *     {@link VALID_DISP_UNITS}.
+ *   - `<c:dispUnits>` is present but neither child resolves to a
+ *     valid value (missing children, malformed `val`, unknown
+ *     `<c:builtInUnit>` token, non-positive / non-finite `<c:custUnit>`).
  *
  * `showLabel` is set `true` only when `<c:dispUnitsLbl>` is present
  * inside `<c:dispUnits>` (Excel paints its automatic annotation in
@@ -863,13 +866,34 @@ const VALID_DISP_UNITS: ReadonlySet<ChartAxisDispUnit> = new Set([
 function parseAxisDispUnits(axis: XmlElement): ChartAxisDispUnits | undefined {
   const dispUnits = findChild(axis, "dispUnits");
   if (!dispUnits) return undefined;
-  const builtInUnit = findChild(dispUnits, "builtInUnit");
-  if (!builtInUnit) return undefined;
-  const raw = builtInUnit.attrs.val;
-  if (typeof raw !== "string") return undefined;
-  const trimmed = raw.trim() as ChartAxisDispUnit;
-  if (!VALID_DISP_UNITS.has(trimmed)) return undefined;
-  const out: ChartAxisDispUnits = { unit: trimmed };
+  const out: ChartAxisDispUnits = {};
+  // `<c:custUnit>` wins when both children are pinned — the OOXML
+  // schema's `xsd:choice` forbids both, but a corrupt template may
+  // declare them simultaneously. The writer mirrors this preference so
+  // the round-trip stays consistent.
+  const custUnit = findChild(dispUnits, "custUnit");
+  if (custUnit) {
+    const raw = custUnit.attrs.val;
+    if (typeof raw === "string") {
+      const parsed = Number.parseFloat(raw.trim());
+      if (Number.isFinite(parsed) && parsed > 0) {
+        out.custUnit = parsed;
+      }
+    }
+  }
+  if (out.custUnit === undefined) {
+    const builtInUnit = findChild(dispUnits, "builtInUnit");
+    if (builtInUnit) {
+      const raw = builtInUnit.attrs.val;
+      if (typeof raw === "string") {
+        const trimmed = raw.trim() as ChartAxisDispUnit;
+        if (VALID_DISP_UNITS.has(trimmed)) {
+          out.unit = trimmed;
+        }
+      }
+    }
+  }
+  if (out.unit === undefined && out.custUnit === undefined) return undefined;
   if (findChild(dispUnits, "dispUnitsLbl")) {
     out.showLabel = true;
   }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1016,6 +1016,16 @@ const VALID_DISP_UNITS: ReadonlySet<ChartAxisDispUnit> = new Set([
  * tokens collapse to `undefined` so the writer never emits a value the
  * OOXML `ST_BuiltInUnit` enum rejects. Non-object / non-string inputs
  * (e.g. `null`, numbers, arrays) also collapse to `undefined`.
+ *
+ * The OOXML schema places `<c:builtInUnit>` and `<c:custUnit>` in an
+ * `xsd:choice` — at most one of the two may appear inside `<c:dispUnits>`.
+ * The normalizer keeps both fields when the input declares both, leaving
+ * the precedence pick to {@link buildAxisDispUnits} (where `custUnit`
+ * wins because it is the more specific OOXML element). When neither
+ * field is valid, the normalizer returns `undefined` so the writer skips
+ * the `<c:dispUnits>` element entirely — a `<c:dispUnits>` shell with
+ * no `<c:builtInUnit>` / `<c:custUnit>` child would fail Excel's strict
+ * validator.
  */
 function normalizeAxisDispUnits(
   value: ChartAxisDispUnits | ChartAxisDispUnit | undefined,
@@ -1027,11 +1037,21 @@ function normalizeAxisDispUnits(
       : undefined;
   }
   if (typeof value !== "object" || value === null) return undefined;
+  const out: ChartAxisDispUnits = {};
   const unit = value.unit;
-  if (typeof unit !== "string" || !VALID_DISP_UNITS.has(unit as ChartAxisDispUnit)) {
-    return undefined;
+  if (typeof unit === "string" && VALID_DISP_UNITS.has(unit as ChartAxisDispUnit)) {
+    out.unit = unit as ChartAxisDispUnit;
   }
-  const out: ChartAxisDispUnits = { unit: unit as ChartAxisDispUnit };
+  const custUnit = value.custUnit;
+  if (typeof custUnit === "number" && Number.isFinite(custUnit) && custUnit > 0) {
+    out.custUnit = custUnit;
+  }
+  // Drop the entire object when neither child resolves — a bare
+  // `<c:dispUnits/>` shell would fail Excel's strict validator (the
+  // CT_DispUnits choice has `minOccurs="0"` on the choice itself, but
+  // an empty element with the parent's `<c:extLst>` slot also empty
+  // is rejected by Excel's reference renderer).
+  if (out.unit === undefined && out.custUnit === undefined) return undefined;
   if (value.showLabel === true) out.showLabel = true;
   return out;
 }
@@ -1039,18 +1059,33 @@ function normalizeAxisDispUnits(
 /**
  * Build the optional `<c:dispUnits>` block that sits at the very end of
  * `<c:valAx>` per CT_ValAx (after `<c:minorUnit>`). The element itself
- * holds the choice between `<c:builtInUnit>` and `<c:custUnit>`; the
- * writer only emits the built-in variant. When `showLabel` is `true`
- * the writer emits a bare `<c:dispUnitsLbl/>` so Excel paints its
- * default automatic annotation; the rich-text label customization is
- * intentionally not surfaced.
+ * holds the choice between `<c:builtInUnit>` and `<c:custUnit>` — the
+ * writer emits exactly one per the OOXML `xsd:choice`, preferring
+ * `<c:custUnit>` when both fields are pinned because the more specific
+ * numeric divisor takes precedence (a caller appending a custom unit to
+ * a cloned source need not manually prune the inherited preset). When
+ * `showLabel` is `true` the writer emits a bare `<c:dispUnitsLbl/>` so
+ * Excel paints its default automatic annotation; the rich-text label
+ * customization is intentionally not surfaced.
  *
- * Returns an empty array when the caller did not pin a preset so the
- * writer leaves Excel's default "no display unit" state untouched.
+ * Returns an empty array when the caller did not pin either child so
+ * the writer leaves Excel's default "no display unit" state untouched.
  */
 function buildAxisDispUnits(dispUnits: ChartAxisDispUnits | undefined): string[] {
   if (!dispUnits) return [];
-  const children: string[] = [xmlSelfClose("c:builtInUnit", { val: dispUnits.unit })];
+  const children: string[] = [];
+  if (dispUnits.custUnit !== undefined) {
+    children.push(xmlSelfClose("c:custUnit", { val: dispUnits.custUnit }));
+  } else if (dispUnits.unit !== undefined) {
+    children.push(xmlSelfClose("c:builtInUnit", { val: dispUnits.unit }));
+  } else {
+    // Neither child resolved — skip emission rather than ship a bare
+    // `<c:dispUnits/>` Excel rejects. The normalizer should have
+    // pre-filtered this case, but the guard here keeps the writer
+    // robust against a stray runtime object slipping past the type
+    // boundary.
+    return [];
+  }
   if (dispUnits.showLabel === true) {
     children.push(xmlSelfClose("c:dispUnitsLbl"));
   }

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6719,6 +6719,118 @@ describe("cloneChart — axis dispUnits", () => {
       showLabel: true,
     });
   });
+
+  // ── custUnit (custom numeric divisor) ─────────────────────────────
+
+  const sourceWithCustUnit: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { y: { dispUnits: { custUnit: 86400 } } },
+  };
+
+  it("inherits axes.y.dispUnits.custUnit from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithCustUnit, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.dispUnits).toEqual({ custUnit: 86400 });
+  });
+
+  it("replaces the inherited preset with a custUnit override", () => {
+    // A caller appending a custom divisor to a cloned source whose
+    // parsed value pinned a built-in preset should swap cleanly into
+    // the new shape.
+    const clone = cloneChart(sourceWithUnit, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { dispUnits: { custUnit: 1500 } } },
+    });
+    expect(clone.axes?.y?.dispUnits).toEqual({ custUnit: 1500 });
+  });
+
+  it("replaces the inherited custUnit with a built-in preset override", () => {
+    const clone = cloneChart(sourceWithCustUnit, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { dispUnits: { unit: "millions" } } },
+    });
+    expect(clone.axes?.y?.dispUnits).toEqual({ unit: "millions" });
+  });
+
+  it("keeps both fields on a clone when the override pins both — writer picks custUnit", () => {
+    // The clone-layer normalizer keeps both values; the writer enforces
+    // the OOXML xsd:choice by preferring `custUnit` on emit. Carrying
+    // both fields lets a caller layer a custom divisor on top of an
+    // inherited preset without manually pruning the original.
+    const clone = cloneChart(sourceWithUnit, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { dispUnits: { unit: "millions", custUnit: 1500 } } },
+    });
+    expect(clone.axes?.y?.dispUnits).toEqual({ unit: "millions", custUnit: 1500 });
+  });
+
+  it("drops invalid custUnit values (zero, negative, non-finite) at the clone layer", () => {
+    for (const bad of [0, -100, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const clone = cloneChart(sourceWithUnit, {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { y: { dispUnits: { custUnit: bad } } },
+      });
+      // Override has no valid field — `unit` is unset and `custUnit`
+      // dropped — so the entire dispUnits object collapses.
+      expect(clone.axes).toBeUndefined();
+    }
+  });
+
+  it("inherits showLabel alongside custUnit", () => {
+    const sourceLabeled: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { y: { dispUnits: { custUnit: 500, showLabel: true } } },
+    };
+    const clone = cloneChart(sourceLabeled, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.y?.dispUnits).toEqual({ custUnit: 500, showLabel: true });
+  });
+
+  it("drops the inherited custUnit when flattening to pie (no axes)", () => {
+    const clone = cloneChart(sourceWithCustUnit, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("round-trips a custUnit chart through parseChart -> cloneChart -> writeChart", async () => {
+    const source: SheetChart = {
+      type: "column",
+      series: [{ name: "Seconds", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { y: { dispUnits: { custUnit: 86400, showLabel: true } } },
+    };
+    const xml = writeChart(source, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    const clone = cloneChart(parsed, { anchor: { from: { row: 5, col: 0 } } });
+    expect(clone.axes?.y?.dispUnits).toEqual({ custUnit: 86400, showLabel: true });
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["H", "Seconds"],
+            ["H1", 360_000],
+            ["H2", 720_000],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:custUnit val="86400"/>');
+    expect(written).toContain("<c:dispUnitsLbl/>");
+    expect(written).not.toContain("c:builtInUnit");
+    expect(parseChart(written)?.axes?.y?.dispUnits).toEqual({
+      custUnit: 86400,
+      showLabel: true,
+    });
+  });
 });
 
 // ── cloneChart — chart style preset ──────────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -6092,6 +6092,161 @@ describe("writeChart — axis dispUnits", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.axes?.y?.dispUnits).toEqual({ unit: "millions", showLabel: true });
   });
+
+  it('emits <c:dispUnits><c:custUnit val=".."/></c:dispUnits> when custUnit is pinned', () => {
+    // The OOXML schema's xsd:choice between <c:builtInUnit> and
+    // <c:custUnit> means the writer must emit exactly one. Pinning
+    // `custUnit` selects the numeric divisor path (Excel's "Display
+    // units → Other") instead of the named preset.
+    const result = writeChart(
+      makeChart({ axes: { y: { dispUnits: { custUnit: 86400 } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:custUnit val="86400"/>');
+    expect(valAxBlock).toContain("<c:dispUnits>");
+    expect(valAxBlock).not.toContain("c:builtInUnit");
+    expect(valAxBlock).not.toContain("c:dispUnitsLbl");
+  });
+
+  it("emits a fractional <c:custUnit> per the OOXML CT_Double schema", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { dispUnits: { custUnit: 2.5 } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:custUnit val="2.5"/>');
+  });
+
+  it("emits a bare <c:dispUnitsLbl/> alongside custUnit when showLabel is true", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { dispUnits: { custUnit: 500, showLabel: true } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:custUnit val="500"/>');
+    expect(valAxBlock).toContain("<c:dispUnitsLbl/>");
+  });
+
+  it("prefers <c:custUnit> over <c:builtInUnit> when both fields are pinned", () => {
+    // The OOXML schema's xsd:choice forbids both children, so the writer
+    // must pick one. `custUnit` is the more specific element — a caller
+    // appending a custom divisor to a cloned source need not manually
+    // prune the inherited preset. The reader mirrors this preference.
+    const result = writeChart(
+      makeChart({ axes: { y: { dispUnits: { unit: "millions", custUnit: 1500 } } } }),
+      "Sheet1",
+    );
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<c:custUnit val="1500"/>');
+    expect(valAxBlock).not.toContain("c:builtInUnit");
+  });
+
+  it("falls back to <c:builtInUnit> when custUnit is non-positive / non-finite", () => {
+    // The normalizer drops invalid custUnit values; if the caller also
+    // pinned a valid `unit` preset, that takes over instead of dropping
+    // the entire element.
+    for (const bad of [0, -100, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const result = writeChart(
+        makeChart({ axes: { y: { dispUnits: { unit: "millions", custUnit: bad } } } }),
+        "Sheet1",
+      );
+      const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+      expect(valAxBlock).toContain('<c:builtInUnit val="millions"/>');
+      expect(valAxBlock).not.toContain("c:custUnit");
+    }
+  });
+
+  it("drops <c:dispUnits> entirely when neither unit nor custUnit resolves", () => {
+    // A bare <c:dispUnits/> shell with no <c:builtInUnit>/<c:custUnit>
+    // child fails Excel's strict validator. The writer skips emission.
+    const result = writeChart(
+      makeChart({
+        axes: {
+          y: {
+            // Both fields invalid — `unit` is an unknown token, `custUnit`
+            // is non-finite.
+            dispUnits: { unit: "quintillions" as never, custUnit: -5 },
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:dispUnits");
+    expect(result.chartXml).not.toContain("c:builtInUnit");
+    expect(result.chartXml).not.toContain("c:custUnit");
+  });
+
+  it("does not emit <c:custUnit> on the X axis of a column chart (catAx rejects it)", () => {
+    // Same scope rule as the built-in preset — `<c:dispUnits>` lives
+    // exclusively on `CT_ValAx`, so a stray hint on the column's X axis
+    // silently drops at the writer.
+    const result = writeChart(
+      makeChart({ type: "column", axes: { x: { dispUnits: { custUnit: 1000 } } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("c:dispUnits");
+    expect(catAxBlock).not.toContain("c:custUnit");
+  });
+
+  it("emits <c:custUnit> on both scatter axes (both are valAx)", () => {
+    const scatter: SheetChart = {
+      type: "scatter",
+      series: [{ name: "S1", values: "B2:B5", categories: "A2:A5" }],
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: { dispUnits: { custUnit: 60 } },
+        y: { dispUnits: { custUnit: 86400, showLabel: true } },
+      },
+    };
+    const result = writeChart(scatter, "Sheet1");
+    const valAxBlocks = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxBlocks).toHaveLength(2);
+    expect(valAxBlocks[0]).toContain('<c:custUnit val="60"/>');
+    expect(valAxBlocks[0]).not.toContain("c:dispUnitsLbl");
+    expect(valAxBlocks[1]).toContain('<c:custUnit val="86400"/>');
+    expect(valAxBlocks[1]).toContain("<c:dispUnitsLbl/>");
+  });
+
+  it("survives a parseChart round-trip on the value axis with custUnit", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { dispUnits: { custUnit: 500, showLabel: true } } } }),
+      "Sheet1",
+    );
+    const reparsed = parseChart(result.chartXml);
+    expect(reparsed?.axes?.y?.dispUnits).toEqual({ custUnit: 500, showLabel: true });
+  });
+
+  it("packages a custUnit chart end-to-end through writeXlsx", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Hour", "Seconds"],
+          ["H1", 360_000],
+          ["H2", 720_000],
+          ["H3", 1_080_000],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Seconds", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            // 86400 seconds per day — convert tick labels to days.
+            axes: { y: { dispUnits: { custUnit: 86400, showLabel: true } } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<c:custUnit val="86400"/>');
+    expect(chartXml).toContain("<c:dispUnitsLbl/>");
+    expect(chartXml).not.toContain("c:builtInUnit");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.y?.dispUnits).toEqual({ custUnit: 86400, showLabel: true });
+  });
 });
 
 // ── writeChart — chart style preset ──────────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6779,10 +6779,10 @@ describe("parseChart — axis dispUnits", () => {
     expect(chart?.axes?.y?.dispUnits).toBeUndefined();
   });
 
-  it("drops the parsed value when <c:builtInUnit> is missing or malformed", () => {
-    // <c:dispUnits> has a choice between <c:builtInUnit> and
-    // <c:custUnit>; the reader only surfaces the built-in path. A
-    // bare <c:dispUnits> (or one with only <c:custUnit>) should drop.
+  it("drops the parsed value when neither <c:builtInUnit> nor <c:custUnit> resolves", () => {
+    // <c:dispUnits> has an xsd:choice between <c:builtInUnit> and
+    // <c:custUnit>. A bare <c:dispUnits>, or one whose lone child has
+    // a missing / malformed `val`, surfaces nothing.
     const bare = `<c:chartSpace ${NS}>
   <c:chart><c:plotArea>
     <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
@@ -6801,14 +6801,14 @@ describe("parseChart — axis dispUnits", () => {
 </c:chartSpace>`;
     expect(parseChart(noVal)?.axes?.y?.dispUnits).toBeUndefined();
 
-    const custUnit = `<c:chartSpace ${NS}>
+    const noCustVal = `<c:chartSpace ${NS}>
   <c:chart><c:plotArea>
     <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
     <c:catAx><c:axId val="1"/></c:catAx>
-    <c:valAx><c:axId val="2"/><c:dispUnits><c:custUnit val="500"/></c:dispUnits></c:valAx>
+    <c:valAx><c:axId val="2"/><c:dispUnits><c:custUnit/></c:dispUnits></c:valAx>
   </c:plotArea></c:chart>
 </c:chartSpace>`;
-    expect(parseChart(custUnit)?.axes?.y?.dispUnits).toBeUndefined();
+    expect(parseChart(noCustVal)?.axes?.y?.dispUnits).toBeUndefined();
   });
 
   it("surfaces dispUnits on both scatter axes (both are valAx)", () => {
@@ -6845,6 +6845,139 @@ describe("parseChart — axis dispUnits", () => {
 </c:chartSpace>`;
     const chart = parseChart(xml);
     expect(chart?.axes?.y?.dispUnits).toBeUndefined();
+  });
+
+  it("surfaces a custom numeric divisor on the value axis", () => {
+    // Excel's "Display units → Other" path emits <c:custUnit val=".."/>
+    // instead of <c:builtInUnit>. The reader surfaces the numeric divisor
+    // as `custUnit` so a templated chart that pins an arbitrary divisor
+    // (e.g. 86400 to convert seconds to days) round-trips through clone.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:dispUnits><c:custUnit val="86400"/></c:dispUnits>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.dispUnits).toEqual({ custUnit: 86400 });
+  });
+
+  it("parses fractional custUnit values per the OOXML CT_Double schema", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:dispUnits><c:custUnit val="2.5"/></c:dispUnits>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.dispUnits).toEqual({ custUnit: 2.5 });
+  });
+
+  it("surfaces showLabel alongside custUnit when <c:dispUnitsLbl> is present", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:dispUnits>
+        <c:custUnit val="500"/>
+        <c:dispUnitsLbl/>
+      </c:dispUnits>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.dispUnits).toEqual({ custUnit: 500, showLabel: true });
+  });
+
+  it("drops custUnit values that are non-positive, non-finite, or malformed", () => {
+    // OOXML CT_Double accepts any double, but a divisor of 0 or below
+    // would silently break the rendered scale. The reader requires a
+    // finite positive value rather than fabricate a token Excel rejects.
+    for (const raw of ["0", "-100", "NaN", "Infinity", "-Infinity", "abc", ""]) {
+      const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:dispUnits><c:custUnit val="${raw}"/></c:dispUnits>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.axes?.y?.dispUnits).toBeUndefined();
+    }
+  });
+
+  it("prefers <c:custUnit> over <c:builtInUnit> when a malformed template declares both", () => {
+    // The OOXML schema's xsd:choice forbids both children, but a
+    // corrupt template may carry both. The reader picks `custUnit`
+    // (the more specific element) and drops the preset; the writer
+    // mirrors this preference so the round-trip stays consistent.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:dispUnits>
+        <c:custUnit val="1500"/>
+        <c:builtInUnit val="thousands"/>
+      </c:dispUnits>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.dispUnits).toEqual({ custUnit: 1500 });
+  });
+
+  it("falls back to <c:builtInUnit> when <c:custUnit> is present but malformed", () => {
+    // A `<c:custUnit>` whose `val` fails the positive-finite gate
+    // does not poison the parse — the reader falls back to the
+    // sibling `<c:builtInUnit>` (also out-of-spec for the schema's
+    // choice, but a corrupt template may declare both).
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:dispUnits>
+        <c:custUnit val="-5"/>
+        <c:builtInUnit val="hundreds"/>
+      </c:dispUnits>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.dispUnits).toEqual({ unit: "hundreds" });
+  });
+
+  it("collapses custUnit to undefined on a category axis (catAx rejects <c:dispUnits>)", () => {
+    // Same scope rule as the built-in preset — `<c:dispUnits>` lives
+    // exclusively on `CT_ValAx`, so a stray element on `<c:catAx>`
+    // never surfaces.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:dispUnits><c:custUnit val="500"/></c:dispUnits>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.dispUnits).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Surfaces the `<c:dispUnits><c:custUnit val=".."/></c:dispUnits>` variant on chart value axes at the read, write, and clone layers so a template authored with Excel's "Format Axis -> Display units -> Other" path survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch alongside the existing `<c:builtInUnit>` preset.

`<c:custUnit>` is the second arm of the OOXML `CT_DispUnits` `xsd:choice` (ECMA-376 Part 1, §21.2.2.32) — the alternative to the named `<c:builtInUnit>` preset. It carries an arbitrary `CT_Double` divisor that rescales every numeric tick label (e.g. `86400` to convert seconds to days; `1500` to scale by an arbitrary factor the named presets cannot express). Until now hucre's reader and writer only modelled the built-in path; the `custUnit` variant was explicitly noted as out-of-scope. A templated chart pinning a custom divisor therefore silently lost the value on every `parse -> clone -> write` loop. Bridges another axis-customization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.y?.dispUnits);
// { custUnit: 86400 }                            ← when the template emits <c:custUnit val="86400"/>
// { custUnit: 500, showLabel: true }             ← with the automatic unit annotation
// { unit: "millions" }                           ← unchanged for the existing built-in path

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Hour", "Seconds"],
      ["H1", 360_000],
      ["H2", 720_000],
    ],
    charts: [{
      type: "column",
      title: "Elapsed time",
      series: [{ name: "Seconds", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
      // 86_400 seconds per day — convert tick labels to days.
      axes: { y: { dispUnits: { custUnit: 86_400, showLabel: true } } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed dispUnits unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { y: { dispUnits: { custUnit: 1500 } } },
});
//   → replaces the inherited preset with a custom divisor.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  // Layer a custom divisor on top of an inherited preset; the writer
  // emits the more specific <c:custUnit> per the OOXML xsd:choice.
  axes: { y: { dispUnits: { unit: "millions", custUnit: 1500 } } },
});
```

## Implementation notes

- **Type model**: `ChartAxisDispUnits.unit` becomes optional and a new optional `custUnit?: number` joins it. The two are mutually exclusive in the OOXML schema's `xsd:choice`; the writer enforces the choice on emit by preferring `custUnit` when both are pinned. Keeping both fields on the cloned object lets a caller append a custom divisor to a parsed source without manually pruning the inherited preset.
- **Reader** (`parseAxisDispUnits`): walks `<c:dispUnits>` and surfaces both children in one pass — `<c:custUnit>` first (it wins on a malformed template that declares both), falling back to `<c:builtInUnit>` if the cust value is malformed. The numeric `<c:custUnit val>` parses via `Number.parseFloat` and only surfaces when the result is finite and strictly positive (`0`, negative, `NaN`, `Infinity` drop). A `<c:dispUnits>` block that resolves neither child surfaces as `undefined` (Excel's strict validator rejects an empty shell).
- **Writer** (`buildAxisDispUnits` + `normalizeAxisDispUnits`): the normalizer keeps both fields when both are valid; the builder emits exactly one element per the OOXML `xsd:choice`, preferring `<c:custUnit>` when both are pinned. A bare `ChartAxisDispUnits` object with neither field valid drops the entire `<c:dispUnits>` element rather than ship a shell Excel rejects. Same value-axis-only scope rule as the existing built-in path — `<c:dispUnits>` only emits on `<c:valAx>` (Y axis on bar / column / line / area; both axes on scatter); category axes and pie / doughnut silently drop the field.
- **Clone** (`normalizeDispUnits` + `applyDispUnitsOverride`): same `undefined` (inherit) / `null` (drop) / value (replace) grammar the existing fields use. The normalizer keeps both fields when valid so a clone-through that layers a custom divisor on top of an inherited preset survives without manual pruning. Invalid `custUnit` values drop at the clone boundary so the writer never sees a token Excel would reject.
- **Validation**: `custUnit` must be a finite positive number; `0`, negative, `NaN`, `Infinity`, and non-number inputs drop silently rather than emit a token Excel rejects. Non-string `unit` tokens and tokens outside the OOXML `ST_BuiltInUnit` enum drop at the same boundary (existing behavior). When both fields drop, the entire `<c:dispUnits>` element is omitted.

## Test plan

- [x] `parseChart — axis dispUnits` (8 new tests) — custUnit surfaces, fractional values per CT_Double, showLabel alongside custUnit, non-positive / non-finite drop, custUnit wins when both pinned, fallback to builtInUnit when cust malformed, catAx scope guard, plus an updated drop-when-malformed case.
- [x] `writeChart — axis dispUnits` (10 new tests) — custUnit emit shape, fractional emit, dispUnitsLbl alongside custUnit, custUnit wins when both pinned, fallback to builtInUnit on invalid custUnit, full element drop when neither field resolves, catAx scope guard, both scatter axes, parse round-trip, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis dispUnits` (8 new tests) — inherit / replace / mixed-pin / drop semantics, invalid custUnit drop at clone boundary, showLabel pass-through, pie flatten guard, end-to-end parse -> clone -> write -> reparse.
- [x] `pnpm test` — all 3981 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)