### PR TITLE
feat(xlsx): chart axis title font size — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1923,6 +1923,39 @@ export interface SheetChart {
        * dropped on those families.
        */
       axisTitleRotation?: number;
+      /**
+       * Axis title font size in whole or half points. Maps to
+       * `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+       * <a:r><a:rPr sz="N"/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format Axis
+       * Title -> Font -> Size" knob. The OOXML attribute is in 100ths
+       * of a point, so 12pt serializes as `sz="1200"` and 10pt (Excel's
+       * reference default for axis titles) as `sz="1000"`; the writer
+       * performs the conversion at emit time and lands the value on
+       * both the default-paragraph `<a:defRPr>` and the literal run's
+       * `<a:rPr>` so a re-parse picks the size up off either canonical
+       * slot.
+       *
+       * Mirrors {@link SheetChart.titleFontSize} for axis titles — same
+       * `1..400`pt band the OOXML `ST_TextFontSize` schema exposes,
+       * same 0.5pt half-step granularity Excel's UI exposes, same
+       * out-of-range / non-finite drop semantics. Useful for shrinking
+       * a long Y-axis unit label so it fits a tight chart frame, or
+       * bumping the X-axis title up to match a presentation slide's
+       * typography.
+       *
+       * Default: omitted — the axis title renders at Excel's reference
+       * 10pt (the writer's hardcoded default before this field was
+       * surfaced). Silently dropped when the axis renders no title
+       * (the `<c:title>` element is absent in either case) and on
+       * `pie` / `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+       * per the OOXML schema, so the field round-trips on every chart
+       * family that has axes (bar / column / line / area / scatter).
+       */
+      axisTitleFontSize?: number;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -2191,6 +2224,23 @@ export interface SheetChart {
        * the rotation).
        */
       axisTitleRotation?: number;
+      /**
+       * Value-axis title font size in whole or half points. Maps to
+       * `<c:valAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+       * <a:r><a:rPr sz="N"/></a:r></a:p></c:rich></c:tx></c:title></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.axisTitleFontSize} for the
+       * value axis — see that field for the full semantics. The OOXML
+       * `sz` attribute is in 100ths of a point; the writer converts at
+       * emit time so callers pin the value in points. Range: `1..400`.
+       *
+       * Useful for shrinking a long Y-axis unit label so it fits a
+       * tight chart frame, or bumping the Y-axis title up to match
+       * the chart-level title's typography on a presentation slide.
+       * Silently dropped on `pie` / `doughnut` charts (no axes at all)
+       * and on any axis whose `title` is unset (no `<c:title>` block
+       * to host the size).
+       */
+      axisTitleFontSize?: number;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3373,6 +3423,37 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleRotation?: number;
+  /**
+   * Axis-title font size in points (range `1..400`), pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>` on the axis element. Reflects
+   * Excel's "Format Axis Title -> Font -> Size" knob.
+   *
+   * The OOXML attribute is in 100ths of a point; the reader converts
+   * to points and rounds to the nearest 0.5pt (Excel's UI exposes the
+   * same 0.5pt granularity, e.g. `sz="1000"` surfaces as `10`,
+   * `sz="1050"` as `10.5`). Out-of-range values (outside the `1..400`
+   * band the OOXML `ST_TextFontSize` schema exposes) drop to
+   * `undefined` rather than fabricate a value the writer would never
+   * emit. Absence of the attribute (or of `<a:defRPr>` / `<a:pPr>` /
+   * `<a:p>` / `<c:rich>` / `<c:tx>` / `<c:title>`) likewise collapses
+   * to `undefined`.
+   *
+   * Reported as `undefined` whenever the axis has no `<c:title>`
+   * element at all, or when the title is a `<c:strRef>` (formula
+   * reference) with no `<c:rich>` body — there is no `<a:p>` slot to
+   * surface the size from in either case. Mirrors the chart-level
+   * {@link Chart.titleFontSize} so a parsed value slots straight back
+   * into the writer-side {@link SheetChart.axes.x.axisTitleFontSize}
+   * without transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the size regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleFontSize?: number;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -687,6 +687,24 @@ export interface CloneChartOptions {
        * rotation).
        */
       axisTitleRotation?: number | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleFontSize`. `undefined`
+       * (or omitted) inherits the source axis's parsed value; `null`
+       * drops the inherited size (the writer falls back to the
+       * hardcoded `1000` (10pt) default Excel itself emits on a fresh
+       * axis title); a number in the `1..400`pt band replaces it
+       * (out-of-range, non-finite, and non-numeric inputs collapse
+       * to `undefined`, and fractional inputs round to the nearest
+       * 0.5pt).
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently
+       * dropped on `pie` / `doughnut` charts (no axes at all) and on
+       * any axis whose `title` is unset (no `<c:title>` block to
+       * host the size).
+       */
+      axisTitleFontSize?: number | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -869,6 +887,8 @@ export interface CloneChartOptions {
       title?: string | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleRotation}. */
       axisTitleRotation?: number | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleFontSize}. */
+      axisTitleFontSize?: number | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2514,6 +2534,24 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleRotation,
     overrides?.y?.axisTitleRotation,
   );
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis title font size in 100ths of a
+  // point. Sits on the same `<c:title>` body as `axisTitleRotation`,
+  // so the resolver applies on every chart family that has axes (pie /
+  // doughnut were short-circuited upstream). Out-of-range / non-finite
+  // / non-numeric values collapse to `undefined` so the writer falls
+  // back to the hardcoded 10pt axis-title default. Like the rotation,
+  // the writer drops the size when the matching axis title is unset,
+  // so a stray pin on an axis with no title silently disappears at
+  // emit time.
+  const xAxisTitleFontSize = applyAxisTitleFontSizeOverride(
+    sourceAxes?.x?.axisTitleFontSize,
+    overrides?.x?.axisTitleFontSize,
+  );
+  const yAxisTitleFontSize = applyAxisTitleFontSizeOverride(
+    sourceAxes?.y?.axisTitleFontSize,
+    overrides?.y?.axisTitleFontSize,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -2650,11 +2688,20 @@ function resolveAxes(
   // when `opts.xAxisTitle` / `opts.yAxisTitle` is set).
   const xAxisTitleRotationResolved = xTitle === undefined ? undefined : xAxisTitleRotation;
   const yAxisTitleRotationResolved = yTitle === undefined ? undefined : yAxisTitleRotation;
+  // The axis-title font size only renders when the axis carries a
+  // title — drop a stray inherited size when the resolved axis title
+  // is unset so the cloned `SheetChart` accurately reflects what the
+  // chart will paint. Symmetric with the writer's title-presence gate
+  // (the per-family axis builder only invokes `buildAxisTitle` when
+  // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
+  const xAxisTitleFontSizeResolved = xTitle === undefined ? undefined : xAxisTitleFontSize;
+  const yAxisTitleFontSizeResolved = yTitle === undefined ? undefined : yAxisTitleFontSize;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
     xTitle !== undefined ||
     xAxisTitleRotationResolved !== undefined ||
+    xAxisTitleFontSizeResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -2679,6 +2726,8 @@ function resolveAxes(
     if (xTitle !== undefined) out.x.title = xTitle;
     if (xAxisTitleRotationResolved !== undefined)
       out.x.axisTitleRotation = xAxisTitleRotationResolved;
+    if (xAxisTitleFontSizeResolved !== undefined)
+      out.x.axisTitleFontSize = xAxisTitleFontSizeResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -2702,6 +2751,7 @@ function resolveAxes(
   if (
     yTitle !== undefined ||
     yAxisTitleRotationResolved !== undefined ||
+    yAxisTitleFontSizeResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -2720,6 +2770,8 @@ function resolveAxes(
     if (yTitle !== undefined) out.y.title = yTitle;
     if (yAxisTitleRotationResolved !== undefined)
       out.y.axisTitleRotation = yAxisTitleRotationResolved;
+    if (yAxisTitleFontSizeResolved !== undefined)
+      out.y.axisTitleFontSize = yAxisTitleFontSizeResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -3079,6 +3131,30 @@ function applyAxisTitleRotationOverride(
   if (override === null) return undefined;
   if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
   return clampLabelRotationDeg(override);
+}
+
+/**
+ * Resolve an `axisTitleFontSize` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. The conversion / clamping rules delegate to
+ * {@link normalizeTitleFontSize} — out-of-range, non-finite, and
+ * non-numeric inputs all collapse to `undefined`, fractional inputs
+ * round to the nearest 0.5pt (Excel's UI granularity), and a `null`
+ * override always drops the inherited size.
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a size that the writer would silently elide (the writer
+ * scopes the size emission to `<c:title>`, which is omitted when the
+ * axis renders no title).
+ */
+function applyAxisTitleFontSizeOverride(
+  source: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeTitleFontSize(source);
+  if (override === null) return undefined;
+  return normalizeTitleFontSize(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -533,6 +533,17 @@ function parseAxisInfo(
   // entirely or when the title is a `<c:strRef>` (formula reference)
   // with no `<c:rich>` body.
   const axisTitleRotation = parseAxisTitleRotation(axis);
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis-title font size in 100ths of a
+  // point. Same `<c:title>` body scope as `axisTitleRotation` so a
+  // stray `<a:defRPr>` elsewhere on the axis (e.g. on the tick-label
+  // `<c:txPr>`) cannot leak in. The value comes back in points (range
+  // `1..400`); out-of-range / non-numeric inputs drop to `undefined`,
+  // and absence of `<c:title>` / `<c:rich>` / `<a:p>` / `<a:pPr>` /
+  // `<a:defRPr>` / the `sz` attribute likewise collapses to
+  // `undefined` for symmetry with the writer-side
+  // {@link SheetChart.axes.x.axisTitleFontSize}.
+  const axisTitleFontSize = parseAxisTitleFontSize(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -623,6 +634,7 @@ function parseAxisInfo(
   if (
     title === undefined &&
     axisTitleRotation === undefined &&
+    axisTitleFontSize === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -648,6 +660,7 @@ function parseAxisInfo(
   const out: ChartAxisInfo = {};
   if (title !== undefined) out.title = title;
   if (axisTitleRotation !== undefined) out.axisTitleRotation = axisTitleRotation;
+  if (axisTitleFontSize !== undefined) out.axisTitleFontSize = axisTitleFontSize;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -1322,6 +1335,61 @@ function parseAxisTitleRotation(axis: XmlElement): number | undefined {
   if (degrees < LABEL_ROTATION_MIN_DEG) return LABEL_ROTATION_MIN_DEG;
   if (degrees > LABEL_ROTATION_MAX_DEG) return LABEL_ROTATION_MAX_DEG;
   return degrees;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` off an axis element. Returns the
+ * font size in points (range `1..400`).
+ *
+ * Mirrors {@link parseTitleFontSize} for axis titles — same 0.5pt
+ * half-step granularity, same `1..400`pt band, same drop-on-out-of-
+ * range / non-numeric / absence semantics. The lookup is scoped to
+ * the axis title's `<c:rich>` body so a stray `<a:defRPr>` elsewhere
+ * on the axis (e.g. on the tick-label `<c:txPr>` surfaced by
+ * {@link parseAxisLabelRotation}) cannot leak in.
+ *
+ * Returns `undefined` whenever the axis omits `<c:title>` entirely
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body — there is no `<a:p>` slot to surface the size
+ * from in either case.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape
+ * per the OOXML schema. Mirrors the chart-level title size
+ * {@link parseTitleFontSize} so a parsed value slots straight into
+ * the writer-side {@link SheetChart.axes}.x.axisTitleFontSize.
+ */
+function parseAxisTitleFontSize(axis: XmlElement): number | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph font size. The reader walks the canonical chain
+  // and bails on the first missing link so a malformed `<c:rich>`
+  // surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.sz;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 100ths of a point to points, rounding to the nearest
+  // 0.5pt to match the granularity Excel's UI exposes. Mirrors the
+  // chart-level `parseTitleFontSize` half-step normalisation.
+  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -598,6 +598,15 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // only honour the rotation when the axis actually renders a title.
     xAxisTitleRotation: normalizeAxisTitleRotation(chart.axes?.x?.axisTitleRotation),
     yAxisTitleRotation: normalizeAxisTitleRotation(chart.axes?.y?.axisTitleRotation),
+    // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+    // <a:r><a:rPr sz="N"/></a:r></a:p></c:rich></c:tx></c:title>`
+    // also sits on every axis flavour. Normalize the caller's point
+    // input — drop out-of-range and non-finite / non-numeric inputs at
+    // write time rather than emit a token Excel would reject; absence
+    // collapses to `undefined` so the writer falls back to the
+    // hardcoded 10pt default Excel itself emits on a fresh axis title.
+    xAxisTitleFontSize: normalizeAxisTitleFontSize(chart.axes?.x?.axisTitleFontSize),
+    yAxisTitleFontSize: normalizeAxisTitleFontSize(chart.axes?.y?.axisTitleFontSize),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1007,6 +1016,23 @@ interface AxisRenderOptions {
    * shape and conversion semantics as {@link xAxisTitleRotation}.
    */
   yAxisTitleRotation: number | undefined;
+  /**
+   * Axis-title font size in points emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+   * <a:r><a:rPr sz="N"/></a:r></a:p></c:rich></c:tx></c:title>`. The
+   * OOXML `sz` attribute is in 100ths of a point; the writer converts
+   * at emit time. Range: `1..400`pt. `undefined` collapses to the
+   * hardcoded `1000` (10pt) default Excel itself emits on a fresh
+   * axis title. Only meaningful when the axis renders a title — the
+   * per-family axis builders gate the value on the `xAxisTitle` /
+   * `yAxisTitle` field.
+   */
+  xAxisTitleFontSize: number | undefined;
+  /**
+   * Axis-title font size in points emitted on the Y axis. Same shape
+   * and conversion semantics as {@link xAxisTitleFontSize}.
+   */
+  yAxisTitleFontSize: number | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -1865,7 +1891,10 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:axPos", { val: catPos }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (opts.xAxisTitle) catAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation));
+  if (opts.xAxisTitle)
+    catAxChildren.push(
+      buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation, opts.xAxisTitleFontSize),
+    );
   catAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
@@ -1918,7 +1947,10 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:axPos", { val: valPos }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (opts.yAxisTitle) valAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation));
+  if (opts.yAxisTitle)
+    valAxChildren.push(
+      buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation, opts.yAxisTitleFontSize),
+    );
   valAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
