### PR TITLE
feat(xlsx): chart axis tick-label font size — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2301,6 +2301,39 @@ export interface SheetChart {
        */
       labelRotation?: number;
       /**
+       * Tick-label font size in whole or half points. Maps to
+       * `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format
+       * Axis -> Font -> Size" knob applied to the tick labels. The
+       * OOXML attribute is in 100ths of a point, so 12pt serializes as
+       * `sz="1200"` and 10pt (Excel's reference default for tick
+       * labels) as `sz="1000"`; the writer performs the conversion at
+       * emit time and lands the value on the default-paragraph
+       * `<a:defRPr>` slot.
+       *
+       * Mirrors {@link SheetChart.axes.x.axisTitleFontSize} for tick
+       * labels — same `1..400`pt band the OOXML `ST_TextFontSize`
+       * schema exposes, same 0.5pt half-step granularity Excel's UI
+       * exposes, same out-of-range / non-finite drop semantics. Useful
+       * for shrinking dense numeric tick labels on a value axis to fit
+       * a tight chart frame, or bumping category-axis labels up to
+       * match a presentation slide's typography.
+       *
+       * Default: omitted — the tick labels render at Excel's reference
+       * size (10pt). Composes independently with
+       * {@link labelRotation}: both fields land on the same
+       * `<c:txPr>` body, so a single configuration call threads cleanly
+       * through both knobs.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+       * the OOXML schema, so the field round-trips on every chart family
+       * that has axes (bar / column / line / area / scatter). Pie /
+       * doughnut have no axes at all, so the field is silently dropped
+       * on those families.
+       */
+      labelFontSize?: number;
+      /**
        * Reverse the axis plotting order. Maps to
        * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
        * Excel's "Categories in reverse order" / "Values in reverse
@@ -2647,6 +2680,22 @@ export interface SheetChart {
        * charts (no axes at all).
        */
       labelRotation?: number;
+      /**
+       * Tick-label font size in points for the value axis. Maps to
+       * `<c:valAx><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.labelFontSize} for the value
+       * axis — see that field for the full semantics. The OOXML `sz`
+       * attribute is in 100ths of a point; the writer converts at emit
+       * time so callers pin the value in points. Range: `1..400`pt
+       * (the OOXML `ST_TextFontSize` band), with 0.5pt granularity.
+       *
+       * Useful for shrinking dense numeric tick labels (e.g. wide
+       * currency totals) so they fit a tight Y-axis column, or
+       * bumping the value-axis labels up to match a chart-level
+       * typography pin. Silently dropped on `pie` / `doughnut`
+       * charts (no axes at all).
+       */
+      labelFontSize?: number;
       /**
        * Hide the entire value axis (line, tick marks, tick labels).
        * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
@@ -4011,6 +4060,31 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   labelRotation?: number;
+  /**
+   * Tick-label font size in points pulled from
+   * `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`
+   * on the axis element. Reflects Excel's "Format Axis -> Font ->
+   * Size" knob applied to tick labels.
+   *
+   * The OOXML attribute is in 100ths of a point; the reader converts
+   * to points and rounds to the nearest 0.5pt (Excel's UI exposes the
+   * same 0.5pt granularity, e.g. `sz="1000"` surfaces as `10`,
+   * `sz="1050"` as `10.5`). Out-of-range values (outside the `1..400`
+   * band the OOXML `ST_TextFontSize` schema exposes) drop to
+   * `undefined` rather than fabricate a value the writer would never
+   * emit. Absence of the attribute / element / chain likewise
+   * collapses to `undefined`.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+   * the OOXML schema. Mirrors the writer-side
+   * {@link SheetChart.axes.x.labelFontSize} so a parsed value slots
+   * straight back into a clone target without transformation. The
+   * lookup is scoped to the axis-level `<c:txPr>` so a stray
+   * `<a:defRPr>` inside `<c:title>` (surfaced by
+   * {@link ChartAxisInfo.axisTitleFontSize}) cannot leak in.
+   */
+  labelFontSize?: number;
   /**
    * Reverse-axis flag pulled from
    * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -873,6 +873,23 @@ export interface CloneChartOptions {
        */
       labelRotation?: number | null;
       /**
+       * Override `SheetChart.axes.x.labelFontSize`. `undefined` (or
+       * omitted) inherits the source axis's tick-label font size;
+       * `null` drops the inherited value (the writer falls back to
+       * Excel's reference 10pt); a number in the `1..400`pt band
+       * replaces it (out-of-range, non-finite, and non-numeric inputs
+       * collapse to `undefined`). Fractional inputs round to the
+       * nearest 0.5pt, matching Excel's UI granularity.
+       *
+       * `<c:txPr>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts since neither has axes. Composes
+       * independently with {@link labelRotation}: both fields land on
+       * the same `<c:txPr>` body.
+       */
+      labelFontSize?: number | null;
+      /**
        * Override the reverse-axis flag. `undefined` (or omitted)
        * inherits the source axis' parsed value; `null` drops it (the
        * writer falls back to the OOXML default `"minMax"` — forward
@@ -1038,6 +1055,8 @@ export interface CloneChartOptions {
       tickLblPos?: ChartAxisTickLabelPosition | null;
       /** See {@link CloneChartOptions.axes.x.labelRotation}. */
       labelRotation?: number | null;
+      /** See {@link CloneChartOptions.axes.x.labelFontSize}. */
+      labelFontSize?: number | null;
       /** See {@link CloneChartOptions.axes.x.hidden}. */
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
@@ -2913,6 +2932,20 @@ function resolveAxes(
     sourceAxes?.y?.labelRotation,
     overrides?.y?.labelRotation,
   );
+  // `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`
+  // shares the same `<c:txPr>` slot as the rotation resolver above,
+  // and the same per-axis scope rule (every axis flavour carries
+  // `<c:txPr>`; pie / doughnut already short-circuited upstream).
+  // Out-of-range / non-finite / non-numeric inputs collapse to
+  // `undefined`; fractional inputs round to the nearest 0.5pt.
+  const xLabelFontSize = applyLabelFontSizeOverride(
+    sourceAxes?.x?.labelFontSize,
+    overrides?.x?.labelFontSize,
+  );
+  const yLabelFontSize = applyLabelFontSizeOverride(
+    sourceAxes?.y?.labelFontSize,
+    overrides?.y?.labelFontSize,
+  );
   const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
   const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
   // `tickLblSkip` / `tickMarkSkip` only render on category axes
@@ -3059,6 +3092,7 @@ function resolveAxes(
     xMinorTickMark !== undefined ||
     xTickLblPos !== undefined ||
     xLabelRotation !== undefined ||
+    xLabelFontSize !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
@@ -3089,6 +3123,7 @@ function resolveAxes(
     if (xMinorTickMark !== undefined) out.x.minorTickMark = xMinorTickMark;
     if (xTickLblPos !== undefined) out.x.tickLblPos = xTickLblPos;
     if (xLabelRotation !== undefined) out.x.labelRotation = xLabelRotation;
+    if (xLabelFontSize !== undefined) out.x.labelFontSize = xLabelFontSize;
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
@@ -3117,6 +3152,7 @@ function resolveAxes(
     yMinorTickMark !== undefined ||
     yTickLblPos !== undefined ||
     yLabelRotation !== undefined ||
+    yLabelFontSize !== undefined ||
     yHidden !== undefined ||
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
@@ -3141,6 +3177,7 @@ function resolveAxes(
     if (yMinorTickMark !== undefined) out.y.minorTickMark = yMinorTickMark;
     if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
     if (yLabelRotation !== undefined) out.y.labelRotation = yLabelRotation;
+    if (yLabelFontSize !== undefined) out.y.labelFontSize = yLabelFontSize;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
@@ -3468,6 +3505,30 @@ function clampLabelRotationDeg(value: number): number | undefined {
   else if (degrees > 90) degrees = 90;
   if (degrees === 0) return undefined;
   return degrees;
+}
+
+/**
+ * Resolve a `labelFontSize` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. The conversion / clamping rules delegate to
+ * {@link normalizeTitleFontSize} — out-of-range, non-finite, and
+ * non-numeric inputs all collapse to `undefined`, fractional inputs
+ * round to the nearest 0.5pt (Excel's UI granularity), and a `null`
+ * override always drops the inherited size so the writer falls back
+ * to Excel's reference 10pt tick-label size.
+ *
+ * The `<c:txPr>` block sits on every axis flavour per the OOXML
+ * schema, so the override applies on every chart family that has
+ * axes. The pie / doughnut short-circuit upstream collapses the
+ * field on those families since neither has axes.
+ */
+function applyLabelFontSizeOverride(
+  source: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeTitleFontSize(source);
+  if (override === null) return undefined;
+  return normalizeTitleFontSize(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -641,6 +641,13 @@ function parseAxisInfo(
   // UI exposes; the OOXML default `0` and absence both collapse to
   // `undefined`.
   const labelRotation = parseAxisLabelRotation(axis);
+  // `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>` —
+  // tick-label font size in 100ths of a point. Same `<c:txPr>` slot
+  // as `labelRotation` above. Out-of-range / non-numeric values drop
+  // to `undefined` so a corrupt template cannot surface a value the
+  // writer would never emit. Surfaced on every axis flavour for
+  // symmetry with the writer.
+  const labelFontSize = parseAxisLabelFontSize(axis);
   // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
   // accepts "minMax" (default, low → high) and "maxMin" (reversed).
   // The default collapses to undefined so a fresh chart and a chart
@@ -723,6 +730,7 @@ function parseAxisInfo(
     minorTickMark === undefined &&
     tickLblPos === undefined &&
     labelRotation === undefined &&
+    labelFontSize === undefined &&
     reverse === undefined &&
     tickLblSkip === undefined &&
     tickMarkSkip === undefined &&
@@ -753,6 +761,7 @@ function parseAxisInfo(
   if (minorTickMark !== undefined) out.minorTickMark = minorTickMark;
   if (tickLblPos !== undefined) out.tickLblPos = tickLblPos;
   if (labelRotation !== undefined) out.labelRotation = labelRotation;
+  if (labelFontSize !== undefined) out.labelFontSize = labelFontSize;
   if (reverse !== undefined) out.reverse = reverse;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
@@ -1077,6 +1086,55 @@ function parseAxisLabelRotation(axis: XmlElement): number | undefined {
   if (degrees < LABEL_ROTATION_MIN_DEG) return LABEL_ROTATION_MIN_DEG;
   if (degrees > LABEL_ROTATION_MAX_DEG) return LABEL_ROTATION_MAX_DEG;
   return degrees;
+}
+
+/**
+ * Pull `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`
+ * off an axis element. Returns the tick-label font size in points
+ * (range `1..400`).
+ *
+ * Mirrors {@link parseAxisTitleFontSize} for tick labels — same
+ * 0.5pt half-step granularity, same `1..400`pt band, same
+ * drop-on-out-of-range / non-numeric / absence semantics. The lookup
+ * is scoped to the axis-level `<c:txPr>` so a stray `<a:defRPr>`
+ * inside `<c:title><c:tx><c:rich>` (surfaced by
+ * {@link parseAxisTitleFontSize}) cannot leak in.
+ *
+ * The OOXML default — `<a:defRPr>` with no `sz` attribute — collapses
+ * to `undefined` so absence and the default round-trip identically
+ * through {@link cloneChart}. Out-of-range / non-numeric `sz` values
+ * drop rather than fabricate a value the writer would never emit.
+ *
+ * The `<c:txPr>` element sits on every axis flavour — `<c:catAx>` /
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry the optional
+ * element per the OOXML schema. The reader surfaces the size
+ * regardless of axis flavour so a parsed chart preserves the value
+ * for symmetry with the writer-side
+ * {@link SheetChart.axes}.x.labelFontSize.
+ */
+function parseAxisLabelFontSize(axis: XmlElement): number | undefined {
+  const txPr = findChild(axis, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.sz;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 100ths of a point to points, rounding to the nearest
+  // 0.5pt to match the granularity Excel's UI exposes. Mirrors the
+  // chart-level / axis-title `parseTitleFontSize` half-step
+  // normalisation.
+  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
 }
 
 /** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -790,6 +790,14 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // `<c:txPr>` block on a fresh chart.
     xLabelRotation: normalizeAxisLabelRotation(chart.axes?.x?.labelRotation),
     yLabelRotation: normalizeAxisLabelRotation(chart.axes?.y?.labelRotation),
+    // `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`
+    // shares the same `<c:txPr>` block as the rotation slot above. The
+    // writer normalizes the points input — clamp to the `1..400`pt
+    // band the OOXML `ST_TextFontSize` schema exposes; non-finite /
+    // out-of-range / non-numeric inputs collapse to `undefined` so a
+    // fresh chart inherits Excel's reference 10pt tick-label size.
+    xLabelFontSize: normalizeAxisLabelFontSize(chart.axes?.x?.labelFontSize),
+    yLabelFontSize: normalizeAxisLabelFontSize(chart.axes?.y?.labelFontSize),
     xReverse: chart.axes?.x?.reverse === true,
     yReverse: chart.axes?.y?.reverse === true,
     // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
@@ -1297,6 +1305,23 @@ interface AxisRenderOptions {
    * shape and conversion semantics as {@link xLabelRotation}.
    */
   yLabelRotation: number | undefined;
+  /**
+   * Tick-label font size in points emitted on the X axis via
+   * `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`.
+   * The OOXML `sz` attribute is in 100ths of a point; the writer
+   * converts at emit time. Range: `1..400`pt (the OOXML
+   * `ST_TextFontSize` band). `undefined` skips the size attribute so
+   * a fresh chart inherits Excel's reference 10pt tick-label size.
+   * The block is emitted whenever `xLabelRotation` or
+   * `xLabelFontSize` is set so the OOXML schema's `<c:txPr>` slot
+   * carries every pinned typography knob.
+   */
+  xLabelFontSize: number | undefined;
+  /**
+   * Tick-label font size in points emitted on the Y axis. Same shape
+   * and conversion semantics as {@link xLabelFontSize}.
+   */
+  yLabelFontSize: number | undefined;
   xReverse: boolean;
   yReverse: boolean;
   /**
@@ -1629,31 +1654,68 @@ function normalizeAxisLabelRotation(value: number | undefined): number | undefin
 }
 
 /**
- * Build the `<c:txPr>` block that carries an axis tick-label rotation.
- * Returns `undefined` when the resolved degree value is unset so the
- * caller can elide the element entirely (Excel's reference
+ * Normalize an axis `labelFontSize` value (whole / half points) for
+ * the `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`
+ * writer slot. Returns `undefined` when the input is unset,
+ * non-finite, non-numeric, or out of the `1..400`pt band the OOXML
+ * `ST_TextFontSize` schema exposes — every absence path collapses to
+ * the same omit-the-attribute shape so a fresh chart inherits Excel's
+ * reference 10pt tick-label size.
+ *
+ * Fractional inputs round to the nearest 0.5pt (the OOXML attribute
+ * is an integer in 100ths of a point and Excel's UI exposes the same
+ * 0.5pt granularity, so finer fractions have no meaningful refinement
+ * at emit time). Mirrors {@link normalizeTitleFontSize} so a value
+ * threads cleanly through both the title and axis-label slots.
+ */
+function normalizeAxisLabelFontSize(value: number | undefined): number | undefined {
+  if (value === undefined || typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  const halfSteps = Math.round(value * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
+}
+
+/**
+ * Build the `<c:txPr>` block that carries an axis tick-label rotation
+ * and / or font size. Returns `undefined` when both inputs are unset
+ * so the caller can elide the element entirely (Excel's reference
  * serialization on a fresh axis omits `<c:txPr>` when the labels
- * render at the default `rot="0"`).
+ * render at the default rotation and inherit the theme font size).
  *
  * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
  * when the user pins a custom angle — `<a:bodyPr rot="N"/>` carries
- * the rotation, `<a:lstStyle/>` is the empty list-style placeholder
- * the schema requires, and `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>`
- * is the empty paragraph stub Excel always emits even when no per-run
- * styling is pinned. Additional `<a:bodyPr>` attributes Excel writes
- * in its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap`
- * / `anchor` / `anchorCtr`) are intentionally omitted — the OOXML
- * schema marks them all optional, and dropping them keeps the writer's
- * footprint minimal while preserving the rotation intent.
+ * the rotation (when set), `<a:lstStyle/>` is the empty list-style
+ * placeholder the schema requires, and the
+ * `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>` paragraph
+ * stub Excel always emits hosts the optional `sz` attribute on
+ * `<a:defRPr>`. Additional `<a:bodyPr>` attributes Excel writes in
+ * its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap` /
+ * `anchor` / `anchorCtr`) are intentionally omitted — the OOXML
+ * schema marks them all optional, and dropping them keeps the
+ * writer's footprint minimal while preserving the rotation / size
+ * intent.
+ *
+ * When only a rotation is pinned, the `<a:defRPr>` slot self-closes
+ * with no attributes (matching the legacy rotation-only emit). When
+ * a font size is pinned, the slot carries `sz="N"` (in 100ths of a
+ * point) so a re-parse picks the value up off the canonical
+ * default-paragraph slot. When the rotation is absent but the size
+ * is pinned, the writer omits `rot` from `<a:bodyPr>` so the OOXML
+ * default `0` collapses to absence.
  */
-function buildAxisTxPr(rotationDeg: number | undefined): string | undefined {
-  if (rotationDeg === undefined) return undefined;
-  const rot = rotationDeg * TXPR_ROT_PER_DEGREE;
+function buildAxisTxPr(
+  rotationDeg: number | undefined,
+  fontSizePt: number | undefined,
+): string | undefined {
+  if (rotationDeg === undefined && fontSizePt === undefined) return undefined;
+  const rot = rotationDeg === undefined ? undefined : rotationDeg * TXPR_ROT_PER_DEGREE;
+  const sz = fontSizePt === undefined ? undefined : fontSizePt * TITLE_FONT_SZ_PER_POINT;
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr", { rot }),
     xmlSelfClose("a:lstStyle"),
     xmlElement("a:p", undefined, [
-      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr")]),
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz })]),
       xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
     ]),
   ]);
@@ -2147,7 +2209,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // `buildAxisTickRendering`) and `<c:crossAx>` per CT_CatAx (ECMA-376
   // Part 1, §21.2.2.7). Skip the entire block when the caller did not
   // pin a rotation so a fresh chart matches Excel's minimal serialization.
-  const xCatAxTxPr = buildAxisTxPr(opts.xLabelRotation);
+  const xCatAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize);
   if (xCatAxTxPr) catAxChildren.push(xCatAxTxPr);
   catAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
@@ -2212,7 +2274,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // contract as the catAx slot above — emit nothing when the caller
   // did not pin a rotation so the writer matches Excel's reference
   // serialization on a fresh value axis.
-  const yValAxTxPr = buildAxisTxPr(opts.yLabelRotation);
+  const yValAxTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize);
   if (yValAxTxPr) valAxChildren.push(yValAxTxPr);
   valAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
@@ -2575,7 +2637,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   // `<c:txPr>` slot — same CT_ValAx position as the bar / column
   // builder above. Scatter X is a value axis, so the rotation pins on
   // the X-axis just as it does on the Y-axis.
-  const xValAxTxPr = buildAxisTxPr(opts.xLabelRotation);
+  const xValAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize);
   if (xValAxTxPr) xAxChildren.push(xValAxTxPr);
   xAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
@@ -2617,7 +2679,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   );
   // `<c:txPr>` slot for the scatter Y axis — same CT_ValAx position
   // and omit-by-default contract as the catAx / valAx builders above.
-  const yScatterTxPr = buildAxisTxPr(opts.yLabelRotation);
+  const yScatterTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize);
   if (yScatterTxPr) yAxChildren.push(yScatterTxPr);
   yAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -9704,6 +9704,217 @@ describe("cloneChart — axis labelRotation", () => {
   });
 });
 
+// ── cloneChart — axis labelFontSize ─────────────────────────────────
+
+describe("cloneChart — axis labelFontSize", () => {
+  const sourceWithSize: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { labelFontSize: 12 }, y: { labelFontSize: 9 } },
+  };
+
+  it("inherits axes.x.labelFontSize from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithSize, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+    expect(clone.axes?.y?.labelFontSize).toBe(9);
+  });
+
+  it("drops the inherited size when override is null", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: null } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBeUndefined();
+    // Y axis stays put — nulling X must not bleed into Y.
+    expect(clone.axes?.y?.labelFontSize).toBe(9);
+  });
+
+  it("replaces the inherited size when override is a literal number", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: 14 } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBe(14);
+  });
+
+  it("rounds a fractional override to the nearest 0.5pt", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: 10.4 } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBe(10.5);
+  });
+
+  it("collapses an out-of-range override (below 1pt) to undefined", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: 0.5 } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBeUndefined();
+  });
+
+  it("collapses an out-of-range override (above 400pt) to undefined", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: 500 } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBeUndefined();
+  });
+
+  it("collapses non-finite overrides (NaN / Infinity) to undefined", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: Number.NaN } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBeUndefined();
+  });
+
+  it("collapses non-numeric overrides to undefined", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { labelFontSize: "12" as any } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBeUndefined();
+  });
+
+  it("adds a size to a source axis that did not pin one", () => {
+    const noSize: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontSize: 12 } },
+    });
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+  });
+
+  it("strips the size silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelFontSize: 12 } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the size silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelFontSize: 12 } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the size through chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+    expect(clone.axes?.y?.labelFontSize).toBe(9);
+  });
+
+  it("composes the size alongside labelRotation", () => {
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelRotation: 45, labelFontSize: 12 } },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+  });
+
+  it("composes the size alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Period",
+          gridlines: { major: true },
+          labelFontSize: 14,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.labelFontSize).toBe(14);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the size", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200"/></a:pPr></a:p></c:txPr>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.labelFontSize).toBe(12);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.labelFontSize).toBe(12);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('<a:defRPr sz="1200"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelFontSize).toBe(12);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the size intact", async () => {
+    const clone = cloneChart(sourceWithSize, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // 12pt on X axis, 9pt on Y axis.
+    expect(written).toContain('<a:defRPr sz="1200"/>');
+    expect(written).toContain('<a:defRPr sz="900"/>');
+  });
+});
+
 // ── cloneChart — data labels showLeaderLines ────────────────────────
 
 describe("cloneChart — data labels showLeaderLines", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -8901,6 +8901,210 @@ describe("writeChart — axis labelRotation", () => {
   });
 });
 
