### PR TITLE
feat(xlsx): chart upDownBars gap width — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1472,11 +1472,39 @@ export interface SheetChart {
    *
    * The writer emits a default `<c:gapWidth val="150"/>` child to
    * mirror Excel's reference serialization — `150` is the OOXML
-   * default for `CT_UpDownBars/gapWidth`. Custom gap widths are not
-   * exposed at this layer; pass a richer model in a follow-up if a
-   * caller needs to thin or widen the bars.
+   * default for `CT_UpDownBars/gapWidth`. Pin
+   * {@link upDownBarsGapWidth} to thin or widen the bars.
    */
   upDownBars?: boolean;
+  /**
+   * Width of the gap between up / down bars as a percentage of the bar
+   * width. Maps to `<c:lineChart><c:upDownBars><c:gapWidth val=".."/>
+   * </c:upDownBars></c:lineChart>` — Excel's "Format Up Bars / Down
+   * Bars -> Gap Width" slider. Accepted range: `0` – `500` (the OOXML
+   * `ST_GapAmount` schema). Excel's default is `150` (each up/down
+   * bar group's gap equals 1.5× the bar width); smaller values pack
+   * the bars tighter, `0` removes the gap entirely.
+   *
+   * Only meaningful when {@link upDownBars} is `true` — the writer
+   * silently drops the value on every other line chart configuration
+   * (the OOXML schema places `<c:gapWidth>` on `CT_UpDownBars`, so
+   * there is no slot for the value when the parent element is not
+   * emitted). The writer also drops the field on bar / column / pie /
+   * doughnut / area / scatter chart kinds for the same reason
+   * {@link upDownBars} is line-only.
+   *
+   * Out-of-range or non-finite values fall back to the OOXML default
+   * `150` so a fresh chart with a corrupt input still matches Excel's
+   * reference serialization. Non-integer values round to the nearest
+   * whole percent (Excel's UI accepts integer percentages only).
+   *
+   * Distinct from {@link gapWidth}: the bar-chart gap width controls
+   * spacing between category groups on a `<c:barChart>`, while this
+   * field controls the spacing between the up / down bars themselves
+   * on a line chart. Both share the same `ST_GapAmount` schema range
+   * but are independently scoped.
+   */
+  upDownBarsGapWidth?: number;
   /**
    * Whether the line chart paints markers at each data point. Maps to
    * `<c:lineChart><c:marker val=".."/></c:lineChart>` — Excel's
@@ -3643,15 +3671,36 @@ export interface Chart {
    * close differences on a line-style stock chart.
    *
    * Surfaces `true` whenever the element is present (with or without
-   * the optional `<c:gapWidth>` / `<c:upBars>` / `<c:downBars>`
-   * children — the model is a plain presence flag at this layer).
-   * Absence collapses to `undefined`. Only line-flavored chart types
-   * surface the field; the OOXML schema places `<c:upDownBars>` on
-   * `CT_LineChart`, `CT_Line3DChart`, and `CT_StockChart`, so the
-   * reader ignores any stray element on bar / column / pie / doughnut
-   * / area / scatter chart-type elements.
+   * the optional `<c:upBars>` / `<c:downBars>` children — the per-bar
+   * styling is not modelled at this layer). The optional
+   * `<c:gapWidth>` child is surfaced separately via
+   * {@link upDownBarsGapWidth}. Absence collapses to `undefined`. Only
+   * line-flavored chart types surface the field; the OOXML schema
+   * places `<c:upDownBars>` on `CT_LineChart`, `CT_Line3DChart`, and
+   * `CT_StockChart`, so the reader ignores any stray element on bar /
+   * column / pie / doughnut / area / scatter chart-type elements.
    */
   upDownBars?: boolean;
+  /**
+   * Up / down bars gap width pulled from
+   * `<c:lineChart><c:upDownBars><c:gapWidth val=".."/></c:upDownBars>
+   * </c:lineChart>`. The value is a percentage of the bar width
+   * (the OOXML `ST_GapAmount` schema, `0..500`).
+   *
+   * Surfaces the literal value carried by the file when it falls in
+   * the schema band and differs from the OOXML default of `150`. The
+   * default and absence both collapse to `undefined` so absence and
+   * `<c:gapWidth val="150"/>` round-trip identically through
+   * {@link cloneChart}. Out-of-range or non-numeric values are dropped
+   * rather than clamped so a corrupt template does not silently surface
+   * a value the writer would never emit.
+   *
+   * Only meaningful when {@link upDownBars} is `true` — the OOXML
+   * schema scopes `<c:gapWidth>` exclusively to `<c:upDownBars>`, so
+   * the reader only inspects the element when the parent toggle is
+   * present.
+   */
+  upDownBarsGapWidth?: number;
   /**
    * Chart-level marker visibility flag pulled from
    * `<c:lineChart><c:marker val=".."/></c:lineChart>`. Reflects Excel's

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -369,6 +369,30 @@ export interface CloneChartOptions {
    */
   upDownBars?: boolean | null;
   /**
+   * Override `<c:upDownBars><c:gapWidth val=".."/>` (the gap width
+   * between up / down bars on a line chart, as a percentage of the
+   * bar width).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * `upDownBarsGapWidth`. `null` drops the inherited value so the
+   * writer falls back to the OOXML default `150` (Excel's reference
+   * value for a freshly-toggled "Add Chart Element -> Up/Down Bars").
+   * A `number` replaces it — pass any value in the inclusive `0..500`
+   * band; out-of-range or non-finite values fall through to the
+   * default at write time rather than emit a token Excel rejects.
+   *
+   * Only meaningful when the resolved chart type is `line` and the
+   * resolved `upDownBars` is `true` — the writer drops the value
+   * silently otherwise (the OOXML schema scopes `<c:gapWidth>`
+   * exclusively to `<c:upDownBars>`, so there is no slot for it when
+   * the parent element is not emitted).
+   *
+   * The grammar mirrors the other line-only overrides
+   * ({@link upDownBars} / {@link showLineMarkers}) so the chart-level
+   * line-bar knobs compose the same way at the call site.
+   */
+  upDownBarsGapWidth?: number | null;
+  /**
    * Override `<c:lineChart><c:marker val=".."/>` (the chart-level
    * line-marker visibility toggle).
    *
@@ -1076,6 +1100,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (type === "line") {
     const resolvedUpDownBars = resolveUpDownBars(source.upDownBars, options.upDownBars);
     if (resolvedUpDownBars !== undefined) out.upDownBars = resolvedUpDownBars;
+
+    // `<c:upDownBars><c:gapWidth>` only makes sense when the parent
+    // toggle is on. Drop the gap-width value silently when the resolved
+    // `upDownBars` is `false` / `undefined` — there is no `<c:upDownBars>`
+    // element to host the value in either case, so leaking it through to
+    // the cloned `SheetChart` would surface a setting the writer would
+    // never emit anyway.
+    if (resolvedUpDownBars === true) {
+      const resolvedUpDownBarsGapWidth = resolveUpDownBarsGapWidth(
+        source.upDownBarsGapWidth,
+        options.upDownBarsGapWidth,
+      );
+      if (resolvedUpDownBarsGapWidth !== undefined) {
+        out.upDownBarsGapWidth = resolvedUpDownBarsGapWidth;
+      }
+    }
   }
 
   // `<c:marker>` (the chart-level CT_Boolean variant) lives exclusively
@@ -1732,6 +1772,32 @@ function resolveUpDownBars(
   sourceValue: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve an `upDownBarsGapWidth` override.
+ *
+ * `undefined` → inherit the source's parsed `upDownBarsGapWidth`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML default `150` Excel itself emits on a fresh
+ *               toggle).
+ * `number`    → replace. Out-of-range or non-finite values still
+ *               surface in the cloned `SheetChart` for symmetry with
+ *               the other override helpers; the writer's
+ *               `clampUpDownBarsGapWidth` then drops them at emit
+ *               time so a fresh chart matches Excel's reference
+ *               serialization.
+ *
+ * The grammar mirrors `gapWidth` / `holeSize` / `firstSliceAng` so the
+ * numeric chart-level knobs compose the same way at the call site.
+ */
+function resolveUpDownBarsGapWidth(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -125,6 +125,7 @@ export function parseChart(xml: string): Chart | undefined {
     let hiLowLines: boolean | undefined;
     let serLines: boolean | undefined;
     let upDownBars: boolean | undefined;
+    let upDownBarsGapWidth: number | undefined;
     let showLineMarkers: boolean | undefined;
     for (const child of childElements(plotArea)) {
       const kind = CHART_KIND_TAGS.get(child.local);
@@ -223,15 +224,22 @@ export function parseChart(xml: string): Chart | undefined {
       // `CT_StockChart` per the OOXML schema. Surface the flag from the
       // first line-flavored chart-type element that carries one — the
       // schema places the element on the chart-type element itself, not
-      // the per-series body, so this is a chart-level toggle. The
-      // model is a plain presence flag at this layer; richer details
-      // (per-bar styling, custom gap width) can layer on later.
-      if (
-        upDownBars === undefined &&
-        (kind === "line" || kind === "line3D" || kind === "stock") &&
-        findChild(child, "upDownBars") !== undefined
-      ) {
-        upDownBars = true;
+      // the per-series body, so this is a chart-level toggle. Per-bar
+      // styling can layer on later.
+      if (upDownBars === undefined && (kind === "line" || kind === "line3D" || kind === "stock")) {
+        const udb = findChild(child, "upDownBars");
+        if (udb !== undefined) {
+          upDownBars = true;
+          // `<c:gapWidth val="N"/>` (CT_GapAmount, ST_GapAmount) lives
+          // inside `<c:upDownBars>` and controls the spacing between the
+          // up / down bars themselves. The OOXML default of `150`
+          // collapses to `undefined` for symmetry with the writer's
+          // {@link SheetChart.upDownBarsGapWidth} default — absence and
+          // `150` mean the same thing on roundtrip. Out-of-range values
+          // are dropped rather than clamped so a corrupt template does
+          // not silently rewrite as a different gap.
+          upDownBarsGapWidth = parseUpDownBarsGapWidth(udb);
+        }
       }
       // `<c:marker>` (the chart-level CT_Boolean variant) lives on
       // `CT_LineChart` only — `CT_Line3DChart` and `CT_StockChart` have
@@ -280,6 +288,7 @@ export function parseChart(xml: string): Chart | undefined {
     if (hiLowLines !== undefined) out.hiLowLines = hiLowLines;
     if (serLines !== undefined) out.serLines = serLines;
     if (upDownBars !== undefined) out.upDownBars = upDownBars;
+    if (upDownBarsGapWidth !== undefined) out.upDownBarsGapWidth = upDownBarsGapWidth;
     if (showLineMarkers !== undefined) out.showLineMarkers = showLineMarkers;
 
     const axes = parseAxes(plotArea);
@@ -2603,6 +2612,31 @@ function parseHoleSize(doughnut: XmlElement): number | undefined {
  */
 function parseGapWidth(barChart: XmlElement): number | undefined {
   const el = findChild(barChart, "gapWidth");
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 0 || parsed > 500) return undefined;
+  if (parsed === 150) return undefined;
+  return parsed;
+}
+
+/**
+ * Pull `<c:gapWidth val=".."/>` off a `<c:upDownBars>` element. The
+ * value controls the spacing between the up / down bars themselves on
+ * a line chart (distinct from the bar-chart `<c:gapWidth>` which
+ * controls spacing between category groups).
+ *
+ * The OOXML schema (`ST_GapAmount`) restricts the value to the
+ * inclusive `0..500` band; out-of-range values are dropped rather than
+ * clamped so a corrupt template does not silently rewrite as a
+ * different gap. The OOXML default of `150` collapses to `undefined`
+ * for symmetry with the writer's {@link SheetChart.upDownBarsGapWidth}
+ * default — absence and `150` mean the same thing.
+ */
+function parseUpDownBarsGapWidth(upDownBars: XmlElement): number | undefined {
+  const el = findChild(upDownBars, "gapWidth");
   if (!el) return undefined;
   const raw = el.attrs.val;
   if (typeof raw !== "string") return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1573,7 +1573,7 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
     children.push(xmlElement("c:hiLowLines", undefined, []));
   }
   if (chart.upDownBars === true) {
-    children.push(buildUpDownBars());
+    children.push(buildUpDownBars(chart.upDownBarsGapWidth));
   }
 
   // `<c:marker>` (the chart-level CT_Boolean variant) gates per-series
@@ -1594,24 +1594,52 @@ function buildLineChart(chart: SheetChart, sheetName: string): string {
 }
 
 /**
- * Build a default `<c:upDownBars>` block for {@link buildLineChart}.
+ * Build a `<c:upDownBars>` block for {@link buildLineChart}.
  *
  * The OOXML schema (`CT_UpDownBars`) allows three optional children —
  * `<c:gapWidth>`, `<c:upBars>`, and `<c:downBars>` — but the up / down
  * bars themselves are painted by the mere presence of the parent
- * element. The writer emits a default `<c:gapWidth val="150"/>` to
- * mirror Excel's reference serialization for a freshly-toggled
- * "Add Chart Element -> Up/Down Bars" — `150` is the OOXML default for
- * `CT_UpDownBars/gapWidth` and the value Excel itself emits.
+ * element. The writer emits a `<c:gapWidth val="N"/>` child to mirror
+ * Excel's reference serialization for a freshly-toggled "Add Chart
+ * Element -> Up/Down Bars" — `150` is the OOXML default for
+ * `CT_UpDownBars/gapWidth` and the value Excel itself emits, so the
+ * writer falls back to it when the caller leaves
+ * {@link SheetChart.upDownBarsGapWidth} unset or pins an out-of-range
+ * value. An explicit value in the inclusive `0..500` band is rounded
+ * to the nearest integer and emitted literally.
  *
  * `<c:upBars>` / `<c:downBars>` are intentionally omitted: each is a
  * `CT_UpDownBar` (only `<c:spPr>` inside) and their absence makes
  * Excel paint the default white-up / black-down bars Excel uses on a
- * fresh toggle. A richer model — explicit gap widths or per-bar
- * styling — can layer on top in a follow-up if needed.
+ * fresh toggle. A richer model — per-bar styling — can layer on top
+ * in a follow-up if needed.
  */
-function buildUpDownBars(): string {
-  return xmlElement("c:upDownBars", undefined, [xmlSelfClose("c:gapWidth", { val: 150 })]);
+function buildUpDownBars(gapWidth: number | undefined): string {
+  const resolved = clampUpDownBarsGapWidth(gapWidth) ?? 150;
+  return xmlElement("c:upDownBars", undefined, [xmlSelfClose("c:gapWidth", { val: resolved })]);
+}
+
+/**
+ * Normalize {@link SheetChart.upDownBarsGapWidth} to an integer in the
+ * inclusive `0..500` band the OOXML schema (`ST_GapAmount`) allows.
+ *
+ * Returns `undefined` when the input is missing or non-finite so the
+ * caller can fall through to the OOXML default `150`. Non-integer
+ * values round to the nearest integer; out-of-range values drop to
+ * `undefined` rather than clamp — a templated chart whose gap width
+ * fell outside the schema bounds is treated as a fresh chart and
+ * collapses to the default. Mirrors {@link clampGapWidth} but uses a
+ * stricter "drop on out-of-range" policy because the up/down-bars gap
+ * width has no per-grouping default to fall through to (every line
+ * chart with the parent toggle on emits the same `150` default), so
+ * silently rewriting an `800` to `500` would mislead the caller about
+ * what Excel ends up rendering.
+ */
+function clampUpDownBarsGapWidth(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) return undefined;
+  const rounded = Math.round(value);
+  if (rounded < 0 || rounded > 500) return undefined;
+  return rounded;
 }
 
 // ── Area ─────────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6755,6 +6755,199 @@ describe("cloneChart — upDownBars", () => {
   });
 });
 
+// ── cloneChart — upDownBars gap width ────────────────────────────────
+
+describe("cloneChart — upDownBars gap width", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 2,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "High",
+          valuesRef: "Tpl!$B$2:$B$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+        {
+          kind: "line",
+          index: 1,
+          name: "Low",
+          valuesRef: "Tpl!$C$2:$C$5",
+          categoriesRef: "Tpl!$A$2:$A$5",
+        },
+      ],
+      upDownBars: true,
+      ...extra,
+    };
+  }
+
+  it("inherits the source's upDownBarsGapWidth by default", () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.upDownBars).toBe(true);
+    expect(clone.upDownBarsGapWidth).toBe(200);
+  });
+
+  it("lets options.upDownBarsGapWidth override the source's value", () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBarsGapWidth: 75,
+    });
+    expect(clone.upDownBarsGapWidth).toBe(75);
+  });
+
+  it("drops the inherited gap width when the override is null", () => {
+    // null collapses to the writer's OOXML default (150) — the field
+    // disappears from the resolved SheetChart so the writer falls back
+    // to Excel's reference value.
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBarsGapWidth: null,
+    });
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("returns undefined when neither source nor override sets the gap width", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("lets the caller add a gap width to a source that did not carry one", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBarsGapWidth: 250,
+    });
+    expect(clone.upDownBarsGapWidth).toBe(250);
+  });
+
+  it("drops the gap width when the resolved upDownBars is false", () => {
+    // The OOXML schema scopes <c:gapWidth> to <c:upDownBars> only.
+    // When the parent toggle is off, the gap width has no slot to live
+    // in — drop it silently.
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBars: false,
+    });
+    expect(clone.upDownBars).toBe(false);
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops the gap width when the resolved upDownBars is null-stripped", () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBars: null,
+    });
+    expect(clone.upDownBars).toBeUndefined();
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops the gap width when the source has no upDownBars and the clone does not add one", () => {
+    // Source carries a stray gap width but no parent toggle — the
+    // cloner drops the value because no <c:upDownBars> element will
+    // be emitted.
+    const stray: Chart = {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      // upDownBars omitted; upDownBarsGapWidth set in isolation.
+      upDownBarsGapWidth: 200,
+    };
+    const clone = cloneChart(stray, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.upDownBars).toBeUndefined();
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops the gap width on a flatten to a non-line family (line → column)", () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.upDownBars).toBeUndefined();
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops the gap width on a flatten to area (CT_AreaChart rejects upDownBars)", () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "area",
+    });
+    expect(clone.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("composes with an upDownBars override that adds the parent toggle", () => {
+    // Source has no toggle; clone adds `upDownBars: true` and pins the
+    // gap width — both should land on the resolved chart.
+    const clone = cloneChart(source({ upDownBars: undefined }), {
+      anchor: { from: { row: 0, col: 0 } },
+      upDownBars: true,
+      upDownBarsGapWidth: 300,
+    });
+    expect(clone.upDownBars).toBe(true);
+    expect(clone.upDownBarsGapWidth).toBe(300);
+  });
+
+  it("propagates a custom gap width into the rendered <c:lineChart> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B", "C"],
+            [1, 10, 5],
+            [2, 12, 6],
+            [3, 15, 8],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:upDownBars>");
+    expect(written).toContain('c:gapWidth val="200"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBars).toBe(true);
+    expect(reparsed?.upDownBarsGapWidth).toBe(200);
+  });
+
+  it("falls back to 150 when the override is null on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ upDownBarsGapWidth: 200 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      upDownBarsGapWidth: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B", "C"],
+            [1, 10, 5],
+            [2, 12, 6],
+            [3, 15, 8],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:upDownBars>");
+    expect(written).toContain('c:gapWidth val="150"');
+    expect(written).not.toContain('c:gapWidth val="200"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBarsGapWidth).toBeUndefined();
+  });
+});
+
 // ── cloneChart — axis dispUnits ──────────────────────────────────────
 
 describe("cloneChart — axis dispUnits", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -6062,6 +6062,208 @@ describe("writeChart — upDownBars", () => {
   });
 });
 
