### PR TITLE
feat(xlsx): chart axis title font color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2033,6 +2033,56 @@ export interface SheetChart {
        * family that has axes (bar / column / line / area / scatter).
        */
       axisTitleItalic?: boolean;
+      /**
+       * Axis title font color. Maps to
+       * `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr>
+       * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr>
+       * </a:pPr><a:r><a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+       * </a:solidFill></a:rPr></a:r></a:p></c:rich></c:tx></c:title>
+       * </c:catAx>` (or `<c:valAx>` for scatter / value axes) — Excel's
+       * "Format Axis Title -> Font -> Font Color" picker. The OOXML
+       * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+       * sRGB color (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32); the
+       * writer lands the fill on both the default-paragraph
+       * `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse
+       * picks the color up off either canonical slot — Excel keeps the
+       * two values in sync.
+       *
+       * Mirrors {@link SheetChart.titleColor} for axis titles — same
+       * canonical-slot pair, same accept-with-or-without-`#` grammar
+       * (`"FF0000"` / `"#FF0000"` / `"ff0000"` all collapse to the
+       * uppercase canonical form), same `string | null` clone grammar
+       * (`undefined` inherits, `null` drops, a hex string replaces) so
+       * a single configuration call threads cleanly through both the
+       * chart title and either axis title without bookkeeping the
+       * canonical OOXML slots. Mirrors {@link axisTitleRotation} /
+       * {@link axisTitleFontSize} / {@link axisTitleBold} /
+       * {@link axisTitleItalic} for the same `<c:title>` body, so all
+       * five axis-title knobs (rotation, size, bold, italic, color)
+       * compose freely on the same axis.
+       *
+       * Default: omitted — the axis title renders in Excel's reference
+       * inherited theme color (no `<a:solidFill>` element, the writer
+       * skips the fill block entirely). Pin a hex value to render the
+       * axis title in that color (e.g. `"1070CA"` for the dashboard
+       * hero blue the issue-#136 example reaches for). The 8-character
+       * `#RRGGBBAA` form is *not* accepted — alpha lives on
+       * `<a:srgbClr><a:alpha val=".."/>` which is a separate runs-level
+       * knob; pinning `axisTitleColor` carries the RGB triple only.
+       * Malformed inputs (wrong length, non-hex characters, alpha-
+       * channel form) collapse to `undefined` so a stray non-hex token
+       * never produces a malformed `<a:srgbClr>`.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+       * per the OOXML schema, so the field round-trips on every chart
+       * family that has axes (bar / column / line / area / scatter).
+       */
+      axisTitleColor?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -2358,6 +2408,28 @@ export interface SheetChart {
        * to host the flag).
        */
       axisTitleItalic?: boolean;
+      /**
+       * Value-axis title font color. Maps to
+       * `<c:valAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr>
+       * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr>
+       * </a:pPr><a:r><a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+       * </a:solidFill></a:rPr></a:r></a:p></c:rich></c:tx></c:title>
+       * </c:valAx>`. Mirrors {@link SheetChart.axes.x.axisTitleColor}
+       * for the value axis — see that field for the full semantics.
+       * The OOXML `<a:srgbClr val=".."/>` carries the 6-character
+       * uppercase hex sRGB color; the writer lands the fill on both
+       * the default-paragraph `<a:defRPr>` and the literal run's
+       * `<a:rPr>` so a re-parse picks the color up off either
+       * canonical slot.
+       *
+       * Useful for tinting a Y-axis unit label to match a dashboard
+       * accent color (e.g. green for revenue, red for expense) without
+       * touching the chart title or axis tick labels. Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * fill).
+       */
+      axisTitleColor?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3627,6 +3699,40 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleItalic?: boolean;
+  /**
+   * Axis-title font color pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+   * </c:rich></c:tx></c:title>` on the axis element. Reflects Excel's
+   * "Format Axis Title -> Font -> Font Color" picker.
+   *
+   * Surfaced as the 6-character uppercase hex string the writer round-
+   * trips (`"FF0000"` / `"1070CA"`) — the leading `#` is stripped on
+   * read so the value threads straight into the writer-side
+   * {@link SheetChart.axes.x.axisTitleColor} without transformation.
+   * Color picks other than the literal sRGB form (`<a:schemeClr>` theme
+   * references, `<a:hslClr>`, `<a:sysClr>`, `<a:prstClr>`) collapse to
+   * `undefined` — the reader records only the resolvable RGB triple to
+   * keep the round-trip lossless against {@link cloneChart} ->
+   * {@link writeXlsx}. Malformed `val` tokens (wrong length, non-hex
+   * characters) likewise drop to `undefined` rather than fabricate a
+   * value the writer would round-trip into a malformed `<a:srgbClr>`.
+   *
+   * Reported as `undefined` whenever the axis omits `<c:title>`
+   * entirely, when the title is a `<c:strRef>` (formula reference)
+   * with no `<c:rich>` body, or when the `<a:defRPr>` slot has no
+   * `<a:solidFill>` child (the title inherits the theme's text color
+   * in that case). Mirrors the chart-level {@link Chart.titleColor} so
+   * a parsed value slots straight back into the writer-side
+   * {@link SheetChart.axes.x.axisTitleColor} without transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the color regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleColor?: string;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -742,6 +742,29 @@ export interface CloneChartOptions {
        * host the flag).
        */
       axisTitleItalic?: boolean | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleColor`. `undefined` (or
+       * omitted) inherits the source axis's parsed value; `null` drops
+       * the inherited fill so the writer falls back to the theme text
+       * color (no `<a:solidFill>` element on the axis title's
+       * default-paragraph properties); a 6-character hex string (with
+       * or without a leading `#`, any case) replaces it.
+       *
+       * Malformed overrides (wrong length, non-hex characters,
+       * alpha-channel forms, non-string escapes from an untyped
+       * caller) collapse to a drop so the cloned `SheetChart` always
+       * carries a value the writer will accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * fill). The grammar mirrors `axisTitleRotation` /
+       * `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic` so
+       * the axis-title knobs compose the same way at the call site.
+       */
+      axisTitleColor?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -930,6 +953,8 @@ export interface CloneChartOptions {
       axisTitleBold?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleItalic}. */
       axisTitleItalic?: boolean | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleColor}. */
