### PR TITLE
feat(xlsx): chart axis tick-label italic flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2434,6 +2434,47 @@ export interface SheetChart {
        */
       labelBold?: boolean;
       /**
+       * Tick-label italic flag. Maps to
+       * `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format
+       * Axis -> Font -> Italic" toggle applied to the tick labels. The
+       * OOXML attribute is the `xsd:boolean` `i` on
+       * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7);
+       * the writer lands the value on the default-paragraph
+       * `<a:defRPr>` slot inside the same `<c:txPr>` block that
+       * carries {@link labelRotation} / {@link labelFontSize} /
+       * {@link labelBold}.
+       *
+       * Mirrors {@link SheetChart.axes.x.axisTitleItalic} for tick
+       * labels — same `boolean | null` clone grammar, same silent drop
+       * on `pie` / `doughnut` (no axes at all). Useful for italicising
+       * dashboard tick labels (e.g. emphasising the bottom-axis
+       * category names so they stand out against the chart frame
+       * without bolding them).
+       *
+       * Default: omitted — the tick labels render non-italic (the
+       * OOXML default; the writer elides the `i` attribute when no
+       * value is pinned). Set `true` to emit `i="1"` on the
+       * default-paragraph slot; set `false` explicitly to pin the
+       * OOXML default `i="0"` (functionally identical to omission, but
+       * useful when overriding a templated chart that had italic
+       * pinned upstream).
+       *
+       * Composes independently with {@link labelRotation} /
+       * {@link labelFontSize} / {@link labelBold}: all four knobs land
+       * on the same `<c:txPr>` body, so a single configuration call
+       * threads cleanly through every tick-label knob the writer
+       * exposes.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+       * the OOXML schema, so the field round-trips on every chart family
+       * that has axes (bar / column / line / area / scatter). Pie /
+       * doughnut have no axes at all, so the field is silently dropped
+       * on those families.
+       */
+      labelItalic?: boolean;
+      /**
        * Reverse the axis plotting order. Maps to
        * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
        * Excel's "Categories in reverse order" / "Values in reverse
@@ -2833,6 +2874,23 @@ export interface SheetChart {
        * `doughnut` charts (no axes at all).
        */
       labelBold?: boolean;
+      /**
+       * Tick-label italic flag for the value axis. Maps to
+       * `<c:valAx><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.labelItalic} for the value
+       * axis — see that field for the full semantics. The OOXML `i`
+       * attribute is the `xsd:boolean` italic flag on
+       * `CT_TextCharacterProperties`; the writer emits `1` / `0` at
+       * the canonical slot. Absence collapses to the OOXML default
+       * (the writer omits the attribute) so a fresh chart inherits
+       * the theme-default tick-label slant.
+       *
+       * Useful for emphasising the value-axis labels on a dashboard
+       * (e.g. italicising the Y-axis numeric totals so they read as
+       * a stylistic accent in a busy chart frame). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all).
+       */
+      labelItalic?: boolean;
       /**
        * Hide the entire value axis (line, tick marks, tick labels).
        * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
@@ -4282,6 +4340,29 @@ export interface ChartAxisInfo {
    * {@link ChartAxisInfo.axisTitleBold}) cannot leak in.
    */
   labelBold?: boolean;
+  /**
+   * Tick-label italic flag pulled from
+   * `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>`
+   * on the axis element. Reflects Excel's "Format Axis -> Font ->
+   * Italic" toggle applied to tick labels.
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `<a:defRPr i="0"/>` round-trip identically through
+   * {@link cloneChart} — only an explicit `<a:defRPr i="1"/>` surfaces
+   * `true`. The reader accepts the OOXML truthy / falsy spellings
+   * (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and missing
+   * `i` attributes drop to `undefined`.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+   * the OOXML schema. Mirrors the writer-side
+   * {@link SheetChart.axes.x.labelItalic} so a parsed value slots
+   * straight back into a clone target without transformation. The
+   * lookup is scoped to the axis-level `<c:txPr>` so a stray
+   * `<a:defRPr i=".."/>` inside `<c:title>` (surfaced by
+   * {@link ChartAxisInfo.axisTitleItalic}) cannot leak in.
+   */
+  labelItalic?: boolean;
   /**
    * Reverse-axis flag pulled from
    * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -933,6 +933,25 @@ export interface CloneChartOptions {
        */
       labelBold?: boolean | null;
       /**
+       * Override `SheetChart.axes.x.labelItalic`. `undefined` (or
+       * omitted) inherits the source axis's tick-label italic flag;
+       * `null` drops the inherited value (the writer falls back to
+       * the OOXML default — the tick labels render at the theme's
+       * default slant); a `boolean` replaces it.
+       *
+       * Non-boolean overrides (typed escapes from an untyped caller)
+       * collapse to a drop so the cloned `SheetChart` always carries
+       * a value the writer will accept.
+       *
+       * `<c:txPr>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts since neither has axes. Composes
+       * independently with {@link labelRotation} / {@link labelFontSize} /
+       * {@link labelBold}: all four knobs land on the same `<c:txPr>` body.
+       */
+      labelItalic?: boolean | null;
+      /**
        * Override the reverse-axis flag. `undefined` (or omitted)
        * inherits the source axis' parsed value; `null` drops it (the
        * writer falls back to the OOXML default `"minMax"` — forward
@@ -1104,6 +1123,8 @@ export interface CloneChartOptions {
       labelFontSize?: number | null;
       /** See {@link CloneChartOptions.axes.x.labelBold}. */
       labelBold?: boolean | null;
+      /** See {@link CloneChartOptions.axes.x.labelItalic}. */
+      labelItalic?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.hidden}. */
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
@@ -3020,6 +3041,20 @@ function resolveAxes(
   // `SheetChart` always carries a value the writer will accept.
   const xLabelBold = applyLabelBoldOverride(sourceAxes?.x?.labelBold, overrides?.x?.labelBold);
   const yLabelBold = applyLabelBoldOverride(sourceAxes?.y?.labelBold, overrides?.y?.labelBold);
+  // `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>`
+  // shares the same `<c:txPr>` slot as the rotation / size / bold
+  // resolvers above, and the same per-axis scope rule (every axis
+  // flavour carries `<c:txPr>`; pie / doughnut already short-circuited
+  // upstream). Non-boolean overrides collapse to a drop so the cloned
+  // `SheetChart` always carries a value the writer will accept.
+  const xLabelItalic = applyLabelItalicOverride(
+    sourceAxes?.x?.labelItalic,
+    overrides?.x?.labelItalic,
+  );
+  const yLabelItalic = applyLabelItalicOverride(
+    sourceAxes?.y?.labelItalic,
+    overrides?.y?.labelItalic,
+  );
   const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
   const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
   // `tickLblSkip` / `tickMarkSkip` only render on category axes
@@ -3177,6 +3212,7 @@ function resolveAxes(
     xLabelRotation !== undefined ||
     xLabelFontSize !== undefined ||
     xLabelBold !== undefined ||
+    xLabelItalic !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
@@ -3211,6 +3247,7 @@ function resolveAxes(
     if (xLabelRotation !== undefined) out.x.labelRotation = xLabelRotation;
     if (xLabelFontSize !== undefined) out.x.labelFontSize = xLabelFontSize;
     if (xLabelBold !== undefined) out.x.labelBold = xLabelBold;
+    if (xLabelItalic !== undefined) out.x.labelItalic = xLabelItalic;
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
@@ -3242,6 +3279,7 @@ function resolveAxes(
     yLabelRotation !== undefined ||
     yLabelFontSize !== undefined ||
     yLabelBold !== undefined ||
+    yLabelItalic !== undefined ||
     yHidden !== undefined ||
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
@@ -3270,6 +3308,7 @@ function resolveAxes(
     if (yLabelRotation !== undefined) out.y.labelRotation = yLabelRotation;
     if (yLabelFontSize !== undefined) out.y.labelFontSize = yLabelFontSize;
     if (yLabelBold !== undefined) out.y.labelBold = yLabelBold;
+    if (yLabelItalic !== undefined) out.y.labelItalic = yLabelItalic;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
@@ -3637,6 +3676,34 @@ function applyLabelFontSizeOverride(
  * field on those families since neither has axes.
  */
 function applyLabelBoldOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    if (source === true) return true;
+    if (source === false) return false;
+    return undefined;
+  }
+  if (override === null) return undefined;
+  if (override === true) return true;
+  if (override === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `labelItalic` override using the same `undefined` (inherit)
+ * / `null` (drop) / value (replace) grammar as the other axis
+ * helpers. Mirrors {@link applyLabelBoldOverride} — non-boolean
+ * overrides (typed escapes from an untyped caller) collapse to
+ * `undefined`, a `null` override always drops the inherited flag, and
+ * a literal `true` / `false` replaces it.
+ *
+ * The `<c:txPr>` block sits on every axis flavour per the OOXML
+ * schema, so the override applies on every chart family that has
+ * axes. The pie / doughnut short-circuit upstream collapses the
+ * field on those families since neither has axes.
+ */
+function applyLabelItalicOverride(
   source: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -668,6 +668,13 @@ function parseAxisInfo(
   // an explicit `b="1"` surfaces `true`. Surfaced on every axis
   // flavour for symmetry with the writer.
   const labelBold = parseAxisLabelBold(axis);
+  // `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>` —
+  // tick-label italic flag. Same `<c:txPr>` slot scope as the bold
+  // reader above. The OOXML default `false` collapses to `undefined`
+  // so absence and `i="0"` round-trip identically; only an explicit
+  // `i="1"` surfaces `true`. Surfaced on every axis flavour for
+  // symmetry with the writer.
+  const labelItalic = parseAxisLabelItalic(axis);
   // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
   // accepts "minMax" (default, low → high) and "maxMin" (reversed).
   // The default collapses to undefined so a fresh chart and a chart
@@ -753,6 +760,7 @@ function parseAxisInfo(
     labelRotation === undefined &&
     labelFontSize === undefined &&
     labelBold === undefined &&
+    labelItalic === undefined &&
     reverse === undefined &&
     tickLblSkip === undefined &&
     tickMarkSkip === undefined &&
@@ -786,6 +794,7 @@ function parseAxisInfo(
   if (labelRotation !== undefined) out.labelRotation = labelRotation;
   if (labelFontSize !== undefined) out.labelFontSize = labelFontSize;
   if (labelBold !== undefined) out.labelBold = labelBold;
+  if (labelItalic !== undefined) out.labelItalic = labelItalic;
   if (reverse !== undefined) out.reverse = reverse;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
@@ -1200,6 +1209,42 @@ function parseAxisLabelBold(axis: XmlElement): boolean | undefined {
   // The OOXML default `false` collapses to `undefined` so absence and
   // `b="0"` round-trip identically through the writer — only an
   // explicit `b="1"` surfaces `true`.
+  if (parsed === true) return true;
+  return undefined;
+}
+
+/**
+ * Pull the axis tick-label italic flag off the canonical
+ * `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>` chain
+ * Excel writes when the user pins italic on the axis tick labels.
+ *
+ * Returns `true` only when the parser walks the full chain and lands on
+ * an `<a:defRPr i="1"/>` (or the OOXML truthy spelling `i="true"`); the
+ * OOXML default `i="0"` collapses to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart}. Returns
+ * `undefined` whenever the axis omits `<c:txPr>` entirely or the
+ * canonical `<a:p><a:pPr><a:defRPr>` chain is malformed.
+ *
+ * The `<c:txPr>` element sits on every axis flavour — `<c:catAx>` /
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry the optional
+ * element per the OOXML schema. The reader surfaces the flag
+ * regardless of axis flavour so a parsed chart preserves the value
+ * for symmetry with the writer-side
+ * {@link SheetChart.axes}.x.labelItalic.
+ */
+function parseAxisLabelItalic(axis: XmlElement): boolean | undefined {
+  const txPr = findChild(axis, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const parsed = parseBoolAttr(defRPr.attrs.i);
+  // The OOXML default `false` collapses to `undefined` so absence and
+  // `i="0"` round-trip identically through the writer — only an
+  // explicit `i="1"` surfaces `true`.
   if (parsed === true) return true;
   return undefined;
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -816,6 +816,14 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // chart inherits the theme-default tick-label weight.
     xLabelBold: normalizeAxisLabelBold(chart.axes?.x?.labelBold),
     yLabelBold: normalizeAxisLabelBold(chart.axes?.y?.labelBold),
+    // `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>`
+    // shares the same `<c:txPr>` block as the rotation / size / bold
+    // slots above. `true` / `false` pass through literally; non-boolean
+    // tokens (typed escapes from an untyped caller) collapse to
+    // `undefined` so the writer omits the `i` attribute and a fresh
+    // chart inherits the theme-default tick-label slant.
+    xLabelItalic: normalizeAxisLabelItalic(chart.axes?.x?.labelItalic),
+    yLabelItalic: normalizeAxisLabelItalic(chart.axes?.y?.labelItalic),
     xReverse: chart.axes?.x?.reverse === true,
     yReverse: chart.axes?.y?.reverse === true,
     // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
@@ -1375,6 +1383,23 @@ interface AxisRenderOptions {
    * semantics as {@link xLabelBold}.
    */
   yLabelBold: boolean | undefined;
+  /**
+   * Tick-label italic flag emitted on the X axis via
+   * `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>`.
+   * The OOXML `i` attribute is the `xsd:boolean` italic flag on
+   * `CT_TextCharacterProperties`; the writer emits `1` / `0` at the
+   * canonical slot. `undefined` skips the attribute so a fresh chart
+   * inherits the theme-default tick-label slant. The block is
+   * emitted whenever `xLabelRotation`, `xLabelFontSize`, `xLabelBold`,
+   * or `xLabelItalic` is set so the OOXML schema's `<c:txPr>` slot
+   * carries every pinned typography knob.
+   */
+  xLabelItalic: boolean | undefined;
+  /**
+   * Tick-label italic flag emitted on the Y axis. Same shape and
+   * semantics as {@link xLabelItalic}.
+   */
+  yLabelItalic: boolean | undefined;
   xReverse: boolean;
   yReverse: boolean;
   /**
@@ -1744,20 +1769,34 @@ function normalizeAxisLabelBold(value: boolean | undefined): boolean | undefined
 }
 
 /**
+ * Normalize an axis `labelItalic` value for the
+ * `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>`
+ * writer slot. Delegates to the chart-level {@link normalizeTitleItalic}
+ * — `true` / `false` pass through literally, every other token (typed
+ * escape from an untyped caller, including `null`-shaped values)
+ * collapses to `undefined` so the writer omits the `i` attribute
+ * entirely. Absence then collapses to the OOXML default Excel itself
+ * emits on a fresh axis (the theme-default tick-label slant).
+ */
+function normalizeAxisLabelItalic(value: boolean | undefined): boolean | undefined {
+  return normalizeTitleItalic(value);
+}
+
+/**
  * Build the `<c:txPr>` block that carries an axis tick-label rotation,
- * font size, and / or bold flag. Returns `undefined` when every input
- * is unset so the caller can elide the element entirely (Excel's
- * reference serialization on a fresh axis omits `<c:txPr>` when the
- * labels render at the default rotation and inherit the theme font /
- * weight).
+ * font size, bold flag, and / or italic flag. Returns `undefined` when
+ * every input is unset so the caller can elide the element entirely
+ * (Excel's reference serialization on a fresh axis omits `<c:txPr>`
+ * when the labels render at the default rotation and inherit the
+ * theme font / weight / slant).
  *
  * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
  * when the user pins a custom typography knob — `<a:bodyPr rot="N"/>`
  * carries the rotation (when set), `<a:lstStyle/>` is the empty
  * list-style placeholder the schema requires, and the
  * `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>` paragraph
- * stub Excel always emits hosts the optional `sz` / `b` attributes on
- * `<a:defRPr>`. Additional `<a:bodyPr>` attributes Excel writes in
+ * stub Excel always emits hosts the optional `sz` / `b` / `i`
+ * attributes on `<a:defRPr>`. Additional `<a:bodyPr>` attributes Excel writes in
  * its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap` /
  * `anchor` / `anchorCtr`) are intentionally omitted — the OOXML
  * schema marks them all optional, and dropping them keeps the
@@ -1765,30 +1804,39 @@ function normalizeAxisLabelBold(value: boolean | undefined): boolean | undefined
  *
  * When only a rotation is pinned, the `<a:defRPr>` slot self-closes
  * with no attributes (matching the legacy rotation-only emit). When a
- * font size or bold flag is pinned, the slot carries `sz="N"` (in
- * 100ths of a point) and / or `b="1"` / `b="0"` so a re-parse picks
- * the values up off the canonical default-paragraph slot. When the
- * rotation is absent but a size or flag is pinned, the writer omits
- * `rot` from `<a:bodyPr>` so the OOXML default `0` collapses to
- * absence. The bold flag emits a literal `b="1"` / `b="0"` whenever
- * the input is a boolean — `false` pins the OOXML default explicitly,
- * which is functionally identical to absence but lets a clone target
- * override an upstream `b="1"` from a templated chart.
+ * font size, bold flag, or italic flag is pinned, the slot carries
+ * `sz="N"` (in 100ths of a point), `b="1"` / `b="0"`, and / or
+ * `i="1"` / `i="0"` so a re-parse picks the values up off the
+ * canonical default-paragraph slot. When the rotation is absent but a
+ * size or flag is pinned, the writer omits `rot` from `<a:bodyPr>` so
+ * the OOXML default `0` collapses to absence. The bold / italic flags
+ * each emit a literal `1` / `0` whenever the input is a boolean —
+ * `false` pins the OOXML default explicitly, which is functionally
+ * identical to absence but lets a clone target override an upstream
+ * `1` from a templated chart.
  */
 function buildAxisTxPr(
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
   bold: boolean | undefined,
+  italic: boolean | undefined,
 ): string | undefined {
-  if (rotationDeg === undefined && fontSizePt === undefined && bold === undefined) return undefined;
+  if (
+    rotationDeg === undefined &&
+    fontSizePt === undefined &&
+    bold === undefined &&
+    italic === undefined
+  )
+    return undefined;
   const rot = rotationDeg === undefined ? undefined : rotationDeg * TXPR_ROT_PER_DEGREE;
   const sz = fontSizePt === undefined ? undefined : fontSizePt * TITLE_FONT_SZ_PER_POINT;
   const b = bold === undefined ? undefined : bold ? 1 : 0;
+  const i = italic === undefined ? undefined : italic ? 1 : 0;
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr", { rot }),
     xmlSelfClose("a:lstStyle"),
     xmlElement("a:p", undefined, [
-      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b })]),
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz, b, i })]),
       xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
     ]),
   ]);
@@ -2283,7 +2331,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // `buildAxisTickRendering`) and `<c:crossAx>` per CT_CatAx (ECMA-376
   // Part 1, §21.2.2.7). Skip the entire block when the caller did not
   // pin a rotation so a fresh chart matches Excel's minimal serialization.
-  const xCatAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize, opts.xLabelBold);
+  const xCatAxTxPr = buildAxisTxPr(
+    opts.xLabelRotation,
+    opts.xLabelFontSize,
+    opts.xLabelBold,
+    opts.xLabelItalic,
+  );
   if (xCatAxTxPr) catAxChildren.push(xCatAxTxPr);
   catAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL }),
@@ -2349,7 +2402,12 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
   // contract as the catAx slot above — emit nothing when the caller
   // did not pin a rotation so the writer matches Excel's reference
   // serialization on a fresh value axis.
-  const yValAxTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize, opts.yLabelBold);
+  const yValAxTxPr = buildAxisTxPr(
+    opts.yLabelRotation,
+    opts.yLabelFontSize,
+    opts.yLabelBold,
+    opts.yLabelItalic,
+  );
   if (yValAxTxPr) valAxChildren.push(yValAxTxPr);
   valAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_CAT }),
