### PR TITLE
feat(xlsx): chart axis tick-label rotation — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ charts; `lineGrouping` and `areaGrouping` accept
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
 attributes for screen readers.
-`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt, dispUnits, crossBetween }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, reverse, crosses, crossesAt, dispUnits, crossBetween } }`
+`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween } }`
 attaches per-axis labels, gridlines, numeric scaling, the tick-label
 number format and the tick-rendering trio — `x` lands inside
 `<c:catAx>` (or the X value axis for scatter), `y` inside the value
@@ -1488,6 +1488,25 @@ exclusively (even `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject
 it), so the flag threads through bar / column / line / area but is
 silently dropped on scatter (both axes are value axes) and pie /
 doughnut (no axes at all).
+The `axes.x.labelRotation` and `axes.y.labelRotation` fields pin the
+tick-label rotation in whole degrees, mapping to
+`<c:txPr><a:bodyPr rot="N"/></c:txPr>` on the matching axis — Excel's
+"Format Axis -> Alignment -> Custom angle" knob. The OOXML `rot`
+attribute is in 60000ths of a degree; the writer converts at emit
+time so callers pin the value in degrees. Useful for rotating long
+category labels diagonally so they fit underneath a column chart's
+bars without overlapping their neighbours, or for tilting a value
+axis's number labels when a tight chart frame would otherwise crowd
+them. Range: `-90..90` (Excel's UI band — out-of-range values clamp
+to the nearest endpoint, fractional inputs round to the nearest whole
+degree, non-finite / non-numeric inputs drop). The writer omits the
+entire `<c:txPr>` block on the OOXML default `0` (and on absence) so a
+fresh chart matches Excel's minimal serialization. The element sits on
+every axis flavour per the OOXML schema (`<c:catAx>` / `<c:valAx>` /
+`<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>`), so the
+field threads through every chart family that has axes (bar / column /
+line / area / scatter); pie / doughnut have no axes at all and the
+field is silently dropped there.
 The `axes.x.reverse` and `axes.y.reverse` flags map to
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` — Excel's
 "Categories / Values in reverse order" toggle. On a category axis,

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1717,6 +1717,37 @@ export interface SheetChart {
        */
       tickLblPos?: ChartAxisTickLabelPosition;
       /**
+       * Tick-label rotation in degrees. Maps to
+       * `<c:catAx><c:txPr><a:bodyPr rot="N"/></c:txPr></c:catAx>` (or
+       * `<c:valAx>` for scatter / value axes) — Excel's "Format Axis ->
+       * Alignment -> Custom angle" knob. Useful for rotating long
+       * category labels diagonally so they fit underneath a column
+       * chart's bars without overlapping their neighbours.
+       *
+       * Accepted range: `-90..90` (the band Excel's UI exposes; values
+       * outside the band clamp to the nearest endpoint). The OOXML
+       * `rot` attribute is in 60000ths of a degree — the writer
+       * converts at emit time so callers pin the value in degrees.
+       *
+       * Default: `0` (no rotation, Excel's reference look). Set a
+       * positive integer (e.g. `45`) to rotate the labels clockwise
+       * (their right edge tilts down — typical "diagonal labels"
+       * dashboard look on a column chart). Negative values rotate
+       * counter-clockwise.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+       * the OOXML schema, so the field round-trips on every chart family
+       * that has axes (bar / column / line / area / scatter). Pie /
+       * doughnut have no axes at all, so the field is silently dropped
+       * on those families.
+       *
+       * Non-finite (`NaN`, `Infinity`) and non-numeric inputs drop at
+       * write time so the writer never emits a token Excel's strict
+       * validator would reject.
+       */
+      labelRotation?: number;
+      /**
        * Reverse the axis plotting order. Maps to
        * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
        * Excel's "Categories in reverse order" / "Values in reverse
@@ -1932,6 +1963,21 @@ export interface SheetChart {
        * `"nextTo"`. See {@link ChartAxisTickLabelPosition}.
        */
       tickLblPos?: ChartAxisTickLabelPosition;
+      /**
+       * Tick-label rotation in degrees for the value axis. Maps to
+       * `<c:valAx><c:txPr><a:bodyPr rot="N"/></c:txPr></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.labelRotation} for the value
+       * axis — see that field for the full semantics. The OOXML `rot`
+       * attribute is in 60000ths of a degree; the writer converts at
+       * emit time so callers pin the value in degrees. Range: `-90..90`.
+       *
+       * Useful for tilting Y-axis number labels when a tight chart
+       * frame would otherwise crowd them, or for rotating the X-axis
+       * value labels on a scatter chart whose long category strings
+       * sit on the value axis. Silently dropped on `pie` / `doughnut`
+       * charts (no axes at all).
+       */
+      labelRotation?: number;
       /**
        * Hide the entire value axis (line, tick marks, tick labels).
        * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
@@ -3076,6 +3122,27 @@ export interface ChartAxisInfo {
    * shape minimal. See {@link ChartAxisTickLabelPosition}.
    */
   tickLblPos?: ChartAxisTickLabelPosition;
+  /**
+   * Tick-label rotation in degrees pulled from
+   * `<c:txPr><a:bodyPr rot="N"/></c:txPr>` on the axis element.
+   * Mirrors Excel's "Format Axis -> Alignment -> Custom angle" pin.
+   *
+   * The OOXML `rot` attribute is in 60000ths of a degree; the reader
+   * converts to whole degrees and surfaces the literal value (range
+   * `-90..90`). The OOXML default `0` (and absence of the element)
+   * collapses to `undefined` so absence and the default round-trip
+   * identically through {@link cloneChart}. Out-of-range values are
+   * clamped to the nearest endpoint so a parsed value slots straight
+   * back into the writer-side {@link SheetChart.axes.x.labelRotation}
+   * field without further transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+   * the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the rotation regardless of
+   * whether the source axis was a category or value axis.
+   */
+  labelRotation?: number;
   /**
    * Reverse-axis flag pulled from
    * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -572,6 +572,19 @@ export interface CloneChartOptions {
        */
       tickLblPos?: ChartAxisTickLabelPosition | null;
       /**
+       * Override `SheetChart.axes.x.labelRotation`. `undefined` (or
+       * omitted) inherits the source axis's rotation; `null` drops the
+       * inherited value (the writer falls back to the OOXML default `0`
+       * — labels render flat); a number in the `-90..90` band replaces
+       * it (out-of-range and non-finite inputs collapse to `undefined`).
+       *
+       * `<c:txPr>` lives on every axis flavour per the OOXML schema, so
+       * the override carries through every chart family that has axes
+       * (bar / column / line / area / scatter). Silently dropped on
+       * `pie` / `doughnut` charts since neither has axes.
+       */
+      labelRotation?: number | null;
+      /**
        * Override the reverse-axis flag. `undefined` (or omitted)
        * inherits the source axis' parsed value; `null` drops it (the
        * writer falls back to the OOXML default `"minMax"` — forward
@@ -723,6 +736,8 @@ export interface CloneChartOptions {
       minorTickMark?: ChartAxisTickMark | null;
       /** See {@link CloneChartOptions.axes.x.tickLblPos}. */
       tickLblPos?: ChartAxisTickLabelPosition | null;
+      /** See {@link CloneChartOptions.axes.x.labelRotation}. */
+      labelRotation?: number | null;
       /** See {@link CloneChartOptions.axes.x.hidden}. */
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
@@ -2049,6 +2064,21 @@ function resolveAxes(
   );
   const xTickLblPos = applyTickLblPosOverride(sourceAxes?.x?.tickLblPos, overrides?.x?.tickLblPos);
   const yTickLblPos = applyTickLblPosOverride(sourceAxes?.y?.tickLblPos, overrides?.y?.tickLblPos);
+  // `<c:txPr><a:bodyPr rot="N"/></c:txPr>` lives on every axis flavour
+  // per the OOXML schema (CT_CatAx, CT_ValAx, CT_DateAx, CT_SerAx all
+  // carry an optional `<c:txPr>`), so the resolver applies on every
+  // chart family that has axes (pie / doughnut were short-circuited
+  // upstream). Out-of-range / non-numeric values clamp to the
+  // `-90..90` band the writer accepts; the OOXML default `0` collapses
+  // to `undefined` so absence and the default round-trip identically.
+  const xLabelRotation = applyLabelRotationOverride(
+    sourceAxes?.x?.labelRotation,
+    overrides?.x?.labelRotation,
+  );
+  const yLabelRotation = applyLabelRotationOverride(
+    sourceAxes?.y?.labelRotation,
+    overrides?.y?.labelRotation,
+  );
   const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
   const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
   // `tickLblSkip` / `tickMarkSkip` only render on category axes
@@ -2141,6 +2171,7 @@ function resolveAxes(
     xMajorTickMark !== undefined ||
     xMinorTickMark !== undefined ||
     xTickLblPos !== undefined ||
+    xLabelRotation !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
@@ -2162,6 +2193,7 @@ function resolveAxes(
     if (xMajorTickMark !== undefined) out.x.majorTickMark = xMajorTickMark;
     if (xMinorTickMark !== undefined) out.x.minorTickMark = xMinorTickMark;
     if (xTickLblPos !== undefined) out.x.tickLblPos = xTickLblPos;
+    if (xLabelRotation !== undefined) out.x.labelRotation = xLabelRotation;
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
@@ -2183,6 +2215,7 @@ function resolveAxes(
     yMajorTickMark !== undefined ||
     yMinorTickMark !== undefined ||
     yTickLblPos !== undefined ||
+    yLabelRotation !== undefined ||
     yHidden !== undefined ||
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
@@ -2198,6 +2231,7 @@ function resolveAxes(
     if (yMajorTickMark !== undefined) out.y.majorTickMark = yMajorTickMark;
     if (yMinorTickMark !== undefined) out.y.minorTickMark = yMinorTickMark;
     if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
+    if (yLabelRotation !== undefined) out.y.labelRotation = yLabelRotation;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
@@ -2490,6 +2524,41 @@ function applyTickLblPosOverride(
   }
   if (override === null) return undefined;
   return VALID_TICK_LBL_POS_VALUES.has(override) ? override : undefined;
+}
+
+/**
+ * Resolve a `labelRotation` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Out-of-range / non-numeric values clamp to the
+ * `-90..90` band the writer accepts and the OOXML default `0`
+ * collapses to `undefined` so absence and the default round-trip
+ * identically — symmetric with the parser-side default-collapse.
+ */
+function applyLabelRotationOverride(
+  source: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) {
+    if (typeof source !== "number" || !Number.isFinite(source)) return undefined;
+    return clampLabelRotationDeg(source);
+  }
+  if (override === null) return undefined;
+  if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
+  return clampLabelRotationDeg(override);
+}
+
+/**
+ * Snap a `labelRotation` value (whole degrees) into the `-90..90` band
+ * the writer accepts. Returns `undefined` for `0` so the OOXML default
+ * collapses to absence — symmetric with the writer-side
+ * {@link normalizeAxisLabelRotation} contract.
+ */
+function clampLabelRotationDeg(value: number): number | undefined {
+  let degrees = Math.round(value);
+  if (degrees < -90) degrees = -90;
+  else if (degrees > 90) degrees = 90;
+  if (degrees === 0) return undefined;
+  return degrees;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -461,6 +461,14 @@ function parseAxisInfo(
   const majorTickMark = parseAxisTickMark(axis, "majorTickMark", "out");
   const minorTickMark = parseAxisTickMark(axis, "minorTickMark", "none");
   const tickLblPos = parseAxisTickLblPos(axis);
+  // `<c:txPr><a:bodyPr rot="N"/></c:txPr>` — tick-label rotation in
+  // 60000ths of a degree. The element sits on every axis flavour per
+  // the OOXML schema (CT_CatAx, CT_ValAx, CT_DateAx, CT_SerAx all
+  // carry an optional `<c:txPr>`), so the reader runs on every axis
+  // flavour. Out-of-range values clamp to the `-90..90` band Excel's
+  // UI exposes; the OOXML default `0` and absence both collapse to
+  // `undefined`.
+  const labelRotation = parseAxisLabelRotation(axis);
   // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
   // accepts "minMax" (default, low → high) and "maxMin" (reversed).
   // The default collapses to undefined so a fresh chart and a chart
@@ -536,6 +544,7 @@ function parseAxisInfo(
     majorTickMark === undefined &&
     minorTickMark === undefined &&
     tickLblPos === undefined &&
+    labelRotation === undefined &&
     reverse === undefined &&
     tickLblSkip === undefined &&
     tickMarkSkip === undefined &&
@@ -559,6 +568,7 @@ function parseAxisInfo(
   if (majorTickMark !== undefined) out.majorTickMark = majorTickMark;
   if (minorTickMark !== undefined) out.minorTickMark = minorTickMark;
   if (tickLblPos !== undefined) out.tickLblPos = tickLblPos;
+  if (labelRotation !== undefined) out.labelRotation = labelRotation;
   if (reverse !== undefined) out.reverse = reverse;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
@@ -835,6 +845,54 @@ function parseAxisHidden(axis: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+/**
+ * Conversion factor between OOXML's `rot` attribute (60000ths of a
+ * degree, the integer Excel writes inside `<a:bodyPr rot="N"/>`) and
+ * whole degrees. Excel's UI exposes the -90..90 degree band — the
+ * reader clamps anything outside that band so a corrupt template
+ * cannot surface a value the writer would never emit.
+ */
+const TXPR_ROT_PER_DEGREE = 60000;
+const LABEL_ROTATION_MIN_DEG = -90;
+const LABEL_ROTATION_MAX_DEG = 90;
+
+/**
+ * Pull `<c:txPr><a:bodyPr rot="N"/></c:txPr>` off an axis element.
+ * Returns the rotation in whole degrees (range `-90..90`).
+ *
+ * The OOXML default `0` (and absence of the element / attribute) all
+ * collapse to `undefined` so absence and the default round-trip
+ * identically through {@link cloneChart}. Non-integer / non-numeric /
+ * out-of-range values clamp to the nearest endpoint of the
+ * `-90..90` band Excel's UI exposes; non-finite (`NaN`, `Infinity`)
+ * inputs drop to `undefined`.
+ *
+ * The `<c:txPr>` element sits on every axis flavour — `<c:catAx>` /
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry the optional
+ * element per the OOXML schema. The reader surfaces the rotation
+ * regardless of axis flavour so a parsed chart preserves the value
+ * for symmetry with the writer-side
+ * {@link SheetChart.axes}.x.labelRotation.
+ */
+function parseAxisLabelRotation(axis: XmlElement): number | undefined {
+  const txPr = findChild(axis, "txPr");
+  if (!txPr) return undefined;
+  const bodyPr = findChild(txPr, "bodyPr");
+  if (!bodyPr) return undefined;
+  const raw = bodyPr.attrs.rot;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 60000ths of a degree to whole degrees.
+  const degrees = Math.round(parsed / TXPR_ROT_PER_DEGREE);
+  if (degrees === 0) return undefined;
+  if (degrees < LABEL_ROTATION_MIN_DEG) return LABEL_ROTATION_MIN_DEG;
+  if (degrees > LABEL_ROTATION_MAX_DEG) return LABEL_ROTATION_MAX_DEG;
+  return degrees;
 }
 
 /** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -309,6 +309,15 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     yMinorTickMark: normalizeTickMark(chart.axes?.y?.minorTickMark),
     xTickLblPos: normalizeTickLblPos(chart.axes?.x?.tickLblPos),
     yTickLblPos: normalizeTickLblPos(chart.axes?.y?.tickLblPos),
+    // `<c:txPr><a:bodyPr rot="N"/></c:txPr>` lives on every axis
+    // flavour per the OOXML schema (CT_CatAx, CT_ValAx, CT_DateAx,
+    // CT_SerAx all carry the optional `<c:txPr>`). Normalize the
+    // caller's degree input — clamp to the `-90..90` band Excel's UI
+    // exposes; non-finite / non-numeric inputs and the OOXML default
+    // `0` collapse to `undefined` so the writer can elide the entire
+    // `<c:txPr>` block on a fresh chart.
+    xLabelRotation: normalizeAxisLabelRotation(chart.axes?.x?.labelRotation),
+    yLabelRotation: normalizeAxisLabelRotation(chart.axes?.y?.labelRotation),
     xReverse: chart.axes?.x?.reverse === true,
     yReverse: chart.axes?.y?.reverse === true,
     // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
@@ -693,6 +702,22 @@ interface AxisRenderOptions {
   yMinorTickMark: ChartAxisTickMark | undefined;
   xTickLblPos: ChartAxisTickLabelPosition | undefined;
   yTickLblPos: ChartAxisTickLabelPosition | undefined;
+  /**
+   * Tick-label rotation in whole degrees emitted on the X axis via
+   * `<c:txPr><a:bodyPr rot="N"/></c:txPr>`. The OOXML `rot` attribute
+   * is in 60000ths of a degree; the writer converts at emit time.
+   * Range: `-90..90` (Excel's UI band). `undefined` skips the
+   * `<c:txPr>` block entirely so a fresh chart matches Excel's
+   * minimal serialization. Surfaces on every axis flavour because the
+   * OOXML schema places `<c:txPr>` on `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` alike.
+   */
+  xLabelRotation: number | undefined;
+  /**
+   * Tick-label rotation in whole degrees emitted on the Y axis. Same
+   * shape and conversion semantics as {@link xLabelRotation}.
+   */
+  yLabelRotation: number | undefined;
   xReverse: boolean;
   yReverse: boolean;
   /**
@@ -990,6 +1015,69 @@ function normalizeAxisLblAlgn(
  */
 function normalizeAxisHidden(value: boolean | undefined): boolean {
   return value === true;
+}
+
+/**
+ * OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree —
+ * the writer holds the value in whole degrees and converts at emit
+ * time. Excel's UI exposes the `-90..90` band; out-of-band values clamp
+ * to the nearest endpoint so a corrupt template cannot leak through to
+ * the writer either.
+ */
+const TXPR_ROT_PER_DEGREE = 60000;
+const LABEL_ROTATION_MIN_DEG = -90;
+const LABEL_ROTATION_MAX_DEG = 90;
+
+/**
+ * Normalize an axis `labelRotation` value (whole degrees) for the
+ * `<c:txPr><a:bodyPr rot="N"/></c:txPr>` writer slot. Returns
+ * `undefined` when the input is unset, non-finite, non-numeric, or
+ * resolves to `0` after rounding — every absence path collapses to the
+ * same omit-the-element shape so absence and the OOXML default `0`
+ * round-trip identically through {@link cloneChart}. Out-of-range
+ * inputs clamp to the `-90..90` band Excel's UI exposes; non-integer
+ * inputs round to the nearest whole degree (the OOXML attribute is an
+ * integer in 60000ths of a degree, so a fractional whole-degree value
+ * has no meaningful refinement at emit time).
+ */
+function normalizeAxisLabelRotation(value: number | undefined): number | undefined {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  let degrees = Math.round(value);
+  if (degrees < LABEL_ROTATION_MIN_DEG) degrees = LABEL_ROTATION_MIN_DEG;
+  else if (degrees > LABEL_ROTATION_MAX_DEG) degrees = LABEL_ROTATION_MAX_DEG;
+  if (degrees === 0) return undefined;
+  return degrees;
+}
+
+/**
+ * Build the `<c:txPr>` block that carries an axis tick-label rotation.
+ * Returns `undefined` when the resolved degree value is unset so the
+ * caller can elide the element entirely (Excel's reference
+ * serialization on a fresh axis omits `<c:txPr>` when the labels
+ * render at the default `rot="0"`).
+ *
+ * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
+ * when the user pins a custom angle — `<a:bodyPr rot="N"/>` carries
+ * the rotation, `<a:lstStyle/>` is the empty list-style placeholder
+ * the schema requires, and `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>`
+ * is the empty paragraph stub Excel always emits even when no per-run
+ * styling is pinned. Additional `<a:bodyPr>` attributes Excel writes
+ * in its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap`
+ * / `anchor` / `anchorCtr`) are intentionally omitted — the OOXML
+ * schema marks them all optional, and dropping them keeps the writer's
+ * footprint minimal while preserving the rotation intent.
+ */
+function buildAxisTxPr(rotationDeg: number | undefined): string | undefined {
+  if (rotationDeg === undefined) return undefined;
+  const rot = rotationDeg * TXPR_ROT_PER_DEGREE;
+  return xmlElement("c:txPr", undefined, [
+    xmlSelfClose("a:bodyPr", { rot }),
+    xmlSelfClose("a:lstStyle"),
+    xmlElement("a:p", undefined, [
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr")]),
+      xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
+    ]),
+  ]);
 }
 
 /** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */
@@ -1463,6 +1551,14 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   catAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
+  );
+  // `<c:txPr>` sits between `<c:tickLblPos>` (the last child of
+  // `buildAxisTickRendering`) and `<c:crossAx>` per CT_CatAx (ECMA-376
+  // Part 1, §21.2.2.7). Skip the entire block when the caller did not
+  // pin a rotation so a fresh chart matches Excel's minimal serialization.
+  const xCatAxTxPr = buildAxisTxPr(opts.xLabelRotation);
+  if (xCatAxTxPr) catAxChildren.push(xCatAxTxPr);
+  catAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
     buildAxisCrosses(opts.xCrosses),
     // `<c:auto>` is always emitted because Excel's reference
@@ -1508,6 +1604,15 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   valAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
+  );
+  // `<c:txPr>` sits between `<c:tickLblPos>` and `<c:crossAx>` per
+  // CT_ValAx (ECMA-376 Part 1, §21.2.2.32). Same omit-by-default
+  // contract as the catAx slot above — emit nothing when the caller
+  // did not pin a rotation so the writer matches Excel's reference
+  // serialization on a fresh value axis.
+  const yValAxTxPr = buildAxisTxPr(opts.yLabelRotation);
+  if (yValAxTxPr) valAxChildren.push(yValAxTxPr);
+  valAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
     buildAxisCrosses(opts.yCrosses),
     // `<c:crossBetween>` sits between `<c:crosses>`/`<c:crossesAt>` and
@@ -1820,6 +1925,13 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   xAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
+  );
+  // `<c:txPr>` slot — same CT_ValAx position as the bar / column
+  // builder above. Scatter X is a value axis, so the rotation pins on
+  // the X-axis just as it does on the Y-axis.
+  const xValAxTxPr = buildAxisTxPr(opts.xLabelRotation);
+  if (xValAxTxPr) xAxChildren.push(xValAxTxPr);
+  xAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
     buildAxisCrosses(opts.xCrosses),
     // Scatter charts default to `"midCat"` (data points sit ON the
@@ -1845,6 +1957,12 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   yAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
+  );
+  // `<c:txPr>` slot for the scatter Y axis — same CT_ValAx position
+  // and omit-by-default contract as the catAx / valAx builders above.
+  const yScatterTxPr = buildAxisTxPr(opts.yLabelRotation);
+  if (yScatterTxPr) yAxChildren.push(yScatterTxPr);
+  yAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),
     buildAxisCrosses(opts.yCrosses),
     // Scatter Y axis defaults to `"midCat"`. Same override grammar as

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -9316,3 +9316,193 @@ describe("cloneChart — view3D", () => {
     expect(parseChart(written)?.view3D).toBeUndefined();
   });
 });
+
+// ── cloneChart — axis label rotation ───────────────────────────────
+
+describe("cloneChart — axis labelRotation", () => {
+  const sourceWithRotation: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { labelRotation: 45 }, y: { labelRotation: -30 } },
+  };
+
+  it("inherits axes.x.labelRotation from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithRotation, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+    expect(clone.axes?.y?.labelRotation).toBe(-30);
+  });
+
+  it("drops the inherited rotation when override is null", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: null } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBeUndefined();
+    // Y axis stays put — nulling X must not bleed into Y.
+    expect(clone.axes?.y?.labelRotation).toBe(-30);
+  });
+
+  it("replaces the inherited rotation when override is a literal number", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: 60 } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBe(60);
+  });
+
+  it("clamps an out-of-range override to the -90..90 band", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: 200 } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBe(90);
+  });
+
+  it("rounds a fractional override to the nearest whole degree", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: 45.6 } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBe(46);
+  });
+
+  it("collapses an override of 0 to undefined (matches OOXML default)", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: 0 } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBeUndefined();
+  });
+
+  it("collapses non-finite overrides (NaN / Infinity) to undefined", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: Number.NaN } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBeUndefined();
+  });
+
+  it("adds a rotation to a source axis that did not pin one", () => {
+    const noRot: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noRot, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelRotation: 45 } },
+    });
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+  });
+
+  it("strips the rotation silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelRotation: 45 } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the rotation silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelRotation: 45 } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the rotation through chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+    expect(clone.axes?.y?.labelRotation).toBe(-30);
+  });
+
+  it("composes the rotation alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Period",
+          gridlines: { major: true },
+          labelRotation: 30,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.labelRotation).toBe(30);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the rotation", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr></a:p></c:txPr>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.labelRotation).toBe(45);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.labelRotation).toBe(45);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('<a:bodyPr rot="2700000"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelRotation).toBe(45);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the rotation intact", async () => {
+    const clone = cloneChart(sourceWithRotation, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // 45° on X axis, -30° on Y axis.
+    expect(written).toContain('<a:bodyPr rot="2700000"/>');
+    expect(written).toContain('<a:bodyPr rot="-1800000"/>');
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -8480,3 +8480,221 @@ describe("writeChart — view3D", () => {
     expect(reparsed?.view3D).toEqual({ rotX: 15, rotY: 20, perspective: 30 });
   });
 });
