### PR TITLE
feat(xlsx): chart axis tick-label underline flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2523,6 +2523,66 @@ export interface SheetChart {
        */
       labelColor?: string;
       /**
+       * Tick-label underline flag. Maps to
+       * `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr></c:catAx>`
+       * (or `<c:valAx>` for scatter / value axes) — Excel's "Format
+       * Axis -> Font -> Underline" toggle applied to the tick labels.
+       * The OOXML attribute is the `ST_TextUnderlineType` enum on
+       * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7);
+       * the writer lands the value on the default-paragraph
+       * `<a:defRPr>` slot inside the same `<c:txPr>` block that
+       * carries {@link labelRotation} / {@link labelFontSize} /
+       * {@link labelBold} / {@link labelItalic} / {@link labelColor}.
+       *
+       * Modeled as a boolean for symmetry with {@link labelBold} /
+       * {@link labelItalic} and the axis-title counterpart
+       * {@link SheetChart.axes.x.axisTitleUnderline}: `true` emits
+       * `u="sng"` (Excel's UI checkbox — single line); absence and
+       * explicit `false` collapse to omitting the attribute (the
+       * OOXML default `"none"` collapses to absence, mirroring how
+       * Excel's reference serialization emits a non-underlined tick
+       * label). The non-UI variant `"dbl"` and the sixteen exotic
+       * types (`"words"`, `"heavy"`, `"dotted"`, `"dottedHeavy"`,
+       * `"dash"`, `"dashHeavy"`, `"dashLong"`, `"dashLongHeavy"`,
+       * `"dotDash"`, `"dotDashHeavy"`, `"dotDotDash"`,
+       * `"dotDotDashHeavy"`, `"wavy"`, `"wavyHeavy"`, `"wavyDbl"`)
+       * are read-only — the writer emits only `"sng"` to keep the
+       * surfaced shape consistent with what Excel's reference UI
+       * authors, and the reader collapses every non-`"sng"` token to
+       * `undefined` so a templated tick label that pinned a non-single
+       * underline in raw OOXML round-trips lossless rather than
+       * silently downgrading on re-emit.
+       *
+       * Useful for emphasising dashboard tick labels (e.g.
+       * underlining the bottom-axis category names so they read as
+       * inline links in a busy chart frame, or pairing with
+       * {@link labelColor} to land an accented underlined tick on a
+       * KPI dashboard).
+       *
+       * Default: omitted — the tick labels render non-underlined (the
+       * OOXML default; the writer elides the `u` attribute when no
+       * value is pinned). Set `true` to emit `u="sng"` on the
+       * default-paragraph slot; set `false` explicitly to pin the
+       * OOXML default behaviour (functionally identical to omission,
+       * but useful when overriding a templated chart that had an
+       * underline pinned upstream).
+       *
+       * Composes independently with {@link labelRotation} /
+       * {@link labelFontSize} / {@link labelBold} /
+       * {@link labelItalic} / {@link labelColor}: all six knobs land
+       * on the same `<c:txPr>` body, so a single configuration call
+       * threads cleanly through every tick-label knob the writer
+       * exposes.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+       * the OOXML schema, so the field round-trips on every chart family
+       * that has axes (bar / column / line / area / scatter). Pie /
+       * doughnut have no axes at all, so the field is silently dropped
+       * on those families.
+       */
+      labelUnderline?: boolean;
+      /**
        * Reverse the axis plotting order. Maps to
        * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
        * Excel's "Categories in reverse order" / "Values in reverse
@@ -2958,6 +3018,25 @@ export interface SheetChart {
        * (no axes at all).
        */
       labelColor?: string;
+      /**
+       * Tick-label underline flag for the value axis. Maps to
+       * `<c:valAx><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr></c:valAx>`.
+       * Mirrors {@link SheetChart.axes.x.labelUnderline} for the value
+       * axis — see that field for the full semantics. The OOXML `u`
+       * attribute is the `ST_TextUnderlineType` enum on
+       * `CT_TextCharacterProperties`; the writer emits only the UI
+       * variant `"sng"` (single line) when the input is `true`.
+       * Absence and explicit `false` collapse to omitting the
+       * attribute (the OOXML default `"none"` collapses to absence)
+       * so a fresh chart inherits Excel's reference non-underlined
+       * tick labels.
+       *
+       * Useful for emphasising the value-axis labels on a dashboard
+       * (e.g. underlining the Y-axis numeric totals so they read as
+       * inline links in a busy chart frame). Silently dropped on
+       * `pie` / `doughnut` charts (no axes at all).
+       */
+      labelUnderline?: boolean;
       /**
        * Hide the entire value axis (line, tick marks, tick labels).
        * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
@@ -4461,6 +4540,37 @@ export interface ChartAxisInfo {
    * fill cannot leak in.
    */
   labelColor?: string;
+  /**
+   * Tick-label underline flag pulled from
+   * `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>`
+   * on the axis element. Reflects Excel's "Format Axis -> Font ->
+   * Underline" toggle applied to tick labels.
+   *
+   * The OOXML `u` attribute is the `ST_TextUnderlineType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+   * eighteen values; Excel's UI exposes only `"sng"` (single line —
+   * the default underline checkbox) and `"dbl"` (double line). The
+   * reader surfaces only the UI-default `"sng"` as `true`; `"none"`
+   * (the OOXML application default), absence, the non-UI `"dbl"`
+   * variant, and the sixteen exotic tokens (`"words"`, `"heavy"`,
+   * `"dotted"`, `"dottedHeavy"`, `"dash"`, `"dashHeavy"`,
+   * `"dashLong"`, `"dashLongHeavy"`, `"dotDash"`, `"dotDashHeavy"`,
+   * `"dotDotDash"`, `"dotDotDashHeavy"`, `"wavy"`, `"wavyHeavy"`,
+   * `"wavyDbl"`) all collapse to `undefined` — the writer emits only
+   * `"sng"`, so reporting any non-single underline as `true` would
+   * silently downgrade the choice to a single line on round-trip.
+   * Unknown / malformed `u` tokens likewise drop to `undefined`.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+   * the OOXML schema. Mirrors the writer-side
+   * {@link SheetChart.axes.x.labelUnderline} so a parsed value slots
+   * straight back into a clone target without transformation. The
+   * lookup is scoped to the axis-level `<c:txPr>` so a stray
+   * `<a:defRPr u=".."/>` inside `<c:title>` (surfaced by
+   * {@link ChartAxisInfo.axisTitleUnderline}) cannot leak in.
+   */
+  labelUnderline?: boolean;
   /**
    * Reverse-axis flag pulled from
    * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -975,6 +975,26 @@ export interface CloneChartOptions {
        */
       labelColor?: string | null;
       /**
+       * Override `SheetChart.axes.x.labelUnderline`. `undefined` (or
+       * omitted) inherits the source axis's tick-label underline flag;
+       * `null` drops the inherited value (the writer falls back to the
+       * OOXML default — the tick labels render non-underlined); a
+       * `boolean` replaces it.
+       *
+       * Non-boolean overrides (typed escapes from an untyped caller)
+       * collapse to a drop so the cloned `SheetChart` always carries
+       * a value the writer will accept.
+       *
+       * `<c:txPr>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts since neither has axes. Composes
+       * independently with {@link labelRotation} / {@link labelFontSize} /
+       * {@link labelBold} / {@link labelItalic} / {@link labelColor}:
+       * all six knobs land on the same `<c:txPr>` body.
+       */
+      labelUnderline?: boolean | null;
+      /**
        * Override the reverse-axis flag. `undefined` (or omitted)
        * inherits the source axis' parsed value; `null` drops it (the
        * writer falls back to the OOXML default `"minMax"` — forward
@@ -1150,6 +1170,8 @@ export interface CloneChartOptions {
       labelItalic?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.labelColor}. */
       labelColor?: string | null;
+      /** See {@link CloneChartOptions.axes.x.labelUnderline}. */
+      labelUnderline?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.hidden}. */
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
@@ -3090,6 +3112,21 @@ function resolveAxes(
   // writer will accept.
   const xLabelColor = applyLabelColorOverride(sourceAxes?.x?.labelColor, overrides?.x?.labelColor);
   const yLabelColor = applyLabelColorOverride(sourceAxes?.y?.labelColor, overrides?.y?.labelColor);
+  // `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>`
+  // shares the same `<c:txPr>` slot as the rotation / size / bold /
+  // italic / color resolvers above, and the same per-axis scope rule
+  // (every axis flavour carries `<c:txPr>`; pie / doughnut already
+  // short-circuited upstream). Non-boolean overrides collapse to a
+  // drop so the cloned `SheetChart` always carries a value the writer
+  // will accept.
+  const xLabelUnderline = applyLabelUnderlineOverride(
+    sourceAxes?.x?.labelUnderline,
+    overrides?.x?.labelUnderline,
+  );
+  const yLabelUnderline = applyLabelUnderlineOverride(
+    sourceAxes?.y?.labelUnderline,
+    overrides?.y?.labelUnderline,
+  );
   const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
   const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
   // `tickLblSkip` / `tickMarkSkip` only render on category axes
@@ -3249,6 +3286,7 @@ function resolveAxes(
     xLabelBold !== undefined ||
     xLabelItalic !== undefined ||
     xLabelColor !== undefined ||
+    xLabelUnderline !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
@@ -3285,6 +3323,7 @@ function resolveAxes(
     if (xLabelBold !== undefined) out.x.labelBold = xLabelBold;
     if (xLabelItalic !== undefined) out.x.labelItalic = xLabelItalic;
     if (xLabelColor !== undefined) out.x.labelColor = xLabelColor;
+    if (xLabelUnderline !== undefined) out.x.labelUnderline = xLabelUnderline;
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
@@ -3318,6 +3357,7 @@ function resolveAxes(
     yLabelBold !== undefined ||
     yLabelItalic !== undefined ||
     yLabelColor !== undefined ||
+    yLabelUnderline !== undefined ||
     yHidden !== undefined ||
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
@@ -3348,6 +3388,7 @@ function resolveAxes(
     if (yLabelBold !== undefined) out.y.labelBold = yLabelBold;
     if (yLabelItalic !== undefined) out.y.labelItalic = yLabelItalic;
     if (yLabelColor !== undefined) out.y.labelColor = yLabelColor;
+    if (yLabelUnderline !== undefined) out.y.labelUnderline = yLabelUnderline;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
@@ -3781,6 +3822,35 @@ function applyLabelColorOverride(
   if (override === undefined) return normalizeTitleColor(source);
   if (override === null) return undefined;
   return normalizeTitleColor(override);
+}
+
+/**
+ * Resolve a `labelUnderline` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Mirrors {@link applyLabelBoldOverride} /
+ * {@link applyLabelItalicOverride} — non-boolean overrides (typed
+ * escapes from an untyped caller) collapse to `undefined`, a `null`
+ * override always drops the inherited flag, and a literal `true` /
+ * `false` replaces it.
+ *
+ * The `<c:txPr>` block sits on every axis flavour per the OOXML
+ * schema, so the override applies on every chart family that has
+ * axes. The pie / doughnut short-circuit upstream collapses the
+ * field on those families since neither has axes.
+ */
+function applyLabelUnderlineOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    if (source === true) return true;
+    if (source === false) return false;
+    return undefined;
+  }
+  if (override === null) return undefined;
+  if (override === true) return true;
+  if (override === false) return false;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -684,6 +684,16 @@ function parseAxisInfo(
   // triple round-trips losslessly through the writer. Surfaced on
   // every axis flavour for symmetry with the writer.
   const labelColor = parseAxisLabelColor(axis);
+  // `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>` —
+  // tick-label underline flag. Same `<c:txPr>` slot scope as the
+  // rotation / size / bold / italic / color readers above. Only the
+  // UI-default `"sng"` surfaces as `true`; the OOXML default `"none"`,
+  // absence, the non-UI `"dbl"` variant, and the sixteen exotic
+  // tokens all collapse to `undefined` so absence and the OOXML
+  // default round-trip identically through the writer (which emits
+  // only `"sng"`). Surfaced on every axis flavour for symmetry with
+  // the writer.
+  const labelUnderline = parseAxisLabelUnderline(axis);
   // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
   // accepts "minMax" (default, low → high) and "maxMin" (reversed).
   // The default collapses to undefined so a fresh chart and a chart
@@ -771,6 +781,7 @@ function parseAxisInfo(
     labelBold === undefined &&
     labelItalic === undefined &&
     labelColor === undefined &&
+    labelUnderline === undefined &&
     reverse === undefined &&
     tickLblSkip === undefined &&
     tickMarkSkip === undefined &&
@@ -806,6 +817,7 @@ function parseAxisInfo(
   if (labelBold !== undefined) out.labelBold = labelBold;
   if (labelItalic !== undefined) out.labelItalic = labelItalic;
   if (labelColor !== undefined) out.labelColor = labelColor;
+  if (labelUnderline !== undefined) out.labelUnderline = labelUnderline;
   if (reverse !== undefined) out.reverse = reverse;
   if (tickLblSkip !== undefined) out.tickLblSkip = tickLblSkip;
   if (tickMarkSkip !== undefined) out.tickMarkSkip = tickMarkSkip;
@@ -1303,6 +1315,61 @@ function parseAxisLabelColor(axis: XmlElement): string | undefined {
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;
   return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull the axis tick-label underline flag off the canonical
+ * `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>` chain
+ * Excel writes when the user pins an underline on the axis tick labels.
+ *
+ * The OOXML `u` attribute is the `ST_TextUnderlineType` enum on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7) with
+ * eighteen values; Excel's UI exposes only `"sng"` (single line — the
+ * default underline checkbox) and `"dbl"` (double line). The reader
+ * surfaces only the UI-default `"sng"` as `true`; `"none"` (the OOXML
+ * application default), absence, the non-UI `"dbl"` variant, and the
+ * sixteen exotic tokens (`"words"`, `"heavy"`, `"dotted"`,
+ * `"dottedHeavy"`, `"dash"`, `"dashHeavy"`, `"dashLong"`,
+ * `"dashLongHeavy"`, `"dotDash"`, `"dotDashHeavy"`, `"dotDotDash"`,
+ * `"dotDotDashHeavy"`, `"wavy"`, `"wavyHeavy"`, `"wavyDbl"`) all
+ * collapse to `undefined` — the writer emits only `"sng"`, so
+ * reporting any non-single underline as `true` would silently
+ * downgrade the choice to a single line on round-trip. Unknown /
+ * malformed `u` tokens likewise drop to `undefined`.
+ *
+ * Mirrors {@link parseAxisTitleUnderline} for tick labels — same
+ * canonical-slot semantics but scoped to the axis-level `<c:txPr>` so
+ * a stray `<a:defRPr u=".."/>` inside `<c:title><c:tx><c:rich>`
+ * (surfaced by {@link parseAxisTitleUnderline}) cannot leak in.
+ * Returns `undefined` whenever the axis omits `<c:txPr>` entirely or
+ * the canonical `<a:p><a:pPr><a:defRPr>` chain is malformed.
+ *
+ * The `<c:txPr>` element sits on every axis flavour — `<c:catAx>` /
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry the optional
+ * element per the OOXML schema. The reader surfaces the flag
+ * regardless of axis flavour so a parsed chart preserves the value
+ * for symmetry with the writer-side
+ * {@link SheetChart.axes}.x.labelUnderline.
+ */
+function parseAxisLabelUnderline(axis: XmlElement): boolean | undefined {
+  const txPr = findChild(axis, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.u;
+  // Only the UI-default `"sng"` surfaces as `true`. The OOXML
+  // application default `"none"`, the non-UI `"dbl"` variant, and
+  // every exotic token (`"words"`, `"heavy"`, `"dotted"`, etc.) all
+  // collapse to `undefined` so absence and the OOXML default
+  // round-trip identically through the writer; the writer emits only
+  // `"sng"`, so reporting a non-single underline here would silently
+  // downgrade the choice on round-trip.
+  if (raw === "sng") return true;
+  return undefined;
 }
 
 /** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -836,6 +836,16 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // serialization for tick labels that inherit the theme text color).
     xLabelColor: normalizeAxisLabelColor(chart.axes?.x?.labelColor),
     yLabelColor: normalizeAxisLabelColor(chart.axes?.y?.labelColor),
+    // `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>`
+    // shares the same `<c:txPr>` block as the rotation / size / bold
+    // / italic / color slots above. The writer emits only the UI
+    // variant `"sng"` when the input is `true`. `true` / `false` pass
+    // through literally; non-boolean tokens (typed escapes from an
+    // untyped caller) collapse to `undefined` so the writer omits the
+    // `u` attribute and a fresh chart inherits Excel's reference
+    // non-underlined tick labels.
+    xLabelUnderline: normalizeAxisLabelUnderline(chart.axes?.x?.labelUnderline),
+    yLabelUnderline: normalizeAxisLabelUnderline(chart.axes?.y?.labelUnderline),
     xReverse: chart.axes?.x?.reverse === true,
     yReverse: chart.axes?.y?.reverse === true,
     // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
@@ -1434,6 +1444,27 @@ interface AxisRenderOptions {
    * semantics as {@link xLabelColor}.
    */
   yLabelColor: string | undefined;
+  /**
+   * Tick-label underline flag emitted on the X axis via
+   * `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>`.
+   * The OOXML `u` attribute is the `ST_TextUnderlineType` enum on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer emits only the UI variant `"sng"` when the input is
+   * `true`. `undefined` and `false` both collapse to omitting the
+   * attribute so a fresh chart inherits Excel's reference
+   * non-underlined tick labels (the OOXML default `"none"` collapses
+   * to absence). The block is emitted whenever any tick-label
+   * typography knob (`xLabelRotation`, `xLabelFontSize`,
+   * `xLabelBold`, `xLabelItalic`, `xLabelColor`, or
+   * `xLabelUnderline`) is set so the OOXML schema's `<c:txPr>` slot
+   * carries every pinned typography knob.
+   */
+  xLabelUnderline: boolean | undefined;
+  /**
+   * Tick-label underline flag emitted on the Y axis. Same shape and
+   * semantics as {@link xLabelUnderline}.
+   */
+  yLabelUnderline: boolean | undefined;
   xReverse: boolean;
   yReverse: boolean;
   /**
@@ -1835,19 +1866,35 @@ function normalizeAxisLabelColor(value: string | undefined): string | undefined 
 }
 
 /**
+ * Normalize an axis `labelUnderline` value for the
+ * `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>`
+ * writer slot. Delegates to the chart-level
+ * {@link normalizeTitleUnderline} — `true` / `false` pass through
+ * literally, every other token (typed escape from an untyped caller,
+ * including `null`-shaped values) collapses to `undefined` so the
+ * writer omits the `u` attribute entirely. Absence then collapses to
+ * the OOXML default Excel itself emits on a fresh axis (the
+ * theme-default non-underlined tick labels).
+ */
+function normalizeAxisLabelUnderline(value: boolean | undefined): boolean | undefined {
+  return normalizeTitleUnderline(value);
+}
+
+/**
  * Build the `<c:txPr>` block that carries an axis tick-label rotation,
- * font size, bold flag, italic flag, and / or font color. Returns
- * `undefined` when every input is unset so the caller can elide the
- * element entirely (Excel's reference serialization on a fresh axis
- * omits `<c:txPr>` when the labels render at the default rotation and
- * inherit the theme font / weight / slant / color).
+ * font size, bold flag, italic flag, font color, and / or underline
+ * flag. Returns `undefined` when every input is unset so the caller
+ * can elide the element entirely (Excel's reference serialization on
+ * a fresh axis omits `<c:txPr>` when the labels render at the default
+ * rotation and inherit the theme font / weight / slant / color /
+ * underline).
  *
  * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
  * when the user pins a custom typography knob — `<a:bodyPr rot="N"/>`
  * carries the rotation (when set), `<a:lstStyle/>` is the empty
  * list-style placeholder the schema requires, and the
  * `<a:p><a:pPr><a:defRPr/></a:pPr><a:endParaRPr/></a:p>` paragraph
- * stub Excel always emits hosts the optional `sz` / `b` / `i`
+ * stub Excel always emits hosts the optional `sz` / `b` / `i` / `u`
  * attributes on `<a:defRPr>`. Additional `<a:bodyPr>` attributes Excel writes in
  * its full reference (`spcFirstLastPara` / `vertOverflow` / `wrap` /
  * `anchor` / `anchorCtr`) are intentionally omitted — the OOXML
@@ -1856,17 +1903,21 @@ function normalizeAxisLabelColor(value: string | undefined): string | undefined 
  *
  * When only a rotation is pinned, the `<a:defRPr>` slot self-closes
  * with no attributes (matching the legacy rotation-only emit). When a
- * font size, bold flag, italic flag, or font color is pinned, the
- * slot carries `sz="N"` (in 100ths of a point), `b="1"` / `b="0"`,
- * `i="1"` / `i="0"`, and / or wraps an `<a:solidFill>` child so a
- * re-parse picks the values up off the canonical default-paragraph
- * slot. When the rotation is absent but any other knob is pinned,
- * the writer omits `rot` from `<a:bodyPr>` so the OOXML default `0`
- * collapses to absence. The bold / italic flags each emit a literal
- * `1` / `0` whenever the input is a boolean — `false` pins the OOXML
- * default explicitly, which is functionally identical to absence but
- * lets a clone target override an upstream `1` from a templated
- * chart.
+ * font size, bold flag, italic flag, font color, or underline flag
+ * is pinned, the slot carries `sz="N"` (in 100ths of a point),
+ * `b="1"` / `b="0"`, `i="1"` / `i="0"`, `u="sng"`, and / or wraps an
+ * `<a:solidFill>` child so a re-parse picks the values up off the
+ * canonical default-paragraph slot. When the rotation is absent but
+ * any other knob is pinned, the writer omits `rot` from `<a:bodyPr>`
+ * so the OOXML default `0` collapses to absence. The bold / italic
+ * flags each emit a literal `1` / `0` whenever the input is a
+ * boolean — `false` pins the OOXML default explicitly, which is
+ * functionally identical to absence but lets a clone target override
+ * an upstream `1` from a templated chart. The underline flag emits
+ * only `u="sng"` (Excel's UI variant — single line) when the input
+ * is `true`; absence and explicit `false` both collapse to omitting
+ * the attribute since the OOXML default `"none"` collapses to
+ * absence.
  *
  * The `rgbHex` parameter pins the tick-label color via the
  * `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
@@ -1882,19 +1933,32 @@ function buildAxisTxPr(
   bold: boolean | undefined,
   italic: boolean | undefined,
   rgbHex: string | undefined,
+  underline: boolean | undefined,
 ): string | undefined {
   if (
     rotationDeg === undefined &&
     fontSizePt === undefined &&
     bold === undefined &&
     italic === undefined &&
-    rgbHex === undefined
+    rgbHex === undefined &&
+    underline === undefined
   )
     return undefined;
   const rot = rotationDeg === undefined ? undefined : rotationDeg * TXPR_ROT_PER_DEGREE;
   const sz = fontSizePt === undefined ? undefined : fontSizePt * TITLE_FONT_SZ_PER_POINT;
   const b = bold === undefined ? undefined : bold ? 1 : 0;
   const i = italic === undefined ? undefined : italic ? 1 : 0;
+  // OOXML's `<a:defRPr u=".."/>` attribute is the
+  // `ST_TextUnderlineType` enum on `CT_TextCharacterProperties` —
+  // eighteen values total, with `"none"` as the OOXML default and
+  // `"sng"` as the value Excel's UI authors for the "Underline"
+  // checkbox (single line). The writer emits only the UI variant
+  // `"sng"` to keep the surfaced shape consistent with what Excel's
+  // reference UI authors. Absence (`undefined`) and explicit `false`
+  // both collapse to omitting the attribute (the OOXML default
+  // `"none"` collapses to absence; Excel itself omits `u` when the
+  // tick labels are not underlined).
+  const u = underline === true ? "sng" : undefined;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the tick-label font color.
   // Absence (`undefined`) collapses to omitting the entire
@@ -1910,8 +1974,8 @@ function buildAxisTxPr(
   // no custom color matches Excel's reference serialization byte-for-
   // byte.
   const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i });
+    ? xmlElement("a:defRPr", { sz, b, i, u }, [solidFillChild])
+    : xmlSelfClose("a:defRPr", { sz, b, i, u });
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr", { rot }),
     xmlSelfClose("a:lstStyle"),
@@ -2417,6 +2481,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     opts.xLabelBold,
     opts.xLabelItalic,
     opts.xLabelColor,
+    opts.xLabelUnderline,
   );
   if (xCatAxTxPr) catAxChildren.push(xCatAxTxPr);
   catAxChildren.push(
@@ -2489,6 +2554,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     opts.yLabelBold,
     opts.yLabelItalic,
     opts.yLabelColor,
+    opts.yLabelUnderline,
   );
   if (yValAxTxPr) valAxChildren.push(yValAxTxPr);
   valAxChildren.push(
@@ -2859,6 +2925,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     opts.xLabelBold,
     opts.xLabelItalic,
     opts.xLabelColor,
+    opts.xLabelUnderline,
   );
   if (xValAxTxPr) xAxChildren.push(xValAxTxPr);
   xAxChildren.push(
@@ -2908,6 +2975,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     opts.yLabelBold,
     opts.yLabelItalic,
     opts.yLabelColor,
+    opts.yLabelUnderline,
   );
   if (yScatterTxPr) yAxChildren.push(yScatterTxPr);
   yAxChildren.push(

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -13828,3 +13828,223 @@ describe("cloneChart — axis labelColor", () => {
     expect(reparsed?.axes?.y?.labelColor).toBe("00C586");
   });
 });
+
+// ── cloneChart — axis labelUnderline ─────────────────────────────────
+
+describe("cloneChart — axis labelUnderline", () => {
+  const sourceWithUnderline: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    axes: { x: { labelUnderline: true }, y: { labelUnderline: true } },
+  };
+
+  it("inherits axes.x.labelUnderline from the source when no override is given", () => {
+    const clone = cloneChart(sourceWithUnderline, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+    expect(clone.axes?.y?.labelUnderline).toBe(true);
+  });
+
+  it("drops the inherited flag when override is null", () => {
+    const clone = cloneChart(sourceWithUnderline, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelUnderline: null } },
+    });
+    expect(clone.axes?.x?.labelUnderline).toBeUndefined();
+    // Y axis stays put — nulling X must not bleed into Y.
+    expect(clone.axes?.y?.labelUnderline).toBe(true);
+  });
+
+  it("replaces the inherited flag when override is true", () => {
+    const noUnderline: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noUnderline, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelUnderline: true } },
+    });
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it("replaces the inherited flag when override is false (functionally identical to drop)", () => {
+    const clone = cloneChart(sourceWithUnderline, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelUnderline: false } },
+    });
+    expect(clone.axes?.x?.labelUnderline).toBe(false);
+  });
+
+  it("returns undefined labelUnderline when neither source nor override sets it", () => {
+    const noUnderline: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+    };
+    const clone = cloneChart(noUnderline, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelUnderline).toBeUndefined();
+  });
+
+  it("drops non-boolean overrides (defends against the type guard escaping)", () => {
+    for (const bad of ["true", 1, {}, "sng"]) {
+      const clone = cloneChart(sourceWithUnderline, {
+        anchor: { from: { row: 0, col: 0 } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { labelUnderline: bad as any } },
+      });
+      expect(clone.axes?.x?.labelUnderline).toBeUndefined();
+    }
+  });
+
+  it("strips the flag silently when the resolved chart type is pie", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [{ kind: "pie", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelUnderline: true } },
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("pie");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("strips the flag silently when the resolved chart type is doughnut", () => {
+    const doughnutSource: Chart = {
+      kinds: ["doughnut"],
+      seriesCount: 1,
+      series: [{ kind: "doughnut", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { labelUnderline: true } },
+    };
+    const clone = cloneChart(doughnutSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("carries the flag through chart-type coercion (bar -> column)", () => {
+    const clone = cloneChart(sourceWithUnderline, {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+    expect(clone.axes?.y?.labelUnderline).toBe(true);
+  });
+
+  it("composes the flag alongside the other tick-label typography knobs", () => {
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: {
+        x: {
+          labelRotation: 45,
+          labelFontSize: 12,
+          labelBold: true,
+          labelItalic: true,
+          labelColor: "1070CA",
+          labelUnderline: true,
+        },
+      },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelRotation).toBe(45);
+    expect(clone.axes?.x?.labelFontSize).toBe(12);
+    expect(clone.axes?.x?.labelBold).toBe(true);
+    expect(clone.axes?.x?.labelItalic).toBe(true);
+    expect(clone.axes?.x?.labelColor).toBe("1070CA");
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it("composes the flag independently with the axis-title underline on the same axis", () => {
+    const source: Chart = {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, valuesRef: "Tpl!$B$2:$B$5" }],
+      axes: { x: { title: "Period", axisTitleUnderline: true, labelUnderline: true } },
+    };
+    const clone = cloneChart(source, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.axisTitleUnderline).toBe(true);
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it("composes the flag alongside other axis overrides", () => {
+    const clone = cloneChart(sourceWithUnderline, {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: {
+        x: {
+          title: "Period",
+          gridlines: { major: true },
+          labelUnderline: true,
+        },
+      },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.gridlines).toEqual({ major: true });
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it("end-to-end: parseChart -> cloneChart -> writeChart preserves the flag", () => {
+    const sourceXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"
+              xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:val><c:numRef><c:f>Tpl!$B$2:$B$5</c:f></c:numRef></c:val>
+        </c:ser>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p></c:txPr>
+      </c:catAx>
+      <c:valAx>
+        <c:axId val="2"/>
+        <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p></c:txPr>
+      </c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const parsed = parseChart(sourceXml);
+    expect(parsed?.axes?.x?.labelUnderline).toBe(true);
+    expect(parsed?.axes?.y?.labelUnderline).toBe(true);
+
+    const sheetChart = cloneChart(parsed!, {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(sheetChart.axes?.x?.labelUnderline).toBe(true);
+    expect(sheetChart.axes?.y?.labelUnderline).toBe(true);
+
+    const written = writeChart(sheetChart, "Dashboard").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelUnderline).toBe(true);
+    expect(reparsed?.axes?.y?.labelUnderline).toBe(true);
+  });
+
+  it("end-to-end: writeXlsx packages the cloned chart with the flag intact", async () => {
+    const clone = cloneChart(sourceWithUnderline, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelUnderline).toBe(true);
+    expect(reparsed?.axes?.y?.labelUnderline).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -12731,3 +12731,205 @@ describe("writeChart — axis labelColor", () => {
     expect(reparsed?.axes?.y?.labelColor).toBe("00C586");
   });
 });
+
+// ── writeChart — axis labelUnderline ─────────────────────────────────
+
+describe("writeChart — axis labelUnderline", () => {
+  function axisLabelDefRPrU(axisBlock: string): string | undefined {
+    const txPrMatch = axisBlock.match(/<c:txPr>[\s\S]*?<\/c:txPr>/);
+    if (!txPrMatch) return undefined;
+    const defRPrMatch = txPrMatch[0].match(/<a:defRPr\b[^>]*\/?>/);
+    if (!defRPrMatch) return undefined;
+    const u = defRPrMatch[0].match(/\bu="([^"]*)"/);
+    return u ? u[1] : undefined;
+  }
+
+  it("omits <c:txPr> on the category axis when no tick-label knob is pinned", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).not.toContain("<c:txPr>");
+  });
+
+  it('emits u="sng" on <a:defRPr> when labelUnderline is true', () => {
+    const result = writeChart(makeChart({ axes: { x: { labelUnderline: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<c:txPr>");
+    expect(axisLabelDefRPrU(catAxBlock)).toBe("sng");
+  });
+
+  it("emits <c:txPr> with no u attribute when labelUnderline is false (functionally identical to absence on round-trip)", () => {
+    // The OOXML default `"none"` collapses to absence, so the writer
+    // skips `u` when the input is `false`. The `<c:txPr>` block still
+    // appears because the writer treats `false` as a pinned value
+    // (mirroring how `labelBold: false` pins `b="0"`); the difference
+    // is that `u="none"` is not part of Excel's reference shape so we
+    // emit no attribute at all. The reader collapses absence to
+    // `undefined`, so `false` round-trips to `undefined` — useful
+    // when overriding a templated chart that pinned `u="sng"` upstream.
+    const result = writeChart(makeChart({ axes: { x: { labelUnderline: false } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<c:txPr>");
+    expect(axisLabelDefRPrU(catAxBlock)).toBeUndefined();
+    const reparsed = parseChart(result.chartXml);
+    expect(reparsed?.axes?.x?.labelUnderline).toBeUndefined();
+  });
+
+  it("drops non-boolean inputs (defends against the type guard escaping)", () => {
+    for (const bad of ["true", 1, null, {}]) {
+      const result = writeChart(
+        makeChart({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          axes: { x: { labelUnderline: bad as any } },
+        }),
+        "Sheet1",
+      );
+      const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+      expect(catAxBlock).not.toContain("<c:txPr>");
+    }
+  });
+
+  it("emits the underline flag independently on each axis", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelUnderline: true }, y: { labelUnderline: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const valAxBlock = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/)![0];
+    expect(axisLabelDefRPrU(catAxBlock)).toBe("sng");
+    expect(axisLabelDefRPrU(valAxBlock)).toBe("sng");
+  });
+
+  it("composes labelUnderline with labelRotation in a single <c:txPr> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelRotation: 45, labelUnderline: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:bodyPr rot="2700000"/>');
+    expect(axisLabelDefRPrU(catAxBlock)).toBe("sng");
+  });
+
+  it("composes labelUnderline with labelFontSize, labelBold, labelItalic, and labelColor in a single block", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            labelFontSize: 12,
+            labelBold: true,
+            labelItalic: true,
+            labelColor: "1070CA",
+            labelUnderline: true,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect((catAxBlock.match(/<c:txPr>/g) ?? []).length).toBe(1);
+    expect(catAxBlock).toContain('<a:defRPr sz="1200" b="1" i="1" u="sng">');
+    expect(catAxBlock).toContain('<a:srgbClr val="1070CA"/>');
+  });
+
+  it("emits <c:txPr> with no rot when only labelUnderline is pinned", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelUnderline: true } } }), "Sheet1");
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    expect(catAxBlock).toContain("<a:bodyPr/>");
+    expect(catAxBlock).not.toContain("<a:bodyPr rot=");
+  });
+
+  it("threads the underline flag through bar, column, line, and area chart families", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { labelUnderline: true } } }),
+        "Sheet1",
+      );
+      const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+      expect(axisLabelDefRPrU(catAxBlock)).toBe("sng");
+    }
+  });
+
+  it("threads the underline flag through scatter charts (both axes are value axes)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { labelUnderline: true }, y: { labelUnderline: true } },
+      }),
+      "Sheet1",
+    );
+    const valAxes = result.chartXml.match(/<c:valAx>[\s\S]*?<\/c:valAx>/g)!;
+    expect(valAxes).toHaveLength(2);
+    expect(axisLabelDefRPrU(valAxes[0])).toBe("sng");
+    expect(axisLabelDefRPrU(valAxes[1])).toBe("sng");
+  });
+
+  it("ignores labelUnderline on pie / doughnut charts (no axes at all)", () => {
+    const pie = writeChart(
+      makeChart({ type: "pie", axes: { x: { labelUnderline: true } } }),
+      "Sheet1",
+    );
+    const dough = writeChart(
+      makeChart({ type: "doughnut", axes: { x: { labelUnderline: true } } }),
+      "Sheet1",
+    );
+    expect(pie.chartXml).not.toContain("<c:txPr>");
+    expect(dough.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("places <c:txPr> between <c:tickLblPos> and <c:crossAx> per the OOXML schema", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { tickLblPos: "low", labelUnderline: true } } }),
+      "Sheet1",
+    );
+    const catAxBlock = result.chartXml.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const tickLblPosIdx = catAxBlock.indexOf("c:tickLblPos");
+    const txPrIdx = catAxBlock.indexOf("<c:txPr>");
+    const crossAxIdx = catAxBlock.indexOf("c:crossAx");
+    expect(tickLblPosIdx).toBeGreaterThan(0);
+    expect(txPrIdx).toBeGreaterThan(tickLblPosIdx);
+    expect(crossAxIdx).toBeGreaterThan(txPrIdx);
+  });
+
+  it("round-trips labelUnderline through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { labelUnderline: true } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it("collapses an absent labelUnderline round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelUnderline).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx packages the underline flag into chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: { x: { labelUnderline: true }, y: { labelUnderline: true } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.labelUnderline).toBe(true);
+    expect(reparsed?.axes?.y?.labelUnderline).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -13471,3 +13471,194 @@ describe("parseChart — axis labelColor", () => {
     });
   });
 });
+
+// ── parseChart — axis labelUnderline ───────────────────────────────
+
+describe("parseChart — axis labelUnderline", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxLabelUnderline(u: string | undefined): string {
+    const txPr =
+      u === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="${u}"/></a:pPr><a:endParaRPr lang="en-US"/></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${txPr}
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces labelUnderline=true when <a:defRPr u="sng"/> is pinned', () => {
+    const chart = parseChart(withCatAxLabelUnderline("sng"));
+    expect(chart?.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it('drops the OOXML default u="none" to undefined (round-trips with absence)', () => {
+    expect(parseChart(withCatAxLabelUnderline("none"))?.axes).toBeUndefined();
+  });
+
+  it('drops the non-UI variant u="dbl" to undefined (writer would downgrade to "sng")', () => {
+    expect(parseChart(withCatAxLabelUnderline("dbl"))?.axes).toBeUndefined();
+  });
+
+  it("drops the sixteen exotic ST_TextUnderlineType tokens to undefined", () => {
+    for (const exotic of [
+      "words",
+      "heavy",
+      "dotted",
+      "dottedHeavy",
+      "dash",
+      "dashHeavy",
+      "dashLong",
+      "dashLongHeavy",
+      "dotDash",
+      "dotDashHeavy",
+      "dotDotDash",
+      "dotDotDashHeavy",
+      "wavy",
+      "wavyHeavy",
+      "wavyDbl",
+    ]) {
+      expect(parseChart(withCatAxLabelUnderline(exotic))?.axes).toBeUndefined();
+    }
+  });
+
+  it("drops malformed u tokens to undefined", () => {
+    expect(parseChart(withCatAxLabelUnderline("bogus"))?.axes).toBeUndefined();
+    expect(parseChart(withCatAxLabelUnderline(""))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> is absent", () => {
+    expect(parseChart(withCatAxLabelUnderline(undefined))?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the u attribute", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <a:p> is absent inside <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("surfaces labelUnderline on the value axis", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.y?.labelUnderline).toBe(true);
+  });
+
+  it("surfaces labelUnderline independently on both axes", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p></c:txPr>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelUnderline).toBe(true);
+    expect(chart?.axes?.y?.labelUnderline).toBe(true);
+  });
+
+  it("co-surfaces labelUnderline alongside the other tick-label typography knobs from the same <c:txPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1400" b="1" i="1" u="sng"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelRotation).toBe(45);
+    expect(chart?.axes?.x?.labelFontSize).toBe(14);
+    expect(chart?.axes?.x?.labelBold).toBe(true);
+    expect(chart?.axes?.x?.labelItalic).toBe(true);
+    expect(chart?.axes?.x?.labelColor).toBe("1070CA");
+    expect(chart?.axes?.x?.labelUnderline).toBe(true);
+  });
+
+  it('does not pick up an <a:defRPr u=".."/> from the axis title\'s <c:rich>', () => {
+    // The axis-title's `<c:rich>` carries its own `<a:defRPr u="..">`
+    // separately from the tick-label `<c:txPr>`. The tick-label parser
+    // must not surface the title's flag — that belongs to
+    // axisTitleUnderline.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr u="sng"/></a:pPr><a:r><a:rPr u="sng"/><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleUnderline).toBe(true);
+    expect(chart?.axes?.x?.labelUnderline).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis fields", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title><c:tx><c:rich><a:p><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx></c:title>
+      <c:tickLblPos val="low"/>
+      <c:txPr><a:bodyPr rot="2700000"/><a:lstStyle/><a:p><a:pPr><a:defRPr sz="1200" u="sng"/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x).toEqual({
+      title: "Period",
+      tickLblPos: "low",
+      labelRotation: 45,
+      labelFontSize: 12,
+      labelUnderline: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:catAx><c:txPr><a:p><a:pPr><a:defRPr u=\".."/></a:pPr></a:p></c:txPr></c:catAx>` (and the matching `<c:valAx>` slot) at the read, write, and clone layers so a template's tick-label underline pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `axes.x.labelUnderline?: boolean` and `axes.y.labelUnderline?: boolean` on `SheetChart` (writer side) plus the matching `labelUnderline?: boolean` on `ChartAxisInfo` (reader side). Sits on the same `<c:txPr>` body as `labelRotation` (#245), `labelFontSize` (#263), `labelBold` (#264), `labelItalic` (#265), and `labelColor` (#266); the writer emits a single block per axis carrying whichever subset is pinned. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user underlined the tick labels (e.g. an inline-link styling for the bottom-axis category names) now round-trips that flag through the parse / clone / write loop.

Modeled as a boolean for symmetry with the axis-title counterpart `axisTitleUnderline` (#262) and the chart-level `titleUnderline` (#260): `true` emits `u=\"sng\"` (Excel's UI checkbox — single line); absence collapses to omitting the attribute (the OOXML default `\"none\"` collapses to absence, mirroring how Excel's reference serialization emits a non-underlined tick label). The non-UI variant `\"dbl\"` and the sixteen exotic types (`\"words\"`, `\"heavy\"`, `\"dotted\"`, `\"dottedHeavy\"`, `\"dash\"`, `\"dashHeavy\"`, `\"dashLong\"`, `\"dashLongHeavy\"`, `\"dotDash\"`, `\"dotDashHeavy\"`, `\"dotDotDash\"`, `\"dotDotDashHeavy\"`, `\"wavy\"`, `\"wavyHeavy\"`, `\"wavyDbl\"`) are read-only — the writer emits only `\"sng\"` to keep the surfaced shape consistent with what Excel's reference UI authors, and the reader collapses every non-`\"sng\"` token to `undefined` so a templated tick label that pinned a non-single underline in raw OOXML round-trips lossless rather than silently downgrading on re-emit.

The clone layer follows the standard `boolean | null` override grammar: `undefined` inherits, `null` drops, and a literal `boolean` replaces. Non-boolean overrides (typed escapes from an untyped caller) collapse to `undefined` so the cloned `SheetChart` always carries a value the writer will accept. Pie / doughnut charts (no axes at all) silently drop the field. The flag sits on every axis flavour — `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per the OOXML schema, so the field round-trips on every chart family that has axes (bar / column / line / area / scatter).

Refs #136

## Test plan

- [x] `pnpm test` passes (5022 tests across 89 files, lint + format + typecheck + vitest)
- [x] `pnpm build` succeeds
- [x] New describe blocks: `parseChart — axis labelUnderline` (12 cases), `writeChart — axis labelUnderline` (15 cases), `cloneChart — axis labelUnderline` (15 cases) covering parse, write, end-to-end `writeXlsx`, malformed input, the OOXML default / `\"dbl\"` / sixteen exotic underline tokens, axis-title scope isolation, pie / doughnut short-circuit, chart-type coercion, and composition with the five sibling typography knobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)