### PR TITLE
feat(xlsx): chart title rotation — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,21 @@ truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
 unknown values and missing `val` attributes drop to `undefined`. The
 flag is dropped whenever the chart omits the `<c:title>` element
 entirely — there is no overlay slot to surface in that case.
+`Chart.titleRotation` surfaces the chart-title rotation pulled from
+`<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+— Excel's "Format Chart Title → Size & Properties → Alignment → Custom
+angle" knob. The OOXML attribute is in 60000ths of a degree; the reader
+divides by 60000 (rounding) to surface a whole-degree value in the
+`-90..90` band Excel's UI exposes. The OOXML default `0` (and absence
+of the `<a:bodyPr>` element / `rot` attribute) collapses to `undefined`
+so absence and the default round-trip identically through `cloneChart`.
+Out-of-range values clamp to the nearest endpoint of the `-90..90` band;
+non-numeric tokens drop back to `undefined`. The field is dropped
+whenever the chart omits the `<c:title>` element entirely — there is no
+rotation to surface in that case. Mirrors the axis-side
+`ChartAxisInfo.labelRotation` field — same range, same conversion
+factor — so a parsed value threads straight back into the writer-side
+`SheetChart.titleRotation`.
 `Chart.autoTitleDeleted` surfaces the chart-level
 `<c:chart><c:autoTitleDeleted val=".."/>` flag — Excel's record of
 whether the user explicitly deleted the auto-generated title that
@@ -1284,6 +1299,22 @@ emitted (no `title` set or `showTitle: false`) — there is no `<c:title>`
 block to host the overlay child in either case. Independent of
 `legendOverlay`: the legend and title `<c:overlay>` elements live on
 different parents, so the two flags compose freely.
+The chart-level `titleRotation` field maps to `<a:bodyPr rot="N"/>`
+inside `<c:title><c:tx><c:rich>` — Excel's "Format Chart Title → Size &
+Properties → Alignment → Custom angle" knob. The OOXML attribute is in
+60000ths of a degree, so `titleRotation: 45` serializes as
+`rot="2700000"` and `titleRotation: -90` as `rot="-5400000"`; the writer
+performs the conversion at emit time. Accepted range: `-90..90` (Excel's
+UI band) — out-of-range inputs clamp to the nearest endpoint, non-integer
+inputs round to the nearest whole degree, and `0` / `NaN` / `Infinity` /
+non-numeric inputs collapse to absence so the writer falls back to the
+OOXML default `rot="0"` (horizontal). The flag is silently ignored when
+no title is emitted (no `title` set or `showTitle: false`) — there is no
+`<c:title>` block to host the rotation in either case. Mirrors the axis-
+side `axes.x.labelRotation` / `axes.y.labelRotation` fields — same
+range, same conversion factor — so a caller can thread a single rotation
+value through both the chart title and an axis label set without
+bookkeeping the units.
 The chart-level `autoTitleDeleted` field maps to
 `<c:autoTitleDeleted val=".."/>` inside `<c:chart>` — Excel's record of
 whether the user explicitly deleted the auto-generated title that
@@ -1783,6 +1814,18 @@ is no `<c:title>` block to host the overlay flag in either case.
 Re-introducing a missing source title through an explicit `title:
 "..."` override re-opens the slot, and an explicit `titleOverlay: true`
 override threads through.
+The chart-level `titleRotation` field follows the same grammar: pass
+`undefined` to inherit the source's parsed value, `null` to drop it
+back to the writer's OOXML `0` default (horizontal title), or a
+`number` to replace it. Out-of-range overrides clamp to the `-90..90`
+band Excel's UI exposes; non-integer overrides round to the nearest
+whole degree; `0` / `NaN` / `Infinity` / non-numeric overrides collapse
+to a drop so the cloned `SheetChart` always carries a value the writer
+will accept. Same scope rule as `titleOverlay`: the rotation lives on
+`<c:title>` so the field is valid on every chart family, but it is
+silently dropped from the cloned `SheetChart` whenever the resolved
+chart renders no title — there is no `<a:bodyPr rot="N"/>` slot to host
+the rotation in either case.
 The chart-level `autoTitleDeleted` flag follows the same grammar: pass
 `undefined` to inherit the source's parsed value, `null` to drop it
 back to the writer's title-presence-derived default, or a `boolean` to

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1309,6 +1309,39 @@ export interface SheetChart {
    */
   titleOverlay?: boolean;
   /**
+   * Chart title rotation in whole degrees, measured clockwise from the
+   * normal horizontal baseline. Maps to `<c:title><c:tx><c:rich>
+   * <a:bodyPr rot="N"/></c:rich></c:tx></c:title>` — Excel's "Format
+   * Chart Title -> Size & Properties -> Alignment -> Custom angle" knob.
+   * The OOXML attribute is in 60000ths of a degree, so 45° serializes
+   * as `rot="2700000"` and -90° as `rot="-5400000"`; the writer
+   * performs the conversion at emit time.
+   *
+   * Accepted range: `-90..90` (Excel's UI band). Out-of-range inputs
+   * clamp to the nearest endpoint; non-integer inputs round to the
+   * nearest whole degree (the OOXML attribute is an integer in
+   * 60000ths, so a fractional whole-degree value has no meaningful
+   * refinement at emit time). `0`, `NaN`, `Infinity`, and non-numeric
+   * inputs collapse to `undefined` so the writer falls back to the
+   * default horizontal orientation.
+   *
+   * Default: omitted — the title renders horizontally (the OOXML
+   * default `rot="0"` Excel itself emits on a fresh chart). Set a
+   * non-zero value to tilt the title diagonally or stand it on its
+   * side, useful when composing a dashboard whose chart titles need to
+   * fit a tight vertical sidebar slot or to mirror the rotation of an
+   * underlying axis label set.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * rotation in either case. Mirrors the axis-side
+   * {@link SheetChart.axes.x.labelRotation} field — same range, same
+   * normalization, same OOXML conversion factor — so a caller can
+   * thread a single rotation value through both the chart title and an
+   * axis label set without bookkeeping the units.
+   */
+  titleRotation?: number;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -3456,6 +3489,29 @@ export interface Chart {
    * element at all — there is no overlay flag to surface in that case.
    */
   titleOverlay?: boolean;
+  /**
+   * Chart title rotation in whole degrees, pulled from
+   * `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`.
+   * Reflects Excel's "Format Chart Title -> Size & Properties ->
+   * Alignment -> Custom angle" knob.
+   *
+   * The OOXML attribute is in 60000ths of a degree; the reader divides
+   * by 60000 (and rounds) to surface a whole-degree value in the
+   * `-90..90` band Excel's UI exposes. The OOXML default `0` (and
+   * absence of the `<a:bodyPr>` element / `rot` attribute) all collapse
+   * to `undefined` so absence and the default round-trip identically
+   * through {@link cloneChart}. Out-of-range values clamp to the
+   * nearest endpoint of the `-90..90` band; non-numeric tokens drop
+   * back to `undefined`.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all — there is no rotation to surface in
+   * that case. Mirrors the axis-side {@link ChartAxisInfo.labelRotation}
+   * field — same range, same conversion factor — so a parsed value
+   * threads straight back into the writer-side
+   * {@link SheetChart.titleRotation} without transformation.
+   */
+  titleRotation?: number;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -255,6 +255,24 @@ export interface CloneChartOptions {
    */
   titleOverlay?: boolean | null;
   /**
+   * Override the chart-level title rotation in whole degrees.
+   * `undefined` (or omitted) inherits the source's parsed value;
+   * `null` drops the inherited rotation so the writer falls back to
+   * the OOXML default `0` (horizontal); a `number` replaces it.
+   *
+   * Out-of-range overrides clamp to the `-90..90` band Excel's UI
+   * exposes; non-integer overrides round to the nearest whole degree;
+   * `0`, `NaN`, `Infinity`, and non-numeric overrides collapse to a
+   * drop (the writer's normalization band) so the cloned `SheetChart`
+   * always carries a value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved chart renders no title (`title` resolved to `undefined`
+   * or `showTitle === false`) — there is no `<c:title>` block to host
+   * the rotation in either case.
+   */
+  titleRotation?: number | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -990,6 +1008,16 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   if (titleRendered) {
     const resolvedTitleOverlay = resolveTitleOverlay(source.titleOverlay, options.titleOverlay);
     if (resolvedTitleOverlay !== undefined) out.titleOverlay = resolvedTitleOverlay;
+
+    // `titleRotation` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:bodyPr rot="N"/>` slot for the writer
+    // to populate. Same scope rule as `titleOverlay`: the override wins
+    // over the source's parsed value; absence inherits, `null` drops,
+    // a `number` replaces. Out-of-range / non-finite / non-numeric
+    // overrides collapse via the writer's normalizer so the cloned
+    // `SheetChart` always carries a value the writer will accept.
+    const resolvedTitleRotation = resolveTitleRotation(source.titleRotation, options.titleRotation);
+    if (resolvedTitleRotation !== undefined) out.titleRotation = resolvedTitleRotation;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -1855,6 +1883,55 @@ function resolveTitleOverlay(
   if (override === undefined) return sourceValue;
   if (override === null) return undefined;
   return override;
+}
+
+/**
+ * Conversion bookkeeping for the chart-title rotation override. Same
+ * `-90..90` band the writer enforces so the cloned `SheetChart` always
+ * carries a value the writer will accept.
+ */
+const TITLE_ROTATION_MIN_DEG = -90;
+const TITLE_ROTATION_MAX_DEG = 90;
+
+/**
+ * Normalize a `titleRotation` value (whole degrees) for the cloned
+ * `SheetChart`. Mirrors the writer's `normalizeTitleRotation` — the
+ * cloned shape is guaranteed to round-trip through the writer without
+ * surprise: out-of-range inputs clamp to the `-90..90` band; non-integer
+ * inputs round to the nearest whole degree; `0`, `NaN`, `Infinity`, and
+ * non-numeric inputs collapse to `undefined` so the cloned chart drops
+ * the field rather than carry a value the writer would silently elide.
+ */
+function normalizeTitleRotation(value: number | undefined): number | undefined {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  let degrees = Math.round(value);
+  if (degrees < TITLE_ROTATION_MIN_DEG) degrees = TITLE_ROTATION_MIN_DEG;
+  else if (degrees > TITLE_ROTATION_MAX_DEG) degrees = TITLE_ROTATION_MAX_DEG;
+  if (degrees === 0) return undefined;
+  return degrees;
+}
+
+/**
+ * Resolve a `titleRotation` override.
+ *
+ * `undefined` → inherit the source's parsed `titleRotation`.
+ * `null`      → drop the inherited value (the writer falls back to the
+ *               OOXML `0` default — the title renders horizontally).
+ * `number`    → replace, after clamping / rounding through
+ *               {@link normalizeTitleRotation}.
+ *
+ * The grammar mirrors `titleOverlay` / `legendOverlay` so the chart-
+ * level title knobs compose the same way at the call site. Callers
+ * should gate the result on the resolved title visibility — when no
+ * title is emitted, the rotation has no slot in the rendered chart.
+ */
+function resolveTitleRotation(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeTitleRotation(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleRotation(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -96,6 +96,17 @@ export function parseChart(xml: string): Chart | undefined {
   const titleOverlay = parseTitleOverlay(chartEl);
   if (titleOverlay !== undefined) out.titleOverlay = titleOverlay;
 
+  // `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+  // mirrors Excel's "Format Chart Title -> Size & Properties ->
+  // Alignment -> Custom angle" knob. Same scope rule as `<c:overlay>` —
+  // a chart that omits the `<c:title>` element has no rotation to
+  // surface, so the helper short-circuits to `undefined` when the title
+  // is absent. The value comes back in whole degrees (range `-90..90`)
+  // for symmetry with the writer-side
+  // {@link SheetChart.titleRotation} field.
+  const titleRotation = parseTitleRotation(chartEl);
+  if (titleRotation !== undefined) out.titleRotation = titleRotation;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -1886,6 +1897,58 @@ function parseTitleOverlay(chartEl: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+/**
+ * Conversion factor between OOXML's `rot` attribute (60000ths of a
+ * degree, the integer Excel writes inside `<a:bodyPr rot="N"/>`) and
+ * whole degrees. Excel's UI exposes the -90..90 degree band — the
+ * reader clamps anything outside that band so a corrupt template
+ * cannot surface a value the writer would never emit.
+ */
+const TITLE_ROT_PER_DEGREE = 60000;
+const TITLE_ROTATION_MIN_DEG = -90;
+const TITLE_ROTATION_MAX_DEG = 90;
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx>
+ * </c:title>` off the chart. Returns the rotation in whole degrees
+ * (range `-90..90`).
+ *
+ * The OOXML default `0` (and absence of the `<a:bodyPr>` element /
+ * `rot` attribute) all collapse to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart}.
+ * Non-integer / non-numeric / out-of-range values clamp to the nearest
+ * endpoint of the `-90..90` band Excel's UI exposes; non-finite
+ * (`NaN`, `Infinity`) inputs drop to `undefined`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` element
+ * — there is no rotation slot to surface in that case. The
+ * `<a:bodyPr>` lives inside `<c:tx><c:rich>` per the CT_Title schema
+ * (the rich-text body's body-properties); the lookup is scoped to that
+ * path so a stray `<a:bodyPr>` elsewhere in the chart cannot leak in.
+ */
+function parseTitleRotation(chartEl: XmlElement): number | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  const bodyPr = findChild(rich, "bodyPr");
+  if (!bodyPr) return undefined;
+  const raw = bodyPr.attrs.rot;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 60000ths of a degree to whole degrees.
+  const degrees = Math.round(parsed / TITLE_ROT_PER_DEGREE);
+  if (degrees === 0) return undefined;
+  if (degrees < TITLE_ROTATION_MIN_DEG) return TITLE_ROTATION_MIN_DEG;
+  if (degrees > TITLE_ROTATION_MAX_DEG) return TITLE_ROTATION_MAX_DEG;
+  return degrees;
 }
 
 // ── Auto Title Deleted ────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -67,7 +67,9 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
   // ── Title ──
   if (showTitle && chart.title) {
-    chartChildren.push(buildTitle(chart.title, resolveTitleOverlay(chart)));
+    chartChildren.push(
+      buildTitle(chart.title, resolveTitleOverlay(chart), resolveTitleRotation(chart)),
+    );
   }
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // Excel's auto-generated title (the synthesised series-name title
@@ -196,14 +198,20 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
 // ── Title ────────────────────────────────────────────────────────────
 
-function buildTitle(title: string, overlay: boolean): string {
+function buildTitle(title: string, overlay: boolean, rotationDeg: number | undefined): string {
+  // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
+  // The writer holds `titleRotation` in whole degrees and converts at
+  // emit time. Absence (`undefined`) collapses to the OOXML default
+  // `0` so a fresh chart matches Excel's reference serialization
+  // byte-for-byte.
+  const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
         xmlElement(
           "a:bodyPr",
           {
-            rot: 0,
+            rot,
             spcFirstLastPara: 1,
             vertOverflow: "ellipsis",
             wrap: "square",
@@ -224,6 +232,55 @@ function buildTitle(title: string, overlay: boolean): string {
     ]),
     xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }),
   ]);
+}
+
+/**
+ * OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree —
+ * the writer holds `titleRotation` in whole degrees and converts at
+ * emit time. Excel's UI exposes the `-90..90` band; out-of-band values
+ * clamp to the nearest endpoint so a corrupt template cannot leak
+ * through to the writer either.
+ */
+const TITLE_ROT_PER_DEGREE = 60000;
+const TITLE_ROTATION_MIN_DEG = -90;
+const TITLE_ROTATION_MAX_DEG = 90;
+
+/**
+ * Normalize a {@link SheetChart.titleRotation} value (whole degrees)
+ * for the `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx>
+ * </c:title>` writer slot. Returns `undefined` when the input is unset,
+ * non-finite, non-numeric, or resolves to `0` after rounding — every
+ * absence path collapses to the same omit-the-attribute shape so
+ * absence and the OOXML default `0` round-trip identically through
+ * {@link cloneChart}. Out-of-range inputs clamp to the `-90..90` band
+ * Excel's UI exposes; non-integer inputs round to the nearest whole
+ * degree (the OOXML attribute is an integer in 60000ths of a degree,
+ * so a fractional whole-degree value has no meaningful refinement at
+ * emit time).
+ */
+function normalizeTitleRotation(value: number | undefined): number | undefined {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  let degrees = Math.round(value);
+  if (degrees < TITLE_ROTATION_MIN_DEG) degrees = TITLE_ROTATION_MIN_DEG;
+  else if (degrees > TITLE_ROTATION_MAX_DEG) degrees = TITLE_ROTATION_MAX_DEG;
+  if (degrees === 0) return undefined;
+  return degrees;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx>
+ * </c:title>` from {@link SheetChart.titleRotation}.
+ *
+ * Returns the rotation in whole degrees, or `undefined` when the chart
+ * leaves the field unset / pinned the OOXML default `0` / passed a
+ * non-numeric or non-finite token. The flag is only meaningful when
+ * the chart actually emits a title — the caller is expected to gate
+ * the call on `showTitle && chart.title`. A chart whose title is
+ * suppressed has no `<c:title>` block to host the rotation in either
+ * case.
+ */
+function resolveTitleRotation(chart: SheetChart): number | undefined {
+  return normalizeTitleRotation(chart.titleRotation);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -9707,3 +9707,242 @@ describe("cloneChart — data labels showLeaderLines", () => {
     expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
   });
 });
+
+// ── cloneChart — title rotation ─────────────────────────────────────
+
+describe("cloneChart — title rotation", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleRotation by default", () => {
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleRotation).toBe(45);
+  });
+
+  it("lets options.titleRotation override the source's value", () => {
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: -30,
+    });
+    expect(clone.titleRotation).toBe(-30);
+  });
+
+  it("drops the inherited titleRotation when the override is null", () => {
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: null,
+    });
+    expect(clone.titleRotation).toBeUndefined();
+  });
+
+  it("returns undefined titleRotation when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleRotation).toBeUndefined();
+  });
+
+  it("clamps an out-of-range override to the -90..90 band", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: 200,
+    });
+    expect(clone.titleRotation).toBe(90);
+  });
+
+  it("clamps a below-range override to -90", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: -200,
+    });
+    expect(clone.titleRotation).toBe(-90);
+  });
+
+  it("rounds a fractional override to the nearest whole degree", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: 45.6,
+    });
+    expect(clone.titleRotation).toBe(46);
+  });
+
+  it("collapses an override of 0 to undefined (matches OOXML default)", () => {
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: 0,
+    });
+    expect(clone.titleRotation).toBeUndefined();
+  });
+
+  it("collapses non-finite overrides (NaN / Infinity) to undefined", () => {
+    const a = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: Number.NaN,
+    });
+    expect(a.titleRotation).toBeUndefined();
+    const b = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleRotation: Number.POSITIVE_INFINITY,
+    });
+    expect(b.titleRotation).toBeUndefined();
+  });
+
+  it("clamps a parsed source rotation that is somehow out of range", () => {
+    // Defensive: a corrupt template parsed by an older reader could
+    // surface an out-of-band value. The clone normalizer collapses it
+    // through the same band so the writer never sees a bad token.
+    const clone = cloneChart(source({ titleRotation: 200 as number }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleRotation).toBe(90);
+  });
+
+  it("carries titleRotation through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleRotation).toBe(45);
+  });
+
+  it("carries titleRotation through a doughnut flatten (line → doughnut)", () => {
+    // Pie / doughnut both render the chart-level title block, so the
+    // rotation must survive coercion into either family.
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleRotation).toBe(45);
+  });
+
+  it("drops the inherited titleRotation when the resolved title is dropped", () => {
+    // `title: null` flattens the inherited title — no `<c:title>` block
+    // will be emitted, so the inherited rotation has no slot in the
+    // rendered chart and the clone collapses it.
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleRotation).toBeUndefined();
+  });
+
+  it("drops the inherited titleRotation when showTitle is set to false", () => {
+    const clone = cloneChart(source({ titleRotation: 45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.showTitle).toBe(false);
+    expect(clone.titleRotation).toBeUndefined();
+  });
+
+  it("drops the titleRotation override when the resolved chart has no title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+      titleRotation: 45,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleRotation).toBeUndefined();
+  });
+
+  it("composes independently with the titleOverlay clone-through", () => {
+    // Both flags live on `<c:title>` but on different children, so they
+    // must not collide on the clone-through.
+    const clone = cloneChart(source({ titleRotation: 45, titleOverlay: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleRotation).toBe(45);
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the rotation", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Tilted</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.titleRotation).toBe(45);
+    expect(parsed?.title).toBe("Tilted");
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.titleRotation).toBe(45);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('rot="2700000"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleRotation).toBe(45);
+  });
+
+  it("propagates titleRotation into the rendered <c:title> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ titleRotation: -45 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('rot="-2700000"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template -> clone -> write -> read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleRotation).toBe(-45);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -8954,3 +8954,185 @@ describe("writeChart — data labels showLeaderLines", () => {
     expect(dLbls).toContain('<c:showLeaderLines val="0"/>');
   });
 });
+
+// ── writeChart — title rotation ────────────────────────────────────
+
+describe("writeChart — title rotation", () => {
+  function titleBodyPrOf(xml: string): string {
+    // The title's <a:bodyPr> lives inside <c:title><c:tx><c:rich>.
+    const titleBlock = xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    const bodyPr = titleBlock.match(/<a:bodyPr[^/]*\/>/)![0];
+    return bodyPr;
+  }
+
+  it('emits <a:bodyPr rot="0"/> by default (matches the OOXML default)', () => {
+    // Excel's reference serialization writes `rot="0"` on every visible
+    // title even when no rotation is pinned — the writer mirrors that
+    // contract so a fresh chart stays byte-clean against Excel's own
+    // output.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="0"');
+  });
+
+  it('emits <a:bodyPr rot="N"/> when the chart pins a positive rotation', () => {
+    const result = writeChart(makeChart({ titleRotation: 45 }), "Sheet1");
+    // 45 degrees * 60000 = 2,700,000.
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="2700000"');
+  });
+
+  it("converts negative rotations to negative 60000ths of a degree", () => {
+    const result = writeChart(makeChart({ titleRotation: -45 }), "Sheet1");
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="-2700000"');
+  });
+
+  it("emits a 90-degree rotation as the band endpoint", () => {
+    const result = writeChart(makeChart({ titleRotation: 90 }), "Sheet1");
+    // 90 degrees * 60000 = 5,400,000.
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="5400000"');
+  });
+
+  it('collapses the OOXML default 0 to absence (writer emits rot="0")', () => {
+    // Pinning the default `0` round-trips identically to absence — the
+    // writer skips the conversion and emits the OOXML default.
+    const result = writeChart(makeChart({ titleRotation: 0 }), "Sheet1");
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="0"');
+  });
+
+  it("clamps rotations above 90 to the 90-degree maximum", () => {
+    const result = writeChart(makeChart({ titleRotation: 180 }), "Sheet1");
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="5400000"');
+  });
+
+  it("clamps rotations below -90 to the -90-degree minimum", () => {
+    const result = writeChart(makeChart({ titleRotation: -180 }), "Sheet1");
+    expect(titleBodyPrOf(result.chartXml)).toContain('rot="-5400000"');
+  });
+
+  it("rounds non-integer degree values to the nearest whole degree", () => {
+    // 45.4 rounds to 45 (-> 2,700,000); 45.6 rounds to 46 (-> 2,760,000).
+    const a = writeChart(makeChart({ titleRotation: 45.4 }), "Sheet1");
+    expect(titleBodyPrOf(a.chartXml)).toContain('rot="2700000"');
+    const b = writeChart(makeChart({ titleRotation: 45.6 }), "Sheet1");
+    expect(titleBodyPrOf(b.chartXml)).toContain('rot="2760000"');
+  });
+
+  it("drops non-finite rotation inputs (NaN, Infinity) back to the default", () => {
+    const nan = writeChart(makeChart({ titleRotation: Number.NaN }), "Sheet1");
+    const inf = writeChart(makeChart({ titleRotation: Number.POSITIVE_INFINITY }), "Sheet1");
+    expect(titleBodyPrOf(nan.chartXml)).toContain('rot="0"');
+    expect(titleBodyPrOf(inf.chartXml)).toContain('rot="0"');
+  });
+
+  it("drops non-numeric rotation inputs (string, boolean) back to the default", () => {
+    const stringy = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ titleRotation: "45" as any }),
+      "Sheet1",
+    );
+    const boolish = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ titleRotation: true as any }),
+      "Sheet1",
+    );
+    expect(titleBodyPrOf(stringy.chartXml)).toContain('rot="0"');
+    expect(titleBodyPrOf(boolish.chartXml)).toContain('rot="0"');
+  });
+
+  it("ignores titleRotation when the chart renders no title (showTitle=false)", () => {
+    // No `<c:title>` block ever emits — there is no slot for the
+    // rotation in either case. The chart still serializes cleanly.
+    const result = writeChart(makeChart({ showTitle: false, titleRotation: 45 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleRotation when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleRotation: 45 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes with titleOverlay (both flags survive on the same title)", () => {
+    const result = writeChart(makeChart({ titleOverlay: true, titleRotation: -45 }), "Sheet1");
+    const titleBlock = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("threads the rotation through every chart family that emits a title", () => {
+    // `<c:title>` lives on `<c:chart>` directly — every chart family
+    // (bar / column / line / pie / doughnut / area / scatter) that
+    // pins a literal title carries the rotation.
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, titleRotation: 30 }), "Sheet1");
+      // 30 degrees * 60000 = 1,800,000.
+      expect(titleBodyPrOf(result.chartXml)).toContain('rot="1800000"');
+    }
+    // Scatter requires a numeric category range.
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        titleRotation: 30,
+      }),
+      "Sheet1",
+    );
+    expect(titleBodyPrOf(scatter.chartXml)).toContain('rot="1800000"');
+  });
+
+  it("emits exactly one <a:bodyPr> on the chart title", () => {
+    const result = writeChart(makeChart({ titleRotation: 45 }), "Sheet1");
+    const titleBlock = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect((titleBlock.match(/<a:bodyPr/g) ?? []).length).toBe(1);
+  });
+
+  it("does not emit an axis-style <c:txPr> on the title", () => {
+    // The chart title carries its rotation on the rich-text body's
+    // `<a:bodyPr>` (inside `<c:tx><c:rich>`), not via an axis-style
+    // `<c:txPr>` sibling. Confirm the writer keeps the two paths
+    // distinct so a parse round-trip does not double-count.
+    const result = writeChart(makeChart({ titleRotation: 45 }), "Sheet1");
+    const titleBlock = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).not.toContain("<c:txPr>");
+  });
+
+  it("round-trips a non-default rotation through parseChart", () => {
+    const written = writeChart(makeChart({ titleRotation: 45 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleRotation).toBe(45);
+  });
+
+  it("collapses a defaulted rotation round-trip back to undefined", () => {
+    // A fresh chart emits `rot="0"`; the reader collapses that to
+    // `undefined` so absence and the default stay symmetric.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleRotation).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the title rotation into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            titleRotation: -45,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('rot="-2700000"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleRotation).toBe(-45);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9526,3 +9526,145 @@ describe("parseChart — data labels showLeaderLines", () => {
     expect(chart?.dataLabels?.showLeaderLines).toBe(false);
   });
 });
+
+describe("parseChart — title rotation", () => {
+  const NS_TR = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleRot(rot: string | undefined): string {
+    const bodyPr = rot === undefined ? "<a:bodyPr/>" : `<a:bodyPr rot="${rot}"/>`;
+    return `<c:chartSpace ${NS_TR}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          ${bodyPr}
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the rotation in whole degrees from the rot attribute (60000ths)", () => {
+    // 45 degrees * 60000 = 2,700,000.
+    const chart = parseChart(withTitleRot("2700000"));
+    expect(chart?.titleRotation).toBe(45);
+  });
+
+  it("surfaces negative rotations literally", () => {
+    const chart = parseChart(withTitleRot("-2700000"));
+    expect(chart?.titleRotation).toBe(-45);
+  });
+
+  it('collapses the OOXML default rot="0" to undefined', () => {
+    // The default `0` round-trips identically to absence — both leave
+    // the title rendering horizontally.
+    const chart = parseChart(withTitleRot("0"));
+    expect(chart?.titleRotation).toBeUndefined();
+  });
+
+  it("returns undefined when <a:bodyPr> omits the rot attribute", () => {
+    const chart = parseChart(withTitleRot(undefined));
+    expect(chart?.titleRotation).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TR}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleRotation).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:bodyPr>` to host the rotation.
+    const xml = `<c:chartSpace ${NS_TR}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Quarterly Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleRotation).toBeUndefined();
+    // Title still surfaces from the strRef cache.
+    expect(chart?.title).toBe("Quarterly Revenue");
+  });
+
+  it("clamps rot values above the 90-degree maximum to 90", () => {
+    // Values outside Excel's UI band collapse to the nearest endpoint
+    // so a corrupt template cannot surface a rotation the writer would
+    // never emit. 180° in 60000ths = 10,800,000.
+    const chart = parseChart(withTitleRot("10800000"));
+    expect(chart?.titleRotation).toBe(90);
+  });
+
+  it("clamps rot values below the -90-degree minimum to -90", () => {
+    const chart = parseChart(withTitleRot("-10800000"));
+    expect(chart?.titleRotation).toBe(-90);
+  });
+
+  it("drops non-numeric rot tokens", () => {
+    expect(parseChart(withTitleRot("forty-five"))?.titleRotation).toBeUndefined();
+  });
+
+  it("drops empty rot tokens", () => {
+    expect(parseChart(withTitleRot(""))?.titleRotation).toBeUndefined();
+  });
+
+  it("rounds non-integer 60000ths to the nearest whole degree", () => {
+    // 2,700,030 ≈ 45.0005°, rounds to 45.
+    const chart = parseChart(withTitleRot("2700030"));
+    expect(chart?.titleRotation).toBe(45);
+  });
+
+  it("co-surfaces alongside titleOverlay and other chart fields", () => {
+    const xml = `<c:chartSpace ${NS_TR}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-5400000"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Sidebar</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Sidebar");
+    expect(chart?.titleOverlay).toBe(true);
+    expect(chart?.titleRotation).toBe(-90);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:bodyPr rot=\"N\"/></c:rich></c:tx></c:title>` (CT_Title body-properties, ECMA-376 Part 1, §21.2.2.210) at the read, write, and clone layers so a template's rotated chart-title pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:bodyPr rot=\"N\"/>` mirrors Excel's \"Format Chart Title -> Size & Properties -> Alignment -> Custom angle\" knob — `N` is in 60000ths of a degree, so 45° serializes as `rot=\"2700000\"` and -90° as `rot=\"-5400000\"`. Until now hucre's writer hardcoded `rot=\"0\"` on the title's rich-text body and the reader ignored the attribute entirely, so a templated dashboard chart whose user rotated the title vertically (a common pattern for fitting a long chart title into a narrow sidebar tile, or for mirroring the rotation of a tilted axis label set) silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Mirrors the axis-side `labelRotation` field added in #245 — same `-90..90` band, same conversion factor, same normalization grammar — so a single rotation value threads cleanly through both the chart title and its axis labels without bookkeeping the units.

Refs #136

## API

\`\`\`ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleRotation);
// 45         ← when the template pinned <a:bodyPr rot=\"2700000\"/> on the title body
// undefined  ← when the template emits no rotation (the OOXML default 0) or no <c:title>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [
      [\"Quarter\", \"Revenue\"],
      [\"Q1 2026\", 100],
      [\"Q2 2026\", 200],
    ],
    charts: [{
      type: \"column\",
      title: \"Quarterly Revenue\",
      series: [{ name: \"Revenue\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
      // Stand the title on its side so it fits a narrow sidebar tile.
      titleRotation: -90,
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed titleRotation unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleRotation: null,
});
//   → drops the inherited rotation (writer falls back to the OOXML default rot=\"0\").
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleRotation: 30,
});
//   → replaces the inherited rotation with 30 degrees.
\`\`\`

## Implementation notes

- **Type model**: `SheetChart.titleRotation?: number` (writer side) and `Chart.titleRotation?: number` (reader side). The clone option `titleRotation?: number | null` follows the standard `undefined` (inherit) / `null` (drop) / `number` (replace) grammar. Same shape as the axis-side `labelRotation` so a parsed value flows straight from the read side back into the write side without transformation. Callers pin the value in degrees; the writer converts to 60000ths at emit time.
- **Reader** (`parseTitleRotation`): walks `<c:title><c:tx><c:rich><a:bodyPr rot=\"N\"/></c:rich></c:tx></c:title>` for the `rot` attribute. The lookup is scoped to the title body (`<c:tx><c:rich>`) so a stray `<a:bodyPr>` elsewhere in the chart cannot leak in. `Number.parseInt` rejects non-numeric tokens; `Math.round(parsed / 60000)` converts to whole degrees. The OOXML default `0` and absence both collapse to `undefined`. Out-of-range values clamp to the `-90..90` band Excel's UI exposes so a corrupt template cannot surface a value the writer would never emit. Returns `undefined` when the chart omits the `<c:title>` element entirely or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body.
- **Writer**: previously hard-coded `rot=\"0\"` in the title body's `<a:bodyPr>` attributes. Now resolves through `resolveTitleRotation(chart)` — `normalizeTitleRotation` clamps inputs to `-90..90`, rounds fractional inputs to the nearest whole degree, and collapses `0` / `NaN` / `Infinity` / non-numeric inputs to `undefined`. The writer threads the resolved value into the existing `buildTitle` helper so the rotation slots into the same `<a:bodyPr>` attribute that already carries the title body's other layout metadata (`spcFirstLastPara` / `vertOverflow` / `wrap` / `anchor` / `anchorCtr` are preserved exactly as before — only the `rot` attribute changes). Threads through every chart family that emits a literal title (bar / column / line / pie / doughnut / area / scatter); silently dropped when no title is rendered (`title` absent or `showTitle === false`) — there is no `<c:title>` block to host the rotation in either case.
- **Clone** (`resolveTitleRotation` + `normalizeTitleRotation`): follows the standard `number | null` override grammar — `undefined` inherits, `null` drops, a literal number replaces. Out-of-range / non-numeric overrides clamp / collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same `titleRendered` short-circuit that gates `titleOverlay` — when the resolved chart renders no title, the inherited rotation drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only literal finite numbers survive the type guard at every layer; non-numeric inputs collapse to the default. This matches how the axis-side `labelRotation` field treats its inputs.

## Test plan

- [x] `parseChart — title rotation` (12 new tests) — surfaces the rotation in whole degrees from the `rot` attribute, surfaces negative rotations literally, collapses the OOXML default `rot=\"0\"` to undefined, returns undefined when `<a:bodyPr>` omits `rot` / `<c:title>` is absent / the title is a `<c:strRef>` formula reference, clamps out-of-range values to `-90..90`, drops non-numeric / empty tokens, rounds non-integer 60000ths, co-surfaces alongside `titleOverlay` and the title text.
- [x] `writeChart — title rotation` (18 new tests) — emits `rot=\"0\"` by default, emits the rotation as 60000ths on positive / negative / endpoint inputs, collapses the OOXML default `0` to absence, clamps above-90 / below-`-90` to the band endpoints, rounds non-integer degrees, drops non-finite / non-numeric inputs back to the default, ignores the rotation when the chart renders no title (`showTitle: false` or `title` absent), composes with `titleOverlay`, threads through every chart family (bar / column / line / pie / doughnut / area / scatter), exactly-one-`<a:bodyPr>` guard, no axis-style `<c:txPr>` emitted on the title, parse round-trip, default round-trip collapse, full `writeXlsx` package round-trip.
- [x] `cloneChart — title rotation` (18 new tests) — inherit / replace / null drop / `0` drop / non-finite drop semantics, clamp out-of-range overrides, round fractional overrides, defensive clamp on a parsed source rotation, source-without-rotation pickup, line -> column / line -> doughnut chart-type coercion, drop on `title: null`, drop on `showTitle: false`, drop on override-`title: null`, composition with `titleOverlay`, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4196 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)