### PR TITLE
feat(xlsx): chart title font color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1424,6 +1424,45 @@ export interface SheetChart {
    */
   titleItalic?: boolean;
   /**
+   * Chart title font color. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr>
+   * <a:r><a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+   * </a:rPr></a:r></a:p></c:rich></c:tx></c:title>` — Excel's
+   * "Format Chart Title -> Font -> Font Color" picker. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32); the
+   * writer lands the fill on both the default-paragraph `<a:defRPr>`
+   * and the literal run's `<a:rPr>` so a re-parse picks the color up
+   * off either canonical slot — Excel keeps the two values in sync.
+   *
+   * Accepts the standard 6-character hex string with or without a
+   * leading `#` (`"FF0000"` / `"#FF0000"` / `"ff0000"`); the writer
+   * normalizes to the OOXML uppercase canonical form
+   * (`<a:srgbClr val="FF0000"/>`). The 8-character `#RRGGBBAA` form
+   * is *not* accepted — alpha lives on `<a:srgbClr><a:alpha val=".."/>`
+   * which is a separate runs-level knob; pinning `titleColor` carries
+   * the RGB triple only.
+   *
+   * Default: omitted — the title renders in Excel's reference
+   * inherited theme color (no `<a:solidFill>` element, the writer
+   * skips the fill block entirely). Pin a hex value to render the
+   * title in that color (e.g. `"1070CA"` for the dashboard hero blue
+   * the issue-#136 example reaches for). Malformed inputs (wrong
+   * length, non-hex characters, alpha-channel form) collapse to
+   * `undefined` so a stray non-hex token never produces a malformed
+   * `<a:srgbClr>`.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * fill in either case. Composes independently with {@link titleBold}
+   * / {@link titleItalic} / {@link titleFontSize} /
+   * {@link titleRotation} / {@link titleOverlay}: all six fields land
+   * on the same `<c:title>` element so a single configuration call
+   * threads cleanly through every chart-title knob Excel exposes.
+   */
+  titleColor?: string;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -3761,6 +3800,31 @@ export interface Chart {
    * without transformation.
    */
   titleItalic?: boolean;
+  /**
+   * Chart title font color pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>`. Reflects Excel's "Format Chart
+   * Title -> Font -> Font Color" picker.
+   *
+   * Surfaced as the 6-character uppercase hex string the writer round-
+   * trips (`"FF0000"` / `"1070CA"`) — the leading `#` is stripped on
+   * read so the value threads straight into the writer-side
+   * {@link SheetChart.titleColor} without transformation. Color picks
+   * other than the literal sRGB form (`<a:schemeClr>` theme references,
+   * `<a:hslClr>`, `<a:sysClr>`, `<a:prstClr>`) collapse to `undefined`
+   * — the reader records only the resolvable RGB triple to keep the
+   * round-trip lossless against {@link cloneChart} -> {@link writeXlsx}.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body, when the
+   * `<a:defRPr>` slot has no `<a:solidFill>` child (the title inherits
+   * the theme's text color in that case), or when the `<a:srgbClr>`
+   * `val` is malformed (wrong length, non-hex characters). There is
+   * no `<a:p>` to host the fill in any of those cases.
+   */
+  titleColor?: string;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -332,6 +332,29 @@ export interface CloneChartOptions {
    */
   titleItalic?: boolean | null;
   /**
+   * Override the chart-level title font color.
+   * `undefined` (or omitted) inherits the source's parsed value;
+   * `null` drops the inherited fill so the writer falls back to the
+   * theme text color (no `<a:solidFill>` element on the title's
+   * default-paragraph properties);
+   * a 6-character hex string (with or without a leading `#`)
+   * replaces it.
+   *
+   * Malformed overrides (wrong length, non-hex characters,
+   * alpha-channel forms, non-string escapes) collapse to a drop so
+   * the cloned `SheetChart` always carries a value the writer will
+   * accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the fill in either case. The grammar mirrors
+   * `titleBold` / `titleItalic` / `titleFontSize` / `titleRotation`
+   * / `titleOverlay` so the chart-level title knobs compose the same
+   * way at the call site.
+   */
+  titleColor?: string | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1152,6 +1175,17 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // the writer will accept.
     const resolvedTitleItalic = resolveTitleItalic(source.titleItalic, options.titleItalic);
     if (resolvedTitleItalic !== undefined) out.titleItalic = resolvedTitleItalic;
+
+    // `titleColor` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr><a:solidFill>` slot for the
+    // writer to populate. Same scope rule as `titleOverlay` /
+    // `titleRotation` / `titleFontSize` / `titleBold` / `titleItalic`:
+    // the override wins over the source's parsed value; absence
+    // inherits, `null` drops, a hex string replaces. Malformed
+    // overrides collapse via the normalizer so the cloned
+    // `SheetChart` always carries a value the writer will accept.
+    const resolvedTitleColor = resolveTitleColor(source.titleColor, options.titleColor);
+    if (resolvedTitleColor !== undefined) out.titleColor = resolvedTitleColor;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -2238,6 +2272,51 @@ function resolveTitleItalic(
   if (override === undefined) return normalizeTitleItalic(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleItalic(override);
+}
+
+/**
+ * Normalize a `titleColor` value for the cloned `SheetChart`. Mirrors
+ * the writer's `normalizeTitleColor` — the cloned shape is guaranteed
+ * to round-trip through the writer without surprise: a valid sRGB
+ * hex string (with or without a leading `#`) collapses to the
+ * 6-character uppercase canonical form; every malformed input (wrong
+ * length, non-hex characters, alpha-channel forms, non-string
+ * escapes) collapses to `undefined` so the cloned chart drops the
+ * field rather than carry a value the writer would silently elide.
+ */
+function normalizeTitleColor(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
+}
+
+/**
+ * Resolve a `titleColor` override.
+ *
+ * `undefined` → inherit the source's parsed `titleColor`.
+ * `null`      → drop the inherited fill (the writer falls back to the
+ *               theme text color — no `<a:solidFill>` block on the
+ *               title's default-paragraph properties).
+ * `string`    → replace with the normalized 6-character uppercase
+ *               hex form.
+ *
+ * The grammar mirrors `titleBold` / `titleItalic` / `titleFontSize` /
+ * `titleRotation` / `titleOverlay` so the chart-level title knobs
+ * compose the same way at the call site. Callers should gate the
+ * result on the resolved title visibility — when no title is
+ * emitted, the fill has no slot in the rendered chart.
+ */
+function resolveTitleColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -145,6 +145,20 @@ export function parseChart(xml: string): Chart | undefined {
   const titleItalic = parseTitleItalic(chartEl);
   if (titleItalic !== undefined) out.titleItalic = titleItalic;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+  // <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` mirrors Excel's "Format Chart Title ->
+  // Font -> Font Color" picker. Same scope rule as the bold/italic
+  // flags — a chart that omits `<c:title>` (or whose title is a
+  // `<c:strRef>` formula reference with no `<c:rich>` body) has no
+  // `<a:p>` slot to surface the fill from, so the helper short-circuits
+  // to `undefined`. Non-sRGB color picks (`<a:schemeClr>` theme refs,
+  // `<a:hslClr>`, etc.) collapse to `undefined` since only the literal
+  // RGB triple round-trips losslessly through the writer. The value
+  // threads straight back into the writer-side {@link SheetChart.titleColor}.
+  const titleColor = parseTitleColor(chartEl);
+  if (titleColor !== undefined) out.titleColor = titleColor;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -2222,6 +2236,76 @@ function parseTitleItalic(chartEl: XmlElement): boolean | undefined {
   // explicit `i="1"` surfaces `true`.
   if (parsed === true) return true;
   return undefined;
+}
+
+// ── Title Color ─────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` off the chart. Returns the title's
+ * sRGB font color as a 6-character uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr val=".."/>` is the literal sRGB triple Excel
+ * lands on the title's default-paragraph properties when the user
+ * picks a custom font color. Theme references (`<a:schemeClr>`),
+ * `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>` all collapse to
+ * `undefined` — only the literal RGB triple round-trips losslessly
+ * through {@link writeChart}. Malformed `val` tokens (wrong length,
+ * non-hex characters) likewise drop to `undefined` rather than
+ * fabricate a value the writer would round-trip into a malformed
+ * `<a:srgbClr>`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>`
+ * element — there is no `<a:p>` slot to surface the fill from in
+ * that case — or when the title is a `<c:strRef>` (formula
+ * reference) with no `<c:rich>` body. The `<a:solidFill>` lives
+ * inside `<c:tx><c:rich><a:p><a:pPr><a:defRPr>` per the CT_Title
+ * schema (the default-paragraph properties on the rich-text body's
+ * first paragraph); the lookup is scoped to that path so a stray
+ * `<a:solidFill>` elsewhere in the chart (e.g. on an axis title or
+ * a data-labels block) cannot leak in.
+ */
+function parseTitleColor(chartEl: XmlElement): string | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr>` is the OOXML path
+  // Excel writes for the default-paragraph font color. The reader
+  // walks the canonical chain and bails on the first missing link so
+  // a malformed `<c:rich>` surfaces as absence rather than a
+  // fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const solidFill = findChild(defRPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  const raw = srgbClr.attrs.val;
+  return normalizeRgbHex(raw);
+}
+
+/**
+ * Normalize an sRGB hex token. Returns the 6-character uppercase form
+ * when the input is a valid 6-character hex string (with or without a
+ * leading `#`), or `undefined` for any malformed input — wrong length,
+ * non-hex characters, alpha-channel forms, or non-string tokens.
+ */
+function normalizeRgbHex(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
 }
 
 // ── Auto Title Deleted ────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -75,6 +75,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleFontSize(chart),
         resolveTitleBold(chart),
         resolveTitleItalic(chart),
+        resolveTitleColor(chart),
       ),
     );
   }
@@ -212,6 +213,7 @@ function buildTitle(
   fontSizePt: number | undefined,
   bold: boolean | undefined,
   italic: boolean | undefined,
+  rgbHex: string | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -248,6 +250,29 @@ function buildTitle(
   // reference serialization byte-for-byte (Excel itself omits `i` when
   // the title is non-italic — only the bold flag is always emitted).
   const i = italic === true ? 1 : undefined;
+  // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></a:defRPr>` carries the title's font color. The
+  // writer holds `titleColor` as a 6-character uppercase hex string
+  // and lands the `<a:solidFill>` block on both the default-paragraph
+  // `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks
+  // the value up off either canonical slot. Absence (`undefined`)
+  // collapses to omitting the entire `<a:solidFill>` block so the
+  // title inherits the theme text color (Excel's reference behavior
+  // for a fresh chart title that has not had a custom color picked).
+  const solidFillChild = rgbHex
+    ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
+    : undefined;
+  // When a fill color is set the `<a:defRPr>` / `<a:rPr>` slots
+  // expand from self-closing to wrapping the `<a:solidFill>` child;
+  // otherwise the writer keeps the existing self-closing form so a
+  // fresh chart with no custom color matches Excel's reference
+  // serialization byte-for-byte.
+  const defRPr = solidFillChild
+    ? xmlElement("a:defRPr", { sz, b, i }, [solidFillChild])
+    : xmlSelfClose("a:defRPr", { sz, b, i });
+  const rPr = solidFillChild
+    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i }, [solidFillChild])
+    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -265,11 +290,8 @@ function buildTitle(
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b, i })]),
-          xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i }),
-            xmlElement("a:t", undefined, xmlEscape(title)),
-          ]),
+          xmlElement("a:pPr", undefined, [defRPr]),
+          xmlElement("a:r", undefined, [rPr, xmlElement("a:t", undefined, xmlEscape(title))]),
         ]),
       ]),
     ]),
