### PR TITLE
feat(ods): numFmt data styles for number formatting

### DIFF
--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -52,6 +52,8 @@ interface OdsStyleDef {
   fontSize?: number;
   fontColor?: string; // hex with '#' prefix
   backgroundColor?: string; // hex with '#' prefix
+  /** Excel-style number format reconstructed from a data style */
+  numFmt?: string;
 }
 
 function parseStyles(doc: XmlElement): Map<string, OdsStyleDef> {
@@ -60,6 +62,10 @@ function parseStyles(doc: XmlElement): Map<string, OdsStyleDef> {
   // Styles live in <office:automatic-styles>
   const autoStyles = findChild(doc, "automatic-styles");
   if (!autoStyles) return styles;
+
+  // First pass — collect data-style definitions (`<number:*-style>`) so we
+  // can resolve `style:data-style-name` references in the second pass.
+  const dataStyleMap = parseDataStyles(autoStyles);
 
   const styleElements = findChildren(autoStyles, "style");
   for (const styleEl of styleElements) {
@@ -101,10 +107,104 @@ function parseStyles(doc: XmlElement): Map<string, OdsStyleDef> {
       }
     }
 
+    // Resolve `style:data-style-name` to an Excel-style format code
+    const dataStyleRef = styleEl.attrs["style:data-style-name"];
+    if (dataStyleRef) {
+      const numFmt = dataStyleMap.get(dataStyleRef);
+      if (numFmt) def.numFmt = numFmt;
+    }
+
     styles.set(name, def);
   }
 
   return styles;
+}
+
+// ── Data-style (number format) parsing ──────────────────────────────
+
+/**
+ * Parse `<number:number-style>`, `<number:percentage-style>`,
+ * `<number:date-style>`, `<number:time-style>`, and
+ * `<number:currency-style>` elements into Excel-compatible format codes.
+ */
+function parseDataStyles(autoStyles: XmlElement): Map<string, string> {
+  const out = new Map<string, string>();
+
+  for (const child of autoStyles.children) {
+    if (typeof child === "string") continue;
+    const local = child.local || child.tag;
+    const name = child.attrs["style:name"];
+    if (!name) continue;
+
+    let code: string | undefined;
+    if (local === "number-style") {
+      code = serializeDataStyleChildren(child, "number");
+    } else if (local === "percentage-style") {
+      code = serializeDataStyleChildren(child, "percentage");
+    } else if (local === "currency-style") {
+      code = serializeDataStyleChildren(child, "currency");
+    } else if (local === "date-style") {
+      code = serializeDataStyleChildren(child, "date");
+    } else if (local === "time-style") {
+      const truncate = child.attrs["number:truncate-on-overflow"];
+      code = serializeDataStyleChildren(child, "time", truncate === "false");
+    }
+    if (code) out.set(name, code);
+  }
+
+  return out;
+}
+
+function serializeDataStyleChildren(
+  el: XmlElement,
+  kind: "number" | "percentage" | "currency" | "date" | "time",
+  bracketDuration = false,
+): string {
+  let out = "";
+  for (const child of el.children) {
+    if (typeof child === "string") continue;
+    const local = child.local || child.tag;
+    if (local === "number") {
+      const decimals = parseInt(child.attrs["number:decimal-places"] ?? "0", 10);
+      const grouping = child.attrs["number:grouping"] === "true";
+      const integerPart = grouping ? "#,##0" : "0";
+      out += decimals > 0 ? `${integerPart}.${"0".repeat(decimals)}` : integerPart;
+    } else if (local === "currency-symbol") {
+      const text = child.children.filter((c: unknown) => typeof c === "string").join("");
+      out += `"${text}"`;
+    } else if (local === "text") {
+      const text = child.children.filter((c: unknown) => typeof c === "string").join("");
+      // Single-character separators stay bare; longer literals get quoted.
+      if (text.length === 1 && /[\s\-/:.,()%]/.test(text)) {
+        out += text;
+      } else {
+        out += `"${text}"`;
+      }
+    } else if (local === "year") {
+      out += child.attrs["number:style"] === "long" ? "yyyy" : "yy";
+    } else if (local === "month") {
+      const long = child.attrs["number:style"] === "long";
+      const textual = child.attrs["number:textual"] === "true";
+      out += textual ? (long ? "mmmm" : "mmm") : long ? "mm" : "m";
+    } else if (local === "day") {
+      out += child.attrs["number:style"] === "long" ? "dd" : "d";
+    } else if (local === "day-of-week") {
+      out += child.attrs["number:style"] === "long" ? "dddd" : "ddd";
+    } else if (local === "hours") {
+      const tok = child.attrs["number:style"] === "long" ? "hh" : "h";
+      out += bracketDuration && !out.includes("[") ? `[${tok}]` : tok;
+    } else if (local === "minutes") {
+      out += child.attrs["number:style"] === "long" ? "mm" : "m";
+    } else if (local === "seconds") {
+      out += child.attrs["number:style"] === "long" ? "ss" : "s";
+    } else if (local === "am-pm") {
+      out += "AM/PM";
+    }
+  }
+  if (kind === "percentage" && !out.endsWith("%")) out += "%";
+  // ODS time elements may emit elapsed-hour brackets via the writer; if the
+  // reader detects truncate-on-overflow=false, surface the bracket form.
+  return out;
 }
 
 /** Convert a parsed ODS style def into a CellStyle */
