### PR TITLE
feat(xlsx): chart axis title bold flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1923,6 +1923,47 @@ export interface SheetChart {
        * dropped on those families.
        */
       axisTitleRotation?: number;
+      /**
+       * Axis title bold flag. Maps to
+       * `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+       * <a:r><a:rPr b=".."/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format
+       * Axis Title -> Font -> Bold" toggle. The OOXML attribute is the
+       * `xsd:boolean` `b` on `CT_TextCharacterProperties` (ECMA-376
+       * Part 1, §21.1.2.3.7); the writer lands the value on both the
+       * default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`
+       * so a re-parse picks the flag up off either canonical slot —
+       * Excel keeps the two attributes in sync.
+       *
+       * Mirrors {@link SheetChart.titleBold} for axis titles — same
+       * canonical-slot pair, same `boolean | null` clone grammar, same
+       * silent drop when the axis renders no title. Useful for matching
+       * the chart-level title's emphasis on the axis labels (e.g.
+       * bolding the Y-axis "Revenue (USD)" caption to align with a
+       * dashboard's heavy-weight typography).
+       *
+       * Default: omitted — the axis title renders non-bold (`b="0"`,
+       * the writer's reference serialization for a fresh axis title).
+       * Set `true` to emit `b="1"` on both slots so the axis title
+       * renders bold; set `false` explicitly to pin the non-default
+       * `b="0"` (functionally identical to omission, but useful when
+       * overriding a templated axis title that had bold pinned
+       * upstream).
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all). Composes independently
+       * with {@link axisTitleRotation} / {@link axisTitleFontSize}: all
+       * three fields land on the same `<c:title>` body so a single
+       * configuration call threads cleanly through every axis-title
+       * knob Excel exposes.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+       * per the OOXML schema, so the field round-trips on every chart
+       * family that has axes (bar / column / line / area / scatter).
+       */
+      axisTitleBold?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -2191,6 +2232,26 @@ export interface SheetChart {
        * the rotation).
        */
       axisTitleRotation?: number;
+      /**
+       * Value-axis title bold flag. Maps to
+       * `<c:valAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+       * <a:r><a:rPr b=".."/></a:r></a:p></c:rich></c:tx></c:title></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.axisTitleBold} for the value
+       * axis — see that field for the full semantics. The OOXML `b`
+       * attribute is the `xsd:boolean` bold flag on
+       * `CT_TextCharacterProperties`; the writer lands the value on
+       * both the default-paragraph `<a:defRPr>` and the literal run's
+       * `<a:rPr>` so a re-parse picks the flag up off either canonical
+       * slot.
+       *
+       * Useful for matching the chart-level title's emphasis on the Y-
+       * axis caption (e.g. bolding "Revenue (USD)" to align with a
+       * dashboard's heavy-weight typography). Silently dropped on
+       * `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * flag).
+       */
+      axisTitleBold?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3373,6 +3434,34 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleRotation?: number;
+  /**
+   * Axis-title bold flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>` on the axis element. Reflects
+   * Excel's "Format Axis Title -> Font -> Bold" toggle.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<a:defRPr b="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<a:defRPr b="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings
+   * (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing
+   * `b` attributes drop to `undefined`.
+   *
+   * Reported as `undefined` whenever the axis has no `<c:title>`
+   * element at all, or when the title is a `<c:strRef>` (formula
+   * reference) with no `<c:rich>` body — there is no `<a:p>` slot to
+   * surface the flag from in either case. Mirrors the chart-level
+   * {@link Chart.titleBold} so a parsed value slots straight back
+   * into the writer-side {@link SheetChart.axes.x.axisTitleBold}
+   * without transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the bold state regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleBold?: boolean;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -687,6 +687,25 @@ export interface CloneChartOptions {
        * rotation).
        */
       axisTitleRotation?: number | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleBold`. `undefined` (or
+       * omitted) inherits the source axis's parsed flag; `null` drops
+       * the inherited flag (the writer falls back to the OOXML
+       * default `b="0"` — the title renders non-bold); a `boolean`
+       * replaces it.
+       *
+       * Non-boolean overrides (typed escapes from an untyped caller)
+       * collapse to a drop so the cloned `SheetChart` always carries
+       * a value the writer will accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * flag).
+       */
+      axisTitleBold?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -869,6 +888,8 @@ export interface CloneChartOptions {
       title?: string | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleRotation}. */
       axisTitleRotation?: number | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleBold}. */
+      axisTitleBold?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2514,6 +2535,23 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleRotation,
     overrides?.y?.axisTitleRotation,
   );
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis-title bold flag. Sits on the
+  // same `<c:title>` body as `axisTitleRotation`, so the resolver
+  // applies on every chart family that has axes (pie / doughnut were
+  // short-circuited upstream). Non-boolean overrides collapse to a
+  // drop so the cloned `SheetChart` always carries a value the writer
+  // will accept. Like the rotation, the writer drops the flag when
+  // the matching axis title is unset, so a stray pin on an axis with
+  // no title silently disappears at emit time.
+  const xAxisTitleBold = applyAxisTitleBoldOverride(
+    sourceAxes?.x?.axisTitleBold,
+    overrides?.x?.axisTitleBold,
+  );
+  const yAxisTitleBold = applyAxisTitleBoldOverride(
+    sourceAxes?.y?.axisTitleBold,
+    overrides?.y?.axisTitleBold,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -2650,11 +2688,17 @@ function resolveAxes(
   // when `opts.xAxisTitle` / `opts.yAxisTitle` is set).
   const xAxisTitleRotationResolved = xTitle === undefined ? undefined : xAxisTitleRotation;
   const yAxisTitleRotationResolved = yTitle === undefined ? undefined : yAxisTitleRotation;
+  // Same title-presence gate for the axis-title bold flag — drop a
+  // stray inherited flag when the resolved axis title is unset so the
+  // cloned `SheetChart` accurately reflects what the chart will paint.
+  const xAxisTitleBoldResolved = xTitle === undefined ? undefined : xAxisTitleBold;
+  const yAxisTitleBoldResolved = yTitle === undefined ? undefined : yAxisTitleBold;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
     xTitle !== undefined ||
     xAxisTitleRotationResolved !== undefined ||
+    xAxisTitleBoldResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -2679,6 +2723,7 @@ function resolveAxes(
     if (xTitle !== undefined) out.x.title = xTitle;
     if (xAxisTitleRotationResolved !== undefined)
       out.x.axisTitleRotation = xAxisTitleRotationResolved;
+    if (xAxisTitleBoldResolved !== undefined) out.x.axisTitleBold = xAxisTitleBoldResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -2702,6 +2747,7 @@ function resolveAxes(
   if (
     yTitle !== undefined ||
     yAxisTitleRotationResolved !== undefined ||
+    yAxisTitleBoldResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -2720,6 +2766,7 @@ function resolveAxes(
     if (yTitle !== undefined) out.y.title = yTitle;
     if (yAxisTitleRotationResolved !== undefined)
       out.y.axisTitleRotation = yAxisTitleRotationResolved;
+    if (yAxisTitleBoldResolved !== undefined) out.y.axisTitleBold = yAxisTitleBoldResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -3079,6 +3126,35 @@ function applyAxisTitleRotationOverride(
   if (override === null) return undefined;
   if (typeof override !== "number" || !Number.isFinite(override)) return undefined;
   return clampLabelRotationDeg(override);
+}
+
+/**
+ * Resolve an `axisTitleBold` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Mirrors the chart-level `resolveTitleBold` —
+ * non-boolean overrides (typed escapes from an untyped caller)
+ * collapse to `undefined`, a `null` override always drops the
+ * inherited flag, and a literal `true` / `false` replaces it.
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a flag the writer would silently elide (the writer scopes
+ * the flag emission to `<c:title>`, which is omitted when the axis
+ * renders no title).
+ */
+function applyAxisTitleBoldOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    if (source === true) return true;
+    if (source === false) return false;
+    return undefined;
+  }
+  if (override === null) return undefined;
+  if (override === true) return true;
+  if (override === false) return false;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -533,6 +533,16 @@ function parseAxisInfo(
   // entirely or when the title is a `<c:strRef>` (formula reference)
   // with no `<c:rich>` body.
   const axisTitleRotation = parseAxisTitleRotation(axis);
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis-title bold flag. Same `<c:title>`
+  // body scope as `axisTitleRotation` so a stray `<a:defRPr>` elsewhere
+  // on the axis (e.g. on the tick-label `<c:txPr>`) cannot leak in.
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `b="0"` round-trip identically through {@link cloneChart} — only
+  // an explicit `b="1"` surfaces `true`. Returns `undefined` when the
+  // axis omits `<c:title>` entirely or when the title is a `<c:strRef>`
+  // (formula reference) with no `<c:rich>` body.
+  const axisTitleBold = parseAxisTitleBold(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -623,6 +633,7 @@ function parseAxisInfo(
   if (
     title === undefined &&
     axisTitleRotation === undefined &&
+    axisTitleBold === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -648,6 +659,7 @@ function parseAxisInfo(
   const out: ChartAxisInfo = {};
   if (title !== undefined) out.title = title;
   if (axisTitleRotation !== undefined) out.axisTitleRotation = axisTitleRotation;
+  if (axisTitleBold !== undefined) out.axisTitleBold = axisTitleBold;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -1322,6 +1334,59 @@ function parseAxisTitleRotation(axis: XmlElement): number | undefined {
   if (degrees < LABEL_ROTATION_MIN_DEG) return LABEL_ROTATION_MIN_DEG;
   if (degrees > LABEL_ROTATION_MAX_DEG) return LABEL_ROTATION_MAX_DEG;
   return degrees;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` off an axis element. Returns the
+ * bold flag.
+ *
+ * Mirrors {@link parseTitleBold} for axis titles — same
+ * canonical-slot pair, same drop-on-default-`false` semantics. The
+ * OOXML `b` attribute is the `xsd:boolean` bold flag on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7). The
+ * default `false` collapses to `undefined` so absence and `b="0"`
+ * round-trip identically — only an explicit `b="1"` surfaces `true`.
+ * Unknown / malformed `b` tokens drop to `undefined` rather than
+ * fabricate a value the writer would never emit.
+ *
+ * The lookup is scoped to the axis title's `<c:rich>` body so a stray
+ * `<a:defRPr>` elsewhere on the axis (e.g. on the tick-label
+ * `<c:txPr>` surfaced by {@link parseAxisLabelRotation}) cannot leak
+ * in. Returns `undefined` when the axis omits `<c:title>` entirely or
+ * when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body — there is no `<a:p>` slot to host the flag in
+ * either case.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape per
+ * the OOXML schema. Mirrors the chart-level title bold
+ * {@link parseTitleBold} so a parsed value slots straight into the
+ * writer-side {@link SheetChart.axes}.x.axisTitleBold.
+ */
+function parseAxisTitleBold(axis: XmlElement): boolean | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph bold flag. The reader walks the canonical chain
+  // and bails on the first missing link so a malformed `<c:rich>`
+  // surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const parsed = parseBoolAttr(defRPr.attrs.b);
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `b="0"` round-trip identically through the writer — only an
+  // explicit `b="1"` surfaces `true`.
+  if (parsed === true) return true;
+  return undefined;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -598,6 +598,16 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // only honour the rotation when the axis actually renders a title.
     xAxisTitleRotation: normalizeAxisTitleRotation(chart.axes?.x?.axisTitleRotation),
     yAxisTitleRotation: normalizeAxisTitleRotation(chart.axes?.y?.axisTitleRotation),
