### PR TITLE
feat(xlsx): chart axis title italic flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1956,6 +1956,42 @@ export interface SheetChart {
        * family that has axes (bar / column / line / area / scatter).
        */
       axisTitleFontSize?: number;
+      /**
+       * Axis title italic flag. Maps to
+       * `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+       * <a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format Axis
+       * Title -> Font -> Italic" toggle. The OOXML attribute is the
+       * `xsd:boolean` `i` on `CT_TextCharacterProperties` (ECMA-376
+       * Part 1, §21.1.2.3.7); the writer lands the value on both the
+       * default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`
+       * so a re-parse picks the flag up off either canonical slot —
+       * Excel keeps the two attributes in sync.
+       *
+       * Mirrors {@link SheetChart.titleItalic} for axis titles — same
+       * canonical-slot pair, same drop-on-default semantics, same
+       * `boolean | null` clone grammar so a single configuration call
+       * threads cleanly through both the chart title and either axis
+       * title without bookkeeping the canonical OOXML slots.
+       *
+       * Default: omitted — the axis title renders non-italic (no `i`
+       * attribute, Excel's reference serialization for a fresh axis
+       * title; the application-default `false` collapses to absence).
+       * Set `true` to emit `i="1"` on both slots so the title renders
+       * italic; set `false` explicitly to pin the non-default `i="0"`
+       * (functionally identical to omission, but useful when overriding
+       * a templated axis title that had italic pinned upstream).
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+       * per the OOXML schema, so the field round-trips on every chart
+       * family that has axes (bar / column / line / area / scatter).
+       */
+      axisTitleItalic?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -2241,6 +2277,26 @@ export interface SheetChart {
        * to host the size).
        */
       axisTitleFontSize?: number;
+      /**
+       * Value-axis title italic flag. Maps to
+       * `<c:valAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+       * <a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.axisTitleItalic} for the value
+       * axis — see that field for the full semantics. The OOXML
+       * attribute is the `xsd:boolean` `i` on
+       * `CT_TextCharacterProperties`; the writer lands the value on
+       * both the default-paragraph `<a:defRPr>` and the literal run's
+       * `<a:rPr>` so a re-parse picks the flag up off either canonical
+       * slot.
+       *
+       * Useful for italicising a Y-axis unit label to mark it as a
+       * derived measure (a common dashboard pattern that distinguishes
+       * an aggregated / computed axis from a raw category axis).
+       * Silently dropped on `pie` / `doughnut` charts (no axes at all)
+       * and on any axis whose `title` is unset (no `<c:title>` block
+       * to host the flag).
+       */
+      axisTitleItalic?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3454,6 +3510,34 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleFontSize?: number;
+  /**
+   * Axis-title italic flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+   * </c:rich></c:tx></c:title>` on the axis element. Reflects Excel's
+   * "Format Axis Title -> Font -> Italic" toggle.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<a:defRPr i="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<a:defRPr i="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings
+   * (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing
+   * `i` attributes drop to `undefined`.
+   *
+   * Reported as `undefined` whenever the axis has no `<c:title>`
+   * element at all, or when the title is a `<c:strRef>` (formula
+   * reference) with no `<c:rich>` body — there is no `<a:p>` to host
+   * the flag in either case. Mirrors the chart-level
+   * {@link Chart.titleItalic} so a parsed value slots straight back
+   * into the writer-side {@link SheetChart.axes.x.axisTitleItalic}
+   * without transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the flag regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleItalic?: boolean;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -705,6 +705,24 @@ export interface CloneChartOptions {
        * host the size).
        */
       axisTitleFontSize?: number | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleItalic`. `undefined` (or
+       * omitted) inherits the source axis's parsed value; `null` drops
+       * the inherited flag (the writer falls back to the OOXML default
+       * — no `i` attribute, equivalent to non-italic); a literal
+       * `boolean` replaces it. Non-boolean overrides (typed escape
+       * from an untyped caller) collapse to `undefined`, so the
+       * cloned `SheetChart` always carries a value the writer will
+       * accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently
+       * dropped on `pie` / `doughnut` charts (no axes at all) and on
+       * any axis whose `title` is unset (no `<c:title>` block to
+       * host the flag).
+       */
+      axisTitleItalic?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -889,6 +907,8 @@ export interface CloneChartOptions {
       axisTitleRotation?: number | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleFontSize}. */
       axisTitleFontSize?: number | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleItalic}. */
+      axisTitleItalic?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2552,6 +2572,23 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleFontSize,
     overrides?.y?.axisTitleFontSize,
   );
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis title italic flag. Sits on the
+  // same `<c:title>` body as `axisTitleRotation` / `axisTitleFontSize`,
+  // so the resolver applies on every chart family that has axes (pie /
+  // doughnut were short-circuited upstream). Non-boolean overrides
+  // collapse to `undefined` so the writer omits the `i` attribute.
+  // Like the rotation and the size, the writer drops the flag when
+  // the matching axis title is unset, so a stray pin on an axis with
+  // no title silently disappears at emit time.
+  const xAxisTitleItalic = applyAxisTitleItalicOverride(
+    sourceAxes?.x?.axisTitleItalic,
+    overrides?.x?.axisTitleItalic,
+  );
+  const yAxisTitleItalic = applyAxisTitleItalicOverride(
+    sourceAxes?.y?.axisTitleItalic,
+    overrides?.y?.axisTitleItalic,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -2696,12 +2733,21 @@ function resolveAxes(
   // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
   const xAxisTitleFontSizeResolved = xTitle === undefined ? undefined : xAxisTitleFontSize;
   const yAxisTitleFontSizeResolved = yTitle === undefined ? undefined : yAxisTitleFontSize;
+  // The axis-title italic flag only renders when the axis carries a
+  // title — drop a stray inherited flag when the resolved axis title
+  // is unset so the cloned `SheetChart` accurately reflects what the
+  // chart will paint. Symmetric with the writer's title-presence gate
+  // (the per-family axis builder only invokes `buildAxisTitle` when
+  // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
+  const xAxisTitleItalicResolved = xTitle === undefined ? undefined : xAxisTitleItalic;
+  const yAxisTitleItalicResolved = yTitle === undefined ? undefined : yAxisTitleItalic;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
     xTitle !== undefined ||
     xAxisTitleRotationResolved !== undefined ||
     xAxisTitleFontSizeResolved !== undefined ||
+    xAxisTitleItalicResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -2728,6 +2774,7 @@ function resolveAxes(
       out.x.axisTitleRotation = xAxisTitleRotationResolved;
     if (xAxisTitleFontSizeResolved !== undefined)
       out.x.axisTitleFontSize = xAxisTitleFontSizeResolved;
+    if (xAxisTitleItalicResolved !== undefined) out.x.axisTitleItalic = xAxisTitleItalicResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -2752,6 +2799,7 @@ function resolveAxes(
     yTitle !== undefined ||
     yAxisTitleRotationResolved !== undefined ||
     yAxisTitleFontSizeResolved !== undefined ||
+    yAxisTitleItalicResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -2772,6 +2820,7 @@ function resolveAxes(
       out.y.axisTitleRotation = yAxisTitleRotationResolved;
     if (yAxisTitleFontSizeResolved !== undefined)
       out.y.axisTitleFontSize = yAxisTitleFontSizeResolved;
+    if (yAxisTitleItalicResolved !== undefined) out.y.axisTitleItalic = yAxisTitleItalicResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -3155,6 +3204,31 @@ function applyAxisTitleFontSizeOverride(
   if (override === undefined) return normalizeTitleFontSize(source);
   if (override === null) return undefined;
   return normalizeTitleFontSize(override);
+}
+
+/**
+ * Resolve an `axisTitleItalic` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Non-boolean overrides (typed escape from an untyped
+ * caller) collapse to `undefined` via {@link normalizeTitleItalic} so
+ * the cloned `SheetChart` always carries a value the writer will
+ * accept. A `null` override always drops the inherited flag (the
+ * writer falls back to the OOXML default — no `i` attribute,
+ * equivalent to non-italic).
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a flag that the writer would silently elide (the writer
+ * scopes the flag emission to `<c:title>`, which is omitted when the
+ * axis renders no title).
+ */
+function applyAxisTitleItalicOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeTitleItalic(source);
+  if (override === null) return undefined;
+  return normalizeTitleItalic(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -544,6 +544,17 @@ function parseAxisInfo(
   // `undefined` for symmetry with the writer-side
   // {@link SheetChart.axes.x.axisTitleFontSize}.
   const axisTitleFontSize = parseAxisTitleFontSize(axis);
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis-title italic flag. Same
+  // `<c:title>` body scope as `axisTitleFontSize`, so a stray
+  // `<a:defRPr>` elsewhere on the axis (e.g. on the tick-label
+  // `<c:txPr>`) cannot leak in. The OOXML default `false` collapses to
+  // `undefined` so absence and `i="0"` round-trip identically through
+  // the writer — only an explicit `i="1"` surfaces `true`. Returns
+  // `undefined` when the axis omits `<c:title>` entirely or when the
+  // title is a `<c:strRef>` (formula reference) with no `<c:rich>`
+  // body.
+  const axisTitleItalic = parseAxisTitleItalic(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -635,6 +646,7 @@ function parseAxisInfo(
     title === undefined &&
     axisTitleRotation === undefined &&
     axisTitleFontSize === undefined &&
+    axisTitleItalic === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -661,6 +673,7 @@ function parseAxisInfo(
   if (title !== undefined) out.title = title;
   if (axisTitleRotation !== undefined) out.axisTitleRotation = axisTitleRotation;
   if (axisTitleFontSize !== undefined) out.axisTitleFontSize = axisTitleFontSize;
+  if (axisTitleItalic !== undefined) out.axisTitleItalic = axisTitleItalic;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -1390,6 +1403,58 @@ function parseAxisTitleFontSize(axis: XmlElement): number | undefined {
   const points = halfSteps / 2;
   if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
   return points;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` off an axis element. Returns
+ * `true` only when the OOXML attribute is the literal truthy spelling
+ * (`"1"` / `"true"`); the OOXML default `false` collapses to
+ * `undefined` so absence and `i="0"` round-trip identically through
+ * the writer.
+ *
+ * Mirrors {@link parseTitleItalic} for axis titles — same canonical-
+ * slot pair (`<a:defRPr>` carries the default-paragraph italic flag,
+ * which the writer keeps in sync with the literal run's `<a:rPr>` so
+ * the reader only needs to consult one of the two slots), same
+ * drop-on-default semantics. The lookup is scoped to the axis title's
+ * `<c:rich>` body so a stray `<a:defRPr>` elsewhere on the axis (e.g.
+ * on the tick-label `<c:txPr>`) cannot leak in.
+ *
+ * Returns `undefined` whenever the axis omits `<c:title>` entirely
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body — there is no `<a:p>` slot to surface the flag
+ * from in either case.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape
+ * per the OOXML schema. Mirrors the chart-level title italic
+ * {@link parseTitleItalic} so a parsed value slots straight into the
+ * writer-side {@link SheetChart.axes}.x.axisTitleItalic.
+ */
+function parseAxisTitleItalic(axis: XmlElement): boolean | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph italic flag. The reader walks the canonical chain
+  // and bails on the first missing link so a malformed `<c:rich>`
+  // surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const parsed = parseBoolAttr(defRPr.attrs.i);
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `i="0"` round-trip identically through the writer — only an
+  // explicit `i="1"` surfaces `true`.
+  if (parsed === true) return true;
+  return undefined;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -607,6 +607,18 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // hardcoded 10pt default Excel itself emits on a fresh axis title.
     xAxisTitleFontSize: normalizeAxisTitleFontSize(chart.axes?.x?.axisTitleFontSize),
     yAxisTitleFontSize: normalizeAxisTitleFontSize(chart.axes?.y?.axisTitleFontSize),
+    // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+    // <a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title>` —
+    // axis-title italic flag. The OOXML attribute is the `xsd:boolean`
+    // `i` on `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7)
+    // and the slot lives on every axis flavour. Normalize the caller's
+    // boolean input — the writer keeps `true` / `false` literally so a
+    // re-parse picks the value up off either canonical slot, while every
+    // other token (typed escape from an untyped caller) collapses to
+    // `undefined` and the writer omits the `i` attribute (Excel's
+    // reference serialization for a non-italic axis title).
+    xAxisTitleItalic: normalizeAxisTitleItalic(chart.axes?.x?.axisTitleItalic),
+    yAxisTitleItalic: normalizeAxisTitleItalic(chart.axes?.y?.axisTitleItalic),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1033,6 +1045,23 @@ interface AxisRenderOptions {
    * and conversion semantics as {@link xAxisTitleFontSize}.
    */
   yAxisTitleFontSize: number | undefined;
+  /**
+   * Axis-title italic flag emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+   * <a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title>`. The
+   * OOXML attribute is the `xsd:boolean` `i` on
+   * `CT_TextCharacterProperties`. `undefined` and `false` both collapse
+   * to omitting the attribute (Excel's reference serialization for a
+   * non-italic axis title); only `true` emits `i="1"`. Only meaningful
+   * when the axis renders a title — the per-family axis builders gate
+   * the value on the `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleItalic: boolean | undefined;
+  /**
+   * Axis-title italic flag emitted on the Y axis. Same shape and emit
+   * semantics as {@link xAxisTitleItalic}.
+   */
+  yAxisTitleItalic: boolean | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -1893,7 +1922,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   ];
   if (opts.xAxisTitle)
     catAxChildren.push(
-      buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation, opts.xAxisTitleFontSize),
+      buildAxisTitle(
+        opts.xAxisTitle,
+        opts.xAxisTitleRotation,
+        opts.xAxisTitleFontSize,
+        opts.xAxisTitleItalic,
+      ),
     );
   catAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
