### PR TITLE
feat(xlsx): chart title underline flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1513,6 +1513,61 @@ export interface SheetChart {
    */
   titleStrike?: boolean;
   /**
+   * Chart title underline flag. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/></a:pPr>
+   * <a:r><a:rPr u=".."/></a:r></a:p></c:rich></c:tx></c:title>` —
+   * Excel's "Format Chart Title -> Font -> Underline" picker. The
+   * OOXML attribute is the `ST_TextUnderlineType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+   * eighteen values; the two Excel surfaces in the ribbon are
+   * `"sng"` (single-line underline — the default checkbox) and
+   * `"dbl"` (double-line underline). The remaining sixteen tokens
+   * (`"none"`, `"words"`, `"heavy"`, `"dotted"`, `"dottedHeavy"`,
+   * `"dash"`, `"dashHeavy"`, `"dashLong"`, `"dashLongHeavy"`,
+   * `"dotDash"`, `"dotDashHeavy"`, `"dotDotDash"`,
+   * `"dotDotDashHeavy"`, `"wavy"`, `"wavyHeavy"`, `"wavyDbl"`) are
+   * non-UI variants Excel does not surface in its ribbon. The writer
+   * lands the value on both the default-paragraph `<a:defRPr>` and
+   * the literal run's `<a:rPr>` so a re-parse picks the flag up off
+   * either canonical slot — Excel keeps the two attributes in sync.
+   *
+   * Modeled as a boolean for symmetry with {@link titleBold} /
+   * {@link titleItalic} / {@link titleStrike}: `true` emits `u="sng"`
+   * (Excel's UI "Underline" checkbox — single line). Absence and
+   * non-boolean tokens collapse to omitting the attribute (Excel's
+   * reference serialization for a non-underlined title — the
+   * application-default `"none"` collapses to absence). Set `false`
+   * explicitly to pin the non-default omission (functionally
+   * identical to omission, but useful when overriding a templated
+   * title that had underline pinned upstream).
+   *
+   * Hucre's writer emits only `"sng"` to keep the surfaced shape
+   * consistent with what Excel's reference UI authors. The reader
+   * collapses every non-`"sng"` token (the non-UI `"dbl"` variant
+   * and the sixteen exotic types) to `undefined` so a templated
+   * chart that pinned a non-single underline in raw OOXML round-trips
+   * to the same `undefined` an unmarked chart parses to (i.e. the
+   * exotic underline silently downgrades to the single-line write
+   * grammar rather than fabricate a value the writer would re-emit
+   * incorrectly).
+   *
+   * Default: omitted — the title renders without underline (no `u`
+   * attribute on either slot, Excel's reference serialization for a
+   * fresh chart title). Set `true` to render the title with a single
+   * underline, useful for emphasising "key metric" or "section header"
+   * dashboard tile titles.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * flag in either case. Composes independently with {@link titleBold}
+   * / {@link titleItalic} / {@link titleStrike} / {@link titleColor} /
+   * {@link titleFontSize} / {@link titleRotation} /
+   * {@link titleOverlay}: all eight fields land on the same
+   * `<c:title>` element so a single configuration call threads
+   * cleanly through every chart-title knob Excel exposes.
+   */
+  titleUnderline?: boolean;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -4264,6 +4319,36 @@ export interface Chart {
    * without transformation.
    */
   titleStrike?: boolean;
+  /**
+   * Chart title underline flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>`. Reflects Excel's "Format Chart
+   * Title -> Font -> Underline" picker.
+   *
+   * The OOXML attribute is the `ST_TextUnderlineType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+   * eighteen values; Excel's UI exposes only `"sng"` (single line —
+   * the default underline checkbox) and `"dbl"` (double line). Only
+   * the UI-default `"sng"` (Excel's "Underline" checkbox — single
+   * line) surfaces as `true`; `"none"` (the OOXML application
+   * default) and absence both collapse to `undefined`, and every
+   * other token (`"dbl"` and the sixteen exotic variants) likewise
+   * collapses to `undefined` rather than surface a value the writer
+   * would silently downgrade on round-trip — hucre's writer emits
+   * only `"sng"`, so reporting any non-single underline as `true`
+   * would round-trip into a lossy single-line replacement.
+   *
+   * Unknown / malformed `u` tokens drop to `undefined` rather than
+   * fabricate a value the writer would never emit.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no `<a:p>`
+   * to host the flag in either case. The parsed value threads
+   * straight back into the writer-side {@link SheetChart.titleUnderline}
+   * without transformation.
+   */
+  titleUnderline?: boolean;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -378,6 +378,28 @@ export interface CloneChartOptions {
    */
   titleStrike?: boolean | null;
   /**
+   * Override the chart-level title underline flag.
+   * `undefined` (or omitted) inherits the source's parsed `titleUnderline`.
+   * `null` drops the inherited flag (the writer falls back to the
+   * OOXML default — no `u` attribute, equivalent to no underline).
+   * A `boolean` replaces it: `true` emits `u="sng"` (Excel's UI
+   * "Underline" — single line); `false` pins the non-default omission
+   * (functionally identical to dropping).
+   *
+   * Non-boolean overrides (typed escapes from an untyped caller)
+   * collapse to a drop so the cloned `SheetChart` always carries a
+   * value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the flag in either case. The grammar mirrors
+   * `titleBold` / `titleItalic` / `titleStrike` / `titleColor` /
+   * `titleFontSize` / `titleRotation` / `titleOverlay` so the
+   * chart-level title knobs compose the same way at the call site.
+   */
+  titleUnderline?: boolean | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1306,6 +1328,21 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // `SheetChart` always carries a value the writer will accept.
     const resolvedTitleStrike = resolveTitleStrike(source.titleStrike, options.titleStrike);
     if (resolvedTitleStrike !== undefined) out.titleStrike = resolvedTitleStrike;
+
+    // `titleUnderline` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr u="..">` slot for the writer
+    // to populate. Same scope rule as `titleStrike` / `titleOverlay`
+    // / `titleRotation` / `titleFontSize` / `titleBold` /
+    // `titleItalic` / `titleColor`: the override wins over the
+    // source's parsed value; absence inherits, `null` drops, a
+    // `boolean` replaces. Non-boolean overrides collapse via the
+    // normalizer so the cloned `SheetChart` always carries a value
+    // the writer will accept.
+    const resolvedTitleUnderline = resolveTitleUnderline(
+      source.titleUnderline,
+      options.titleUnderline,
+    );
+    if (resolvedTitleUnderline !== undefined) out.titleUnderline = resolvedTitleUnderline;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -2476,6 +2513,46 @@ function resolveTitleStrike(
   if (override === undefined) return normalizeTitleStrike(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleStrike(override);
+}
+
+/**
+ * Normalize a `titleUnderline` value for the cloned `SheetChart`. Mirrors
+ * the writer's `normalizeTitleUnderline` — the cloned shape is guaranteed
+ * to round-trip through the writer without surprise: `true` / `false`
+ * pass through literally, every other token (typed escape from an
+ * untyped caller) collapses to `undefined` so the cloned chart drops
+ * the field rather than carry a value the writer would silently elide
+ * back to absence.
+ */
+function normalizeTitleUnderline(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `titleUnderline` override.
+ *
+ * `undefined` → inherit the source's parsed `titleUnderline`.
+ * `null`      → drop the inherited flag (the writer falls back to the
+ *               OOXML default — no `u` attribute, equivalent to no
+ *               underline).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `titleBold` / `titleItalic` / `titleStrike` /
+ * `titleColor` / `titleFontSize` / `titleRotation` / `titleOverlay`
+ * so the chart-level title knobs compose the same way at the call
+ * site. Callers should gate the result on the resolved title
+ * visibility — when no title is emitted, the flag has no slot in the
+ * rendered chart.
+ */
+function resolveTitleUnderline(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeTitleUnderline(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleUnderline(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -174,6 +174,22 @@ export function parseChart(xml: string): Chart | undefined {
   const titleStrike = parseTitleStrike(chartEl);
   if (titleStrike !== undefined) out.titleStrike = titleStrike;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/></a:pPr>
+  // </a:p></c:rich></c:tx></c:title>` mirrors Excel's "Format Chart
+  // Title -> Font -> Underline" picker. Same scope rule as the
+  // bold / italic / strike flags — a chart that omits `<c:title>`
+  // (or whose title is a `<c:strRef>` formula reference with no
+  // `<c:rich>` body) has no `<a:p>` slot to surface the flag from,
+  // so the helper short-circuits to `undefined`. Only the UI-default
+  // `"sng"` surfaces as `true`; `"none"` (the OOXML application
+  // default), the non-UI `"dbl"` variant, and the sixteen exotic
+  // tokens (`"words"`, `"heavy"`, `"dotted"`, etc.) all collapse to
+  // `undefined` so absence and the OOXML default round-trip
+  // identically through {@link cloneChart}. The value threads
+  // straight back into the writer-side {@link SheetChart.titleUnderline}.
+  const titleUnderline = parseTitleUnderline(chartEl);
+  if (titleUnderline !== undefined) out.titleUnderline = titleUnderline;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -2653,6 +2669,67 @@ function parseTitleStrike(chartEl: XmlElement): boolean | undefined {
   // so reporting `"dblStrike"` here would silently downgrade the choice
   // on round-trip.
   if (raw === "sngStrike") return true;
+  return undefined;
+}
+
+// ── Title Underline ─────────────────────────────────────────────────
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` off the chart. Returns
+ * the underline flag.
+ *
+ * The OOXML `u` attribute is the `ST_TextUnderlineType` enum on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+ * eighteen values; Excel's UI exposes only `"sng"` (single line —
+ * the default underline checkbox) and `"dbl"` (double line). The
+ * reader surfaces only the UI-default `"sng"` as `true`; `"none"`
+ * (the OOXML application default), absence, the non-UI `"dbl"`
+ * variant, and the sixteen exotic tokens (`"words"`, `"heavy"`,
+ * `"dotted"`, `"dottedHeavy"`, `"dash"`, `"dashHeavy"`, `"dashLong"`,
+ * `"dashLongHeavy"`, `"dotDash"`, `"dotDashHeavy"`, `"dotDotDash"`,
+ * `"dotDotDashHeavy"`, `"wavy"`, `"wavyHeavy"`, `"wavyDbl"`) all
+ * collapse to `undefined` — the writer emits only `"sng"`, so
+ * reporting any non-single underline as `true` would silently
+ * downgrade the choice to a single line on round-trip. Unknown /
+ * malformed `u` tokens likewise drop to `undefined`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>`
+ * element — there is no `<a:p>` slot to surface the flag from in
+ * that case — or when the title is a `<c:strRef>` (formula
+ * reference) with no `<c:rich>` body. The `<a:defRPr>` lives inside
+ * `<c:tx><c:rich><a:p><a:pPr>` per the CT_Title schema (the default-
+ * paragraph properties on the rich-text body's first paragraph); the
+ * lookup is scoped to that path so a stray `<a:defRPr>` elsewhere in
+ * the chart (e.g. on an axis title or a data-labels block) cannot
+ * leak in.
+ */
+function parseTitleUnderline(chartEl: XmlElement): boolean | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph underline flag. The reader walks the canonical
+  // chain and bails on the first missing link so a malformed
+  // `<c:rich>` surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.u;
+  // Only the UI-default `"sng"` surfaces as `true`. The OOXML
+  // application default `"none"`, the non-UI `"dbl"` variant, and
+  // every exotic token (`"words"`, `"heavy"`, `"dotted"`, etc.) all
+  // collapse to `undefined` so absence and the OOXML default
+  // round-trip identically through the writer; the writer emits only
+  // `"sng"`, so reporting a non-single underline here would silently
+  // downgrade the choice on round-trip.
+  if (raw === "sng") return true;
   return undefined;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -77,6 +77,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleItalic(chart),
         resolveTitleColor(chart),
         resolveTitleStrike(chart),
+        resolveTitleUnderline(chart),
       ),
     );
   }
@@ -216,6 +217,7 @@ function buildTitle(
   italic: boolean | undefined,
   rgbHex: string | undefined,
   strike: boolean | undefined,
+  underline: boolean | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -266,6 +268,22 @@ function buildTitle(
   // a re-parse picks the value up off either canonical slot — Excel
   // keeps the two attributes in sync.
   const strikeAttr = strike === true ? "sngStrike" : undefined;
+  // OOXML's `<a:defRPr u=".."/>` / `<a:rPr u=".."/>` attribute is the
+  // `ST_TextUnderlineType` enum on `CT_TextCharacterProperties` —
+  // eighteen values total, with `"none"` as the OOXML default,
+  // `"sng"` as the value Excel's UI authors for the "Underline"
+  // checkbox (single line), `"dbl"` for the non-UI double-line
+  // variant, and sixteen exotic types Excel does not surface. The
+  // writer emits only the UI variant `"sng"` to keep the surfaced
+  // shape consistent with what Excel's reference UI authors. Absence
+  // (`undefined`) and explicit `false` both collapse to omitting the
+  // attribute (Excel itself omits `u` when the title is not
+  // underlined — the OOXML default `"none"` collapses to absence).
+  // Like bold / italic / strike, the value lands on both the
+  // default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
+  // a re-parse picks the value up off either canonical slot — Excel
+  // keeps the two attributes in sync.
+  const underlineAttr = underline === true ? "sng" : undefined;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the title's font color. The
   // writer holds `titleColor` as a 6-character uppercase hex string
@@ -284,11 +302,20 @@ function buildTitle(
   // fresh chart with no custom color matches Excel's reference
   // serialization byte-for-byte.
   const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i, strike: strikeAttr }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i, strike: strikeAttr });
+    ? xmlElement("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr }, [solidFillChild])
+    : xmlSelfClose("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr });
   const rPr = solidFillChild
-    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i, strike: strikeAttr }, [solidFillChild])
-    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i, strike: strikeAttr });
+    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i, u: underlineAttr, strike: strikeAttr }, [
+        solidFillChild,
+      ])
+    : xmlSelfClose("a:rPr", {
+        lang: "en-US",
+        sz,
+        b,
+        i,
+        u: underlineAttr,
+        strike: strikeAttr,
+      });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -565,6 +592,40 @@ function normalizeTitleStrike(value: boolean | undefined): boolean | undefined {
  */
 function resolveTitleStrike(chart: SheetChart): boolean | undefined {
   return normalizeTitleStrike(chart.titleStrike);
+}
+
+/**
+ * Normalize a {@link SheetChart.titleUnderline} value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` writer slot. Returns the literal
+ * boolean when the input is `true` / `false`, or `undefined` for any
+ * other token (including `null`-shaped escapes from an untyped
+ * caller). Absence and non-boolean tokens both collapse to
+ * `undefined` so the writer omits the `u` attribute entirely (Excel's
+ * reference serialization for a non-underlined title — the OOXML
+ * default `"none"` collapses to absence; only an explicit `true`
+ * emits `u="sng"`).
+ */
+function normalizeTitleUnderline(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` from
+ * {@link SheetChart.titleUnderline}.
+ *
+ * Returns the literal boolean, or `undefined` when the chart leaves
+ * the field unset / passed a non-boolean token. The flag is only
+ * meaningful when the chart actually emits a title — the caller is
+ * expected to gate the call on `showTitle && chart.title`. A chart
+ * whose title is suppressed has no `<c:title>` block to host the flag
+ * in either case.
+ */
+function resolveTitleUnderline(chart: SheetChart): boolean | undefined {
+  return normalizeTitleUnderline(chart.titleUnderline);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -11134,6 +11134,192 @@ describe("cloneChart — title strike", () => {
   });
 });
 
+describe("cloneChart — title underline", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleUnderline by default", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleUnderline).toBe(true);
+  });
+
+  it("lets options.titleUnderline override the source's value", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleUnderline: false,
+    });
+    expect(clone.titleUnderline).toBe(false);
+  });
+
+  it("drops the inherited titleUnderline when the override is null", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleUnderline: null,
+    });
+    expect(clone.titleUnderline).toBeUndefined();
+  });
+
+  it("returns undefined titleUnderline when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleUnderline).toBeUndefined();
+  });
+
+  it("lets options.titleUnderline pin true on a non-underlined source", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleUnderline: true,
+    });
+    expect(clone.titleUnderline).toBe(true);
+  });
+
+  it("drops a non-boolean override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleUnderline: "true" as any,
+    });
+    // The malformed override drops via the normalizer; the source's
+    // parsed value is shadowed (override wins, even when the override is
+    // malformed). Mirrors the titleStrike / titleBold / titleItalic behavior.
+    expect(clone.titleUnderline).toBeUndefined();
+  });
+
+  it("drops the cloned titleUnderline when the resolved title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleUnderline).toBeUndefined();
+  });
+
+  it("drops the cloned titleUnderline when showTitle is false", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleUnderline).toBeUndefined();
+  });
+
+  it("preserves titleUnderline when an override pins a fresh title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleUnderline: true,
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleUnderline).toBe(true);
+  });
+
+  it("composes with titleBold / titleItalic / titleStrike / titleColor / titleFontSize / titleRotation / titleOverlay", () => {
+    const clone = cloneChart(
+      source({
+        titleUnderline: true,
+        titleStrike: true,
+        titleColor: "1070CA",
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 18,
+        titleRotation: -45,
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        titleOverlay: true,
+      },
+    );
+    expect(clone.titleUnderline).toBe(true);
+    expect(clone.titleStrike).toBe(true);
+    expect(clone.titleColor).toBe("1070CA");
+    expect(clone.titleItalic).toBe(true);
+    expect(clone.titleBold).toBe(true);
+    expect(clone.titleFontSize).toBe(18);
+    expect(clone.titleRotation).toBe(-45);
+    expect(clone.titleOverlay).toBe(true);
+  });
+
+  it("threads through line -> column flatten", () => {
+    const clone = cloneChart(source({ titleUnderline: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleUnderline).toBe(true);
+  });
+
+  it("end-to-end parse -> clone -> write -> reparse round-trip", async () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2000" u="sng"/></a:pPr><a:r><a:t>Source</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:lineChart>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$3</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(xml)!;
+    expect(parsed.titleUnderline).toBe(true);
+
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleUnderline).toBe(true);
+
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Region", "Revenue"],
+            ["North", 100],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const titleBlock = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('u="sng"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleUnderline).toBe(true);
+  });
+});
+
 describe("cloneChart — axis title rotation", () => {
   function source(extra?: Partial<Chart>): Chart {
     return {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10162,6 +10162,173 @@ describe("writeChart — title strike", () => {
   });
 });
 
+// ── writeChart — title underline ────────────────────────────────────
+
+describe("writeChart — title underline", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrUnderlineOf(xml: string): string | undefined {
+    // The title's <a:defRPr> lives inside <c:title><c:tx><c:rich><a:p><a:pPr>.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:defRPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const u = m[0].match(/\bu="([^"]+)"/);
+    return u ? u[1] : undefined;
+  }
+
+  function rPrUnderlineOf(xml: string): string | undefined {
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:rPr\b[^/]*\/>/);
+    if (!m) return undefined;
+    const u = m[0].match(/\bu="([^"]+)"/);
+    return u ? u[1] : undefined;
+  }
+
+  it("omits the u attribute by default (matches Excel's reference non-underlined title)", () => {
+    // Excel itself omits `u` on a non-underlined title — the OOXML
+    // default `"none"` collapses to absence. Only the bold flag is
+    // always emitted.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(defRPrUnderlineOf(result.chartXml)).toBeUndefined();
+    expect(rPrUnderlineOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("emits u='sng' on titleUnderline=true", () => {
+    const result = writeChart(makeChart({ titleUnderline: true }), "Sheet1");
+    expect(defRPrUnderlineOf(result.chartXml)).toBe("sng");
+    expect(rPrUnderlineOf(result.chartXml)).toBe("sng");
+  });
+
+  it("omits the u attribute on titleUnderline=false (functionally identical to omission)", () => {
+    const result = writeChart(makeChart({ titleUnderline: false }), "Sheet1");
+    expect(defRPrUnderlineOf(result.chartXml)).toBeUndefined();
+    expect(rPrUnderlineOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (defends against type guard escape)", () => {
+    const result = writeChart(makeChart({ titleUnderline: "true" as any }), "Sheet1");
+    expect(defRPrUnderlineOf(result.chartXml)).toBeUndefined();
+    const result2 = writeChart(makeChart({ titleUnderline: 1 as any }), "Sheet1");
+    expect(defRPrUnderlineOf(result2.chartXml)).toBeUndefined();
+    const result3 = writeChart(makeChart({ titleUnderline: "sng" as any }), "Sheet1");
+    expect(defRPrUnderlineOf(result3.chartXml)).toBeUndefined();
+    const result4 = writeChart(makeChart({ titleUnderline: "dbl" as any }), "Sheet1");
+    expect(defRPrUnderlineOf(result4.chartXml)).toBeUndefined();
+  });
+
+  it("ignores titleUnderline when the chart renders no title (showTitle=false)", () => {
+    // The whole `<c:title>` block is suppressed — no `<a:defRPr>` to
+    // host the underline flag.
+    const result = writeChart(makeChart({ showTitle: false, titleUnderline: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleUnderline when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleUnderline: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleBold, titleItalic, titleStrike, titleColor, titleFontSize, titleRotation, and titleOverlay", () => {
+    const result = writeChart(
+      makeChart({
+        titleUnderline: true,
+        titleStrike: true,
+        titleColor: "1070CA",
+        titleItalic: true,
+        titleBold: true,
+        titleFontSize: 24,
+        titleRotation: -45,
+        titleOverlay: true,
+      }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('rot="-2700000"');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('u="sng"');
+    expect(titleBlock).toContain('strike="sngStrike"');
+    expect(titleBlock).toContain('val="1070CA"');
+    expect(titleBlock).toContain('<c:overlay val="1"/>');
+  });
+
+  it("preserves the title body's other attributes (lang='en-US', sz, b)", () => {
+    const result = writeChart(makeChart({ titleUnderline: true }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('lang="en-US"');
+    // The default 14pt size still lands on both slots even when underline flips.
+    expect(titleBlock.match(/sz="1400"/g)?.length).toBeGreaterThanOrEqual(2);
+    // The default `b="0"` is still emitted on both slots.
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+    // `u="sng"` lands on both the <a:defRPr> and the <a:rPr>.
+    expect(titleBlock.match(/u="sng"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleUnderline: true }), "Sheet1");
+      expect(defRPrUnderlineOf(result.chartXml)).toBe("sng");
+    }
+  });
+
+  it("parse round-trip surfaces titleUnderline from the writer's output", () => {
+    const written = writeChart(makeChart({ titleUnderline: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleUnderline).toBe(true);
+  });
+
+  it("collapses the default (no-underline) round-trip back to undefined", () => {
+    // A fresh chart emits no `u` attribute; the reader collapses
+    // absence to `undefined` so absence and the default round-trip
+    // identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleUnderline).toBeUndefined();
+  });
+
+  it("collapses the explicit titleUnderline=false round-trip back to undefined", () => {
+    // titleUnderline=false drops the attribute entirely (the OOXML
+    // default is `"none"`, but the writer omits the attribute for
+    // symmetry with how Excel's reference UI emits a non-underlined
+    // title); the reader collapses absence to `undefined`.
+    const written = writeChart(makeChart({ titleUnderline: false }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleUnderline).toBeUndefined();
+  });
+
+  it("writeXlsx package round-trip surfaces titleUnderline from the chart part", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Revenue"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Quarterly Revenue",
+            titleUnderline: true,
+            series: [{ name: "Revenue", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const titleBlock = chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).toContain('u="sng"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleUnderline).toBe(true);
+  });
+});
+
 // ── writeChart — axis title rotation ────────────────────────────────
 
 describe("writeChart — axis title rotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10795,6 +10795,225 @@ describe("parseChart — title strike", () => {
   });
 });
 
+// ── parseChart — title underline ─────────────────────────────────────
+
+describe("parseChart — title underline", () => {
+  const NS_TU = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleUnderline(u: string | undefined): string {
+    const defRPr = u === undefined ? "<a:defRPr/>" : `<a:defRPr u="${u}"/>`;
+    return `<c:chartSpace ${NS_TU}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true when the title pinned u='sng' (Excel UI checkbox)", () => {
+    const chart = parseChart(withTitleUnderline("sng"));
+    expect(chart?.titleUnderline).toBe(true);
+  });
+
+  it("collapses u='none' to undefined (OOXML default round-trips identically)", () => {
+    const chart = parseChart(withTitleUnderline("none"));
+    expect(chart?.titleUnderline).toBeUndefined();
+  });
+
+  it("collapses absence of the u attribute to undefined", () => {
+    const chart = parseChart(withTitleUnderline(undefined));
+    expect(chart?.titleUnderline).toBeUndefined();
+  });
+
+  it("collapses the non-UI 'dbl' variant to undefined (avoids lossy downgrade)", () => {
+    // Hucre's writer emits only "sng". Surfacing "dbl" as true would
+    // silently downgrade the choice on round-trip, so the reader
+    // collapses it to undefined to keep the round-trip lossless.
+    const chart = parseChart(withTitleUnderline("dbl"));
+    expect(chart?.titleUnderline).toBeUndefined();
+  });
+
+  it("collapses every exotic ST_TextUnderlineType variant to undefined", () => {
+    // The OOXML enum has eighteen values; Excel's UI exposes only "sng"
+    // and "dbl". The remaining sixteen tokens are not surfaced in the
+    // ribbon and the writer never emits them, so the reader collapses
+    // each to undefined to keep the round-trip lossless.
+    const exotic = [
+      "words",
+      "heavy",
+      "dotted",
+      "dottedHeavy",
+      "dash",
+      "dashHeavy",
+      "dashLong",
+      "dashLongHeavy",
+      "dotDash",
+      "dotDashHeavy",
+      "dotDotDash",
+      "dotDotDashHeavy",
+      "wavy",
+      "wavyHeavy",
+      "wavyDbl",
+    ];
+    for (const variant of exotic) {
+      expect(parseChart(withTitleUnderline(variant))?.titleUnderline).toBeUndefined();
+    }
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TU}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleUnderline).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body (strRef)", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:p><a:pPr><a:defRPr>` to host the underline flag.
+    const xml = `<c:chartSpace ${NS_TU}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleUnderline).toBeUndefined();
+    expect(chart?.title).toBe("Revenue");
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_TU}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleUnderline).toBeUndefined();
+  });
+
+  it("drops unknown u tokens to undefined", () => {
+    expect(parseChart(withTitleUnderline("yes"))?.titleUnderline).toBeUndefined();
+    expect(parseChart(withTitleUnderline("on"))?.titleUnderline).toBeUndefined();
+    expect(parseChart(withTitleUnderline(""))?.titleUnderline).toBeUndefined();
+    expect(parseChart(withTitleUnderline("1"))?.titleUnderline).toBeUndefined();
+    expect(parseChart(withTitleUnderline("true"))?.titleUnderline).toBeUndefined();
+    expect(parseChart(withTitleUnderline("single"))?.titleUnderline).toBeUndefined();
+  });
+
+  it("does not leak from a stray axis-title <a:defRPr>", () => {
+    // The category axis title carries <a:defRPr u="sng"/>, but the
+    // chart-level title does not — `titleUnderline` reflects only the
+    // chart-level title's <a:defRPr>, not a stray sibling element.
+    const xml = `<c:chartSpace ${NS_TU}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Header</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr u="sng"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleUnderline).toBeUndefined();
+  });
+
+  it("co-surfaces alongside titleBold, titleItalic, titleStrike, titleColor, titleFontSize, titleRotation, and titleOverlay", () => {
+    const xml = `<c:chartSpace ${NS_TU}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="-2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="2400" b="1" i="1" u="sng" strike="sngStrike"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.title).toBe("Hero");
+    expect(chart?.titleUnderline).toBe(true);
+    expect(chart?.titleStrike).toBe(true);
+    expect(chart?.titleColor).toBe("1070CA");
+    expect(chart?.titleItalic).toBe(true);
+    expect(chart?.titleBold).toBe(true);
+    expect(chart?.titleFontSize).toBe(24);
+    expect(chart?.titleRotation).toBe(-45);
+    expect(chart?.titleOverlay).toBe(true);
+  });
+});
+
 // ── parseChart — axis title rotation ─────────────────────────────────
 
 describe("parseChart — axis title rotation", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u=".."/></a:pPr><a:r><a:rPr u=".."/></a:r></a:p></c:rich></c:tx></c:title>` (ST_TextUnderlineType on CT_TextCharacterProperties, ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's custom chart-title underline flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Modeled as a boolean for symmetry with `titleBold` (#252) / `titleItalic` (#253) / `titleStrike` (#259): `true` emits `u="sng"` (Excel's UI checkbox — single line); absence and explicit `false` collapse to omitting the attribute (the OOXML default `"none"` collapses to absence, mirroring how Excel's reference serialization emits a non-underlined title). The non-UI variant `"dbl"` (double line) and the sixteen exotic `ST_TextUnderlineType` tokens (`"words"`, `"heavy"`, `"dotted"`, `"dottedHeavy"`, `"dash"`, `"dashHeavy"`, `"dashLong"`, `"dashLongHeavy"`, `"dotDash"`, `"dotDashHeavy"`, `"dotDotDash"`, `"dotDotDashHeavy"`, `"wavy"`, `"wavyHeavy"`, `"wavyDbl"`) are read-only — the writer emits only `"sng"` to keep the surfaced shape consistent with what Excel's reference UI authors, and the reader collapses every non-`"sng"` token to `undefined` so a templated chart that pinned a non-single underline in raw OOXML round-trips lossless rather than silently downgrading on re-emit.

Mirrors `titleFontSize` (#251), `titleBold` (#252), `titleItalic` (#253), `titleColor` (#254), and `titleStrike` (#259) for the same `<c:title>` body, so all eight chart-title typography knobs (size, rotation, bold, italic, color, strike, underline) compose freely on the same title — the writer threads them through a single `buildTitle` call, the reader picks them up off the shared `<a:defRPr>` slot, and the clone resolver follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) override grammar.

Bridges another title-customization gap for the dashboard composition flow tracked in #136 — useful for emphasising "key metric" or "section header" dashboard tile titles without leaking the styling out of the chart's own typography slot.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.titleUnderline);
// true       <- when the template pinned <a:defRPr u="sng"/>
// undefined  <- when the attribute is absent / equals "none"
// undefined  <- when the attribute equals "dbl" or any of the 16 exotic types
// undefined  <- when the chart omits <c:title> or the title is a <c:strRef>

// -- Write side --
await writeXlsx({
  sheets: [{
    name: "Dashboard",
    rows: [/* ... */],
    charts: [{
      type: "column",
      title: "Key Metric",
      titleUnderline: true,
      series: [/* ... */],
      anchor: { from: { row: 5, col: 0 } },
    }],
  }],
});

// -- Clone-through --
const clone = cloneChart(source, {
  anchor: { from: { row: 0, col: 8 } },
  titleUnderline: true,    // pin an underline on a non-underlined source
  // titleUnderline: null  // drops the inherited flag (writer omits the attribute)
  // titleUnderline: false // explicit non-underline (functionally identical to null)
});
```

## Implementation notes

- **Type model**: `SheetChart.titleUnderline?: boolean` (writer side); `Chart.titleUnderline?: boolean` (reader side); `CloneChartOptions.titleUnderline?: boolean | null` (clone override).
- **Reader** (`parseTitleUnderline`): walks `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr u="...">` for the `u` attribute. Only the UI-default `"sng"` surfaces as `true`; `"none"`, `"dbl"`, every exotic token, and unknown / malformed tokens all collapse to `undefined` to keep the round-trip lossless against the writer's `"sng"`-only emit grammar. Lookup is scoped to the chart-level title's rich-text body so a stray `<a:defRPr u="..">` elsewhere on the chart (e.g. on an axis title or a data-labels block) cannot leak in.
- **Writer**: `buildTitle` now resolves through a `underline?: boolean` parameter — `normalizeTitleUnderline` accepts only literal `true` / `false`; every other token (typed escape from an untyped caller — `"sng"`, `1`, `null`) collapses to `undefined`. When `true`, the writer lands `u="sng"` on both the default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks the value up off either canonical slot. Absence / `false` omit the attribute entirely (matches Excel's reference serialization for a non-underlined title — the OOXML default `"none"` collapses to absence).
- **Clone** (`resolveTitleUnderline`): follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse the same way as the writer's normalizer, so the cloned `SheetChart` always carries a value the writer will accept. The title-presence scope rule applies via the same gate the writer uses — when the resolved title is dropped (`title: null`, `showTitle: false`, or a sourceless chart with no `title` override), the inherited flag drops silently so the cloned `SheetChart` accurately reflects what the chart will paint.

## Test plan

- [x] `parseChart — title underline` (10 new tests) — surfaces `true` from `"sng"`, collapses `"none"` / absence / `"dbl"` / every exotic token / unknown tokens to `undefined`, returns `undefined` when `<c:title>` / `<c:rich>` / `<a:pPr>` is missing, does not leak from a stray axis-title `<a:defRPr u="sng"/>`, co-surfaces alongside `titleBold` / `titleItalic` / `titleStrike` / `titleColor` / `titleFontSize` / `titleRotation` / `titleOverlay`.
- [x] `writeChart — title underline` (13 new tests) — omits the `u` attribute by default, emits `u="sng"` on `true`, omits on `false` and on non-boolean inputs (`"true"` / `1` / `"sng"` / `"dbl"`), ignores when the chart renders no title (`showTitle: false` / no literal title), composes with `titleBold` / `titleItalic` / `titleStrike` / `titleColor` / `titleFontSize` / `titleRotation` / `titleOverlay`, lands on both `<a:defRPr>` and `<a:rPr>`, threads through every chart family (bar / column / line / pie / scatter / area), parse round-trip, default round-trip collapses to `undefined`, explicit `false` round-trip collapses to `undefined`, full `writeXlsx` package round-trip.
- [x] `cloneChart — title underline` (13 new tests) — inherits the source's value, override replaces (true / false), `null` drops, undefined source + undefined override yields undefined, override pins `true` on a non-underlined source, drops on non-boolean override, drops when `title: null` / `showTitle: false`, preserves when an override pins a fresh title on a sourceless chart, composes with the rest of the chart-title knobs, threads through `line -> column` flatten, end-to-end parse -> clone -> write -> reparse round-trip.
- [x] `pnpm test` — all 4719 tests pass (lint + format + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)