### PR TITLE
feat(xlsx): chart axis title rotation — read, write, clone-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,7 +1092,7 @@ charts; `lineGrouping` and `areaGrouping` accept
 `top` / `bottom` / `left` / `right` / `topRight` / `false`, and
 `altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
 attributes for screen readers.
-`axes: { x: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween }, y: { title, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween } }`
+`axes: { x: { title, axisTitleRotation, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween }, y: { title, axisTitleRotation, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween } }`
 attaches per-axis labels, gridlines, numeric scaling, the tick-label
 number format and the tick-rendering trio — `x` lands inside
 `<c:catAx>` (or the X value axis for scatter), `y` inside the value
@@ -1538,6 +1538,24 @@ every axis flavour per the OOXML schema (`<c:catAx>` / `<c:valAx>` /
 field threads through every chart family that has axes (bar / column /
 line / area / scatter); pie / doughnut have no axes at all and the
 field is silently dropped there.
+The `axes.x.axisTitleRotation` and `axes.y.axisTitleRotation` fields
+pin the rotation of the axis title in whole degrees, mapping to
+`<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+on the matching axis — Excel's "Format Axis Title -> Size & Properties
+-> Alignment -> Custom angle" knob. Mirrors the chart-level
+`titleRotation` field for axis titles: same `-90..90` band, same
+60000ths-of-a-degree on-the-wire conversion, same `0` / absence /
+non-finite collapse to the OOXML default `rot="0"`. Useful for
+standing the Y-axis title vertically next to the value labels (the
+typical "rotated axis label" dashboard look) or pinning a custom angle
+on a long X-axis title that would otherwise crowd the plot area. The
+field is silently dropped when the matching axis has no title (no
+`<c:title>` block to host the rotation in either case) and on
+`pie` / `doughnut` charts (no axes at all). Out-of-range inputs clamp
+to the nearest endpoint, fractional inputs round to the nearest whole
+degree, and non-finite / non-numeric inputs collapse to absence so a
+corrupt input never leaks through to a token Excel's strict validator
+would reject.
 The `axes.x.reverse` and `axes.y.reverse` flags map to
 `<c:scaling><c:orientation val="maxMin"/></c:scaling>` — Excel's
 "Categories / Values in reverse order" toggle. On a category axis,
@@ -1826,6 +1844,19 @@ will accept. Same scope rule as `titleOverlay`: the rotation lives on
 silently dropped from the cloned `SheetChart` whenever the resolved
 chart renders no title — there is no `<a:bodyPr rot="N"/>` slot to host
 the rotation in either case.
