### PR TITLE
feat(xlsx): chart legend font size — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1289,6 +1289,43 @@ export interface SheetChart {
    * emits in that order so a re-parse sees the canonical sequence.
    */
   legendEntries?: ChartLegendEntry[];
+  /**
+   * Legend font size in whole or half points. Maps to
+   * `<c:legend><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+   * </c:txPr></c:legend>` — Excel's "Format Legend -> Font -> Size"
+   * knob. The OOXML attribute is in 100ths of a point, so 12pt
+   * serializes as `sz="1200"` and 9pt (Excel's reference default for
+   * the legend) as `sz="900"`; the writer performs the conversion at
+   * emit time and lands the value on the default-paragraph
+   * `<a:defRPr>` slot inside the legend's `<c:txPr>` block so a
+   * re-parse picks the size up off the canonical slot the OOXML schema
+   * exposes.
+   *
+   * Accepted range: `1..400`pt (the band the OOXML `ST_TextFontSize`
+   * schema exposes — `100..400000` in 100ths of a point). Fractional
+   * inputs round to the nearest 0.5pt (Excel's UI granularity); inputs
+   * outside the band, `NaN`, `Infinity`, and non-numeric inputs all
+   * collapse to `undefined` so the writer drops the `<c:txPr>` block
+   * rather than emit a token Excel would reject — the rendered legend
+   * falls back to the theme-default 9pt.
+   *
+   * Default: omitted — the legend renders at Excel's reference 9pt
+   * (the OOXML schema's application-default for chart legend text). Set
+   * an explicit value to scale the legend up for a hero dashboard tile
+   * (e.g. `14`) or down to fit a tight sidebar slot (e.g. `7`).
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no slot to host the size in that case.
+   *
+   * Mirrors {@link titleFontSize} / {@link axes.x.axisTitleFontSize} /
+   * {@link axes.x.labelFontSize} — same range, same normalization,
+   * same OOXML conversion factor — so a caller can thread a single
+   * size value through every typography-pinning slot without bookkeeping
+   * the units. Composes independently with {@link legend} /
+   * {@link legendOverlay} / {@link legendEntries}: all four fields land
+   * on the same `<c:legend>` element so a single configuration call
+   * threads cleanly through every legend knob Excel exposes.
+   */
+  legendFontSize?: number;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -4932,6 +4969,26 @@ export interface Chart {
    * legend entries to surface in either case.
    */
   legendEntries?: ChartLegendEntry[];
+  /**
+   * Legend font size in points pulled from
+   * `<c:legend><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+   * </c:txPr></c:legend>`. The OOXML `sz` attribute is in 100ths of a
+   * point — the reader converts to points and rounds to the nearest
+   * 0.5pt (Excel's UI exposes the same 0.5pt granularity). Range:
+   * `1..400`pt (the band the OOXML `ST_TextFontSize` schema exposes).
+   *
+   * Absence of the element / attribute and out-of-range / non-numeric
+   * / non-finite values all collapse to `undefined` so a fresh chart
+   * and a chart that pinned an out-of-range size both round-trip to
+   * the writer's "skip the size attribute" path.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:txPr>` slot to surface the size from in either case. Mirrors
+   * the writer-side {@link SheetChart.legendFontSize} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   */
+  legendFontSize?: number;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -178,6 +178,31 @@ export interface CloneChartOptions {
    * caller can pass `null` (or an empty array) to start fresh.
    */
   legendEntries?: ChartLegendEntry[] | null;
+  /**
+   * Override `SheetChart.legendFontSize`. `undefined` (or omitted)
+   * inherits the source's parsed `legendFontSize`; `null` drops the
+   * inherited size (the writer emits no `<c:txPr>` block on the
+   * legend, falling back to Excel's theme-default 9pt); a number
+   * replaces. Out-of-range / non-numeric / non-finite overrides
+   * collapse to `undefined` (inherit) so a typed escape from an
+   * untyped caller cannot pin a value the writer would silently elide
+   * back to absence. Fractional inputs round to the nearest 0.5pt
+   * (Excel's UI granularity).
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved legend is `false` (no `<c:legend>` element will be
+   * emitted) — there is no `<c:txPr>` slot to host the size on a
+   * hidden legend, so leaking the value into the output would carry a
+   * pin Excel never reads.
+   *
+   * The grammar mirrors `titleFontSize` / `axes.x.axisTitleFontSize` /
+   * `axes.x.labelFontSize` so the typography knobs compose the same way
+   * at the call site. Bridges another typography-customization gap for
+   * the dashboard composition flow tracked in #136 — a templated
+   * dashboard chart whose user pinned a custom legend size now
+   * round-trips that pin through the parse / clone / write loop.
+   */
+  legendFontSize?: number | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1345,6 +1370,20 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // replaces it outright.
     const resolvedLegendEntries = resolveLegendEntries(source.legendEntries, options.legendEntries);
     if (resolvedLegendEntries !== undefined) out.legendEntries = resolvedLegendEntries;
+
+    // `<c:txPr>` only renders inside `<c:legend>`, so the same hidden /
+    // missing-legend scoping that drops `legendOverlay` /
+    // `legendEntries` also drops the inherited font size — the writer
+    // has no slot to populate when the legend is hidden. Mirrors the
+    // `titleFontSize` / `axisTitleFontSize` grammar: `undefined`
+    // inherits the parsed value (after running it through the
+    // half-step / range normalizer), `null` drops it (the writer
+    // emits no `<c:txPr>` block), a number replaces.
+    const resolvedLegendFontSize = resolveLegendFontSize(
+      source.legendFontSize,
+      options.legendFontSize,
+    );
+    if (resolvedLegendFontSize !== undefined) out.legendFontSize = resolvedLegendFontSize;
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -2411,6 +2450,33 @@ function resolveLegendEntries(
   if (override === null) return undefined;
   if (!Array.isArray(override) || override.length === 0) return undefined;
   return override.map((entry) => ({ ...entry }));
+}
+
+/**
+ * Resolve a `legendFontSize` override.
+ *
+ * `undefined` → inherit the source's parsed `legendFontSize` (after
+ *               running it through {@link normalizeTitleFontSize} so
+ *               an out-of-range parsed value drops cleanly).
+ * `null`      → drop the inherited value (the writer falls back to
+ *               Excel's theme-default 9pt — no `<c:txPr>` block on
+ *               the legend).
+ * `number`    → replace, after clamping / rounding through
+ *               {@link normalizeTitleFontSize}.
+ *
+ * The grammar mirrors `titleFontSize` / `axisTitleFontSize` /
+ * `axes.x.labelFontSize` so the typography knobs compose the same way
+ * at the call site. Callers should gate the result on the resolved
+ * legend visibility — when no legend is emitted, the size has no slot
+ * in the rendered chart.
+ */
+function resolveLegendFontSize(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeTitleFontSize(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleFontSize(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -418,6 +418,16 @@ export function parseChart(xml: string): Chart | undefined {
     // visible legend. Same scoping rule as `legendOverlay`.
     const legendEntries = parseLegendEntries(chartEl);
     if (legendEntries !== undefined) out.legendEntries = legendEntries;
+
+    // `<c:legend><c:txPr>` carries the legend's typography pins —
+    // tick-label / axis-title / chart-title style. The CT_Legend schema
+    // places `<c:txPr>` after `<c:overlay>` (and before `<c:extLst>`).
+    // A hidden or missing legend has no slot for the block, so the
+    // parser only inspects it when the chart actually declares a
+    // visible legend. Same scoping rule as `legendOverlay` /
+    // `legendEntries`.
+    const legendFontSize = parseLegendFontSize(chartEl);
+    if (legendFontSize !== undefined) out.legendFontSize = legendFontSize;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -2791,6 +2801,59 @@ function parseLegendEntries(chartEl: XmlElement): ChartLegendEntry[] | undefined
   }
 
   return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Pull `<c:legend><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+ * </c:txPr></c:legend>` off the chart. Returns the font size in points
+ * (range `1..400`).
+ *
+ * The OOXML `sz` attribute is in 100ths of a point — the reader
+ * converts to points and rounds to the nearest 0.5pt (Excel's UI
+ * exposes the same 0.5pt granularity). Absence of the element /
+ * attribute and out-of-range / non-numeric / non-finite values all
+ * collapse to `undefined` so a fresh chart and a chart that pinned an
+ * out-of-range size both round-trip to the writer's "skip the size
+ * attribute" path.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:legend>` element
+ * — there is no `<c:txPr>` slot to surface the size from in that case.
+ * The `<a:defRPr>` lives inside `<c:txPr><a:p><a:pPr>` per the
+ * CT_TextBody schema (the default-paragraph properties on the
+ * legend's text-body's first paragraph); the lookup is scoped to that
+ * path so a stray `<a:defRPr>` elsewhere in the chart (e.g. on the
+ * chart title or an axis) cannot leak in. Mirrors the chart-title /
+ * axis-title / axis tick-label readers exactly so a parsed value slots
+ * straight back into the writer's emit path.
+ */
+function parseLegendFontSize(chartEl: XmlElement): number | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const txPr = findChild(legend, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.sz;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 100ths of a point to points, rounding to the nearest
+  // 0.5pt to match the granularity Excel's UI exposes. `Math.round`
+  // on `2 * (parsed / 100)` and dividing by 2 gives a clean half-step
+  // band that mirrors the writer's emit-time normalization. The
+  // chart-title / axis-title / tick-label sibling parsers use the
+  // identical conversion so a parsed value flows through every
+  // typography slot without bookkeeping the units.
+  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -124,7 +124,12 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   // ── Legend ──
   if (legendPos) {
     chartChildren.push(
-      buildLegend(legendPos, resolveLegendOverlay(chart), resolveLegendEntries(chart)),
+      buildLegend(
+        legendPos,
+        resolveLegendOverlay(chart),
+        resolveLegendEntries(chart),
+        resolveLegendFontSize(chart),
+      ),
     );
   }
 
@@ -3922,6 +3927,7 @@ function buildLegend(
   pos: LegendPos,
   overlay: boolean,
   entries: readonly ResolvedLegendEntry[],
+  fontSizePt: number | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -3944,7 +3950,74 @@ function buildLegend(
   }
 
   children.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
+
+  // CT_Legend sequence places `<c:txPr>` after `<c:overlay>` (and
+  // before the optional `<c:extLst>`). The writer skips emission
+  // entirely when no typography knob is pinned so a fresh chart matches
+  // Excel's reference serialization byte-for-byte (Excel itself omits
+  // the block whenever the legend renders at the theme-default 9pt).
+  // Currently the block carries the legend font size only; future
+  // typography pins (bold / italic / color) will land on the same
+  // `<a:defRPr>` slot. The `<a:bodyPr>` carries no rotation attribute
+  // — the legend is not rotatable in Excel's UI, mirroring how the
+  // axis tick-label `<c:txPr>` slot drops `rot` when only a size is
+  // pinned.
+  const txPrXml = buildLegendTxPr(fontSizePt);
+  if (txPrXml !== undefined) {
+    children.push(txPrXml);
+  }
+
   return xmlElement("c:legend", undefined, children);
+}
+
+/**
+ * Build the `<c:txPr>` block that carries the legend's typography pins
+ * (currently the font size). Returns `undefined` when every input is
+ * unset so the caller can elide the element entirely (Excel's
+ * reference serialization omits `<c:txPr>` from `<c:legend>` when the
+ * legend renders at the theme-default 9pt).
+ *
+ * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
+ * when the user pins a legend font size — `<a:bodyPr/>` (no rotation
+ * because the legend is not rotatable), `<a:lstStyle/>` is the empty
+ * list-style placeholder the schema requires, and the
+ * `<a:p><a:pPr><a:defRPr sz="N"/></a:pPr><a:endParaRPr/></a:p>`
+ * paragraph stub Excel always emits hosts the size attribute on
+ * `<a:defRPr>`. Mirrors {@link buildAxisTxPr} for the tick-label slot
+ * exactly so a re-parse picks the value off the canonical
+ * default-paragraph slot every other typography reader expects.
+ */
+function buildLegendTxPr(fontSizePt: number | undefined): string | undefined {
+  if (fontSizePt === undefined) return undefined;
+  const sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  return xmlElement("c:txPr", undefined, [
+    xmlSelfClose("a:bodyPr"),
+    xmlSelfClose("a:lstStyle"),
+    xmlElement("a:p", undefined, [
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", { sz })]),
+      xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
+    ]),
+  ]);
+}
+
+/**
+ * Resolve `<c:legend><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+ * </a:p></c:txPr></c:legend>` from {@link SheetChart.legendFontSize}.
+ *
+ * Returns the size in points (`1..400`), or `undefined` when the chart
+ * leaves the field unset / passed an out-of-range or non-numeric token.
+ * The flag is only meaningful when the chart actually emits a legend —
+ * the caller is expected to gate the call on the resolved legend
+ * visibility (`resolveLegendPosition` returning a non-null value), so a
+ * chart that hides the legend silently drops the value rather than
+ * emit a `<c:txPr>` block with no on-screen effect.
+ *
+ * Mirrors `resolveTitleFontSize` / `resolveAxisTitleFontSize` /
+ * `resolveAxisLabelFontSize` exactly so a single configuration call
+ * threads cleanly through every typography slot Excel exposes.
+ */
+function resolveLegendFontSize(chart: SheetChart): number | undefined {
+  return normalizeTitleFontSize(chart.legendFontSize);
 }
 
 interface ResolvedLegendEntry {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4492,6 +4492,300 @@ describe("cloneChart — legendOverlay", () => {
   });
 });
 
+// ── cloneChart — legendFontSize ──────────────────────────────────────
+
+describe("cloneChart — legendFontSize", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendFontSize by default", () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFontSize).toBe(12);
+  });
+
+  it("lets options.legendFontSize override the source's value", () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: 16,
+    });
+    expect(clone.legendFontSize).toBe(16);
+  });
+
+  it("drops the inherited legendFontSize when the override is null", () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: null,
+    });
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("returns undefined legendFontSize when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("rounds the override to the nearest 0.5pt (Excel UI granularity)", () => {
+    // 12.3 rounds to 12.5; 12.24 rounds to 12.
+    const a = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: 12.3,
+    });
+    expect(a.legendFontSize).toBe(12.5);
+    const b = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: 12.24,
+    });
+    expect(b.legendFontSize).toBe(12);
+  });
+
+  it("rounds an inherited fractional source value through the same half-step normalizer", () => {
+    // A parsed value just slightly off the half-step grid (e.g. 12.3
+    // pt) collapses to the nearest 0.5pt so the cloned SheetChart is
+    // guaranteed to round-trip.
+    const clone = cloneChart(source({ legendFontSize: 12.3 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFontSize).toBe(12.5);
+  });
+
+  it("collapses out-of-range overrides to undefined (>400pt, inherit path)", () => {
+    // Override is non-finite / out-of-range — the cloned shape drops
+    // to undefined rather than carry a value the writer would silently
+    // elide. (`undefined` semantics: inherit; the inherit then drops.)
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: 401,
+    });
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("collapses out-of-range overrides to undefined (<1pt)", () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: 0.5,
+    });
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("collapses non-finite overrides (NaN / Infinity)", () => {
+    const a = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: Number.NaN,
+    });
+    expect(a.legendFontSize).toBeUndefined();
+    const b = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontSize: Number.POSITIVE_INFINITY,
+    });
+    expect(b.legendFontSize).toBeUndefined();
+  });
+
+  it("collapses non-numeric overrides (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendFontSize: "twelve" as any,
+    });
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("carries legendFontSize through a flatten (line → column)", () => {
+    // The size lives on `<c:legend>` and is valid on every chart family.
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendFontSize).toBe(12);
+  });
+
+  it("carries legendFontSize through a doughnut flatten (line → doughnut)", () => {
+    // No chart-family restriction — even doughnut, which has no axes,
+    // must preserve the legend font size.
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendFontSize).toBe(12);
+  });
+
+  it("drops the inherited legendFontSize when the resolved legend is hidden", () => {
+    // legend === false suppresses the entire <c:legend> on the writer
+    // side, so an inherited size would never render. The clone collapses
+    // the field to keep the SheetChart honest.
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("drops the legendFontSize override when the resolved legend is hidden", () => {
+    // Same guard, this time on the override path.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendFontSize: 12,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendFontSize).toBeUndefined();
+  });
+
+  it("retains the legendFontSize override when the override re-enables a hidden source legend", () => {
+    // Source pinned legend:false (so legendFontSize would normally be
+    // undefined), but the override re-enables a visible legend — the
+    // size the override carries must thread through.
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendFontSize: 12,
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendFontSize).toBe(12);
+  });
+
+  it("composes with legendOverlay and legendEntries on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendFontSize).toBe(12);
+    expect(clone.legendOverlay).toBe(true);
+    expect(clone.legendEntries).toEqual([{ idx: 0, delete: true }]);
+  });
+
+  it("propagates legendFontSize into the rendered <c:legend><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('sz="1200"');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFontSize).toBe(12);
+  });
+
+  it("emits no <c:txPr> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendFontSize).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ legendFontSize: 9 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendFontSize: 18,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('sz="1800"');
+    expect(legend).not.toContain('sz="900"');
+    expect(parseChart(written)?.legendFontSize).toBe(18);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:txPr> emitted)", async () => {
+    const clone = cloneChart(source({ legendFontSize: 12 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendFontSize: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendFontSize).toBeUndefined();
+  });
+});
+
 // ── cloneChart — axis lblAlgn ───────────────────────────────────────
 
 describe("cloneChart — axis lblAlgn", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4253,6 +4253,195 @@ describe("writeChart — legendOverlay", () => {
   });
 });
 