+
+// ── writeChart — axis label rotation ────────────────────────────────
+
+describe("writeChart — axis labelRotation", () => {
+  it("omits <c:txPr> on the category axis when the rotation is unset", () => {
+    // Excel's reference serialization omits `<c:txPr>` on every axis
+    // whose labels render flat — the writer mirrors that contract so a
+    // fresh chart stays byte-clean against Excel's own output.
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it('emits <c:txPr><a:bodyPr rot="N"/></c:txPr> when the X axis pins a rotation', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: 45 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<c:txPr>");
+    // 45 degrees * 60000 = 2,700,000.
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+  });
+
+  it("converts negative rotations to negative 60000ths of a degree", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: -45 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<a:bodyPr rot="-2700000"/>');
+  });
+
+  it("emits the rotation on the Y axis (value axis)", () => {
+    const result = writeChart(makeChart({ axes: { y: { labelRotation: 30 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain("<c:txPr>");
+    expect(valAxBlock).toContain('<a:bodyPr rot="1800000"/>');
+  });
+
+  it("emits independently on both axes when both pin a rotation", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45 }, y: { labelRotation: -30 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(valAxBlock).toContain('<a:bodyPr rot="-1800000"/>');
+  });
+
+  it("collapses the OOXML default 0 to absence (no <c:txPr> emitted)", () => {
+    // Pinning the default `0` round-trips identically to absence — the
+    // writer skips the entire `<c:txPr>` block. Mirrors how every other
+    // axis-default-collapse field treats its input.
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: 0 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it("clamps rotations above 90 to the 90-degree maximum", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: 180 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    // 90 degrees * 60000 = 5,400,000.
+    expect(catAxBlock).toContain('<a:bodyPr rot="5400000"/>');
+  });
+
+  it("clamps rotations below -90 to the -90-degree minimum", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: -180 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<a:bodyPr rot="-5400000"/>');
+  });
+
+  it("rounds non-integer degree values to the nearest whole degree", () => {
+    // The OOXML attribute is an integer in 60000ths of a degree, so a
+    // fractional whole-degree input has no meaningful refinement at
+    // emit time. Rounding keeps the wire output stable.
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: 45.4 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    const result2 = writeChart(makeChart({ axes: { x: { labelRotation: 45.6 } } }), "Sheet1");
+    const catAxBlock2 = result2.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock2).toContain('<a:bodyPr rot="2760000"/>');
+  });
+
+  it("drops non-finite rotation inputs (NaN, Infinity)", () => {
+    const nan = writeChart(makeChart({ axes: { x: { labelRotation: Number.NaN } } }), "Sheet1");
+    const inf = writeChart(
+      makeChart({ axes: { x: { labelRotation: Number.POSITIVE_INFINITY } } }),
+      "Sheet1",
+    );
+    expect(nan.chartXml).not.toContain("<c:txPr>");
+    expect(inf.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-numeric rotation inputs (string, boolean)", () => {
+    // The type guard rejects non-numeric inputs at the normalizer
+    // boundary — the writer never emits a value Excel's strict
+    // validator would reject.
+    const stringy = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelRotation: "45" as any } } }),
+      "Sheet1",
+    );
+    const boolish = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelRotation: true as any } } }),
+      "Sheet1",
+    );
+    expect(stringy.chartXml).not.toContain("<c:txPr>");
+    expect(boolish.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("places <c:txPr> between <c:tickLblPos> and <c:crossAx> per the OOXML schema", () => {
+    // CT_CatAx: ... tickLblPos -> spPr? -> txPr? -> crossAx -> ...
+    const result = writeChart(
+      makeChart({
+        axes: { x: { tickLblPos: "low", labelRotation: 45 } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const tickLblPosIdx = catAxBlock.indexOf("c:tickLblPos");
+    const txPrIdx = catAxBlock.indexOf("<c:txPr>");
+    const crossAxIdx = catAxBlock.indexOf("c:crossAx");
+    expect(tickLblPosIdx).toBeGreaterThan(0);
+    expect(txPrIdx).toBeGreaterThan(tickLblPosIdx);
+    expect(crossAxIdx).toBeGreaterThan(txPrIdx);
+  });
+
+  it("threads the rotation through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { labelRotation: 30 } } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:bodyPr rot="1800000"/>');
+    }
+  });
+
+  it("threads the rotation through scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { labelRotation: 45 }, y: { labelRotation: -45 } },
+      }),
+      "Sheet1",
+    );
+    // Scatter has two `<c:valAx>` siblings — confirm both pins survive.
+    const valAxes = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxes).toHaveLength(2);
+    expect(valAxes[0]).toContain('<a:bodyPr rot="2700000"/>');
+    expect(valAxes[1]).toContain('<a:bodyPr rot="-2700000"/>');
+  });
+
+  it("ignores the rotation on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(
+      makeChart({ type: "pie", axes: { x: { labelRotation: 45 } } }),
+      "Sheet1",
+    );
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { labelRotation: 45 } } }),
+      "Sheet1",
+    );
+    expect(pie.chartXml).not.toContain("<c:txPr>");
+    expect(dough.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("emits exactly one <c:txPr> per axis", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45 }, y: { labelRotation: 30 } } }),
+      "Sheet1",
+    );
+    expect((result.chartXml.match(/<c:txPr>/g) ?? []).length).toBe(2);
+  });
+
+  it("emits the minimal <c:txPr> shape (bodyPr + lstStyle + p)", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: 45 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<a:lstStyle/>");
+    expect(catAxBlock).toMatch(/<a:p>.*<\/a:p>/);
+    expect(catAxBlock).toContain("<a:endParaRPr");
+  });
+
+  it("round-trips a non-default rotation through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45 } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelRotation).toBe(45);
+  });
+
+  it("collapses a defaulted rotation round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelRotation).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the rotation into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { labelRotation: -45 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:bodyPr rot="-2700000"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.labelRotation).toBe(-45);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9111,3 +9111,180 @@ describe("parseChart — legend entries", () => {
     expect(parseChart(xml)?.legendEntries).toEqual([{ idx: 1, delete: true }]);
   });
 });
