### PR TITLE
feat(xlsx): chart axis tick-label bold flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2397,6 +2397,43 @@ export interface SheetChart {
        */
       labelFontSize?: number;
       /**
+       * Tick-label bold flag. Maps to
+       * `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format
+       * Axis -> Font -> Bold" toggle applied to the tick labels. The
+       * OOXML attribute is the `xsd:boolean` `b` on
+       * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7);
+       * the writer lands the value on the default-paragraph
+       * `<a:defRPr>` slot inside the same `<c:txPr>` block that
+       * carries {@link labelRotation} / {@link labelFontSize}.
+       *
+       * Mirrors {@link SheetChart.axes.x.axisTitleBold} for tick
+       * labels — same `boolean | null` clone grammar, same silent drop
+       * on `pie` / `doughnut` (no axes at all). Useful for emphasising
+       * dashboard tick labels (e.g. bolding the bottom-axis category
+       * names so they read as headers in a busy chart frame).
+       *
+       * Default: omitted — the tick labels render non-bold (the OOXML
+       * default; the writer elides the `b` attribute when no value is
+       * pinned). Set `true` to emit `b="1"` on the default-paragraph
+       * slot; set `false` explicitly to pin the OOXML default `b="0"`
+       * (functionally identical to omission, but useful when overriding
+       * a templated chart that had bold pinned upstream).
+       *
+       * Composes independently with {@link labelRotation} /
+       * {@link labelFontSize}: all three knobs land on the same
+       * `<c:txPr>` body, so a single configuration call threads cleanly
+       * through every tick-label knob the writer exposes.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+       * the OOXML schema, so the field round-trips on every chart family
+       * that has axes (bar / column / line / area / scatter). Pie /
+       * doughnut have no axes at all, so the field is silently dropped
+       * on those families.
+       */
+      labelBold?: boolean;
+      /**
        * Reverse the axis plotting order. Maps to
        * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
        * Excel's "Categories in reverse order" / "Values in reverse
@@ -2779,6 +2816,23 @@ export interface SheetChart {
        * charts (no axes at all).
        */
       labelFontSize?: number;
+      /**
+       * Tick-label bold flag for the value axis. Maps to
+       * `<c:valAx><c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.labelBold} for the value
+       * axis — see that field for the full semantics. The OOXML `b`
+       * attribute is the `xsd:boolean` bold flag on
+       * `CT_TextCharacterProperties`; the writer emits `1` / `0` at
+       * the canonical slot. Absence collapses to the OOXML default
+       * (the writer omits the attribute) so a fresh chart inherits
+       * the theme-default tick-label weight.
+       *
+       * Useful for emphasising the value-axis labels on a dashboard
+       * (e.g. bolding the Y-axis numeric totals so they read as
+       * headers in a busy chart frame). Silently dropped on `pie` /
+       * `doughnut` charts (no axes at all).
+       */
+      labelBold?: boolean;
       /**
        * Hide the entire value axis (line, tick marks, tick labels).
        * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
@@ -4205,6 +4259,29 @@ export interface ChartAxisInfo {
    * {@link ChartAxisInfo.axisTitleFontSize}) cannot leak in.
    */
   labelFontSize?: number;
+  /**
+   * Tick-label bold flag pulled from
+   * `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>`
+   * on the axis element. Reflects Excel's "Format Axis -> Font ->
+   * Bold" toggle applied to tick labels.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<a:defRPr b="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<a:defRPr b="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings
+   * (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing
+   * `b` attributes drop to `undefined`.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+   * the OOXML schema. Mirrors the writer-side
+   * {@link SheetChart.axes.x.labelBold} so a parsed value slots
+   * straight back into a clone target without transformation. The
+   * lookup is scoped to the axis-level `<c:txPr>` so a stray
+   * `<a:defRPr b=".."/>` inside `<c:title>` (surfaced by
+   * {@link ChartAxisInfo.axisTitleBold}) cannot leak in.
+   */
+  labelBold?: boolean;
   /**
    * Reverse-axis flag pulled from
    * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -914,6 +914,25 @@ export interface CloneChartOptions {
        */
       labelFontSize?: number | null;
       /**
+       * Override `SheetChart.axes.x.labelBold`. `undefined` (or
+       * omitted) inherits the source axis's tick-label bold flag;
+       * `null` drops the inherited value (the writer falls back to
+       * the OOXML default — the tick labels render at the theme's
+       * default weight); a `boolean` replaces it.
+       *
+       * Non-boolean overrides (typed escapes from an untyped caller)
+       * collapse to a drop so the cloned `SheetChart` always carries
+       * a value the writer will accept.
+       *
+       * `<c:txPr>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts since neither has axes. Composes
+       * independently with {@link labelRotation} / {@link labelFontSize}:
+       * all three knobs land on the same `<c:txPr>` body.
+       */
+      labelBold?: boolean | null;
+      /**
        * Override the reverse-axis flag. `undefined` (or omitted)
        * inherits the source axis' parsed value; `null` drops it (the
        * writer falls back to the OOXML default `"minMax"` — forward
@@ -1083,6 +1102,8 @@ export interface CloneChartOptions {
       labelRotation?: number | null;
       /** See {@link CloneChartOptions.axes.x.labelFontSize}. */
       labelFontSize?: number | null;
+      /** See {@link CloneChartOptions.axes.x.labelBold}. */
+      labelBold?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.hidden}. */
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
@@ -2991,6 +3012,14 @@ function resolveAxes(
     sourceAxes?.y?.labelFontSize,
     overrides?.y?.labelFontSize,
   );