+    // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+    // <a:r><a:rPr b=".."/></a:r></a:p></c:rich></c:tx></c:title>` also
+    // sits on every axis flavour. Normalize the caller's boolean
+    // input — non-boolean tokens (typed escapes from an untyped
+    // caller) collapse to `undefined` so the writer falls back to the
+    // OOXML default `b="0"` (non-bold) Excel itself emits on a fresh
+    // axis title. The per-family axis builders only honour the flag
+    // when the axis actually renders a title.
+    xAxisTitleBold: normalizeAxisTitleBold(chart.axes?.x?.axisTitleBold),
+    yAxisTitleBold: normalizeAxisTitleBold(chart.axes?.y?.axisTitleBold),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1007,6 +1017,24 @@ interface AxisRenderOptions {
    * shape and conversion semantics as {@link xAxisTitleRotation}.
    */
   yAxisTitleRotation: number | undefined;
+  /**
+   * Axis-title bold flag emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+   * <a:r><a:rPr b=".."/></a:r></a:p></c:rich></c:tx></c:title>`. The
+   * OOXML `b` attribute is the `xsd:boolean` bold flag on
+   * `CT_TextCharacterProperties`; the writer emits `1` / `0` at the
+   * canonical slots. `undefined` collapses to the OOXML default `0`
+   * (non-bold) so a fresh chart matches Excel's reference
+   * serialization byte-for-byte. Only meaningful when the axis
+   * renders a title — the per-family axis builders gate the value on
+   * the `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleBold: boolean | undefined;
+  /**
+   * Axis-title bold flag emitted on the Y axis. Same shape and
+   * semantics as {@link xAxisTitleBold}.
+   */
+  yAxisTitleBold: boolean | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -1865,7 +1893,10 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:axPos", { val: catPos }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (opts.xAxisTitle) catAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation));
+  if (opts.xAxisTitle)
+    catAxChildren.push(
+      buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation, opts.xAxisTitleBold),
+    );
   catAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