+      axisTitleColor?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2627,6 +2652,26 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleItalic,
     overrides?.y?.axisTitleItalic,
   );
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+  // <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis title font color. Sits on the
+  // same `<c:title>` body as `axisTitleRotation` / `axisTitleFontSize` /
+  // `axisTitleBold` / `axisTitleItalic`, so the resolver applies on
+  // every chart family that has axes (pie / doughnut were short-
+  // circuited upstream). Malformed overrides collapse to a drop via
+  // the normalizer so the cloned `SheetChart` always carries a value
+  // the writer will accept. Like the rotation, size, bold, and italic
+  // knobs, the writer drops the fill when the matching axis title is
+  // unset, so a stray pin on an axis with no title silently disappears
+  // at emit time.
+  const xAxisTitleColor = applyAxisTitleColorOverride(
+    sourceAxes?.x?.axisTitleColor,
+    overrides?.x?.axisTitleColor,
+  );
+  const yAxisTitleColor = applyAxisTitleColorOverride(
+    sourceAxes?.y?.axisTitleColor,
+    overrides?.y?.axisTitleColor,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -2784,6 +2829,14 @@ function resolveAxes(
   // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
   const xAxisTitleItalicResolved = xTitle === undefined ? undefined : xAxisTitleItalic;
   const yAxisTitleItalicResolved = yTitle === undefined ? undefined : yAxisTitleItalic;
+  // The axis-title font color only renders when the axis carries a
+  // title — drop a stray inherited fill when the resolved axis title
+  // is unset so the cloned `SheetChart` accurately reflects what the
+  // chart will paint. Symmetric with the writer's title-presence gate
+  // (the per-family axis builder only invokes `buildAxisTitle` when
+  // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
+  const xAxisTitleColorResolved = xTitle === undefined ? undefined : xAxisTitleColor;
+  const yAxisTitleColorResolved = yTitle === undefined ? undefined : yAxisTitleColor;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -2792,6 +2845,7 @@ function resolveAxes(
     xAxisTitleFontSizeResolved !== undefined ||
     xAxisTitleBoldResolved !== undefined ||
     xAxisTitleItalicResolved !== undefined ||
+    xAxisTitleColorResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -2820,6 +2874,7 @@ function resolveAxes(
       out.x.axisTitleFontSize = xAxisTitleFontSizeResolved;
     if (xAxisTitleBoldResolved !== undefined) out.x.axisTitleBold = xAxisTitleBoldResolved;
     if (xAxisTitleItalicResolved !== undefined) out.x.axisTitleItalic = xAxisTitleItalicResolved;
+    if (xAxisTitleColorResolved !== undefined) out.x.axisTitleColor = xAxisTitleColorResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -2846,6 +2901,7 @@ function resolveAxes(
     yAxisTitleFontSizeResolved !== undefined ||
     yAxisTitleBoldResolved !== undefined ||
     yAxisTitleItalicResolved !== undefined ||
+    yAxisTitleColorResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -2868,6 +2924,7 @@ function resolveAxes(
       out.y.axisTitleFontSize = yAxisTitleFontSizeResolved;
     if (yAxisTitleBoldResolved !== undefined) out.y.axisTitleBold = yAxisTitleBoldResolved;
     if (yAxisTitleItalicResolved !== undefined) out.y.axisTitleItalic = yAxisTitleItalicResolved;
+    if (yAxisTitleColorResolved !== undefined) out.y.axisTitleColor = yAxisTitleColorResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -3305,6 +3362,33 @@ function applyAxisTitleItalicOverride(
   if (override === undefined) return normalizeTitleItalic(source);
   if (override === null) return undefined;
   return normalizeTitleItalic(override);
+}
+
+/**
+ * Resolve an `axisTitleColor` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Non-string overrides and malformed hex tokens (typed
+ * escapes from an untyped caller, wrong length, non-hex characters,
+ * alpha-channel forms) collapse to `undefined` via
+ * {@link normalizeTitleColor} so the cloned `SheetChart` always
+ * carries a value the writer will accept. A `null` override always
+ * drops the inherited fill (the writer falls back to the theme text
+ * color — no `<a:solidFill>` block on the axis title's
+ * default-paragraph properties).
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a fill that the writer would silently elide (the writer
+ * scopes the fill emission to `<c:title>`, which is omitted when
+ * the axis renders no title).
+ */
+function applyAxisTitleColorOverride(
+  source: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(source);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -565,6 +565,19 @@ function parseAxisInfo(
   // title is a `<c:strRef>` (formula reference) with no `<c:rich>`
   // body.
   const axisTitleItalic = parseAxisTitleItalic(axis);
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+  // <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+  // </c:rich></c:tx></c:title>` — axis-title font color. Same
+  // `<c:title>` body scope as `axisTitleItalic`, so a stray
+  // `<a:solidFill>` elsewhere on the axis (e.g. on a tick-label
+  // `<c:txPr>` block or a `<c:spPr>` series fill) cannot leak in.
+  // Theme references (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`,
+  // `<a:prstClr>`, and malformed `val` tokens all collapse to
+  // `undefined` since only the literal RGB triple round-trips
+  // losslessly through the writer. Returns `undefined` when the axis
+  // omits `<c:title>` entirely or when the title is a `<c:strRef>`
+  // (formula reference) with no `<c:rich>` body.
+  const axisTitleColor = parseAxisTitleColor(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -658,6 +671,7 @@ function parseAxisInfo(
     axisTitleFontSize === undefined &&
     axisTitleBold === undefined &&
     axisTitleItalic === undefined &&
+    axisTitleColor === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -686,6 +700,7 @@ function parseAxisInfo(
   if (axisTitleFontSize !== undefined) out.axisTitleFontSize = axisTitleFontSize;
   if (axisTitleBold !== undefined) out.axisTitleBold = axisTitleBold;
   if (axisTitleItalic !== undefined) out.axisTitleItalic = axisTitleItalic;
+  if (axisTitleColor !== undefined) out.axisTitleColor = axisTitleColor;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -1520,6 +1535,68 @@ function parseAxisTitleItalic(axis: XmlElement): boolean | undefined {
   // explicit `i="1"` surfaces `true`.
   if (parsed === true) return true;
   return undefined;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` off an axis element. Returns the axis
+ * title's sRGB font color as a 6-character uppercase hex string.
+ *
+ * Mirrors {@link parseTitleColor} for axis titles — same canonical-
+ * slot pair (`<a:defRPr>` carries the default-paragraph fill, which
+ * the writer keeps in sync with the literal run's `<a:rPr>` so the
+ * reader only needs to consult one of the two slots), same drop-on-
+ * non-sRGB semantics. The lookup is scoped to the axis title's
+ * `<c:rich>` body so a stray `<a:solidFill>` elsewhere on the axis
+ * (e.g. on a tick-label `<c:txPr>` block or a `<c:spPr>` series
+ * fill) cannot leak in.
+ *
+ * The OOXML `<a:srgbClr val=".."/>` is the literal sRGB triple Excel
+ * lands on the axis title's default-paragraph properties when the
+ * user picks a custom font color. Theme references (`<a:schemeClr>`),
+ * `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>` all collapse to
+ * `undefined` — only the literal RGB triple round-trips losslessly
+ * through {@link writeChart}. Malformed `val` tokens (wrong length,
+ * non-hex characters) likewise drop to `undefined` rather than
+ * fabricate a value the writer would round-trip into a malformed
+ * `<a:srgbClr>`.
+ *
+ * Returns `undefined` whenever the axis omits `<c:title>` entirely
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body — there is no `<a:p>` slot to surface the fill
+ * from in either case.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape
+ * per the OOXML schema. Mirrors the chart-level title color
+ * {@link parseTitleColor} so a parsed value slots straight into the
+ * writer-side {@link SheetChart.axes}.x.axisTitleColor.
+ */
+function parseAxisTitleColor(axis: XmlElement): string | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr>` is the OOXML path
+  // Excel writes for the default-paragraph font color. The reader walks
+  // the canonical chain and bails on the first missing link so a
+  // malformed `<c:rich>` surfaces as absence rather than a fabricated
+  // value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const solidFill = findChild(defRPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  const raw = srgbClr.attrs.val;
+  return normalizeRgbHex(raw);
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -629,6 +629,23 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // reference serialization for a non-italic axis title).
     xAxisTitleItalic: normalizeAxisTitleItalic(chart.axes?.x?.axisTitleItalic),
     yAxisTitleItalic: normalizeAxisTitleItalic(chart.axes?.y?.axisTitleItalic),
+    // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+    // <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr>
+    // <a:r><a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+    // </a:rPr></a:r></a:p></c:rich></c:tx></c:title>` — axis-title
+    // font color. The OOXML `<a:srgbClr val=".."/>` carries the
+    // 6-character uppercase hex sRGB color (CT_SRgbColor inside
+    // CT_TextCharacterProperties' fill choice — ECMA-376 Part 1,
+    // §20.1.2.3.32 / §21.1.2.3.7) and the slot lives on every axis
+    // flavour. Normalize the caller's hex input — the writer accepts
+    // a leading `#` and any case, then collapses to the OOXML
+    // canonical uppercase form. Malformed inputs (wrong length,
+    // non-hex characters, alpha-channel forms, non-string escapes)
+    // collapse to `undefined` and the writer omits the entire
+    // `<a:solidFill>` block (Excel's reference serialization for an
+    // axis title that inherits the theme text color).
+    xAxisTitleColor: normalizeAxisTitleColor(chart.axes?.x?.axisTitleColor),
+    yAxisTitleColor: normalizeAxisTitleColor(chart.axes?.y?.axisTitleColor),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1090,6 +1107,27 @@ interface AxisRenderOptions {
    * semantics as {@link xAxisTitleItalic}.
    */
   yAxisTitleItalic: boolean | undefined;
+  /**
+   * Axis-title font color emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr>
+   * <a:r><a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+   * </a:rPr></a:r></a:p></c:rich></c:tx></c:title>`. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color. `undefined` collapses to omitting the entire
+   * `<a:solidFill>` block (Excel's reference serialization for an
+   * axis title that inherits the theme text color); any non-`undefined`
+   * value is the normalized uppercase hex string the writer lands on
+   * both `<a:defRPr>` and `<a:rPr>`. Only meaningful when the axis
+   * renders a title — the per-family axis builders gate the value on
+   * the `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleColor: string | undefined;
+  /**
+   * Axis-title font color emitted on the Y axis. Same shape and emit
+   * semantics as {@link xAxisTitleColor}.
+   */
+  yAxisTitleColor: string | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -1956,6 +1994,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleFontSize,
         opts.xAxisTitleBold,
         opts.xAxisTitleItalic,
+        opts.xAxisTitleColor,
       ),
     );
   catAxChildren.push(
@@ -2018,6 +2057,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleFontSize,
         opts.yAxisTitleBold,
         opts.yAxisTitleItalic,
+        opts.yAxisTitleColor,
       ),
     );
   valAxChildren.push(
@@ -2381,6 +2421,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleFontSize,
         opts.xAxisTitleBold,
         opts.xAxisTitleItalic,
+        opts.xAxisTitleColor,
       ),
     );
   xAxChildren.push(
@@ -2422,6 +2463,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleFontSize,
         opts.yAxisTitleBold,
         opts.yAxisTitleItalic,
+        opts.yAxisTitleColor,
       ),
     );
   yAxChildren.push(
@@ -2492,6 +2534,17 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
  * axis title — only the bold flag is always emitted); only `true`
  * emits `i="1"` on both slots so a re-parse picks the flag up off
  * either canonical slot.
+ *
+ * The optional `rgbHex` parameter pins the title's
+ * `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+ * </a:defRPr>` / `<a:rPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:rPr>` font color. Mirrors the chart-level
+ * `buildTitle` color emit: when set, the `<a:defRPr>` / `<a:rPr>`
+ * slots expand from self-closing to wrapping a single
+ * `<a:solidFill>` child; otherwise the writer keeps the existing
+ * self-closing form so a fresh axis title with no custom color
+ * matches Excel's reference serialization byte-for-byte (the title
+ * inherits the theme text color in that case).
  */
 function buildAxisTitle(
   label: string,
@@ -2499,6 +2552,7 @@ function buildAxisTitle(
   fontSizePt: number | undefined,
   bold: boolean | undefined,
   italic: boolean | undefined,
+  rgbHex: string | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -2534,6 +2588,29 @@ function buildAxisTitle(
   // serialization byte-for-byte (Excel itself omits `i` on a non-
   // italic axis title — only the bold flag is always emitted).
   const i = italic === true ? 1 : undefined;
+  // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></a:defRPr>` carries the title's font color. Mirrors
+  // the chart-level `buildTitle` color emit: `axisTitleColor` lands on
+  // both the default-paragraph `<a:defRPr>` and the literal run's
+  // `<a:rPr>` so a re-parse picks the value up off either canonical
+  // slot. Absence (`undefined`) collapses to omitting the entire
+  // `<a:solidFill>` block so the title inherits the theme text color
+  // (Excel's reference behavior for a fresh axis title that has not
+  // had a custom color picked).
+  const solidFillChild = rgbHex
+    ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
+    : undefined;
+  // When a fill color is set the `<a:defRPr>` / `<a:rPr>` slots
+  // expand from self-closing to wrapping the `<a:solidFill>` child;
+  // otherwise the writer keeps the existing self-closing form so a
+  // fresh axis title with no custom color matches Excel's reference
+  // serialization byte-for-byte.
+  const defRPr = solidFillChild
+    ? xmlElement("a:defRPr", { sz, b, i }, [solidFillChild])
+    : xmlSelfClose("a:defRPr", { sz, b, i });
+  const rPr = solidFillChild
+    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i }, [solidFillChild])
+    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -2551,11 +2628,8 @@ function buildAxisTitle(
         ),
         xmlSelfClose("a:lstStyle"),
         xmlElement("a:p", undefined, [
-          xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b, i })]),
-          xmlElement("a:r", undefined, [
-            xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i }),
-            xmlElement("a:t", undefined, xmlEscape(label)),
-          ]),
+          xmlElement("a:pPr", undefined, [defRPr]),
+          xmlElement("a:r", undefined, [rPr, xmlElement("a:t", undefined, xmlEscape(label))]),
         ]),
       ]),
     ]),