+  // `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>`
+  // shares the same `<c:txPr>` slot as the rotation / size resolvers
+  // above, and the same per-axis scope rule (every axis flavour
+  // carries `<c:txPr>`; pie / doughnut already short-circuited
+  // upstream). Non-boolean overrides collapse to a drop so the cloned
+  // `SheetChart` always carries a value the writer will accept.
+  const xLabelBold = applyLabelBoldOverride(sourceAxes?.x?.labelBold, overrides?.x?.labelBold);
+  const yLabelBold = applyLabelBoldOverride(sourceAxes?.y?.labelBold, overrides?.y?.labelBold);
   const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
   const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
   // `tickLblSkip` / `tickMarkSkip` only render on category axes
@@ -3147,6 +3176,7 @@ function resolveAxes(
     xTickLblPos !== undefined ||
     xLabelRotation !== undefined ||
     xLabelFontSize !== undefined ||
+    xLabelBold !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
@@ -3180,6 +3210,7 @@ function resolveAxes(
     if (xTickLblPos !== undefined) out.x.tickLblPos = xTickLblPos;
     if (xLabelRotation !== undefined) out.x.labelRotation = xLabelRotation;
     if (xLabelFontSize !== undefined) out.x.labelFontSize = xLabelFontSize;
+    if (xLabelBold !== undefined) out.x.labelBold = xLabelBold;
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
@@ -3210,6 +3241,7 @@ function resolveAxes(
     yTickLblPos !== undefined ||
     yLabelRotation !== undefined ||
     yLabelFontSize !== undefined ||
+    yLabelBold !== undefined ||
     yHidden !== undefined ||
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
@@ -3237,6 +3269,7 @@ function resolveAxes(
     if (yTickLblPos !== undefined) out.y.tickLblPos = yTickLblPos;
     if (yLabelRotation !== undefined) out.y.labelRotation = yLabelRotation;
     if (yLabelFontSize !== undefined) out.y.labelFontSize = yLabelFontSize;
+    if (yLabelBold !== undefined) out.y.labelBold = yLabelBold;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
@@ -3588,6 +3621,34 @@ function applyLabelFontSizeOverride(
   if (override === undefined) return normalizeTitleFontSize(source);
   if (override === null) return undefined;
   return normalizeTitleFontSize(override);
+}
+
+/**
+ * Resolve a `labelBold` override using the same `undefined` (inherit)
+ * / `null` (drop) / value (replace) grammar as the other axis
+ * helpers. Mirrors the chart-level `resolveTitleBold` — non-boolean
+ * overrides (typed escapes from an untyped caller) collapse to
+ * `undefined`, a `null` override always drops the inherited flag, and
+ * a literal `true` / `false` replaces it.
+ *
+ * The `<c:txPr>` block sits on every axis flavour per the OOXML
+ * schema, so the override applies on every chart family that has
+ * axes. The pie / doughnut short-circuit upstream collapses the
+ * field on those families since neither has axes.
+ */
+function applyLabelBoldOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    if (source === true) return true;
+    if (source === false) return false;
+    return undefined;
+  }
+  if (override === null) return undefined;
+  if (override === true) return true;
+  if (override === false) return false;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -661,6 +661,13 @@ function parseAxisInfo(
   // writer would never emit. Surfaced on every axis flavour for
   // symmetry with the writer.
   const labelFontSize = parseAxisLabelFontSize(axis);
+  // `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>` —
+  // tick-label bold flag. Same `<c:txPr>` slot scope as the rotation /
+  // size readers above. The OOXML default `false` collapses to
+  // `undefined` so absence and `b="0"` round-trip identically; only
+  // an explicit `b="1"` surfaces `true`. Surfaced on every axis
+  // flavour for symmetry with the writer.
+  const labelBold = parseAxisLabelBold(axis);
   // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
   // accepts "minMax" (default, low → high) and "maxMin" (reversed).
   // The default collapses to undefined so a fresh chart and a chart
@@ -745,6 +752,7 @@ function parseAxisInfo(
     tickLblPos === undefined &&
     labelRotation === undefined &&
     labelFontSize === undefined &&
+    labelBold === undefined &&
     reverse === undefined &&
     tickLblSkip === undefined &&
     tickMarkSkip === undefined &&
@@ -777,6 +785,7 @@ function parseAxisInfo(
   if (tickLblPos !== undefined) out.tickLblPos = tickLblPos;
   if (labelRotation !== undefined) out.labelRotation = labelRotation;
   if (labelFontSize !== undefined) out.labelFontSize = labelFontSize;
+  if (labelBold !== undefined) out.labelBold = labelBold;
   if (reverse !== undefined) out.reverse = reverse;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
@@ -1150,6 +1159,49 @@ function parseAxisLabelFontSize(axis: XmlElement): number | undefined {
   const points = halfSteps / 2;
   if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
   return points;
+}
+
+/**
+ * Pull `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>`
+ * off an axis element. Returns the tick-label bold flag.
+ *
+ * Mirrors {@link parseAxisTitleBold} for tick labels — same
+ * canonical-slot pair, same drop-on-default-`false` semantics. The
+ * OOXML `b` attribute is the `xsd:boolean` bold flag on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7). The
+ * default `false` collapses to `undefined` so absence and `b="0"`
+ * round-trip identically — only an explicit `b="1"` surfaces `true`.
+ * Unknown / malformed `b` tokens drop to `undefined` rather than
+ * fabricate a value the writer would never emit.
+ *
+ * The lookup is scoped to the axis-level `<c:txPr>` so a stray
+ * `<a:defRPr b=".."/>` inside `<c:title><c:tx><c:rich>` (surfaced by
+ * {@link parseAxisTitleBold}) cannot leak in. Returns `undefined`
+ * whenever the axis omits `<c:txPr>` entirely or the canonical
+ * `<a:p><a:pPr><a:defRPr>` chain is malformed.
+ *
+ * The `<c:txPr>` element sits on every axis flavour — `<c:catAx>` /
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry the optional
+ * element per the OOXML schema. The reader surfaces the flag
+ * regardless of axis flavour so a parsed chart preserves the value
+ * for symmetry with the writer-side
+ * {@link SheetChart.axes}.x.labelBold.
+ */
+function parseAxisLabelBold(axis: XmlElement): boolean | undefined {
+  const txPr = findChild(axis, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const parsed = parseBoolAttr(defRPr.attrs.b);
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `b="0"` round-trip identically through the writer — only an
+  // explicit `b="1"` surfaces `true`.
+  if (parsed === true) return true;
+  return undefined;
 }
 
 /** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -808,6 +808,14 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // fresh chart inherits Excel's reference 10pt tick-label size.
     xLabelFontSize: normalizeAxisLabelFontSize(chart.axes?.x?.labelFontSize),
     yLabelFontSize: normalizeAxisLabelFontSize(chart.axes?.y?.labelFontSize),
+    // `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>`
+    // shares the same `<c:txPr>` block as the rotation / size slots
+    // above. `true` / `false` pass through literally; non-boolean
+    // tokens (typed escapes from an untyped caller) collapse to
+    // `undefined` so the writer omits the `b` attribute and a fresh
+    // chart inherits the theme-default tick-label weight.
+    xLabelBold: normalizeAxisLabelBold(chart.axes?.x?.labelBold),
+    yLabelBold: normalizeAxisLabelBold(chart.axes?.y?.labelBold),
     xReverse: chart.axes?.x?.reverse === true,
     yReverse: chart.axes?.y?.reverse === true,
     // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
@@ -1350,6 +1358,23 @@ interface AxisRenderOptions {
    * and conversion semantics as {@link xLabelFontSize}.
    */
   yLabelFontSize: number | undefined;
+  /**
+   * Tick-label bold flag emitted on the X axis via
+   * `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>`.
+   * The OOXML `b` attribute is the `xsd:boolean` bold flag on
+   * `CT_TextCharacterProperties`; the writer emits `1` / `0` at the
+   * canonical slot. `undefined` skips the attribute so a fresh chart
+   * inherits the theme-default tick-label weight. The block is
+   * emitted whenever `xLabelRotation`, `xLabelFontSize`, or
+   * `xLabelBold` is set so the OOXML schema's `<c:txPr>` slot
+   * carries every pinned typography knob.
+   */
+  xLabelBold: boolean | undefined;
+  /**
+   * Tick-label bold flag emitted on the Y axis. Same shape and
+   * semantics as {@link xLabelBold}.
+   */
+  yLabelBold: boolean | undefined;
   xReverse: boolean;
   yReverse: boolean;
   /**
@@ -1705,45 +1730,65 @@ function normalizeAxisLabelFontSize(value: number | undefined): number | undefin
 }
 
 /**
- * Build the `<c:txPr>` block that carries an axis tick-label rotation
- * and / or font size. Returns `undefined` when both inputs are unset
- * so the caller can elide the element entirely (Excel's reference
- * serialization on a fresh axis omits `<c:txPr>` when the labels
- * render at the default rotation and inherit the theme font size).
+ * Normalize an axis `labelBold` value for the
+ * `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>`
+ * writer slot. Delegates to the chart-level {@link normalizeTitleBold}
+ * — `true` / `false` pass through literally, every other token (typed
+ * escape from an untyped caller, including `null`-shaped values)
+ * collapses to `undefined` so the writer omits the `b` attribute
+ * entirely. Absence then collapses to the OOXML default Excel itself
+ * emits on a fresh axis (the theme-default tick-label weight).
+ */
+function normalizeAxisLabelBold(value: boolean | undefined): boolean | undefined {
+  return normalizeTitleBold(value);
+}
+
+/**
+ * Build the `<c:txPr>` block that carries an axis tick-label rotation,
+ * font size, and / or bold flag. Returns `undefined` when every input
+ * is unset so the caller can elide the element entirely (Excel's
+ * reference serialization on a fresh axis omits `<c:txPr>` when the
+ * labels render at the default rotation and inherit the theme font /
+ * weight).
  *
  * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
- * when the user pins a custom angle — `<a:bodyPr rot="N"/>` carries
- * the rotation (when set), `<a:lstStyle/>` is the empty list-style
- * placeholder the schema requires, and the
+ * when the user pins a custom typography knob — `<a:bodyPr rot="N"/>`
+ * carries the rotation (when set), `<a:lstStyle/>` is the empty
+ * list-style placeholder the schema requires, and the
  * `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>` paragraph
- * stub Excel always emits hosts the optional `sz` attribute on
+ * stub Excel always emits hosts the optional `sz` / `b` attributes on
  * `<a:defRPr>`. Additional `<a:bodyPr>` attributes Excel writes in
  * its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap` /
  * `anchor` / `anchorCtr`) are intentionally omitted — the OOXML
  * schema marks them all optional, and dropping them keeps the
- * writer's footprint minimal while preserving the rotation / size
- * intent.
+ * writer's footprint minimal while preserving the typography intent.
  *
  * When only a rotation is pinned, the `<a:defRPr>` slot self-closes
- * with no attributes (matching the legacy rotation-only emit). When
- * a font size is pinned, the slot carries `sz="N"` (in 100ths of a
- * point) so a re-parse picks the value up off the canonical
- * default-paragraph slot. When the rotation is absent but the size
- * is pinned, the writer omits `rot` from `<a:bodyPr>` so the OOXML
- * default `0` collapses to absence.
+ * with no attributes (matching the legacy rotation-only emit). When a
+ * font size or bold flag is pinned, the slot carries `sz="N"` (in
+ * 100ths of a point) and / or `b="1"` / `b="0"` so a re-parse picks
+ * the values up off the canonical default-paragraph slot. When the
+ * rotation is absent but a size or flag is pinned, the writer omits
+ * `rot` from `<a:bodyPr>` so the OOXML default `0` collapses to
+ * absence. The bold flag emits a literal `b="1"` / `b="0"` whenever
+ * the input is a boolean — `false` pins the OOXML default explicitly,
+ * which is functionally identical to absence but lets a clone target
+ * override an upstream `b="1"` from a templated chart.
  */
 function buildAxisTxPr(
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
+  bold: boolean | undefined,
 ): string | undefined {
-  if (rotationDeg === undefined && fontSizePt === undefined) return undefined;
+  if (rotationDeg === undefined && fontSizePt === undefined && bold === undefined) return undefined;
   const rot = rotationDeg === undefined ? undefined : rotationDeg * TXPR_ROT_PER_DEGREE;
   const sz = fontSizePt === undefined ? undefined : fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  const b = bold === undefined ? undefined : bold ? 1 : 0;
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr", { rot }),
     xmlSelfClose("a:lstStyle"),
     xmlElement("a:p", undefined, [
-      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz })]),
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b })]),
       xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
     ]),
   ]);
