### PR TITLE
feat(xlsx): chart category-axis auto type detection — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,20 @@ ignores the element on every other axis flavour. Only an explicit
 unknown tokens all collapse to `undefined` so absence and the default
 round-trip identically. The reader accepts the OOXML truthy / falsy
 spellings (`"1"` / `"true"` / `"0"` / `"false"`).
+`ChartAxisInfo.auto` surfaces the per-axis `<c:auto val=".."/>` flag
+— Excel's "Format Axis -> Axis Options -> Axis Type" radio (the
+"Text axis" choice flips the value to `0`). The OOXML default `true`
+lets Excel inspect the axis labels and decide at render time whether
+to treat the axis as a discrete category axis or a chronological
+date axis; `false` pins the axis as a literal category axis so a
+date-shaped category range still renders as a flat category axis
+without any chronological grouping. The OOXML schema places the
+element on `CT_CatAx` exclusively, so the parser ignores it on every
+other axis flavour. Only an explicit `val="0"` surfaces `false`; the
+OOXML default `val="1"`, absence, missing `val`, and unknown tokens
+all collapse to `undefined` so absence and the default round-trip
+identically. The reader accepts the OOXML truthy / falsy spellings
+(`"1"` / `"true"` / `"0"` / `"false"`).
 `ChartAxisInfo.reverse` surfaces the per-axis
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
 "Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
@@ -1444,6 +1458,22 @@ only an explicit `true` emits `val="1"`. The element lives on
 `<c:serAx>` reject it), so the flag threads through bar / column /
 line / area but is silently dropped on scatter (both axes are value
 axes) and pie / doughnut (no axes at all).
