### PR TITLE
feat(xlsx): chart data labels showLeaderLines flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -634,6 +634,26 @@ export interface ChartDataLabels {
    * from the source cell formatting.
    */
   numberFormat?: ChartAxisNumberFormat;
+  /**
+   * Render the leader lines that connect each data label back to its
+   * pie / doughnut slice when Excel pushes a label outside the slice it
+   * belongs to. Mirrors Excel's "Format Data Labels -> Label Options ->
+   * Show Leader Lines" checkbox.
+   *
+   * Maps to `<c:showLeaderLines val=".."/>` inside `<c:dLbls>`, which
+   * sits at the tail of the `EG_DLbls` group (after `<c:separator>`,
+   * before `<c:extLst>`). The OOXML schema scopes the element to
+   * pie / doughnut chart families exclusively (`EG_DLbls` for
+   * `CT_PieChart` / `CT_DoughnutChart` only — bar / column / line /
+   * area / scatter route through `EG_DLblsShared` which omits it). The
+   * writer drops the field silently on every non-pie / non-doughnut
+   * family to mirror Excel's reference serialization.
+   *
+   * The OOXML default is `true` (Excel paints leader lines on every
+   * label that gets pushed outside its slice). Set to `false` to opt
+   * out and render labels without the connecting lines.
+   */
+  showLeaderLines?: boolean;
 }
 
 /**
@@ -2720,6 +2740,25 @@ export interface ChartDataLabelsInfo {
    * empty.
    */
   numberFormat?: ChartAxisNumberFormat;
+  /**
+   * Mirror of {@link ChartDataLabels.showLeaderLines}. Surfaces the
+   * `<c:showLeaderLines val=".."/>` flag parsed from the source
+   * `<c:dLbls>` block — Excel's "Format Data Labels -> Show Leader
+   * Lines" checkbox.
+   *
+   * The OOXML default is `true`. Surfaces `false` only when the source
+   * pinned `<c:showLeaderLines val="0"/>`; absence and the default
+   * `val="1"` collapse to `undefined` so a re-parse of a writer that
+   * omits the element matches a re-parse of one that pins the default
+   * explicitly.
+   *
+   * The element only appears on pie / doughnut data-labels per the
+   * OOXML schema (`EG_DLbls` is scoped to `CT_PieChart` /
+   * `CT_DoughnutChart`); the parser surfaces it on every chart family
+   * the source emits it for so a templated chart can round-trip
+   * cleanly even when the chart-type element ends up coerced.
+   */
+  showLeaderLines?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -1439,6 +1439,29 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const numFmt = parseDataLabelsNumberFormat(el);
   if (numFmt) out.numberFormat = numFmt;
 
+  // `<c:showLeaderLines val=".."/>` mirrors Excel's "Format Data
+  // Labels -> Show Leader Lines" checkbox. The OOXML default is
+  // `true` (Excel paints leader lines on every label that gets pushed
+  // outside its slice), so absence and `val="1"` collapse to
+  // `undefined` — only an explicit `val="0"` (or `"false"`) surfaces
+  // `false`. Mirrors how the writer-side scope guard treats the
+  // element: only meaningful on pie / doughnut, but the parser is
+  // permissive (the OOXML schema scopes the element to `EG_DLbls` for
+  // `CT_PieChart` / `CT_DoughnutChart`, but a templated chart whose
+  // type element ends up coerced should still surface the source's
+  // intent so the cloned model stays accurate).
+  // Only the literal OOXML falsy spellings (`"0"` / `"false"`) flip the
+  // toggle — unknown / missing val tokens collapse to `undefined` rather
+  // than surface a `false` the writer would round-trip into a non-default
+  // `<c:showLeaderLines val="0"/>` Excel never authored.
+  const showLeader = findChild(el, "showLeaderLines");
+  if (showLeader) {
+    const v = showLeader.attrs.val;
+    if (typeof v === "string" && (v === "0" || v.toLowerCase() === "false")) {
+      out.showLeaderLines = false;
+    }
+  }
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -1448,7 +1471,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     !out.showPercent &&
     !out.showLegendKey &&
     out.separator === undefined &&
