### PR TITLE
feat(xlsx): chart title italic flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1396,6 +1396,34 @@ export interface SheetChart {
    */
   titleBold?: boolean;
   /**
+   * Chart title italic flag. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+   * <a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title>` —
+   * Excel's "Format Chart Title -> Font -> Italic" toggle. The OOXML
+   * attribute is the `xsd:boolean` `i` on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7); the writer lands the value on both
+   * the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`
+   * so a re-parse picks the flag up off either canonical slot — Excel
+   * keeps the two attributes in sync.
+   *
+   * Default: omitted — the title renders non-italic (no `i` attribute,
+   * Excel's reference serialization for a fresh chart title; the
+   * application-default `false` collapses to absence). Set `true` to
+   * emit `i="1"` on both slots so the title renders italic; set `false`
+   * explicitly to pin the non-default `i="0"` (functionally identical
+   * to omission, but useful when overriding a templated title that had
+   * italic pinned upstream).
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * flag in either case. Composes independently with {@link titleBold}
+   * / {@link titleFontSize} / {@link titleRotation} /
+   * {@link titleOverlay}: all five fields land on the same
+   * `<c:title>` element so a single configuration call threads cleanly
+   * through every chart-title knob Excel exposes.
+   */
+  titleItalic?: boolean;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -3712,6 +3740,27 @@ export interface Chart {
    * without transformation.
    */
   titleBold?: boolean;
+  /**
+   * Chart title italic flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>`. Reflects Excel's "Format Chart
+   * Title -> Font -> Italic" toggle.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<a:defRPr i="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<a:defRPr i="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings
+   * (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing
+   * `i` attributes drop to `undefined`.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no `<a:p>`
+   * to host the flag in either case. The parsed value threads
+   * straight back into the writer-side {@link SheetChart.titleItalic}
+   * without transformation.
+   */
+  titleItalic?: boolean;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -312,6 +312,26 @@ export interface CloneChartOptions {
    */
   titleBold?: boolean | null;
   /**
+   * Override the chart-level title italic flag.
+   * `undefined` (or omitted) inherits the source's parsed value;
+   * `null` drops the inherited flag so the writer falls back to the
+   * OOXML default (no `i` attribute, equivalent to non-italic);
+   * a `boolean` replaces it.
+   *
+   * Non-boolean overrides (typed escapes from an untyped caller)
+   * collapse to a drop so the cloned `SheetChart` always carries a
+   * value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the flag in either case. The grammar mirrors
+   * `titleBold` / `titleFontSize` / `titleRotation` / `titleOverlay`
+   * so the chart-level title knobs compose the same way at the call
+   * site.
+   */
+  titleItalic?: boolean | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1121,6 +1141,17 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // `SheetChart` always carries a value the writer will accept.
     const resolvedTitleBold = resolveTitleBold(source.titleBold, options.titleBold);
     if (resolvedTitleBold !== undefined) out.titleBold = resolvedTitleBold;
+
+    // `titleItalic` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr i=".."/>` slot for the writer
+    // to populate. Same scope rule as `titleOverlay` / `titleRotation`
+    // / `titleFontSize` / `titleBold`: the override wins over the
+    // source's parsed value; absence inherits, `null` drops, a
+    // `boolean` replaces. Non-boolean overrides collapse via the
+    // normalizer so the cloned `SheetChart` always carries a value
+    // the writer will accept.
+    const resolvedTitleItalic = resolveTitleItalic(source.titleItalic, options.titleItalic);
+    if (resolvedTitleItalic !== undefined) out.titleItalic = resolvedTitleItalic;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -2168,6 +2199,45 @@ function resolveTitleBold(
   if (override === undefined) return normalizeTitleBold(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleBold(override);
+}
+
+/**
+ * Normalize a `titleItalic` value for the cloned `SheetChart`. Mirrors
+ * the writer's `normalizeTitleItalic` — the cloned shape is guaranteed
+ * to round-trip through the writer without surprise: `true` / `false`
+ * pass through literally, every other token (typed escape from an
+ * untyped caller) collapses to `undefined` so the cloned chart drops
+ * the field rather than carry a value the writer would silently elide
+ * back to absence.
+ */
+function normalizeTitleItalic(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `titleItalic` override.
+ *
+ * `undefined` → inherit the source's parsed `titleItalic`.
+ * `null`      → drop the inherited flag (the writer falls back to the
+ *               OOXML default — no `i` attribute, equivalent to
+ *               non-italic).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `titleBold` / `titleFontSize` / `titleRotation`
+ * / `titleOverlay` so the chart-level title knobs compose the same way
+ * at the call site. Callers should gate the result on the resolved
+ * title visibility — when no title is emitted, the flag has no slot
+ * in the rendered chart.
+ */
+function resolveTitleItalic(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeTitleItalic(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleItalic(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -132,6 +132,19 @@ export function parseChart(xml: string): Chart | undefined {
   const titleBold = parseTitleBold(chartEl);
   if (titleBold !== undefined) out.titleBold = titleBold;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` mirrors Excel's "Format Chart Title ->
+  // Font -> Italic" toggle. Same scope rule as the bold flag — a chart
+  // that omits `<c:title>` (or whose title is a `<c:strRef>` formula
+  // reference with no `<c:rich>` body) has no `<a:p>` slot to surface
+  // the flag from, so the helper short-circuits to `undefined`. The
+  // OOXML default `false` collapses to `undefined` so absence and
+  // `i="0"` round-trip identically through {@link cloneChart} — only
+  // an explicit `i="1"` surfaces `true`. The value threads straight
+  // back into the writer-side {@link SheetChart.titleItalic} field.
+  const titleItalic = parseTitleItalic(chartEl);
+  if (titleItalic !== undefined) out.titleItalic = titleItalic;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -2158,6 +2171,55 @@ function parseTitleBold(chartEl: XmlElement): boolean | undefined {
   // The OOXML default `false` collapses to `undefined` so absence and
   // `b="0"` round-trip identically through the writer — only an
   // explicit `b="1"` surfaces `true`.
+  if (parsed === true) return true;
+  return undefined;
+}
+
+// ── Title Italic ─────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` off the chart. Returns the italic
+ * flag.
+ *
+ * The OOXML `i` attribute is the `xsd:boolean` italic flag on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7). The
+ * OOXML default `false` collapses to `undefined` so absence and
+ * `i="0"` round-trip identically — only an explicit `i="1"` surfaces
+ * `true`. Unknown / malformed `i` tokens drop to `undefined` rather
+ * than fabricate a value the writer would never emit.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` element
+ * — there is no `<a:p>` slot to surface the flag from in that case —
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body. The `<a:defRPr>` lives inside
+ * `<c:tx><c:rich><a:p><a:pPr>` per the CT_Title schema (the
+ * default-paragraph properties on the rich-text body's first
+ * paragraph); the lookup is scoped to that path so a stray
+ * `<a:defRPr>` elsewhere in the chart (e.g. on an axis title or a
+ * data-labels block) cannot leak in.
+ */
+function parseTitleItalic(chartEl: XmlElement): boolean | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph italic flag. The reader walks the canonical chain
+  // and bails on the first missing link so a malformed `<c:rich>`
+  // surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const parsed = parseBoolAttr(defRPr.attrs.i);
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `i="0"` round-trip identically through the writer — only an
+  // explicit `i="1"` surfaces `true`.
   if (parsed === true) return true;
   return undefined;
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -74,6 +74,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleRotation(chart),
         resolveTitleFontSize(chart),
         resolveTitleBold(chart),
+        resolveTitleItalic(chart),
       ),
     );
   }
@@ -210,6 +211,7 @@ function buildTitle(
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
   bold: boolean | undefined,
+  italic: boolean | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -236,6 +238,16 @@ function buildTitle(
   // a re-parse picks the value up off either canonical slot — Excel
   // keeps the two attributes in sync.
   const b = bold ? 1 : 0;
+  // OOXML's `<a:defRPr i=".."/>` / `<a:rPr i=".."/>` attribute is the
+  // `xsd:boolean` italic flag on `CT_TextCharacterProperties`. Mirrors
+  // the bold pattern: `titleItalic` lands on both the default-paragraph
+  // `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks
+  // the value up off either canonical slot — Excel keeps the two
+  // attributes in sync. Absence (`undefined`) and explicit `false` both
+  // collapse to omitting the attribute so a fresh chart matches Excel's
+  // reference serialization byte-for-byte (Excel itself omits `i` when
+  // the title is non-italic — only the bold flag is always emitted).
+  const i = italic === true ? 1 : undefined;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -253,9 +265,9 @@ function buildTitle(
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b })]),
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b, i })]),
           xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz, b }),