+// ── writeChart — legend font size ────────────────────────────────────
+
+describe("writeChart — legendFontSize", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when legendFontSize is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:txPr>");
+    expect(legend).not.toContain("a:defRPr");
+  });
+
+  it("threads legendFontSize=12 through to <c:legend><c:txPr> as sz=1200", () => {
+    const result = writeChart(makeChart({ legendFontSize: 12 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('sz="1200"');
+  });
+
+  it("threads legendFontSize=14 through as sz=1400", () => {
+    const result = writeChart(makeChart({ legendFontSize: 14 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('sz="1400"');
+  });
+
+  it("threads half-point sizes through (legendFontSize=10.5 -> sz=1050)", () => {
+    const result = writeChart(makeChart({ legendFontSize: 10.5 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('sz="1050"');
+  });
+
+  it("rounds finer-than-half-step inputs to the nearest 0.5pt", () => {
+    // 10.3 -> halfSteps = round(20.6) = 21 -> 10.5pt -> sz=1050.
+    const a = writeChart(makeChart({ legendFontSize: 10.3 }), "Sheet1");
+    expect(legendOf(a.chartXml)).toContain('sz="1050"');
+    // 10.24 -> halfSteps = round(20.48) = 20 -> 10pt -> sz=1000.
+    const b = writeChart(makeChart({ legendFontSize: 10.24 }), "Sheet1");
+    expect(legendOf(b.chartXml)).toContain('sz="1000"');
+  });
+
+  it("places <c:txPr> after <c:overlay> inside <c:legend> (OOXML order)", () => {
+    // CT_Legend sequence: legendPos?, legendEntry*, layout?, overlay?,
+    // spPr?, txPr?, extLst? — `<c:txPr>` lands after `<c:overlay>`.
+    const result = writeChart(makeChart({ legendFontSize: 12 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits <c:txPr> once inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendFontSize: 12 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendFontSize set", () => {
+    const result = writeChart(makeChart({ legend: false, legendFontSize: 12 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendFontSize through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendFontSize: 12 }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('sz="1200"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendFontSize: 12,
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('sz="1200"');
+  });
+
+  it("drops out-of-range values (>400pt) — the txPr block is not emitted", () => {
+    const result = writeChart(makeChart({ legendFontSize: 401 }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops out-of-range values (<1pt) — the txPr block is not emitted", () => {
+    const result = writeChart(makeChart({ legendFontSize: 0.5 }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-finite inputs (NaN / Infinity)", () => {
+    const a = writeChart(makeChart({ legendFontSize: Number.NaN }), "Sheet1");
+    expect(legendOf(a.chartXml)).not.toContain("<c:txPr>");
+    const b = writeChart(makeChart({ legendFontSize: Number.POSITIVE_INFINITY }), "Sheet1");
+    expect(legendOf(b.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-numeric inputs (string leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendFontSize: "twelve" as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    // The block should mirror Excel's reference legend-typography
+    // emission: <a:bodyPr/> with no rotation, <a:lstStyle/>, and a
+    // <a:p><a:pPr><a:defRPr sz="N"/></a:pPr><a:endParaRPr/></a:p>
+    // paragraph stub.
+    const result = writeChart(makeChart({ legendFontSize: 12 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<a:bodyPr/>");
+    expect(legend).toContain("<a:lstStyle/>");
+    expect(legend).toContain('<a:defRPr sz="1200"/>');
+    expect(legend).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("emits <a:bodyPr/> without a rot attribute (legend is not rotatable)", () => {
+    const result = writeChart(makeChart({ legendFontSize: 12 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    // The bodyPr should have no rotation attribute — only an empty
+    // self-closing element.
+    expect(legend).toContain("<a:bodyPr/>");
+    // Sanity-check no rot attribute leaks in.
+    const bodyPr = legend.match(/<a:bodyPr[^/]*\/>/);
+    expect(bodyPr?.[0]).toBe("<a:bodyPr/>");
+  });
+
+  it("round-trips a legendFontSize value through parseChart", () => {
+    const written = writeChart(makeChart({ legendFontSize: 12 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFontSize).toBe(12);
+  });
+
+  it("collapses an unset legendFontSize round-trip back to undefined", () => {
+    // Absence on the writer side => no <c:txPr>; the reader returns
+    // undefined for absence. Round-trip is lossless.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendFontSize).toBeUndefined();
+  });
+
+  it("composes with legendOverlay and legendEntries on the same <c:legend>", () => {
+    const result = writeChart(
+      makeChart({
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('sz="1200"');
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).toContain("c:legendEntry");
+    // OOXML ordering: legendPos -> legendEntry -> overlay -> txPr.
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:legendEntry"));
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:overlay"));
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("survives a writeXlsx round trip — legendFontSize lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendFontSize: 12,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const legend = chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('sz="1200"');
+  });
+});
+
 // ── writeChart — data labels showLegendKey ──────────────────────────
 
 describe("writeChart — data labels showLegendKey", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5032,6 +5032,235 @@ describe("parseChart — legendOverlay", () => {
   });
 });
 
+// ── parseChart — legend font size ────────────────────────────────────
+
+describe("parseChart — legendFontSize", () => {
+  const NS_LFS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendSz(sz: string | undefined): string {
+    const defRPr = sz === undefined ? "<a:defRPr/>" : `<a:defRPr sz="${sz}"/>`;
+    return `<c:chartSpace ${NS_LFS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the size in points from the sz attribute (100ths of a point)", () => {
+    // 12pt * 100 = 1200.
+    const chart = parseChart(withLegendSz("1200"));
+    expect(chart?.legendFontSize).toBe(12);
+  });
+
+  it("surfaces the default 9pt size literally", () => {
+    // Excel writes sz="900" on every fresh chart legend whose typography
+    // has been customized — the reader surfaces it because it is a
+    // literal pin on the wire.
+    const chart = parseChart(withLegendSz("900"));
+    expect(chart?.legendFontSize).toBe(9);
+  });
+
+  it("rounds to the nearest 0.5pt", () => {
+    // sz="950" = 9.5pt — surfaces literally.
+    const a = parseChart(withLegendSz("950"));
+    expect(a?.legendFontSize).toBe(9.5);
+    // sz="924" = 9.24pt — rounds down to 9.
+    const b = parseChart(withLegendSz("924"));
+    expect(b?.legendFontSize).toBe(9);
+    // sz="980" = 9.8pt — rounds up to 10 (halfSteps `Math.round(19.6)=20`).
+    const c = parseChart(withLegendSz("980"));
+    expect(c?.legendFontSize).toBe(10);
+    // sz="930" = 9.3pt — rounds to 9.5 (halfSteps `Math.round(18.6)=19`).
+    const d = parseChart(withLegendSz("930"));
+    expect(d?.legendFontSize).toBe(9.5);
+  });
+
+  it("returns undefined when <a:defRPr> omits the sz attribute", () => {
+    const chart = parseChart(withLegendSz(undefined));
+    expect(chart?.legendFontSize).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS_LFS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legendFontSize).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:txPr> body", () => {
+    // A bare legend with only <c:legendPos> / <c:overlay> children has
+    // no <a:p><a:pPr><a:defRPr> to host the size.
+    const xml = `<c:chartSpace ${NS_LFS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFontSize).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> has no <a:p><a:pPr> chain", () => {
+    // A degenerate <c:txPr> with only <a:bodyPr> and <a:lstStyle> has
+    // no defRPr slot to surface a size from. The reader bails on the
+    // first missing link rather than fabricate a value.
+    const xml = `<c:chartSpace ${NS_LFS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFontSize).toBeUndefined();
+  });
+
+  it('drops the size when the legend is hidden via <c:delete val="1"/>', () => {
+    // A hidden legend (legend === false) has no <c:txPr> slot in the
+    // rendered chart, so the reader does not surface a value that would
+    // carry no on-screen effect through cloneChart.
+    const xml = `<c:chartSpace ${NS_LFS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendFontSize).toBeUndefined();
+  });
+
+  it("drops sz values below the 1pt minimum after rounding (sz=49)", () => {
+    // 49 / 100 = 0.49pt — half-step round lands at 0.5pt, which is
+    // outside the OOXML ST_TextFontSize 1pt minimum. (sz values from
+    // 75 onwards round up to 1.0pt and surface literally; 74 and below
+    // are dropped.)
+    expect(parseChart(withLegendSz("49"))?.legendFontSize).toBeUndefined();
+  });
+
+  it("drops sz values above the 400pt maximum (sz=400001)", () => {
+    expect(parseChart(withLegendSz("400001"))?.legendFontSize).toBeUndefined();
+  });
+
+  it("surfaces the 1pt minimum (sz=100)", () => {
+    expect(parseChart(withLegendSz("100"))?.legendFontSize).toBe(1);
+  });
+
+  it("surfaces the 400pt maximum (sz=40000)", () => {
+    expect(parseChart(withLegendSz("40000"))?.legendFontSize).toBe(400);
+  });
+
+  it("drops non-numeric sz tokens", () => {
+    expect(parseChart(withLegendSz("twelve"))?.legendFontSize).toBeUndefined();
+  });
+
+  it("drops empty sz tokens", () => {
+    expect(parseChart(withLegendSz(""))?.legendFontSize).toBeUndefined();
+  });
+
+  it("co-surfaces alongside legendOverlay and other legend fields", () => {
+    const xml = `<c:chartSpace ${NS_LFS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:legendEntry>
+        <c:idx val="0"/>
+        <c:delete val="1"/>
+      </c:legendEntry>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("bottom");
+    expect(chart?.legendOverlay).toBe(true);
+    expect(chart?.legendEntries).toEqual([{ idx: 0, delete: true }]);
+    expect(chart?.legendFontSize).toBe(14);
+  });
+
+  it("surfaces the size on every chart family that emits a legend", () => {
+    // The element lives on <c:legend>, which is a sibling of
+    // <c:plotArea> on every chart-family <c:chart>; the size should
+    // round-trip identically across families. Pie / doughnut / line /
+    // bar all emit legends by default.
+    for (const kind of ["lineChart", "barChart", "pieChart", "doughnutChart"]) {
+      const xml = `<c:chartSpace ${NS_LFS}>
+  <c:chart>
+    <c:plotArea>
+      <c:${kind}><c:ser><c:idx val="0"/></c:ser></c:${kind}>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1100"/></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.legendFontSize).toBe(11);
+    }
+  });
+});
+
 // ── parseChart — data labels showLegendKey ──────────────────────────
 
 describe("parseChart — data labels showLegendKey", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:legend><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr></c:legend>` at the read, write, and clone layers so a template's legend font-size pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `legendFontSize?: number` on `SheetChart` (writer side) and the matching `legendFontSize?: number` on `Chart` (reader side). Sits on the same `<c:legend>` element as `legend` / `legendOverlay` / `legendEntries`; the writer emits a single `<c:txPr>` block on the legend whenever the field is set. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user pinned a custom legend size (e.g. shrinking the swatch labels to fit a tight sidebar slot) now round-trips that pin through the parse / clone / write loop.

Modeled in points (whole / half) for symmetry with the chart-title `titleFontSize` (#250-ish), the axis-title `axisTitleFontSize` (#255), and the axis tick-label `labelFontSize` (#263): same `1..400`pt band, same 0.5pt half-step rounding (Excel's UI granularity), same OOXML 100ths-of-a-point conversion factor. Out-of-range / non-finite / non-numeric inputs collapse to `undefined` so the writer drops the `<c:txPr>` block entirely and the rendered legend falls back to Excel's theme-default 9pt.

The clone layer follows the standard `number | null` override grammar: `undefined` inherits, `null` drops, and a literal number replaces. Non-numeric overrides (typed escapes from an untyped caller) collapse to `undefined` so the cloned `SheetChart` always carries a value the writer will accept. A hidden legend (`legend === false`) silently drops the inherited / overridden value — there is no `<c:txPr>` slot to host the size on a hidden legend, so leaking the value into the output would carry a pin Excel never reads.

The `<c:txPr>` block lands after `<c:overlay>` and before the optional `<c:extLst>`, matching the CT_Legend schema sequence (ECMA-376 Part 1, §21.2.2.114). The `<a:bodyPr>` is emitted without a `rot` attribute — the legend is not rotatable in Excel's UI, so the writer keeps the body-properties element minimal and only carries the `<a:defRPr sz="N"/>` slot inside the paragraph stub. The flag rides on every chart family that emits a legend (bar / column / line / area / scatter / pie / doughnut).

Refs #136

## Test plan

- [x] `pnpm test` passes (5118 tests across 89 files, lint + format + typecheck + vitest)
- [x] `pnpm build` succeeds
- [x] New describe blocks: `parseChart — legendFontSize` (15 cases), `writeChart — legendFontSize` (17 cases), `cloneChart — legendFontSize` (20 cases) covering parse, write, end-to-end `writeXlsx`, half-step rounding, out-of-range / non-numeric / non-finite drops, hidden-legend scoping, OOXML element ordering, multi-family coverage (bar / column / line / pie / doughnut / area / scatter), and composition with the sibling legend knobs (`legendOverlay` / `legendEntries`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)