@@ -2713,7 +2771,12 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   // `<c:txPr>` slot — same CT_ValAx position as the bar / column
   // builder above. Scatter X is a value axis, so the rotation pins on
   // the X-axis just as it does on the Y-axis.
-  const xValAxTxPr = buildAxisTxPr(opts.xLabelRotation, opts.xLabelFontSize, opts.xLabelBold);
+  const xValAxTxPr = buildAxisTxPr(
+    opts.xLabelRotation,
+    opts.xLabelFontSize,
+    opts.xLabelBold,
+    opts.xLabelItalic,
+  );
   if (xValAxTxPr) xAxChildren.push(xValAxTxPr);
   xAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_Y }),
@@ -2756,7 +2819,12 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
   );
   // `<c:txPr>` slot for the scatter Y axis — same CT_ValAx position
   // and omit-by-default contract as the catAx / valAx builders above.
-  const yScatterTxPr = buildAxisTxPr(opts.yLabelRotation, opts.yLabelFontSize, opts.yLabelBold);
+  const yScatterTxPr = buildAxisTxPr(
+    opts.yLabelRotation,
+    opts.yLabelFontSize,
+    opts.yLabelBold,
+    opts.yLabelItalic,
+  );
   if (yScatterTxPr) yAxChildren.push(yScatterTxPr);
   yAxChildren.push(
     xmlSelfClose("c:crossAx", { val: AXIS_ID_VAL_X }),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -13378,3 +13378,196 @@ describe("cloneChart — axis labelBold", () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 });