@@ -2630,6 +2704,24 @@ function normalizeAxisTitleBold(value: boolean | undefined): boolean | undefined
  */
 function normalizeAxisTitleItalic(value: boolean | undefined): boolean | undefined {
   return normalizeTitleItalic(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleColor value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:rich></c:tx></c:title>` writer slot inside an axis. Delegates
+ * to the chart-level {@link normalizeTitleColor} so the two share the
+ * same accept-with-or-without-`#` grammar — `"FF0000"`, `"#FF0000"`,
+ * and `"ff0000"` all collapse to the OOXML uppercase canonical form;
+ * malformed inputs (wrong length, non-hex characters, alpha-channel
+ * forms, non-string escapes from an untyped caller) collapse to
+ * `undefined` so the writer skips the entire `<a:solidFill>` block
+ * and the axis title inherits the theme text color (Excel's
+ * reference behavior for a fresh axis title without a custom color).
+ */
+function normalizeAxisTitleColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -11859,3 +11859,295 @@ describe("cloneChart — axis title italic", () => {
     expect(reparsed?.axes?.x?.axisTitleItalic).toBe(true);
   });
 });
+
+// ── cloneChart — axis title color ────────────────────────────────────
+
+describe("cloneChart — axis title color", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleColor by default", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleColor: "FF0000" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleColor by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleColor: "00C586" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleColor).toBe("00C586");
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleColor replace the source's value", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleColor: "FF0000" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleColor: "1070CA" } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("normalizes a lowercase hex override to uppercase", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleColor: "1070ca" } },
+    });
+    expect(clone.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("strips a leading '#' on override input", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleColor: "#1070CA" } },
+    });
+    expect(clone.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("drops the inherited axisTitleColor when the override is null", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleColor: "FF0000" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleColor: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleColor with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleColor: "1070CA" } },
+    });
+    expect(clone.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("drops malformed hex overrides (defends against the type guard escaping)", () => {
+    for (const bad of ["", "FFF", "ZZZZZZ", "FF0000FF"]) {
+      const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleColor: bad } },
+      });
+      expect(clone.axes?.x?.axisTitleColor).toBeUndefined();
+    }
+  });
+
+  it("drops non-string overrides (defends against the type guard escaping)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleColor: 123 as any } },
+    });
+    expect(clone.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("normalises a parsed source value that is somehow malformed", () => {
+    // Defensive: a corrupt template parsed by an older reader could
+    // surface a non-canonical value. The clone normalizer drops it
+    // through the same hex band so the writer never sees a bad token.
+    const clone = cloneChart(
+      source({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleColor: "ZZZZZZ" as any } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("drops the inherited axisTitleColor when the resolved axis title is dropped", () => {
+    // `title: null` flattens the inherited axis title — no `<c:title>`
+    // block will be emitted, so the inherited fill has no slot in the
+    // rendered axis and the clone collapses it.
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleColor: "FF0000" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("drops an override axisTitleColor when no axis title resolves", () => {
+    // The axis has no source title and the caller did not pin one —
+    // the writer would silently elide the fill either way, so the
+    // clone-side resolver mirrors that by dropping the field.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleColor: "FF0000" } },
+    });
+    expect(clone.axes?.x).toBeUndefined();
+  });
+
+  it("preserves the override when the override also pins a title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleColor: "1070CA" } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("composes independently with the chart-level titleColor", () => {
+    const clone = cloneChart(
+      source({
+        titleColor: "1070CA",
+        axes: { x: { title: "Period", axisTitleColor: "FF0000" } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleColor).toBe("1070CA");
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+  });
+
+  it("composes independently with rotation / size / bold / italic on the same axis title", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleRotation: 45,
+            axisTitleFontSize: 14,
+            axisTitleBold: true,
+            axisTitleItalic: true,
+            axisTitleColor: "1070CA",
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleRotation).toBe(45);
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+    expect(clone.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("threads the color through both axes independently on the clone", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleColor: "FF0000" },
+          y: { title: "USD", axisTitleColor: "00C586" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(clone.axes?.y?.axisTitleColor).toBe("00C586");
+  });
+
+  it("round-trips a templated chart's axis title color through parseChart -> cloneChart -> writeChart", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:tx><c:v>Revenue</c:v></c:tx>
+          <c:cat><c:strRef><c:f>Tpl!$A$2:$A$5</c:f></c:strRef></c:cat>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="00C586"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.axisTitleColor).toBe("1070CA");
+    expect(parsed?.axes?.y?.axisTitleColor).toBe("00C586");
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.axisTitleColor).toBe("1070CA");
+    expect(sheetChart.axes?.y?.axisTitleColor).toBe("00C586");
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleColor).toBe("1070CA");
+    expect(reparsed?.axes?.y?.axisTitleColor).toBe("00C586");
+  });
+
+  it("propagates axisTitleColor into the rendered axis on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleColor: "1070CA" } } }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10915,3 +10915,235 @@ describe("writeChart — axis title italic", () => {
     expect(reparsed?.axes?.y?.axisTitleItalic).toBe(true);
   });
 });
