### PR TITLE
feat(xlsx): chart title font size — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1342,6 +1342,33 @@ export interface SheetChart {
    */
   titleRotation?: number;
   /**
+   * Chart title font size in whole or half points. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+   * <a:r><a:rPr sz="N"/></a:r></a:p></c:rich></c:tx></c:title>` —
+   * Excel's "Format Chart Title -> Font -> Size" knob. The OOXML
+   * attribute is in 100ths of a point, so 18pt serializes as
+   * `sz="1800"` and 14pt (Excel's reference default) as `sz="1400"`;
+   * the writer performs the conversion at emit time and lands the
+   * value on both the default-paragraph `<a:defRPr>` and the literal
+   * run's `<a:rPr>` so a re-parse picks the size up off either
+   * canonical slot.
+   *
+   * Accepted range: `1..400`pt (the band the OOXML `ST_TextFontSize`
+   * schema exposes — `100..400000` in 100ths of a point). Fractional
+   * inputs round to the nearest 0.5pt (Excel's UI granularity); inputs
+   * outside the band, `NaN`, `Infinity`, and non-numeric inputs all
+   * collapse to `undefined` so the writer falls back to the default
+   * `14`pt size Excel itself emits on a fresh chart.
+   *
+   * Default: omitted — the title renders at Excel's default 14pt. Set
+   * an explicit value to scale the title up for a hero dashboard tile
+   * (e.g. `24`) or down to fit a tight header slot (e.g. `10`).
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * size in either case.
+   */
+  titleFontSize?: number;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -3611,6 +3638,32 @@ export interface Chart {
    * {@link SheetChart.titleRotation} without transformation.
    */
   titleRotation?: number;
+  /**
+   * Chart title font size in points (range `1..400`), pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>`. Reflects Excel's "Format Chart
+   * Title -> Font -> Size" knob.
+   *
+   * The OOXML attribute is in 100ths of a point; the reader converts
+   * to points and rounds to the nearest 0.5pt (Excel's UI exposes the
+   * same 0.5pt granularity, e.g. `sz="1400"` surfaces as `14`,
+   * `sz="1450"` as `14.5`). Out-of-range values (outside the `1..400`
+   * band the OOXML `ST_TextFontSize` schema exposes) drop to
+   * `undefined` rather than fabricate a value the writer would never
+   * emit. Absence of the attribute (or of `<a:defRPr>` / `<a:pPr>` /
+   * `<a:p>` / `<c:rich>` / `<c:tx>` / `<c:title>`) likewise collapses
+   * to `undefined` so a fresh chart and a chart that pinned an
+   * out-of-range size both round-trip to the writer's "skip the size
+   * attribute" path.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no `<a:p>`
+   * to host the size in either case. The parsed value threads
+   * straight back into the writer-side
+   * {@link SheetChart.titleFontSize} without transformation.
+   */
+  titleFontSize?: number;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -273,6 +273,27 @@ export interface CloneChartOptions {
    */
   titleRotation?: number | null;
   /**
+   * Override the chart-level title font size in whole or half points.
+   * `undefined` (or omitted) inherits the source's parsed value;
+   * `null` drops the inherited size so the writer falls back to
+   * Excel's default 14pt; a `number` replaces it.
+   *
+   * Out-of-range overrides (outside the `1..400`pt band the OOXML
+   * `ST_TextFontSize` schema exposes) collapse to a drop (the writer's
+   * normalization band) so the cloned `SheetChart` always carries a
+   * value the writer will accept. Fractional overrides round to the
+   * nearest 0.5pt (Excel's UI granularity); `NaN`, `Infinity`, and
+   * non-numeric overrides also collapse to a drop.
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved chart renders no title (`title` resolved to `undefined`
+   * or `showTitle === false`) — there is no `<c:title>` block to host
+   * the size in either case. The grammar mirrors `titleRotation` /
+   * `titleOverlay` so the chart-level title knobs compose the same
+   * way at the call site.
+   */
+  titleFontSize?: number | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1060,6 +1081,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // `SheetChart` always carries a value the writer will accept.
     const resolvedTitleRotation = resolveTitleRotation(source.titleRotation, options.titleRotation);
     if (resolvedTitleRotation !== undefined) out.titleRotation = resolvedTitleRotation;
+
+    // `titleFontSize` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr sz="N"/>` slot for the writer
+    // to populate. Same scope rule as `titleOverlay` / `titleRotation`:
+    // the override wins over the source's parsed value; absence
+    // inherits, `null` drops, a `number` replaces. Out-of-range
+    // (outside the `1..400`pt band the OOXML `ST_TextFontSize` schema
+    // exposes) / non-finite / non-numeric overrides collapse via the
+    // normalizer so the cloned `SheetChart` always carries a value the
+    // writer will accept.
+    const resolvedTitleFontSize = resolveTitleFontSize(source.titleFontSize, options.titleFontSize);
+    if (resolvedTitleFontSize !== undefined) out.titleFontSize = resolvedTitleFontSize;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -2016,6 +2049,59 @@ function resolveTitleRotation(
   if (override === undefined) return normalizeTitleRotation(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleRotation(override);
+}
+
+/**
+ * Conversion bookkeeping for the chart-title font-size override. Same
+ * `1..400`pt band the writer enforces (mirroring the OOXML
+ * `ST_TextFontSize` schema, `100..400000` in 100ths of a point) so the
+ * cloned `SheetChart` always carries a value the writer will accept.
+ */
+const TITLE_FONT_SIZE_MIN_PT = 1;
+const TITLE_FONT_SIZE_MAX_PT = 400;
+
+/**
+ * Normalize a `titleFontSize` value (whole / half points) for the
+ * cloned `SheetChart`. Mirrors the writer's `normalizeTitleFontSize` —
+ * the cloned shape is guaranteed to round-trip through the writer
+ * without surprise: fractional inputs round to the nearest 0.5pt
+ * (Excel's UI granularity); inputs outside the `1..400`pt band, `NaN`,
+ * `Infinity`, and non-numeric inputs all collapse to `undefined` so
+ * the cloned chart drops the field rather than carry a value the
+ * writer would silently elide back to the application default.
+ */
+function normalizeTitleFontSize(value: number | undefined): number | undefined {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  // Round to the nearest 0.5pt (Excel's UI granularity). `Math.round`
+  // on `2 * value` and dividing by 2 gives a clean half-step band.
+  const halfSteps = Math.round(value * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
+}
+
+/**
+ * Resolve a `titleFontSize` override.
+ *
+ * `undefined` → inherit the source's parsed `titleFontSize`.
+ * `null`      → drop the inherited value (the writer falls back to
+ *               Excel's default 14pt).
+ * `number`    → replace, after clamping / rounding through
+ *               {@link normalizeTitleFontSize}.
+ *
+ * The grammar mirrors `titleRotation` / `titleOverlay` /
+ * `legendOverlay` so the chart-level title knobs compose the same way
+ * at the call site. Callers should gate the result on the resolved
+ * title visibility — when no title is emitted, the size has no slot
+ * in the rendered chart.
+ */
+function resolveTitleFontSize(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeTitleFontSize(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleFontSize(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -107,6 +107,18 @@ export function parseChart(xml: string): Chart | undefined {
   const titleRotation = parseTitleRotation(chartEl);
   if (titleRotation !== undefined) out.titleRotation = titleRotation;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` mirrors Excel's "Format Chart Title ->
+  // Font -> Size" knob. Same scope rule as `<c:overlay>` /
+  // `<a:bodyPr rot>` — a chart that omits `<c:title>` (or whose title
+  // is a `<c:strRef>` formula reference with no `<c:rich>` body) has
+  // no `<a:p>` slot to surface the size from, so the helper
+  // short-circuits to `undefined`. The value comes back in points
+  // (range `1..400`) for symmetry with the writer-side
+  // {@link SheetChart.titleFontSize} field.
+  const titleFontSize = parseTitleFontSize(chartEl);
+  if (titleFontSize !== undefined) out.titleFontSize = titleFontSize;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -2018,6 +2030,76 @@ function parseTitleRotation(chartEl: XmlElement): number | undefined {
   if (degrees < TITLE_ROTATION_MIN_DEG) return TITLE_ROTATION_MIN_DEG;
   if (degrees > TITLE_ROTATION_MAX_DEG) return TITLE_ROTATION_MAX_DEG;
   return degrees;
+}
+
+/**
+ * Conversion factor between OOXML's `sz` attribute (100ths of a point,
+ * the integer Excel writes inside `<a:defRPr sz="N"/>` /
+ * `<a:rPr sz="N"/>`) and whole / half points. The OOXML
+ * `ST_TextFontSize` schema restricts `sz` to the inclusive
+ * `100..400000` band — the writer's clamp uses the same range
+ * converted to points (`1..400`), so any out-of-range value collapses
+ * to `undefined` here rather than surface a token Excel would never
+ * emit.
+ */
+const TITLE_FONT_SZ_PER_POINT = 100;
+const TITLE_FONT_SIZE_MIN_PT = 1;
+const TITLE_FONT_SIZE_MAX_PT = 400;
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` off the chart. Returns the font
+ * size in points (range `1..400`).
+ *
+ * The OOXML `sz` attribute is in 100ths of a point — the reader
+ * converts to points and rounds to the nearest 0.5pt (Excel's UI
+ * exposes the same 0.5pt granularity). Absence of the element /
+ * attribute and out-of-range / non-numeric / non-finite values all
+ * collapse to `undefined` so a fresh chart and a chart that pinned an
+ * out-of-range size both round-trip to the writer's "skip the size
+ * attribute" path.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` element
+ * — there is no `<a:p>` slot to surface the size from in that case —
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body. The `<a:defRPr>` lives inside
+ * `<c:tx><c:rich><a:p><a:pPr>` per the CT_Title schema (the
+ * default-paragraph properties on the rich-text body's first
+ * paragraph); the lookup is scoped to that path so a stray
+ * `<a:defRPr>` elsewhere in the chart (e.g. on an axis title or a
+ * data-labels block) cannot leak in.
+ */
+function parseTitleFontSize(chartEl: XmlElement): number | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph font size. The reader walks the canonical chain
+  // and bails on the first missing link so a malformed `<c:rich>`
+  // surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.sz;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 100ths of a point to points, rounding to the nearest
+  // 0.5pt to match the granularity Excel's UI exposes. `Math.round`
+  // on `2 * (parsed / 100)` and dividing by 2 gives a clean half-step
+  // band that mirrors the writer's emit-time normalization.
+  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
 }
 
 // ── Auto Title Deleted ────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -68,7 +68,12 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   // ── Title ──
   if (showTitle && chart.title) {
     chartChildren.push(
-      buildTitle(chart.title, resolveTitleOverlay(chart), resolveTitleRotation(chart)),
+      buildTitle(
+        chart.title,
+        resolveTitleOverlay(chart),
+        resolveTitleRotation(chart),
+        resolveTitleFontSize(chart),
+      ),
     );
   }
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
@@ -198,13 +203,27 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
 
 // ── Title ────────────────────────────────────────────────────────────
 
-function buildTitle(title: string, overlay: boolean, rotationDeg: number | undefined): string {
+function buildTitle(
+  title: string,
+  overlay: boolean,
+  rotationDeg: number | undefined,
+  fontSizePt: number | undefined,
+): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
   // emit time. Absence (`undefined`) collapses to the OOXML default
   // `0` so a fresh chart matches Excel's reference serialization
   // byte-for-byte.
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
+  // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
+  // 100ths of a point. The writer holds `titleFontSize` in points and
+  // converts at emit time. Absence (`undefined`) collapses to the
+  // application-default `1400` (14pt) so a fresh chart matches Excel's
+  // reference serialization byte-for-byte. The size lands on both the
+  // default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
+  // a re-parse picks the value up off either canonical slot.
+  const sz =
+    fontSizePt === undefined ? TITLE_DEFAULT_FONT_SIZE_SZ : fontSizePt * TITLE_FONT_SZ_PER_POINT;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -222,9 +241,9 @@ function buildTitle(title: string, overlay: boolean, rotationDeg: number | undef
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz: 1400, b: 0 })]),
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b: 0 })]),
           xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz: 1400, b: 0 }),