@@ -452,6 +474,47 @@ function normalizeTitleItalic(value: boolean | undefined): boolean | undefined {
  */
 function resolveTitleItalic(chart: SheetChart): boolean | undefined {
   return normalizeTitleItalic(chart.titleItalic);
+}
+
+/**
+ * Normalize a {@link SheetChart.titleColor} value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` writer slot. Returns the 6-character
+ * uppercase hex form when the input is a valid sRGB triple (with or
+ * without a leading `#`), or `undefined` for any malformed token —
+ * wrong length, non-hex characters, alpha-channel forms, or
+ * non-string escapes from an untyped caller.
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<a:solidFill>` block and the title
+ * inherits the theme text color (Excel's reference behavior for a
+ * fresh chart title without a custom color).
+ */
+function normalizeTitleColor(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` from {@link SheetChart.titleColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the chart leaves the field unset / passed a
+ * malformed token. The fill is only meaningful when the chart
+ * actually emits a title — the caller is expected to gate the call
+ * on `showTitle && chart.title`. A chart whose title is suppressed
+ * has no `<c:title>` block to host the fill in either case.
+ */
+function resolveTitleColor(chart: SheetChart): string | undefined {
+  return normalizeTitleColor(chart.titleColor);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10732,6 +10732,220 @@ describe("cloneChart — title italic", () => {
   });
 });
 
+// ── cloneChart — title color ────────────────────────────────────────
+
+describe("cloneChart — title color", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleColor by default", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleColor).toBe("1070CA");
+  });
+
+  it("lets options.titleColor override the source's value", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: "FF0000",
+    });
+    expect(clone.titleColor).toBe("FF0000");
+  });
+
+  it("normalizes a lowercase override to uppercase", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: "ff8800",
+    });
+    expect(clone.titleColor).toBe("FF8800");
+  });
+
+  it("strips a leading '#' from the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: "#1070CA",
+    });
+    expect(clone.titleColor).toBe("1070CA");
+  });
+
+  it("drops the inherited titleColor when the override is null", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: null,
+    });
+    expect(clone.titleColor).toBeUndefined();
+  });
+
+  it("returns undefined titleColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleColor).toBeUndefined();
+  });
+
+  it("lets options.titleColor pin a color on a sourceless chart", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: "FF0000",
+    });
+    expect(clone.titleColor).toBe("FF0000");
+  });
+
+  it("drops a malformed override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: "ZZZZZZ" as any,
+    });
+    expect(clone.titleColor).toBeUndefined();
+  });
+
+  it("drops a non-string override", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleColor: 0xff0000 as any,
+    });
+    expect(clone.titleColor).toBeUndefined();
+  });
+
+  it("drops the cloned titleColor when the resolved title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleColor).toBeUndefined();
+  });
+
+  it("drops the cloned titleColor when showTitle is false", () => {
+    const clone = cloneChart(source({ titleColor: "1070CA" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleColor).toBeUndefined();
+  });
+
+  it("preserves titleColor when an override pins a fresh title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleColor: "1070CA",
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleColor).toBe("1070CA");
+  });
+
+  it("composes with titleBold / titleItalic / titleFontSize / titleRotation / titleOverlay", () => {
+    const clone = cloneChart(
+      source({
+        titleColor: "1070CA",
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 18,
+        titleRotation: -45,
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        titleOverlay: true,
+      },
+    );
+    expect(clone.titleColor).toBe("1070CA");
+    expect(clone.titleItalic).toBe(true);
+    expect(clone.titleBold).toBe(true);
+    expect(clone.titleFontSize).toBe(18);
+    expect(clone.titleRotation).toBe(-45);
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("threads through line -> column flatten", () => {
+    const clone = cloneChart(source({ titleColor: "FF0000" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleColor).toBe("FF0000");
+  });
+
+  it("threads through line -> doughnut flatten", () => {
+    const clone = cloneChart(source({ titleColor: "FF0000" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleColor).toBe("FF0000");
+  });
+
+  it("end-to-end parse -> clone -> write -> reparse round-trip", async () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2000"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Source</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$3</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(xml)!;
+    expect(parsed.titleColor).toBe("1070CA");
+
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleColor).toBe("1070CA");
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Region", "Revenue"],
+            ["North", 100],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('val="1070CA"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleColor).toBe("1070CA");
+  });
+});
+
 describe("cloneChart — axis title rotation", () => {
   function source(extra?: Partial<Chart>): Chart {
     return {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9821,6 +9821,184 @@ describe("writeChart — title italic", () => {
   });
 });
 
+// ── writeChart — title color ────────────────────────────────────────
+
+describe("writeChart — title color", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrSrgbOf(xml: string): string | undefined {
+    // <a:defRPr><a:solidFill><a:srgbClr val=".."/></a:solidFill></a:defRPr>
+    const titleBlock = titleBlockOf(xml);
+    const defBlock = titleBlock.match(/<a:defRPr\b[\s\S]*?<\/a:defRPr>/)?.[0];
+    if (!defBlock) return undefined;
+    const m = defBlock.match(/<a:srgbClr\s+val="([^"]+)"/);
+    return m ? m[1] : undefined;
+  }
+
+  function rPrSrgbOf(xml: string): string | undefined {
+    const titleBlock = titleBlockOf(xml);
+    const rBlock = titleBlock.match(/<a:rPr\b[\s\S]*?<\/a:rPr>/)?.[0];
+    if (!rBlock) return undefined;
+    const m = rBlock.match(/<a:srgbClr\s+val="([^"]+)"/);
+    return m ? m[1] : undefined;
+  }
+
+  it("omits the <a:solidFill> block by default (theme-color inherited)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).not.toContain("<a:solidFill>");
+    expect(titleBlock).not.toContain("<a:srgbClr");
+    // The <a:defRPr> / <a:rPr> stay self-closing in the default case so
+    // a fresh chart matches Excel's reference serialization.
+    expect(titleBlock).toContain("<a:defRPr ");
+    expect(titleBlock).toContain("<a:rPr ");
+  });
+
+  it("emits <a:solidFill><a:srgbClr val='..'/></a:solidFill> on titleColor='FF0000'", () => {
+    const result = writeChart(makeChart({ titleColor: "FF0000" }), "Sheet1");
+    expect(defRPrSrgbOf(result.chartXml)).toBe("FF0000");
+    expect(rPrSrgbOf(result.chartXml)).toBe("FF0000");
+  });
+
+  it("normalizes a lowercase hex input to uppercase", () => {
+    const result = writeChart(makeChart({ titleColor: "1070ca" }), "Sheet1");
+    expect(defRPrSrgbOf(result.chartXml)).toBe("1070CA");
+    expect(rPrSrgbOf(result.chartXml)).toBe("1070CA");
+  });
+
+  it("strips a leading '#' on emit", () => {
+    const result = writeChart(makeChart({ titleColor: "#1070CA" }), "Sheet1");
+    expect(defRPrSrgbOf(result.chartXml)).toBe("1070CA");
+    expect(rPrSrgbOf(result.chartXml)).toBe("1070CA");
+  });
+
+  it("drops malformed inputs back to the OOXML default (defends against type-guard escape)", () => {
+    expect(
+      defRPrSrgbOf(writeChart(makeChart({ titleColor: "" }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      defRPrSrgbOf(writeChart(makeChart({ titleColor: "FFF" }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      defRPrSrgbOf(writeChart(makeChart({ titleColor: "ZZZZZZ" }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      defRPrSrgbOf(writeChart(makeChart({ titleColor: "FF0000FF" }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      defRPrSrgbOf(writeChart(makeChart({ titleColor: 0xff0000 as any }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      defRPrSrgbOf(writeChart(makeChart({ titleColor: null as any }), "Sheet1").chartXml),
+    ).toBeUndefined();
+  });
+
+  it("ignores titleColor when the chart renders no title (showTitle=false)", () => {
+    const result = writeChart(makeChart({ showTitle: false, titleColor: "FF0000" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleColor when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleColor: "FF0000" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleBold, titleItalic, titleFontSize, titleRotation, and titleOverlay", () => {
+    const result = writeChart(
+      makeChart({
+        titleColor: "1070CA",
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 24,
+        titleRotation: -45,
+        titleOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('val="1070CA"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("preserves the title body's other attributes (lang='en-US', sz, b)", () => {
+    const result = writeChart(makeChart({ titleColor: "FF0000" }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('lang="en-US"');
+    // The default 14pt size still lands on both slots when color flips.
+    expect(titleBlock.match(/sz="1400"/g)?.length).toBeGreaterThanOrEqual(2);
+    // The default `b="0"` (non-bold) is still emitted on both slots.
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+    // `<a:srgbClr val="FF0000"/>` lands on both the <a:defRPr> and the <a:rPr>.
+    expect(titleBlock.match(/val="FF0000"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleColor: "1070CA" }), "Sheet1");
+      expect(defRPrSrgbOf(result.chartXml)).toBe("1070CA");
+    }
+  });
+
+  it("parse round-trip surfaces titleColor from the writer's output", () => {
+    const written = writeChart(makeChart({ titleColor: "1070CA" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleColor).toBe("1070CA");
+  });
+
+  it("collapses the default (no-color) round-trip back to undefined", () => {
+    // A fresh chart emits no `<a:solidFill>`; the reader collapses
+    // absence to `undefined` so absence and the default round-trip
+    // identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleColor).toBeUndefined();
+  });
+
+  it("collapses a malformed titleColor input round-trip back to undefined", () => {
+    // Malformed inputs drop the `<a:solidFill>` block, which the
+    // reader collapses to `undefined`. So pinning a malformed token
+    // is functionally equivalent to absence on round-trip.
+    const written = writeChart(makeChart({ titleColor: "ZZZZZZ" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleColor).toBeUndefined();
+  });
+
+  it("writeXlsx package round-trip surfaces titleColor from the chart part", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Revenue"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Quarterly Revenue",
+            titleColor: "1070CA",
+            series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('val="1070CA"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleColor).toBe("1070CA");
+  });
+});
+
 // ── writeChart — axis title rotation ────────────────────────────────
 
 describe("writeChart — axis title rotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10395,6 +10395,216 @@ describe("parseChart — title italic", () => {
   });
 });
 
+// ── parseChart — title color ─────────────────────────────────────────
+
+describe("parseChart — title color", () => {
+  const NS_TC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleColor(srgb: string | undefined): string {
+    const fill = srgb === undefined ? "" : `<a:solidFill><a:srgbClr val="${srgb}"/></a:solidFill>`;
+    return `<c:chartSpace ${NS_TC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr>${fill}</a:defRPr></a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the uppercase hex value pinned by <a:srgbClr val='..'>", () => {
+    const chart = parseChart(withTitleColor("FF0000"));
+    expect(chart?.titleColor).toBe("FF0000");
+  });
+
+  it("normalizes a lowercase hex value to uppercase", () => {
+    const chart = parseChart(withTitleColor("1070ca"));
+    expect(chart?.titleColor).toBe("1070CA");
+  });
+
+  it("strips a leading '#' on read", () => {
+    const chart = parseChart(withTitleColor("#1070CA"));
+    expect(chart?.titleColor).toBe("1070CA");
+  });
+
+  it("collapses absence of <a:solidFill> to undefined (theme-color default)", () => {
+    const chart = parseChart(withTitleColor(undefined));
+    expect(chart?.titleColor).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a <c:strRef> formula reference", () => {
+    const xml = `<c:chartSpace ${NS_TC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBeUndefined();
+    expect(chart?.title).toBe("Revenue");
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_TC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBeUndefined();
+  });
+
+  it("collapses theme color (<a:schemeClr>) to undefined", () => {
+    // Theme references don't round-trip losslessly — only literal sRGB
+    // triples surface.
+    const xml = `<c:chartSpace ${NS_TC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Header</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBeUndefined();
+  });
+
+  it("drops malformed val tokens (wrong length / non-hex / 8-char alpha form)", () => {
+    expect(parseChart(withTitleColor(""))?.titleColor).toBeUndefined();
+    expect(parseChart(withTitleColor("FFF"))?.titleColor).toBeUndefined();
+    expect(parseChart(withTitleColor("ZZZZZZ"))?.titleColor).toBeUndefined();
+    // 8-character alpha form (Excel uses <a:alpha> sibling for that)
+    expect(parseChart(withTitleColor("FF0000FF"))?.titleColor).toBeUndefined();
+  });
+
+  it("does not leak from a stray axis-title <a:solidFill>", () => {
+    // The category axis title carries an italic-colored <a:solidFill>,
+    // but the chart-level title's defRPr has no fill — `titleColor`
+    // reflects only the chart-level title's defRPr.
+    const xml = `<c:chartSpace ${NS_TC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Header</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBeUndefined();
+  });
+
+  it("co-surfaces alongside titleBold, titleItalic, titleFontSize, titleRotation, and titleOverlay", () => {
+    const xml = `<c:chartSpace ${NS_TC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400" b="1" i="1"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Hero");
+    expect(chart?.titleColor).toBe("1070CA");
+    expect(chart?.titleItalic).toBe(true);
+    expect(chart?.titleBold).toBe(true);
+    expect(chart?.titleFontSize).toBe(24);
+    expect(chart?.titleRotation).toBe(-45);
+    expect(chart?.titleOverlay).toBe(true);
+  });
+});
+
 // ── parseChart — axis title rotation ─────────────────────────────────
 
 describe("parseChart — axis title rotation", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr><a:r><a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` (CT_SRgbColor inside CT_TextCharacterProperties' fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §21.1.2.3.7) at the read, write, and clone layers so a template's custom title font color survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Mirrors the chart-level `titleBold` / `titleItalic` fields added in #252 / #253 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same title-presence scope rule (silently ignored when `showTitle === false` or no literal title), same clone grammar (`undefined` inherits, `null` drops, a literal value replaces) — so a single configuration call threads cleanly through every chart-title knob Excel exposes (color, bold, italic, size, rotation, overlay) without bookkeeping the canonical OOXML slots.

Bridges another title-customization gap for the dashboard composition flow tracked in #136 — the issue's example explicitly calls for "axis labels, colors, and titles", and the title font color is the most visible knob a dashboard hero tile reaches for.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleColor);
// "1070CA"   <- when the template pinned <a:defRPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr>
// undefined  <- when the template emits no <a:solidFill> (theme text color inherited)
// undefined  <- when the chart has no <c:title> or the title is a <c:strRef> formula reference
// undefined  <- when the fill is a <a:schemeClr> theme reference (only literal sRGB triples round-trip)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [
      ["Region", "Revenue"],
      ["North", 100],
      ["South", 200],
    ],
    charts: [{
      type: "column",
      title: "Quarterly Revenue",
      // Render the title in the dashboard's hero blue.
      titleColor: "1070CA",
      series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   -> inherits the source's parsed titleColor unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleColor: null,
});
//   -> drops the inherited fill (writer falls back to the theme text color — no <a:solidFill>).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  titleColor: "#FF0000",
});
//   -> replaces the inherited fill with the dashboard's red accent (the leading '#' is stripped).
```

## Implementation notes

- **Type model**: `SheetChart.titleColor?: string` (writer side); `Chart.titleColor?: string` (reader side). The clone option `titleColor?: string | null` follows the standard `undefined` (inherit) / `null` (drop) / `string` (replace) grammar. The string format is the 6-character uppercase hex sRGB triple; the writer / reader / clone all accept a leading `#` and a lowercase form on input but normalize to the canonical uppercase form on output so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseTitleColor`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="..."/></a:solidFill></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>` for the `val` attribute. The lookup is scoped to the title's default-paragraph slot so a stray `<a:solidFill>` elsewhere in the chart (e.g. on an axis title or a data-labels block) cannot leak in. Theme references (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>` all collapse to `undefined` since only the literal RGB triple round-trips losslessly through the writer. Malformed `val` tokens (wrong length, non-hex characters, alpha-channel forms) likewise drop to `undefined` rather than fabricate a value the writer would round-trip into a malformed `<a:srgbClr>`. Returns `undefined` when the chart has no `<c:title>` element, or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body — there is no `<a:p>` slot to host the fill in either case.
- **Writer**: `buildTitle` now resolves through an `rgbHex?: string` parameter — `normalizeTitleColor` strips a leading `#`, validates the 6-character hex form, and uppercases the canonical output; every other token (typed escape from an untyped caller — wrong length, non-hex, alpha-channel form, non-string) collapses to `undefined`. When the color is set, the `<a:defRPr>` / `<a:rPr>` slots expand from self-closing to wrapping a single `<a:solidFill><a:srgbClr val="..."/></a:solidFill>` child; otherwise the writer keeps the existing self-closing form so a fresh chart with no custom color matches Excel's reference serialization byte-for-byte. The fill lands on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks the value up off either canonical slot — Excel keeps the two slots in sync.
- **Clone** (`resolveTitleColor`): follows the standard `string | null` override grammar — `undefined` inherits, `null` drops, a literal hex string replaces. Malformed overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same `titleRendered` gate the writer uses — when the resolved title is dropped (`title: null` or `showTitle: false`), the inherited fill drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.
- **Validation**: only valid 6-character hex strings (with or without leading `#`, any case) survive the type guard at every layer; non-string inputs and malformed hex collapse to the default. This matches how `titleBold` / `titleItalic` / `titleOverlay` / `roundedCorners` / `plotVisOnly` treat their inputs (a literal valid value is the only path to a non-default emission).

## Test plan

- [x] `parseChart — title color` (10 new tests) — surfaces uppercase canonical hex from `<a:srgbClr val="FF0000"/>`, normalizes lowercase input to uppercase, strips leading `#`, collapses absence of `<a:solidFill>` to `undefined`, returns undefined when `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>`, collapses theme-color references (`<a:schemeClr>`) to undefined, drops malformed val tokens (wrong length / non-hex / 8-char alpha form), does not leak from a stray axis-title `<a:solidFill>`, co-surfaces alongside `titleBold` / `titleItalic` / `titleFontSize` / `titleRotation` / `titleOverlay`.
- [x] `writeChart — title color` (12 new tests) — omits `<a:solidFill>` by default (theme inherit), emits the fill on a hex input, normalizes lowercase to uppercase, strips leading `#`, drops malformed inputs back to the default, ignores the field when the chart renders no title (`showTitle=false` or absent title), composes independently with `titleBold` / `titleItalic` / `titleFontSize` / `titleRotation` / `titleOverlay`, preserves the title body's other attributes (`lang="en-US"`, `sz`, `b`), threads through every chart family (bar / column / line / pie / scatter / area), parse round-trip, default round-trip collapses to `undefined`, malformed-input round-trip also collapses to `undefined`, full `writeXlsx` package round-trip.
- [x] `cloneChart — title color` (16 new tests) — inherit, replace, lowercase normalization, leading-`#` strip, null drop, replace null source with hex override, drop on malformed override, drop on non-string override, drop on `title: null`, drop on `showTitle: false`, preserve when an override pins a fresh title, composition with `titleBold` / `titleItalic` / `titleFontSize` / `titleRotation` / `titleOverlay`, threads through line -> column / line -> doughnut flatten, end-to-end parse -> clone -> write -> reparse round-trip.
- [x] `pnpm test` — all 4473 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.