@@ -1949,7 +1983,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   ];
   if (opts.yAxisTitle)
     valAxChildren.push(
-      buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation, opts.yAxisTitleFontSize),
+      buildAxisTitle(
+        opts.yAxisTitle,
+        opts.yAxisTitleRotation,
+        opts.yAxisTitleFontSize,
+        opts.yAxisTitleItalic,
+      ),
     );
   valAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
@@ -2306,7 +2345,12 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   ];
   if (opts.xAxisTitle)
     xAxChildren.push(
-      buildAxisTitle(opts.xAxisTitle, opts.xAxisTitleRotation, opts.xAxisTitleFontSize),
+      buildAxisTitle(
+        opts.xAxisTitle,
+        opts.xAxisTitleRotation,
+        opts.xAxisTitleFontSize,
+        opts.xAxisTitleItalic,
+      ),
     );
   xAxChildren.push(
     ...buildAxisNumFmt(opts.xNumFmt),
@@ -2341,7 +2385,12 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   ];
   if (opts.yAxisTitle)
     yAxChildren.push(
-      buildAxisTitle(opts.yAxisTitle, opts.yAxisTitleRotation, opts.yAxisTitleFontSize),
+      buildAxisTitle(
+        opts.yAxisTitle,
+        opts.yAxisTitleRotation,
+        opts.yAxisTitleFontSize,
+        opts.yAxisTitleItalic,
+      ),
     );
   yAxChildren.push(
     ...buildAxisNumFmt(opts.yNumFmt),
@@ -2392,11 +2441,21 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
  * that never set the field. The size lands on both the
  * default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
  * a re-parse picks the value up off either canonical slot.
+ *
+ * The optional `italic` parameter pins the title's
+ * `<a:defRPr i=".."/>` / `<a:rPr i=".."/>` attributes. The OOXML
+ * attribute is the `xsd:boolean` `i` on `CT_TextCharacterProperties`.
+ * Absence (`undefined`) and explicit `false` both collapse to omitting
+ * the attribute (Excel's reference serialization for a non-italic
+ * axis title — only the bold flag is always emitted); only `true`
+ * emits `i="1"` on both slots so a re-parse picks the flag up off
+ * either canonical slot.
  */
 function buildAxisTitle(
   label: string,
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
+  italic: boolean | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -2411,6 +2470,17 @@ function buildAxisTitle(
     fontSizePt === undefined
       ? AXIS_TITLE_DEFAULT_FONT_SIZE_SZ
       : fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  // OOXML's `<a:defRPr i=".."/>` / `<a:rPr i=".."/>` attribute is the
+  // `xsd:boolean` italic flag on `CT_TextCharacterProperties`. Mirrors
+  // the chart-level `buildTitle` italic emit: `axisTitleItalic` lands
+  // on both the default-paragraph `<a:defRPr>` and the literal run's
+  // `<a:rPr>` so a re-parse picks the value up off either canonical
+  // slot — Excel keeps the two attributes in sync. Absence
+  // (`undefined`) and explicit `false` both collapse to omitting the
+  // attribute so a fresh axis title matches Excel's reference
+  // serialization byte-for-byte (Excel itself omits `i` on a non-
+  // italic axis title — only the bold flag is always emitted).
+  const i = italic === true ? 1 : undefined;
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -2428,9 +2498,9 @@ function buildAxisTitle(
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b: 0 })]),
+          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b: 0, i })]),
           xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz, b: 0 }),