+// ── writeChart — axis labelFontSize ──────────────────────────────────
+
+describe("writeChart — axis labelFontSize", () => {
+  it("omits <c:txPr> on the category axis when the size is unset", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it('emits <c:txPr> with <a:defRPr sz="N"/> when the X axis pins a size', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelFontSize: 12 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<c:txPr>");
+    expect(catAxBlock).toContain('<a:defRPr sz="1200"/>');
+  });
+
+  it("emits the size on the Y axis (value axis)", () => {
+    const result = writeChart(makeChart({ axes: { y: { labelFontSize: 9 } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<a:defRPr sz="900"/>');
+  });
+
+  it("emits independently on both axes when both pin a size", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelFontSize: 12 }, y: { labelFontSize: 8 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<a:defRPr sz="1200"/>');
+    expect(valAxBlock).toContain('<a:defRPr sz="800"/>');
+  });
+
+  it("rounds fractional inputs to the nearest 0.5pt (Excel UI granularity)", () => {
+    // 10.4 rounds to 10.5 (5 half-steps from 0).
+    const result = writeChart(makeChart({ axes: { x: { labelFontSize: 10.4 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<a:defRPr sz="1050"/>');
+  });
+
+  it("drops out-of-range sizes (below 1pt)", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelFontSize: 0.5 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it("drops out-of-range sizes (above 400pt)", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelFontSize: 500 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-finite sizes (NaN, Infinity)", () => {
+    const nan = writeChart(makeChart({ axes: { x: { labelFontSize: Number.NaN } } }), "Sheet1");
+    const inf = writeChart(
+      makeChart({ axes: { x: { labelFontSize: Number.POSITIVE_INFINITY } } }),
+      "Sheet1",
+    );
+    expect(nan.chartXml).not.toContain("<c:txPr>");
+    expect(inf.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-numeric sizes (string, boolean)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stringy = writeChart(
+      makeChart({ axes: { x: { labelFontSize: "12" as any } } }),
+      "Sheet1",
+    );
+    const boolish = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelFontSize: true as any } } }),
+      "Sheet1",
+    );
+    expect(stringy.chartXml).not.toContain("<c:txPr>");
+    expect(boolish.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("composes with labelRotation in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45, labelFontSize: 12 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    // Only one <c:txPr> per axis even with both knobs pinned.
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(catAxBlock).toContain('<a:defRPr sz="1200"/>');
+  });
+
+  it("emits <c:txPr> with no rot when only labelFontSize is pinned", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelFontSize: 12 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<a:bodyPr/>");
+    expect(catAxBlock).not.toContain("<a:bodyPr rot=");
+  });
+
+  it('emits <a:defRPr sz=".."/> with no sz when only labelRotation is pinned', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelRotation: 45 } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<a:defRPr/>");
+    expect(catAxBlock).not.toContain("<a:defRPr sz=");
+  });
+
+  it("threads the size through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { labelFontSize: 11 } } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr sz="1100"/>');
+    }
+  });
+
+  it("threads the size through scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { labelFontSize: 12 }, y: { labelFontSize: 9 } },
+      }),
+      "Sheet1",
+    );
+    const valAxes = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxes).toHaveLength(2);
+    expect(valAxes[0]).toContain('<a:defRPr sz="1200"/>');
+    expect(valAxes[1]).toContain('<a:defRPr sz="900"/>');
+  });
+
+  it("ignores the size on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(
+      makeChart({ type: "pie", axes: { x: { labelFontSize: 12 } } }),
+      "Sheet1",
+    );
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { labelFontSize: 12 } } }),
+      "Sheet1",
+    );
+    expect(pie.chartXml).not.toContain("<c:txPr>");
+    expect(dough.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("places <c:txPr> between <c:tickLblPos> and <c:crossAx> per the OOXML schema", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblPos: "low", labelFontSize: 12 } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const tickLblPosIdx = catAxBlock.indexOf("c:tickLblPos");
+    const txPrIdx = catAxBlock.indexOf("<c:txPr>");
+    const crossAxIdx = catAxBlock.indexOf("c:crossAx");
+    expect(tickLblPosIdx).toBeGreaterThan(0);
+    expect(txPrIdx).toBeGreaterThan(tickLblPosIdx);
+    expect(crossAxIdx).toBeGreaterThan(txPrIdx);
+  });
+
+  it("round-trips a non-default size through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { labelFontSize: 12 } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelFontSize).toBe(12);
+  });
+
+  it("round-trips a half-point size through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { labelFontSize: 10.5 } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelFontSize).toBe(10.5);
+  });
+
+  it("collapses an absent size round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelFontSize).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the size into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { labelFontSize: 14 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:defRPr sz="1400"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.labelFontSize).toBe(14);
+  });
+});
+
 // ── writeChart — data labels showLeaderLines ─────────────────────────
 
 describe("writeChart — data labels showLeaderLines", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9454,6 +9454,183 @@ describe("parseChart — axis labelRotation", () => {
   });
 });
 