+
+// ── cloneChart — axis labelItalic ────────────────────────────────────
+
+describe("cloneChart — axis labelItalic", () => {
+  const sourceWithItalic: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { labelItalic: true }, y: { labelItalic: true } },
+  };
+
+  it("inherits axes.x.labelItalic from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithItalic, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelItalic).toBe(true);
+    expect(clone.axes?.y?.labelItalic).toBe(true);
+  });
+
+  it("drops the inherited italic flag when override is null", () => {
+    const clone = cloneChart(sourceWithItalic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelItalic: null } },
+    });
+    expect(clone.axes?.x?.labelItalic).toBeUndefined();
+    // Y axis stays put — nulling X must not bleed into Y.
+    expect(clone.axes?.y?.labelItalic).toBe(true);
+  });
+
+  it("replaces the inherited flag when override is false", () => {
+    const clone = cloneChart(sourceWithItalic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelItalic: false } },
+    });
+    expect(clone.axes?.x?.labelItalic).toBe(false);
+  });
+
+  it("replaces a missing source flag when override is true", () => {
+    const noItalic: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noItalic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelItalic: true } },
+    });
+    expect(clone.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it("returns undefined labelItalic when neither source nor override sets it", () => {
+    const noItalic: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noItalic, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelItalic).toBeUndefined();
+  });
+
+  it("collapses non-boolean overrides to undefined", () => {
+    const clone = cloneChart(sourceWithItalic, {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { labelItalic: "true" as any } },
+    });
+    expect(clone.axes?.x?.labelItalic).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelItalic: true } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelItalic: true } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the flag through chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithItalic, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.labelItalic).toBe(true);
+    expect(clone.axes?.y?.labelItalic).toBe(true);
+  });
+
+  it("composes the flag alongside labelRotation, labelFontSize, and labelBold", () => {
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        x: { labelRotation: 45, labelFontSize: 12, labelBold: true, labelItalic: true },
+      },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+    expect(clone.axes?.x?.labelBold).toBe(true);
+    expect(clone.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it("composes the flag alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithItalic, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Period",
+          gridlines: { major: true },
+          labelItalic: false,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.labelItalic).toBe(false);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the flag", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p></c:txPr>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.labelItalic).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.labelItalic).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    expect(written).toContain('<a:defRPr i="1"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the flag intact", async () => {
+    const clone = cloneChart(sourceWithItalic, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // Both axes carry i="1".
+    const matches = written.match(/<a:defRPr i="1"\/>/g) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -12318,3 +12318,214 @@ describe("writeChart — axis labelBold", () => {
     expect(reparsed?.axes?.y?.labelBold).toBe(true);
   });
 });
+
+// ── writeChart — axis labelItalic ────────────────────────────────────
+
+describe("writeChart — axis labelItalic", () => {
+  it("omits <c:txPr> on the category axis when no tick-label knob is pinned", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it('emits <c:txPr> with <a:defRPr i="1"/> when labelItalic=true on the X axis', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelItalic: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<c:txPr>");
+    expect(catAxBlock).toContain('<a:defRPr i="1"/>');
+  });
+
+  it('emits <a:defRPr i="0"/> on labelItalic=false (functionally identical to omission)', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelItalic: false } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain('<a:defRPr i="0"/>');
+  });
+
+  it('emits <a:defRPr i="1"/> on the Y axis (value axis) when labelItalic=true', () => {
+    const result = writeChart(makeChart({ axes: { y: { labelItalic: true } } }), "Sheet1");
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(valAxBlock).toContain('<a:defRPr i="1"/>');
+  });
+
+  it("emits the italic flag independently on each axis", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelItalic: true }, y: { labelItalic: false } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(catAxBlock).toContain('<a:defRPr i="1"/>');
+    expect(valAxBlock).toContain('<a:defRPr i="0"/>');
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (no <c:txPr>)", () => {
+    const stringy = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelItalic: "true" as any } } }),
+      "Sheet1",
+    );
+    const numeric = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelItalic: 1 as any } } }),
+      "Sheet1",
+    );
+    const catA = stringy.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const catB = numeric.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catA).not.toContain("<c:txPr>");
+    expect(catB).not.toContain("<c:txPr>");
+  });
+
+  it("composes labelItalic with labelRotation in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45, labelItalic: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(catAxBlock).toContain('<a:defRPr i="1"/>');
+  });
+
+  it("composes labelItalic with labelFontSize in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelFontSize: 12, labelItalic: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:defRPr sz="1200" i="1"/>');
+  });
+
+  it("composes labelItalic with labelBold in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelBold: true, labelItalic: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:defRPr b="1" i="1"/>');
+  });
+
+  it("composes labelItalic with labelRotation, labelFontSize, and labelBold in a single block", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { labelRotation: 45, labelFontSize: 12, labelBold: true, labelItalic: true } },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(catAxBlock).toContain('<a:defRPr sz="1200" b="1" i="1"/>');
+  });
+
+  it("emits <c:txPr> with no rot when only labelItalic is pinned", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelItalic: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<a:bodyPr/>");
+    expect(catAxBlock).not.toContain("<a:bodyPr rot=");
+  });
+
+  it("threads the italic flag through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, axes: { x: { labelItalic: true } } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr i="1"/>');
+    }
+  });
+
+  it("threads the italic flag through scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { labelItalic: true }, y: { labelItalic: true } },
+      }),
+      "Sheet1",
+    );
+    const valAxes = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxes).toHaveLength(2);
+    expect(valAxes[0]).toContain('<a:defRPr i="1"/>');
+    expect(valAxes[1]).toContain('<a:defRPr i="1"/>');
+  });
+
+  it("ignores labelItalic on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(
+      makeChart({ type: "pie", axes: { x: { labelItalic: true } } }),
+      "Sheet1",
+    );
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { labelItalic: true } } }),
+      "Sheet1",
+    );
+    expect(pie.chartXml).not.toContain("<c:txPr>");
+    expect(dough.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("places <c:txPr> between <c:tickLblPos> and <c:crossAx> per the OOXML schema", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblPos: "low", labelItalic: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const tickLblPosIdx = catAxBlock.indexOf("c:tickLblPos");
+    const txPrIdx = catAxBlock.indexOf("<c:txPr>");
+    const crossAxIdx = catAxBlock.indexOf("c:crossAx");
+    expect(tickLblPosIdx).toBeGreaterThan(0);
+    expect(txPrIdx).toBeGreaterThan(tickLblPosIdx);
+    expect(crossAxIdx).toBeGreaterThan(txPrIdx);
+  });
+
+  it("round-trips labelItalic=true through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { labelItalic: true } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it("collapses an absent labelItalic round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelItalic).toBeUndefined();
+  });
+
+  it('collapses labelItalic=false round-trip back to undefined (i="0" matches the OOXML default)', () => {
+    // The reader collapses the OOXML default `false` to `undefined` so
+    // a writer emit of `i="0"` and absence round-trip identically.
+    const written = writeChart(
+      makeChart({ axes: { x: { labelItalic: false } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelItalic).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the italic flag into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { labelItalic: true }, y: { labelItalic: true } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:defRPr i="1"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.labelItalic).toBe(true);
+    expect(reparsed?.axes?.y?.labelItalic).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -13136,3 +13136,174 @@ describe("parseChart — axis labelBold", () => {
     });
   });
 });