+            xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i }),
             xmlElement("a:t", undefined, xmlEscape(title)),
           ]),
         ]),
@@ -407,6 +419,39 @@ function normalizeTitleBold(value: boolean | undefined): boolean | undefined {
  */
 function resolveTitleBold(chart: SheetChart): boolean | undefined {
   return normalizeTitleBold(chart.titleBold);
+}
+
+/**
+ * Normalize a {@link SheetChart.titleItalic} value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` writer slot. Returns the literal
+ * boolean when the input is `true` / `false`, or `undefined` for any
+ * other token (including `null`-shaped escapes from an untyped
+ * caller). Absence and non-boolean tokens both collapse to
+ * `undefined` so the writer omits the `i` attribute (Excel's reference
+ * serialization for a non-italic title — the OOXML default `false`
+ * collapses to absence).
+ */
+function normalizeTitleItalic(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` from
+ * {@link SheetChart.titleItalic}.
+ *
+ * Returns the literal boolean, or `undefined` when the chart leaves
+ * the field unset / passed a non-boolean token. The flag is only
+ * meaningful when the chart actually emits a title — the caller is
+ * expected to gate the call on `showTitle && chart.title`. A chart
+ * whose title is suppressed has no `<c:title>` block to host the flag
+ * in either case.
+ */
+function resolveTitleItalic(chart: SheetChart): boolean | undefined {
+  return normalizeTitleItalic(chart.titleItalic);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10546,6 +10546,192 @@ describe("cloneChart — title bold", () => {
   });
 });
 
+// ── cloneChart — title italic ───────────────────────────────────────
+
+describe("cloneChart — title italic", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleItalic by default", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleItalic).toBe(true);
+  });
+
+  it("lets options.titleItalic override the source's value", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleItalic: false,
+    });
+    expect(clone.titleItalic).toBe(false);
+  });
+
+  it("drops the inherited titleItalic when the override is null", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleItalic: null,
+    });
+    expect(clone.titleItalic).toBeUndefined();
+  });
+
+  it("returns undefined titleItalic when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleItalic).toBeUndefined();
+  });
+
+  it("lets options.titleItalic pin true on a non-italic source", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleItalic: true,
+    });
+    expect(clone.titleItalic).toBe(true);
+  });
+
+  it("drops a non-boolean override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleItalic: "true" as any,
+    });
+    // Override is non-boolean, so it collapses to drop — and the
+    // inherited value is replaced by the dropped override (not
+    // inherited).
+    expect(clone.titleItalic).toBeUndefined();
+  });
+
+  it("drops the cloned titleItalic when the resolved title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleItalic).toBeUndefined();
+  });
+
+  it("drops the cloned titleItalic when showTitle is false", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleItalic).toBeUndefined();
+  });
+
+  it("preserves titleItalic when an override pins a fresh title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleItalic: true,
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleItalic).toBe(true);
+  });
+
+  it("composes with titleBold / titleFontSize / titleRotation / titleOverlay", () => {
+    const clone = cloneChart(
+      source({ titleItalic: true, titleBold: true, titleFontSize: 18, titleRotation: -45 }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        titleOverlay: true,
+      },
+    );
+    expect(clone.titleItalic).toBe(true);
+    expect(clone.titleBold).toBe(true);
+    expect(clone.titleFontSize).toBe(18);
+    expect(clone.titleRotation).toBe(-45);
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("threads through line -> column flatten", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleItalic).toBe(true);
+  });
+
+  it("threads through line -> doughnut flatten", () => {
+    const clone = cloneChart(source({ titleItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleItalic).toBe(true);
+  });
+
+  it("end-to-end parse -> clone -> write -> reparse round-trip", async () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2000" i="1"/></a:pPr><a:r><a:t>Source</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$3</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(xml)!;
+    expect(parsed.titleItalic).toBe(true);
+
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleItalic).toBe(true);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Region", "Revenue"],
+            ["North", 100],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('i="1"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleItalic).toBe(true);
+  });
+});
+
 describe("cloneChart — axis title rotation", () => {
   function source(extra?: Partial<Chart>): Chart {
     return {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9665,6 +9665,162 @@ describe("writeChart — title bold", () => {
   });
 });
 
+// ── writeChart — title italic ───────────────────────────────────────
+
+describe("writeChart — title italic", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrIOf(xml: string): string | undefined {
+    // The title's <a:defRPr> lives inside <c:title><c:tx><c:rich><a:p><a:pPr>.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const i = m[0].match(/\bi="([^"]+)"/);
+    return i ? i[1] : undefined;
+  }
+
+  function rPrIOf(xml: string): string | undefined {
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const i = m[0].match(/\bi="([^"]+)"/);
+    return i ? i[1] : undefined;
+  }
+
+  it("omits the i attribute by default (matches Excel's reference non-italic title)", () => {
+    // Excel itself omits `i` on a non-italic title — the OOXML default
+    // `false` collapses to absence of the attribute. Only the bold flag
+    // is always emitted.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(defRPrIOf(result.chartXml)).toBeUndefined();
+    expect(rPrIOf(result.chartXml)).toBeUndefined();
+  });
+
+  it('emits i="1" on titleItalic=true', () => {
+    const result = writeChart(makeChart({ titleItalic: true }), "Sheet1");
+    expect(defRPrIOf(result.chartXml)).toBe("1");
+    expect(rPrIOf(result.chartXml)).toBe("1");
+  });
+
+  it("omits the i attribute on titleItalic=false (functionally identical to omission)", () => {
+    const result = writeChart(makeChart({ titleItalic: false }), "Sheet1");
+    expect(defRPrIOf(result.chartXml)).toBeUndefined();
+    expect(rPrIOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (defends against type guard escape)", () => {
+    const result = writeChart(makeChart({ titleItalic: "true" as any }), "Sheet1");
+    expect(defRPrIOf(result.chartXml)).toBeUndefined();
+    const result2 = writeChart(makeChart({ titleItalic: 1 as any }), "Sheet1");
+    expect(defRPrIOf(result2.chartXml)).toBeUndefined();
+  });
+
+  it("ignores titleItalic when the chart renders no title (showTitle=false)", () => {
+    // The whole `<c:title>` block is suppressed — no `<a:defRPr>` to
+    // host the italic flag.
+    const result = writeChart(makeChart({ showTitle: false, titleItalic: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleItalic when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleItalic: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleBold, titleFontSize, titleRotation, and titleOverlay", () => {
+    const result = writeChart(
+      makeChart({
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 24,
+        titleRotation: -45,
+        titleOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("preserves the title body's other attributes (lang='en-US', sz, b)", () => {
+    const result = writeChart(makeChart({ titleItalic: true }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('lang="en-US"');
+    // The default 14pt size still lands on both slots even when italic flips.
+    expect(titleBlock.match(/sz="1400"/g)?.length).toBeGreaterThanOrEqual(2);
+    // The default `b="0"` (non-bold) is still emitted on both slots.
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+    // `i="1"` lands on both the <a:defRPr> and the <a:rPr>.
+    expect(titleBlock.match(/i="1"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleItalic: true }), "Sheet1");
+      expect(defRPrIOf(result.chartXml)).toBe("1");
+    }
+  });
+
+  it("parse round-trip surfaces titleItalic from the writer's output", () => {
+    const written = writeChart(makeChart({ titleItalic: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleItalic).toBe(true);
+  });
+
+  it("collapses the default (non-italic) round-trip back to undefined", () => {
+    // A fresh chart omits the `i` attribute; the reader collapses
+    // absence to `undefined` so absence and the default round-trip
+    // identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleItalic).toBeUndefined();
+  });
+
+  it("collapses the explicit titleItalic=false round-trip back to undefined", () => {
+    // titleItalic=false omits the `i` attribute (the OOXML default)
+    // which the reader collapses to `undefined`. So pinning `false` is
+    // functionally equivalent to absence on round-trip.
+    const written = writeChart(makeChart({ titleItalic: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleItalic).toBeUndefined();
+  });
+
+  it("writeXlsx package round-trip surfaces titleItalic from the chart part", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Revenue"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Quarterly Revenue",
+            titleItalic: true,
+            series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('i="1"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleItalic).toBe(true);
+  });
+});
+
 // ── writeChart — axis title rotation ────────────────────────────────
 
 describe("writeChart — axis title rotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10207,6 +10207,194 @@ describe("parseChart — title bold", () => {
   });
 });
 
+// ── parseChart — title italic ────────────────────────────────────────
+
+describe("parseChart — title italic", () => {
+  const NS_TI = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleItalic(i: string | undefined): string {
+    const defRPr = i === undefined ? "<a:defRPr/>" : `<a:defRPr i="${i}"/>`;
+    return `<c:chartSpace ${NS_TI}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true when the title pinned i='1'", () => {
+    const chart = parseChart(withTitleItalic("1"));
+    expect(chart?.titleItalic).toBe(true);
+  });
+
+  it("collapses i='0' to undefined (OOXML default round-trips identically)", () => {
+    const chart = parseChart(withTitleItalic("0"));
+    expect(chart?.titleItalic).toBeUndefined();
+  });
+
+  it("collapses absence of the i attribute to undefined", () => {
+    const chart = parseChart(withTitleItalic(undefined));
+    expect(chart?.titleItalic).toBeUndefined();
+  });
+
+  it("accepts the OOXML truthy spelling 'true'", () => {
+    const chart = parseChart(withTitleItalic("true"));
+    expect(chart?.titleItalic).toBe(true);
+  });
+
+  it("collapses the OOXML falsy spelling 'false' to undefined", () => {
+    const chart = parseChart(withTitleItalic("false"));
+    expect(chart?.titleItalic).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TI}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleItalic).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body (strRef)", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:p><a:pPr><a:defRPr>` to host the italic flag.
+    const xml = `<c:chartSpace ${NS_TI}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleItalic).toBeUndefined();
+    expect(chart?.title).toBe("Revenue");
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_TI}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleItalic).toBeUndefined();
+  });
+
+  it("drops unknown i tokens to undefined", () => {
+    expect(parseChart(withTitleItalic("yes"))?.titleItalic).toBeUndefined();
+    expect(parseChart(withTitleItalic("on"))?.titleItalic).toBeUndefined();
+    expect(parseChart(withTitleItalic(""))?.titleItalic).toBeUndefined();
+  });
+
+  it("does not leak from a stray axis-title <a:defRPr>", () => {
+    // The category axis title carries an italic <a:defRPr i="1"/>, but
+    // the chart-level title does not — `titleItalic` reflects only the
+    // chart-level title's <a:defRPr>, not a stray sibling element.
+    const xml = `<c:chartSpace ${NS_TI}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Header</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleItalic).toBeUndefined();
+  });
+
+  it("co-surfaces alongside titleBold, titleFontSize, titleRotation, and titleOverlay", () => {
+    const xml = `<c:chartSpace ${NS_TI}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400" b="1" i="1"/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Hero");
+    expect(chart?.titleItalic).toBe(true);
+    expect(chart?.titleBold).toBe(true);
+    expect(chart?.titleFontSize).toBe(24);
+    expect(chart?.titleRotation).toBe(-45);
+    expect(chart?.titleOverlay).toBe(true);
+  });
+});
+
 // ── parseChart — axis title rotation ─────────────────────────────────
 
 describe("parseChart — axis title rotation", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr><a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title>` (CT_TextCharacterProperties' italic flag — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's italic chart title survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

`<a:defRPr i=".."/>` mirrors Excel's "Format Chart Title -> Font -> Italic" toggle. Until now hucre's writer never emitted the attribute (the title always rendered non-italic) and the reader ignored the attribute entirely, so a templated dashboard chart whose user italicized the title for emphasis silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Mirrors the chart-level `titleBold` field added in #252 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same title-presence scope rule (silently ignored when `showTitle === false` or no literal title), same `boolean | null` clone grammar (`undefined` inherits, `null` drops, a literal boolean replaces) — so a single configuration call threads cleanly through every chart-title knob Excel exposes (bold, italic, size, rotation, overlay) without bookkeeping the canonical OOXML slots.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleItalic);
// true       <- when the template pinned <a:defRPr i="1"/> on the title's <a:p><a:pPr>
// undefined  <- when the template emits i="0" or omits the attribute (Excel's reference non-italic)
// undefined  <- when the chart has no <c:title> or the title is a <c:strRef> formula reference

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Region", "Revenue"],
      ["North", 100],
      ["South", 200],
    ],
    charts: [{
      type: "column",
      title: "Quarterly Revenue",
      // Italicize the title for a hero dashboard tile.
      titleItalic: true,
      series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   -> inherits the source's parsed titleItalic unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleItalic: null,
});
//   -> drops the inherited italic flag (writer falls back to the OOXML default — no `i` attribute).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleItalic: false,
});
//   -> replaces the inherited flag with explicit non-italic (omits `i` on emit).
```

## Implementation notes

- **Type model**: `SheetChart.titleItalic?: boolean` (writer side); `Chart.titleItalic?: boolean` (reader side). The clone option `titleItalic?: boolean | null` follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar. Same shape as `titleBold` so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseTitleItalic`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:rich></c:tx></c:title>` for the `i` attribute. The lookup is scoped to the title's default-paragraph slot so a stray `<a:defRPr>` elsewhere in the chart (e.g. on an axis title or a data-labels block) cannot leak in. Uses the existing `parseBoolAttr` helper to accept the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing `i` attributes drop to `undefined`. The OOXML default `false` collapses to `undefined` so absence and `i="0"` round-trip identically — only an explicit `i="1"` surfaces `true`. Returns `undefined` when the chart has no `<c:title>` element, or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body — there is no `<a:p>` slot to host the flag in either case.
- **Writer**: `buildTitle` now resolves through an `italic?: boolean` parameter — `normalizeTitleItalic` accepts only literal booleans and collapses every other token (typed escapes from an untyped caller) to `undefined`. Unlike `titleBold` (which Excel always emits), Excel itself omits the `i` attribute on a non-italic title, so the writer follows suit: only an explicit `true` produces `i="1"` on both the `<a:defRPr>` and the `<a:rPr>`; absence and `false` both omit the attribute. Other title attributes (`<a:bodyPr>` rotation, `sz`, `b`, `lang="en-US"`) are preserved exactly; only the `i` attribute changes.
- **Clone** (`resolveTitleItalic`): follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same `titleRendered` gate the writer uses — when the resolved title is dropped (`title: null` or `showTitle: false`), the inherited flag drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only literal `true` / `false` survive the type guard at every layer; non-boolean inputs collapse to the default. This matches how `titleBold` / `titleOverlay` / `roundedCorners` / `plotVisOnly` treat their inputs.

## Test plan

- [x] `parseChart — title italic` (10 new tests) — surfaces `true` from `i="1"`, collapses `i="0"` and absence to `undefined`, accepts truthy / falsy spellings (`"true"` / `"false"`), returns undefined when `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>`, drops unknown / empty tokens, does not leak from a stray axis-title `<a:defRPr>`, co-surfaces alongside `titleBold` / `titleFontSize` / `titleRotation` / `titleOverlay`.
- [x] `writeChart — title italic` (12 new tests) — omits `i` by default, emits `i="1"` on `true`, omits `i` on `false` (functionally equivalent to omission), drops non-boolean inputs back to the default, ignores the flag when the chart renders no title (`showTitle=false` or absent title), composes independently with `titleBold` / `titleFontSize` / `titleRotation` / `titleOverlay`, preserves the title body's other attributes (`lang="en-US"`, `sz`, `b`), threads through every chart family (bar / column / line / pie / scatter / area), parse round-trip, default round-trip collapses to `undefined`, explicit `false` round-trip also collapses to `undefined`, full `writeXlsx` package round-trip.
- [x] `cloneChart — title italic` (13 new tests) — inherit, replace (true to false), null drop, replace null source with true override, drop on non-boolean override, drop on `title: null`, drop on `showTitle: false`, preserve when an override pins a fresh title, composition with `titleBold` / `titleFontSize` / `titleRotation` / `titleOverlay`, threads through line -> column / line -> doughnut flatten, end-to-end parse -> clone -> write -> reparse round-trip.
- [x] `pnpm test` — all 4432 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)