+
+// ── writeChart — axis title color ────────────────────────────────────
+
+describe("writeChart — axis title color", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  function axisTitleDefRPrFillVal(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    // The writer wraps the `<a:defRPr>` element when a color is set
+    // (`<a:defRPr ...><a:solidFill>...</a:solidFill></a:defRPr>`); when
+    // no color is pinned the slot stays self-closing. Match the
+    // wrapping form explicitly so the helper does not stop at the
+    // `<a:srgbClr.../>` self-close inside.
+    const defRPrMatch = titleBlock.match(/<a:defRPr\b[^>]*>([\s\S]*?)<\/a:defRPr>/);
+    if (!defRPrMatch) return undefined;
+    const fill = defRPrMatch[1].match(
+      /<a:solidFill>\s*<a:srgbClr\b[^/]*val="([0-9A-Fa-f]{6})"\s*\/>\s*<\/a:solidFill>/,
+    );
+    return fill ? fill[1] : undefined;
+  }
+
+  function axisTitleRPrFillVal(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    // Same wrapping-form story as `<a:defRPr>` — the writer expands the
+    // slot from self-closing to wrapping when a color is set.
+    const rPrMatch = titleBlock.match(/<a:rPr\b[^>]*>([\s\S]*?)<\/a:rPr>/);
+    if (!rPrMatch) return undefined;
+    const fill = rPrMatch[1].match(
+      /<a:solidFill>\s*<a:srgbClr\b[^/]*val="([0-9A-Fa-f]{6})"\s*\/>\s*<\/a:solidFill>/,
+    );
+    return fill ? fill[1] : undefined;
+  }
+
+  it("omits <a:solidFill> by default (matches Excel's reference theme-color axis title)", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrFillVal(xAx)).toBeUndefined();
+    expect(axisTitleRPrFillVal(xAx)).toBeUndefined();
+  });
+
+  it("emits <a:solidFill><a:srgbClr/> on both <a:defRPr> and <a:rPr> when axisTitleColor is set", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleColor: "FF0000" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrFillVal(xAx)).toBe("FF0000");
+    expect(axisTitleRPrFillVal(xAx)).toBe("FF0000");
+  });
+
+  it("normalizes a lowercase hex value to uppercase", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleColor: "1070ca" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrFillVal(xAx)).toBe("1070CA");
+  });
+
+  it("strips a leading '#' on input", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleColor: "#1070CA" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrFillVal(xAx)).toBe("1070CA");
+  });
+
+  it("drops malformed hex inputs back to the theme-color default", () => {
+    for (const bad of ["", "FFF", "ZZZZZZ", "FF0000FF"]) {
+      const result = writeChart(
+        makeChart({ axes: { x: { title: "Period", axisTitleColor: bad } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleDefRPrFillVal(xAx)).toBeUndefined();
+    }
+  });
+
+  it("drops non-string inputs (defends against the type guard escaping)", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleColor: 123 as any } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrFillVal(xAx)).toBeUndefined();
+  });
+
+  it("threads the color through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleColor: "FF0000" },
+          y: { title: "USD", axisTitleColor: "00C586" },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrFillVal(xAx)).toBe("FF0000");
+    expect(axisTitleDefRPrFillVal(yAx)).toBe("00C586");
+  });
+
+  it("ignores axisTitleColor when the axis renders no title", () => {
+    // No title means no `<c:title>` block — there is no slot for the
+    // fill in either case.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleColor: "FF0000" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with rotation / size / bold / italic on the same axis title", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleRotation: 45,
+            axisTitleFontSize: 14,
+            axisTitleBold: true,
+            axisTitleItalic: true,
+            axisTitleColor: "1070CA",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock).toContain('rot="2700000"');
+    expect(titleBlock).toContain('sz="1400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('val="1070CA"');
+  });
+
+  it("threads the color through line / area chart families and scatter (both axes via valAx)", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleColor: "1070CA" } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleDefRPrFillVal(xAx)).toBe("1070CA");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleColor: "00C586" } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    const yAx = blocks[1];
+    expect(axisTitleDefRPrFillVal(yAx)).toBe("00C586");
+  });
+
+  it("preserves the surrounding font defaults (lang='en-US', sz='1000', b='0')", () => {
+    // Only the fill should be added; the writer keeps the existing
+    // size / language / bold defaults so a templated axis title only
+    // gains the color, not lose the surrounding font defaults.
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleColor: "FF0000" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock).toContain('lang="en-US"');
+    expect(titleBlock).toContain('sz="1000"');
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("round-trips axisTitleColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleColor: "1070CA" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("round-trips a defaulted axis title to undefined color", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the axis title color into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleColor: "FF0000" },
+              y: { title: "USD", axisTitleColor: "00C586" },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(reparsed?.axes?.y?.axisTitleColor).toBe("00C586");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -11550,3 +11550,291 @@ describe("parseChart — axis title italic", () => {
     });
   });
 });