@@ -132,6 +232,10 @@ function odsStyleToCellStyle(def: OdsStyleDef): CellStyle {
       pattern: "solid",
       fgColor: { rgb: hex.toUpperCase() },
     };
+  }
+
+  if (def.numFmt) {
+    style.numFmt = def.numFmt;
   }
 
   return style;

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -62,6 +62,280 @@ function formatOdsDateValue(date: Date): string {
   return `${y}-${m}-${d}T${hh}:${mm}:${ss}`;
 }
 
+// ── Number Format Translation ───────────────────────────────────────
+//
+// Translate an Excel-style format code (e.g. "0.00%", "yyyy-mm-dd",
+// "[HH]:MM") into an ODS data-style element from the
+// `urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0` namespace.
+//
+// ODS data styles are wrappers — the actual presentation lives in
+// child `<number:number>`, `<number:year>`, `<number:hours>` etc
+// elements that describe each token of the formatted output. A cell
+// references a data style by name through `style:data-style-name` on
+// its `<style:style>` element.
+
+type OdsNumFmtKind = "number" | "percentage" | "currency" | "date" | "time";
+
+interface OdsNumFmtDef {
+  /** Element local name (no namespace prefix) */
+  kind: OdsNumFmtKind;
+  /** Children of the data-style element, in document order */
+  children: string[];
+  /** Extra attributes on the data-style root (e.g. `number:truncate-on-overflow`) */
+  attrs?: Record<string, string>;
+}
+
+function isDateFormat(code: string): boolean {
+  // Strip locale / colour tags / bracketed duration tokens so they don't
+  // interfere — `[HH]`, `[red]`, `[$$-409]` are not date markers.
+  const stripped = code.replace(/\[[^\]]*\]/g, "");
+  return /[yY]/.test(stripped) || /[dD]/.test(stripped);
+}
+
+function isTimeFormat(code: string): boolean {
+  // Bracketed [h], [m], [s] always mean elapsed-time, otherwise the bare
+  // letters h or s mark a clock-style time. Excel uses `m` for both month
+  // and minute; we let the date check above win when only `m` is present.
+  if (/\[[hHmMsS]+\]/.test(code)) return true;
+  if (/[hHsS]/.test(code)) return true;
+  return false;
+}
+
+function isPercentageFormat(code: string): boolean {
+  // Strip quoted literals so a literal "%" inside a string doesn't trigger
+  return /(?<!\\)%/.test(code.replace(/"[^"]*"/g, "").replace(/\\./g, ""));
+}
+
+function detectCurrencySymbol(code: string): string | undefined {
+  // [$<symbol>-<locale>] form, e.g. [$$-409], [$€-2], [$£-809]
+  const bracketed = code.match(/\[\$([^-\]]*)(?:-[^\]]*)?\]/);
+  if (bracketed && bracketed[1]) return bracketed[1];
+  // "$" or "€" etc. as a quoted literal
+  const quoted = code.match(/"([^"]+)"/);
+  if (quoted && /[$€£¥₺₽₹]/.test(quoted[1])) return quoted[1];
+  // Bare $ at the start
+  if (/^\$/.test(code) || /[$€£¥₺₽₹]/.test(code)) {
+    const m = code.match(/[$€£¥₺₽₹]/);
+    if (m) return m[0];
+  }
+  return undefined;
+}
+
+function decimalsFromCode(code: string): number {
+  // Find the first decimal section like "0.00" / "#.##" / "#,##0.000"
+  const m = code.match(/[0#]\.([0#]+)/);
+  return m ? m[1].length : 0;
+}
+
+function hasGrouping(code: string): boolean {
+  return /#,##0|0,000/.test(code);
+}
+
+/** Build a `<number:number>` child for numeric / percentage / currency styles */
+function buildNumberChild(decimals: number, grouping: boolean): string {
+  const attrs: Record<string, string> = {
+    "number:decimal-places": String(decimals),
+    "number:min-integer-digits": "1",
+  };
+  if (grouping) attrs["number:grouping"] = "true";
+  return xmlSelfClose("number:number", attrs);
+}
+
+/** Translate a date-format code into a sequence of `<number:*>` children */
+function buildDateChildren(code: string): string[] {
+  const out: string[] = [];
+  // Tokenise: longest matches first. Bracketed elapsed tokens like `[hh]`
+  // collapse onto the same hour/minute/second elements but with style:long
+  // when two letters are present.
+  const tokenRegex =
+    /\[[hH]{1,2}\]|\[[mM]{1,2}\]|\[[sS]{1,2}\]|yyyy|yy|mmmm|mmm|mm|m|dddd|ddd|dd|d|hh|h|ss|s|AM\/PM|am\/pm|"[^"]*"|\\.|./g;
+
+  // Heuristic: an `m` token is treated as minute when the previous non-literal
+  // token is hours, otherwise as month.
+  let lastWasHours = false;
+  let nextIsSeconds = false;
+  const tokens: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = tokenRegex.exec(code)) !== null) {
+    tokens.push(match[0]);
+  }
+
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    const lower = tok.toLowerCase();
+    nextIsSeconds = false;
+    for (let j = i + 1; j < tokens.length; j++) {
+      const t = tokens[j].toLowerCase();
+      if (t === "s" || t === "ss") {
+        nextIsSeconds = true;
+        break;
+      }
+      if (
+        t === "h" ||
+        t === "hh" ||
+        t === "m" ||
+        t === "mm" ||
+        t === "d" ||
+        t === "dd" ||
+        t === "yyyy" ||
+        t === "yy"
+      )
+        break;
+    }
+
+    // Bracketed elapsed tokens: `[h]`, `[hh]`, `[m]`, `[mm]`, `[s]`, `[ss]`.
+    if (/^\[[hH]{1,2}\]$/.test(tok)) {
+      const long = tok.length === 4; // `[hh]` -> 4 chars
+      const attrs: Record<string, string> = {};
+      if (long) attrs["number:style"] = "long";
+      out.push(xmlSelfClose("number:hours", attrs));
+      lastWasHours = true;
+      continue;
+    }
+    if (/^\[[mM]{1,2}\]$/.test(tok)) {
+      const long = tok.length === 4;
+      const attrs: Record<string, string> = {};
+      if (long) attrs["number:style"] = "long";
+      out.push(xmlSelfClose("number:minutes", attrs));
+      lastWasHours = false;
+      continue;
+    }
+    if (/^\[[sS]{1,2}\]$/.test(tok)) {
+      const long = tok.length === 4;
+      const attrs: Record<string, string> = {};
+      if (long) attrs["number:style"] = "long";
+      out.push(xmlSelfClose("number:seconds", attrs));
+      lastWasHours = false;
+      continue;
+    }
+
+    if (lower === "yyyy") {
+      out.push(xmlSelfClose("number:year", { "number:style": "long" }));
+      lastWasHours = false;
+    } else if (lower === "yy") {
+      out.push(xmlSelfClose("number:year"));
+      lastWasHours = false;
+    } else if (lower === "mmmm") {
+      out.push(xmlSelfClose("number:month", { "number:textual": "true", "number:style": "long" }));
+      lastWasHours = false;
+    } else if (lower === "mmm") {
+      out.push(xmlSelfClose("number:month", { "number:textual": "true" }));
+      lastWasHours = false;
+    } else if (lower === "mm" || lower === "m") {
+      // minute when between hours and seconds, else month
+      const isMinute = lastWasHours || nextIsSeconds;
+      if (isMinute) {
+        const attrs: Record<string, string> = {};
+        if (lower === "mm") attrs["number:style"] = "long";
+        out.push(xmlSelfClose("number:minutes", attrs));
+      } else {
+        const attrs: Record<string, string> = {};
+        if (lower === "mm") attrs["number:style"] = "long";
+        out.push(xmlSelfClose("number:month", attrs));
+        lastWasHours = false;
+      }
+    } else if (lower === "dddd") {
+      out.push(xmlSelfClose("number:day-of-week", { "number:style": "long" }));
+      lastWasHours = false;
+    } else if (lower === "ddd") {
+      out.push(xmlSelfClose("number:day-of-week"));
+      lastWasHours = false;
+    } else if (lower === "dd") {
+      out.push(xmlSelfClose("number:day", { "number:style": "long" }));
+      lastWasHours = false;
+    } else if (lower === "d") {
+      out.push(xmlSelfClose("number:day"));
+      lastWasHours = false;
+    } else if (lower === "hh") {
+      out.push(xmlSelfClose("number:hours", { "number:style": "long" }));
+      lastWasHours = true;
+    } else if (lower === "h") {
+      out.push(xmlSelfClose("number:hours"));
+      lastWasHours = true;
+    } else if (lower === "ss") {
+      out.push(xmlSelfClose("number:seconds", { "number:style": "long" }));
+      lastWasHours = false;
+    } else if (lower === "s") {
+      out.push(xmlSelfClose("number:seconds"));
+      lastWasHours = false;
+    } else if (lower === "am/pm") {
+      out.push(xmlSelfClose("number:am-pm"));
+      lastWasHours = false;
+    } else if (tok.startsWith('"') && tok.endsWith('"')) {
+      out.push(xmlElement("number:text", undefined, xmlEscape(tok.slice(1, -1))));
+    } else if (tok.startsWith("\\") && tok.length === 2) {
+      out.push(xmlElement("number:text", undefined, xmlEscape(tok.slice(1))));
+    } else {
+      // Literal separator (`-`, `/`, `:`, `.`, ` `, etc.)
+      out.push(xmlElement("number:text", undefined, xmlEscape(tok)));
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Convert an Excel-style `numFmt` code into an ODS data-style definition.
+ * Returns `undefined` for codes the writer cannot translate — those are
+ * silently dropped rather than emitting an invalid style.
+ */
+function translateNumFmt(code: string): OdsNumFmtDef | undefined {
+  if (!code) return undefined;
+
+  const trimmed = code.trim();
+  // "General" or "@" (text) — no data style needed
+  if (trimmed === "General" || trimmed === "@" || trimmed === "") return undefined;
+
+  // Take only the first section (before `;`); negative/zero sections are
+  // ODS' `<style:map>` territory and outside this writer's scope.
+  const firstSection = trimmed.split(";")[0];
+
+  if (isPercentageFormat(firstSection)) {
+    const decimals = decimalsFromCode(firstSection);
+    const grouping = hasGrouping(firstSection);
+    const children = [
+      buildNumberChild(decimals, grouping),
+      xmlElement("number:text", undefined, "%"),
+    ];
+    return { kind: "percentage", children };
+  }
+
+  const currency = detectCurrencySymbol(firstSection);
+  if (currency) {
+    const decimals = decimalsFromCode(firstSection);
+    const grouping = hasGrouping(firstSection);
+    const symbol = xmlElement("number:currency-symbol", undefined, xmlEscape(currency));
+    const number = buildNumberChild(decimals, grouping);
+    // Detect symbol position: leading vs trailing
+    const beforeNum = /^[^0#]*(\$|\[\$|"[$€£¥₺₽₹])/.test(firstSection);
+    const children = beforeNum ? [symbol, number] : [number, symbol];
+    return { kind: "currency", children, attrs: { "number:automatic-order": "true" } };
+  }
+
+  const time = isTimeFormat(firstSection);
+  const date = isDateFormat(firstSection);
+  // Bracketed-hour durations like `[HH]:MM` are pure time; check time first.
+  const isElapsed = /\[[hHmMsS]+\]/.test(firstSection);
+  if (isElapsed || (time && !date)) {
+    const def: OdsNumFmtDef = {
+      kind: "time",
+      children: buildDateChildren(firstSection),
+    };
+    // `[H]`, `[M]`, `[S]` request a duration presentation that doesn't wrap
+    // at 24h — ODS marks this with `number:truncate-on-overflow="false"`.
+    if (isElapsed) def.attrs = { "number:truncate-on-overflow": "false" };
+    return def;
+  }
+  if (date) {
+    return { kind: "date", children: buildDateChildren(firstSection) };
+  }
+
+  // Plain number
+  const decimals = decimalsFromCode(firstSection);
+  const grouping = hasGrouping(firstSection);
+  return { kind: "number", children: [buildNumberChild(decimals, grouping)] };
+}
+
 // ── Style Generation ────────────────────────────────────────────────
 
 /** Maps a CellStyle to a unique string key for deduplication */
@@ -74,11 +348,12 @@ function styleKey(style: CellStyle): string {
   if (style.fill?.type === "pattern" && style.fill.fgColor?.rgb) {
     parts.push(`bg${style.fill.fgColor.rgb}`);
   }
+  if (style.numFmt) parts.push(`nf:${style.numFmt}`);
   return parts.join("|");
 }
 
 /** Generate a <style:style> element for a cell style */
-function generateStyleElement(name: string, style: CellStyle): string {
+function generateStyleElement(name: string, style: CellStyle, dataStyleName?: string): string {
   const textProps: Record<string, string> = {};
   const cellProps: Record<string, string> = {};
 
@@ -107,7 +382,10 @@ function generateStyleElement(name: string, style: CellStyle): string {
     children.push(xmlSelfClose("style:table-cell-properties", cellProps));
   }
 
-  return xmlElement("style:style", { "style:name": name, "style:family": "table-cell" }, children);
+  const attrs: Record<string, string> = { "style:name": name, "style:family": "table-cell" };
+  if (dataStyleName) attrs["style:data-style-name"] = dataStyleName;
+
+  return xmlElement("style:style", attrs, children);
 }
 
 // ── Style Collector ────────────────────────────────────────────────
@@ -117,12 +395,53 @@ interface StyleCollector {
   styleMap: Map<string, string>;
   /** Map from style name → XML element string */
   styleElements: Map<string, string>;
-  /** Counter for generating unique names */
+  /** Counter for generating unique cell-style names */
   counter: number;
+  /** Map from numFmt code → data-style name (e.g. "N100") */
+  dataStyleMap: Map<string, string>;
+  /** Map from data-style name → XML element string */
+  dataStyleElements: Map<string, string>;
+  /** Counter for generating unique data-style names */
+  dataStyleCounter: number;
 }
 
 function createStyleCollector(): StyleCollector {
-  return { styleMap: new Map(), styleElements: new Map(), counter: 1 };
+  return {
+    styleMap: new Map(),
+    styleElements: new Map(),
+    counter: 1,
+    dataStyleMap: new Map(),
+    dataStyleElements: new Map(),
+    dataStyleCounter: 100,
+  };
+}
+
+function getOrCreateDataStyleName(collector: StyleCollector, numFmt: string): string | undefined {
+  const existing = collector.dataStyleMap.get(numFmt);
+  if (existing) return existing;
+
+  const def = translateNumFmt(numFmt);
+  if (!def) return undefined;
+
+  const name = `N${collector.dataStyleCounter++}`;
+  collector.dataStyleMap.set(numFmt, name);
+
+  const tag = `number:${def.kind}-style`;
+  const attrs: Record<string, string> = { "style:name": name };
+  if (def.attrs) Object.assign(attrs, def.attrs);
+
+  collector.dataStyleElements.set(name, xmlElement(tag, attrs, def.children));
+  return name;
+}
+
+function hasVisualProps(style: CellStyle): boolean {
+  return Boolean(
+    style.font?.bold ||
+    style.font?.italic ||
+    style.font?.size ||
+    style.font?.color?.rgb ||
+    (style.fill?.type === "pattern" && style.fill.fgColor?.rgb),
+  );
 }
 
 function getOrCreateStyleName(collector: StyleCollector, style: CellStyle): string {
@@ -132,9 +451,18 @@ function getOrCreateStyleName(collector: StyleCollector, style: CellStyle): stri
   const existing = collector.styleMap.get(key);
   if (existing) return existing;
 
+  const dataStyleName = style.numFmt
+    ? getOrCreateDataStyleName(collector, style.numFmt)
+    : undefined;
+
+  // If the only piece of styling is a numFmt that translated to nothing
+  // (e.g. "General" / "@"), drop the cell-style entirely — emitting an
+  // empty `<style:style>` would just bloat the document.
+  if (!dataStyleName && !hasVisualProps(style)) return "";
+
   const name = `ce${collector.counter++}`;
   collector.styleMap.set(key, name);
-  collector.styleElements.set(name, generateStyleElement(name, style));
+  collector.styleElements.set(name, generateStyleElement(name, style, dataStyleName));
   return name;
 }
 
@@ -474,10 +802,16 @@ function writeContentXml(options: WriteOptions): string {
   const spreadsheetBody = xmlElement("office:spreadsheet", undefined, tableElements);
   const body = xmlElement("office:body", undefined, spreadsheetBody);
 
-  // Build automatic styles from collected styles
+  // Build automatic styles from collected styles. Per ODS spec the data
+  // styles (`<number:*-style>`) MUST appear before any `<style:style>`
+  // that references them through `style:data-style-name`.
+  const allStyleParts: string[] = [
+    ...styleCollector.dataStyleElements.values(),
+    ...styleCollector.styleElements.values(),
+  ];
   const styleXml =
-    styleCollector.styleElements.size > 0
-      ? xmlElement("office:automatic-styles", undefined, [...styleCollector.styleElements.values()])
+    allStyleParts.length > 0
+      ? xmlElement("office:automatic-styles", undefined, allStyleParts)
       : xmlElement("office:automatic-styles", undefined, "");
 
   // Build content sections in order per ODS spec:

--- a/test/ods-numfmt.test.ts
+++ b/test/ods-numfmt.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import { writeOds } from "../src/ods/writer";
+import { readOds } from "../src/ods/reader";
+import { ZipReader } from "../src/zip/reader";
+import { parseXml } from "../src/xml/parser";
+import type { Cell, WriteSheet } from "../src/_types";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const decoder = new TextDecoder("utf-8");
+
+async function extractFile(data: Uint8Array, path: string): Promise<string> {
+  const zip = new ZipReader(data);
+  const raw = await zip.extract(path);
+  return decoder.decode(raw);
+}
+
+async function parseXmlFromZip(data: Uint8Array, path: string) {
+  const xml = await extractFile(data, path);
+  return parseXml(xml);
+}
+
+function findChild(el: { children: Array<unknown> }, localName: string): any {
+  return el.children.find((c: any) => typeof c !== "string" && (c.local || c.tag) === localName);
+}
+
+function findChildren(el: { children: Array<unknown> }, localName: string): any[] {
+  return el.children.filter((c: any) => typeof c !== "string" && (c.local || c.tag) === localName);
+}
+
+async function getAutomaticStyles(data: Uint8Array) {
+  const contentDoc = await parseXmlFromZip(data, "content.xml");
+  return findChild(contentDoc, "automatic-styles");
+}
+
+function singleCellSheet(numFmt: string, value: number): WriteSheet {
+  const cells = new Map<string, Partial<Cell>>();
+  cells.set("0,0", { value, style: { numFmt } });
+  return { name: "Sheet1", rows: [[value]], cells };
+}
+
+// ── Writer: data style emission ─────────────────────────────────────
+
+describe("ODS writer — numFmt data styles", () => {
+  it("emits a number-style for a plain numeric format", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00", 3.14)] });
+    const autoStyles = await getAutomaticStyles(data);
+
+    const numberStyle = findChild(autoStyles, "number-style");
+    expect(numberStyle).toBeDefined();
+    expect(typeof numberStyle.attrs["style:name"]).toBe("string");
+
+    const numEl = findChild(numberStyle, "number");
+    expect(numEl.attrs["number:decimal-places"]).toBe("2");
+    expect(numEl.attrs["number:min-integer-digits"]).toBe("1");
+    expect(numEl.attrs["number:grouping"]).toBeUndefined();
+  });
+
+  it("propagates the thousands-separator into number:grouping", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("#,##0.00", 1234.5)] });
+    const autoStyles = await getAutomaticStyles(data);
+    const numberStyle = findChild(autoStyles, "number-style");
+    const numEl = findChild(numberStyle, "number");
+    expect(numEl.attrs["number:grouping"]).toBe("true");
+    expect(numEl.attrs["number:decimal-places"]).toBe("2");
+  });
+
+  it("emits a percentage-style for percent codes", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00%", 0.5)] });
+    const autoStyles = await getAutomaticStyles(data);
+    const pctStyle = findChild(autoStyles, "percentage-style");
+    expect(pctStyle).toBeDefined();
+    const numEl = findChild(pctStyle, "number");
+    expect(numEl.attrs["number:decimal-places"]).toBe("2");
+    // Trailing literal "%" sits in <number:text>%</number:text>
+    const textEls = findChildren(pctStyle, "text");
+    const collected = textEls
+      .map((t: any) => t.children.filter((c: unknown) => typeof c === "string").join(""))
+      .join("");
+    expect(collected).toContain("%");
+  });
+
+  it("emits a date-style for yyyy-mm-dd", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("yyyy-mm-dd", 45000)] });
+    const autoStyles = await getAutomaticStyles(data);
+    const dateStyle = findChild(autoStyles, "date-style");
+    expect(dateStyle).toBeDefined();
+
+    const year = findChild(dateStyle, "year");
+    expect(year).toBeDefined();
+    expect(year.attrs["number:style"]).toBe("long");
+
+    // Two month elements? No — there is exactly one `<number:month>` between the
+    // two literal `-` separators. We assert it's there with style="long".
+    const month = findChild(dateStyle, "month");
+    expect(month).toBeDefined();
+    expect(month.attrs["number:style"]).toBe("long");
+
+    const day = findChild(dateStyle, "day");
+    expect(day).toBeDefined();
+    expect(day.attrs["number:style"]).toBe("long");
+  });
+
+  it("emits a time-style for hh:mm:ss", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("hh:mm:ss", 0.5)] });
+    const autoStyles = await getAutomaticStyles(data);
+    const timeStyle = findChild(autoStyles, "time-style");
+    expect(timeStyle).toBeDefined();
+
+    expect(findChild(timeStyle, "hours")).toBeDefined();
+    expect(findChild(timeStyle, "minutes")).toBeDefined();
+    expect(findChild(timeStyle, "seconds")).toBeDefined();
+
+    // No truncate-on-overflow for plain "hh:mm:ss" — it wraps at 24h
+    expect(timeStyle.attrs["number:truncate-on-overflow"]).toBeUndefined();
+  });
+
+  it("flags duration formats with truncate-on-overflow=false", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("[HH]:MM", 0.020833)] });
+    const autoStyles = await getAutomaticStyles(data);
+    const timeStyle = findChild(autoStyles, "time-style");
+    expect(timeStyle).toBeDefined();
+    expect(timeStyle.attrs["number:truncate-on-overflow"]).toBe("false");
+
+    const hours = findChild(timeStyle, "hours");
+    expect(hours).toBeDefined();
+    const minutes = findChild(timeStyle, "minutes");
+    expect(minutes).toBeDefined();
+  });
+
+  it("emits a currency-style for $#,##0.00", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("$#,##0.00", 99.95)] });
+    const autoStyles = await getAutomaticStyles(data);
+    const currencyStyle = findChild(autoStyles, "currency-style");
+    expect(currencyStyle).toBeDefined();
+
+    const symbol = findChild(currencyStyle, "currency-symbol");
+    expect(symbol).toBeDefined();
+    const symbolText = symbol.children.filter((c: unknown) => typeof c === "string").join("");
+    expect(symbolText).toBe("$");
+
+    const numEl = findChild(currencyStyle, "number");
+    expect(numEl).toBeDefined();
+    expect(numEl.attrs["number:decimal-places"]).toBe("2");
+    expect(numEl.attrs["number:grouping"]).toBe("true");
+  });
+
+  it("references the data style from the cell <style:style> via style:data-style-name", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00", 3.14)] });
+    const autoStyles = await getAutomaticStyles(data);
+
+    const numberStyle = findChild(autoStyles, "number-style");
+    const dataStyleName = numberStyle.attrs["style:name"];
+    expect(dataStyleName).toBeTruthy();
+
+    const cellStyle = findChild(autoStyles, "style");
+    expect(cellStyle).toBeDefined();
+    expect(cellStyle.attrs["style:family"]).toBe("table-cell");
+    expect(cellStyle.attrs["style:data-style-name"]).toBe(dataStyleName);
+  });
+
+  it("orders data styles before cell styles inside automatic-styles", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00", 3.14)] });
+    const autoStyles = await getAutomaticStyles(data);
+
+    const order: string[] = [];
+    for (const child of autoStyles.children) {
+      if (typeof child === "string") continue;
+      order.push((child as any).local || (child as any).tag);
+    }
+    const dataIdx = order.indexOf("number-style");
+    const styleIdx = order.indexOf("style");
+    expect(dataIdx).toBeGreaterThanOrEqual(0);
+    expect(styleIdx).toBeGreaterThanOrEqual(0);
+    expect(dataIdx).toBeLessThan(styleIdx);
+  });
+
+  it("deduplicates styles that share a numFmt", async () => {
+    const cells = new Map<string, Partial<Cell>>();
+    cells.set("0,0", { value: 1, style: { numFmt: "0.00" } });
+    cells.set("0,1", { value: 2, style: { numFmt: "0.00" } });
+    cells.set("0,2", { value: 3, style: { numFmt: "0.00%" } });
+    const data = await writeOds({
+      sheets: [{ name: "Sheet1", rows: [[1, 2, 3]], cells }],
+    });
+    const autoStyles = await getAutomaticStyles(data);
+
+    expect(findChildren(autoStyles, "number-style")).toHaveLength(1);
+    expect(findChildren(autoStyles, "percentage-style")).toHaveLength(1);
+    // Two distinct cell styles (number-style vs percentage-style)
+    expect(findChildren(autoStyles, "style")).toHaveLength(2);
+  });
+
+  it("ignores numFmt = 'General' / '@'", async () => {
+    const cells = new Map<string, Partial<Cell>>();
+    cells.set("0,0", { value: 1, style: { numFmt: "General" } });
+    cells.set("0,1", { value: 2, style: { numFmt: "@" } });
+    const data = await writeOds({
+      sheets: [{ name: "Sheet1", rows: [[1, 2]], cells }],
+    });
+    const autoStyles = await getAutomaticStyles(data);
+    expect(findChildren(autoStyles, "number-style")).toHaveLength(0);
+    expect(findChildren(autoStyles, "percentage-style")).toHaveLength(0);
+    expect(findChildren(autoStyles, "date-style")).toHaveLength(0);
+    expect(findChildren(autoStyles, "time-style")).toHaveLength(0);
+    // The cell-level <style:style> is also dropped because it carries no
+    // visual properties — same behaviour as an unstyled cell.
+    expect(findChildren(autoStyles, "style")).toHaveLength(0);
+  });
+
+  it("co-exists with font and fill properties on the same cell style", async () => {
+    const cells = new Map<string, Partial<Cell>>();
+    cells.set("0,0", {
+      value: 0.5,
+      style: {
+        numFmt: "0.00%",
+        font: { bold: true },
+        fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } },
+      },
+    });
+    const data = await writeOds({
+      sheets: [{ name: "Sheet1", rows: [[0.5]], cells }],
+    });
+    const autoStyles = await getAutomaticStyles(data);
+
+    const pctStyle = findChild(autoStyles, "percentage-style");
+    expect(pctStyle).toBeDefined();
+
+    const cellStyle = findChild(autoStyles, "style");
+    expect(cellStyle.attrs["style:data-style-name"]).toBe(pctStyle.attrs["style:name"]);
+    expect(findChild(cellStyle, "text-properties").attrs["fo:font-weight"]).toBe("bold");
+    expect(findChild(cellStyle, "table-cell-properties").attrs["fo:background-color"]).toBe(
+      "#FFFF00",
+    );
+  });
+});
+
+// ── Roundtrip: write → read with readStyles ─────────────────────────
+
+describe("ODS parity — numFmt roundtrip", () => {
+  it("plain number format roundtrips through write/read", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00", 3.14)] });
+    const wb = await readOds(data, { readStyles: true });
+    const cell = wb.sheets[0].cells!.get("0,0");
+    expect(cell?.style?.numFmt).toBe("0.00");
+  });
+
+  it("grouping number format roundtrips", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("#,##0.00", 1234.5)] });
+    const wb = await readOds(data, { readStyles: true });
+    expect(wb.sheets[0].cells!.get("0,0")?.style?.numFmt).toBe("#,##0.00");
+  });
+
+  it("percentage format roundtrips", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00%", 0.5)] });
+    const wb = await readOds(data, { readStyles: true });
+    expect(wb.sheets[0].cells!.get("0,0")?.style?.numFmt).toBe("0.00%");
+  });
+
+  it("date format yyyy-mm-dd roundtrips", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("yyyy-mm-dd", 45000)] });
+    const wb = await readOds(data, { readStyles: true });
+    expect(wb.sheets[0].cells!.get("0,0")?.style?.numFmt).toBe("yyyy-mm-dd");
+  });
+
+  it("time format hh:mm:ss roundtrips", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("hh:mm:ss", 0.5)] });
+    const wb = await readOds(data, { readStyles: true });
+    expect(wb.sheets[0].cells!.get("0,0")?.style?.numFmt).toBe("hh:mm:ss");
+  });
+
+  it("duration format [HH]:MM roundtrips", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("[HH]:MM", 0.020833)] });
+    const wb = await readOds(data, { readStyles: true });
+    // Output normalises to lowercase brackets and short minute token
+    const code = wb.sheets[0].cells!.get("0,0")?.style?.numFmt;
+    expect(code).toBeDefined();
+    expect(code!.startsWith("[h")).toBe(true);
+    expect(code!.toLowerCase()).toContain("m");
+  });
+
+  it("readStyles=false keeps numFmt out of the cell metadata", async () => {
+    const data = await writeOds({ sheets: [singleCellSheet("0.00%", 0.5)] });
+    const wb = await readOds(data); // default: readStyles=false
+    const cell = wb.sheets[0].cells?.get("0,0");
+    // No style key collected when readStyles is off
+    expect(cell?.style?.numFmt).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

The ODS writer ignored `CellStyle.numFmt` — every numeric value
serialised as a raw float with `office:value-type="float"`, so format
codes like `[HH]:MM`, `0.00%`, or currency patterns silently dropped.
This wires `numFmt` through both the writer and the reader so cells
carry their format through ODS roundtrips.

The writer translates Excel-style format codes into the ODS
`urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0` namespace and
emits one of the five spec'd data-style flavours inside
`<office:automatic-styles>`:

- `<number:number-style>` for plain numeric formats (decimals,
  thousands grouping)
- `<number:percentage-style>` for `0%` / `0.00%`
- `<number:currency-style>` for `$#,##0.00`, `[$$-409]#,##0.00`, etc.
- `<number:date-style>` for `yyyy-mm-dd`, `dd/mm/yyyy hh:mm`, etc.
- `<number:time-style>` for clock and `[HH]:MM` elapsed-time formats —
  the elapsed flavour gets `number:truncate-on-overflow="false"` per
  ODS-1.2

Each cell's `<style:style>` element references the data style through
`style:data-style-name`, and the writer emits all data styles before
the `<style:style>` elements that reference them so parsers see the
names in document order. Identical `numFmt` codes deduplicate to a
single data-style entry.

The reader's `readStyles` path runs an extra first pass over
`<office:automatic-styles>` to collect data-style definitions and
reverse-translates them into Excel-compatible format codes, so a
`numFmt` set on a cell roundtrips intact.

Closes #249

## API

```ts
import { writeOds, readOds } from "hucre/ods";

const data = await writeOds({
  sheets: [{
    name: "Sheet1",
    rows: [["Duration", 0.020833]],
    cells: new Map([
      ["1,1", { style: { numFmt: "[HH]:MM" } }],
    ]),
  }],
});

// content.xml now contains:
// <number:time-style style:name="N100" number:truncate-on-overflow="false">
//   <number:hours number:style="long"/>
//   <number:text>:</number:text>
//   <number:minutes number:style="long"/>
// </number:time-style>
// <style:style style:name="ce1" style:family="table-cell"
//              style:data-style-name="N100"/>

const wb = await readOds(data, { readStyles: true });
wb.sheets[0].cells!.get("1,1")?.style?.numFmt;
// → "[hh]:mm"
```

## Test plan

- [x] `pnpm vitest run --dir=test test/ods-numfmt.test.ts` — 19 new tests covering data-style emission for every flavour, ordering, deduplication, and full write/read roundtrips
- [x] `pnpm vitest run --dir=test` — 4259 tests pass (no existing ODS test broken)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — 1.29 MB dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)