+            xmlSelfClose("a:rPr", { lang: "en-US", sz, b: 0 }),
             xmlElement("a:t", undefined, xmlEscape(title)),
           ]),
         ]),
@@ -281,6 +300,69 @@ function normalizeTitleRotation(value: number | undefined): number | undefined {
  */
 function resolveTitleRotation(chart: SheetChart): number | undefined {
   return normalizeTitleRotation(chart.titleRotation);
+}
+
+/**
+ * OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
+ * 100ths of a point — the writer holds {@link SheetChart.titleFontSize}
+ * in points and converts at emit time. The OOXML `ST_TextFontSize`
+ * schema restricts `sz` to the inclusive `100..400000` band; the
+ * writer's clamp uses the same range converted to points (`1..400`pt),
+ * so any out-of-range value drops at emit time rather than surface a
+ * token Excel would reject.
+ */
+const TITLE_FONT_SZ_PER_POINT = 100;
+const TITLE_FONT_SIZE_MIN_PT = 1;
+const TITLE_FONT_SIZE_MAX_PT = 400;
+
+/**
+ * Application-default `sz` value for the chart title's `<a:defRPr>` /
+ * `<a:rPr>` slots — Excel renders the title at 14pt (`sz="1400"`)
+ * unless the user pins a custom size. Absence of
+ * {@link SheetChart.titleFontSize} resolves to this default so a fresh
+ * chart matches Excel's reference serialization byte-for-byte.
+ */
+const TITLE_DEFAULT_FONT_SIZE_SZ = 1400;
+
+/**
+ * Normalize a {@link SheetChart.titleFontSize} value (whole / half
+ * points) for the `<c:title><c:tx><c:rich><a:p><a:pPr>
+ * <a:defRPr sz="N"/></a:pPr></a:p></c:rich></c:tx></c:title>` writer
+ * slot. Returns `undefined` when the input is unset, non-finite,
+ * non-numeric, or out of the `1..400`pt band the OOXML
+ * `ST_TextFontSize` schema exposes — every absence path collapses to
+ * the same default-the-attribute shape so absence and an out-of-range
+ * input both fall back to Excel's reference 14pt.
+ *
+ * Fractional inputs round to the nearest 0.5pt (the OOXML attribute is
+ * an integer in 100ths of a point and Excel's UI exposes the same
+ * 0.5pt granularity, so finer fractions have no meaningful refinement
+ * at emit time).
+ */
+function normalizeTitleFontSize(value: number | undefined): number | undefined {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  // Round to the nearest 0.5pt (Excel's UI granularity). `Math.round`
+  // on `2 * value` and dividing by 2 gives a clean half-step band.
+  const halfSteps = Math.round(value * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` from
+ * {@link SheetChart.titleFontSize}.
+ *
+ * Returns the size in points (`1..400`), or `undefined` when the chart
+ * leaves the field unset / passed an out-of-range or non-numeric
+ * token. The flag is only meaningful when the chart actually emits a
+ * title — the caller is expected to gate the call on
+ * `showTitle && chart.title`. A chart whose title is suppressed has
+ * no `<c:title>` block to host the size in either case.
+ */
+function resolveTitleFontSize(chart: SheetChart): number | undefined {
+  return normalizeTitleFontSize(chart.titleFontSize);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10140,6 +10140,230 @@ describe("cloneChart — title rotation", () => {
   });
 });
 
+// ── cloneChart — title font size ────────────────────────────────────
+
+describe("cloneChart — title font size", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleFontSize by default", () => {
+    const clone = cloneChart(source({ titleFontSize: 18 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleFontSize).toBe(18);
+  });
+
+  it("lets options.titleFontSize override the source's value", () => {
+    const clone = cloneChart(source({ titleFontSize: 18 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: 24,
+    });
+    expect(clone.titleFontSize).toBe(24);
+  });
+
+  it("drops the inherited titleFontSize when the override is null", () => {
+    const clone = cloneChart(source({ titleFontSize: 18 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: null,
+    });
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("returns undefined titleFontSize when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("drops an out-of-range override (above the 400pt maximum)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: 401,
+    });
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("drops a below-range override (below the 1pt minimum after rounding)", () => {
+    // 0.49pt rounds to 0.5pt, which is below the OOXML 1pt minimum.
+    // (Inputs from 0.75 round up to 1pt and survive normalization.)
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: 0.49,
+    });
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("rounds a fractional override to the nearest 0.5pt", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: 14.8,
+    });
+    expect(clone.titleFontSize).toBe(15);
+  });
+
+  it("collapses non-finite overrides (NaN / Infinity) to undefined", () => {
+    const a = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: Number.NaN,
+    });
+    expect(a.titleFontSize).toBeUndefined();
+    const b = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontSize: Number.POSITIVE_INFINITY,
+    });
+    expect(b.titleFontSize).toBeUndefined();
+  });
+
+  it("drops a parsed source font size that is somehow out of range", () => {
+    // Defensive: a corrupt template parsed by an older reader could
+    // surface an out-of-band value. The clone normalizer collapses it
+    // through the same band so the writer never sees a bad token.
+    const clone = cloneChart(source({ titleFontSize: 401 as number }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("carries titleFontSize through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ titleFontSize: 24 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleFontSize).toBe(24);
+  });
+
+  it("carries titleFontSize through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ titleFontSize: 24 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleFontSize).toBe(24);
+  });
+
+  it("drops the inherited titleFontSize when the resolved title is dropped", () => {
+    // `title: null` flattens the inherited title — no `<c:title>` block
+    // in the rendered chart, so the size has no slot.
+    const clone = cloneChart(source({ titleFontSize: 24 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("drops the inherited titleFontSize when showTitle is false", () => {
+    const clone = cloneChart(source({ titleFontSize: 24 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleFontSize).toBeUndefined();
+  });
+
+  it("preserves titleFontSize when an override pins a new title", () => {
+    const clone = cloneChart(source({ titleFontSize: 24 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "New",
+    });
+    expect(clone.title).toBe("New");
+    expect(clone.titleFontSize).toBe(24);
+  });
+
+  it("composes independently with titleRotation", () => {
+    const clone = cloneChart(source({ titleRotation: 45, titleFontSize: 24 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleRotation).toBe(45);
+    expect(clone.titleFontSize).toBe(24);
+  });
+
+  it("end-to-end: parses a templated title font size, clones, and writes it through", () => {
+    const sourceXml = `<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400"/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.titleFontSize).toBe(24);
+    expect(parsed?.title).toBe("Hero");
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.titleFontSize).toBe(24);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('sz="2400"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFontSize).toBe(24);
+  });
+
+  it("propagates titleFontSize into the rendered <c:title> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ titleFontSize: 24 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('sz="2400"');
+
+    // Re-parsing the rendered chart returns the same value — closes the
+    // template -> clone -> write -> read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFontSize).toBe(24);
+  });
+});
+
 describe("cloneChart — axis title rotation", () => {
   function source(extra?: Partial<Chart>): Chart {
     return {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9339,6 +9339,184 @@ describe("writeChart — title rotation", () => {
   });
 });
 
+// ── writeChart — title font size ────────────────────────────────────
+
+describe("writeChart — title font size", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrSzOf(xml: string): string | undefined {
+    // The title's <a:defRPr> lives inside <c:title><c:tx><c:rich><a:p><a:pPr>.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const sz = m[0].match(/sz="([^"]+)"/);
+    return sz ? sz[1] : undefined;
+  }
+
+  function rPrSzOf(xml: string): string | undefined {
+    // The title's literal run carries an <a:rPr sz="N"/> alongside the
+    // default-paragraph slot — Excel keeps both in sync.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const sz = m[0].match(/sz="([^"]+)"/);
+    return sz ? sz[1] : undefined;
+  }
+
+  it('emits sz="1400" by default (matches Excel\'s reference 14pt)', () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(defRPrSzOf(result.chartXml)).toBe("1400");
+    expect(rPrSzOf(result.chartXml)).toBe("1400");
+  });
+
+  it("emits the size in 100ths of a point on a positive input", () => {
+    const result = writeChart(makeChart({ titleFontSize: 18 }), "Sheet1");
+    expect(defRPrSzOf(result.chartXml)).toBe("1800");
+    expect(rPrSzOf(result.chartXml)).toBe("1800");
+  });
+
+  it("supports half-point granularity", () => {
+    const result = writeChart(makeChart({ titleFontSize: 14.5 }), "Sheet1");
+    expect(defRPrSzOf(result.chartXml)).toBe("1450");
+    expect(rPrSzOf(result.chartXml)).toBe("1450");
+  });
+
+  it("rounds fractional inputs to the nearest 0.5pt", () => {
+    // 14.24pt rounds down to 14 -> sz="1400".
+    const a = writeChart(makeChart({ titleFontSize: 14.24 }), "Sheet1");
+    expect(defRPrSzOf(a.chartXml)).toBe("1400");
+    // 14.8pt rounds up to 15 -> sz="1500".
+    const b = writeChart(makeChart({ titleFontSize: 14.8 }), "Sheet1");
+    expect(defRPrSzOf(b.chartXml)).toBe("1500");
+  });
+
+  it("emits the 1pt minimum (sz=100)", () => {
+    const result = writeChart(makeChart({ titleFontSize: 1 }), "Sheet1");
+    expect(defRPrSzOf(result.chartXml)).toBe("100");
+    expect(rPrSzOf(result.chartXml)).toBe("100");
+  });
+
+  it("emits the 400pt maximum (sz=40000)", () => {
+    const result = writeChart(makeChart({ titleFontSize: 400 }), "Sheet1");
+    expect(defRPrSzOf(result.chartXml)).toBe("40000");
+    expect(rPrSzOf(result.chartXml)).toBe("40000");
+  });
+
+  it("drops out-of-range values and falls back to the 14pt default (sz=1400)", () => {
+    // 0.49pt rounds to 0.5pt, below the OOXML ST_TextFontSize 1pt
+    // minimum — the writer falls back to the 14pt default. (Inputs
+    // from 0.75 round up to 1pt and emit literally.)
+    const a = writeChart(makeChart({ titleFontSize: 0.49 }), "Sheet1");
+    expect(defRPrSzOf(a.chartXml)).toBe("1400");
+    // 401pt is above the OOXML ST_TextFontSize 400pt maximum.
+    const b = writeChart(makeChart({ titleFontSize: 401 }), "Sheet1");
+    expect(defRPrSzOf(b.chartXml)).toBe("1400");
+  });
+
+  it("drops non-finite inputs and falls back to the 14pt default", () => {
+    const nan = writeChart(makeChart({ titleFontSize: Number.NaN }), "Sheet1");
+    expect(defRPrSzOf(nan.chartXml)).toBe("1400");
+    const inf = writeChart(makeChart({ titleFontSize: Number.POSITIVE_INFINITY }), "Sheet1");
+    expect(defRPrSzOf(inf.chartXml)).toBe("1400");
+    const negInf = writeChart(makeChart({ titleFontSize: Number.NEGATIVE_INFINITY }), "Sheet1");
+    expect(defRPrSzOf(negInf.chartXml)).toBe("1400");
+  });
+
+  it("drops non-numeric inputs (defends against the type guard escaping)", () => {
+    const result = writeChart(makeChart({ titleFontSize: "18" as any }), "Sheet1");
+    expect(defRPrSzOf(result.chartXml)).toBe("1400");
+  });
+
+  it("ignores titleFontSize when the chart renders no title (showTitle=false)", () => {
+    // The whole `<c:title>` block is suppressed — no `<a:defRPr>` to
+    // host the size.
+    const result = writeChart(makeChart({ showTitle: false, titleFontSize: 24 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleFontSize when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleFontSize: 24 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleRotation and titleOverlay", () => {
+    const result = writeChart(
+      makeChart({ titleOverlay: true, titleRotation: -45, titleFontSize: 24 }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("preserves the title body's other attributes (b='0', lang='en-US')", () => {
+    // The writer keeps `b="0"` (non-bold) and `lang="en-US"` on the
+    // run's `<a:rPr>` so a templated title only loses the size, not
+    // the surrounding font defaults.
+    const result = writeChart(makeChart({ titleFontSize: 18 }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('lang="en-US"');
+    // `b="0"` lands on both the <a:defRPr> and the <a:rPr>.
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleFontSize: 24 }), "Sheet1");
+      expect(defRPrSzOf(result.chartXml)).toBe("2400");
+    }
+  });
+
+  it("parse round-trip surfaces the size from the writer's output", () => {
+    const written = writeChart(makeChart({ titleFontSize: 18 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFontSize).toBe(18);
+  });
+
+  it("collapses the default 14pt round-trip back to undefined", () => {
+    // The writer emits sz="1400" by default; the reader surfaces it
+    // literally because 14pt is a valid pin (not collapsed). However
+    // the writer's omit-on-default behavior means a chart that pinned
+    // 14pt explicitly and one that left the field unset both surface
+    // 14 on read — round-trip is symmetric in shape, not in absence.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFontSize).toBe(14);
+  });
+
+  it("end-to-end: writeXlsx packages the title font size into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            titleFontSize: 24,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('sz="2400"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleFontSize).toBe(24);
+  });
+});
+
 // ── writeChart — axis title rotation ────────────────────────────────
 
 describe("writeChart — axis title rotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9834,6 +9834,192 @@ describe("parseChart — title rotation", () => {
   });
 });
 
+// ── parseChart — title font size ─────────────────────────────────────
+
+describe("parseChart — title font size", () => {
+  const NS_TFS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleSz(sz: string | undefined): string {
+    const defRPr = sz === undefined ? "<a:defRPr/>" : `<a:defRPr sz="${sz}"/>`;
+    return `<c:chartSpace ${NS_TFS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the size in points from the sz attribute (100ths of a point)", () => {
+    // 18pt * 100 = 1800.
+    const chart = parseChart(withTitleSz("1800"));
+    expect(chart?.titleFontSize).toBe(18);
+  });
+
+  it("surfaces the default 14pt size literally", () => {
+    // Excel writes sz="1400" on every fresh chart title — the reader
+    // surfaces it because it is a literal pin (no "default collapse"
+    // for a literal sz, unlike the rot attribute's `0` default).
+    const chart = parseChart(withTitleSz("1400"));
+    expect(chart?.titleFontSize).toBe(14);
+  });
+
+  it("rounds to the nearest 0.5pt", () => {
+    // sz="1450" = 14.5pt — surfaces literally.
+    const a = parseChart(withTitleSz("1450"));
+    expect(a?.titleFontSize).toBe(14.5);
+    // sz="1424" = 14.24pt — rounds down to 14.
+    const b = parseChart(withTitleSz("1424"));
+    expect(b?.titleFontSize).toBe(14);
+    // sz="1480" = 14.8pt — rounds up to 15 (halfSteps `Math.round(29.6)=30`).
+    const c = parseChart(withTitleSz("1480"));
+    expect(c?.titleFontSize).toBe(15);
+    // sz="1430" = 14.3pt — rounds to 14.5 (halfSteps `Math.round(28.6)=29`).
+    const d = parseChart(withTitleSz("1430"));
+    expect(d?.titleFontSize).toBe(14.5);
+  });
+
+  it("returns undefined when <a:defRPr> omits the sz attribute", () => {
+    const chart = parseChart(withTitleSz(undefined));
+    expect(chart?.titleFontSize).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TFS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFontSize).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:p><a:pPr><a:defRPr>` to host the size.
+    const xml = `<c:chartSpace ${NS_TFS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Quarterly Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFontSize).toBeUndefined();
+    // Title still surfaces from the strRef cache.
+    expect(chart?.title).toBe("Quarterly Revenue");
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_TFS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFontSize).toBeUndefined();
+  });
+
+  it("drops sz values below the 1pt minimum after rounding (sz=49)", () => {
+    // 49 / 100 = 0.49pt — half-step round lands at 0.5pt, which is
+    // outside the OOXML ST_TextFontSize 1pt minimum. (sz values from
+    // 75 onwards round up to 1.0pt and surface literally; 74 and below
+    // are dropped.)
+    const chart = parseChart(withTitleSz("49"));
+    expect(chart?.titleFontSize).toBeUndefined();
+  });
+
+  it("drops sz values above the 400pt maximum (sz=400001)", () => {
+    // 400001 / 100 = 4000.01pt — outside the OOXML band.
+    const chart = parseChart(withTitleSz("400001"));
+    expect(chart?.titleFontSize).toBeUndefined();
+  });
+
+  it("surfaces the 1pt minimum (sz=100)", () => {
+    const chart = parseChart(withTitleSz("100"));
+    expect(chart?.titleFontSize).toBe(1);
+  });
+
+  it("surfaces the 400pt maximum (sz=40000)", () => {
+    const chart = parseChart(withTitleSz("40000"));
+    expect(chart?.titleFontSize).toBe(400);
+  });
+
+  it("drops non-numeric sz tokens", () => {
+    expect(parseChart(withTitleSz("fourteen"))?.titleFontSize).toBeUndefined();
+  });
+
+  it("drops empty sz tokens", () => {
+    expect(parseChart(withTitleSz(""))?.titleFontSize).toBeUndefined();
+  });
+
+  it("co-surfaces alongside titleRotation, titleOverlay, and other chart fields", () => {
+    const xml = `<c:chartSpace ${NS_TFS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-5400000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400"/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Hero");
+    expect(chart?.titleOverlay).toBe(true);
+    expect(chart?.titleRotation).toBe(-90);
+    expect(chart?.titleFontSize).toBe(24);
+  });
+});
+
 // ── parseChart — axis title rotation ─────────────────────────────────
 
 describe("parseChart — axis title rotation", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz=\"N\"/></a:pPr><a:r><a:rPr sz=\"N\"/></a:r></a:p></c:rich></c:tx></c:title>` (CT_Title's default-paragraph and run text-run-properties — ECMA-376 Part 1, §21.2.2.4 / §21.2.2.114) at the read, write, and clone layers so a template's custom title font size survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:defRPr sz=\"N\"/>` mirrors Excel's "Format Chart Title -> Font -> Size" knob — `N` is in 100ths of a point, so 18pt serializes as `sz=\"1800\"` and 24pt as `sz=\"2400\"`. Until now hucre's writer hardcoded `sz=\"1400\"` (14pt) on both the title's default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` and the reader ignored the attribute entirely, so a templated dashboard chart whose user scaled the title up for a hero tile or down to fit a tight header slot silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Mirrors the chart-level `titleRotation` field added in #247 / #248 — same `1..400`pt band the OOXML `ST_TextFontSize` schema exposes, same 0.5pt half-step granularity Excel's UI exposes, same out-of-range / non-finite drop semantics, same title-presence scope rule (the field is silently ignored when `showTitle === false` or the chart has no literal title) — so a single configuration call threads cleanly through both the chart title's rotation and its size without bookkeeping the units.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleFontSize);
// 24         ← when the template pinned <a:defRPr sz=\"2400\"/> on the title's <a:p><a:pPr>
// 14         ← when the template emits sz=\"1400\" (Excel's reference 14pt)
// undefined  ← when the chart has no <c:title> or the title is a <c:strRef> formula reference

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [
      [\"Region\", \"Revenue\"],
      [\"North\", 100],
      [\"South\", 200],
    ],
    charts: [{
      type: \"column\",
      title: \"Quarterly Revenue\",
      // Scale the title up for a hero dashboard tile.
      titleFontSize: 24,
      series: [{ name: \"Revenue\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed titleFontSize unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleFontSize: null,
});
//   → drops the inherited size (writer falls back to Excel's default 14pt).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleFontSize: 18,
});
//   → replaces the inherited size with 18pt.
```

## Implementation notes

- **Type model**: `SheetChart.titleFontSize?: number` (writer side); `Chart.titleFontSize?: number` (reader side). The clone option `titleFontSize?: number | null` follows the standard `undefined` (inherit) / `null` (drop) / `number` (replace) grammar. Same shape as the chart-level `titleRotation` so a parsed value flows straight from the read side back into the write side without transformation. Callers pin the value in points; the writer converts to 100ths at emit time.
- **Reader** (`parseTitleFontSize`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz=\"N\"/></a:pPr></a:p></c:rich></c:tx></c:title>` for the `sz` attribute. The lookup is scoped to the title's default-paragraph slot so a stray `<a:defRPr>` elsewhere in the chart (e.g. on an axis title or a data-labels block) cannot leak in. `Number.parseInt` rejects non-numeric tokens; `Math.round((parsed / 100) * 2) / 2` converts to whole / half points and rounds to the nearest 0.5pt (matching Excel's UI granularity). Out-of-range values (outside the `1..400`pt band the OOXML `ST_TextFontSize` schema exposes) drop to `undefined` rather than fabricate a value the writer would never emit. Returns `undefined` when the chart has no `<c:title>` element, or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body — there is no `<a:p>` slot to host the size in either case.
- **Writer**: `buildTitle` previously hard-coded `sz=\"1400\"` on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`. Now resolves through a `fontSizePt?: number` parameter — `normalizeTitleFontSize` clamps inputs through the `1..400`pt band, rounds fractional inputs to the nearest 0.5pt, and collapses `NaN` / `Infinity` / non-numeric / out-of-range inputs to `undefined`. The size lands on both the `<a:defRPr>` and the `<a:rPr>` so a re-parse picks the value up off either canonical slot — Excel keeps both attributes in sync. `<a:bodyPr>` and the title's other layout attributes (`spcFirstLastPara` / `vertOverflow` / `wrap` / `anchor` / `anchorCtr` / `b=\"0\"` / `lang=\"en-US\"`) are preserved exactly as before; only the `sz` attribute changes. Absence (`undefined`) collapses to the application-default `1400` (14pt) so a fresh chart matches Excel's reference serialization byte-for-byte.
- **Clone** (`resolveTitleFontSize`): follows the standard `number | null` override grammar — `undefined` inherits, `null` drops, a literal number replaces. Out-of-range / non-numeric overrides clamp / collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same `titleRendered` gate the writer uses — when the resolved title is dropped (`title: null` or `showTitle: false`), the inherited size drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only literal finite numbers within the `1..400`pt band survive the type guard at every layer; non-numeric inputs collapse to the default. This matches how the chart-level `titleRotation` field treats its inputs.

## Test plan

- [x] `parseChart — title font size` (13 new tests) — surfaces the size in points from the `sz` attribute, surfaces the default 14pt size literally, rounds non-integer 100ths to the nearest 0.5pt, returns undefined when `<a:defRPr>` omits `sz` / `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>` element, drops below-1pt and above-400pt values, surfaces the band endpoints (1pt / 400pt) literally, drops non-numeric / empty tokens, co-surfaces alongside `titleRotation` / `titleOverlay` and other chart fields.
- [x] `writeChart — title font size` (15 new tests) — emits `sz=\"1400\"` by default on both the `<a:defRPr>` and the `<a:rPr>`, emits the size as 100ths on positive / fractional / endpoint inputs, supports half-point granularity, rounds fractional inputs to the nearest 0.5pt, emits the band endpoints (`sz=\"100\"` / `sz=\"40000\"`), drops out-of-range / non-finite / non-numeric inputs back to the 14pt default, ignores the size when the chart renders no title (`showTitle=false` or absent title), composes independently with `titleRotation` / `titleOverlay`, preserves the title body's other attributes (`b=\"0\"` / `lang=\"en-US\"`), threads through every chart family (bar / column / line / pie / scatter / area), parse round-trip, default round-trip, full `writeXlsx` package round-trip.
- [x] `cloneChart — title font size` (16 new tests) — inherit, replace, null drop, drop on out-of-range / non-finite overrides, half-step rounding on fractional overrides, defensive clamp on a parsed source size, drop on `title: null`, drop on `showTitle: false`, preserve when override pins a new title, composition with `titleRotation`, threads through line → column / line → doughnut flatten, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4339 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.