@@ -2272,7 +2304,10 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     xmlSelfClose("c:axPos", { val: "b" }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (opts.xAxisTitle) xAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation));
+  if (opts.xAxisTitle)
+    xAxChildren.push(
+      buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation, opts.xAxisTitleFontSize),
+    );
   xAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
@@ -2304,7 +2339,10 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     xmlSelfClose("c:axPos", { val: "l" }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (opts.yAxisTitle) yAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation));
+  if (opts.yAxisTitle)
+    yAxChildren.push(
+      buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation, opts.yAxisTitleFontSize),
+    );
   yAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
@@ -2344,9 +2382,35 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
  * default `0` so a fresh chart matches Excel's reference serialization
  * byte-for-byte. Mirrors the chart-title `buildTitle` slot exactly so
  * an axis title and the chart-level title carry the same shape.
+ *
+ * The optional `fontSizePt` parameter pins the title's
+ * `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attributes. The OOXML
+ * attribute is in 100ths of a point; the writer holds the size in
+ * points and converts at emit time. Absence (`undefined`) collapses
+ * to the hardcoded `1000` (10pt) default Excel itself emits on a
+ * fresh axis title, keeping the rendered shape stable for callers
+ * that never set the field. The size lands on both the
+ * default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
+ * a re-parse picks the value up off either canonical slot.
  */
-function buildAxisTitle(label: string, rotationDeg: number | undefined): string {
+function buildAxisTitle(
+  label: string,
+  rotationDeg: number | undefined,
+  fontSizePt: number | undefined,
+): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
+  // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
+  // 100ths of a point. The writer holds the size in points and
+  // converts at emit time. Absence (`undefined`) collapses to the
+  // hardcoded `1000` (10pt) default — Excel's reference axis-title
+  // size — so callers that never pin the field still match Excel's
+  // shape byte-for-byte. The size lands on both `<a:defRPr>` and
+  // `<a:rPr>` so a re-parse picks the value up off either canonical
+  // slot, mirroring the chart-level `buildTitle` writer.
+  const sz =
+    fontSizePt === undefined
+      ? AXIS_TITLE_DEFAULT_FONT_SIZE_SZ
+      : fontSizePt * TITLE_FONT_SZ_PER_POINT;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -2364,9 +2428,9 @@ function buildAxisTitle(label: string, rotationDeg: number | undefined): string 
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz: 1000, b: 0 })]),
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b: 0 })]),
           xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz: 1000, b: 0 }),
+            xmlSelfClose("a:rPr", { lang: "en-US", sz, b: 0 }),
             xmlElement("a:t", undefined, xmlEscape(label)),
           ]),
         ]),
@@ -2375,6 +2439,17 @@ function buildAxisTitle(label: string, rotationDeg: number | undefined): string 
     xmlSelfClose("c:overlay", { val: 0 }),
   ]);
 }
+
+/**
+ * Application-default `sz` value for an axis title's `<a:defRPr>` /
+ * `<a:rPr>` slots — Excel renders axis titles at 10pt (`sz="1000"`)
+ * unless the user pins a custom size. Absence of
+ * {@link SheetChart.axes.x.axisTitleFontSize} resolves to this default
+ * so a fresh chart matches Excel's reference serialization byte-for-
+ * byte, and round-trips of templates that never pinned the field stay
+ * stable across the parse -> clone -> write loop.
+ */
+const AXIS_TITLE_DEFAULT_FONT_SIZE_SZ = 1000;
 
 /**
  * Normalize a {@link SheetChart.axes}.x.axisTitleRotation value (whole
@@ -2388,6 +2463,21 @@ function buildAxisTitle(label: string, rotationDeg: number | undefined): string 
  */
 function normalizeAxisTitleRotation(value: number | undefined): number | undefined {
   return normalizeTitleRotation(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleFontSize value
+ * (whole / half points) for the `<c:title><c:tx><c:rich><a:p><a:pPr>
+ * <a:defRPr sz="N"/></a:pPr></a:p></c:rich></c:tx></c:title>` writer
+ * slot inside an axis. Delegates to the chart-level
+ * {@link normalizeTitleFontSize} so the two share a clamping band
+ * (`1..400`pt, the OOXML `ST_TextFontSize` schema range) and the
+ * same 0.5pt half-step rounding. Out-of-range, non-finite, and
+ * non-numeric inputs all collapse to `undefined` so the writer falls
+ * back to the hardcoded 10pt axis-title default.
+ */
+function normalizeAxisTitleFontSize(value: number | undefined): number | undefined {
+  return normalizeTitleFontSize(value);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -1215,9 +1215,13 @@ describe("cloneChart — integration", () => {
     const zip = new ZipReader(xlsx);
     const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
     const reparsed = parseChart(written);
+    // The writer emits the hardcoded 10pt axis-title default
+    // (`sz="1000"`) on every axis whose title renders, so the reader
+    // surfaces `axisTitleFontSize: 10` literally — same shape contract
+    // as `titleFontSize` for the chart-level title.
     expect(reparsed?.axes).toEqual({
-      x: { title: "Quarter" },
-      y: { title: "Revenue (USD)" },
+      x: { title: "Quarter", axisTitleFontSize: 10 },
+      y: { title: "Revenue (USD)", axisTitleFontSize: 10 },
     });
   });
 
@@ -11196,5 +11200,280 @@ describe("cloneChart — axis title rotation", () => {
     const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
     const reparsed = parseChart(written);
     expect(reparsed?.axes?.x?.axisTitleRotation).toBe(-45);
+  });
+});
+
+// ── cloneChart — axis title font size ───────────────────────────────
+
+describe("cloneChart — axis title font size", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleFontSize by default", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleFontSize by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleFontSize: 16 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleFontSize).toBe(16);
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleFontSize override the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: 18 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(18);
+  });
+
+  it("drops the inherited axisTitleFontSize when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: null } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleFontSize when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("rounds a fractional override to the nearest 0.5pt", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: 14.8 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(15);
+  });
+
+  it("preserves a half-point override literally", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: 10.5 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(10.5);
+  });
+
+  it("drops out-of-range overrides (below 1pt)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: 0.5 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops out-of-range overrides (above 400pt)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: 401 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops non-finite overrides (NaN / Infinity)", () => {
+    const a = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: Number.NaN } },
+    });
+    expect(a.axes?.x?.axisTitleFontSize).toBeUndefined();
+    const b = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: Number.POSITIVE_INFINITY } },
+    });
+    expect(b.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("normalises a parsed source size that is somehow out of range", () => {
+    // Defensive: a corrupt template parsed by an older reader could
+    // surface an out-of-band value. The clone normalizer drops it
+    // through the same `1..400`pt band so the writer never sees a
+    // bad token.
+    const clone = cloneChart(
+      source({
+        axes: { x: { title: "Period", axisTitleFontSize: 500 as number } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops the inherited axisTitleFontSize when the resolved axis title is dropped", () => {
+    // `title: null` flattens the inherited axis title — no `<c:title>`
+    // block will be emitted, so the inherited size has no slot in
+    // the rendered axis and the clone collapses it.
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: null } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops an override axisTitleFontSize when no axis title resolves", () => {
+    // The axis has no source title and the caller did not pin one —
+    // the writer would silently elide the size either way, so the
+    // clone-side resolver mirrors that by dropping the field.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontSize: 14 } },
+    });
+    expect(clone.axes?.x).toBeUndefined();
+  });
+
+  it("preserves the override when the override also pins a title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleFontSize: 14 } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+  });
+
+  it("composes independently with the chart-level titleFontSize", () => {
+    const clone = cloneChart(
+      source({
+        titleFontSize: 24,
+        axes: { x: { title: "Period", axisTitleFontSize: 14 } },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+      },
+    );
+    expect(clone.titleFontSize).toBe(24);
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+  });
+
+  it("composes independently with axisTitleRotation on the same axis", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleRotation: 45, axisTitleFontSize: 14 },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+  });
+
+  it("threads the size through both axes independently on the clone", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleFontSize: 14 },
+          y: { title: "USD", axisTitleFontSize: 18 },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(clone.axes?.y?.axisTitleFontSize).toBe(18);
+  });
+
+  it("round-trips a templated chart's axis title size through parseChart -> cloneChart -> writeChart", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr sz="1600"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(parsed?.axes?.y?.axisTitleFontSize).toBe(16);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(sheetChart.axes?.y?.axisTitleFontSize).toBe(16);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(reparsed?.axes?.y?.axisTitleFontSize).toBe(16);
+  });
+
+  it("propagates axisTitleFontSize into the rendered axis on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleFontSize).toBe(14);
   });
 });

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10272,3 +10272,270 @@ describe("writeChart — axis title rotation", () => {
     expect(reparsed?.axes?.y?.axisTitleRotation).toBe(-90);
   });
 });
+
+// ── writeChart — axis title font size ───────────────────────────────
+
+describe("writeChart — axis title font size", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleDefRPrSzOf(axisBlock: string): string | undefined {
+    const titleMatch = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) return undefined;
+    const m = titleMatch[0].match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const sz = m[0].match(/sz="([^"]+)"/);
+    return sz ? sz[1] : undefined;
+  }
+
+  function axisTitleRPrSzOf(axisBlock: string): string | undefined {
+    const titleMatch = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) return undefined;
+    const m = titleMatch[0].match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const sz = m[0].match(/sz="([^"]+)"/);
+    return sz ? sz[1] : undefined;
+  }
+
+  it('emits sz="1000" on the X-axis title by default (matches Excel\'s reference 10pt)', () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrSzOf(xAx)).toBe("1000");
+    expect(axisTitleRPrSzOf(xAx)).toBe("1000");
+  });
+
+  it("emits the size in 100ths of a point on a positive input", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrSzOf(xAx)).toBe("1400");
+    expect(axisTitleRPrSzOf(xAx)).toBe("1400");
+  });
+
+  it("supports half-point granularity", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 10.5 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrSzOf(xAx)).toBe("1050");
+    expect(axisTitleRPrSzOf(xAx)).toBe("1050");
+  });
+
+  it("rounds fractional inputs to the nearest 0.5pt", () => {
+    // 10.24pt rounds down to 10 -> sz="1000".
+    const a = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 10.24 } } }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(a.chartXml)[0])).toBe("1000");
+    // 10.8pt rounds up to 11 -> sz="1100".
+    const b = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 10.8 } } }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(b.chartXml)[0])).toBe("1100");
+  });
+
+  it("emits the 1pt minimum (sz=100)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 1 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrSzOf(xAx)).toBe("100");
+  });
+
+  it("emits the 400pt maximum (sz=40000)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 400 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrSzOf(xAx)).toBe("40000");
+  });
+
+  it("drops out-of-range values and falls back to the 10pt default (sz=1000)", () => {
+    // 0.49pt rounds to 0.5pt, below the OOXML ST_TextFontSize 1pt
+    // minimum — the writer falls back to the 10pt default.
+    const a = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 0.49 } } }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(a.chartXml)[0])).toBe("1000");
+    // 401pt is above the OOXML ST_TextFontSize 400pt maximum.
+    const b = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 401 } } }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(b.chartXml)[0])).toBe("1000");
+  });
+
+  it("drops non-finite inputs and falls back to the 10pt default", () => {
+    const nan = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: Number.NaN } } }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(nan.chartXml)[0])).toBe("1000");
+    const inf = writeChart(
+      makeChart({
+        axes: { x: { title: "Period", axisTitleFontSize: Number.POSITIVE_INFINITY } },
+      }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(inf.chartXml)[0])).toBe("1000");
+  });
+
+  it("drops non-numeric inputs (defends against the type guard escaping)", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleFontSize: "12" as any } },
+      }),
+      "Sheet1",
+    );
+    expect(axisTitleDefRPrSzOf(axisBlocks(result.chartXml)[0])).toBe("1000");
+  });
+
+  it("ignores axisTitleFontSize when the axis renders no title", () => {
+    // No title means no `<c:title>` block — there is no slot for the
+    // size in either case.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleFontSize: 14 } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with axisTitleRotation on the same axis", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: "Period", axisTitleRotation: 45, axisTitleFontSize: 14 } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = xAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('rot="2700000"');
+    expect(titleBlock).toContain('sz="1400"');
+  });
+
+  it("composes independently with the chart-level title font size", () => {
+    const result = writeChart(
+      makeChart({
+        titleFontSize: 24,
+        axes: { x: { title: "Period", axisTitleFontSize: 14 } },
+      }),
+      "Sheet1",
+    );
+    const chartTitle = result.chartXml.match(/<c:chart>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(chartTitle).toContain('sz="2400"');
+    const [xAx] = axisBlocks(result.chartXml);
+    const xTitleBlock = xAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(xTitleBlock).toContain('sz="1400"');
+  });
+
+  it("threads the size through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleFontSize: 14 },
+          y: { title: "USD", axisTitleFontSize: 16 },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrSzOf(xAx)).toBe("1400");
+    expect(axisTitleDefRPrSzOf(yAx)).toBe("1600");
+  });
+
+  it("threads the size through line / area / scatter chart families", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleFontSize: 12 } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleDefRPrSzOf(xAx)).toBe("1200");
+    }
+    // Scatter routes both axes through `<c:valAx>` — confirm the size
+    // still threads to the Y axis.
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleFontSize: 16 } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    const yAx = blocks[1];
+    expect(axisTitleDefRPrSzOf(yAx)).toBe("1600");
+  });
+
+  it("preserves the axis title's other attributes (b='0', lang='en-US')", () => {
+    // The writer keeps `b="0"` (non-bold) and `lang="en-US"` on the
+    // run's `<a:rPr>` so a templated axis title only loses the size,
+    // not the surrounding font defaults.
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = xAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('lang="en-US"');
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("round-trips a non-default axis title size through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontSize: 14 } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleFontSize).toBe(14);
+  });
+
+  it("round-trips a defaulted axis title back to the writer's reference 10pt", () => {
+    // The writer emits sz="1000" by default; the reader surfaces it
+    // literally because 10pt is a valid pin (mirrors the chart-level
+    // titleFontSize round-trip behaviour).
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleFontSize).toBe(10);
+  });
+
+  it("end-to-end: writeXlsx packages the axis title size into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleFontSize: 14 },
+              y: { title: "USD", axisTitleFontSize: 16 },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(reparsed?.axes?.y?.axisTitleFontSize).toBe(16);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10826,3 +10826,260 @@ describe("parseChart — axis title rotation", () => {
     });
   });
 });
+
+// ── parseChart — axis title font size ───────────────────────────────
+
+describe("parseChart — axis title font size", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitle(sz: string | undefined): string {
+    const defRPr = sz === undefined ? "<a:defRPr/>" : `<a:defRPr sz="${sz}"/>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the axis-title size in points from the sz attribute (100ths of a point)", () => {
+    // 12pt * 100 = 1200.
+    const chart = parseChart(withCatAxTitle("1200"));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(12);
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("surfaces the writer's reference 10pt size literally", () => {
+    // Excel writes sz="1000" on every fresh axis title — the reader
+    // surfaces it because it is a literal pin (no "default collapse"
+    // for a literal sz, mirroring `titleFontSize`).
+    const chart = parseChart(withCatAxTitle("1000"));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(10);
+  });
+
+  it("rounds to the nearest 0.5pt", () => {
+    // sz="1050" = 10.5pt — surfaces literally.
+    const a = parseChart(withCatAxTitle("1050"));
+    expect(a?.axes?.x?.axisTitleFontSize).toBe(10.5);
+    // sz="1024" = 10.24pt — rounds down to 10.
+    const b = parseChart(withCatAxTitle("1024"));
+    expect(b?.axes?.x?.axisTitleFontSize).toBe(10);
+    // sz="1080" = 10.8pt — rounds up to 11.
+    const c = parseChart(withCatAxTitle("1080"));
+    expect(c?.axes?.x?.axisTitleFontSize).toBe(11);
+  });
+
+  it("returns undefined when <a:defRPr> omits the sz attribute", () => {
+    const chart = parseChart(withCatAxTitle(undefined));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBeUndefined();
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a <c:strRef> (no <c:rich> body)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache>
+        </c:strRef></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops sz values below the 1pt minimum after rounding (sz=49)", () => {
+    // 49 / 100 = 0.49pt — half-step rounds to 0.5pt, below the OOXML
+    // ST_TextFontSize 1pt minimum.
+    const chart = parseChart(withCatAxTitle("49"));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops sz values above the 400pt maximum (sz=400001)", () => {
+    // 400001 / 100 = 4000.01pt — outside the OOXML band.
+    const chart = parseChart(withCatAxTitle("400001"));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("surfaces the 1pt minimum (sz=100)", () => {
+    const chart = parseChart(withCatAxTitle("100"));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(1);
+  });
+
+  it("surfaces the 400pt maximum (sz=40000)", () => {
+    const chart = parseChart(withCatAxTitle("40000"));
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(400);
+  });
+
+  it("drops non-numeric sz tokens", () => {
+    expect(parseChart(withCatAxTitle("twelve"))?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("drops empty sz tokens", () => {
+    expect(parseChart(withCatAxTitle(""))?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("does not leak the tick-label <c:txPr> size into the title size", () => {
+    // The reader scopes the lookup to the title's <c:rich> body —
+    // the tick-label `<c:txPr>` is a sibling element on the axis and
+    // must not feed its `<a:defRPr sz>` into the title size.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="800"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleFontSize).toBeUndefined();
+  });
+
+  it("surfaces the size on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1600"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("USD");
+    expect(chart?.axes?.y?.axisTitleFontSize).toBe(16);
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="900"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1800"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(9);
+    expect(chart?.axes?.y?.axisTitleFontSize).toBe(18);
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      axisTitleRotation: 45,
+      axisTitleFontSize: 14,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr sz=\"N\"/></a:pPr><a:r><a:rPr sz=\"N\"/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>` (and the matching `<c:valAx>` shape — CT_Title's default-paragraph and run text-run-properties on every axis flavour, ECMA-376 Part 1, §21.2.2.4 / §21.1.2.3.7) at the read, write, and clone layers so a template's custom axis-title font size survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Mirrors the chart-level `titleFontSize` field added in #251 — same `1..400`pt band the OOXML `ST_TextFontSize` schema exposes, same 0.5pt half-step granularity Excel's UI exposes, same out-of-range / non-finite drop semantics, same title-presence scope rule (silently ignored when the axis renders no title) — so a single configuration call threads cleanly through both the chart title and either axis title without bookkeeping the units. Mirrors `axisTitleRotation` (#248) for the same OOXML slot-pair, so `axisTitleFontSize` and `axisTitleRotation` compose freely on the same `<c:title>` body.

Until now hucre's writer hardcoded `sz=\"1000\"` (10pt) on both axis titles' `<a:defRPr>` and `<a:rPr>` and the reader ignored the attribute entirely, so a templated dashboard chart whose user scaled an axis title up for a hero tile or down to fit a tight axis-label slot silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136 — the issue's example explicitly calls for axis-label customization and the title font size is the last knob the chart-title family had that the axis-title family didn't.

Refs #136

## API

\`\`\`ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.axisTitleFontSize);
// 14         <- when the template pinned <a:defRPr sz=\"1400\"/>
// 10         <- the writer's reference 10pt default round-trips literally
// undefined  <- when the chart has no <c:title> on the X axis or the title is a <c:strRef>
// undefined  <- when the size is out-of-range / non-numeric (corrupt template)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [/* ... */],
    charts: [{
      type: \"column\",
      title: \"Q4 Revenue\",
      series: [/* ... */],
      anchor: { from: { row: 5, col: 0 } },
      axes: {
        x: { title: \"Period\", axisTitleFontSize: 12 },
        y: { title: \"USD\", axisTitleFontSize: 16 },
      },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 0, col: 8 } },
  axes: {
    x: { axisTitleFontSize: 14 },     // replaces the inherited size
    y: { axisTitleFontSize: null },   // drops it (writer falls back to 10pt)
  },
});
\`\`\`

## Test plan

- [x] \`pnpm test\` (lint + format + typecheck + 4527 vitest tests; 54 new tests covering parser / writer / clone for the new field) — all pass
- [x] \`pnpm build\` — completes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)