-    out.numberFormat === undefined
+    out.numberFormat === undefined &&
+    out.showLeaderLines === undefined
   ) {
     return undefined;
   }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1345,6 +1345,7 @@ function buildBarChart(chart: SheetChart, sheetName: string): string {
   for (let i = 0; i < chart.series.length; i++) {
     children.push(
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
+        chartType: chart.type,
         dataLabels: chart.dataLabels,
         invertIfNegative: chart.series[i].invertIfNegative === true,
       }),
@@ -1544,6 +1545,7 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
     // the line writer always emits the element — straight by default
     // (`val="0"`), curved when the caller pinned `smooth: true`.
     const seriesXml = buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
+      chartType: chart.type,
       smooth: chart.series[i].smooth === true,
       dataLabels: chart.dataLabels,
       stroke: chart.series[i].stroke,
@@ -1624,6 +1626,7 @@ function buildAreaChart(chart: SheetChart, sheetName: string): string {
   for (let i = 0; i < chart.series.length; i++) {
     children.push(
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
+        chartType: chart.type,
         dataLabels: chart.dataLabels,
       }),
     );
@@ -1659,6 +1662,7 @@ function buildPieChart(chart: SheetChart, sheetName: string): string {
   if (chart.series.length > 0) {
     children.push(
       buildSeries(chart.series[0], 0, sheetName, /* numericCategories */ false, {
+        chartType: chart.type,
         dataLabels: chart.dataLabels,
         explosion: chart.series[0].explosion,
       }),
@@ -1696,6 +1700,7 @@ function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
   for (let i = 0; i < chart.series.length; i++) {
     children.push(
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ false, {
+        chartType: chart.type,
         dataLabels: chart.dataLabels,
         explosion: chart.series[i].explosion,
       }),
@@ -1791,6 +1796,7 @@ function buildScatterChart(chart: SheetChart, sheetName: string): string {
     // shape Excel writes for straight scatter series.
     children.push(
       buildSeries(chart.series[i], i, sheetName, /* numericCategories */ true, {
+        chartType: chart.type,
         smooth: chart.series[i].smooth === true ? true : undefined,
         dataLabels: chart.dataLabels,
         stroke: chart.series[i].stroke,
@@ -1903,6 +1909,15 @@ function buildAxisTitle(label: string): string {
 interface SeriesOptions {
   smooth?: boolean;
   /**
+   * Owning chart's family. Used to scope-guard schema-restricted
+   * data-label flags such as `<c:showLeaderLines>` (pie / doughnut
+   * only) so a templated chart's pin never leaks onto a chart family
+   * Excel's strict validator would reject. Required so the per-family
+   * caller cannot forget to thread the type through; every chart
+   * builder passes `chart.type` directly.
+   */
+  chartType: WriteChartKind;
+  /**
    * Chart-level data label defaults from {@link SheetChart.dataLabels}.
    * Used when the series itself does not specify `dataLabels`. Series
    * passing `dataLabels: false` always wins over this default.
@@ -1951,7 +1966,7 @@ function buildSeries(
   index: number,
   sheetName: string,
   numericCategories: boolean,
-  options?: SeriesOptions,
+  options: SeriesOptions,
 ): string {
   const children: string[] = [
     xmlSelfClose("c:idx", { val: index }),
@@ -2008,8 +2023,14 @@ function buildSeries(
 
   // Data labels — series-level override always wins over the chart-level
   // default. `<c:dLbls>` sits between <c:spPr> and <c:cat>/<c:val> per
-  // the OOXML series schema (CT_BarSer, CT_LineSer, ...).
-  const seriesDLblsXml = buildSeriesDataLabels(series.dataLabels, options?.dataLabels);
+  // the OOXML series schema (CT_BarSer, CT_LineSer, ...). The chart
+  // type threads through so the dLbls body can scope-guard the pie /
+  // doughnut-only `<c:showLeaderLines>` flag.
+  const seriesDLblsXml = buildSeriesDataLabels(
+    series.dataLabels,
+    options.dataLabels,
+    options.chartType,
+  );
   if (seriesDLblsXml) children.push(seriesDLblsXml);
 
   // Categories (skipped for pie when omitted; allowed for all)
@@ -2282,6 +2303,7 @@ function normalizeRgbHex(value: string | undefined): string | undefined {
 function buildSeriesDataLabels(
   seriesDLbls: ChartDataLabels | false | undefined,
   chartDLbls: ChartDataLabels | undefined,
+  chartType: WriteChartKind,
 ): string | undefined {
   if (seriesDLbls === false) {
     // Suppress this series even when chart-level labels are on.
@@ -2294,7 +2316,7 @@ function buildSeriesDataLabels(
     ]);
   }
   if (seriesDLbls) {
-    return buildDataLabelsBody(seriesDLbls);
+    return buildDataLabelsBody(seriesDLbls, chartType);
   }
   // Series doesn't override → fall through to chart-level. Returning
   // undefined here keeps the chart-level <c:dLbls> as the single source
@@ -2310,7 +2332,7 @@ function buildSeriesDataLabels(
  */
 function buildChartLevelDataLabels(chart: SheetChart): string | undefined {
   if (!chart.dataLabels) return undefined;
-  return buildDataLabelsBody(chart.dataLabels);
+  return buildDataLabelsBody(chart.dataLabels, chart.type);
 }
 
 /**
@@ -2319,8 +2341,14 @@ function buildChartLevelDataLabels(chart: SheetChart): string | undefined {
  * showLegendKey, showVal, showCatName, showSerName, showPercent,
  * showBubbleSize, separator?, showLeaderLines? — toggles must appear
  * in that exact order or Excel ignores the block.
+ *
+ * `chartType` lets the builder gate the pie / doughnut-only
+ * `<c:showLeaderLines>` element — the OOXML schema scopes that flag to
+ * `EG_DLbls` for `CT_PieChart` / `CT_DoughnutChart` only, so the writer
+ * silently drops `dl.showLeaderLines` on every other family rather than
+ * emit a child Excel's strict validator would reject.
  */
-function buildDataLabelsBody(dl: ChartDataLabels): string {
+function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): string {
   const children: string[] = [];
 
   // `<c:numFmt>` sits at the head of the CT_DLbls sequence (before
@@ -2355,6 +2383,24 @@ function buildDataLabelsBody(dl: ChartDataLabels): string {
 
   if (dl.separator !== undefined) {
     children.push(xmlElement("c:separator", undefined, xmlEscape(dl.separator)));
+  }
+
+  // `<c:showLeaderLines>` sits at the tail of the `EG_DLbls` group
+  // (after `<c:separator>`, before `<c:extLst>`). The OOXML schema
+  // scopes the element to pie / doughnut chart families exclusively
+  // (`EG_DLbls` for `CT_PieChart` / `CT_DoughnutChart` only — bar /
+  // column / line / area / scatter route through `EG_DLblsShared` which
+  // omits it). The writer drops the field silently on every non-pie /
+  // non-doughnut family to mirror Excel's reference serialization.
+  //
+  // The OOXML default is `true` (Excel paints leader lines on every
+  // label that gets pushed outside its slice). Only an explicit
+  // `false` flips the toggle, so absence and the default round-trip
+  // identically through {@link parseChart}. Non-boolean inputs collapse
+  // to the default, mirroring how the other `show*` toggles treat
+  // their inputs.
+  if ((chartType === "pie" || chartType === "doughnut") && dl.showLeaderLines === false) {
+    children.push(xmlSelfClose("c:showLeaderLines", { val: 0 }));
   }
 
   return xmlElement("c:dLbls", undefined, children);

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -9316,3 +9316,204 @@ describe("cloneChart — view3D", () => {
     expect(parseChart(written)?.view3D).toBeUndefined();
   });
 });
+
+// ── cloneChart — data labels showLeaderLines ────────────────────────
+
+describe("cloneChart — data labels showLeaderLines", () => {
+  const sourceWithLeaderLines: Chart = {
+    kinds: ["pie"],
+    seriesCount: 1,
+    series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    dataLabels: { showValue: true, showLeaderLines: false },
+  };
+
+  it("inherits chart-level showLeaderLines from the source by default", () => {
+    const clone = cloneChart(sourceWithLeaderLines, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels?.showLeaderLines).toBe(false);
+    expect(clone.dataLabels?.showValue).toBe(true);
+  });
+
+  it("drops the inherited showLeaderLines when chart-level dataLabels override is null", () => {
+    const clone = cloneChart(sourceWithLeaderLines, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("replaces the dataLabels block wholesale, dropping the inherited showLeaderLines", () => {
+    const clone = cloneChart(sourceWithLeaderLines, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showCategoryName: true },
+    });
+    // The override is wholesale — the inherited showLeaderLines does
+    // not bleed through.
+    expect(clone.dataLabels).toEqual({ showCategoryName: true });
+  });
+
+  it("can pin showLeaderLines via a chart-level dataLabels override", () => {
+    const noLeaderLines: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      dataLabels: { showValue: true },
+    };
+    const clone = cloneChart(noLeaderLines, {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, showLeaderLines: false },
+    });
+    expect(clone.dataLabels).toEqual({ showValue: true, showLeaderLines: false });
+  });
+
+  it("inherits showLeaderLines on per-series dataLabels by default", () => {
+    const src: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "doughnut",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, showLeaderLines: false, position: "bestFit" },
+        },
+      ],
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series[0].dataLabels).toEqual({
+      showValue: true,
+      showLeaderLines: false,
+      position: "bestFit",
+    });
+  });
+
+  it("drops the per-series showLeaderLines when the override is null", () => {
+    const src: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "pie",
+          index: 0,
+          valuesRef: "Tpl!$B$2:$B$5",
+          dataLabels: { showValue: true, showLeaderLines: false },
+        },
+      ],
+    };
+    const clone = cloneChart(src, {
+      anchor: { from: { row: 0, col: 0 } },
+      seriesOverrides: [{ dataLabels: null }],
+    });
+    expect(clone.series[0].dataLabels).toBeUndefined();
+  });
+
+  it("composes showLeaderLines alongside numberFormat and other show toggles", () => {
+    const src: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      dataLabels: {
+        showValue: true,
+        showPercent: true,
+        showLegendKey: true,
+        showLeaderLines: false,
+        position: "bestFit",
+        numberFormat: { formatCode: "0.00%" },
+      },
+    };
+    const clone = cloneChart(src, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toEqual({
+      showValue: true,
+      showPercent: true,
+      showLegendKey: true,
+      showLeaderLines: false,
+      position: "bestFit",
+      numberFormat: { formatCode: "0.00%" },
+    });
+  });
+
+  it("carries showLeaderLines through a chart-type coercion (pie -> doughnut)", () => {
+    const doughnutClone = cloneChart(sourceWithLeaderLines, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(doughnutClone.type).toBe("doughnut");
+    expect(doughnutClone.dataLabels?.showLeaderLines).toBe(false);
+  });
+
+  it("carries showLeaderLines through but the writer drops it on a non-pie / non-doughnut coercion", () => {
+    // The clone always carries the source's intent forward — the
+    // writer is the layer that scope-guards the OOXML schema. So the
+    // cloned model preserves `showLeaderLines: false` even after the
+    // type is coerced to bar; the rendered XML simply omits the
+    // element on the non-pie family.
+    const barClone = cloneChart(sourceWithLeaderLines, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "bar",
+    });
+    expect(barClone.type).toBe("bar");
+    expect(barClone.dataLabels?.showLeaderLines).toBe(false);
+
+    const written = writeChart(barClone, "Dashboard").chartXml;
+    expect(written).not.toContain("<c:showLeaderLines");
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves showLeaderLines on a pie", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart">
+  <c:chart>
+    <c:plotArea>
+      <c:pieChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:dLbls>
+          <c:dLblPos val="bestFit"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="1"/>
+          <c:showBubbleSize val="0"/>
+          <c:showLeaderLines val="0"/>
+        </c:dLbls>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.dataLabels?.showLeaderLines).toBe(false);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.dataLabels?.showLeaderLines).toBe(false);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const dLbls = written.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
+
+    // Re-parse to confirm the round-trip.
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.showLeaderLines).toBe(false);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned pie chart with showLeaderLines intact", async () => {
+    const clone = cloneChart(sourceWithLeaderLines, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [["Header"], [10], [20], [30], [40]],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const dLbls = written.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -8480,3 +8480,259 @@ describe("writeChart — view3D", () => {
     expect(reparsed?.view3D).toEqual({ rotX: 15, rotY: 20, perspective: 30 });
   });
 });
+
+// ── writeChart — data labels showLeaderLines ─────────────────────────
+
+describe("writeChart — data labels showLeaderLines", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does not emit <c:showLeaderLines> on a pie chart by default (OOXML default true)", () => {
+    // Excel's reference serialization omits the element when the user
+    // did not flip the toggle off — the OOXML default is `true`.
+    // Mirroring that on emit keeps absence and the default
+    // round-tripping identically through parseChart.
+    const result = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:showLeaderLines");
+  });
+
+  it('emits <c:showLeaderLines val="0"/> on a pie chart when showLeaderLines=false', () => {
+    const result = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true, showLeaderLines: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
+  });
+
+  it('emits <c:showLeaderLines val="0"/> on a doughnut chart when showLeaderLines=false', () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        dataLabels: { showValue: true, showLeaderLines: false },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
+  });
+
+  it("treats showLeaderLines=true the same as omitting the field (no element emitted)", () => {
+    // Pinning the OOXML default has the same wire shape as omitting
+    // the field — only an explicit `false` flips the toggle.
+    const explicit = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true, showLeaderLines: true } }),
+      "Sheet1",
+    ).chartXml;
+    const implicit = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true } }),
+      "Sheet1",
+    ).chartXml;
+    expect(explicit).toEqual(implicit);
+  });
+
+  it("collapses non-boolean showLeaderLines inputs to the OOXML default (no element)", () => {
+    // A stray non-boolean leaking past the type guard (e.g. 0 / "false"
+    // / null) must collapse to the default rather than emit something
+    // Excel would reject. Mirrors how the other show* toggles treat
+    // their inputs — only literal `false` flips the toggle.
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        dataLabels: { showValue: true, showLeaderLines: 0 as unknown as boolean },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:showLeaderLines");
+  });
+
+  it("scope-guards showLeaderLines on bar / column / line / area / scatter (drops the override)", () => {
+    // The OOXML schema scopes <c:showLeaderLines> to EG_DLbls (pie /
+    // doughnut only). Every other family routes through EG_DLblsShared
+    // which omits the element — emitting it would break Excel's
+    // strict validator.
+    const families: Array<{ type: WriteChartKind; setup?: Partial<SheetChart> }> = [
+      { type: "bar" },
+      { type: "column" },
+      { type: "line" },
+      { type: "area" },
+      {
+        type: "scatter",
+        setup: { series: [{ values: "B2:B4", categories: "A2:A4" }] },
+      },
+    ];
+    for (const { type, setup } of families) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, showLeaderLines: false }, ...setup }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).not.toContain("<c:showLeaderLines");
+    }
+  });
+
+  it("places <c:showLeaderLines> after <c:separator> when both are emitted (CT_DLbls order)", () => {
+    // CT_DLbls sequence: ... showBubbleSize, separator?, showLeaderLines?
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        dataLabels: { showValue: true, separator: " | ", showLeaderLines: false },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const idxSep = dLbls.indexOf("<c:separator");
+    const idxLead = dLbls.indexOf("<c:showLeaderLines");
+    expect(idxSep).toBeGreaterThan(0);
+    expect(idxLead).toBeGreaterThan(idxSep);
+  });
+
+  it("places <c:showLeaderLines> after <c:showBubbleSize> when no separator is set", () => {
+    const result = writeChart(
+      makeChart({
+        type: "doughnut",
+        dataLabels: { showValue: true, showLeaderLines: false },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const idxBub = dLbls.indexOf("<c:showBubbleSize");
+    const idxLead = dLbls.indexOf("<c:showLeaderLines");
+    expect(idxBub).toBeGreaterThan(0);
+    expect(idxLead).toBeGreaterThan(idxBub);
+  });
+
+  it("emits exactly one <c:showLeaderLines> per <c:dLbls> block", () => {
+    // Guard against a regression that would double-emit the element.
+    const result = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true, showLeaderLines: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect((dLbls.match(/<c:showLeaderLines /g) ?? []).length).toBe(1);
+  });
+
+  it("threads showLeaderLines through a series-level <c:dLbls> on a pie chart", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [
+          {
+            name: "S1",
+            values: "B2:B4",
+            categories: "A2:A4",
+            dataLabels: { showValue: true, showLeaderLines: false },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const serStart = xml.indexOf("<c:ser>");
+    const serEnd = xml.indexOf("</c:ser>");
+    const inner = xml.slice(serStart, serEnd);
+    expect(inner).toContain('<c:showLeaderLines val="0"/>');
+  });
+
+  it("scope-guards series-level showLeaderLines on a column chart", () => {
+    // The OOXML schema scopes the element to pie / doughnut on the
+    // series-level dLbls just as it does on the chart level. The
+    // override must be silently dropped on every other family.
+    const result = writeChart(
+      makeChart({
+        type: "column",
+        series: [
+          {
+            name: "S1",
+            values: "B2:B4",
+            categories: "A2:A4",
+            dataLabels: { showValue: true, showLeaderLines: false },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const serStart = xml.indexOf("<c:ser>");
+    const serEnd = xml.indexOf("</c:ser>");
+    const inner = xml.slice(serStart, serEnd);
+    expect(inner).not.toContain("<c:showLeaderLines");
+  });
+
+  it("composes independently with showLegendKey and numberFormat", () => {
+    // The three knobs live on different lines of the CT_DLbls
+    // sequence; pinning one must not change the others.
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        dataLabels: {
+          showValue: true,
+          showLegendKey: true,
+          showLeaderLines: false,
+          numberFormat: { formatCode: "0.00%" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<c:numFmt formatCode="0.00%"');
+    expect(dLbls).toContain('<c:showLegendKey val="1"/>');
+    expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
+  });
+
+  it("round-trips a pie chart with showLeaderLines=false through parseChart", () => {
+    const written = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true, showLeaderLines: false } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.showLeaderLines).toBe(false);
+    expect(reparsed?.dataLabels?.showValue).toBe(true);
+  });
+
+  it("collapses a defaulted pie showLeaderLines round-trip back to undefined", () => {
+    // A fresh pie chart (showLeaderLines omitted) emits no element and
+    // re-parses to undefined — absence and the OOXML default round-trip
+    // identically.
+    const written = writeChart(
+      makeChart({ type: "pie", dataLabels: { showValue: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.showLeaderLines).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages a pie chart with showLeaderLines=false", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Slice", "Value"],
+          ["A", 30],
+          ["B", 70],
+        ],
+        charts: [
+          {
+            type: "pie",
+            title: "Distribution",
+            series: [{ name: "Distribution", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, showLeaderLines: false },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const dLbls = chartXml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/)![0];
+    expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9111,3 +9111,241 @@ describe("parseChart — legend entries", () => {
     expect(parseChart(xml)?.legendEntries).toEqual([{ idx: 1, delete: true }]);
   });
 });
+
+// ── parseChart — data labels showLeaderLines ─────────────────────────
+
+describe("parseChart — data labels showLeaderLines", () => {
+  const NS_LL = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it('surfaces showLeaderLines=false on a pie chart-level dLbls when val="0"', () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="0"/>
+        <c:showVal val="1"/>
+        <c:showCatName val="0"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="0"/>
+        <c:showBubbleSize val="0"/>
+        <c:showLeaderLines val="0"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({
+      showValue: true,
+      showLeaderLines: false,
+    });
+  });
+
+  it('collapses the OOXML default val="1" to undefined', () => {
+    // The OOXML default is `true`; absence and the default round-trip
+    // identically through cloneChart, so the parser collapses
+    // `val="1"` to `undefined`.
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+        <c:showLeaderLines val="1"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBeUndefined();
+    expect(chart?.dataLabels?.showValue).toBe(true);
+  });
+
+  it("collapses absence of <c:showLeaderLines> to undefined", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBeUndefined();
+  });
+
+  it('accepts the OOXML falsy spelling val="false"', () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+        <c:showLeaderLines val="false"/>
+      </c:dLbls>
+    </c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBe(false);
+  });
+
+  it('accepts the OOXML truthy spelling val="true" and collapses to undefined', () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+        <c:showLeaderLines val="true"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBeUndefined();
+  });
+
+  it("ignores unknown val tokens", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+        <c:showLeaderLines val="off"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBeUndefined();
+  });
+
+  it("returns undefined when <c:showLeaderLines> is missing the val attribute", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+        <c:showLeaderLines/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBeUndefined();
+  });
+
+  it("makes showLeaderLines=false alone enough to surface a dataLabels record", () => {
+    // Even when no value/category/series/percent toggle is on, a pinned
+    // showLeaderLines=false is still meaningful — Excel suppresses the
+    // connecting lines on every otherwise-empty label slot. The reader
+    // must not collapse the block to undefined in that case.
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showLegendKey val="0"/>
+        <c:showVal val="0"/>
+        <c:showCatName val="0"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="0"/>
+        <c:showBubbleSize val="0"/>
+        <c:showLeaderLines val="0"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({ showLeaderLines: false });
+  });
+
+  it("surfaces showLeaderLines on a series-level <c:dLbls>", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:doughnutChart>
+      <c:ser>
+        <c:idx val="0"/>
+        <c:tx><c:v>Distribution</c:v></c:tx>
+        <c:dLbls>
+          <c:dLblPos val="bestFit"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="1"/>
+          <c:showBubbleSize val="0"/>
+          <c:showLeaderLines val="0"/>
+        </c:dLbls>
+        <c:val><c:numRef><c:f>S!$B$2:$B$5</c:f></c:numRef></c:val>
+      </c:ser>
+    </c:doughnutChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0].dataLabels).toEqual({
+      position: "bestFit",
+      showValue: true,
+      showPercent: true,
+      showLeaderLines: false,
+    });
+  });
+
+  it("co-surfaces showLeaderLines alongside numberFormat and other show toggles", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:pieChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:numFmt formatCode="0.00%" sourceLinked="0"/>
+        <c:dLblPos val="bestFit"/>
+        <c:showLegendKey val="1"/>
+        <c:showVal val="1"/>
+        <c:showCatName val="1"/>
+        <c:showSerName val="0"/>
+        <c:showPercent val="1"/>
+        <c:showBubbleSize val="0"/>
+        <c:separator>; </c:separator>
+        <c:showLeaderLines val="0"/>
+      </c:dLbls>
+    </c:pieChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels).toEqual({
+      position: "bestFit",
+      showLegendKey: true,
+      showValue: true,
+      showCategoryName: true,
+      showPercent: true,
+      separator: "; ",
+      numberFormat: { formatCode: "0.00%" },
+      showLeaderLines: false,
+    });
+  });
+
+  it("permissively surfaces showLeaderLines on non-pie families (parser is type-agnostic)", () => {
+    // The OOXML schema scopes <c:showLeaderLines> to pie / doughnut on
+    // the writer side, but the reader is permissive — a templated
+    // chart whose chart-type element ends up coerced still surfaces the
+    // source's intent so the cloned model stays accurate.
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:dLbls>
+        <c:showVal val="1"/>
+        <c:showLeaderLines val="0"/>
+      </c:dLbls>
+    </c:barChart>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.showLeaderLines).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:showLeaderLines>` (CT_DLbls, ECMA-376 Part 1, §21.2.2.196) at the read, write, and clone layers so a templated pie / doughnut chart's leader-lines pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<c:showLeaderLines>` mirrors Excel's "Format Data Labels -> Label Options -> Show Leader Lines" checkbox on pie / doughnut data labels. The OOXML default is `true` (Excel paints the connecting lines on every label that gets pushed outside its slice); pinning `false` opts out and renders labels without the connectors. Until now hucre's writer had no slot for the element and the reader ignored it entirely, so a templated pie/doughnut dashboard chart whose user unchecked "Show Leader Lines" silently lost the choice on every parse -> clone -> write loop. Bridges another data-labels customization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.dataLabels?.showLeaderLines);
// false      ← when the template pinned <c:showLeaderLines val="0"/>
// undefined  ← when the template pinned <c:showLeaderLines val="1"/> or omits the element

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Slice", "Value"],
      ["A", 30],
      ["B", 70],
    ],
    charts: [{
      type: "pie",
      title: "Distribution",
      series: [{ name: "Distribution", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
      // Suppress the leader lines — labels render without the
      // connecting lines back to their slice.
      dataLabels: { showValue: true, showLeaderLines: false },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed `showLeaderLines: false` unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  dataLabels: null,
});
//   → drops the inherited block (no `<c:dLbls>` emitted).
```

## Implementation notes

- **Type model**: `ChartDataLabels.showLeaderLines?: boolean` (writer side) and `ChartDataLabelsInfo.showLeaderLines?: boolean` (reader side). Same shape as the other `show*` toggles so a parsed value can flow straight from the read side back into the write side without transformation.
- **Reader** (`parseDataLabels`): walks `<c:dLbls>` for `<c:showLeaderLines val=".."/>`. Only the literal OOXML falsy spellings (`val="0"` / `val="false"`) surface `false`; the OOXML default `val="1"` (and `val="true"`, missing `val`, unknown tokens, absence) collapses to `undefined`. Permissive on chart family — surfaces the flag on any chart's data labels so a templated chart whose chart-type element ends up coerced still surfaces the source's intent.
- **Writer**: emits `<c:showLeaderLines val="0"/>` only when `dl.showLeaderLines === false` AND the chart type is `pie` or `doughnut`. The OOXML schema scopes the element to `EG_DLbls` (pie / doughnut only — every other family routes through `EG_DLblsShared` which omits it). Bar / column / line / area / scatter silently drop the override to mirror Excel's reference serialization; emitting it on those families would break Excel's strict validator. The element slots between `<c:separator>` and `<c:extLst>` per the `EG_DLbls` sequence.
  - Threads `chartType: chart.type` through `SeriesOptions` so per-series `<c:dLbls>` blocks honour the same scope guard as the chart-level block.
- **Clone**: the existing `{ ...sourceLabels }` spread in `resolveChartDataLabels` and `resolveSeriesDataLabels` carries the new field forward without changes — the standard `undefined` (inherit) / `null` (drop) / object (replace) grammar applies wholesale just as it does for `showLegendKey` / `numberFormat`. The cloned model preserves `showLeaderLines: false` even after a chart-type coercion to a non-pie family; the writer is the layer that drops it on emit.
- **Validation**: only literal `boolean` survives the type guard at the write layer; non-boolean inputs collapse to the default. This matches how `showLegendKey` / `legendOverlay` / `roundedCorners` / axis `hidden` treat their inputs.

## Test plan

- [x] `parseChart — data labels showLeaderLines` (11 new tests) — surfaces `false` on `val="0"`, collapses `val="1"` and absence to `undefined`, OOXML truthy / falsy spellings, missing `val`, unknown tokens, makes the flag alone enough to surface a record, surfaces on per-series `<c:dLbls>`, co-surfaces alongside numberFormat and other show* toggles, permissive on non-pie families.
- [x] `writeChart — data labels showLeaderLines` (15 new tests) — omits the element by default on a pie chart, emits `val="0"` on pie / doughnut overrides, treats `true` like absence, collapses non-boolean inputs, scope-guards bar / column / line / area / scatter, OOXML schema position (after `<c:separator>` / `<c:showBubbleSize>`), exactly-one-element guard, threads through series-level dLbls, scope-guards series-level overrides on column, composes with showLegendKey / numberFormat, parse round-trip, full `writeXlsx` package round-trip.
- [x] `cloneChart — data labels showLeaderLines` (11 new tests) — inherit / null drop / wholesale replace / per-series inherit / per-series null drop semantics, source-without-flag pickup, composition with other data-labels fields, chart-type coercion (pie → doughnut preserves; pie → bar carries through but writer drops), end-to-end parse → clone → write → reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4099 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)