+// ── parseChart — axis labelFontSize ──────────────────────────────────
+
+describe("parseChart — axis labelFontSize", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTxPrSize(sz: string | undefined): string {
+    const txPr =
+      sz === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="${sz}"/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${txPr}
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the font size in points from the sz attribute (100ths of a point)", () => {
+    // 12pt * 100 = 1200.
+    const chart = parseChart(withCatAxTxPrSize("1200"));
+    expect(chart?.axes?.x?.labelFontSize).toBe(12);
+  });
+
+  it("surfaces the reference 10pt size", () => {
+    const chart = parseChart(withCatAxTxPrSize("1000"));
+    expect(chart?.axes?.x?.labelFontSize).toBe(10);
+  });
+
+  it("rounds half-point inputs to the nearest 0.5pt (Excel UI granularity)", () => {
+    // 1050 => 10.5pt.
+    const chart = parseChart(withCatAxTxPrSize("1050"));
+    expect(chart?.axes?.x?.labelFontSize).toBe(10.5);
+  });
+
+  it("returns undefined when <c:txPr> is absent", () => {
+    expect(parseChart(withCatAxTxPrSize(undefined))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the sz attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> is absent inside <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("drops out-of-range sz tokens (below 100)", () => {
+    // 50 / 100 = 0.5pt — below the 1pt minimum.
+    expect(parseChart(withCatAxTxPrSize("50"))?.axes).toBeUndefined();
+  });
+
+  it("drops out-of-range sz tokens (above 400000)", () => {
+    // 500000 / 100 = 5000pt — above the 400pt maximum.
+    expect(parseChart(withCatAxTxPrSize("500000"))?.axes).toBeUndefined();
+  });
+
+  it("drops non-numeric sz tokens", () => {
+    expect(parseChart(withCatAxTxPrSize("twelve-pt"))?.axes).toBeUndefined();
+  });
+
+  it("surfaces the font size on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="900"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.y?.labelFontSize).toBe(9);
+  });
+
+  it("surfaces independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="900"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelFontSize).toBe(12);
+    expect(chart?.axes?.y?.labelFontSize).toBe(9);
+  });
+
+  it("surfaces co-existing rotation and font size from the same <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1400"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+    expect(chart?.axes?.x?.labelFontSize).toBe(14);
+  });
+
+  it('does not pick up an <a:defRPr sz=".."/> from the axis title\'s <c:rich>', () => {
+    // The axis-title's `<c:rich>` carries its own `<a:defRPr sz="..">`
+    // separately from the tick-label `<c:txPr>`. The tick-label parser
+    // must not surface the title's size — that belongs to
+    // axisTitleFontSize.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1800"/></a:pPr><a:r><a:rPr/><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(18);
+    expect(chart?.axes?.x?.labelFontSize).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      tickLblPos: "low",
+      labelRotation: 45,
+      labelFontSize: 12,
+    });
+  });
+});
+
 // ── parseChart — data labels showLeaderLines ─────────────────────────
 
 describe("parseChart — data labels showLeaderLines", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr sz=\"N\"/></a:pPr></a:p></c:txPr></c:catAx>` (and the matching `<c:valAx>` slot) at the read, write, and clone layers so a template's tick-label font size pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `axes.x.labelFontSize?: number` and `axes.y.labelFontSize?: number` on `SheetChart` (writer side) plus the matching `labelFontSize?: number` on `ChartAxisInfo` (reader side). Callers pin the value in points; the writer converts to 100ths at emit time. Range: `1..400`pt (the OOXML `ST_TextFontSize` band) with 0.5pt half-step granularity matching Excel's UI. Out-of-range, non-finite, and non-numeric inputs collapse to `undefined` so a fresh chart inherits Excel's reference 10pt tick-label size.

Until now hucre's writer omitted `<c:txPr>` whenever the rotation was unset and the reader ignored the `<a:defRPr sz=\"..\"/>` slot entirely, so a templated dashboard chart whose user shrunk dense numeric tick labels (a common pattern for fitting wide currency totals on a Y axis column) silently lost the choice on every parse -> clone -> write loop. Bridges another axis-customization gap for the dashboard composition flow tracked in #136.

Composes cleanly with the existing `labelRotation` field added in #245 — both knobs land on the same `<c:txPr>` body, the writer emits a single block per axis carrying whichever subset is pinned, and the reader picks up each value off its canonical slot. `<a:bodyPr rot=>` absent collapses to the OOXML default 0, `<a:defRPr sz=>` absent collapses to the OOXML default (theme-inherited), so a chart that pins only one of the two knobs round-trips without leaking a fabricated value through the other slot.

The clone layer follows the standard `number | null` override grammar: `undefined` inherits, `null` drops, and a literal number replaces (clamped / rounded the same way as the writer). The catAx / valAx scope rule applies — pie / doughnut clones drop the inherited field silently so the cloned `SheetChart` accurately reflects what the chart will paint.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from "hucre";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.labelFontSize);
// 12         ← when the template pinned <a:defRPr sz=\"1200\"/> on the catAx
// undefined  ← when the template emits no size (theme-inherited)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [[\"Quarter\", \"Revenue\"], [\"Q1\", 12000], [\"Q2\", 15500]],
    charts: [{
      type: \"column\",
      series: [{ name: \"Revenue\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
      // Bump category-axis labels up to match the dashboard typography,
      // and shrink the Y-axis numeric labels to fit the tight column.
      axes: { x: { labelFontSize: 12 }, y: { labelFontSize: 9 } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   → inherits the source's parsed labelFontSize unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelFontSize: null } },
});
//   → drops the inherited size (writer falls back to the theme default).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelFontSize: 14 } },
});
//   → replaces the inherited size with 14pt.
```

## Implementation notes

- **Type model**: `axes.x.labelFontSize?: number` and `axes.y.labelFontSize?: number` on `SheetChart` (writer side) plus the matching `labelFontSize?: number` on `ChartAxisInfo` (reader side). Same shape as `axisTitleFontSize` so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseAxisLabelFontSize`): walks `<c:txPr><a:p><a:pPr><a:defRPr sz=\"N\"/></a:pPr></a:p></c:txPr>` for the `sz` attribute. The lookup is scoped to the axis-level `<c:txPr>` so a stray `<a:defRPr sz=\"..\"/>` inside `<c:title><c:tx><c:rich>` (which belongs to `axisTitleFontSize`) cannot leak in. `Number.parseInt` rejects non-numeric tokens; out-of-range values drop rather than clamp (matching the chart-level title-size contract). Surfaces on every axis flavour.
- **Writer**: extends the existing `buildAxisTxPr(rotationDeg, fontSizePt)` helper to optionally include a `<a:defRPr sz=\"N\"/>` inside `<a:pPr>`. The block is emitted whenever either knob is pinned; absent inputs collapse so a chart that pins only one knob keeps the other slot at its OOXML default. Threads through bar / column / line / area via `buildBarAxes` and scatter via `buildScatterAxes`; pie / doughnut have no axes at all and the field is silently dropped on those families.
  - `normalizeAxisLabelFontSize(value)` rounds inputs to the nearest 0.5pt and collapses out-of-range / non-finite / non-numeric inputs to `undefined`.