+
+// ── parseChart — axis title color ────────────────────────────────────
+
+describe("parseChart — axis title color", () => {
+  const NS_AC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitleColor(srgb: string | undefined): string {
+    const fill = srgb === undefined ? "" : `<a:solidFill><a:srgbClr val="${srgb}"/></a:solidFill>`;
+    return `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr>${fill}</a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the uppercase hex value pinned by <a:srgbClr val='..'>", () => {
+    const chart = parseChart(withCatAxTitleColor("FF0000"));
+    expect(chart?.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("normalizes a lowercase hex value to uppercase", () => {
+    const chart = parseChart(withCatAxTitleColor("1070ca"));
+    expect(chart?.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("strips a leading '#' on read", () => {
+    const chart = parseChart(withCatAxTitleColor("#1070CA"));
+    expect(chart?.axes?.x?.axisTitleColor).toBe("1070CA");
+  });
+
+  it("collapses absence of <a:solidFill> to undefined (theme-color default)", () => {
+    const chart = parseChart(withCatAxTitleColor(undefined));
+    expect(chart?.axes?.x?.axisTitleColor).toBeUndefined();
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a <c:strRef> formula reference", () => {
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache>
+        </c:strRef></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("collapses theme color (<a:schemeClr>) to undefined", () => {
+    // Theme references don't round-trip losslessly — only literal sRGB
+    // triples surface.
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("drops malformed val tokens (wrong length / non-hex / 8-char alpha form)", () => {
+    expect(parseChart(withCatAxTitleColor(""))?.axes?.x?.axisTitleColor).toBeUndefined();
+    expect(parseChart(withCatAxTitleColor("FFF"))?.axes?.x?.axisTitleColor).toBeUndefined();
+    expect(parseChart(withCatAxTitleColor("ZZZZZZ"))?.axes?.x?.axisTitleColor).toBeUndefined();
+    // 8-character alpha form (Excel uses <a:alpha> sibling for that).
+    expect(parseChart(withCatAxTitleColor("FF0000FF"))?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("does not leak the chart-level title <a:solidFill> into the axis title color", () => {
+    // The chart-level title carries an <a:solidFill>, but the axis
+    // title's defRPr has no fill — `axisTitleColor` reflects only the
+    // axis title's defRPr.
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBe("FF0000");
+    expect(chart?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("does not leak the tick-label <c:txPr> <a:solidFill> into the axis title color", () => {
+    // The reader scopes the lookup to the axis title's <c:rich> body
+    // — the tick-label `<c:txPr>` is a sibling element on the axis
+    // and must not feed its `<a:defRPr>` fill into the title color.
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleColor).toBeUndefined();
+  });
+
+  it("surfaces the color on the value axis", () => {
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="00C586"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("USD");
+    expect(chart?.axes?.y?.axisTitleColor).toBe("00C586");
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(chart?.axes?.y?.axisTitleColor).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other axis-title knobs on the same axis", () => {
+    const xml = `<c:chartSpace ${NS_AC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1400" b="1" i="1"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      axisTitleRotation: 45,
+      axisTitleFontSize: 14,
+      axisTitleBold: true,
+      axisTitleItalic: true,
+      axisTitleColor: "1070CA",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></a:defRPr></a:pPr><a:r><a:rPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></a:rPr></a:r></a:p></c:rich></c:tx></c:title></c:catAx>` (and the matching `<c:valAx>` shape — CT_SRgbColor inside CT_TextCharacterProperties' fill choice on every axis flavour, ECMA-376 Part 1, §20.1.2.3.32 / §21.1.2.3.7) at the read, write, and clone layers so a template's custom axis-title font color survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Mirrors the chart-level `titleColor` field added in #254 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same accept-with-or-without-`#` grammar (`"FF0000"` / `"#FF0000"` / `"ff0000"` all collapse to the OOXML uppercase canonical form), same `string | null` clone grammar (`undefined` inherits, `null` drops, a hex string replaces) — so a single configuration call threads cleanly through both the chart title and either axis title without bookkeeping the canonical OOXML slots. Mirrors `axisTitleRotation` (#248), `axisTitleFontSize` (#255), `axisTitleBold` (#256), and `axisTitleItalic` (#257) for the same `<c:title>` body, so all five axis-title knobs (rotation, size, bold, italic, color) compose freely on the same axis.

Until now hucre's writer hardcoded a theme-color axis title (omitted the `<a:solidFill>` block) and the reader ignored the fill entirely, so a templated dashboard chart whose user tinted an axis title to match an accent color silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136 — the issue's example explicitly calls for \"axis labels, colors, and titles\".

Refs #136

## API

\`\`\`ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.axisTitleColor);
// \"1070CA\"   <- when the template pinned <a:srgbClr val=\"1070CA\"/>
// undefined  <- when the fill is absent (theme text color inherited)
// undefined  <- when the fill is a <a:schemeClr> theme reference
// undefined  <- when the axis omits <c:title> or the title is a <c:strRef>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [/* ... */],
    charts: [{
      type: \"column\",
      title: \"Q4 Revenue\",
      series: [/* ... */],
      anchor: { from: { row: 5, col: 0 } },
      axes: {
        // Render the X-axis title in the dashboard's hero blue.
        x: { title: \"Period\", axisTitleColor: \"1070CA\" },
        // Render the Y-axis title in the revenue accent green.
        y: { title: \"USD\", axisTitleColor: \"#00C586\" },
      },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 0, col: 8 } },
  axes: {
    x: { axisTitleColor: \"FF0000\" }, // replaces the inherited fill
    y: { axisTitleColor: null },     // drops it (writer omits <a:solidFill>)
  },
});
\`\`\`

## Implementation notes

- **Type model**: `SheetChart.axes.{x,y}.axisTitleColor?: string` (writer side); `ChartAxisInfo.axisTitleColor?: string` (reader side). The clone option `axisTitleColor?: string | null` follows the standard `undefined` (inherit) / `null` (drop) / `string` (replace) grammar. The string format is the 6-character uppercase hex sRGB triple; the writer / reader / clone all accept a leading `#` and a lowercase form on input but normalize to the canonical uppercase form on output so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseAxisTitleColor`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val=\"...\"/></a:solidFill></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>` for the `val` attribute. The lookup is scoped to the axis title's `<c:rich>` body so a stray `<a:solidFill>` elsewhere on the axis (e.g. on the tick-label `<c:txPr>` or a `<c:spPr>` series fill) cannot leak in. Theme references (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>` all collapse to `undefined` since only the literal RGB triple round-trips losslessly through the writer. Malformed `val` tokens (wrong length, non-hex characters, alpha-channel forms) likewise drop to `undefined` rather than fabricate a value the writer would round-trip into a malformed `<a:srgbClr>`. Returns `undefined` when the axis omits `<c:title>` or when the title is a `<c:strRef>` (formula reference) with no `<c:rich>` body. Reuses the `normalizeRgbHex` helper introduced for the chart-level `titleColor` (#254).
- **Writer**: `buildAxisTitle` now resolves through an `rgbHex?: string` parameter — `normalizeAxisTitleColor` strips a leading `#`, validates the 6-character hex form, and uppercases the canonical output via the chart-level `normalizeTitleColor`; every other token (typed escape from an untyped caller — wrong length, non-hex, alpha-channel form, non-string) collapses to `undefined`. When the color is set, the `<a:defRPr>` / `<a:rPr>` slots expand from self-closing to wrapping a single `<a:solidFill><a:srgbClr val=\"...\"/></a:solidFill>` child; otherwise the writer keeps the existing self-closing form so a fresh axis title with no custom color matches Excel's reference serialization byte-for-byte. The fill lands on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks the value up off either canonical slot.
- **Clone** (`applyAxisTitleColorOverride`): follows the standard `string | null` override grammar — `undefined` inherits, `null` drops, a literal hex string replaces. Malformed overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same gate the writer uses — when the resolved title is dropped (`title: null` or override), the inherited fill drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.

## Test plan

- [x] `parseChart — axis title color` (12 new tests) — surfaces the uppercase canonical hex from `<a:srgbClr val=\"FF0000\"/>`, normalizes lowercase input to uppercase, strips leading `#`, collapses absence of `<a:solidFill>` to `undefined`, returns undefined when `<c:title>` is absent / the title is a `<c:strRef>` formula reference / `<a:p>` has no `<a:pPr>`, collapses theme-color references (`<a:schemeClr>`) to undefined, drops malformed val tokens (wrong length / non-hex / 8-char alpha form), does not leak from a stray chart-level title `<a:solidFill>`, does not leak from a stray tick-label `<c:txPr>` `<a:solidFill>`, surfaces on both X and Y axes, surfaces independently on both axes, co-surfaces alongside `axisTitleRotation` / `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic` on the same axis title.
- [x] `writeChart — axis title color` (14 new tests) — omits `<a:solidFill>` by default (theme inherit), emits the fill on a hex input, normalizes lowercase to uppercase, strips leading `#`, drops malformed inputs back to the default, drops non-string inputs, threads through both axes independently, ignores when no axis title renders, composes with `axisTitleRotation` / `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic`, threads through every chart family that has axes (line / area / scatter), preserves the surrounding `b=\"0\"` / `lang=\"en-US\"` / `sz=\"1000\"` defaults, parse round-trip, default round-trip collapses to `undefined`, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis title color` (17 new tests) — inherits the source's value (X / Y), inherits independently per axis, override replaces, lowercase normalization, leading-`#` strip, `null` drops, replace unset source with override, drop on malformed override, drop on non-string override, normalises a parsed source value that is somehow malformed, drops on `title: null`, drops an override when no axis title resolves, preserves override when override pins a title, composes with chart-level `titleColor`, composes with `axisTitleRotation` / `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic`, threads through both axes independently on the clone, end-to-end parse -> clone -> write -> reparse round-trip, full `writeXlsx` propagation.
- [x] `pnpm test` — all 4648 tests pass (lint + format + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)