### PR TITLE
feat(xlsx): chart title bold flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1369,6 +1369,33 @@ export interface SheetChart {
    */
   titleFontSize?: number;
   /**
+   * Chart title bold flag. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+   * <a:r><a:rPr b=".."/></a:r></a:p></c:rich></c:tx></c:title>` —
+   * Excel's "Format Chart Title -> Font -> Bold" toggle. The OOXML
+   * attribute is the `xsd:boolean` `b` on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7); the writer lands the value on both
+   * the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`
+   * so a re-parse picks the flag up off either canonical slot — Excel
+   * keeps the two attributes in sync.
+   *
+   * Default: omitted — the title renders non-bold (`b="0"`, Excel's
+   * reference serialization for a fresh chart title). Set `true` to
+   * emit `b="1"` on both slots so the title renders bold; set `false`
+   * explicitly to pin the non-default `b="0"` (functionally identical
+   * to omission, but useful when overriding a templated title that
+   * had bold pinned upstream).
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * flag in either case. Composes independently with
+   * {@link titleFontSize} / {@link titleRotation} / {@link titleOverlay}:
+   * all four fields land on the same `<c:title>` element so a single
+   * configuration call threads cleanly through every chart-title knob
+   * Excel exposes.
+   */
+  titleBold?: boolean;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -3664,6 +3691,27 @@ export interface Chart {
    * {@link SheetChart.titleFontSize} without transformation.
    */
   titleFontSize?: number;
+  /**
+   * Chart title bold flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>`. Reflects Excel's "Format Chart
+   * Title -> Font -> Bold" toggle.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<a:defRPr b="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<a:defRPr b="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings
+   * (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing
+   * `b` attributes drop to `undefined`.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no `<a:p>`
+   * to host the flag in either case. The parsed value threads
+   * straight back into the writer-side {@link SheetChart.titleBold}
+   * without transformation.
+   */
+  titleBold?: boolean;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -294,6 +294,24 @@ export interface CloneChartOptions {
    */
   titleFontSize?: number | null;
   /**
+   * Override the chart-level title bold flag.
+   * `undefined` (or omitted) inherits the source's parsed value;
+   * `null` drops the inherited flag so the writer falls back to the
+   * OOXML default `b="0"` (non-bold); a `boolean` replaces it.
+   *
+   * Non-boolean overrides (typed escapes from an untyped caller)
+   * collapse to a drop so the cloned `SheetChart` always carries a
+   * value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the flag in either case. The grammar mirrors
+   * `titleFontSize` / `titleRotation` / `titleOverlay` so the
+   * chart-level title knobs compose the same way at the call site.
+   */
+  titleBold?: boolean | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1093,6 +1111,16 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // writer will accept.
     const resolvedTitleFontSize = resolveTitleFontSize(source.titleFontSize, options.titleFontSize);
     if (resolvedTitleFontSize !== undefined) out.titleFontSize = resolvedTitleFontSize;
+
+    // `titleBold` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr b=".."/>` slot for the writer
+    // to populate. Same scope rule as `titleOverlay` / `titleRotation`
+    // / `titleFontSize`: the override wins over the source's parsed
+    // value; absence inherits, `null` drops, a `boolean` replaces.
+    // Non-boolean overrides collapse via the normalizer so the cloned
+    // `SheetChart` always carries a value the writer will accept.
+    const resolvedTitleBold = resolveTitleBold(source.titleBold, options.titleBold);
+    if (resolvedTitleBold !== undefined) out.titleBold = resolvedTitleBold;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -2102,6 +2130,44 @@ function resolveTitleFontSize(
   if (override === undefined) return normalizeTitleFontSize(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleFontSize(override);
+}
+
+/**
+ * Normalize a `titleBold` value for the cloned `SheetChart`. Mirrors
+ * the writer's `normalizeTitleBold` — the cloned shape is guaranteed
+ * to round-trip through the writer without surprise: `true` / `false`
+ * pass through literally, every other token (typed escape from an
+ * untyped caller) collapses to `undefined` so the cloned chart drops
+ * the field rather than carry a value the writer would silently elide
+ * back to the OOXML default.
+ */
+function normalizeTitleBold(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `titleBold` override.
+ *
+ * `undefined` → inherit the source's parsed `titleBold`.
+ * `null`      → drop the inherited flag (the writer falls back to the
+ *               OOXML default `b="0"`, non-bold).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `titleFontSize` / `titleRotation` /
+ * `titleOverlay` so the chart-level title knobs compose the same way
+ * at the call site. Callers should gate the result on the resolved
+ * title visibility — when no title is emitted, the flag has no slot
+ * in the rendered chart.
+ */
+function resolveTitleBold(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeTitleBold(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleBold(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -119,6 +119,19 @@ export function parseChart(xml: string): Chart | undefined {
   const titleFontSize = parseTitleFontSize(chartEl);
   if (titleFontSize !== undefined) out.titleFontSize = titleFontSize;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` mirrors Excel's "Format Chart Title ->
+  // Font -> Bold" toggle. Same scope rule as the size — a chart that
+  // omits `<c:title>` (or whose title is a `<c:strRef>` formula
+  // reference with no `<c:rich>` body) has no `<a:p>` slot to surface
+  // the flag from, so the helper short-circuits to `undefined`. The
+  // OOXML default `false` collapses to `undefined` so absence and
+  // `b="0"` round-trip identically through {@link cloneChart} — only
+  // an explicit `b="1"` surfaces `true`. The value threads straight
+  // back into the writer-side {@link SheetChart.titleBold} field.
+  const titleBold = parseTitleBold(chartEl);
+  if (titleBold !== undefined) out.titleBold = titleBold;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -2100,6 +2113,53 @@ function parseTitleFontSize(chartEl: XmlElement): number | undefined {
   const points = halfSteps / 2;
   if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
   return points;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` off the chart. Returns the bold
+ * flag.
+ *
+ * The OOXML `b` attribute is the `xsd:boolean` bold flag on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7). The
+ * OOXML default `false` collapses to `undefined` so absence and
+ * `b="0"` round-trip identically — only an explicit `b="1"` surfaces
+ * `true`. Unknown / malformed `b` tokens drop to `undefined` rather
+ * than fabricate a value the writer would never emit.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` element
+ * — there is no `<a:p>` slot to surface the flag from in that case —
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body. The `<a:defRPr>` lives inside
+ * `<c:tx><c:rich><a:p><a:pPr>` per the CT_Title schema (the
+ * default-paragraph properties on the rich-text body's first
+ * paragraph); the lookup is scoped to that path so a stray
+ * `<a:defRPr>` elsewhere in the chart (e.g. on an axis title or a
+ * data-labels block) cannot leak in.
+ */
+function parseTitleBold(chartEl: XmlElement): boolean | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph bold flag. The reader walks the canonical chain
+  // and bails on the first missing link so a malformed `<c:rich>`
+  // surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const parsed = parseBoolAttr(defRPr.attrs.b);
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `b="0"` round-trip identically through the writer — only an
+  // explicit `b="1"` surfaces `true`.
+  if (parsed === true) return true;
+  return undefined;
 }
 
 // ── Auto Title Deleted ────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -73,6 +73,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleOverlay(chart),
         resolveTitleRotation(chart),
         resolveTitleFontSize(chart),
+        resolveTitleBold(chart),
       ),
     );
   }
@@ -208,6 +209,7 @@ function buildTitle(
   overlay: boolean,
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
+  bold: boolean | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -224,6 +226,16 @@ function buildTitle(
   // a re-parse picks the value up off either canonical slot.
   const sz =
     fontSizePt === undefined ? TITLE_DEFAULT_FONT_SIZE_SZ : fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  // OOXML's `<a:defRPr b=".."/>` / `<a:rPr b=".."/>` attribute is the
+  // `xsd:boolean` bold flag on `CT_TextCharacterProperties`. The writer
+  // holds `titleBold` as a boolean and emits `1` / `0` at the canonical
+  // slots. Absence (`undefined`) collapses to the OOXML default `0`
+  // (non-bold) so a fresh chart matches Excel's reference serialization
+  // byte-for-byte. Like the size, the flag lands on both the
+  // default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
+  // a re-parse picks the value up off either canonical slot — Excel
+  // keeps the two attributes in sync.
+  const b = bold ? 1 : 0;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -241,9 +253,9 @@ function buildTitle(
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b: 0 })]),
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b })]),
           xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz, b: 0 }),
+            xmlSelfClose("a:rPr", { lang: "en-US", sz, b }),
             xmlElement("a:t", undefined, xmlEscape(title)),
           ]),
         ]),
@@ -363,6 +375,38 @@ function normalizeTitleFontSize(value: number | undefined): number | undefined {
  */
 function resolveTitleFontSize(chart: SheetChart): number | undefined {
   return normalizeTitleFontSize(chart.titleFontSize);
+}
+
+/**
+ * Normalize a {@link SheetChart.titleBold} value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` writer slot. Returns the literal
+ * boolean when the input is `true` / `false`, or `undefined` for any
+ * other token (including `null`-shaped escapes from an untyped
+ * caller). Absence and non-boolean tokens both collapse to
+ * `undefined` so the writer falls back to the OOXML default `b="0"`
+ * (non-bold) Excel itself emits on a fresh chart title.
+ */
+function normalizeTitleBold(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` from
+ * {@link SheetChart.titleBold}.
+ *
+ * Returns the literal boolean, or `undefined` when the chart leaves
+ * the field unset / passed a non-boolean token. The flag is only
+ * meaningful when the chart actually emits a title — the caller is
+ * expected to gate the call on `showTitle && chart.title`. A chart
+ * whose title is suppressed has no `<c:title>` block to host the flag
+ * in either case.
+ */
+function resolveTitleBold(chart: SheetChart): boolean | undefined {
+  return normalizeTitleBold(chart.titleBold);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10364,6 +10364,188 @@ describe("cloneChart — title font size", () => {
   });
 });
 
+// ── cloneChart — title bold ─────────────────────────────────────────
+
+describe("cloneChart — title bold", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleBold by default", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleBold).toBe(true);
+  });
+
+  it("lets options.titleBold override the source's value", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBold: false,
+    });
+    expect(clone.titleBold).toBe(false);
+  });
+
+  it("drops the inherited titleBold when the override is null", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBold: null,
+    });
+    expect(clone.titleBold).toBeUndefined();
+  });
+
+  it("returns undefined titleBold when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleBold).toBeUndefined();
+  });
+
+  it("lets options.titleBold pin true on a non-bold source", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBold: true,
+    });
+    expect(clone.titleBold).toBe(true);
+  });
+
+  it("drops a non-boolean override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBold: "true" as any,
+    });
+    // Override is non-boolean, so it collapses to drop — and the
+    // inherited value is replaced by the dropped override (not
+    // inherited).
+    expect(clone.titleBold).toBeUndefined();
+  });
+
+  it("drops the cloned titleBold when the resolved title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleBold).toBeUndefined();
+  });
+
+  it("drops the cloned titleBold when showTitle is false", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleBold).toBeUndefined();
+  });
+
+  it("preserves titleBold when an override pins a fresh title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleBold: true,
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleBold).toBe(true);
+  });
+
+  it("composes with titleFontSize / titleRotation / titleOverlay", () => {
+    const clone = cloneChart(source({ titleBold: true, titleFontSize: 18, titleRotation: -45 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleOverlay: true,
+    });
+    expect(clone.titleBold).toBe(true);
+    expect(clone.titleFontSize).toBe(18);
+    expect(clone.titleRotation).toBe(-45);
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("threads through line -> column flatten", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleBold).toBe(true);
+  });
+
+  it("threads through line -> doughnut flatten", () => {
+    const clone = cloneChart(source({ titleBold: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleBold).toBe(true);
+  });
+
+  it("end-to-end parse -> clone -> write -> reparse round-trip", async () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2000" b="1"/></a:pPr><a:r><a:t>Source</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$3</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(xml)!;
+    expect(parsed.titleBold).toBe(true);
+
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleBold).toBe(true);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Region", "Revenue"],
+            ["North", 100],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('b="1"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleBold).toBe(true);
+  });
+});
+
 describe("cloneChart — axis title rotation", () => {
   function source(extra?: Partial<Chart>): Chart {
     return {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9517,6 +9517,154 @@ describe("writeChart — title font size", () => {
   });
 });
 
+// ── writeChart — title bold ─────────────────────────────────────────
+
+describe("writeChart — title bold", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrBOf(xml: string): string | undefined {
+    // The title's <a:defRPr> lives inside <c:title><c:tx><c:rich><a:p><a:pPr>.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const b = m[0].match(/\bb="([^"]+)"/);
+    return b ? b[1] : undefined;
+  }
+
+  function rPrBOf(xml: string): string | undefined {
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const b = m[0].match(/\bb="([^"]+)"/);
+    return b ? b[1] : undefined;
+  }
+
+  it('emits b="0" by default (matches Excel\'s reference non-bold title)', () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(defRPrBOf(result.chartXml)).toBe("0");
+    expect(rPrBOf(result.chartXml)).toBe("0");
+  });
+
+  it('emits b="1" on titleBold=true', () => {
+    const result = writeChart(makeChart({ titleBold: true }), "Sheet1");
+    expect(defRPrBOf(result.chartXml)).toBe("1");
+    expect(rPrBOf(result.chartXml)).toBe("1");
+  });
+
+  it('emits b="0" on titleBold=false (functionally identical to omission)', () => {
+    const result = writeChart(makeChart({ titleBold: false }), "Sheet1");
+    expect(defRPrBOf(result.chartXml)).toBe("0");
+    expect(rPrBOf(result.chartXml)).toBe("0");
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (defends against type guard escape)", () => {
+    const result = writeChart(makeChart({ titleBold: "true" as any }), "Sheet1");
+    expect(defRPrBOf(result.chartXml)).toBe("0");
+    const result2 = writeChart(makeChart({ titleBold: 1 as any }), "Sheet1");
+    expect(defRPrBOf(result2.chartXml)).toBe("0");
+  });
+
+  it("ignores titleBold when the chart renders no title (showTitle=false)", () => {
+    // The whole `<c:title>` block is suppressed — no `<a:defRPr>` to
+    // host the bold flag.
+    const result = writeChart(makeChart({ showTitle: false, titleBold: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleBold when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleBold: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleFontSize, titleRotation, and titleOverlay", () => {
+    const result = writeChart(
+      makeChart({
+        titleBold: true,
+        titleFontSize: 24,
+        titleRotation: -45,
+        titleOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("preserves the title body's other attributes (lang='en-US', sz)", () => {
+    const result = writeChart(makeChart({ titleBold: true }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('lang="en-US"');
+    // The default 14pt size still lands on both slots even when bold flips.
+    expect(titleBlock.match(/sz="1400"/g)?.length).toBeGreaterThanOrEqual(2);
+    // `b="1"` lands on both the <a:defRPr> and the <a:rPr>.
+    expect(titleBlock.match(/b="1"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleBold: true }), "Sheet1");
+      expect(defRPrBOf(result.chartXml)).toBe("1");
+    }
+  });
+
+  it("parse round-trip surfaces titleBold from the writer's output", () => {
+    const written = writeChart(makeChart({ titleBold: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleBold).toBe(true);
+  });
+
+  it("collapses the default (non-bold) round-trip back to undefined", () => {
+    // A fresh chart writes `b="0"`; the reader collapses the default
+    // to `undefined` so absence and the default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleBold).toBeUndefined();
+  });
+
+  it("collapses the explicit titleBold=false round-trip back to undefined", () => {
+    // titleBold=false emits `b="0"` (the OOXML default) which the
+    // reader collapses to `undefined`. So pinning `false` is
+    // functionally equivalent to absence on round-trip.
+    const written = writeChart(makeChart({ titleBold: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleBold).toBeUndefined();
+  });
+
+  it("writeXlsx package round-trip surfaces titleBold from the chart part", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Revenue"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Quarterly Revenue",
+            titleBold: true,
+            series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('b="1"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleBold).toBe(true);
+  });
+});
+
 // ── writeChart — axis title rotation ────────────────────────────────
 
 describe("writeChart — axis title rotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10020,6 +10020,193 @@ describe("parseChart — title font size", () => {
   });
 });
 
+// ── parseChart — title bold ──────────────────────────────────────────
+
+describe("parseChart — title bold", () => {
+  const NS_TB = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleBold(b: string | undefined): string {
+    const defRPr = b === undefined ? "<a:defRPr/>" : `<a:defRPr b="${b}"/>`;
+    return `<c:chartSpace ${NS_TB}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true when the title pinned b='1'", () => {
+    const chart = parseChart(withTitleBold("1"));
+    expect(chart?.titleBold).toBe(true);
+  });
+
+  it("collapses b='0' to undefined (OOXML default round-trips identically)", () => {
+    const chart = parseChart(withTitleBold("0"));
+    expect(chart?.titleBold).toBeUndefined();
+  });
+
+  it("collapses absence of the b attribute to undefined", () => {
+    const chart = parseChart(withTitleBold(undefined));
+    expect(chart?.titleBold).toBeUndefined();
+  });
+
+  it("accepts the OOXML truthy spelling 'true'", () => {
+    const chart = parseChart(withTitleBold("true"));
+    expect(chart?.titleBold).toBe(true);
+  });
+
+  it("collapses the OOXML falsy spelling 'false' to undefined", () => {
+    const chart = parseChart(withTitleBold("false"));
+    expect(chart?.titleBold).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleBold).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body (strRef)", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:p><a:pPr><a:defRPr>` to host the bold flag.
+    const xml = `<c:chartSpace ${NS_TB}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleBold).toBeUndefined();
+    expect(chart?.title).toBe("Revenue");
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_TB}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleBold).toBeUndefined();
+  });
+
+  it("drops unknown b tokens to undefined", () => {
+    expect(parseChart(withTitleBold("yes"))?.titleBold).toBeUndefined();
+    expect(parseChart(withTitleBold("on"))?.titleBold).toBeUndefined();
+    expect(parseChart(withTitleBold(""))?.titleBold).toBeUndefined();
+  });
+
+  it("does not leak from a stray axis-title <a:defRPr>", () => {
+    // The category axis title carries a bold <a:defRPr b="1"/>, but
+    // the chart-level title does not — `titleBold` reflects only the
+    // chart-level title's <a:defRPr>, not a stray sibling element.
+    const xml = `<c:chartSpace ${NS_TB}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Header</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleBold).toBeUndefined();
+  });
+
+  it("co-surfaces alongside titleFontSize, titleRotation, and titleOverlay", () => {
+    const xml = `<c:chartSpace ${NS_TB}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400" b="1"/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Hero");
+    expect(chart?.titleBold).toBe(true);
+    expect(chart?.titleFontSize).toBe(24);
+    expect(chart?.titleRotation).toBe(-45);
+    expect(chart?.titleOverlay).toBe(true);
+  });
+});
+
 // ── parseChart — axis title rotation ─────────────────────────────────
 
 describe("parseChart — axis title rotation", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=\".."/></a:pPr><a:r><a:rPr b=\".."/></a:r></a:p></c:rich></c:tx></c:title>` (CT_Title's default-paragraph and run text-character-properties bold flag — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's bold chart title survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:defRPr b=\"..\"/>` mirrors Excel's "Format Chart Title -> Font -> Bold" toggle. Until now hucre's writer hardcoded `b=\"0\"` (non-bold) on both the title's default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` and the reader ignored the attribute entirely, so a templated dashboard chart whose user bolded the title for emphasis silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Mirrors the chart-level `titleFontSize` field added in #251 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same title-presence scope rule (silently ignored when `showTitle === false` or no literal title), same `boolean | null` clone grammar (`undefined` inherits, `null` drops, a literal boolean replaces) — so a single configuration call threads cleanly through every chart-title knob Excel exposes (bold, size, rotation, overlay) without bookkeeping the canonical OOXML slots.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleBold);
// true       ← when the template pinned <a:defRPr b="1"/> on the title's <a:p><a:pPr>
// undefined  ← when the template emits b="0" (Excel's reference non-bold)
// undefined  ← when the chart has no <c:title> or the title is a <c:strRef> formula reference

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Region", "Revenue"],
      ["North", 100],
      ["South", 200],
    ],
    charts: [{
      type: "column",
      title: "Quarterly Revenue",
      // Bold the title for a hero dashboard tile.
      titleBold: true,
      series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed titleBold unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleBold: null,
});
//   → drops the inherited bold flag (writer falls back to OOXML default b="0").
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleBold: false,
});
//   → replaces the inherited bold flag with explicit non-bold (b="0").
```

## Implementation notes

- **Type model**: `SheetChart.titleBold?: boolean` (writer side); `Chart.titleBold?: boolean` (reader side). The clone option `titleBold?: boolean | null` follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar. Same shape as `titleFontSize` so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseTitleBold`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=\".."/></a:pPr></a:p></c:rich></c:tx></c:title>` for the `b` attribute. The lookup is scoped to the title's default-paragraph slot so a stray `<a:defRPr>` elsewhere in the chart (e.g. on an axis title or a data-labels block) cannot leak in. Uses the existing `parseBoolAttr` helper to accept the OOXML truthy / falsy spellings (`\"1\"` / `\"true\"` / `\"0\"` / `\"false\"`); unknown values and missing `b` attributes drop to `undefined`. The OOXML default `false` collapses to `undefined` so absence and `b=\"0\"` round-trip identically — only an explicit `b=\"1\"` surfaces `true`. Returns `undefined` when the chart has no `<c:title>` element, or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body — there is no `<a:p>` slot to host the flag in either case.
- **Writer**: `buildTitle` previously hard-coded `b=\"0\"` (non-bold) on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`. Now resolves through a `bold?: boolean` parameter — `normalizeTitleBold` accepts only literal booleans and collapses every other token (typed escapes from an untyped caller) to `undefined`. The flag lands on both the `<a:defRPr>` and the `<a:rPr>` so a re-parse picks the value up off either canonical slot — Excel keeps both attributes in sync. Other title attributes (`<a:bodyPr>` rotation, `sz`, `lang=\"en-US\"`) are preserved exactly; only the `b` attribute changes. Absence (`undefined`) collapses to the application-default `0` (non-bold) so a fresh chart matches Excel's reference serialization.
- **Clone** (`resolveTitleBold`): follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same `titleRendered` gate the writer uses — when the resolved title is dropped (`title: null` or `showTitle: false`), the inherited flag drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only literal `true` / `false` survive the type guard at every layer; non-boolean inputs collapse to the default. This matches how `titleOverlay` / `roundedCorners` / `plotVisOnly` treat their inputs.

## Test plan

- [x] `parseChart — title bold` (10 new tests) — surfaces `true` from `b=\"1\"`, collapses `b=\"0\"` and absence to `undefined`, accepts truthy / falsy spellings (`\"true\"` / `\"false\"`), returns undefined when `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>`, drops unknown / empty tokens, does not leak from a stray axis-title `<a:defRPr>`, co-surfaces alongside `titleFontSize` / `titleRotation` / `titleOverlay`.
- [x] `writeChart — title bold` (12 new tests) — emits `b=\"0\"` by default on both slots, emits `b=\"1\"` on `true`, emits `b=\"0\"` on `false` (functionally equivalent to omission), drops non-boolean inputs back to the default, ignores the flag when the chart renders no title (`showTitle=false` or absent title), composes independently with `titleFontSize` / `titleRotation` / `titleOverlay`, preserves the title body's other attributes (`lang=\"en-US\"`, `sz`), threads through every chart family (bar / column / line / pie / scatter / area), parse round-trip, default round-trip collapses to `undefined`, explicit `false` round-trip also collapses to `undefined`, full `writeXlsx` package round-trip.
- [x] `cloneChart — title bold` (13 new tests) — inherit, replace (true to false), null drop, replace null source with true override, drop on non-boolean override, drop on `title: null`, drop on `showTitle: false`, preserve when an override pins a fresh title, composition with `titleFontSize` / `titleRotation` / `titleOverlay`, threads through line -> column / line -> doughnut flatten, end-to-end parse -> clone -> write -> reparse round-trip.
- [x] `pnpm test` — all 4395 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.