@@ -1918,7 +1949,10 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     xmlSelfClose("c:axPos", { val: valPos }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (opts.yAxisTitle) valAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation));
+  if (opts.yAxisTitle)
+    valAxChildren.push(
+      buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation, opts.yAxisTitleBold),
+    );
   valAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
@@ -2272,7 +2306,8 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     xmlSelfClose("c:axPos", { val: "b" }),
     ...buildAxisGridlines(opts.xGridlines),
   ];
-  if (opts.xAxisTitle) xAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation));
+  if (opts.xAxisTitle)
+    xAxChildren.push(buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation, opts.xAxisTitleBold));
   xAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
     ...buildAxisTickRendering(opts.xMajorTickMark, opts.xMinorTickMark, opts.xTickLblPos),
@@ -2304,7 +2339,8 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     xmlSelfClose("c:axPos", { val: "l" }),
     ...buildAxisGridlines(opts.yGridlines),
   ];
-  if (opts.yAxisTitle) yAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation));
+  if (opts.yAxisTitle)
+    yAxChildren.push(buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation, opts.yAxisTitleBold));
   yAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
     ...buildAxisTickRendering(opts.yMajorTickMark, opts.yMinorTickMark, opts.yTickLblPos),
@@ -2344,9 +2380,33 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
  * default `0` so a fresh chart matches Excel's reference serialization
  * byte-for-byte. Mirrors the chart-title `buildTitle` slot exactly so
  * an axis title and the chart-level title carry the same shape.