+
+// ── parseChart — axis label rotation ───────────────────────────────
+
+describe("parseChart — axis labelRotation", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTxPr(rot: string | undefined): string {
+    const txPr =
+      rot === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr rot="${rot}"/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${txPr}
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the rotation in whole degrees from the rot attribute (60000ths)", () => {
+    // 45 degrees * 60000 = 2,700,000.
+    const chart = parseChart(withCatAxTxPr("2700000"));
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+  });
+
+  it("surfaces negative rotations literally", () => {
+    const chart = parseChart(withCatAxTxPr("-2700000"));
+    expect(chart?.axes?.x?.labelRotation).toBe(-45);
+  });
+
+  it('collapses the OOXML default rot="0" to undefined', () => {
+    // The default `0` round-trips identically to absence — both leave
+    // the labels rendering flat.
+    const chart = parseChart(withCatAxTxPr("0"));
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> is absent", () => {
+    const chart = parseChart(withCatAxTxPr(undefined));
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:bodyPr> is absent inside <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:lstStyle/><a:p/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:bodyPr> omits the rot attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("clamps rot values above the 90-degree maximum to 90", () => {
+    // Values outside Excel's UI band collapse to the nearest endpoint
+    // so a corrupt template cannot surface a rotation the writer would
+    // never emit. 180° in 60000ths = 10,800,000.
+    const chart = parseChart(withCatAxTxPr("10800000"));
+    expect(chart?.axes?.x?.labelRotation).toBe(90);
+  });
+
+  it("clamps rot values below the -90-degree minimum to -90", () => {
+    const chart = parseChart(withCatAxTxPr("-10800000"));
+    expect(chart?.axes?.x?.labelRotation).toBe(-90);
+  });
+
+  it("drops non-numeric rot tokens", () => {
+    expect(parseChart(withCatAxTxPr("forty-five"))?.axes).toBeUndefined();
+  });
+
+  it("rounds non-integer 60000ths to the nearest whole degree", () => {
+    // 2,700,030 ≈ 45.0005°, rounds to 45.
+    const chart = parseChart(withCatAxTxPr("2700030"));
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+  });
+
+  it("surfaces the rotation on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr rot="-1800000"/><a:lstStyle/><a:p/></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.labelRotation).toBe(-30);
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p/></c:txPr>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr rot="-1800000"/><a:lstStyle/><a:p/></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+    expect(chart?.axes?.y?.labelRotation).toBe(-30);
+  });
+
+  it("surfaces the rotation on a scatter chart's value axes", () => {
+    // Scatter has two `<c:valAx>` siblings — the rotation surfaces on
+    // both axes for symmetry with the writer-side scatter builder.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:scatterChart><c:ser><c:idx val="0"/></c:ser></c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:axPos val="b"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p/></c:txPr>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:axPos val="l"/>
+      <c:txPr><a:bodyPr rot="-2700000"/><a:lstStyle/><a:p/></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+    expect(chart?.axes?.y?.labelRotation).toBe(-45);
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p/></c:txPr>
+      <c:noMultiLvlLbl val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      tickLblPos: "low",
+      labelRotation: 45,
+      noMultiLvlLbl: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:txPr><a:bodyPr rot="N"/></c:txPr></c:catAx>` (and the matching `<c:valAx>` slot) at the read, write, and clone layers so a template's axis-label rotation pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:bodyPr rot="N"/>` mirrors Excel's "Format Axis -> Alignment -> Custom angle" knob — `N` is in 60000ths of a degree, so 45° serializes as `rot="2700000"` and -90° as `rot="-5400000"`. Until now hucre's writer had no slot for the element and the reader ignored it entirely, so a templated dashboard chart whose user rotated the category labels diagonally (a common pattern for fitting long category strings under a column chart's bars) silently lost the choice on every parse -> clone -> write loop. Bridges another category-axis customization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.labelRotation);
// 45         ← when the template pinned <a:bodyPr rot="2700000"/> on the catAx
// undefined  ← when the template emits no rotation (the OOXML default 0)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Quarter", "Revenue"],
      ["Q1 2026 (Americas)", 100],
      ["Q2 2026 (Americas)", 200],
    ],
    charts: [{
      type: "column",
      title: "Quarterly Revenue",
      series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
      // Tilt long category labels diagonally so they fit under the
      // column bars without overlapping their neighbours.
      axes: { x: { labelRotation: -45 } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed labelRotation unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelRotation: null } },
});
//   → drops the inherited rotation (writer skips <c:txPr> entirely).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelRotation: 30 } },
});
//   → replaces the inherited rotation with 30 degrees.
```

## Implementation notes

- **Type model**: `axes.x.labelRotation?: number` and `axes.y.labelRotation?: number` on `SheetChart` (writer side) plus the matching `labelRotation?: number` on `ChartAxisInfo` (reader side). Same shape as the other numeric axis fields (`tickLblSkip`, `lblOffset`) so a parsed value flows straight from the read side back into the write side without transformation. Callers pin the value in degrees; the writer converts to 60000ths at emit time.
- **Reader** (`parseAxisLabelRotation`): walks `<c:txPr><a:bodyPr rot="N"/></c:txPr>` for the `rot` attribute. `Number.parseInt` rejects non-numeric tokens; `Math.round(parsed / 60000)` converts to whole degrees. The OOXML default `0` and absence both collapse to `undefined`. Out-of-range values clamp to the `-90..90` band Excel's UI exposes so a corrupt template cannot surface a value the writer would never emit. Surfaces on every axis flavour — the OOXML schema places `<c:txPr>` on `CT_CatAx` / `CT_ValAx` / `CT_DateAx` / `CT_SerAx` alike.
- **Writer**: `buildAxisTxPr(rotationDeg)` returns `undefined` when the rotation is unset / 0 / non-finite (writer skips emission), or a minimal `<c:txPr>` shell — `<a:bodyPr rot="N"/>` carries the rotation, `<a:lstStyle/>` is the empty list-style placeholder the schema requires, and `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>` is the empty paragraph stub Excel always emits even when no per-run styling is pinned. Additional `<a:bodyPr>` attributes Excel writes in its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap` / `anchor` / `anchorCtr`) are intentionally omitted — the OOXML schema marks them all optional, and dropping them keeps the writer's footprint minimal while preserving the rotation intent. The block slots between `<c:tickLblPos>` and `<c:crossAx>` per the CT_CatAx / CT_ValAx sequence. Threads through bar / column / line / area / scatter via `buildBarAxes` / `buildScatterAxes`; pie / doughnut have no axes at all and the field is silently dropped on those families.
  - `normalizeAxisLabelRotation(value)` clamps inputs to `-90..90`, rounds fractional inputs to the nearest whole degree, and collapses `0` / `NaN` / `Infinity` / non-numeric inputs to `undefined`.