+            xmlSelfClose("a:rPr", { lang: "en-US", sz, b: 0, i }),
             xmlElement("a:t", undefined, xmlEscape(label)),
           ]),
         ]),
@@ -2478,6 +2548,21 @@ function normalizeAxisTitleRotation(value: number | undefined): number | undefin
  */
 function normalizeAxisTitleFontSize(value: number | undefined): number | undefined {
   return normalizeTitleFontSize(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleItalic value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` writer slot inside an axis.
+ * Delegates to the chart-level {@link normalizeTitleItalic} so the two
+ * share the same drop-on-non-boolean grammar — `true` / `false` pass
+ * through literally, every other token (typed escape from an untyped
+ * caller) collapses to `undefined` and the writer omits the `i`
+ * attribute (Excel's reference serialization for a non-italic axis
+ * title).
+ */
+function normalizeAxisTitleItalic(value: boolean | undefined): boolean | undefined {
+  return normalizeTitleItalic(value);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -11477,3 +11477,257 @@ describe("cloneChart — axis title font size", () => {
     expect(reparsed?.axes?.x?.axisTitleFontSize).toBe(14);
   });
 });
+
+// ── cloneChart — axis title italic ───────────────────────────────────
+
+describe("cloneChart — axis title italic", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleItalic by default", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleItalic: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleItalic by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleItalic: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleItalic).toBe(true);
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleItalic replace the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleItalic: false } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleItalic: true } },
+    });
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+  });
+
+  it("drops the inherited axisTitleItalic when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleItalic: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleItalic: null } },
+    });
+    expect(clone.axes?.x?.axisTitleItalic).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleItalic when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("replaces a null source axisTitleItalic with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleItalic: true } },
+    });
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+  });
+
+  it("drops non-boolean overrides (defends against the type guard escaping)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleItalic: "true" as any } },
+    });
+    expect(clone.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("normalises a parsed source flag that is somehow non-boolean", () => {
+    // Defensive: a corrupt template parsed by an older reader could
+    // surface a non-boolean value. The clone normalizer drops it
+    // through the same boolean band so the writer never sees a
+    // bad token.
+    const clone = cloneChart(
+      source({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleItalic: "yes" as any } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("drops the inherited axisTitleItalic when the resolved axis title is dropped", () => {
+    // `title: null` flattens the inherited axis title — no `<c:title>`
+    // block will be emitted, so the inherited flag has no slot in the
+    // rendered axis and the clone collapses it.
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleItalic: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: null } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("drops an override axisTitleItalic when no axis title resolves", () => {
+    // The axis has no source title and the caller did not pin one —
+    // the writer would silently elide the flag either way, so the
+    // clone-side resolver mirrors that by dropping the field.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleItalic: true } },
+    });
+    expect(clone.axes?.x).toBeUndefined();
+  });
+
+  it("preserves the override when the override also pins a title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleItalic: true } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+  });
+
+  it("composes independently with the chart-level titleItalic", () => {
+    const clone = cloneChart(
+      source({
+        titleItalic: true,
+        axes: { x: { title: "Period", axisTitleItalic: false } },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+      },
+    );
+    expect(clone.titleItalic).toBe(true);
+    expect(clone.axes?.x?.axisTitleItalic).toBe(false);
+  });
+
+  it("composes independently with axisTitleRotation and axisTitleFontSize on the same axis", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleRotation: 45,
+            axisTitleFontSize: 14,
+            axisTitleItalic: true,
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+  });
+
+  it("threads the flag through both axes independently on the clone", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleItalic: true },
+          y: { title: "USD", axisTitleItalic: false },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+    expect(clone.axes?.y?.axisTitleItalic).toBe(false);
+  });
+
+  it("round-trips a templated chart's axis title italic through parseChart -> cloneChart -> writeChart", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.axisTitleItalic).toBe(true);
+    expect(parsed?.axes?.y?.axisTitleItalic).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.axisTitleItalic).toBe(true);
+    expect(sheetChart.axes?.y?.axisTitleItalic).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleItalic).toBe(true);
+    expect(reparsed?.axes?.y?.axisTitleItalic).toBe(true);
+  });
+
+  it("propagates axisTitleItalic into the rendered axis on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleItalic: true } } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleItalic).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10539,3 +10539,198 @@ describe("writeChart — axis title font size", () => {
     expect(reparsed?.axes?.y?.axisTitleFontSize).toBe(16);
   });
 });
+
+// ── writeChart — axis title italic ───────────────────────────────────
+
+describe("writeChart — axis title italic", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleDefRPrIOf(axisBlock: string): string | undefined {
+    const titleMatch = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) return undefined;
+    const m = titleMatch[0].match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const i = m[0].match(/\bi="([^"]+)"/);
+    return i ? i[1] : undefined;
+  }
+
+  function axisTitleRPrIOf(axisBlock: string): string | undefined {
+    const titleMatch = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) return undefined;
+    const m = titleMatch[0].match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const i = m[0].match(/\bi="([^"]+)"/);
+    return i ? i[1] : undefined;
+  }
+
+  it("omits the i attribute by default (matches Excel's reference non-italic axis title)", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrIOf(xAx)).toBeUndefined();
+    expect(axisTitleRPrIOf(xAx)).toBeUndefined();
+  });
+
+  it('emits i="1" on both <a:defRPr> and <a:rPr> when axisTitleItalic=true', () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleItalic: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrIOf(xAx)).toBe("1");
+    expect(axisTitleRPrIOf(xAx)).toBe("1");
+  });
+
+  it("omits the i attribute when axisTitleItalic=false (matches the OOXML default)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleItalic: false } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrIOf(xAx)).toBeUndefined();
+    expect(axisTitleRPrIOf(xAx)).toBeUndefined();
+  });
+
+  it("threads the flag through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleItalic: false },
+          y: { title: "USD", axisTitleItalic: true },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrIOf(xAx)).toBeUndefined();
+    expect(axisTitleDefRPrIOf(yAx)).toBe("1");
+  });
+
+  it("drops non-boolean inputs (defends against the type guard escaping)", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleItalic: "true" as any } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrIOf(xAx)).toBeUndefined();
+  });
+
+  it("ignores axisTitleItalic when the axis renders no title", () => {
+    // No title means no `<c:title>` block — there is no slot for the
+    // flag in either case.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleItalic: true } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with axisTitleRotation and axisTitleFontSize on the same axis", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleRotation: 45,
+            axisTitleFontSize: 14,
+            axisTitleItalic: true,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = xAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('rot="2700000"');
+    expect(titleBlock).toContain('sz="1400"');
+    expect(titleBlock).toContain('i="1"');
+  });
+
+  it("threads the flag through line / area / scatter chart families", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleItalic: true } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleDefRPrIOf(xAx)).toBe("1");
+    }
+    // Scatter routes both axes through `<c:valAx>` — confirm the flag
+    // still threads to the Y axis.
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleItalic: true } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    const yAx = blocks[1];
+    expect(axisTitleDefRPrIOf(yAx)).toBe("1");
+  });
+
+  it("preserves the axis title's other attributes (b='0', lang='en-US', sz='1000')", () => {
+    // The writer keeps `b="0"` (non-bold), `lang="en-US"`, and the
+    // default `sz="1000"` so a templated axis title only gains the
+    // italic flag, not lose the surrounding font defaults.
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleItalic: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = xAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('lang="en-US"');
+    expect(titleBlock).toContain('sz="1000"');
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("round-trips axisTitleItalic=true through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleItalic: true } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleItalic).toBe(true);
+  });
+
+  it("round-trips a defaulted axis title to undefined italic", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the axis title italic flag into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleItalic: false },
+              y: { title: "USD", axisTitleItalic: true },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleItalic).toBeUndefined();
+    expect(reparsed?.axes?.y?.axisTitleItalic).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -11083,3 +11083,230 @@ describe("parseChart — axis title font size", () => {
     });
   });
 });
+
+// ── parseChart — axis title italic ───────────────────────────────────
+
+describe("parseChart — axis title italic", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitle(iAttr: string | undefined): string {
+    const defRPr = iAttr === undefined ? "<a:defRPr/>" : `<a:defRPr i="${iAttr}"/>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the axis-title italic flag from the i attribute (i=1)", () => {
+    const chart = parseChart(withCatAxTitle("1"));
+    expect(chart?.axes?.x?.axisTitleItalic).toBe(true);
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("collapses i=0 to undefined (OOXML default round-trip)", () => {
+    const chart = parseChart(withCatAxTitle("0"));
+    expect(chart?.axes?.x?.axisTitleItalic).toBeUndefined();
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("collapses absence to undefined", () => {
+    const chart = parseChart(withCatAxTitle(undefined));
+    expect(chart?.axes?.x?.axisTitleItalic).toBeUndefined();
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it('accepts the OOXML truthy spelling i="true"', () => {
+    const chart = parseChart(withCatAxTitle("true"));
+    expect(chart?.axes?.x?.axisTitleItalic).toBe(true);
+  });
+
+  it('accepts the OOXML falsy spelling i="false"', () => {
+    const chart = parseChart(withCatAxTitle("false"));
+    expect(chart?.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("drops unknown i tokens", () => {
+    expect(parseChart(withCatAxTitle("yes"))?.axes?.x?.axisTitleItalic).toBeUndefined();
+    expect(parseChart(withCatAxTitle(""))?.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a <c:strRef> (no <c:rich> body)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache>
+        </c:strRef></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("does not leak the tick-label <c:txPr> italic flag into the title flag", () => {
+    // The reader scopes the lookup to the title's <c:rich> body —
+    // the tick-label `<c:txPr>` is a sibling element on the axis and
+    // must not feed its `<a:defRPr i>` into the title flag.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("surfaces the italic flag on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("USD");
+    expect(chart?.axes?.y?.axisTitleItalic).toBe(true);
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr i="0"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleItalic).toBe(true);
+    expect(chart?.axes?.y?.axisTitleItalic).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1400" i="1"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      axisTitleRotation: 45,
+      axisTitleFontSize: 14,
+      axisTitleItalic: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr><a:r><a:rPr i=".."/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>` (and the matching `<c:valAx>` shape — CT_TextCharacterProperties italic flag on every axis flavour, ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's italic axis-title pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Mirrors the chart-level `titleItalic` field added in #253 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same drop-on-default-`false` / drop-on-non-boolean semantics, same `boolean | null` clone grammar (`undefined` inherits, `null` drops, a literal boolean replaces) — so a single configuration call threads cleanly through both the chart title and either axis title without bookkeeping the canonical OOXML slots. Mirrors `axisTitleRotation` (#248) and `axisTitleFontSize` (#255) for the same OOXML slot-pair, so all four axis-title knobs (rotation, size, bold (#256), italic) compose freely on the same `<c:title>` body.

Until now hucre's writer hardcoded a non-italic axis title (omitted `i` attribute) and the reader ignored the attribute entirely, so a templated dashboard chart whose user italicised an axis title for emphasis silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.axisTitleItalic);
// true       <- when the template pinned <a:defRPr i="1"/>
// undefined  <- when the template emits <a:defRPr i="0"/> or omits the attribute

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [/* ... */],
    charts: [{
      type: "column",
      title: "Q4 Revenue",
      series: [/* ... */],
      anchor: { from: { row: 5, col: 0 } },
      axes: {
        x: { title: "Period", axisTitleItalic: false },
        y: { title: "USD", axisTitleItalic: true },
      },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 0, col: 8 } },
  axes: {
    x: { axisTitleItalic: true },     // replaces the inherited flag
    y: { axisTitleItalic: null },     // drops it (writer omits the attribute)
  },
});
```

## Implementation notes

- **Type model**: `SheetChart.axes.{x,y}.axisTitleItalic?: boolean` (writer side); `ChartAxisInfo.axisTitleItalic?: boolean` (reader side). The clone option `axisTitleItalic?: boolean | null` follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar.
- **Reader** (`parseAxisTitleItalic`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:rich></c:tx></c:title>` for the `i` attribute. The lookup is scoped to the axis title's `<c:rich>` body so a stray `<a:defRPr>` elsewhere on the axis (e.g. on the tick-label `<c:txPr>`) cannot leak in. The OOXML default `false` collapses to `undefined` so absence and `i="0"` round-trip identically through `cloneChart` — only an explicit `i="1"` surfaces `true`. Returns `undefined` when the axis omits `<c:title>` or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body.
- **Writer**: `buildAxisTitle` now resolves through an `italic?: boolean` parameter — `normalizeAxisTitleItalic` accepts `true` / `false` literally and collapses every other token (typed escape from an untyped caller) to `undefined`. Absence and explicit `false` both collapse to omitting the `i` attribute (Excel's reference serialization for a non-italic axis title — only the bold flag is always emitted). Only `true` emits `i="1"` on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks the value up off either canonical slot — Excel keeps the two attributes in sync.
- **Clone** (`applyAxisTitleItalicOverride`): follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same gate the writer uses — when the resolved title is dropped (`title: null` or override), the inherited flag drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.

## Test plan

- [x] `parseChart — axis title italic` (12 new tests) — surfaces `true` from `i="1"`, collapses `i="0"` and absence to `undefined`, accepts the OOXML truthy / falsy spellings, drops unknown tokens, returns undefined when `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>`, surfaces on both X and Y axes, does not leak from a stray tick-label `<c:txPr>` italic flag, co-surfaces alongside `axisTitleRotation` / `axisTitleFontSize` on the same axis title.
- [x] `writeChart — axis title italic` (12 new tests) — omits the `i` attribute by default, emits `i="1"` on both `<a:defRPr>` and `<a:rPr>` on `axisTitleItalic=true`, omits the attribute on `axisTitleItalic=false` (matches OOXML default), emits independently per axis, drops non-boolean inputs to omission, silently ignores when no axis title renders, composes with `axisTitleRotation` / `axisTitleFontSize`, threads through every chart family that has axes (line / area / scatter), preserves the surrounding `b="0"` / `lang="en-US"` / `sz="1000"` defaults, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis title italic` (15 new tests) — inherits the source's value, inherits independently per axis, override replaces, `null` drops, replace null source with override, returns undefined with no source / no override, drops non-boolean override, normalises a parsed source flag that is somehow non-boolean, drops on `title: null`, drops an override when no axis title resolves, preserves override when override pins a title, composes with chart-level `titleItalic` / `axisTitleRotation` / `axisTitleFontSize`, end-to-end parse -> clone -> write -> reparse round-trip, full `writeXlsx` propagation.
- [x] `pnpm test` — all 4568 tests pass (lint + format + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)