+ *
+ * The optional `bold` parameter pins the title's `<a:defRPr b=".."/>`
+ * / `<a:rPr b=".."/>` attributes. The OOXML `b` attribute is the
+ * `xsd:boolean` bold flag on `CT_TextCharacterProperties`; the writer
+ * emits `1` / `0` at the canonical slots. Absence (`undefined`)
+ * collapses to the OOXML default `0` (non-bold) so a fresh chart
+ * matches Excel's reference serialization byte-for-byte. The flag
+ * lands on both `<a:defRPr>` and `<a:rPr>` so a re-parse picks the
+ * value up off either canonical slot — Excel keeps the two attributes
+ * in sync.
  */
-function buildAxisTitle(label: string, rotationDeg: number | undefined): string {
+function buildAxisTitle(
+  label: string,
+  rotationDeg: number | undefined,
+  bold: boolean | undefined,
+): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
+  // OOXML's `<a:defRPr b=".."/>` / `<a:rPr b=".."/>` attribute is the
+  // `xsd:boolean` bold flag on `CT_TextCharacterProperties`. The
+  // writer holds `axisTitleBold` as a boolean and emits `1` / `0` at
+  // the canonical slots. Absence (`undefined`) collapses to the OOXML
+  // default `0` (non-bold) so a fresh chart matches Excel's reference
+  // serialization byte-for-byte. The flag lands on both
+  // `<a:defRPr>` and `<a:rPr>` so a re-parse picks the value up off
+  // either canonical slot, mirroring the chart-level `buildTitle`
+  // writer.
+  const b = bold ? 1 : 0;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -2364,9 +2424,9 @@ function buildAxisTitle(label: string, rotationDeg: number | undefined): string 
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz: 1000, b: 0 })]),
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz: 1000, b })]),
           xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz: 1000, b: 0 }),