@@ -2238,7 +2283,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // `buildAxisTickRendering`) and `<c:crossAx>` per CT_CatAx (ECMA-376
   // Part 1, §21.2.2.7). Skip the entire block when the caller did not
   // pin a rotation so a fresh chart matches Excel's minimal serialization.
-  const xCatAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize);
+  const xCatAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize, opts.xLabelBold);
   if (xCatAxTxPr) catAxChildren.push(xCatAxTxPr);
   catAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
@@ -2304,7 +2349,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // contract as the catAx slot above — emit nothing when the caller
   // did not pin a rotation so the writer matches Excel's reference
   // serialization on a fresh value axis.
-  const yValAxTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize);
+  const yValAxTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize, opts.yLabelBold);
   if (yValAxTxPr) valAxChildren.push(yValAxTxPr);
   valAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
@@ -2668,7 +2713,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   // `<c:txPr>` slot — same CT_ValAx position as the bar / column
   // builder above. Scatter X is a value axis, so the rotation pins on
   // the X-axis just as it does on the Y-axis.
-  const xValAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize);
+  const xValAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize, opts.xLabelBold);
   if (xValAxTxPr) xAxChildren.push(xValAxTxPr);
   xAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
@@ -2711,7 +2756,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   );
   // `<c:txPr>` slot for the scatter Y axis — same CT_ValAx position
   // and omit-by-default contract as the catAx / valAx builders above.