+The `axes.x.auto` flag maps to `<c:catAx><c:auto val=".."/>` — Excel's
+"Format Axis -> Axis Options -> Axis Type" radio (the "Text axis"
+choice flips the value to `0`). Excel's default `true` lets the
+renderer inspect the axis labels and decide at render time whether to
+treat the axis as a discrete category axis or a chronological date
+axis; `false` pins the axis as a literal category axis so a
+date-shaped category range still renders as a flat category axis
+without any chronological grouping. The writer always emits the
+element because Excel's reference serialization includes
+`<c:auto val="1"/>` on every category axis; `true`, absence, and
+non-boolean inputs all collapse to the default `val="1"`, while only
+an explicit `false` emits `val="0"`. The element lives on `CT_CatAx`
+exclusively (even `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject
+it), so the flag threads through bar / column / line / area but is
+silently dropped on scatter (both axes are value axes) and pie /
+doughnut (no axes at all).
 The `axes.x.reverse` and `axes.y.reverse` flags map to
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` — Excel's
 "Categories / Values in reverse order" toggle. On a category axis,

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1785,6 +1785,30 @@ export interface SheetChart {
        */
       noMultiLvlLbl?: boolean;
       /**
+       * Automatic axis-type detection on a category axis. Maps to
+       * `<c:catAx><c:auto val=".."/></c:catAx>` (CT_CatAx, ECMA-376
+       * Part 1, §21.2.2.7). The OOXML default `true` lets Excel inspect
+       * the axis labels and decide at render time whether to treat the
+       * axis as a discrete category axis or a chronological date axis.
+       *
+       * Set `false` to pin the axis as a literal category axis — Excel
+       * keeps every label as-is regardless of whether the cells parse as
+       * dates or numerics. Useful when porting a template that pins the
+       * "Text axis" radio button under "Format Axis -> Axis Options ->
+       * Axis Type" so a date-shaped category range still renders as a
+       * flat category axis without any chronological grouping.
+       *
+       * Only meaningful for bar / column / line / area charts (whose X
+       * axis is `<c:catAx>`); silently ignored for scatter (both axes
+       * are value axes) and pie / doughnut (no axes at all). The OOXML
+       * schema places the element on `CT_CatAx` only — `CT_ValAx`,
+       * `CT_DateAx`, and `CT_SerAx` reject it. Mirrors how the writer
+       * always emits Excel's reference `<c:auto val="1"/>` on a stock
+       * chart and only flips the value when the caller explicitly
+       * pins `auto: false`.
+       */
+      auto?: boolean;
+      /**
        * Horizontal alignment of the tick labels on a category axis —
        * `"ctr"` (center, the OOXML default), `"l"` (left), or `"r"`
        * (right). Maps to `<c:catAx><c:lblAlgn val=".."/></c:catAx>`.
@@ -3091,6 +3115,23 @@ export interface ChartAxisInfo {
    * `undefined`.
    */
   noMultiLvlLbl?: boolean;
+  /**
+   * Automatic axis-type detection flag pulled from
+   * `<c:auto val=".."/>`. Surfaces `false` only when the axis pinned
+   * `val="0"` (Excel's "Text axis" radio under "Format Axis -> Axis
+   * Options -> Axis Type" — Excel keeps every label as-is regardless
+   * of whether the cells parse as dates / numerics). The OOXML default
+   * `val="1"` (and absence of the element) collapse to `undefined` so
+   * absence and the default round-trip identically through
+   * {@link cloneChart}.
+   *
+   * Surfaces only on category axes (`<c:catAx>`) — the OOXML schema
+   * places the element on `CT_CatAx` exclusively. The reader accepts
+   * the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
+   * `"false"`); unknown values and missing `val` attributes drop to
+   * `undefined`.
+   */
+  auto?: boolean;
   /**
    * Axis hidden flag pulled from `<c:delete val=".."/>`. Surfaces
    * `true` when the axis pinned `val="1"` (Excel's "Format Axis ->

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -625,6 +625,21 @@ export interface CloneChartOptions {
        */
       noMultiLvlLbl?: boolean | null;
       /**
+       * Override `SheetChart.axes.x.auto`. `undefined` (or omitted)
+       * inherits the source axis's flag; `null` drops the inherited
+       * value (the writer falls back to the OOXML `true` default —
+       * Excel auto-detects whether to render the axis as a date or
+       * category axis); a `boolean` replaces it. Only `false` actually
+       * surfaces on the cloned `SheetChart` (the writer treats `true`
+       * and absence identically — both produce `<c:auto val="1"/>`),
+       * so an override of `true` collapses to `undefined`.
+       *
+       * Only meaningful for resolved chart types whose X axis is
+       * `<c:catAx>` (bar / column / line / area); silently dropped on
+       * scatter and pie / doughnut.
+       */
+      auto?: boolean | null;
+      /**
        * Override `SheetChart.axes.x.hidden`. `undefined` (or omitted)
        * inherits the source axis's flag; `null` drops the inherited
        * value (the writer falls back to the OOXML `false` default —
@@ -2065,6 +2080,12 @@ function resolveAxes(
   const xNoMultiLvlLbl = isCatAxisX
     ? applyNoMultiLvlLblOverride(sourceAxes?.x?.noMultiLvlLbl, overrides?.x?.noMultiLvlLbl)
     : undefined;
+  // `<c:auto>` is also `CT_CatAx`-only per ECMA-376 §21.2.2.7 — same
+  // scope rule as `noMultiLvlLbl`. The flag defaults to `true` in the
+  // OOXML schema (Excel auto-detects whether to render the axis as a
+  // date or category axis), so the resolver collapses `true` to
+  // `undefined` and only surfaces an explicit `false`.
+  const xAuto = isCatAxisX ? applyAutoOverride(sourceAxes?.x?.auto, overrides?.x?.auto) : undefined;
   // `<c:delete>` lives on every axis flavour — both `<c:catAx>` and
   // `<c:valAx>` accept it — so the hidden flag carries through every
   // chart family that has axes. Pie / doughnut have no axes at all
@@ -2126,6 +2147,7 @@ function resolveAxes(
     xLblOffset !== undefined ||
     xLblAlgn !== undefined ||
     xNoMultiLvlLbl !== undefined ||
+    xAuto !== undefined ||
     xHidden !== undefined ||
     xCrossesPair.crosses !== undefined ||
     xCrossesPair.crossesAt !== undefined ||
@@ -2146,6 +2168,7 @@ function resolveAxes(
     if (xLblOffset !== undefined) out.x.lblOffset = xLblOffset;
     if (xLblAlgn !== undefined) out.x.lblAlgn = xLblAlgn;
     if (xNoMultiLvlLbl !== undefined) out.x.noMultiLvlLbl = xNoMultiLvlLbl;
+    if (xAuto !== undefined) out.x.auto = xAuto;
     if (xHidden !== undefined) out.x.hidden = xHidden;
     if (xCrossesPair.crosses !== undefined) out.x.crosses = xCrossesPair.crosses;
     if (xCrossesPair.crossesAt !== undefined) out.x.crossesAt = xCrossesPair.crossesAt;
@@ -2276,6 +2299,31 @@ function applyNoMultiLvlLblOverride(
   }
   if (override === null) return undefined;
   return override === true ? true : undefined;
+}
+
+/**
+ * Resolve an `auto` override using the same `undefined` (inherit) /
+ * `null` (drop) / `boolean` (replace) grammar as the other axis
+ * helpers. Only `false` surfaces (the writer treats `true` and absence
+ * identically — both produce `<c:auto val="1"/>`), so an override of
+ * `true` collapses to `undefined` to keep the cloned `SheetChart`
+ * shape minimal. Non-boolean inputs fall through the type guard to
+ * `undefined`.
+ *
+ * Inverse of {@link applyNoMultiLvlLblOverride}: `<c:auto>` defaults to
+ * `true` in the OOXML schema, so the helper collapses `true` rather
+ * than `false` — symmetric with the parser-side default-collapse on
+ * the read layer.
+ */
+function applyAutoOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    return source === false ? false : undefined;
+  }
+  if (override === null) return undefined;
+  return override === false ? false : undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -490,6 +490,13 @@ function parseAxisInfo(
   // a corrupt template carrying a stray flag does not surface a value
   // the writer would never emit anyway.
   const noMultiLvlLbl = axis.local === "catAx" ? parseAxisNoMultiLvlLbl(axis) : undefined;
+  // `<c:auto>` lives exclusively on `CT_CatAx` per ECMA-376 Part 1,
+  // §21.2.2.7 — `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject the
+  // element. Skip the parse on every other axis flavour for symmetry
+  // with the writer's catAx-only emit path. Only `false` surfaces; the
+  // OOXML default `true` (Excel inspects the data and decides whether
+  // to treat the axis as a date axis) collapses to `undefined`.
+  const auto = axis.local === "catAx" ? parseAxisAuto(axis) : undefined;
   // `<c:delete>` sits on every axis flavour (CT_CatAx / CT_ValAx /
   // CT_DateAx / CT_SerAx) per ECMA-376 Part 1, §21.2.2. The OOXML
   // default `val="0"` (axis visible) collapses to `undefined` so
@@ -535,6 +542,7 @@ function parseAxisInfo(
     lblOffset === undefined &&
     lblAlgn === undefined &&
     noMultiLvlLbl === undefined &&
+    auto === undefined &&
     hidden === undefined &&
     crosses === undefined &&
     crossesAt === undefined &&
@@ -557,6 +565,7 @@ function parseAxisInfo(
   if (lblOffset !== undefined) out.lblOffset = lblOffset;
   if (lblAlgn !== undefined) out.lblAlgn = lblAlgn;
   if (noMultiLvlLbl !== undefined) out.noMultiLvlLbl = noMultiLvlLbl;
+  if (auto !== undefined) out.auto = auto;
   if (hidden !== undefined) out.hidden = hidden;
   if (crosses !== undefined) out.crosses = crosses;
   if (crossesAt !== undefined) out.crossesAt = crossesAt;
@@ -753,6 +762,44 @@ function parseAxisNoMultiLvlLbl(axis: XmlElement): boolean | undefined {
       return true;
     case "0":
     case "false":
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pull `<c:auto val=".."/>` off a category axis element. Returns
+ * `false` only when the axis pinned `val="0"` / `val="false"` (Excel's
+ * "Text axis" radio button under "Format Axis -> Axis Options -> Axis
+ * Type" — Excel keeps every label as-is regardless of whether the
+ * cells parse as dates / numerics). The OOXML default `val="1"` /
+ * `val="true"` (Excel inspects the data and decides whether to treat
+ * the axis as a discrete category axis or a chronological date axis),
+ * absence, missing `val`, and unknown tokens all collapse to
+ * `undefined` so absence and the default round-trip identically
+ * through {@link cloneChart}.
+ *
+ * Mirrors the truthy / falsy parsing in {@link parseAxisNoMultiLvlLbl}
+ * — the OOXML schema (`xsd:boolean`) accepts `0` / `1` / `false` /
+ * `true` for `<c:auto>` just as it does for every other Boolean-valued
+ * chart attribute. The element's default is the OOXML inverse of
+ * `noMultiLvlLbl` (auto defaults to `true`, noMultiLvlLbl defaults to
+ * `false`), so this parser collapses `true` rather than `false`.
+ */
+function parseAxisAuto(axis: XmlElement): boolean | undefined {
+  const el = findChild(axis, "auto");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw.trim()) {
+    case "0":
+    case "false":
+      return false;
+    case "1":
+    case "true":
+      // OOXML default — collapse to undefined so absence and the
+      // default round-trip identically.
       return undefined;
     default:
       return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -332,6 +332,14 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // catAx-only scope rule as the surrounding category-axis knobs;
     // the catAx builder is the sole consumer.
     xNoMultiLvlLbl: chart.axes?.x?.noMultiLvlLbl === true,
+    // `<c:auto>` lives exclusively on `CT_CatAx` per ECMA-376 Part 1,
+    // §21.2.2.7 — `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject the
+    // element. Same catAx-only scope rule as `noMultiLvlLbl`. Only an
+    // explicit `axes.x.auto === false` flips the toggle off; absence
+    // (and any non-boolean) falls back to the OOXML default `true` so
+    // the writer always emits Excel's reference `<c:auto val="1"/>`
+    // shape on a stock chart.
+    xAuto: chart.axes?.x?.auto !== false,
     // `<c:delete>` lives on every axis flavour (CT_CatAx / CT_ValAx /
     // CT_DateAx / CT_SerAx). The writer always emits the element —
     // Excel's reference serialization includes `<c:delete val="0"/>`
@@ -720,6 +728,17 @@ interface AxisRenderOptions {
    * dropped at the per-chart-type branch.
    */
   xNoMultiLvlLbl: boolean;
+  /**
+   * Whether the X axis should render its `<c:auto>` element with
+   * `val="1"` (Excel's default — auto-detect whether the axis is a
+   * date axis or category axis). Always defined — `true` keeps Excel's
+   * reference `val="1"` while `false` pins the axis as a literal
+   * category axis (Excel's "Text axis" radio under "Format Axis -> Axis
+   * Options"). Only meaningful for the catAx builder; scatter has no
+   * category axis, so the value is silently dropped at the per-chart-
+   * type branch.
+   */
+  xAuto: boolean;
   /**
    * Whether the X axis should render its `<c:delete>` element with
    * `val="1"` (axis hidden). Always defined — `false` keeps Excel's
@@ -1411,7 +1430,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
     buildAxisCrosses(opts.xCrosses),
-    xmlSelfClose("c:auto", { val: 1 }),
+    // `<c:auto>` is always emitted because Excel's reference
+    // serialization includes it on every category axis. The writer
+    // pins the caller's override when `false`; absence (and any non-
+    // boolean) collapses to the OOXML default `true` so untouched
+    // charts match Excel's output byte-for-byte.
+    xmlSelfClose("c:auto", { val: opts.xAuto ? 1 : 0 }),
     // `<c:lblAlgn>` is always emitted because Excel's reference
     // serialization includes it on every category axis. The writer
     // pins the caller's override when set; absence (or the OOXML

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -5230,6 +5230,194 @@ describe("cloneChart — axis noMultiLvlLbl", () => {
   });
 });
 
+// ── cloneChart — axis auto ──────────────────────────────────────────
+
+describe("cloneChart — axis auto", () => {
+  const sourceWithFlag: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { auto: false } },
+  };
+
+  it("inherits axes.x.auto=false from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithFlag, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.auto).toBe(false);
+  });
+
+  it("drops the inherited flag when override is null", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { auto: null } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("drops the inherited flag when override is true", () => {
+    // `true` collapses to undefined the same way `null` does because the
+    // writer treats both shapes identically (val="1" is the default).
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { auto: true } },
+    });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("replaces the inherited false with override false (no-op)", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { auto: false } },
+    });
+    expect(clone.axes?.x?.auto).toBe(false);
+  });
+
+  it("adds auto=false to a source axis that did not declare it", () => {
+    const noFlag: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { auto: false } },
+    });
+    expect(clone.axes?.x?.auto).toBe(false);
+  });
+
+  it("collapses non-boolean overrides to undefined", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { auto: 0 as unknown as boolean } },
+    });
+    // The non-boolean override drops, falling back to undefined (not the
+    // inherited false) since the override was non-undefined.
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { auto: false } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { auto: false } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is scatter", () => {
+    // Scatter uses two value axes, so the X axis is no longer a category
+    // axis. Drop inherited auto so the cloned model accurately reflects
+    // what the chart will paint — the schema rejects the element on every
+    // value-axis flavour.
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "scatter",
+      series: [{ values: "Sheet1!$B$2:$B$5", categories: "Sheet1!$A$2:$A$5" }],
+    });
+    expect(clone.type).toBe("scatter");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the flag through a chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.auto).toBe(false);
+  });
+
+  it("composes the flag alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Period",
+          gridlines: { major: true },
+          noMultiLvlLbl: true,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.noMultiLvlLbl).toBe(true);
+    expect(clone.axes?.x?.auto).toBe(false);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the flag", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:auto val="0"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.auto).toBe(false);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.auto).toBe(false);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const catAxBlock = written.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:auto val="0"');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.auto).toBe(false);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the flag intact", async () => {
+    const clone = cloneChart(sourceWithFlag, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('c:auto val="0"');
+  });
+});
+
 // ── cloneChart — titleOverlay ────────────────────────────────────────
 
 describe("cloneChart — titleOverlay", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4795,6 +4795,151 @@ describe("writeChart — axis noMultiLvlLbl", () => {
   });
 });
 
+// ── writeChart — axis auto ───────────────────────────────────────────
+
+describe("writeChart — axis auto", () => {
+  it('emits the OOXML default <c:auto val="1"/> on the category axis when the field is unset', () => {
+    // Excel's reference serialization always emits `<c:auto val="1"/>` on
+    // every category axis, so the writer keeps that contract on a stock
+    // chart even though the parser collapses `1` to undefined on the
+    // read side.
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:auto val="1"');
+    expect(catAxBlock).not.toContain('c:auto val="0"');
+  });
+
+  it('emits <c:auto val="0"/> on the category axis when the override is false', () => {
+    const result = writeChart(makeChart({ axes: { x: { auto: false } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:auto val="0"');
+    expect(catAxBlock).not.toContain('c:auto val="1"');
+  });
+
+  it("emits the default when the override is explicitly true", () => {
+    // Pinning the default has the same wire effect as omitting the field —
+    // the OOXML default `true` round-trips identically with absence.
+    const result = writeChart(makeChart({ axes: { x: { auto: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:auto val="1"');
+  });
+
+  it("emits exactly one <c:auto> element per category axis", () => {
+    const result = writeChart(makeChart({ axes: { x: { auto: false } } }), "Sheet1");
+    // Use a precise pattern so `<c:autoTitleDeleted>` does not collide
+    // with the catAx `<c:auto val=".."/>` element.
+    expect((result.chartXml.match(/<c:auto val="/g) ?? []).length).toBe(1);
+  });
+
+  it("threads the override through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { auto: false } } }), "Sheet1");
+      expect(result.chartXml).toContain('c:auto val="0"');
+    }
+  });
+
+  it("ignores the override on scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { auto: false } },
+      }),
+      "Sheet1",
+    );
+    // `<c:autoTitleDeleted>` is always emitted on `<c:chart>`, so check
+    // the precise CT_CatAx form to confirm the catAx element never
+    // surfaces on a chart whose axes are both `<c:valAx>`.
+    expect(result.chartXml).not.toContain("<c:auto val=");
+  });
+
+  it("ignores the override on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(makeChart({ type: "pie", axes: { x: { auto: false } } }), "Sheet1");
+    expect(pie.chartXml).not.toContain("<c:auto val=");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { auto: false } } }),
+      "Sheet1",
+    );
+    expect(dough.chartXml).not.toContain("<c:auto val=");
+  });
+
+  it("does not emit auto on the value axis", () => {
+    // The model surfaces the flag only on `axes.x`; setting it via
+    // `axes.y` is impossible at the type level. This test pins the
+    // negative case for the writer: a valAx never carries the element.
+    const result = writeChart(makeChart({ axes: { x: { auto: false } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).not.toContain("<c:auto");
+  });
+
+  it("places auto between crosses and lblAlgn per the OOXML schema", () => {
+    // CT_CatAx: ... crossAx -> crosses? -> auto -> lblAlgn -> lblOffset.
+    const result = writeChart(
+      makeChart({
+        axes: { x: { crosses: "max", auto: false, lblAlgn: "l" } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const crossesIdx = catAxBlock.indexOf("c:crosses");
+    const autoIdx = catAxBlock.indexOf("c:auto");
+    const lblAlgnIdx = catAxBlock.indexOf("c:lblAlgn");
+    expect(crossesIdx).toBeGreaterThan(0);
+    expect(autoIdx).toBeGreaterThan(crossesIdx);
+    expect(lblAlgnIdx).toBeGreaterThan(autoIdx);
+  });
+
+  it("ignores non-boolean auto values (falls back to default 1)", () => {
+    // Match how `legendOverlay` / `roundedCorners` / axis `hidden` treat
+    // their inputs: only literal `false` produces the non-default `0`. A
+    // stray non-boolean collapses to the default.
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { auto: "no" as any } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('c:auto val="1"');
+  });
+
+  it("round-trips a non-default auto through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { x: { auto: false } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.auto).toBe(false);
+  });
+
+  it("collapses a defaulted auto round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the flag into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { auto: false } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('c:auto val="0"');
+  });
+});
+
 // ── writeChart — title overlay ───────────────────────────────────────
 
 describe("writeChart — titleOverlay", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5672,6 +5672,186 @@ describe("parseChart — axis noMultiLvlLbl", () => {
   });
 });
 
+// ── parseChart — axis auto ─────────────────────────────────────────
+
+describe("parseChart — axis auto", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces auto=false on the category axis when val="0"', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:auto val="0"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.auto).toBe(false);
+    expect(chart?.axes?.y?.auto).toBeUndefined();
+  });
+
+  it('collapses the OOXML default val="1" to undefined', () => {
+    // Excel's reference serialization always emits `<c:auto val="1"/>`
+    // on every category axis even though the schema default is `true`.
+    // The parser collapses the default so absence and the default
+    // round-trip identically through the writer's elision logic.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:auto val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("collapses absence of <c:auto> to undefined", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it('accepts the OOXML falsy spelling val="false"', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:auto val="false"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.auto).toBe(false);
+  });
+
+  it('accepts the OOXML truthy spelling val="true" and collapses to undefined', () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:auto val="true"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:auto> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:auto/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined for unknown val tokens", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:auto val="maybe"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface auto on a value axis", () => {
+    // The OOXML schema places `<c:auto>` on CT_CatAx exclusively —
+    // `<c:valAx>` rejects it entirely. A corrupt template carrying a
+    // stray flag on a value axis should not surface a field the writer
+    // would never emit anyway.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:auto val="0"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.auto).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("does not surface auto on a scatter chart's value axes", () => {
+    // Scatter has two valAx — the schema rejects `<c:auto>` on both, so
+    // a stray flag on either axis must not bleed through into the
+    // parsed shape.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:auto val="0"/>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:auto val="0"/>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.auto).toBeUndefined();
+    expect(chart?.axes?.y?.auto).toBeUndefined();
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("co-surfaces auto alongside other catAx fields", () => {
+    const xml = `<c:chartSpace ${NS}
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:auto val="0"/>
+      <c:noMultiLvlLbl val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      auto: false,
+      noMultiLvlLbl: true,
+    });
+  });
+});
+
 // ── parseChart — titleOverlay ───────────────────────────────────────
 
 describe("parseChart — titleOverlay", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:auto val=\"..\"/>` (CT_CatAx, ECMA-376 Part 1, §21.2.2.7) at the read, write, and clone layers so a template's \"Text axis\" pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:auto>` mirrors Excel's \"Format Axis -> Axis Options -> Axis Type\" radio. The OOXML default `true` lets Excel inspect the axis labels and decide at render time whether to treat the axis as a discrete category axis or a chronological date axis. `false` pins the axis as a literal category axis — Excel keeps every label as-is regardless of whether the cells parse as dates / numerics. Until now hucre's writer hardcoded `<c:auto val=\"1\"/>` and the reader ignored the element entirely, so a templated chart whose user pinned the \"Text axis\" radio silently lost the choice on every parse -> clone -> write loop. Bridges another category-axis customization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.auto);
// false                                ← when the template pinned <c:auto val=\"0\"/>
// undefined                            ← when the template pinned <c:auto val=\"1\"/> or omits the element

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [
      [\"Period\", \"Sales\"],
      [\"Q1 2024\", 100],
      [\"Q2 2024\", 200],
    ],
    charts: [{
      type: \"column\",
      title: \"Quarterly sales\",
      series: [{ name: \"Sales\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
      // Pin the axis as a literal category axis so Excel does not
      // collapse the period strings into a chronological date axis.
      axes: { x: { auto: false } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed `auto: false` unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { auto: null } },
});
//   → drops the inherited flag (the writer falls back to the OOXML default `true`).
```

## Implementation notes

- **Type model**: `SheetChart.axes.x.auto?: boolean` (writer side, X-axis only) and `ChartAxisInfo.auto?: boolean` (reader side). The clone option `axes.x.auto?: boolean | null` follows the standard `undefined` (inherit) / `null` (drop) / boolean (replace) grammar.
- **Reader** (`parseAxisAuto`): walks `<c:catAx>` for `<c:auto val=\"..\"/>`. Only `val=\"0\"` / `val=\"false\"` surfaces `false`; the OOXML default `val=\"1\"` (and `val=\"true\"`, missing `val`, unknown tokens, absence) collapses to `undefined`. The element lives on `CT_CatAx` exclusively per the OOXML schema — `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject it — so the parser ignores it on every other axis flavour, mirroring the writer's catAx-only emit path.
- **Writer**: previously hardcoded `<c:auto val=\"1\"/>` in the catAx builder. Now resolves through `xAuto: chart.axes?.x?.auto !== false` so only an explicit `axes.x.auto === false` flips the toggle off; absence (and any non-boolean) falls back to the OOXML default `true`, matching Excel's reference serialization. The element slots between `<c:crosses>` and `<c:lblAlgn>` per the CT_CatAx schema sequence. The flag threads through bar / column / line / area but is silently dropped on scatter (both axes are value axes) and pie / doughnut (no axes at all).
- **Clone** (`applyAutoOverride`): inverse of `applyNoMultiLvlLblOverride` — `<c:auto>` defaults to `true` in the OOXML schema, so the helper collapses `true` rather than `false` (symmetric with the parser-side default-collapse). The catAx-only scope is enforced in the resolver — scatter / pie / doughnut clones drop the inherited flag silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only literal `boolean` survives the type guard; non-boolean inputs collapse to the default. This matches how `noMultiLvlLbl` / `legendOverlay` / `roundedCorners` / axis `hidden` treat their inputs at the write layer.

## Test plan

- [x] `parseChart — axis auto` (10 new tests) — surfaces `false` on `val=\"0\"`, collapses `val=\"1\"` and absence to `undefined`, OOXML truthy / falsy spellings, missing `val`, unknown tokens, valAx scope guard, scatter scope guard, co-surfaces alongside other catAx fields.
- [x] `writeChart — axis auto` (12 new tests) — emits `val=\"1\"` by default, emits `val=\"0\"` on override, emits default on `auto: true` and non-boolean, exactly-one-element guard, threads through bar / column / line / area, scatter scope guard, pie / doughnut scope guard, valAx scope guard, OOXML schema position, parse round-trip, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis auto` (12 new tests) — inherit / replace / null drop / `true` drop / non-boolean drop semantics, source-without-flag pickup, pie / doughnut / scatter scope guards, chart-type coercion, composition with other axis overrides, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4037 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)