### PR TITLE
feat(xlsx): chart axis title strikethrough flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2188,6 +2188,63 @@ export interface SheetChart {
        * family that has axes (bar / column / line / area / scatter).
        */
       axisTitleColor?: string;
+      /**
+       * Axis title strikethrough flag. Maps to
+       * `<c:catAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+       * <a:r><a:rPr strike=".."/></a:r></a:p></c:rich></c:tx></c:title></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format Axis
+       * Title -> Font -> Strikethrough" toggle. The OOXML attribute is
+       * the `ST_TextStrikeType` enum on `CT_TextCharacterProperties`
+       * (ECMA-376 Part 1, §21.1.2.3.7) with three values: `"noStrike"`
+       * (the OOXML default — no strikethrough), `"sngStrike"` (single
+       * horizontal line, the value Excel's UI checkbox emits), and
+       * `"dblStrike"` (double horizontal line, a non-UI variant Excel
+       * does not surface in its ribbon). The writer lands the value on
+       * both the default-paragraph `<a:defRPr>` and the literal run's
+       * `<a:rPr>` so a re-parse picks the flag up off either canonical
+       * slot — Excel keeps the two attributes in sync.
+       *
+       * Modeled as a boolean for symmetry with {@link axisTitleBold} /
+       * {@link axisTitleItalic}: `true` emits `strike="sngStrike"`
+       * (Excel's UI "Strikethrough" checkbox — single line). Absence
+       * and non-boolean tokens collapse to omitting the attribute
+       * (Excel's reference serialization for a non-strikethrough axis
+       * title — the application-default `"noStrike"` collapses to
+       * absence). Set `false` explicitly to pin the non-default
+       * omission (functionally identical to omission, but useful when
+       * overriding a templated axis title that had strikethrough pinned
+       * upstream).
+       *
+       * Hucre's writer emits only `"sngStrike"` to keep the surfaced
+       * shape consistent with what Excel's reference UI authors. The
+       * reader collapses the non-UI `"dblStrike"` to `undefined` so a
+       * templated axis title that pinned the double-line variant in
+       * raw OOXML round-trips to the same `undefined` an unmarked axis
+       * title parses to (i.e. the double-line variant silently
+       * downgrades to the single-line write grammar rather than
+       * fabricate a value the writer would re-emit incorrectly).
+       *
+       * Mirrors {@link SheetChart.titleStrike} for axis titles — same
+       * canonical-slot pair, same drop-on-default semantics, same
+       * `boolean | null` clone grammar so a single configuration call
+       * threads cleanly through both the chart title and either axis
+       * title without bookkeeping the canonical OOXML slots. Mirrors
+       * {@link axisTitleRotation} / {@link axisTitleFontSize} /
+       * {@link axisTitleBold} / {@link axisTitleItalic} /
+       * {@link axisTitleColor} for the same `<c:title>` body, so all
+       * six axis-title knobs (rotation, size, bold, italic, color,
+       * strike) compose freely on the same axis.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+       * per the OOXML schema, so the field round-trips on every chart
+       * family that has axes (bar / column / line / area / scatter).
+       */
+      axisTitleStrike?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -2535,6 +2592,25 @@ export interface SheetChart {
        * fill).
        */
       axisTitleColor?: string;
+      /**
+       * Value-axis title strikethrough flag. Maps to
+       * `<c:valAx><c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+       * <a:r><a:rPr strike=".."/></a:r></a:p></c:rich></c:tx></c:title></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.axisTitleStrike} for the value
+       * axis — see that field for the full semantics. The OOXML
+       * attribute is the `ST_TextStrikeType` enum on
+       * `CT_TextCharacterProperties`; the writer emits only the UI
+       * variant `"sngStrike"` and lands it on both the default-paragraph
+       * `<a:defRPr>` and the literal run's `<a:rPr>` so a re-parse picks
+       * the flag up off either canonical slot.
+       *
+       * Useful for marking a Y-axis unit label as "before" or
+       * "deprecated" in dashboard tile typography without touching the
+       * chart title. Silently dropped on `pie` / `doughnut` charts (no
+       * axes at all) and on any axis whose `title` is unset (no
+       * `<c:title>` block to host the flag).
+       */
+      axisTitleStrike?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3838,6 +3914,41 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleColor?: string;
+  /**
+   * Axis-title strikethrough flag pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+   * </a:p></c:rich></c:tx></c:title>` on the axis element. Reflects
+   * Excel's "Format Axis Title -> Font -> Strikethrough" toggle.
+   *
+   * The OOXML attribute is the `ST_TextStrikeType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+   * three values: `"noStrike"`, `"sngStrike"`, `"dblStrike"`. Only the
+   * UI-default `"sngStrike"` (Excel's "Strikethrough" checkbox —
+   * single line) surfaces as `true`; `"noStrike"` (the OOXML
+   * application default) and absence both collapse to `undefined`,
+   * and the non-UI `"dblStrike"` variant likewise collapses to
+   * `undefined` rather than surface a value the writer would silently
+   * downgrade on round-trip — hucre's writer emits only `"sngStrike"`,
+   * so reporting `"dblStrike"` as `true` would round-trip into a lossy
+   * single-line replacement.
+   *
+   * Unknown / malformed `strike` tokens drop to `undefined` rather
+   * than fabricate a value the writer would never emit.
+   *
+   * Reported as `undefined` whenever the axis omits `<c:title>`
+   * entirely, or when the title is a `<c:strRef>` (formula reference)
+   * with no `<c:rich>` body — there is no `<a:p>` to host the flag in
+   * either case. Mirrors the chart-level {@link Chart.titleStrike} so
+   * a parsed value slots straight back into the writer-side
+   * {@link SheetChart.axes.x.axisTitleStrike} without transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the flag regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleStrike?: boolean;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -810,6 +810,31 @@ export interface CloneChartOptions {
        * the axis-title knobs compose the same way at the call site.
        */
       axisTitleColor?: string | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleStrike`. `undefined` (or
+       * omitted) inherits the source axis's parsed value; `null` drops
+       * the inherited flag so the writer falls back to the OOXML
+       * default — no `strike` attribute, equivalent to no
+       * strikethrough. A `boolean` replaces it: `true` emits
+       * `strike="sngStrike"` (Excel's UI "Strikethrough" — single line);
+       * `false` pins the non-default omission (functionally identical
+       * to dropping).
+       *
+       * Non-boolean overrides (typed escapes from an untyped caller)
+       * collapse to a drop so the cloned `SheetChart` always carries
+       * a value the writer will accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * flag). The grammar mirrors `axisTitleRotation` /
+       * `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic` /
+       * `axisTitleColor` so the axis-title knobs compose the same way
+       * at the call site.
+       */
+      axisTitleStrike?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1000,6 +1025,8 @@ export interface CloneChartOptions {
       axisTitleItalic?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleColor}. */
       axisTitleColor?: string | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleStrike}. */
+      axisTitleStrike?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2822,6 +2849,25 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleColor,
     overrides?.y?.axisTitleColor,
   );
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+  // </a:p></c:rich></c:tx></c:title>` — axis title strikethrough flag.
+  // Sits on the same `<c:title>` body as `axisTitleRotation` /
+  // `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic` /
+  // `axisTitleColor`, so the resolver applies on every chart family
+  // that has axes (pie / doughnut were short-circuited upstream).
+  // Non-boolean overrides collapse to `undefined` so the writer omits
+  // the `strike` attribute. Like the rotation, size, bold, italic, and
+  // color knobs, the writer drops the flag when the matching axis
+  // title is unset, so a stray pin on an axis with no title silently
+  // disappears at emit time.
+  const xAxisTitleStrike = applyAxisTitleStrikeOverride(
+    sourceAxes?.x?.axisTitleStrike,
+    overrides?.x?.axisTitleStrike,
+  );
+  const yAxisTitleStrike = applyAxisTitleStrikeOverride(
+    sourceAxes?.y?.axisTitleStrike,
+    overrides?.y?.axisTitleStrike,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -2987,6 +3033,15 @@ function resolveAxes(
   // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
   const xAxisTitleColorResolved = xTitle === undefined ? undefined : xAxisTitleColor;
   const yAxisTitleColorResolved = yTitle === undefined ? undefined : yAxisTitleColor;
+  // The axis-title strikethrough flag only renders when the axis
+  // carries a title — drop a stray inherited flag when the resolved
+  // axis title is unset so the cloned `SheetChart` accurately reflects
+  // what the chart will paint. Symmetric with the writer's
+  // title-presence gate (the per-family axis builder only invokes
+  // `buildAxisTitle` when `opts.xAxisTitle` / `opts.yAxisTitle` is
+  // set).
+  const xAxisTitleStrikeResolved = xTitle === undefined ? undefined : xAxisTitleStrike;
+  const yAxisTitleStrikeResolved = yTitle === undefined ? undefined : yAxisTitleStrike;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -2996,6 +3051,7 @@ function resolveAxes(
     xAxisTitleBoldResolved !== undefined ||
     xAxisTitleItalicResolved !== undefined ||
     xAxisTitleColorResolved !== undefined ||
+    xAxisTitleStrikeResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -3025,6 +3081,7 @@ function resolveAxes(
     if (xAxisTitleBoldResolved !== undefined) out.x.axisTitleBold = xAxisTitleBoldResolved;
     if (xAxisTitleItalicResolved !== undefined) out.x.axisTitleItalic = xAxisTitleItalicResolved;
     if (xAxisTitleColorResolved !== undefined) out.x.axisTitleColor = xAxisTitleColorResolved;
+    if (xAxisTitleStrikeResolved !== undefined) out.x.axisTitleStrike = xAxisTitleStrikeResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -3052,6 +3109,7 @@ function resolveAxes(
     yAxisTitleBoldResolved !== undefined ||
     yAxisTitleItalicResolved !== undefined ||
     yAxisTitleColorResolved !== undefined ||
+    yAxisTitleStrikeResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -3075,6 +3133,7 @@ function resolveAxes(
     if (yAxisTitleBoldResolved !== undefined) out.y.axisTitleBold = yAxisTitleBoldResolved;
     if (yAxisTitleItalicResolved !== undefined) out.y.axisTitleItalic = yAxisTitleItalicResolved;
     if (yAxisTitleColorResolved !== undefined) out.y.axisTitleColor = yAxisTitleColorResolved;
+    if (yAxisTitleStrikeResolved !== undefined) out.y.axisTitleStrike = yAxisTitleStrikeResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -3539,6 +3598,31 @@ function applyAxisTitleColorOverride(
   if (override === undefined) return normalizeTitleColor(source);
   if (override === null) return undefined;
   return normalizeTitleColor(override);
+}
+
+/**
+ * Resolve an `axisTitleStrike` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Non-boolean overrides (typed escape from an untyped
+ * caller) collapse to `undefined` via {@link normalizeTitleStrike} so
+ * the cloned `SheetChart` always carries a value the writer will
+ * accept. A `null` override always drops the inherited flag (the
+ * writer falls back to the OOXML default — no `strike` attribute,
+ * equivalent to no strikethrough).
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a flag that the writer would silently elide (the writer
+ * scopes the flag emission to `<c:title>`, which is omitted when the
+ * axis renders no title).
+ */
+function applyAxisTitleStrikeOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeTitleStrike(source);
+  if (override === null) return undefined;
+  return normalizeTitleStrike(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -609,6 +609,18 @@ function parseAxisInfo(
   // omits `<c:title>` entirely or when the title is a `<c:strRef>`
   // (formula reference) with no `<c:rich>` body.
   const axisTitleColor = parseAxisTitleColor(axis);
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+  // </a:p></c:rich></c:tx></c:title>` — axis-title strikethrough flag.
+  // Same `<c:title>` body scope as `axisTitleItalic`, so a stray
+  // `<a:defRPr>` elsewhere on the axis (e.g. on the tick-label
+  // `<c:txPr>`) cannot leak in. Only the UI-default `"sngStrike"`
+  // surfaces as `true`; `"noStrike"` (the OOXML application default)
+  // and the non-UI `"dblStrike"` both collapse to `undefined` so absence
+  // and the OOXML default round-trip identically through the writer
+  // (which emits only `"sngStrike"`). Returns `undefined` when the axis
+  // omits `<c:title>` entirely or when the title is a `<c:strRef>`
+  // (formula reference) with no `<c:rich>` body.
+  const axisTitleStrike = parseAxisTitleStrike(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -703,6 +715,7 @@ function parseAxisInfo(
     axisTitleBold === undefined &&
     axisTitleItalic === undefined &&
     axisTitleColor === undefined &&
+    axisTitleStrike === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -732,6 +745,7 @@ function parseAxisInfo(
   if (axisTitleBold !== undefined) out.axisTitleBold = axisTitleBold;
   if (axisTitleItalic !== undefined) out.axisTitleItalic = axisTitleItalic;
   if (axisTitleColor !== undefined) out.axisTitleColor = axisTitleColor;
+  if (axisTitleStrike !== undefined) out.axisTitleStrike = axisTitleStrike;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -1628,6 +1642,70 @@ function parseAxisTitleColor(axis: XmlElement): string | undefined {
   if (!srgbClr) return undefined;
   const raw = srgbClr.attrs.val;
   return normalizeRgbHex(raw);
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/>
+ * </a:pPr></a:p></c:rich></c:tx></c:title>` off an axis element.
+ * Returns the axis-title strikethrough flag.
+ *
+ * The OOXML `strike` attribute is the `ST_TextStrikeType` enum on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+ * three values: `"noStrike"` (the OOXML application default),
+ * `"sngStrike"` (single line, the value Excel's UI checkbox emits),
+ * and `"dblStrike"` (double line, a non-UI variant). The reader
+ * surfaces only the UI-default `"sngStrike"` as `true`; `"noStrike"`,
+ * absence, and the non-UI `"dblStrike"` all collapse to `undefined` —
+ * the writer emits only `"sngStrike"`, so reporting `"dblStrike"` as
+ * `true` would silently downgrade the choice to a single line on
+ * round-trip. Unknown / malformed `strike` tokens likewise drop to
+ * `undefined`.
+ *
+ * Mirrors {@link parseTitleStrike} for axis titles — same canonical-
+ * slot pair (`<a:defRPr>` carries the default-paragraph strike flag,
+ * which the writer keeps in sync with the literal run's `<a:rPr>` so
+ * the reader only needs to consult one of the two slots), same
+ * drop-on-default semantics. The lookup is scoped to the axis title's
+ * `<c:rich>` body so a stray `<a:defRPr>` elsewhere on the axis (e.g.
+ * on the tick-label `<c:txPr>`) cannot leak in.
+ *
+ * Returns `undefined` whenever the axis omits `<c:title>` entirely or
+ * when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body — there is no `<a:p>` slot to surface the flag from
+ * in either case.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape per
+ * the OOXML schema. Mirrors the chart-level title strike
+ * {@link parseTitleStrike} so a parsed value slots straight into the
+ * writer-side {@link SheetChart.axes}.x.axisTitleStrike.
+ */
+function parseAxisTitleStrike(axis: XmlElement): boolean | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
+  // default-paragraph strikethrough flag. The reader walks the
+  // canonical chain and bails on the first missing link so a malformed
+  // `<c:rich>` surfaces as absence rather than a fabricated value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.strike;
+  // Only the UI-default `"sngStrike"` surfaces as `true`. The OOXML
+  // application default `"noStrike"` and the non-UI `"dblStrike"` both
+  // collapse to `undefined` so absence and the OOXML default round-trip
+  // identically through the writer; the writer emits only `"sngStrike"`,
+  // so reporting `"dblStrike"` here would silently downgrade the choice
+  // on round-trip.
+  if (raw === "sngStrike") return true;
+  return undefined;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -757,6 +757,18 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // axis title that inherits the theme text color).
     xAxisTitleColor: normalizeAxisTitleColor(chart.axes?.x?.axisTitleColor),
     yAxisTitleColor: normalizeAxisTitleColor(chart.axes?.y?.axisTitleColor),
+    // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+    // <a:r><a:rPr strike=".."/></a:r></a:p></c:rich></c:tx></c:title>` —
+    // axis-title strikethrough flag. The OOXML attribute is the
+    // `ST_TextStrikeType` enum on `CT_TextCharacterProperties` (ECMA-376
+    // Part 1, §21.1.2.3.7) and the slot lives on every axis flavour.
+    // The writer emits only the UI variant `"sngStrike"`. Normalize the
+    // caller's boolean input — `true` / `false` pass through literally,
+    // every other token (typed escape from an untyped caller) collapses
+    // to `undefined` and the writer omits the `strike` attribute (Excel's
+    // reference serialization for a non-strikethrough axis title).
+    xAxisTitleStrike: normalizeAxisTitleStrike(chart.axes?.x?.axisTitleStrike),
+    yAxisTitleStrike: normalizeAxisTitleStrike(chart.axes?.y?.axisTitleStrike),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1239,6 +1251,24 @@ interface AxisRenderOptions {
    * semantics as {@link xAxisTitleColor}.
    */
   yAxisTitleColor: string | undefined;
+  /**
+   * Axis-title strikethrough flag emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+   * <a:r><a:rPr strike=".."/></a:r></a:p></c:rich></c:tx></c:title>`.
+   * The OOXML attribute is the `ST_TextStrikeType` enum on
+   * `CT_TextCharacterProperties`. `undefined` and `false` both collapse
+   * to omitting the attribute (Excel's reference serialization for a
+   * non-strikethrough axis title); only `true` emits
+   * `strike="sngStrike"` (Excel's UI checkbox — single line). Only
+   * meaningful when the axis renders a title — the per-family axis
+   * builders gate the value on the `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleStrike: boolean | undefined;
+  /**
+   * Axis-title strikethrough flag emitted on the Y axis. Same shape
+   * and emit semantics as {@link xAxisTitleStrike}.
+   */
+  yAxisTitleStrike: boolean | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -2106,6 +2136,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleBold,
         opts.xAxisTitleItalic,
         opts.xAxisTitleColor,
+        opts.xAxisTitleStrike,
       ),
     );
   catAxChildren.push(
@@ -2169,6 +2200,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleBold,
         opts.yAxisTitleItalic,
         opts.yAxisTitleColor,
+        opts.yAxisTitleStrike,
       ),
     );
   valAxChildren.push(
@@ -2533,6 +2565,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleBold,
         opts.xAxisTitleItalic,
         opts.xAxisTitleColor,
+        opts.xAxisTitleStrike,
       ),
     );
   xAxChildren.push(
@@ -2575,6 +2608,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleBold,
         opts.yAxisTitleItalic,
         opts.yAxisTitleColor,
+        opts.yAxisTitleStrike,
       ),
     );
   yAxChildren.push(
@@ -2664,6 +2698,7 @@ function buildAxisTitle(
   bold: boolean | undefined,
   italic: boolean | undefined,
   rgbHex: string | undefined,
+  strike: boolean | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -2699,6 +2734,20 @@ function buildAxisTitle(
   // serialization byte-for-byte (Excel itself omits `i` on a non-
   // italic axis title — only the bold flag is always emitted).
   const i = italic === true ? 1 : undefined;
+  // OOXML's `<a:defRPr strike=".."/>` / `<a:rPr strike=".."/>` attribute
+  // is the `ST_TextStrikeType` enum on `CT_TextCharacterProperties` —
+  // `"noStrike"` (default), `"sngStrike"` (single line, the value
+  // Excel's UI emits), `"dblStrike"` (double line, non-UI). The writer
+  // emits only the UI variant `"sngStrike"` to keep the surfaced shape
+  // consistent with what Excel's reference UI authors. Absence
+  // (`undefined`) and explicit `false` both collapse to omitting the
+  // attribute (Excel itself omits `strike` when the title is not
+  // strikethrough — the OOXML default `"noStrike"` collapses to
+  // absence). Like bold / italic, the value lands on both the
+  // default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so
+  // a re-parse picks the value up off either canonical slot — Excel
+  // keeps the two attributes in sync.
+  const strikeAttr = strike === true ? "sngStrike" : undefined;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the title's font color. Mirrors
   // the chart-level `buildTitle` color emit: `axisTitleColor` lands on
@@ -2717,11 +2766,11 @@ function buildAxisTitle(
   // fresh axis title with no custom color matches Excel's reference
   // serialization byte-for-byte.
   const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i });
+    ? xmlElement("a:defRPr", { sz, b, i, strike: strikeAttr }, [solidFillChild])
+    : xmlSelfClose("a:defRPr", { sz, b, i, strike: strikeAttr });
   const rPr = solidFillChild
-    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i }, [solidFillChild])
-    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i });
+    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i, strike: strikeAttr }, [solidFillChild])
+    : xmlSelfClose("a:rPr", { lang: "en-US", sz, b, i, strike: strikeAttr });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -2833,6 +2882,21 @@ function normalizeAxisTitleItalic(value: boolean | undefined): boolean | undefin
  */
 function normalizeAxisTitleColor(value: string | undefined): string | undefined {
   return normalizeTitleColor(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleStrike value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:rich></c:tx></c:title>` writer slot inside an axis.
+ * Delegates to the chart-level {@link normalizeTitleStrike} so the two
+ * share the same drop-on-non-boolean grammar — `true` / `false` pass
+ * through literally, every other token (typed escape from an untyped
+ * caller) collapses to `undefined` and the writer omits the `strike`
+ * attribute (Excel's reference serialization for a non-strikethrough
+ * axis title).
+ */
+function normalizeAxisTitleStrike(value: boolean | undefined): boolean | undefined {
+  return normalizeTitleStrike(value);
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -12521,3 +12521,223 @@ describe("cloneChart — axis title color", () => {
     expect(reparsed?.axes?.x?.axisTitleColor).toBe("1070CA");
   });
 });
+
+// ── cloneChart — axis title strike ───────────────────────────────────
+
+describe("cloneChart — axis title strike", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleStrike by default", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleStrike).toBe(true);
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleStrike by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleStrike).toBe(true);
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleStrike replace the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleStrike: false } },
+    });
+    expect(clone.axes?.x?.axisTitleStrike).toBe(false);
+  });
+
+  it("drops the inherited axisTitleStrike when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleStrike: null } },
+    });
+    expect(clone.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleStrike when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleStrike with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleStrike: true } },
+    });
+    expect(clone.axes?.x?.axisTitleStrike).toBe(true);
+  });
+
+  it("drops a non-boolean override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleStrike: "true" as any } },
+    });
+    // The malformed override drops via the normalizer; the source's
+    // parsed value is shadowed (override wins, even when malformed).
+    expect(clone.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("drops the cloned axisTitleStrike when the resolved axis title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: null } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("preserves axisTitleStrike when an override pins a fresh title on a sourceless axis", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleStrike: true } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleStrike).toBe(true);
+  });
+
+  it("composes with axisTitleBold, axisTitleItalic, axisTitleColor, axisTitleFontSize, axisTitleRotation", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleStrike: true,
+            axisTitleColor: "1070CA",
+            axisTitleItalic: true,
+            axisTitleBold: true,
+            axisTitleFontSize: 14,
+            axisTitleRotation: 45,
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x).toEqual({
+      title: "Period",
+      axisTitleStrike: true,
+      axisTitleColor: "1070CA",
+      axisTitleItalic: true,
+      axisTitleBold: true,
+      axisTitleFontSize: 14,
+      axisTitleRotation: 45,
+    });
+  });
+
+  it("threads independently across both axes", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleStrike: true },
+          y: { title: "USD" },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { y: { axisTitleStrike: true } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleStrike).toBe(true);
+    expect(clone.axes?.y?.axisTitleStrike).toBe(true);
+  });
+
+  it("end-to-end parse -> clone -> write -> reparse round-trip", async () => {
+    const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+    const sourceXml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/><c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$3</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.axisTitleStrike).toBe(true);
+    expect(parsed?.axes?.y?.axisTitleStrike).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.axisTitleStrike).toBe(true);
+    expect(sheetChart.axes?.y?.axisTitleStrike).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleStrike).toBe(true);
+    expect(reparsed?.axes?.y?.axisTitleStrike).toBe(true);
+  });
+
+  it("propagates axisTitleStrike into the rendered axis on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleStrike: true } } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleStrike).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -11477,3 +11477,235 @@ describe("writeChart — axis title color", () => {
     expect(reparsed?.axes?.y?.axisTitleColor).toBe("00C586");
   });
 });
+
+// ── writeChart — axis title strike ──────────────────────────────────
+
+describe("writeChart — axis title strike", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  function axisTitleDefRPrStrike(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    // The writer keeps `<a:defRPr>` self-closing when no fill is set
+    // but expands it when a fill is applied. Match either form.
+    const defRPrMatch = titleBlock.match(
+      /<a:defRPr\b[^/>]*\/>|<a:defRPr\b[^>]*>[\s\S]*?<\/a:defRPr>/,
+    );
+    if (!defRPrMatch) return undefined;
+    const s = defRPrMatch[0].match(/\bstrike="([^"]+)"/);
+    return s ? s[1] : undefined;
+  }
+
+  function axisTitleRPrStrike(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    const rPrMatch = titleBlock.match(/<a:rPr\b[^/>]*\/>|<a:rPr\b[^>]*>[\s\S]*?<\/a:rPr>/);
+    if (!rPrMatch) return undefined;
+    const s = rPrMatch[0].match(/\bstrike="([^"]+)"/);
+    return s ? s[1] : undefined;
+  }
+
+  it("omits the strike attribute by default (matches Excel's reference non-strikethrough axis title)", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrStrike(xAx)).toBeUndefined();
+    expect(axisTitleRPrStrike(xAx)).toBeUndefined();
+  });
+
+  it("emits strike='sngStrike' on axisTitleStrike=true", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrStrike(xAx)).toBe("sngStrike");
+    expect(axisTitleRPrStrike(xAx)).toBe("sngStrike");
+  });
+
+  it("omits the strike attribute on axisTitleStrike=false (functionally identical to omission)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: false } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrStrike(xAx)).toBeUndefined();
+    expect(axisTitleRPrStrike(xAx)).toBeUndefined();
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (defends against type guard escape)", () => {
+    const r1 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: "true" as any } } }),
+      "Sheet1",
+    );
+    const [r1XAx] = axisBlocks(r1.chartXml);
+    expect(axisTitleDefRPrStrike(r1XAx)).toBeUndefined();
+    const r2 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: 1 as any } } }),
+      "Sheet1",
+    );
+    const [r2XAx] = axisBlocks(r2.chartXml);
+    expect(axisTitleDefRPrStrike(r2XAx)).toBeUndefined();
+    const r3 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: "sngStrike" as any } } }),
+      "Sheet1",
+    );
+    const [r3XAx] = axisBlocks(r3.chartXml);
+    expect(axisTitleDefRPrStrike(r3XAx)).toBeUndefined();
+  });
+
+  it("threads the strike flag through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleStrike: true },
+          y: { title: "USD", axisTitleStrike: false },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrStrike(xAx)).toBe("sngStrike");
+    expect(axisTitleDefRPrStrike(yAx)).toBeUndefined();
+  });
+
+  it("ignores axisTitleStrike when the axis renders no title", () => {
+    // No title means no `<c:title>` block — there is no slot for the
+    // flag in either case.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleStrike: true } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with rotation / size / bold / italic / color on the same axis title", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleRotation: 45,
+            axisTitleFontSize: 14,
+            axisTitleBold: true,
+            axisTitleItalic: true,
+            axisTitleColor: "1070CA",
+            axisTitleStrike: true,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock).toContain('rot="2700000"');
+    expect(titleBlock).toContain('sz="1400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('strike="sngStrike"');
+    expect(titleBlock).toContain('val="1070CA"');
+  });
+
+  it("threads the strike flag through line / area chart families and scatter (both axes via valAx)", () => {
+    for (const type of ["line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleStrike: true } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleDefRPrStrike(xAx)).toBe("sngStrike");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleStrike: true } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    const yAx = blocks[1];
+    expect(axisTitleDefRPrStrike(yAx)).toBe("sngStrike");
+  });
+
+  it("preserves the surrounding font defaults (lang='en-US', sz='1000', b='0')", () => {
+    // Only the strike attribute should be added; the writer keeps the
+    // existing size / language / bold defaults so a templated axis title
+    // only gains the strikethrough, not lose the surrounding font defaults.
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock).toContain('lang="en-US"');
+    expect(titleBlock).toContain('sz="1000"');
+    expect(titleBlock.match(/b="0"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(titleBlock.match(/strike="sngStrike"/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("round-trips axisTitleStrike through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: true } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleStrike).toBe(true);
+  });
+
+  it("round-trips a defaulted axis title to undefined strike", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("round-trips an explicit axisTitleStrike=false back to undefined", () => {
+    // axisTitleStrike=false drops the attribute entirely; the reader
+    // collapses absence to `undefined`.
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleStrike: false } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the axis title strike into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleStrike: true },
+              y: { title: "USD", axisTitleStrike: true },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleStrike).toBe(true);
+    expect(reparsed?.axes?.y?.axisTitleStrike).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -12247,3 +12247,274 @@ describe("parseChart — axis title color", () => {
     });
   });
 });
+
+// ── parseChart — axis title strike ───────────────────────────────────
+
+describe("parseChart — axis title strike", () => {
+  const NS_AS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitleStrike(strike: string | undefined): string {
+    const defRPr = strike === undefined ? "<a:defRPr/>" : `<a:defRPr strike="${strike}"/>`;
+    return `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true when the axis title pinned strike='sngStrike' (Excel UI checkbox)", () => {
+    const chart = parseChart(withCatAxTitleStrike("sngStrike"));
+    expect(chart?.axes?.x?.axisTitleStrike).toBe(true);
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("collapses strike='noStrike' to undefined (OOXML default round-trips identically)", () => {
+    const chart = parseChart(withCatAxTitleStrike("noStrike"));
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("collapses absence of the strike attribute to undefined", () => {
+    const chart = parseChart(withCatAxTitleStrike(undefined));
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("collapses the non-UI 'dblStrike' variant to undefined (avoids lossy downgrade)", () => {
+    // Hucre's writer emits only "sngStrike". Surfacing "dblStrike" as
+    // true would silently downgrade the choice on round-trip, so the
+    // reader collapses it to undefined to keep the round-trip lossless.
+    const chart = parseChart(withCatAxTitleStrike("dblStrike"));
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("drops unknown strike tokens to undefined", () => {
+    expect(parseChart(withCatAxTitleStrike("yes"))?.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(parseChart(withCatAxTitleStrike("on"))?.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(parseChart(withCatAxTitleStrike(""))?.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(parseChart(withCatAxTitleStrike("1"))?.axes?.x?.axisTitleStrike).toBeUndefined();
+    expect(parseChart(withCatAxTitleStrike("true"))?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a <c:strRef> formula reference", () => {
+    // A title that only carries `<c:strRef>` (formula reference) has
+    // no `<a:p><a:pPr><a:defRPr>` to host the strike flag.
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache>
+        </c:strRef></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> has no <a:pPr> element", () => {
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("does not leak the chart-level title strike into the axis title strike", () => {
+    // The chart-level title pins strike="sngStrike", but the axis
+    // title's defRPr has no strike — `axisTitleStrike` reflects only
+    // the axis title's defRPr.
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleStrike).toBe(true);
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("does not leak the tick-label <c:txPr> strike flag into the axis title strike", () => {
+    // The reader scopes the lookup to the axis title's <c:rich> body —
+    // the tick-label `<c:txPr>` is a sibling element on the axis and
+    // must not feed its `<a:defRPr strike>` into the title flag.
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("surfaces the strike flag on the value axis", () => {
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.y?.title).toBe("USD");
+    expect(chart?.axes?.y?.axisTitleStrike).toBe(true);
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleStrike).toBe(true);
+    expect(chart?.axes?.y?.axisTitleStrike).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis-title knobs on the same axis", () => {
+    const xml = `<c:chartSpace ${NS_AS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="2700000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1400" b="1" i="1" strike="sngStrike"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      axisTitleRotation: 45,
+      axisTitleFontSize: 14,
+      axisTitleBold: true,
+      axisTitleItalic: true,
+      axisTitleColor: "1070CA",
+      axisTitleStrike: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx>`/`<c:valAx>`/`<c:dateAx>`/`<c:serAx>`'s `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr strike=".."/></a:pPr><a:r><a:rPr strike=".."/></a:r></a:p></c:rich></c:tx></c:title>` (ST_TextStrikeType on CT_TextCharacterProperties, ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's custom axis-title strikethrough flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

Modeled as a boolean for symmetry with `axisTitleBold` (#256) / `axisTitleItalic` (#257) and the chart-level `titleStrike` (#259): `true` emits `strike="sngStrike"` (Excel's UI checkbox — single line); absence and explicit `false` collapse to omitting the attribute (the OOXML default `"noStrike"` collapses to absence, mirroring how Excel's reference serialization emits a non-strikethrough axis title). The non-UI variant `"dblStrike"` is read-only — the writer emits only `"sngStrike"` to keep the surfaced shape consistent with what Excel's reference UI authors, and the reader collapses `"dblStrike"` to `undefined` so a templated axis title that pinned the double-line variant in raw OOXML round-trips lossless rather than silently downgrading on re-emit.

Mirrors `axisTitleRotation` (#248), `axisTitleFontSize` (#255), `axisTitleBold` (#256), `axisTitleItalic` (#257), and `axisTitleColor` (#258) for the same `<c:title>` body, so all six axis-title typography knobs (rotation, size, bold, italic, color, strike) compose freely on the same axis — the writer threads them through a single `buildAxisTitle` call, the reader picks them up off the shared `<a:defRPr>` slot, and the clone resolver follows the standard `undefined` (inherit) / `null` (drop) / `boolean` (replace) override grammar. The flag sits on every axis flavour (bar / column / line / area / scatter); pie / doughnut have no axes at all so the field is silently dropped, and an axis with no `title` has no `<c:title>` block to host the flag in either case.

Refs #136

## Test plan

- [x] `pnpm test` passes (lint + typecheck + 4758 vitest tests across 89 files)
- [x] `pnpm build` succeeds
- [x] New parser tests cover `sngStrike` / `noStrike` / `dblStrike` / absence / unknown tokens / `<c:strRef>` titles / missing `<a:pPr>` / cross-axis isolation / chart-level title leak guard / tick-label `<c:txPr>` leak guard
- [x] New writer tests cover default omission / `true` emit / explicit `false` / non-boolean escape drops / X+Y axis independence / no-title gating / composition with rotation/size/bold/italic/color / line/area/scatter family threading / preserved font defaults / round-trip through `parseChart`
- [x] New clone tests cover inherit / `null` drop / boolean replace / unset-source override / non-boolean escape drops / drop on `title=null` / fresh-title pin / six-knob composition / cross-axis independence / end-to-end parse -> clone -> write -> reparse round-trip / `writeXlsx` package round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)