-  const yScatterTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize);
+  const yScatterTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize, opts.yLabelBold);
   if (yScatterTxPr) yAxChildren.push(yScatterTxPr);
   yAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -13188,3 +13188,193 @@ describe("cloneChart — axis title underline", () => {
     expect(reparsed?.axes?.x?.axisTitleUnderline).toBe(true);
   });
 });
+
+// ── cloneChart — axis labelBold ─────────────────────────────────────
+
+describe("cloneChart — axis labelBold", () => {
+  const sourceWithBold: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { labelBold: true }, y: { labelBold: true } },
+  };
+
+  it("inherits axes.x.labelBold from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithBold, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelBold).toBe(true);
+    expect(clone.axes?.y?.labelBold).toBe(true);
+  });
+
+  it("drops the inherited bold flag when override is null", () => {
+    const clone = cloneChart(sourceWithBold, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelBold: null } },
+    });
+    expect(clone.axes?.x?.labelBold).toBeUndefined();
+    // Y axis stays put — nulling X must not bleed into Y.
+    expect(clone.axes?.y?.labelBold).toBe(true);
+  });
+
+  it("replaces the inherited flag when override is false", () => {
+    const clone = cloneChart(sourceWithBold, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelBold: false } },
+    });
+    expect(clone.axes?.x?.labelBold).toBe(false);
+  });
+
+  it("replaces a missing source flag when override is true", () => {
+    const noBold: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noBold, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelBold: true } },
+    });
+    expect(clone.axes?.x?.labelBold).toBe(true);
+  });
+
+  it("returns undefined labelBold when neither source nor override sets it", () => {
+    const noBold: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noBold, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelBold).toBeUndefined();
+  });
+
+  it("collapses non-boolean overrides to undefined", () => {
+    const clone = cloneChart(sourceWithBold, {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { labelBold: "true" as any } },
+    });
+    expect(clone.axes?.x?.labelBold).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelBold: true } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelBold: true } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the flag through chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithBold, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.labelBold).toBe(true);
+    expect(clone.axes?.y?.labelBold).toBe(true);
+  });
+
+  it("composes the flag alongside labelRotation and labelFontSize", () => {
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelRotation: 45, labelFontSize: 12, labelBold: true } },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+    expect(clone.axes?.x?.labelBold).toBe(true);
+  });
+
+  it("composes the flag alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithBold, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Period",
+          gridlines: { major: true },
+          labelBold: false,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.labelBold).toBe(false);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the flag", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr b="1"/></a:pPr></a:p></c:txPr>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.labelBold).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.labelBold).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('<a:defRPr b="1"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelBold).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the flag intact", async () => {
+    const clone = cloneChart(sourceWithBold, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // Both axes carry b="1".
+    const matches = written.match(/<a:defRPr b="1"\/>/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -12128,3 +12128,193 @@ describe("writeChart — axis title underline", () => {
     expect(reparsed?.axes?.y?.axisTitleUnderline).toBe(true);
   });
 });
+
+// ── writeChart — axis labelBold ──────────────────────────────────────
+
+describe("writeChart — axis labelBold", () => {
+  it("omits <c:txPr> on the category axis when no tick-label knob is pinned", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it('emits <c:txPr> with <a:defRPr b="1"/> when labelBold=true on the X axis', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelBold: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<c:txPr>");
+    expect(catAxBlock).toContain('<a:defRPr b="1"/>');
+  });
+
+  it('emits <a:defRPr b="0"/> on labelBold=false (functionally identical to omission)', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelBold: false } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<a:defRPr b="0"/>');
+  });
+
+  it('emits <a:defRPr b="1"/> on the Y axis (value axis) when labelBold=true', () => {
+    const result = writeChart(makeChart({ axes: { y: { labelBold: true } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<a:defRPr b="1"/>');
+  });
+
+  it("emits the bold flag independently on each axis", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelBold: true }, y: { labelBold: false } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<a:defRPr b="1"/>');
+    expect(valAxBlock).toContain('<a:defRPr b="0"/>');
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (no <c:txPr>)", () => {
+    const stringy = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelBold: "true" as any } } }),
+      "Sheet1",
+    );
+    const numeric = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelBold: 1 as any } } }),
+      "Sheet1",
+    );
+    const catA = stringy.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const catB = numeric.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catA).not.toContain("<c:txPr>");
+    expect(catB).not.toContain("<c:txPr>");
+  });
+
+  it("composes labelBold with labelRotation in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45, labelBold: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(catAxBlock).toContain('<a:defRPr b="1"/>');
+  });
+
+  it("composes labelBold with labelFontSize in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelFontSize: 12, labelBold: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:defRPr sz="1200" b="1"/>');
+  });
+
+  it("composes labelBold with both labelRotation and labelFontSize in a single block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45, labelFontSize: 12, labelBold: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(catAxBlock).toContain('<a:defRPr sz="1200" b="1"/>');
+  });
+
+  it("emits <c:txPr> with no rot when only labelBold is pinned", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelBold: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<a:bodyPr/>");
+    expect(catAxBlock).not.toContain("<a:bodyPr rot=");
+  });
+
+  it("threads the bold flag through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { labelBold: true } } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr b="1"/>');
+    }
+  });
+
+  it("threads the bold flag through scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { labelBold: true }, y: { labelBold: true } },
+      }),
+      "Sheet1",
+    );
+    const valAxes = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxes).toHaveLength(2);
+    expect(valAxes[0]).toContain('<a:defRPr b="1"/>');
+    expect(valAxes[1]).toContain('<a:defRPr b="1"/>');
+  });
+
+  it("ignores labelBold on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(makeChart({ type: "pie", axes: { x: { labelBold: true } } }), "Sheet1");
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { labelBold: true } } }),
+      "Sheet1",
+    );
+    expect(pie.chartXml).not.toContain("<c:txPr>");
+    expect(dough.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("places <c:txPr> between <c:tickLblPos> and <c:crossAx> per the OOXML schema", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblPos: "low", labelBold: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const tickLblPosIdx = catAxBlock.indexOf("c:tickLblPos");
+    const txPrIdx = catAxBlock.indexOf("<c:txPr>");
+    const crossAxIdx = catAxBlock.indexOf("c:crossAx");
+    expect(tickLblPosIdx).toBeGreaterThan(0);
+    expect(txPrIdx).toBeGreaterThan(tickLblPosIdx);
+    expect(crossAxIdx).toBeGreaterThan(txPrIdx);
+  });
+
+  it("round-trips labelBold=true through parseChart", () => {
+    const written = writeChart(makeChart({ axes: { x: { labelBold: true } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelBold).toBe(true);
+  });
+
+  it("collapses an absent labelBold round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelBold).toBeUndefined();
+  });
+
+  it('collapses labelBold=false round-trip back to undefined (b="0" matches the OOXML default)', () => {
+    // The reader collapses the OOXML default `false` to `undefined` so
+    // a writer emit of `b="0"` and absence round-trip identically.
+    const written = writeChart(makeChart({ axes: { x: { labelBold: false } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelBold).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the bold flag into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { labelBold: true }, y: { labelBold: true } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:defRPr b="1"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.labelBold).toBe(true);
+    expect(reparsed?.axes?.y?.labelBold).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -12966,3 +12966,173 @@ describe("parseChart — axis title underline", () => {
     });
   });
 });
+
+// ── parseChart — axis labelBold ──────────────────────────────────────
+
+describe("parseChart — axis labelBold", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTxPrBold(b: string | undefined): string {
+    const txPr =
+      b === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr b="${b}"/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${txPr}
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces labelBold=true when <a:defRPr b="1"/> is pinned', () => {
+    const chart = parseChart(withCatAxTxPrBold("1"));
+    expect(chart?.axes?.x?.labelBold).toBe(true);
+  });
+
+  it('surfaces labelBold=true on the OOXML truthy spelling b="true"', () => {
+    const chart = parseChart(withCatAxTxPrBold("true"));
+    expect(chart?.axes?.x?.labelBold).toBe(true);
+  });
+
+  it('drops the OOXML default b="0" to undefined (round-trips with absence)', () => {
+    expect(parseChart(withCatAxTxPrBold("0"))?.axes).toBeUndefined();
+  });
+
+  it('drops the falsy spelling b="false" to undefined', () => {
+    expect(parseChart(withCatAxTxPrBold("false"))?.axes).toBeUndefined();
+  });
+
+  it("drops malformed b tokens to undefined", () => {
+    expect(parseChart(withCatAxTxPrBold("yes"))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> is absent", () => {
+    expect(parseChart(withCatAxTxPrBold(undefined))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the b attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> is absent inside <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("surfaces labelBold on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr b="1"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.y?.labelBold).toBe(true);
+  });
+
+  it("surfaces labelBold independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr b="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr b="1"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelBold).toBe(true);
+    expect(chart?.axes?.y?.labelBold).toBe(true);
+  });
+
+  it("co-surfaces labelBold alongside labelRotation and labelFontSize from the same <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1400" b="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+    expect(chart?.axes?.x?.labelFontSize).toBe(14);
+    expect(chart?.axes?.x?.labelBold).toBe(true);
+  });
+
+  it('does not pick up an <a:defRPr b=".."/> from the axis title\'s <c:rich>', () => {
+    // The axis-title's `<c:rich>` carries its own `<a:defRPr b="..">`
+    // separately from the tick-label `<c:txPr>`. The tick-label parser
+    // must not surface the title's flag — that belongs to
+    // axisTitleBold.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr b="1"/></a:pPr><a:r><a:rPr/><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleBold).toBe(true);
+    expect(chart?.axes?.x?.labelBold).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200" b="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      tickLblPos: "low",
+      labelRotation: 45,
+      labelFontSize: 12,
+      labelBold: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr b=\"..\"/></a:pPr></a:p></c:txPr></c:catAx>` (and the matching `<c:valAx>` slot) at the read, write, and clone layers so a template's tick-label bold pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `axes.x.labelBold?: boolean` and `axes.y.labelBold?: boolean` on `SheetChart` (writer side) plus the matching `labelBold?: boolean` on `ChartAxisInfo` (reader side). Until now hucre's writer omitted the `b` attribute on `<a:defRPr>` for tick-label `<c:txPr>` and the reader ignored the slot entirely, so a templated dashboard chart whose user bolded the bottom-axis category names (a common pattern when an axis label needs to read as a header in a busy chart frame) silently lost the choice on every parse -> clone -> write loop. Bridges another typography-customization gap for the dashboard composition flow tracked in #136.

Composes cleanly with the existing `labelRotation` (#245) and `labelFontSize` (#263) fields — all three knobs land on the same `<c:txPr>` body, the writer emits a single block per axis carrying whichever subset is pinned, and the reader picks up each value off its canonical slot. `<a:bodyPr rot=>` absent collapses to the OOXML default 0, `<a:defRPr sz=>` absent collapses to the theme-inherited size, and `<a:defRPr b=>` absent collapses to the theme-inherited weight, so a chart that pins only one of the three knobs round-trips without leaking a fabricated value through the other slots.

The clone layer follows the standard `boolean | null` override grammar: `undefined` inherits, `null` drops, and a literal `boolean` replaces. Non-boolean overrides (typed escapes from an untyped caller) collapse to `undefined` so the cloned `SheetChart` always carries a value the writer will accept. Pie / doughnut clones drop the inherited field silently via the same axis-scope short-circuit the surrounding axis helpers use.

Refs #136

## API

\`\`\`ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.labelBold);
// true       <- when the template pinned <a:defRPr b=\"1\"/> on the catAx
// undefined  <- when the template emits no flag (theme-inherited)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [[\"Quarter\", \"Revenue\"], [\"Q1\", 12000], [\"Q2\", 15500]],
    charts: [{
      type: \"column\",
      series: [{ name: \"Revenue\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
      // Bold the category-axis labels so they read as headers,
      // and leave the Y-axis numeric labels at the theme weight.
      axes: { x: { labelBold: true } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   -> inherits the source's parsed labelBold unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelBold: null } },
});
//   -> drops the inherited flag (writer falls back to the theme default).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelBold: false } },
});
//   -> replaces the inherited flag with the explicit OOXML default b=\"0\".
\`\`\`

## Implementation notes

- **Type model**: `axes.x.labelBold?: boolean` and `axes.y.labelBold?: boolean` on `SheetChart` (writer side) plus the matching `labelBold?: boolean` on `ChartAxisInfo` (reader side). Same shape as `axisTitleBold` so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseAxisLabelBold`): walks `<c:txPr><a:p><a:pPr><a:defRPr b=\"..\"/></a:pPr></a:p></c:txPr>` for the `b` attribute and runs it through the existing `parseBoolAttr` (accepts `\"0\"` / `\"1\"` / `\"true\"` / `\"false\"`). The lookup is scoped to the axis-level `<c:txPr>` so a stray `<a:defRPr b=\"..\"/>` inside `<c:title><c:tx><c:rich>` (which belongs to `axisTitleBold`) cannot leak in. The OOXML default `false` collapses to `undefined` so absence and `b=\"0\"` round-trip identically; only an explicit `b=\"1\"` surfaces `true`. Surfaces on every axis flavour.
- **Writer**: extends the existing `buildAxisTxPr(rotationDeg, fontSizePt, bold)` helper to optionally include a `b=\"1\"` / `b=\"0\"` on `<a:defRPr>`. The block is emitted whenever any of the three knobs is pinned; absent inputs collapse so a chart that pins only one knob keeps the other slots at their OOXML defaults. Threads through bar / column / line / area via `buildBarAxes` and scatter via `buildScatterAxes`; pie / doughnut have no axes at all and the field is silently dropped on those families.
  - `normalizeAxisLabelBold(value)` delegates to the chart-level `normalizeTitleBold` — `true` / `false` pass through literally, every other token collapses to `undefined`.
- **Clone**: `applyLabelBoldOverride` follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse to `undefined`. Pie / doughnut clones drop the inherited field silently via the same axis-scope short-circuit the surrounding axis helpers use.

## Test plan

- [x] `parseChart — axis labelBold` (12 new tests) — surfaces the flag from `b=\"1\"` / `b=\"true\"`, drops the OOXML default `b=\"0\"` / `b=\"false\"` to undefined, drops malformed tokens, returns undefined when `<c:txPr>` / `<a:defRPr>` / `<a:p>` are absent, surfaces on the value axis, surfaces independently on both axes, co-surfaces alongside rotation and font size, isolates from the axis title's `<c:rich>` block, co-surfaces alongside other axis fields.
- [x] `writeChart — axis labelBold` (16 new tests) — omits `<c:txPr>` by default, emits `b=\"1\"` / `b=\"0\"`, emits independently on both axes, drops non-boolean inputs, composes with `labelRotation` / `labelFontSize` in a single block, threads through bar / column / line / area / scatter, drops on pie / doughnut, places `<c:txPr>` between `<c:tickLblPos>` and `<c:crossAx>`, parse round-trip, default-collapse round-trip, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis labelBold` (12 new tests) — inherit / null drop / replace semantics, collapse non-boolean overrides, add to a source axis without one, drop on pie / doughnut chart-type coercion, carry through bar -> column coercion, compose with rotation and font size, compose with other axis overrides, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm vitest run --dir=test` — all 4889 tests pass.
- [x] `pnpm build` — obuild succeeds.
- [x] `pnpm typecheck` — clean.