- **Clone**: `applyLabelFontSizeOverride` follows the standard `number | null` override grammar — `undefined` inherits, `null` drops, a literal number replaces. Out-of-range / non-numeric overrides collapse via `normalizeTitleFontSize` so the cloned `SheetChart` always carries a value the writer will accept. Pie / doughnut clones drop the inherited field silently via the same axis-scope short-circuit the surrounding axis helpers use.
- **Validation**: only literal finite numbers in the `1..400`pt band survive the type guard at every layer; non-numeric inputs collapse to the default.

## Test plan

- [x] `parseChart — axis labelFontSize` (14 new tests) — surfaces the size in points from the `sz` attribute, surfaces the reference 10pt size, rounds half-point inputs, returns undefined when `<c:txPr>` / `<a:defRPr>` / `<a:p>` are absent, drops out-of-range and non-numeric tokens, surfaces on the value axis, surfaces independently on both axes, co-surfaces alongside rotation, isolates from the axis title's `<c:rich>` block, co-surfaces alongside other axis fields.
- [x] `writeChart — axis labelFontSize` (18 new tests) — omits `<c:txPr>` by default, emits the X-axis size, emits the Y-axis size, emits independently on both axes, rounds fractional inputs, drops out-of-range / non-finite / non-numeric inputs, composes with `labelRotation` in a single block, emits `<a:bodyPr/>` (no rot) when only the size is pinned, emits `<a:defRPr/>` (no sz) when only rotation is pinned, threads through bar / column / line / area / scatter, drops on pie / doughnut, places `<c:txPr>` between `<c:tickLblPos>` and `<c:crossAx>` per the OOXML schema, parse round-trip, half-point round-trip, default round-trip collapse, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis labelFontSize` (16 new tests) — inherit / null drop / replace semantics, round fractional overrides, collapse out-of-range / non-finite / non-numeric overrides, add to a source axis without one, drop on pie / doughnut chart-type coercion, carry through bar -> column coercion, compose with rotation, compose with other axis overrides, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — all 4808 tests pass (lint + typecheck + vitest).
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)