+The per-axis `axes.x.axisTitleRotation` and `axes.y.axisTitleRotation`
+fields follow the same grammar: pass `undefined` to inherit the source
+axis's parsed rotation, `null` to drop it back to the writer's OOXML
+`0` default (horizontal axis title), or a `number` to replace it.
+Range, clamp, rounding, and non-finite-collapse semantics mirror the
+chart-level `titleRotation` knob exactly, so a single rotation value
+threads cleanly through both the chart title and either axis title.
+The override is silently dropped from the cloned `SheetChart` whenever
+the resolved axis title is unset (no `<c:title>` block to host the
+rotation) and on `pie` / `doughnut` charts (no axes at all). Re-
+introducing a missing axis title through an explicit
+`axes.x.title: "..."` override re-opens the slot for the matching
+`axisTitleRotation` to take effect.
 The chart-level `autoTitleDeleted` flag follows the same grammar: pass
 `undefined` to inherit the source's parsed value, `null` to drop it
 back to the writer's title-presence-derived default, or a `boolean` to

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1773,6 +1773,35 @@ export interface SheetChart {
     /** Category axis (bar/column/line/area) or X value axis (scatter). */
     x?: {
       title?: string;
+      /**
+       * Rotation of the axis title in whole degrees. Maps to
+       * `<c:catAx><c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format Axis
+       * Title -> Size & Properties -> Alignment -> Custom angle" knob.
+       *
+       * Mirrors {@link SheetChart.titleRotation} for axis titles — same
+       * `-90..90` band Excel's UI exposes, same conversion factor
+       * (60000ths of a degree on the wire). Useful for standing the Y-
+       * axis title vertically next to the value labels (the typical
+       * "rotated axis label" dashboard look) or pinning a custom angle
+       * on a long X-axis title that would otherwise crowd the plot
+       * area.
+       *
+       * Default: `0` (no rotation, Excel's reference look). Out-of-range
+       * inputs clamp to the nearest endpoint; non-finite (`NaN`,
+       * `Infinity`) and non-numeric inputs drop at write time so the
+       * writer never emits a token Excel's strict validator would
+       * reject. Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+       * per the OOXML schema, so the field round-trips on every chart
+       * family that has axes (bar / column / line / area / scatter).
+       * Pie / doughnut have no axes at all, so the field is silently
+       * dropped on those families.
+       */
+      axisTitleRotation?: number;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -2023,6 +2052,24 @@ export interface SheetChart {
     /** Value axis. */
     y?: {
       title?: string;
+      /**
+       * Rotation of the value-axis title in whole degrees. Maps to
+       * `<c:valAx><c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.axisTitleRotation} for the
+       * value axis — see that field for the full semantics. The OOXML
+       * `rot` attribute is in 60000ths of a degree; the writer converts
+       * at emit time so callers pin the value in degrees. Range:
+       * `-90..90`.
+       *
+       * Useful for standing the Y-axis title vertically (a common
+       * dashboard pattern that reclaims horizontal real estate next to
+       * the value labels) or pinning a custom angle on a long axis
+       * title that would otherwise crowd the plot area. Silently
+       * dropped on `pie` / `doughnut` charts (no axes at all) and on
+       * any axis whose `title` is unset (no `<c:title>` block to host
+       * the rotation).
+       */
+      axisTitleRotation?: number;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3181,6 +3228,30 @@ export interface ChartAxisDispUnits {
 export interface ChartAxisInfo {
   /** Plain-text title from the axis's `<c:title>`. Omitted when absent. */
   title?: string;
+  /**
+   * Axis-title rotation in degrees pulled from
+   * `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+   * on the axis element. Mirrors Excel's "Format Axis Title -> Size &
+   * Properties -> Alignment -> Custom angle" pin.
+   *
+   * The OOXML `rot` attribute is in 60000ths of a degree; the reader
+   * converts to whole degrees and surfaces the literal value (range
+   * `-90..90`). The OOXML default `0` (and absence of the element)
+   * collapses to `undefined` so absence and the default round-trip
+   * identically through {@link cloneChart}. Out-of-range values clamp
+   * to the nearest endpoint so a parsed value slots straight back into
+   * the writer-side {@link SheetChart.axes.x.axisTitleRotation} field
+   * without further transformation. Returns `undefined` when the axis
+   * omits `<c:title>` entirely or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the rotation regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleRotation?: number;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -589,6 +589,22 @@ export interface CloneChartOptions {
   axes?: {
     x?: {
       title?: string | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleRotation`. `undefined` (or
+       * omitted) inherits the source axis's parsed value; `null` drops
+       * the inherited rotation (the writer falls back to the OOXML
+       * default `0` — the title renders horizontally); a number in the
+       * `-90..90` band replaces it (out-of-range and non-finite inputs
+       * collapse to `undefined`).
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * rotation).
+       */
+      axisTitleRotation?: number | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -769,6 +785,8 @@ export interface CloneChartOptions {
     };
     y?: {
       title?: string | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleRotation}. */
+      axisTitleRotation?: number | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2177,6 +2195,24 @@ function resolveAxes(
 ): SheetChart["axes"] | undefined {
   const xTitle = applyOverride(sourceAxes?.x?.title, overrides?.x?.title);
   const yTitle = applyOverride(sourceAxes?.y?.title, overrides?.y?.title);
+  // `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+  // lives on every axis flavour per the OOXML schema (CT_CatAx,
+  // CT_ValAx, CT_DateAx, CT_SerAx all share the same `<c:title>`
+  // shape), so the resolver applies on every chart family that has
+  // axes (pie / doughnut were short-circuited upstream). Out-of-range
+  // / non-numeric values clamp to the `-90..90` band the writer
+  // accepts; the OOXML default `0` collapses to `undefined` so absence
+  // and the default round-trip identically. The writer drops the
+  // rotation when the matching axis title is unset, so a stray pin on
+  // an axis with no title silently disappears at emit time.
+  const xAxisTitleRotation = applyAxisTitleRotationOverride(
+    sourceAxes?.x?.axisTitleRotation,
+    overrides?.x?.axisTitleRotation,
+  );
+  const yAxisTitleRotation = applyAxisTitleRotationOverride(
+    sourceAxes?.y?.axisTitleRotation,
+    overrides?.y?.axisTitleRotation,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -2305,9 +2341,19 @@ function resolveAxes(
     overrides?.y?.crossBetween,
   );
 
+  // The axis-title rotation only renders when the axis carries a
+  // title — drop a stray inherited rotation when the resolved axis
+  // title is unset so the cloned `SheetChart` accurately reflects what
+  // the chart will paint. Symmetric with the writer's title-presence
+  // gate (the per-family axis builder only invokes `buildAxisTitle`
+  // when `opts.xAxisTitle` / `opts.yAxisTitle` is set).
+  const xAxisTitleRotationResolved = xTitle === undefined ? undefined : xAxisTitleRotation;
+  const yAxisTitleRotationResolved = yTitle === undefined ? undefined : yAxisTitleRotation;
+
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
     xTitle !== undefined ||
+    xAxisTitleRotationResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -2330,6 +2376,8 @@ function resolveAxes(
   ) {
     out.x = {};
     if (xTitle !== undefined) out.x.title = xTitle;
+    if (xAxisTitleRotationResolved !== undefined)
+      out.x.axisTitleRotation = xAxisTitleRotationResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -2352,6 +2400,7 @@ function resolveAxes(
   }
   if (
     yTitle !== undefined ||
+    yAxisTitleRotationResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -2368,6 +2417,8 @@ function resolveAxes(
   ) {
     out.y = {};
     if (yTitle !== undefined) out.y.title = yTitle;
+    if (yAxisTitleRotationResolved !== undefined)
+      out.y.axisTitleRotation = yAxisTitleRotationResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -2702,6 +2753,31 @@ function clampLabelRotationDeg(value: number): number | undefined {
   else if (degrees > 90) degrees = 90;
   if (degrees === 0) return undefined;
   return degrees;
+}
+
+/**
+ * Resolve an `axisTitleRotation` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. The conversion / clamping rules mirror
+ * {@link applyLabelRotationOverride} — out-of-range and non-numeric
+ * inputs clamp to the `-90..90` band the writer accepts, the OOXML
+ * default `0` collapses to `undefined`, and a `null` override always
+ * drops the inherited rotation. The caller is expected to additionally
+ * gate the resolved value on the matching axis title's presence so the
+ * cloned shape never carries a rotation that the writer would silently
+ * elide.
+ */
+function applyAxisTitleRotationOverride(
+  source: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) {
+    if (typeof source !== "number" || !Number.isFinite(source)) return undefined;
+    return clampLabelRotationDeg(source);
+  }
+  if (override === null) return undefined;
+  if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
+  return clampLabelRotationDeg(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -469,6 +469,18 @@ function parseAxisInfo(
   familyDefaultCrossBetween: ChartAxisCrossBetween,
 ): ChartAxisInfo | undefined {
   const title = parseAxisTitle(axis);
+  // `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>` —
+  // axis-title rotation in 60000ths of a degree. Sits on every axis
+  // flavour per the OOXML schema (CT_CatAx, CT_ValAx, CT_DateAx,
+  // CT_SerAx all share the same `<c:title>` shape). The lookup is
+  // scoped to the `<c:title>` body so a stray `<a:bodyPr>` elsewhere
+  // on the axis (e.g. on the tick-label `<c:txPr>`) cannot leak in.
+  // Out-of-range values clamp to the `-90..90` band Excel's UI
+  // exposes; the OOXML default `0` and absence both collapse to
+  // `undefined`. Returns `undefined` when the axis omits `<c:title>`
+  // entirely or when the title is a `<c:strRef>` (formula reference)
+  // with no `<c:rich>` body.
+  const axisTitleRotation = parseAxisTitleRotation(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -558,6 +570,7 @@ function parseAxisInfo(
     parsedCrossBetween === familyDefaultCrossBetween ? undefined : parsedCrossBetween;
   if (
     title === undefined &&
+    axisTitleRotation === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -582,6 +595,7 @@ function parseAxisInfo(
   }
   const out: ChartAxisInfo = {};
   if (title !== undefined) out.title = title;
+  if (axisTitleRotation !== undefined) out.axisTitleRotation = axisTitleRotation;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -1210,6 +1224,52 @@ function parseAxisTitle(axis: XmlElement): string | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+ * off an axis element. Returns the rotation in whole degrees (range
+ * `-90..90`).
+ *
+ * The OOXML default `0` (and absence of the element / attribute) all
+ * collapse to `undefined` so absence and the default round-trip
+ * identically through {@link cloneChart}. Out-of-range values clamp to
+ * the nearest endpoint of the `-90..90` band Excel's UI exposes;
+ * non-finite (`NaN`, `Infinity`) inputs drop to `undefined`.
+ *
+ * The lookup is scoped to the title's `<c:rich>` body so a stray
+ * `<a:bodyPr>` elsewhere on the axis (e.g. the tick-label `<c:txPr>`
+ * surfaced by {@link parseAxisLabelRotation}) cannot leak in. Returns
+ * `undefined` when the axis omits `<c:title>` entirely or when the
+ * title is a `<c:strRef>` (formula reference) with no `<c:rich>` body.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape per
+ * the OOXML schema. Mirrors the chart-level title rotation
+ * {@link parseTitleRotation} so a parsed value slots straight into the
+ * writer-side {@link SheetChart.axes}.x.axisTitleRotation.
+ */
+function parseAxisTitleRotation(axis: XmlElement): number | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  const bodyPr = findChild(rich, "bodyPr");
+  if (!bodyPr) return undefined;
+  const raw = bodyPr.attrs.rot;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 60000ths of a degree to whole degrees.
+  const degrees = Math.round(parsed / TXPR_ROT_PER_DEGREE);
+  if (degrees === 0) return undefined;
+  if (degrees < LABEL_ROTATION_MIN_DEG) return LABEL_ROTATION_MIN_DEG;
+  if (degrees > LABEL_ROTATION_MAX_DEG) return LABEL_ROTATION_MAX_DEG;
+  return degrees;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -354,6 +354,16 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
   const opts: AxisRenderOptions = {
     xAxisTitle: normalizeAxisTitle(chart.axes?.x?.title),
     yAxisTitle: normalizeAxisTitle(chart.axes?.y?.title),
+    // `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+    // sits on every axis flavour per the OOXML schema (CT_CatAx,
+    // CT_ValAx, CT_DateAx, CT_SerAx all carry the same `<c:title>`
+    // shape). Normalize the caller's degree input — clamp to the
+    // `-90..90` band Excel's UI exposes; non-finite / non-numeric
+    // inputs collapse to `undefined` so the writer emits the OOXML
+    // default `rot="0"` byte-for-byte. The per-family axis builders
+    // only honour the rotation when the axis actually renders a title.
+    xAxisTitleRotation: normalizeAxisTitleRotation(chart.axes?.x?.axisTitleRotation),
+    yAxisTitleRotation: normalizeAxisTitleRotation(chart.axes?.y?.axisTitleRotation),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -747,6 +757,22 @@ function clampView3DInt(value: number | undefined, min: number, max: number): nu
 interface AxisRenderOptions {
   xAxisTitle: string | undefined;
   yAxisTitle: string | undefined;
+  /**
+   * Axis-title rotation in whole degrees emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`.
+   * The OOXML `rot` attribute is in 60000ths of a degree; the writer
+   * converts at emit time. Range: `-90..90` (Excel's UI band).
+   * `undefined` collapses to the OOXML default `0` so a fresh chart
+   * matches Excel's reference serialization byte-for-byte. Only
+   * meaningful when the axis renders a title — the per-family axis
+   * builders gate the value on the `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleRotation: number | undefined;
+  /**
+   * Axis-title rotation in whole degrees emitted on the Y axis. Same
+   * shape and conversion semantics as {@link xAxisTitleRotation}.
+   */
+  yAxisTitleRotation: number | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -1605,7 +1631,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:axPos", { val: catPos }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (opts.xAxisTitle) catAxChildren.push(buildAxisTitle(opts.xAxisTitle));
+  if (opts.xAxisTitle) catAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation));
   catAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
@@ -1658,7 +1684,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:axPos", { val: valPos }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (opts.yAxisTitle) valAxChildren.push(buildAxisTitle(opts.yAxisTitle));
+  if (opts.yAxisTitle) valAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation));
   valAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
@@ -2012,7 +2038,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     xmlSelfClose("c:axPos", { val: "b" }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (opts.xAxisTitle) xAxChildren.push(buildAxisTitle(opts.xAxisTitle));
+  if (opts.xAxisTitle) xAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation));
   xAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
@@ -2044,7 +2070,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     xmlSelfClose("c:axPos", { val: "l" }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (opts.yAxisTitle) yAxChildren.push(buildAxisTitle(opts.yAxisTitle));
+  if (opts.yAxisTitle) yAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation));
   yAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
@@ -2076,15 +2102,24 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
  * Build a `<c:title>` for an axis. The structure mirrors the chart-
  * level title but renders the label at a smaller default font (10pt vs
  * 14pt) to match Excel's axis-title style.
+ *
+ * The optional `rotationDeg` parameter pins the title's
+ * `<a:bodyPr rot="N"/>` attribute. The OOXML attribute is in 60000ths
+ * of a degree; the writer holds the rotation in whole degrees and
+ * converts at emit time. Absence (`undefined`) collapses to the OOXML
+ * default `0` so a fresh chart matches Excel's reference serialization
+ * byte-for-byte. Mirrors the chart-title `buildTitle` slot exactly so
+ * an axis title and the chart-level title carry the same shape.
  */
-function buildAxisTitle(label: string): string {
+function buildAxisTitle(label: string, rotationDeg: number | undefined): string {
+  const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
         xmlElement(
           "a:bodyPr",
           {
-            rot: 0,
+            rot,
             spcFirstLastPara: 1,
             vertOverflow: "ellipsis",
             wrap: "square",
@@ -2105,6 +2140,20 @@ function buildAxisTitle(label: string): string {
     ]),
     xmlSelfClose("c:overlay", { val: 0 }),
   ]);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleRotation value (whole
+ * degrees) for the `<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
+ * writer slot inside an axis. Same conversion / clamping grammar as
+ * the chart-level {@link normalizeTitleRotation} — non-finite,
+ * non-numeric, and out-of-range inputs collapse to `undefined` (or
+ * clamp to the `-90..90` band Excel's UI exposes), and the OOXML
+ * default `0` collapses to `undefined` so absence and the default
+ * round-trip identically through {@link cloneChart}.
+ */
+function normalizeAxisTitleRotation(value: number | undefined): number | undefined {
+  return normalizeTitleRotation(value);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10139,3 +10139,256 @@ describe("cloneChart — title rotation", () => {
     expect(reparsed?.titleRotation).toBe(-45);
   });
 });
+
+describe("cloneChart — axis title rotation", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleRotation by default", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleRotation by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleRotation: -90 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleRotation).toBe(-90);
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleRotation override the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: -30 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBe(-30);
+  });
+
+  it("drops the inherited axisTitleRotation when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: null } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleRotation when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("clamps an out-of-range override to the -90..90 band", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: 200 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBe(90);
+  });
+
+  it("clamps a below-range override to -90", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: -200 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBe(-90);
+  });
+
+  it("rounds a fractional override to the nearest whole degree", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: 45.6 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBe(46);
+  });
+
+  it("collapses an override of 0 to undefined (matches OOXML default)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("collapses non-finite overrides (NaN / Infinity) to undefined", () => {
+    const a = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: Number.NaN } },
+    });
+    expect(a.axes?.x?.axisTitleRotation).toBeUndefined();
+    const b = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: Number.POSITIVE_INFINITY } },
+    });
+    expect(b.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("clamps a parsed source rotation that is somehow out of range", () => {
+    // Defensive: a corrupt template parsed by an older reader could
+    // surface an out-of-band value. The clone normalizer collapses it
+    // through the same band so the writer never sees a bad token.
+    const clone = cloneChart(
+      source({
+        axes: { x: { title: "Period", axisTitleRotation: 200 as number } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleRotation).toBe(90);
+  });
+
+  it("drops the inherited axisTitleRotation when the resolved axis title is dropped", () => {
+    // `title: null` flattens the inherited axis title — no `<c:title>`
+    // block will be emitted, so the inherited rotation has no slot in
+    // the rendered axis and the clone collapses it.
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: null } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("drops an override axisTitleRotation when no axis title resolves", () => {
+    // The axis has no source title and the caller did not pin one —
+    // the writer would silently elide the rotation either way, so the
+    // clone-side resolver mirrors that by dropping the field.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleRotation: 45 } },
+    });
+    expect(clone.axes?.x).toBeUndefined();
+  });
+
+  it("preserves the override when the override also pins a title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleRotation: 45 } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+  });
+
+  it("composes independently with the chart-level titleRotation", () => {
+    const clone = cloneChart(
+      source({
+        titleRotation: -45,
+        axes: { x: { title: "Period", axisTitleRotation: 30 } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleRotation).toBe(-45);
+    expect(clone.axes?.x?.axisTitleRotation).toBe(30);
+  });
+
+  it("threads X and Y axis title rotations independently", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleRotation: 45 },
+          y: { title: "USD", axisTitleRotation: -30 },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+    expect(clone.axes?.y?.axisTitleRotation).toBe(-30);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the axis title rotation", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr rot="2700000"/>
+            <a:lstStyle/>
+            <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr rot="-5400000"/>
+            <a:lstStyle/>
+            <a:p><a:r><a:t>USD</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.axisTitleRotation).toBe(45);
+    expect(parsed?.axes?.y?.axisTitleRotation).toBe(-90);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.axisTitleRotation).toBe(45);
+    expect(sheetChart.axes?.y?.axisTitleRotation).toBe(-90);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleRotation).toBe(45);
+    expect(reparsed?.axes?.y?.axisTitleRotation).toBe(-90);
+  });
+
+  it("propagates axisTitleRotation into the rendered axis on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleRotation: -45 } } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleRotation).toBe(-45);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9338,3 +9338,277 @@ describe("writeChart — title rotation", () => {
     expect(reparsed?.titleRotation).toBe(-45);
   });
 });
+
+// ── writeChart — axis title rotation ────────────────────────────────
+
+describe("writeChart — axis title rotation", () => {
+  function axisBlocks(xml: string): string[] {
+    // <c:catAx>, <c:valAx> (and <c:dateAx>) — return every axis block in
+    // document order so callers can probe X / Y independently.
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBodyPrOf(axisBlock: string): string | undefined {
+    const titleMatch = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) return undefined;
+    const bodyPr = titleMatch[0].match(/<a:bodyPr[^/]*\/>/);
+    return bodyPr?.[0];
+  }
+
+  it('emits rot="0" on the X-axis title by default', () => {
+    // Excel's reference serialization writes `rot="0"` on every axis
+    // title even when no rotation is pinned — the writer mirrors that
+    // contract so a fresh chart stays byte-clean against Excel's own
+    // output.
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="0"');
+  });
+
+  it('emits rot="N" when the X-axis title pins a positive rotation', () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    // 45 degrees * 60000 = 2,700,000.
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="2700000"');
+  });
+
+  it("converts negative rotations to negative 60000ths of a degree", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: -45 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="-2700000"');
+  });
+
+  it("emits a 90-degree rotation as the band endpoint", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { title: "USD", axisTitleRotation: -90 } } }),
+      "Sheet1",
+    );
+    const [, yAx] = axisBlocks(result.chartXml);
+    // -90 degrees * 60000 = -5,400,000.
+    expect(axisTitleBodyPrOf(yAx)).toContain('rot="-5400000"');
+  });
+
+  it('collapses the OOXML default 0 to absence (writer emits rot="0")', () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 0 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="0"');
+  });
+
+  it("clamps rotations above 90 to the 90-degree maximum", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 180 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="5400000"');
+  });
+
+  it("clamps rotations below -90 to the -90-degree minimum", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: -180 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="-5400000"');
+  });
+
+  it("rounds non-integer degree values to the nearest whole degree", () => {
+    // 45.4 -> 45 -> 2,700,000; 45.6 -> 46 -> 2,760,000.
+    const a = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 45.4 } } }),
+      "Sheet1",
+    );
+    expect(axisTitleBodyPrOf(axisBlocks(a.chartXml)[0])).toContain('rot="2700000"');
+    const b = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 45.6 } } }),
+      "Sheet1",
+    );
+    expect(axisTitleBodyPrOf(axisBlocks(b.chartXml)[0])).toContain('rot="2760000"');
+  });
+
+  it("drops non-finite rotation inputs (NaN, Infinity) back to the default", () => {
+    const nan = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: Number.NaN } } }),
+      "Sheet1",
+    );
+    const inf = writeChart(
+      makeChart({
+        axes: { x: { title: "Period", axisTitleRotation: Number.POSITIVE_INFINITY } },
+      }),
+      "Sheet1",
+    );
+    expect(axisTitleBodyPrOf(axisBlocks(nan.chartXml)[0])).toContain('rot="0"');
+    expect(axisTitleBodyPrOf(axisBlocks(inf.chartXml)[0])).toContain('rot="0"');
+  });
+
+  it("drops non-numeric rotation inputs (string, boolean) back to the default", () => {
+    const stringy = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleRotation: "45" as any } },
+      }),
+      "Sheet1",
+    );
+    const boolish = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleRotation: true as any } },
+      }),
+      "Sheet1",
+    );
+    expect(axisTitleBodyPrOf(axisBlocks(stringy.chartXml)[0])).toContain('rot="0"');
+    expect(axisTitleBodyPrOf(axisBlocks(boolish.chartXml)[0])).toContain('rot="0"');
+  });
+
+  it("ignores axisTitleRotation when the axis renders no title", () => {
+    // No title means no `<c:title>` block — there is no slot for the
+    // rotation in either case.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleRotation: 45 } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with the chart-level title rotation", () => {
+    const result = writeChart(
+      makeChart({
+        titleRotation: -45,
+        axes: { x: { title: "Period", axisTitleRotation: 30 } },
+      }),
+      "Sheet1",
+    );
+    // The chart-level title sits on `<c:chart><c:title>`; the axis
+    // title sits inside the axis block. Each <bodyPr> carries its own
+    // rotation independently.
+    const chartTitle = result.chartXml.match(/<c:chart>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(chartTitle).toContain('rot="-2700000"');
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="1800000"');
+  });
+
+  it("threads the rotation through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleRotation: 45 },
+          y: { title: "USD", axisTitleRotation: -30 },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBodyPrOf(xAx)).toContain('rot="2700000"');
+    expect(axisTitleBodyPrOf(yAx)).toContain('rot="-1800000"');
+  });
+
+  it("threads the rotation through line / area / scatter chart families", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({
+          type,
+          axes: { x: { title: "Period", axisTitleRotation: 30 } },
+        }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleBodyPrOf(xAx)).toContain('rot="1800000"');
+    }
+    // Scatter requires a numeric category range and routes both axes
+    // through `<c:valAx>` — confirm the rotation still threads.
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleRotation: -90 } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    // Scatter emits two `<c:valAx>` siblings; the Y-axis title sits on
+    // the second.
+    const yAx = blocks[1];
+    expect(axisTitleBodyPrOf(yAx)).toContain('rot="-5400000"');
+  });
+
+  it("emits exactly one <a:bodyPr> on the axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = xAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect((titleBlock.match(/<a:bodyPr/g) ?? []).length).toBe(1);
+  });
+
+  it("preserves the axis title's other <a:bodyPr> attributes", () => {
+    // The reference serialization carries `spcFirstLastPara`,
+    // `vertOverflow`, `wrap`, `anchor`, and `anchorCtr` alongside `rot`.
+    // Confirm the rotation pin does not strip them.
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const bodyPr = axisTitleBodyPrOf(xAx)!;
+    expect(bodyPr).toContain('spcFirstLastPara="1"');
+    expect(bodyPr).toContain('vertOverflow="ellipsis"');
+    expect(bodyPr).toContain('wrap="square"');
+    expect(bodyPr).toContain('anchor="ctr"');
+    expect(bodyPr).toContain('anchorCtr="1"');
+  });
+
+  it("round-trips a non-default axis title rotation through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleRotation: 45 } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleRotation).toBe(45);
+  });
+
+  it("collapses a defaulted axis title rotation round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the axis title rotation into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleRotation: 45 },
+              y: { title: "USD", axisTitleRotation: -90 },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleRotation).toBe(45);
+    expect(reparsed?.axes?.y?.axisTitleRotation).toBe(-90);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9833,3 +9833,225 @@ describe("parseChart — title rotation", () => {
     expect(chart?.titleRotation).toBe(-90);
   });
 });
+
+// ── parseChart — axis title rotation ─────────────────────────────────
+
+describe("parseChart — axis title rotation", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitle(rot: string | undefined): string {
+    const bodyPr = rot === undefined ? "<a:bodyPr/>" : `<a:bodyPr rot="${rot}"/>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          ${bodyPr}
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the axis-title rotation in whole degrees from the rot attribute", () => {
+    // 45° in 60000ths = 2,700,000.
+    const chart = parseChart(withCatAxTitle("2700000"));
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(45);
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("surfaces negative rotations literally", () => {
+    const chart = parseChart(withCatAxTitle("-2700000"));
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(-45);
+  });
+
+  it('collapses the OOXML default rot="0" to undefined', () => {
+    const chart = parseChart(withCatAxTitle("0"));
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("returns undefined when <a:bodyPr> omits the rot attribute", () => {
+    const chart = parseChart(withCatAxTitle(undefined));
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> is absent on the axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a <c:strRef> (no <c:rich> body)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache>
+        </c:strRef></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("clamps rot above 90° to 90", () => {
+    // 180° in 60000ths = 10,800,000.
+    const chart = parseChart(withCatAxTitle("10800000"));
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(90);
+  });
+
+  it("clamps rot below -90° to -90", () => {
+    const chart = parseChart(withCatAxTitle("-10800000"));
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(-90);
+  });
+
+  it("drops non-numeric rot tokens", () => {
+    const chart = parseChart(withCatAxTitle("forty-five"));
+    expect(chart?.axes?.x?.axisTitleRotation).toBeUndefined();
+  });
+
+  it("rounds non-integer 60000ths to the nearest whole degree", () => {
+    // 2,700,030 ≈ 45.0005°, rounds to 45.
+    const chart = parseChart(withCatAxTitle("2700030"));
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(45);
+  });
+
+  it("does not leak the tick-label <c:txPr> rotation into the title rotation", () => {
+    // The reader must scope its lookup to the title's <c:rich> body —
+    // the tick-label rotation lives on a sibling <c:txPr> that the
+    // axis-title rotation parser must not see.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleRotation).toBeUndefined();
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+  });
+
+  it("surfaces the rotation on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="-5400000"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("USD");
+    expect(chart?.axes?.y?.axisTitleRotation).toBe(-90);
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="-1800000"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(45);
+    expect(chart?.axes?.y?.axisTitleRotation).toBe(-30);
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:tickLblPos val="low"/>
+      <c:txPr><a:bodyPr rot="-1800000"/><a:lstStyle/><a:p/></c:txPr>
+      <c:noMultiLvlLbl val="1"/>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      axisTitleRotation: 45,
+      tickLblPos: "low",
+      labelRotation: -30,
+      noMultiLvlLbl: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:title><c:tx><c:rich><a:bodyPr rot=\"N\"/></c:rich></c:tx></c:title></c:catAx>` (and the matching `<c:valAx>` shape — CT_Title body-properties on every axis flavour, ECMA-376 Part 1, §21.2.2.7 / §21.2.2.32) at the read, write, and clone layers so a template's rotated axis-title pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:bodyPr rot=\"N\"/>` mirrors Excel's "Format Axis Title -> Size & Properties -> Alignment -> Custom angle" knob — `N` is in 60000ths of a degree, so 45° serializes as `rot=\"2700000\"` and -90° as `rot=\"-5400000\"`. Until now hucre's writer hardcoded `rot=\"0\"` on the axis title's rich-text body and the reader ignored the attribute entirely, so a templated dashboard chart whose user stood the Y-axis title vertically (a common pattern that reclaims horizontal real estate next to the value labels) silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Mirrors the chart-level `titleRotation` field added in #247 — same `-90..90` band, same conversion factor (60000ths-of-a-degree), same `0` / absence / non-finite collapse to the OOXML default `rot=\"0\"`, same normalization grammar — so a single rotation value threads cleanly through both the chart title and either axis title without bookkeeping the units.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.axisTitleRotation);
// 45         ← when the template pinned <a:bodyPr rot=\"2700000\"/> on the X-axis title body
// undefined  ← when the template emits no rotation (the OOXML default 0) or no <c:title>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [
      [\"Quarter\", \"Revenue\"],
      [\"Q1 2026\", 100],
      [\"Q2 2026\", 200],
    ],
    charts: [{
      type: \"column\",
      title: \"Quarterly Revenue\",
      series: [{ name: \"Revenue\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
      axes: {
        x: { title: \"Period\", axisTitleRotation: 45 },
        // Stand the Y-axis title on its side next to the value labels.
        y: { title: \"USD\", axisTitleRotation: -90 },
      },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed axisTitleRotation on each axis unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { axisTitleRotation: null } },
});
//   → drops the inherited X-axis rotation (writer falls back to the OOXML default rot=\"0\").
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { y: { axisTitleRotation: 30 } },
});
//   → replaces the inherited Y-axis rotation with 30 degrees.
```

## Implementation notes

- **Type model**: `SheetChart.axes.x.axisTitleRotation?: number` and `SheetChart.axes.y.axisTitleRotation?: number` (writer side); `ChartAxisInfo.axisTitleRotation?: number` (reader side). The clone option `axes.{x,y}.axisTitleRotation?: number | null` follows the standard `undefined` (inherit) / `null` (drop) / `number` (replace) grammar. Same shape as the chart-level `titleRotation` so a parsed value flows straight from the read side back into the write side without transformation. Callers pin the value in degrees; the writer converts to 60000ths at emit time.
- **Reader** (`parseAxisTitleRotation`): walks `<c:title><c:tx><c:rich><a:bodyPr rot=\"N\"/></c:rich></c:tx></c:title>` for the `rot` attribute. The lookup is scoped to the title's `<c:rich>` body so the tick-label `<c:txPr>` rotation surfaced by `parseAxisLabelRotation` (a sibling element on the axis) cannot leak in. `Number.parseInt` rejects non-numeric tokens; `Math.round(parsed / 60000)` converts to whole degrees. The OOXML default `0` and absence both collapse to `undefined`. Out-of-range values clamp to the `-90..90` band Excel's UI exposes so a corrupt template cannot surface a value the writer would never emit. Returns `undefined` when the axis omits the `<c:title>` element entirely or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body.
- **Writer**: `buildAxisTitle` previously hard-coded `rot=\"0\"` in the title body's `<a:bodyPr>` attributes. Now resolves through a `rotationDeg?: number` parameter — `normalizeAxisTitleRotation` (which delegates to the chart-level `normalizeTitleRotation`) clamps inputs to `-90..90`, rounds fractional inputs to the nearest whole degree, and collapses `0` / `NaN` / `Infinity` / non-numeric inputs to `undefined`. The opts pipeline threads `xAxisTitleRotation` / `yAxisTitleRotation` into `AxisRenderOptions` so every per-family axis builder (`buildBarAxes` for bar / column / line / area, `buildScatterAxes` for scatter — all four `buildAxisTitle` callsites) hands the value off. `<a:bodyPr>` keeps every layout sibling attribute exactly as before (`spcFirstLastPara` / `vertOverflow` / `wrap` / `anchor` / `anchorCtr` are preserved); only the `rot` attribute changes. The writer silently drops the rotation when the axis renders no title — the per-family axis builders gate the `buildAxisTitle` call on `opts.xAxisTitle` / `opts.yAxisTitle`, so a stray rotation pin on an axis with no title has no slot to host it.
- **Clone** (`applyAxisTitleRotationOverride`): follows the standard `number | null` override grammar — `undefined` inherits, `null` drops, a literal number replaces. Out-of-range / non-numeric overrides clamp / collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same gate the writer uses — when the resolved axis title is unset, the inherited rotation drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only literal finite numbers survive the type guard at every layer; non-numeric inputs collapse to the default. This matches how the chart-level `titleRotation` and the axis-side `labelRotation` fields treat their inputs.

## Test plan

- [x] `parseChart — axis title rotation` (12 new tests) — surfaces the rotation in whole degrees from the `rot` attribute, surfaces negative rotations literally, collapses the OOXML default `rot=\"0\"` to undefined, returns undefined when `<a:bodyPr>` omits `rot` / `<c:title>` is absent / the axis title is a `<c:strRef>` formula reference, clamps out-of-range values to `-90..90`, drops non-numeric / empty tokens, rounds non-integer 60000ths, scope-isolates the title's `<a:bodyPr>` from the tick-label `<c:txPr>` rotation, surfaces on the value axis, surfaces independently on both axes, co-surfaces alongside the title text / `tickLblPos` / `labelRotation` / `noMultiLvlLbl`.
- [x] `writeChart — axis title rotation` (18 new tests) — emits `rot=\"0\"` by default, emits the rotation as 60000ths on positive / negative / endpoint inputs, collapses the OOXML default `0` to absence, clamps above-90 / below-`-90` to the band endpoints, rounds non-integer degrees, drops non-finite / non-numeric inputs back to the default, ignores the rotation when the axis renders no title, composes independently with the chart-level `titleRotation`, threads through both axes independently, threads through line / area / scatter chart families, exactly-one-`<a:bodyPr>` guard, preserves the title body's other layout attributes, parse round-trip, default round-trip collapse, full `writeXlsx` package round-trip on both axes.
- [x] `cloneChart — axis title rotation` (18 new tests) — inherit on X / Y, replace, null drop, `0` drop, non-finite drop semantics, clamp out-of-range overrides, round fractional overrides, defensive clamp on a parsed source rotation, drop on `axes.x.title: null`, drop on absent axis title with override, preserve when override pins a title, composition with chart-level `titleRotation`, threads X / Y independently, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4291 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)