+
+// ── parseChart — axis labelItalic ────────────────────────────────────
+
+describe("parseChart — axis labelItalic", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTxPrItalic(i: string | undefined): string {
+    const txPr =
+      i === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="${i}"/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${txPr}
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces labelItalic=true when <a:defRPr i="1"/> is pinned', () => {
+    const chart = parseChart(withCatAxTxPrItalic("1"));
+    expect(chart?.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it('surfaces labelItalic=true on the OOXML truthy spelling i="true"', () => {
+    const chart = parseChart(withCatAxTxPrItalic("true"));
+    expect(chart?.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it('drops the OOXML default i="0" to undefined (round-trips with absence)', () => {
+    expect(parseChart(withCatAxTxPrItalic("0"))?.axes).toBeUndefined();
+  });
+
+  it('drops the falsy spelling i="false" to undefined', () => {
+    expect(parseChart(withCatAxTxPrItalic("false"))?.axes).toBeUndefined();
+  });
+
+  it("drops malformed i tokens to undefined", () => {
+    expect(parseChart(withCatAxTxPrItalic("yes"))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> is absent", () => {
+    expect(parseChart(withCatAxTxPrItalic(undefined))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the i attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> is absent inside <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("surfaces labelItalic on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.y?.labelItalic).toBe(true);
+  });
+
+  it("surfaces labelItalic independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelItalic).toBe(true);
+    expect(chart?.axes?.y?.labelItalic).toBe(true);
+  });
+
+  it("co-surfaces labelItalic alongside labelBold, labelRotation, and labelFontSize from the same <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1400" b="1" i="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+    expect(chart?.axes?.x?.labelFontSize).toBe(14);
+    expect(chart?.axes?.x?.labelBold).toBe(true);
+    expect(chart?.axes?.x?.labelItalic).toBe(true);
+  });
+
+  it('does not pick up an <a:defRPr i=".."/> from the axis title\'s <c:rich>', () => {
+    // The axis-title's `<c:rich>` carries its own `<a:defRPr i="..">`
+    // separately from the tick-label `<c:txPr>`. The tick-label parser
+    // must not surface the title's flag — that belongs to
+    // axisTitleItalic.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:r><a:rPr/><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleItalic).toBe(true);
+    expect(chart?.axes?.x?.labelItalic).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200" i="1"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      tickLblPos: "low",
+      labelRotation: 45,
+      labelFontSize: 12,
+      labelItalic: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr i=\"..\"/></a:pPr></a:p></c:txPr></c:catAx>` (and the matching `<c:valAx>` slot) at the read, write, and clone layers so a template's tick-label italic pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `axes.x.labelItalic?: boolean` and `axes.y.labelItalic?: boolean` on `SheetChart` (writer side) plus the matching `labelItalic?: boolean` on `ChartAxisInfo` (reader side). Until now hucre's writer omitted the `i` attribute on `<a:defRPr>` for tick-label `<c:txPr>` and the reader ignored the slot entirely, so a templated dashboard chart whose user italicised the bottom-axis category names (a common pattern when a typography accent should land on the tick labels without bolding them) silently lost the choice on every parse -> clone -> write loop. Bridges another typography-customization gap for the dashboard composition flow tracked in #136.

Composes cleanly with the existing `labelRotation` (#245), `labelFontSize` (#263), and `labelBold` (#264) fields — all four knobs land on the same `<c:txPr>` body, the writer emits a single block per axis carrying whichever subset is pinned, and the reader picks up each value off its canonical slot. `<a:bodyPr rot=>` absent collapses to the OOXML default 0, `<a:defRPr sz=>` absent collapses to the theme-inherited size, `<a:defRPr b=>` absent collapses to the theme-inherited weight, and `<a:defRPr i=>` absent collapses to the theme-inherited slant, so a chart that pins only one of the four knobs round-trips without leaking a fabricated value through the other slots.

The clone layer follows the standard `boolean | null` override grammar: `undefined` inherits, `null` drops, and a literal `boolean` replaces. Non-boolean overrides (typed escapes from an untyped caller) collapse to `undefined` so the cloned `SheetChart` always carries a value the writer will accept. Pie / doughnut clones drop the inherited field silently via the same axis-scope short-circuit the surrounding axis helpers use.

Refs #136

## API

```ts
import { readXlsx, writeXlsx, cloneChart, parseChart } from \"hucre\";

// -- Read side --
const wb = await readXlsx(templateBytes);
const source = wb.sheets[0].charts![0];
console.log(source.axes?.x?.labelItalic);
// true       <- when the template pinned <a:defRPr i=\"1\"/> on the catAx
// undefined  <- when the template emits no flag (theme-inherited)

// -- Write side --
await writeXlsx({
  sheets: [{
    name: \"Dashboard\",
    rows: [[\"Quarter\", \"Revenue\"], [\"Q1\", 12000], [\"Q2\", 15500]],
    charts: [{
      type: \"column\",
      series: [{ name: \"Revenue\", values: \"B2:B3\", categories: \"A2:A3\" }],
      anchor: { from: { row: 5, col: 0 } },
      // Italicise the category-axis labels for a typographic accent
      // without bolding them; leave the Y-axis numeric labels at the
      // theme slant.
      axes: { x: { labelItalic: true } },
    }],
  }],
});

// -- Clone-through --
cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
//   -> inherits the source's parsed labelItalic unchanged.
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelItalic: null } },
});
//   -> drops the inherited flag (writer falls back to the theme default).
cloneChart(source, {
  anchor: { from: { row: 0, col: 0 } },
  axes: { x: { labelItalic: false } },
});
//   -> replaces the inherited flag with the explicit OOXML default i=\"0\".
```

## Implementation notes

- **Type model**: `axes.x.labelItalic?: boolean` and `axes.y.labelItalic?: boolean` on `SheetChart` (writer side) plus the matching `labelItalic?: boolean` on `ChartAxisInfo` (reader side). Same shape as `labelBold` so a parsed value flows straight from the read side back into the write side without transformation.
- **Reader** (`parseAxisLabelItalic`): walks `<c:txPr><a:p><a:pPr><a:defRPr i=\"..\"/></a:pPr></a:p></c:txPr>` for the `i` attribute and runs it through the existing `parseBoolAttr` (accepts `\"0\"` / `\"1\"` / `\"true\"` / `\"false\"`). The lookup is scoped to the axis-level `<c:txPr>` so a stray `<a:defRPr i=\"..\"/>` inside `<c:title><c:tx><c:rich>` (which belongs to `axisTitleItalic`) cannot leak in. The OOXML default `false` collapses to `undefined` so absence and `i=\"0\"` round-trip identically; only an explicit `i=\"1\"` surfaces `true`. Surfaces on every axis flavour.
- **Writer**: extends the existing `buildAxisTxPr(rotationDeg, fontSizePt, bold, italic)` helper to optionally include an `i=\"1\"` / `i=\"0\"` on `<a:defRPr>`. The block is emitted whenever any of the four knobs is pinned; absent inputs collapse so a chart that pins only one knob keeps the other slots at their OOXML defaults. Threads through bar / column / line / area via `buildBarAxes` and scatter via `buildScatterAxes`; pie / doughnut have no axes at all and the field is silently dropped on those families.
  - `normalizeAxisLabelItalic(value)` delegates to the chart-level `normalizeTitleItalic` — `true` / `false` pass through literally, every other token collapses to `undefined`.
- **Clone**: `applyLabelItalicOverride` follows the standard `boolean | null` override grammar — `undefined` inherits, `null` drops, a literal boolean replaces. Non-boolean overrides collapse to `undefined`. Pie / doughnut clones drop the inherited field silently via the same axis-scope short-circuit the surrounding axis helpers use.

## Test plan

- [x] `parseChart — axis labelItalic` (12 new tests) — surfaces the flag from `i=\"1\"` / `i=\"true\"`, drops the OOXML default `i=\"0\"` / `i=\"false\"` to undefined, drops malformed tokens, returns undefined when `<c:txPr>` / `<a:defRPr>` / `<a:p>` are absent, surfaces on the value axis, surfaces independently on both axes, co-surfaces alongside rotation / font size / bold, isolates from the axis title's `<c:rich>` block, co-surfaces alongside other axis fields.
- [x] `writeChart — axis labelItalic` (17 new tests) — omits `<c:txPr>` by default, emits `i=\"1\"` / `i=\"0\"`, emits independently on both axes, drops non-boolean inputs, composes with `labelRotation` / `labelFontSize` / `labelBold` in a single block, threads through bar / column / line / area / scatter, drops on pie / doughnut, places `<c:txPr>` between `<c:tickLblPos>` and `<c:crossAx>`, parse round-trip, default-collapse round-trip, full `writeXlsx` package round-trip.
- [x] `cloneChart — axis labelItalic` (12 new tests) — inherit / null drop / replace semantics, collapse non-boolean overrides, add to a source axis without one, drop on pie / doughnut chart-type coercion, carry through bar -> column coercion, compose with rotation / font size / bold, compose with other axis overrides, end-to-end parse -> clone -> write -> reparse, full `writeXlsx` cloned-chart round-trip.
- [x] `pnpm test` — 4934 tests pass, lint clean, typecheck clean.
- [x] `pnpm build` — obuild succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)