### PR TITLE
feat(xlsx): chart title strikethrough flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1463,6 +1463,56 @@ export interface SheetChart {
    */
   titleColor?: string;
   /**
+   * Chart title strikethrough flag. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+   * <a:r><a:rPr strike=".."/></a:r></a:p></c:rich></c:tx></c:title>` —
+   * Excel's "Format Chart Title -> Font -> Strikethrough" toggle. The
+   * OOXML attribute is the `ST_TextStrikeType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+   * three values: `"noStrike"` (the OOXML default — no strikethrough),
+   * `"sngStrike"` (single horizontal line, the value Excel's UI
+   * checkbox emits), and `"dblStrike"` (double horizontal line, a
+   * non-UI variant Excel does not surface in its ribbon). The writer
+   * lands the value on both the default-paragraph `<a:defRPr>` and
+   * the literal run's `<a:rPr>` so a re-parse picks the flag up off
+   * either canonical slot — Excel keeps the two attributes in sync.
+   *
+   * Modeled as a boolean for symmetry with {@link titleBold} /
+   * {@link titleItalic}: `true` emits `strike="sngStrike"` (Excel's
+   * UI "Strikethrough" checkbox — single line). Absence and
+   * non-boolean tokens collapse to omitting the attribute (Excel's
+   * reference serialization for a non-strikethrough title — the
+   * application-default `"noStrike"` collapses to absence). Set
+   * `false` explicitly to pin the non-default `strike="noStrike"`
+   * (functionally identical to omission, but useful when overriding a
+   * templated title that had strikethrough pinned upstream).
+   *
+   * Hucre's writer emits only `"sngStrike"` to keep the surfaced shape
+   * consistent with what Excel's reference UI authors. The reader
+   * collapses the non-UI `"dblStrike"` to `undefined` so a templated
+   * chart that pinned the double-line variant in raw OOXML round-trips
+   * to the same `undefined` an unmarked chart parses to (i.e. the
+   * double-line variant silently downgrades to the single-line write
+   * grammar rather than fabricate a value the writer would re-emit
+   * incorrectly).
+   *
+   * Default: omitted — the title renders without strikethrough (no
+   * `strike` attribute on either slot, Excel's reference serialization
+   * for a fresh chart title). Set `true` to render the title with a
+   * single strikethrough line, useful for marking "before / after" or
+   * "deprecated" dashboard tile headers.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * flag in either case. Composes independently with {@link titleBold}
+   * / {@link titleItalic} / {@link titleColor} /
+   * {@link titleFontSize} / {@link titleRotation} /
+   * {@link titleOverlay}: all seven fields land on the same
+   * `<c:title>` element so a single configuration call threads
+   * cleanly through every chart-title knob Excel exposes.
+   */
+  titleStrike?: boolean;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -4185,6 +4235,35 @@ export interface Chart {
    * no `<a:p>` to host the fill in any of those cases.
    */
   titleColor?: string;
+  /**
+   * Chart title strikethrough flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>`. Reflects Excel's "Format Chart
+   * Title -> Font -> Strikethrough" toggle.
+   *
+   * The OOXML attribute is the `ST_TextStrikeType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+   * three values: `"noStrike"`, `"sngStrike"`, `"dblStrike"`. Only
+   * the UI-default `"sngStrike"` (Excel's "Strikethrough" checkbox —
+   * single line) surfaces as `true`; `"noStrike"` (the OOXML
+   * application default) and absence both collapse to `undefined`,
+   * and the non-UI `"dblStrike"` variant likewise collapses to
+   * `undefined` rather than surface a value the writer would silently
+   * downgrade on round-trip — hucre's writer emits only `"sngStrike"`,
+   * so reporting `"dblStrike"` as `true` would round-trip into a
+   * lossy single-line replacement.
+   *
+   * Unknown / malformed `strike` tokens drop to `undefined` rather
+   * than fabricate a value the writer would never emit.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no `<a:p>`
+   * to host the flag in either case. The parsed value threads
+   * straight back into the writer-side {@link SheetChart.titleStrike}
+   * without transformation.
+   */
+  titleStrike?: boolean;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -355,6 +355,29 @@ export interface CloneChartOptions {
    */
   titleColor?: string | null;
   /**
+   * Override the chart-level title strikethrough flag.
+   * `undefined` (or omitted) inherits the source's parsed `titleStrike`.
+   * `null` drops the inherited flag (the writer falls back to the
+   * OOXML default — no `strike` attribute, equivalent to no
+   * strikethrough).
+   * A `boolean` replaces it: `true` emits `strike="sngStrike"`
+   * (Excel's UI "Strikethrough" — single line); `false` pins the
+   * non-default omission (functionally identical to dropping).
+   *
+   * Non-boolean overrides (typed escapes from an untyped caller)
+   * collapse to a drop so the cloned `SheetChart` always carries a
+   * value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the flag in either case. The grammar mirrors
+   * `titleBold` / `titleItalic` / `titleColor` / `titleFontSize` /
+   * `titleRotation` / `titleOverlay` so the chart-level title knobs
+   * compose the same way at the call site.
+   */
+  titleStrike?: boolean | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1272,6 +1295,17 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // `SheetChart` always carries a value the writer will accept.
     const resolvedTitleColor = resolveTitleColor(source.titleColor, options.titleColor);
     if (resolvedTitleColor !== undefined) out.titleColor = resolvedTitleColor;
+
+    // `titleStrike` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr strike="..">` slot for the
+    // writer to populate. Same scope rule as `titleOverlay` /
+    // `titleRotation` / `titleFontSize` / `titleBold` / `titleItalic`
+    // / `titleColor`: the override wins over the source's parsed
+    // value; absence inherits, `null` drops, a `boolean` replaces.
+    // Non-boolean overrides collapse via the normalizer so the cloned
+    // `SheetChart` always carries a value the writer will accept.
+    const resolvedTitleStrike = resolveTitleStrike(source.titleStrike, options.titleStrike);
+    if (resolvedTitleStrike !== undefined) out.titleStrike = resolvedTitleStrike;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -2403,6 +2437,45 @@ function resolveTitleColor(
   if (override === undefined) return normalizeTitleColor(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleColor(override);
+}
+
+/**
+ * Normalize a `titleStrike` value for the cloned `SheetChart`. Mirrors
+ * the writer's `normalizeTitleStrike` — the cloned shape is guaranteed
+ * to round-trip through the writer without surprise: `true` / `false`
+ * pass through literally, every other token (typed escape from an
+ * untyped caller) collapses to `undefined` so the cloned chart drops
+ * the field rather than carry a value the writer would silently elide
+ * back to absence.
+ */
+function normalizeTitleStrike(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `titleStrike` override.
+ *
+ * `undefined` → inherit the source's parsed `titleStrike`.
+ * `null`      → drop the inherited flag (the writer falls back to the
+ *               OOXML default — no `strike` attribute, equivalent to
+ *               no strikethrough).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `titleBold` / `titleItalic` / `titleColor` /
+ * `titleFontSize` / `titleRotation` / `titleOverlay` so the chart-level
+ * title knobs compose the same way at the call site. Callers should
+ * gate the result on the resolved title visibility — when no title is
+ * emitted, the flag has no slot in the rendered chart.
+ */
+function resolveTitleStrike(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeTitleStrike(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleStrike(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -159,6 +159,21 @@ export function parseChart(xml: string): Chart | undefined {
   const titleColor = parseTitleColor(chartEl);
   if (titleColor !== undefined) out.titleColor = titleColor;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+  // </a:p></c:rich></c:tx></c:title>` mirrors Excel's "Format Chart
+  // Title -> Font -> Strikethrough" toggle. Same scope rule as the
+  // bold/italic flags — a chart that omits `<c:title>` (or whose
+  // title is a `<c:strRef>` formula reference with no `<c:rich>`
+  // body) has no `<a:p>` slot to surface the flag from, so the
+  // helper short-circuits to `undefined`. Only the UI-default
+  // `"sngStrike"` surfaces as `true`; `"noStrike"` (the OOXML
+  // application default) and the non-UI `"dblStrike"` both collapse
+  // to `undefined` so absence and the OOXML default round-trip
+  // identically through {@link cloneChart}. The value threads
+  // straight back into the writer-side {@link SheetChart.titleStrike}.
+  const titleStrike = parseTitleStrike(chartEl);
+  if (titleStrike !== undefined) out.titleStrike = titleStrike;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -2581,6 +2596,64 @@ function normalizeRgbHex(raw: unknown): string | undefined {
   if (hex.length !== 6) return undefined;
   if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
   return hex.toUpperCase();
+}
+
+// ── Title Strike ────────────────────────────────────────────────────
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` off the chart. Returns
+ * the strikethrough flag.
+ *
+ * The OOXML `strike` attribute is the `ST_TextStrikeType` enum on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+ * three values: `"noStrike"` (the OOXML application default),
+ * `"sngStrike"` (single line, the value Excel's UI checkbox emits),
+ * and `"dblStrike"` (double line, a non-UI variant). The reader
+ * surfaces only the UI-default `"sngStrike"` as `true`; `"noStrike"`,
+ * absence, and the non-UI `"dblStrike"` all collapse to `undefined` —
+ * the writer emits only `"sngStrike"`, so reporting `"dblStrike"` as
+ * `true` would silently downgrade the choice to a single line on
+ * round-trip. Unknown / malformed `strike` tokens likewise drop to
+ * `undefined`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>`
+ * element — there is no `<a:p>` slot to surface the flag from in
+ * that case — or when the title is a `<c:strRef>` (formula
+ * reference) with no `<c:rich>` body. The `<a:defRPr>` lives inside
+ * `<c:tx><c:rich><a:p><a:pPr>` per the CT_Title schema (the default-
+ * paragraph properties on the rich-text body's first paragraph); the
+ * lookup is scoped to that path so a stray `<a:defRPr>` elsewhere in
+ * the chart (e.g. on an axis title or a data-labels block) cannot
+ * leak in.
+ */
+function parseTitleStrike(chartEl: XmlElement): boolean | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph strikethrough flag. The reader walks the
+  // canonical chain and bails on the first missing link so a
+  // malformed `<c:rich>` surfaces as absence rather than a fabricated
+  // value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.strike;
+  // Only the UI-default `"sngStrike"` surfaces as `true`. The OOXML
+  // application default `"noStrike"` and the non-UI `"dblStrike"` both
+  // collapse to `undefined` so absence and the OOXML default round-trip
+  // identically through the writer; the writer emits only `"sngStrike"`,
+  // so reporting `"dblStrike"` here would silently downgrade the choice
+  // on round-trip.
+  if (raw === "sngStrike") return true;
+  return undefined;
 }
 
 // ── Auto Title Deleted ────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -76,6 +76,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleBold(chart),
         resolveTitleItalic(chart),
         resolveTitleColor(chart),
+        resolveTitleStrike(chart),
       ),
     );
   }
@@ -214,6 +215,7 @@ function buildTitle(
   bold: boolean | undefined,
   italic: boolean | undefined,
   rgbHex: string | undefined,
+  strike: boolean | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -250,6 +252,20 @@ function buildTitle(
   // reference serialization byte-for-byte (Excel itself omits `i` when
   // the title is non-italic — only the bold flag is always emitted).
   const i = italic === true ? 1 : undefined;
+  // OOXML's `<a:defRPr strike=".."/>` / `<a:rPr strike=".."/>` attribute
+  // is the `ST_TextStrikeType` enum on `CT_TextCharacterProperties` —
+  // `"noStrike"` (default), `"sngStrike"` (single line, the value
+  // Excel's UI emits), `"dblStrike"` (double line, non-UI). The writer
+  // emits only the UI variant `"sngStrike"` to keep the surfaced shape
+  // consistent with what Excel's reference UI authors. Absence
+  // (`undefined`) and explicit `false` both collapse to omitting the
+  // attribute (Excel itself omits `strike` when the title is not
+  // strikethrough — the OOXML default `"noStrike"` collapses to
+  // absence). Like bold / italic, the value lands on both the
+  // default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
+  // a re-parse picks the value up off either canonical slot — Excel
+  // keeps the two attributes in sync.
+  const strikeAttr = strike === true ? "sngStrike" : undefined;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the title's font color. The
   // writer holds `titleColor` as a 6-character uppercase hex string
@@ -268,11 +284,11 @@ function buildTitle(
   // fresh chart with no custom color matches Excel's reference
   // serialization byte-for-byte.
   const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i });
+    ? xmlElement("a:defRPr", { sz, b, i, strike: strikeAttr }, [solidFillChild])
+    : xmlSelfClose("a:defRPr", { sz, b, i, strike: strikeAttr });
   const rPr = solidFillChild
-    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i }, [solidFillChild])
-    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i });
+    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i, strike: strikeAttr }, [solidFillChild])
+    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i, strike: strikeAttr });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -515,6 +531,40 @@ function normalizeTitleColor(value: string | undefined): string | undefined {
  */
 function resolveTitleColor(chart: SheetChart): string | undefined {
   return normalizeTitleColor(chart.titleColor);
+}
+
+/**
+ * Normalize a {@link SheetChart.titleStrike} value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` writer slot. Returns the literal
+ * boolean when the input is `true` / `false`, or `undefined` for any
+ * other token (including `null`-shaped escapes from an untyped
+ * caller). Absence and non-boolean tokens both collapse to
+ * `undefined` so the writer omits the `strike` attribute entirely
+ * (Excel's reference serialization for a non-strikethrough title —
+ * the OOXML default `"noStrike"` collapses to absence; only an
+ * explicit `true` emits `strike="sngStrike"`).
+ */
+function normalizeTitleStrike(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` from
+ * {@link SheetChart.titleStrike}.
+ *
+ * Returns the literal boolean, or `undefined` when the chart leaves
+ * the field unset / passed a non-boolean token. The flag is only
+ * meaningful when the chart actually emits a title — the caller is
+ * expected to gate the call on `showTitle && chart.title`. A chart
+ * whose title is suppressed has no `<c:title>` block to host the flag
+ * in either case.
+ */
+function resolveTitleStrike(chart: SheetChart): boolean | undefined {
+  return normalizeTitleStrike(chart.titleStrike);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10950,6 +10950,190 @@ describe("cloneChart — title color", () => {
   });
 });
 
+describe("cloneChart — title strike", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleStrike by default", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleStrike).toBe(true);
+  });
+
+  it("lets options.titleStrike override the source's value", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleStrike: false,
+    });
+    expect(clone.titleStrike).toBe(false);
+  });
+
+  it("drops the inherited titleStrike when the override is null", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleStrike: null,
+    });
+    expect(clone.titleStrike).toBeUndefined();
+  });
+
+  it("returns undefined titleStrike when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleStrike).toBeUndefined();
+  });
+
+  it("lets options.titleStrike pin true on a non-strike source", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleStrike: true,
+    });
+    expect(clone.titleStrike).toBe(true);
+  });
+
+  it("drops a non-boolean override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleStrike: "true" as any,
+    });
+    // The malformed override drops via the normalizer; the source's
+    // parsed value is shadowed (override wins, even when the override is
+    // malformed). Mirrors the titleBold / titleItalic behavior.
+    expect(clone.titleStrike).toBeUndefined();
+  });
+
+  it("drops the cloned titleStrike when the resolved title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleStrike).toBeUndefined();
+  });
+
+  it("drops the cloned titleStrike when showTitle is false", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleStrike).toBeUndefined();
+  });
+
+  it("preserves titleStrike when an override pins a fresh title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleStrike: true,
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleStrike).toBe(true);
+  });
+
+  it("composes with titleBold / titleItalic / titleColor / titleFontSize / titleRotation / titleOverlay", () => {
+    const clone = cloneChart(
+      source({
+        titleStrike: true,
+        titleColor: "1070CA",
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 18,
+        titleRotation: -45,
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        titleOverlay: true,
+      },
+    );
+    expect(clone.titleStrike).toBe(true);
+    expect(clone.titleColor).toBe("1070CA");
+    expect(clone.titleItalic).toBe(true);
+    expect(clone.titleBold).toBe(true);
+    expect(clone.titleFontSize).toBe(18);
+    expect(clone.titleRotation).toBe(-45);
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("threads through line -> column flatten", () => {
+    const clone = cloneChart(source({ titleStrike: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleStrike).toBe(true);
+  });
+
+  it("end-to-end parse -> clone -> write -> reparse round-trip", async () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2000" strike="sngStrike"/></a:pPr><a:r><a:t>Source</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$3</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(xml)!;
+    expect(parsed.titleStrike).toBe(true);
+
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleStrike).toBe(true);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Region", "Revenue"],
+            ["North", 100],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('strike="sngStrike"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleStrike).toBe(true);
+  });
+});
+
 describe("cloneChart — axis title rotation", () => {
   function source(extra?: Partial<Chart>): Chart {
     return {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9999,6 +9999,169 @@ describe("writeChart — title color", () => {
   });
 });
 
+// ── writeChart — title strike ───────────────────────────────────────
+
+describe("writeChart — title strike", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrStrikeOf(xml: string): string | undefined {
+    // The title's <a:defRPr> lives inside <c:title><c:tx><c:rich><a:p><a:pPr>.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const s = m[0].match(/\bstrike="([^"]+)"/);
+    return s ? s[1] : undefined;
+  }
+
+  function rPrStrikeOf(xml: string): string | undefined {
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const s = m[0].match(/\bstrike="([^"]+)"/);
+    return s ? s[1] : undefined;
+  }
+
+  it("omits the strike attribute by default (matches Excel's reference non-strikethrough title)", () => {
+    // Excel itself omits `strike` on a non-strikethrough title — the
+    // OOXML default `"noStrike"` collapses to absence. Only the bold
+    // flag is always emitted.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(defRPrStrikeOf(result.chartXml)).toBeUndefined();
+    expect(rPrStrikeOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("emits strike='sngStrike' on titleStrike=true", () => {
+    const result = writeChart(makeChart({ titleStrike: true }), "Sheet1");
+    expect(defRPrStrikeOf(result.chartXml)).toBe("sngStrike");
+    expect(rPrStrikeOf(result.chartXml)).toBe("sngStrike");
+  });
+
+  it("omits the strike attribute on titleStrike=false (functionally identical to omission)", () => {
+    const result = writeChart(makeChart({ titleStrike: false }), "Sheet1");
+    expect(defRPrStrikeOf(result.chartXml)).toBeUndefined();
+    expect(rPrStrikeOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (defends against type guard escape)", () => {
+    const result = writeChart(makeChart({ titleStrike: "true" as any }), "Sheet1");
+    expect(defRPrStrikeOf(result.chartXml)).toBeUndefined();
+    const result2 = writeChart(makeChart({ titleStrike: 1 as any }), "Sheet1");
+    expect(defRPrStrikeOf(result2.chartXml)).toBeUndefined();
+    const result3 = writeChart(makeChart({ titleStrike: "sngStrike" as any }), "Sheet1");
+    expect(defRPrStrikeOf(result3.chartXml)).toBeUndefined();
+  });
+
+  it("ignores titleStrike when the chart renders no title (showTitle=false)", () => {
+    // The whole `<c:title>` block is suppressed — no `<a:defRPr>` to
+    // host the strike flag.
+    const result = writeChart(makeChart({ showTitle: false, titleStrike: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleStrike when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleStrike: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleBold, titleItalic, titleColor, titleFontSize, titleRotation, and titleOverlay", () => {
+    const result = writeChart(
+      makeChart({
+        titleStrike: true,
+        titleColor: "1070CA",
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 24,
+        titleRotation: -45,
+        titleOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('strike="sngStrike"');
+    expect(titleBlock).toContain('val="1070CA"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("preserves the title body's other attributes (lang='en-US', sz, b)", () => {
+    const result = writeChart(makeChart({ titleStrike: true }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('lang="en-US"');
+    // The default 14pt size still lands on both slots even when strike flips.
+    expect(titleBlock.match(/sz="1400"/g)?.length).toBeGreaterThanOrEqual(2);
+    // The default `b="0"` is still emitted on both slots.
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+    // `strike="sngStrike"` lands on both the <a:defRPr> and the <a:rPr>.
+    expect(titleBlock.match(/strike="sngStrike"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleStrike: true }), "Sheet1");
+      expect(defRPrStrikeOf(result.chartXml)).toBe("sngStrike");
+    }
+  });
+
+  it("parse round-trip surfaces titleStrike from the writer's output", () => {
+    const written = writeChart(makeChart({ titleStrike: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleStrike).toBe(true);
+  });
+
+  it("collapses the default (no-strike) round-trip back to undefined", () => {
+    // A fresh chart emits no `strike` attribute; the reader collapses
+    // absence to `undefined` so absence and the default round-trip
+    // identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleStrike).toBeUndefined();
+  });
+
+  it("collapses the explicit titleStrike=false round-trip back to undefined", () => {
+    // titleStrike=false drops the attribute entirely (the OOXML default
+    // is `"noStrike"`, but the writer omits the attribute for symmetry
+    // with how Excel's reference UI emits a non-strikethrough title);
+    // the reader collapses absence to `undefined`.
+    const written = writeChart(makeChart({ titleStrike: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleStrike).toBeUndefined();
+  });
+
+  it("writeXlsx package round-trip surfaces titleStrike from the chart part", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Revenue"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Quarterly Revenue",
+            titleStrike: true,
+            series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('strike="sngStrike"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleStrike).toBe(true);
+  });
+});
+
 // ── writeChart — axis title rotation ────────────────────────────────
 
 describe("writeChart — axis title rotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10605,6 +10605,196 @@ describe("parseChart — title color", () => {
   });
 });
 
+// ── parseChart — title strike ────────────────────────────────────────
+
+describe("parseChart — title strike", () => {
+  const NS_TS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleStrike(strike: string | undefined): string {
+    const defRPr = strike === undefined ? "<a:defRPr/>" : `<a:defRPr strike="${strike}"/>`;
+    return `<c:chartSpace ${NS_TS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true when the title pinned strike='sngStrike' (Excel UI checkbox)", () => {
+    const chart = parseChart(withTitleStrike("sngStrike"));
+    expect(chart?.titleStrike).toBe(true);
+  });
+
+  it("collapses strike='noStrike' to undefined (OOXML default round-trips identically)", () => {
+    const chart = parseChart(withTitleStrike("noStrike"));
+    expect(chart?.titleStrike).toBeUndefined();
+  });
+
+  it("collapses absence of the strike attribute to undefined", () => {
+    const chart = parseChart(withTitleStrike(undefined));
+    expect(chart?.titleStrike).toBeUndefined();
+  });
+
+  it("collapses the non-UI 'dblStrike' variant to undefined (avoids lossy downgrade)", () => {
+    // Hucre's writer emits only "sngStrike". Surfacing "dblStrike" as
+    // true would silently downgrade the choice on round-trip, so the
+    // reader collapses it to undefined to keep the round-trip lossless.
+    const chart = parseChart(withTitleStrike("dblStrike"));
+    expect(chart?.titleStrike).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleStrike).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body (strRef)", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:p><a:pPr><a:defRPr>` to host the strike flag.
+    const xml = `<c:chartSpace ${NS_TS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleStrike).toBeUndefined();
+    expect(chart?.title).toBe("Revenue");
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_TS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleStrike).toBeUndefined();
+  });
+
+  it("drops unknown strike tokens to undefined", () => {
+    expect(parseChart(withTitleStrike("yes"))?.titleStrike).toBeUndefined();
+    expect(parseChart(withTitleStrike("on"))?.titleStrike).toBeUndefined();
+    expect(parseChart(withTitleStrike(""))?.titleStrike).toBeUndefined();
+    expect(parseChart(withTitleStrike("1"))?.titleStrike).toBeUndefined();
+    expect(parseChart(withTitleStrike("true"))?.titleStrike).toBeUndefined();
+  });
+
+  it("does not leak from a stray axis-title <a:defRPr>", () => {
+    // The category axis title carries a strike <a:defRPr strike="sngStrike"/>,
+    // but the chart-level title does not — `titleStrike` reflects only
+    // the chart-level title's <a:defRPr>, not a stray sibling element.
+    const xml = `<c:chartSpace ${NS_TS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Header</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleStrike).toBeUndefined();
+  });
+
+  it("co-surfaces alongside titleBold, titleItalic, titleColor, titleFontSize, titleRotation, and titleOverlay", () => {
+    const xml = `<c:chartSpace ${NS_TS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400" b="1" i="1" strike="sngStrike"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Hero");
+    expect(chart?.titleStrike).toBe(true);
+    expect(chart?.titleColor).toBe("1070CA");
+    expect(chart?.titleItalic).toBe(true);
+    expect(chart?.titleBold).toBe(true);
+    expect(chart?.titleFontSize).toBe(24);
+    expect(chart?.titleRotation).toBe(-45);
+    expect(chart?.titleOverlay).toBe(true);
+  });
+});
+
 // ── parseChart — axis title rotation ─────────────────────────────────
 
 describe("parseChart — axis title rotation", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=\"..\"/></a:pPr><a:r><a:rPr strike=\"..\"/></a:r></a:p></c:rich></c:tx></c:title>` (ST_TextStrikeType on CT_TextCharacterProperties, ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's custom chart-title strikethrough flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Modeled as a boolean for symmetry with `titleBold` (#252) / `titleItalic` (#253): `true` emits `strike=\"sngStrike\"` (Excel's UI checkbox — single line); absence and explicit `false` collapse to omitting the attribute (the OOXML default `\"noStrike\"` collapses to absence, mirroring how Excel's reference serialization emits a non-strikethrough title). The non-UI variant `\"dblStrike\"` (double line) is read-only — the writer emits only `\"sngStrike\"` to keep the surfaced shape consistent with what Excel's reference UI authors, and the reader collapses `\"dblStrike\"` to `undefined` so a templated chart that pinned the double-line variant in raw OOXML round-trips lossless rather than silently downgrading on re-emit.

Mirrors `titleFontSize` (#251), `titleBold` (#252), `titleItalic` (#253), and `titleColor` (#254) for the same `<c:title>` body, so all six chart-title typography knobs (size, rotation, bold, italic, color, strike) compose freely on the same title — the writer threads them through a single `buildTitle` call, the reader picks them up off the shared `<a:defRPr>` slot, and the clone resolver follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) override grammar.

Bridges another title-customization gap for the dashboard composition flow tracked in #136 — useful for marking \"before / after\" or \"deprecated\" dashboard tile headers without leaking the styling out of the chart's own typography slot.

Refs #136

## API

\`\`\`ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleStrike);
// true       <- when the template pinned <a:defRPr strike=\"sngStrike\"/>
// undefined  <- when the attribute is absent / equals \"noStrike\"
// undefined  <- when the attribute equals \"dblStrike\" (non-UI variant)
// undefined  <- when the chart omits <c:title> or the title is a <c:strRef>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [/* ... */],
    charts: [{
      type: \"column\",
      title: \"Q3 Revenue (deprecated)\",
      titleStrike: true,
      series: [/* ... */],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 0, col: 8 } },
  titleStrike: true,    // pin a strikethrough on a non-strikethrough source
  // titleStrike: null  // drops the inherited flag (writer omits the attribute)
  // titleStrike: false // explicit non-strikethrough (functionally identical to null)
});
\`\`\`

## Implementation notes

- **Type model**: `SheetChart.titleStrike?: boolean` (writer side); `Chart.titleStrike?: boolean` (reader side); `CloneChartOptions.titleStrike?: boolean | null` (clone override).
- **Reader** (`parseTitleStrike`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=\"...\"/>` for the `strike` attribute. Only the UI-default `\"sngStrike\"` surfaces as `true`; `\"noStrike\"`, `\"dblStrike\"`, and unknown / malformed tokens all collapse to `undefined` to keep the round-trip lossless against the writer's `\"sngStrike\"`-only emit grammar. Lookup is scoped to the chart-level title's rich-text body so a stray `<a:defRPr strike=\"..\">` elsewhere on the chart (e.g. on an axis title or a data-labels block) cannot leak in.
- **Writer**: `buildTitle` now resolves through a `strike?: boolean` parameter — `normalizeTitleStrike` accepts only literal `true` / `false`; every other token (typed escape from an untyped caller — `\"sngStrike\"`, `1`, `null`) collapses to `undefined`. When `true`, the writer lands `strike=\"sngStrike\"` on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks the value up off either canonical slot. Absence / `false` omit the attribute entirely (matches Excel's reference serialization for a non-strikethrough title — the OOXML default `\"noStrike\"` collapses to absence).
- **Clone** (`resolveTitleStrike`): follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same gate the writer uses — when the resolved title is dropped (`title: null`, `showTitle: false`, or a sourceless chart with no `title` override), the inherited flag drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.

## Test plan

- [x] `parseChart — title strike` (10 new tests) — surfaces `true` from `\"sngStrike\"`, collapses `\"noStrike\"` / absence / `\"dblStrike\"` / unknown tokens to `undefined`, returns `undefined` when `<c:title>` / `<c:rich>` / `<a:pPr>` is missing, does not leak from a stray axis-title `<a:defRPr strike=\"sngStrike\"/>`, co-surfaces alongside `titleBold` / `titleItalic` / `titleColor` / `titleFontSize` / `titleRotation` / `titleOverlay`.
- [x] `writeChart — title strike` (13 new tests) — omits the `strike` attribute by default, emits `strike=\"sngStrike\"` on `true`, omits on `false` and on non-boolean inputs (`\"true\"` / `1` / `\"sngStrike\"`), ignores when the chart renders no title (`showTitle: false` / no literal title), composes with `titleBold` / `titleItalic` / `titleColor` / `titleFontSize` / `titleRotation` / `titleOverlay`, lands on both `<a:defRPr>` and `<a:rPr>`, threads through every chart family (bar / column / line / pie / scatter / area), parse round-trip, default round-trip collapses to `undefined`, explicit `false` round-trip collapses to `undefined`, full `writeXlsx` package round-trip.
- [x] `cloneChart — title strike` (12 new tests) — inherits the source's value, override replaces (true / false), `null` drops, undefined source + undefined override yields undefined, override pins `true` on a non-strike source, drops on non-boolean override, drops when `title: null` / `showTitle: false`, preserves when an override pins a fresh title on a sourceless chart, composes with the rest of the chart-title knobs, threads through `line -> column` flatten, end-to-end parse -> clone -> write -> reparse round-trip.
- [x] `pnpm test` — all 4683 tests pass (lint + format + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)