- **Clone**: `applyLabelRotationOverride` follows the standard `number | null` override grammar — `undefined` inherits, `null` drops, a literal number replaces. Out-of-range / non-numeric overrides clamp / collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The catAx / valAx scope rule applies via the same `pie / doughnut` short-circuit the surrounding axis helpers use — those families have no axes at all and the field is silently dropped.
- **Validation**: only literal finite numbers survive the type guard at every layer; non-numeric inputs collapse to the default. This matches how `tickLblSkip` / `tickMarkSkip` / `lblOffset` treat their inputs.

## Test plan

- [x] `parseChart — axis labelRotation` (14 new tests) — surfaces the rotation in whole degrees from the `rot` attribute, surfaces negative rotations literally, collapses the OOXML default `rot="0"` to undefined, returns undefined when `<c:txPr>` is absent / `<a:bodyPr>` is absent / `rot` is missing, clamps out-of-range values to `-90..90`, drops non-numeric tokens, rounds non-integer 60000ths, surfaces on the value axis, surfaces independently on both axes, surfaces on scatter Y axis, co-surfaces alongside other axis fields.
- [x] `writeChart — axis labelRotation` (20 new tests) — omits `<c:txPr>` by default, emits the X-axis rotation, emits negative rotations as negative 60000ths, emits the Y-axis rotation, emits independently on both axes, collapses the OOXML default `0` to absence, clamps above-90 / below-`-90` to the band endpoints, rounds non-integer degrees, drops non-finite / non-numeric inputs, places `<c:txPr>` between `<c:tickLblPos>` and `<c:crossAx>` per the OOXML schema, threads through bar / column / line / area, threads through scatter (both axes), drops on pie / doughnut, single-emit guard, minimal CT_TextBody shape, parse round-trip, default round-trip collapse, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis labelRotation` (14 new tests) — inherit / null drop / replace semantics, clamp out-of-range overrides, round fractional overrides, collapse 0 to undefined, collapse non-finite overrides, add to a source axis without one, drop on pie / doughnut chart-type coercion, carry through bar -> column coercion, compose with other axis overrides, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4110 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.