+            xmlSelfClose("a:rPr", { lang: "en-US", sz: 1000, b }),
             xmlElement("a:t", undefined, xmlEscape(label)),
           ]),
         ]),
@@ -2388,6 +2448,20 @@ function buildAxisTitle(label: string, rotationDeg: number | undefined): string 
  */
 function normalizeAxisTitleRotation(value: number | undefined): number | undefined {
   return normalizeTitleRotation(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleBold value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` writer slot inside an axis. Delegates
+ * to the chart-level {@link normalizeTitleBold} — `true` / `false`
+ * pass through literally, every other token (typed escape from an
+ * untyped caller, including `null`-shaped values) collapses to
+ * `undefined` so the writer falls back to the OOXML default `b="0"`
+ * (non-bold) Excel itself emits on a fresh axis title.
+ */
+function normalizeAxisTitleBold(value: boolean | undefined): boolean | undefined {
+  return normalizeTitleBold(value);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -11198,3 +11198,131 @@ describe("cloneChart — axis title rotation", () => {
     expect(reparsed?.axes?.x?.axisTitleRotation).toBe(-45);
   });
 });
+
+// ── cloneChart — axis title bold ────────────────────────────────────
+
+describe("cloneChart — axis title bold", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleBold by default", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleBold: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleBold by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleBold: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleBold).toBe(true);
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleBold override the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleBold: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBold: false } },
+    });
+    expect(clone.axes?.x?.axisTitleBold).toBe(false);
+  });
+
+  it("drops the inherited axisTitleBold when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleBold: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBold: null } },
+    });
+    expect(clone.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("replaces with a fresh value when the source has none", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBold: true } },
+    });
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+  });
+
+  it("returns undefined axisTitleBold when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("drops a non-boolean override to undefined", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleBold: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleBold: "true" as any } },
+    });
+    expect(clone.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("drops the inherited axisTitleBold when the resolved title is null", () => {
+    // Without an axis title there is no `<c:title>` block to host the
+    // bold flag, so the resolver drops the inherited flag silently.
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleBold: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: null } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("composes independently with axisTitleRotation on the same axis", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleRotation: 45, axisTitleBold: true },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+  });
+
+  it("end-to-end: parse -> clone -> write -> reparse round-trip", async () => {
+    // Pinning bold on a templated chart's X-axis title preserves the
+    // flag through the entire dashboard composition flow.
+    const decoder = new TextDecoder();
+    const src = source({ axes: { x: { title: "Period", axisTitleBold: true } } });
+    const clone = cloneChart(src, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", 1],
+            ["B", 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleBold).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10272,3 +10272,184 @@ describe("writeChart — axis title rotation", () => {
     expect(reparsed?.axes?.y?.axisTitleRotation).toBe(-90);
   });
 });
+
+// ── writeChart — axis title bold ────────────────────────────────────
+
+describe("writeChart — axis title bold", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBOf(axisBlock: string): { defRPr?: string; rPr?: string } {
+    const titleMatch = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) return {};
+    const def = titleMatch[0].match(/<a:defRPr\b[^/]*\/>/);
+    const r = titleMatch[0].match(/<a:rPr\b[^/]*\/>/);
+    const out: { defRPr?: string; rPr?: string } = {};
+    if (def) {
+      const m = def[0].match(/\bb="([^"]+)"/);
+      if (m) out.defRPr = m[1];
+    }
+    if (r) {
+      const m = r[0].match(/\bb="([^"]+)"/);
+      if (m) out.rPr = m[1];
+    }
+    return out;
+  }
+
+  it('emits b="0" on both <a:defRPr> and <a:rPr> by default', () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBOf(xAx)).toEqual({ defRPr: "0", rPr: "0" });
+  });
+
+  it('emits b="1" on the X-axis title when axisTitleBold=true', () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBold: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBOf(xAx)).toEqual({ defRPr: "1", rPr: "1" });
+  });
+
+  it('emits b="0" on axisTitleBold=false (functionally identical to omission)', () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBold: false } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBOf(xAx)).toEqual({ defRPr: "0", rPr: "0" });
+  });
+
+  it('emits b="1" on the Y-axis title when axisTitleBold=true', () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { title: "Revenue (USD)", axisTitleBold: true } } }),
+      "Sheet1",
+    );
+    const [, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBOf(yAx)).toEqual({ defRPr: "1", rPr: "1" });
+  });
+
+  it("emits the bold flag independently on each axis", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleBold: false },
+          y: { title: "Revenue", axisTitleBold: true },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBOf(xAx)).toEqual({ defRPr: "0", rPr: "0" });
+    expect(axisTitleBOf(yAx)).toEqual({ defRPr: "1", rPr: "1" });
+  });
+
+  it("drops non-boolean inputs back to the OOXML default", () => {
+    const stringy = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleBold: "true" as any } },
+      }),
+      "Sheet1",
+    );
+    const numeric = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleBold: 1 as any } },
+      }),
+      "Sheet1",
+    );
+    expect(axisTitleBOf(axisBlocks(stringy.chartXml)[0])).toEqual({ defRPr: "0", rPr: "0" });
+    expect(axisTitleBOf(axisBlocks(numeric.chartXml)[0])).toEqual({ defRPr: "0", rPr: "0" });
+  });
+
+  it("silently ignores axisTitleBold when the axis renders no title", () => {
+    // The writer scopes the bold flag to `<c:title>` — when the axis
+    // has no title to render, the entire `<c:title>` block is omitted
+    // and there is no `<a:defRPr>` slot to host the flag.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleBold: true } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with axisTitleRotation on the same axis title", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: "Period", axisTitleRotation: 45, axisTitleBold: true } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleMatch = xAx.match(/<c:title>[\s\S]*?<\/c:title>/);
+    expect(titleMatch?.[0]).toContain('rot="2700000"');
+    expect(axisTitleBOf(xAx)).toEqual({ defRPr: "1", rPr: "1" });
+  });
+
+  it("threads through every chart family that has axes", async () => {
+    // Bar / column / line / area route X through `<c:catAx>` and Y
+    // through `<c:valAx>`; scatter routes both through `<c:valAx>`.
+    // The flag lands on every axis-title `<a:defRPr>` for every
+    // family. Pie / doughnut were short-circuited upstream — the
+    // resolver never invokes the axis builder for those families.
+    for (const type of ["bar", "column", "line", "area", "scatter"] as WriteChartKind[]) {
+      const sheets: WriteSheet[] = [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", 1],
+            ["B", 2],
+          ],
+          charts: [
+            {
+              type,
+              title: "Sales",
+              series: [{ name: "S", values: "B1:B2", categories: "A1:A2" }],
+              anchor: { from: { row: 5, col: 0 } },
+              axes: {
+                x: { title: "X", axisTitleBold: true },
+                y: { title: "Y", axisTitleBold: true },
+              },
+            },
+          ],
+        },
+      ];
+      const out = await writeXlsx({ sheets });
+      const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+      const reparsed = parseChart(chartXml);
+      expect(reparsed?.axes?.x?.axisTitleBold).toBe(true);
+      expect(reparsed?.axes?.y?.axisTitleBold).toBe(true);
+    }
+  });
+
+  it("round-trips through writeXlsx -> readXlsx", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["A", 1],
+          ["B", 2],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Test Chart",
+            series: [{ name: "Revenue", values: "B1:B2", categories: "A1:A2" }],
+            anchor: { from: { row: 5, col: 0 } },
+            axes: {
+              x: { title: "Period", axisTitleBold: true },
+              y: { title: "USD", axisTitleBold: false },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleBold).toBe(true);
+    // axisTitleBold=false collapses to the OOXML default `b="0"`,
+    // which the reader surfaces as `undefined` for round-trip parity.
+    expect(reparsed?.axes?.y?.axisTitleBold).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10826,3 +10826,243 @@ describe("parseChart — axis title rotation", () => {
     });
   });
 });
+
+// ── parseChart — axis title bold ─────────────────────────────────────
+
+describe("parseChart — axis title bold", () => {
+  const NS_AXB = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitleBold(b: string | undefined): string {
+    const defRPr = b === undefined ? "<a:defRPr/>" : `<a:defRPr b="${b}"/>`;
+    return `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true on the X axis when the axis title pinned b='1'", () => {
+    const chart = parseChart(withCatAxTitleBold("1"));
+    expect(chart?.axes?.x?.axisTitleBold).toBe(true);
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("collapses b='0' to undefined (OOXML default round-trips identically)", () => {
+    const chart = parseChart(withCatAxTitleBold("0"));
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("collapses absence of the b attribute to undefined", () => {
+    const chart = parseChart(withCatAxTitleBold(undefined));
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("accepts the OOXML truthy spelling 'true'", () => {
+    const chart = parseChart(withCatAxTitleBold("true"));
+    expect(chart?.axes?.x?.axisTitleBold).toBe(true);
+  });
+
+  it("collapses the OOXML falsy spelling 'false' to undefined", () => {
+    const chart = parseChart(withCatAxTitleBold("false"));
+    expect(chart?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("drops unknown b tokens to undefined", () => {
+    expect(parseChart(withCatAxTitleBold("yes"))?.axes?.x?.axisTitleBold).toBeUndefined();
+    expect(parseChart(withCatAxTitleBold(""))?.axes?.x?.axisTitleBold).toBeUndefined();
+    expect(parseChart(withCatAxTitleBold("on"))?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when the axis title is a <c:strRef> (no <c:rich> body)", () => {
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache>
+        </c:strRef></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("surfaces the bold flag on the value axis as well", () => {
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:t>Revenue</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("Revenue");
+    expect(chart?.axes?.y?.axisTitleBold).toBe(true);
+  });
+
+  it("surfaces the bold flag on a scatter chart's value-axis pair", () => {
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:scatterChart>
+      <c:scatterStyle val="lineMarker"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:scatterChart>
+    <c:valAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:t>X</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:t>Y</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleBold).toBe(true);
+    expect(chart?.axes?.y?.axisTitleBold).toBe(true);
+  });
+
+  it("does not leak from a stray chart-level <a:defRPr b='1'> onto the axis", () => {
+    // The chart-level title is bold, but the axis title is not — the
+    // axis-level reader scopes the lookup to its own `<c:title>` body
+    // and never reads the chart-level slot.
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleBold).toBe(true);
+    expect(chart?.axes?.x?.axisTitleBold).toBeUndefined();
+  });
+
+  it("co-surfaces alongside axisTitleRotation on the same axis title", () => {
+    // Axis-title rotation 45° (`rot="2700000"`) and bold `b="1"` both
+    // sit on the same `<c:title>` body — the reader surfaces both
+    // independently on the parsed `ChartAxisInfo`.
+    const xml = `<c:chartSpace ${NS_AXB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(45);
+    expect(chart?.axes?.x?.axisTitleBold).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=\"..\"/></a:pPr><a:r><a:rPr b=\"..\"/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>` (and the matching `<c:valAx>` shape — CT_Title's default-paragraph and run text-character-properties bold flag on every axis flavour, ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's bold axis-title pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Mirrors the chart-level `titleBold` field added in #252 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same drop-on-default-`false` semantics, same `boolean | null` clone grammar (`undefined` inherits, `null` drops, a literal boolean replaces) — so a single configuration call threads cleanly through both the chart title and either axis title without bookkeeping the canonical OOXML slots. Mirrors `axisTitleRotation` (#248) and `axisTitleFontSize` (#255) for the same OOXML slot-pair, so all three axis-title knobs compose freely on the same `<c:title>` body.

Until now hucre's writer hardcoded `b=\"0\"` (non-bold) on both axis titles' `<a:defRPr>` and `<a:rPr>` and the reader ignored the attribute entirely, so a templated dashboard chart whose user bolded an axis title for emphasis silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136 — the issue's example explicitly calls for axis-label customization and the bold flag is one of the most visible knobs the chart-title family had that the axis-title family didn't.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.axisTitleBold);
// true       <- when the template pinned <a:defRPr b="1"/>
// undefined  <- when the template emits <a:defRPr b="0"/> (OOXML default round-trips identically)
// undefined  <- when the chart has no <c:title> on the X axis or the title is a <c:strRef>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [/* ... */],
    charts: [{
      type: "column",
      title: "Q4 Revenue",
      series: [/* ... */],
      anchor: { from: { row: 5, col: 0 } },
      axes: {
        x: { title: "Period", axisTitleBold: false },
        y: { title: "USD", axisTitleBold: true },
      },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 0, col: 8 } },
  axes: {
    x: { axisTitleBold: true },     // replaces the inherited flag
    y: { axisTitleBold: null },     // drops it (writer falls back to b="0")
  },
});
```

## Implementation notes

- **Type model**: `SheetChart.axes.{x,y}.axisTitleBold?: boolean` (writer side); `ChartAxisInfo.axisTitleBold?: boolean` (reader side). The clone option `axisTitleBold?: boolean | null` follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar.
- **Reader** (`parseAxisTitleBold`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr b=\"..\"/></a:pPr></a:p></c:rich></c:tx></c:title>` for the `b` attribute. The lookup is scoped to the axis title's `<c:rich>` body so a stray `<a:defRPr>` elsewhere on the axis (e.g. on the tick-label `<c:txPr>`) cannot leak in. The OOXML default `false` collapses to `undefined` so absence and `b=\"0\"` round-trip identically through `cloneChart` — only an explicit `b=\"1\"` surfaces `true`. Returns `undefined` when the axis omits `<c:title>` or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body.
- **Writer**: `buildAxisTitle` now resolves through a `bold?: boolean` parameter — `normalizeAxisTitleBold` accepts `true` / `false` literally and collapses every other token (typed escape from an untyped caller) to `undefined`. Absence falls back to the OOXML default `b=\"0\"` (non-bold) so a fresh chart matches Excel's reference serialization byte-for-byte. The flag lands on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks the value up off either canonical slot — Excel keeps the two attributes in sync.
- **Clone** (`applyAxisTitleBoldOverride`): follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same gate the writer uses — when the resolved title is dropped (`title: null` or `showTitle: false`), the inherited flag drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.

## Test plan

- [x] `parseChart — axis title bold` (12 new tests) — surfaces `true` from `b=\"1\"`, collapses `b=\"0\"` and absence to `undefined`, accepts the OOXML truthy / falsy spellings, drops unknown tokens, returns undefined when `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>`, surfaces on both X and Y axes including scatter's value-axis pair, does not leak from a stray chart-level `<a:defRPr>`, co-surfaces alongside `axisTitleRotation` on the same axis title.
- [x] `writeChart — axis title bold` (10 new tests) — emits `b=\"0\"` on both `<a:defRPr>` and `<a:rPr>` by default, emits `b=\"1\"` on `axisTitleBold=true`, emits `b=\"0\"` on `axisTitleBold=false` (functionally identical to omission), emits independently per axis, drops non-boolean inputs to the default, silently ignores when no axis title renders, composes with `axisTitleRotation`, threads through every chart family that has axes (bar / column / line / area / scatter), full `writeXlsx` package round-trip.
- [x] `cloneChart — axis title bold` (10 new tests) — inherits the source's value, inherits independently per axis, override replaces, `null` drops, replace null source with override, returns undefined with no source / no override, drops non-boolean override, drops on `title: null`, composes with `axisTitleRotation`, end-to-end parse -> clone -> write -> reparse round-trip.
- [x] `pnpm test` — all 4506 tests pass (lint + format + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)