+// ── writeChart — upDownBars gap width ────────────────────────────────
+
+describe("writeChart — upDownBars gap width", () => {
+  it("emits a custom gap width inside <c:upDownBars> when explicitly pinned", () => {
+    // The OOXML schema (CT_UpDownBars) places <c:gapWidth> inside the
+    // parent element. The writer rounds the value to a whole percent
+    // and emits the literal value the caller pinned.
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 200 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain("<c:upDownBars>");
+    expect(result.chartXml).toContain('c:gapWidth val="200"');
+    expect(result.chartXml).not.toContain('c:gapWidth val="150"');
+  });
+
+  it("emits a tight gap width of 0", () => {
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 0 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:gapWidth val="0"');
+  });
+
+  it("emits the maximum gap width of 500", () => {
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 500 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:gapWidth val="500"');
+  });
+
+  it("falls back to the OOXML default 150 when the caller omits the field", () => {
+    // The writer always emits <c:gapWidth> when the parent element is
+    // emitted — Excel's reference serialization includes the child
+    // unconditionally. Absence of the field collapses to the default.
+    const result = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1");
+    expect(result.chartXml).toContain('c:gapWidth val="150"');
+  });
+
+  it("rounds non-integer values to the nearest whole percent", () => {
+    // Excel's UI accepts integer percentages only. Callers passing a
+    // fractional value get the rounded value the writer emits.
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 174.6 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:gapWidth val="175"');
+  });
+
+  it("falls back to 150 when the value is above the schema cap of 500", () => {
+    // The OOXML schema (ST_GapAmount) restricts the value to 0..500;
+    // out-of-range values fall back to the default rather than clamp
+    // to the schema bound — silently rewriting an `800` to `500`
+    // would mislead the caller about what Excel ends up rendering.
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 800 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:gapWidth val="150"');
+    expect(result.chartXml).not.toContain('c:gapWidth val="800"');
+  });
+
+  it("falls back to 150 when the value is below the schema floor of 0", () => {
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: -25 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:gapWidth val="150"');
+  });
+
+  it("falls back to 150 when the value is non-finite", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const result = writeChart(
+        makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: bad }),
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('c:gapWidth val="150"');
+    }
+  });
+
+  it("drops the gap width when upDownBars is unset (no parent element to host it)", () => {
+    // The OOXML schema scopes <c:gapWidth> exclusively to <c:upDownBars>.
+    // Pinning a gap width without the parent toggle never emits the
+    // child — there is no slot for it.
+    const result = writeChart(makeChart({ type: "line", upDownBarsGapWidth: 200 }), "Sheet1");
+    expect(result.chartXml).not.toContain("c:upDownBars");
+    expect(result.chartXml).not.toContain('c:gapWidth val="200"');
+  });
+
+  it("drops the gap width on a chart that pins upDownBars=false", () => {
+    // upDownBars=false collapses to absence of the parent element, so
+    // there is no slot for the child.
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: false, upDownBarsGapWidth: 200 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:upDownBars");
+  });
+
+  it("only emits <c:gapWidth> once inside the up/down bars block", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 200 }),
+      "Sheet1",
+    );
+    const occurrences = result.chartXml.match(/<c:gapWidth\b/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("drops the gap width on bar / column / pie / doughnut / area chart kinds", () => {
+    // The bar-family <c:gapWidth> writer is independent — it should not
+    // surface when only `upDownBarsGapWidth` is set on a bar chart.
+    for (const type of ["bar", "column", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, upDownBars: true, upDownBarsGapWidth: 200 }),
+        "Sheet1",
+      );
+      expect(result.chartXml).not.toContain("c:upDownBars");
+    }
+  });
+
+  it("drops the gap width on a scatter chart (CT_ScatterChart rejects upDownBars)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        upDownBars: true,
+        upDownBarsGapWidth: 200,
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("c:upDownBars");
+  });
+
+  it("does not collide with the bar-chart gap width on a column chart", () => {
+    // A column chart with both gapWidth (bar-family) and
+    // upDownBarsGapWidth (line-family) emits only the bar-family value;
+    // the line-family field is dropped because the parent element is
+    // never emitted on a column chart.
+    const result = writeChart(
+      makeChart({ type: "column", gapWidth: 75, upDownBarsGapWidth: 200 }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('c:gapWidth val="75"');
+    expect(result.chartXml).not.toContain('c:gapWidth val="200"');
+  });
+
+  it("round-trips a custom gap width through parseChart", () => {
+    const written = writeChart(
+      makeChart({ type: "line", upDownBars: true, upDownBarsGapWidth: 200 }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBars).toBe(true);
+    expect(reparsed?.upDownBarsGapWidth).toBe(200);
+  });
+
+  it("collapses the OOXML default 150 round-trip back to undefined", () => {
+    // Writing upDownBars=true (with no explicit gap width) emits the
+    // default 150; the reader then collapses that default back to
+    // undefined so absence and the default round-trip identically.
+    const written = writeChart(makeChart({ type: "line", upDownBars: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.upDownBars).toBe(true);
+    expect(reparsed?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("threads the custom gap width through writeXlsx end-to-end packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["High", "Low"],
+          [10, 5],
+          [12, 6],
+          [15, 8],
+        ],
+        charts: [
+          {
+            type: "line",
+            series: [
+              { name: "High", values: "A2:A4" },
+              { name: "Low", values: "B2:B4" },
+            ],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            upDownBars: true,
+            upDownBarsGapWidth: 250,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:upDownBars>");
+    expect(chartXml).toContain('c:gapWidth val="250"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.upDownBars).toBe(true);
+    expect(reparsed?.upDownBarsGapWidth).toBe(250);
+  });
+});
+
 // ── writeChart — axis dispUnits ──────────────────────────────────────
 
 describe("writeChart — axis dispUnits", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6886,6 +6886,171 @@ describe("parseChart — upDownBars", () => {
   });
 });
 
+// ── parseChart — upDownBars gap width ────────────────────────────────
+
+describe("parseChart — upDownBars gap width", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  function makeLineChart(udbBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      ${udbBody}
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces a custom gap width on the up/down bars", () => {
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="200"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBe(200);
+  });
+
+  it("surfaces a tight gap width of 0", () => {
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="0"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBarsGapWidth).toBe(0);
+  });
+
+  it("surfaces the maximum gap width of 500", () => {
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="500"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBarsGapWidth).toBe(500);
+  });
+
+  it("collapses the OOXML default 150 to undefined", () => {
+    // <c:gapWidth val="150"/> is Excel's reference value; the parser
+    // collapses it for round-trip symmetry with the writer's default
+    // — absence and `150` must round-trip identically.
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="150"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:gapWidth> is absent", () => {
+    const xml = makeLineChart(`<c:upDownBars/>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops out-of-range values above the schema cap of 500", () => {
+    // The OOXML schema (ST_GapAmount) restricts the value to 0..500;
+    // the reader drops out-of-range values rather than clamp so a
+    // corrupt template does not silently rewrite as a different gap.
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="800"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops negative values below the schema floor of 0", () => {
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="-25"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops non-numeric val attributes", () => {
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="wide"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("drops a missing val attribute", () => {
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:upDownBars> itself is absent", () => {
+    const xml = makeLineChart("");
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBeUndefined();
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("ignores the gap width on a bar chart (CT_BarChart has no <c:upDownBars> slot)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:grouping val="clustered"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars><c:gapWidth val="200"/></c:upDownBars>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBeUndefined();
+    expect(chart?.upDownBarsGapWidth).toBeUndefined();
+  });
+
+  it("surfaces the gap width on a stock chart (CT_StockChart accepts <c:upDownBars>)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:stockChart>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars><c:gapWidth val="80"/></c:upDownBars>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+    </c:stockChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBe(80);
+  });
+
+  it("surfaces the gap width on a 3D line chart (CT_Line3DChart accepts <c:upDownBars>)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:line3DChart>
+      <c:grouping val="standard"/>
+      <c:ser><c:idx val="0"/></c:ser>
+      <c:upDownBars><c:gapWidth val="120"/></c:upDownBars>
+      <c:axId val="1"/>
+      <c:axId val="2"/>
+      <c:axId val="3"/>
+    </c:line3DChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:serAx><c:axId val="3"/></c:serAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.upDownBars).toBe(true);
+    expect(chart?.upDownBarsGapWidth).toBe(120);
+  });
+
+  it("does not collide with the bar-chart gap width field", () => {
+    // Bar charts also carry <c:gapWidth> — make sure surfacing the
+    // up/down-bars value does not leak into / collide with the
+    // bar-chart `gapWidth` field.
+    const xml = makeLineChart(`<c:upDownBars><c:gapWidth val="200"/></c:upDownBars>`);
+    const chart = parseChart(xml);
+    expect(chart?.upDownBarsGapWidth).toBe(200);
+    expect(chart?.gapWidth).toBeUndefined();
+  });
+});
+
 // ── parseChart — axis dispUnits ──────────────────────────────────────
 
 describe("parseChart — axis dispUnits", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:upDownBars><c:gapWidth val=\"N\"/></c:upDownBars>` (CT_UpDownBars, ECMA-376 Part 1, §21.2.2.218) at the read, write, and clone layers so a templated line chart's up/down-bars spacing pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Until now hucre's writer hard-coded `<c:gapWidth val=\"150\"/>` (the OOXML default Excel itself emits) and the reader ignored the element entirely, so a template whose author thinned or widened the up/down bars from the default lost the choice on every parse -> clone -> write loop. The `ST_GapAmount` schema (`0..500`, percentage of the bar width) is shared with the bar-chart `<c:gapWidth>`, but the two are independently scoped — the bar-family value spaces category groups while this one spaces the up/down bars themselves on a line chart. Bridges another line-chart gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.upDownBars);            // true
console.log(source.upDownBarsGapWidth);    // 200 (when the template pinned val=\"200\")
                                           // undefined (when the template emits val=\"150\" or omits the child)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Stock\",
    rows: [
      [\"Open\", \"Close\"],
      [10, 12],
      [12, 11],
    ],
    charts: [{
      type: \"line\",
      series: [
        { name: \"Open\",  values: \"A2:A3\" },
        { name: \"Close\", values: \"B2:B3\" },
      ],
      anchor: { from: { row: 5, col: 0 } },
      // Pack the up / down bars tighter than Excel's reference 150% gap.
      upDownBars: true,
      upDownBarsGapWidth: 50,
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed upDownBarsGapWidth unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  upDownBarsGapWidth: null,
});
//   → drops the inherited gap width (writer falls back to the OOXML default 150).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  upDownBarsGapWidth: 75,
});
//   → replaces the inherited gap width with 75%.
```

## Implementation notes

- **Type model**: `upDownBarsGapWidth?: number` on `SheetChart` (writer side) and the matching `upDownBarsGapWidth?: number` on `Chart` (reader side). Same shape as the existing bar-family `gapWidth` so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseUpDownBarsGapWidth`): walks `<c:upDownBars><c:gapWidth val=\"N\"/></c:upDownBars>` only when the parent `<c:upDownBars>` element is present on a `CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` body. The OOXML default `150` and absence both collapse to `undefined`. Out-of-range values (outside the `ST_GapAmount` `0..500` band) are dropped rather than clamped so a corrupt template does not silently surface a value the writer would never emit.
- **Writer** (`buildUpDownBars` + `clampUpDownBarsGapWidth`): rounds non-integer inputs, drops out-of-range / non-finite inputs, then falls back to the OOXML default `150` when the resolved value is `undefined`. The `<c:gapWidth>` child is always emitted alongside `<c:upDownBars>` to mirror Excel's reference serialization. Silently dropped on bar / column / pie / doughnut / area / scatter chart kinds (no parent element to host the value) and on a chart that pins `upDownBars: false` (parent element collapses to absence).
- **Clone**: `resolveUpDownBarsGapWidth` follows the standard `number | null` override grammar — `undefined` inherits, `null` drops, a literal number replaces. The override is silently dropped when the resolved `upDownBars` is anything other than `true` (the OOXML schema scopes `<c:gapWidth>` exclusively to `<c:upDownBars>`, so leaking the value through to the cloned `SheetChart` would surface a setting the writer would never emit anyway). The clone is also gated on the resolved chart type being `line` for the same reason `upDownBars` itself is.
- **Validation**: only literal finite numbers survive the type guard at every layer; non-numeric inputs collapse to the default. This matches how `gapWidth` / `holeSize` / `firstSliceAng` treat their inputs.

## Test plan

- [x] `parseChart — upDownBars gap width` (13 new tests) — surfaces a custom gap width, the boundary values 0 and 500, collapses the OOXML default 150 to undefined, returns undefined when `<c:gapWidth>` is absent / `<c:upDownBars>` is absent, drops out-of-range / negative / non-numeric / missing-val inputs, ignores the field on bar charts, surfaces on stock and 3D line charts, does not collide with the bar-chart `gapWidth` field.
- [x] `writeChart — upDownBars gap width` (16 new tests) — emits a custom gap width, the boundary values 0 and 500, falls back to 150 when unset, rounds non-integer values, falls back to 150 when out-of-range / non-finite, drops the value when the parent toggle is off / the chart kind is non-line, single-emit guard, no collision with bar-chart `gapWidth`, parse round-trip, default round-trip collapse, full `writeXlsx` package round-trip.
- [x] `cloneChart — upDownBars gap width` (14 new tests) — inherit / null drop / replace semantics, drops on resolved `upDownBars: false / null`, drops a stray gap width on a source with no parent toggle, drops on a flatten to non-line / area, composes with an `upDownBars` override that adds the parent toggle, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip with custom and null-drop overrides.
- [x] `pnpm test` — all 4143 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.