### PR TITLE
feat(xlsx): chart legend italic flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1356,6 +1356,38 @@ export interface SheetChart {
    * cleanly through every legend knob Excel exposes.
    */
   legendBold?: boolean;
+  /**
+   * Legend italic flag. Maps to `<c:legend><c:txPr><a:p><a:pPr>
+   * <a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:legend>` — Excel's
+   * "Format Legend -> Font -> Italic" toggle. The OOXML attribute is
+   * the `xsd:boolean` `i` on `CT_TextCharacterProperties` (ECMA-376
+   * Part 1, §21.1.2.3.7); the writer lands the value on the
+   * default-paragraph `<a:defRPr>` slot inside the legend's
+   * `<c:txPr>` block so a re-parse picks the flag up off the canonical
+   * slot the OOXML schema exposes.
+   *
+   * Default: omitted — the legend renders non-italic (no `i`
+   * attribute, matching Excel's reference serialization for a fresh
+   * chart legend whose typography has not been customized; the OOXML
+   * default `false` collapses to absence). Set `true` to emit `i="1"`
+   * so the legend renders italic; set `false` explicitly to pin the
+   * non-default `i="0"` (functionally identical to omission, but
+   * useful when overriding a templated legend that had italic pinned
+   * upstream).
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no `<c:txPr>` slot to host the flag in
+   * that case. Mirrors {@link titleItalic} /
+   * {@link axes.x.axisTitleItalic} / {@link axes.x.labelItalic} —
+   * same boolean-with-explicit-default shape, same OOXML
+   * `<a:defRPr i=".."/>` mapping — so a caller can thread a single
+   * italic value through every typography-pinning slot. Composes
+   * independently with {@link legend} / {@link legendOverlay} /
+   * {@link legendEntries}: all four fields land on the same
+   * `<c:legend>` element so a single configuration call threads
+   * cleanly through every legend knob Excel exposes.
+   */
+  legendItalic?: boolean;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -5037,6 +5069,24 @@ export interface Chart {
    * slots straight into {@link cloneChart} without conversion.
    */
   legendBold?: boolean;
+  /**
+   * Legend italic flag pulled from `<c:legend><c:txPr><a:p><a:pPr>
+   * <a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:legend>`. The OOXML
+   * `i` attribute is the `xsd:boolean` italic flag on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `i="0"` round-trip identically — only an explicit `i="1"` surfaces
+   * `true`. Unknown / malformed `i` tokens drop to `undefined` rather
+   * than fabricate a value the writer would never emit.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:txPr>` slot to surface the flag from in either case. Mirrors
+   * the writer-side {@link SheetChart.legendItalic} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   */
+  legendItalic?: boolean;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -226,6 +226,30 @@ export interface CloneChartOptions {
    * round-trips that pin through the parse / clone / write loop.
    */
   legendBold?: boolean | null;
+  /**
+   * Override `SheetChart.legendItalic`. `undefined` (or omitted)
+   * inherits the source's parsed `legendItalic`; `null` drops the
+   * inherited flag (the writer emits no `<c:txPr>` block on the
+   * legend, falling back to the OOXML default — no `i` attribute,
+   * equivalent to non-italic); a `boolean` replaces. Non-boolean
+   * overrides (typed escapes from an untyped caller) collapse to
+   * `undefined` so a typed escape cannot pin a value the writer
+   * would silently elide.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved legend is `false` (no `<c:legend>` element will
+   * be emitted) — there is no `<c:txPr>` slot to host the flag on a
+   * hidden legend, so leaking the value into the output would carry
+   * a pin Excel never reads.
+   *
+   * The grammar mirrors `titleItalic` / `axes.x.axisTitleItalic` /
+   * `axes.x.labelItalic` so the typography knobs compose the same way
+   * at the call site. Bridges another typography-customization gap
+   * for the dashboard composition flow tracked in #136 — a templated
+   * dashboard chart whose user pinned a custom legend italic flag now
+   * round-trips that pin through the parse / clone / write loop.
+   */
+  legendItalic?: boolean | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1415,6 +1439,12 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // (the writer emits no `<c:txPr>` block), a `boolean` replaces.
     const resolvedLegendBold = resolveLegendBold(source.legendBold, options.legendBold);
     if (resolvedLegendBold !== undefined) out.legendBold = resolvedLegendBold;
+
+    // Same hidden-legend scoping for the italic flag: `undefined`
+    // inherits (after the boolean normalizer), `null` drops, a
+    // `boolean` replaces.
+    const resolvedLegendItalic = resolveLegendItalic(source.legendItalic, options.legendItalic);
+    if (resolvedLegendItalic !== undefined) out.legendItalic = resolvedLegendItalic;
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -2549,6 +2579,44 @@ function resolveLegendBold(
   if (override === undefined) return normalizeLegendBold(sourceValue);
   if (override === null) return undefined;
   return normalizeLegendBold(override);
+}
+
+/**
+ * Normalize a `legendItalic` value for the cloned `SheetChart`. Mirrors
+ * the writer's `resolveLegendItalic` — `true` / `false` pass through
+ * literally, every other token (typed escape from an untyped caller)
+ * collapses to `undefined`.
+ */
+function normalizeLegendItalic(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `legendItalic` override.
+ *
+ * `undefined` → inherit the source's parsed `legendItalic` (after
+ *               running it through {@link normalizeLegendItalic} so a
+ *               typed escape on the source path drops cleanly).
+ * `null`      → drop the inherited flag (the writer falls back to the
+ *               OOXML default — no `i` attribute, equivalent to
+ *               non-italic).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `titleItalic` / `axisTitleItalic` /
+ * `axes.x.labelItalic` so the typography knobs compose the same way at
+ * the call site. Callers should gate the result on the resolved legend
+ * visibility — when no legend is emitted, the flag has no slot in the
+ * rendered chart.
+ */
+function resolveLegendItalic(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeLegendItalic(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendItalic(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -434,6 +434,12 @@ export function parseChart(xml: string): Chart | undefined {
     // so absence and `b="0"` round-trip identically.
     const legendBold = parseLegendBold(chartEl);
     if (legendBold !== undefined) out.legendBold = legendBold;
+
+    // Same scoping for the italic flag — only an explicit `i="1"`
+    // surfaces `true`; the OOXML default and absence both collapse to
+    // `undefined`.
+    const legendItalic = parseLegendItalic(chartEl);
+    if (legendItalic !== undefined) out.legendItalic = legendItalic;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -2901,6 +2907,39 @@ function parseLegendBold(chartEl: XmlElement): boolean | undefined {
   // explicit `b="0"` round-trip identically through `cloneChart`.
   // Unknown / missing `b` tokens drop to `undefined` for the same
   // reason — never fabricate a flag Excel would not emit.
+  if (raw === "1" || raw === "true") return true;
+  return undefined;
+}
+
+/**
+ * Pull `<c:legend><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+ * </c:txPr></c:legend>` off the chart. Returns the italic flag.
+ *
+ * The OOXML `i` attribute is the `xsd:boolean` italic flag on
+ * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7). The
+ * OOXML default `false` collapses to `undefined` so absence and
+ * `i="0"` round-trip identically — only an explicit `i="1"` surfaces
+ * `true`. Unknown / malformed `i` tokens drop to `undefined` rather
+ * than fabricate a value the writer would never emit.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:legend>`
+ * element — there is no `<c:txPr>` slot to surface the flag from in
+ * that case. Mirrors the chart-title / axis-title / axis tick-label
+ * readers exactly so a parsed value slots straight back into the
+ * writer's emit path.
+ */
+function parseLegendItalic(chartEl: XmlElement): boolean | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const txPr = findChild(legend, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.i;
   if (raw === "1" || raw === "true") return true;
   return undefined;
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -130,6 +130,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendEntries(chart),
         resolveLegendFontSize(chart),
         resolveLegendBold(chart),
+        resolveLegendItalic(chart),
       ),
     );
   }
@@ -3930,6 +3931,7 @@ function buildLegend(
   entries: readonly ResolvedLegendEntry[],
   fontSizePt: number | undefined,
   bold: boolean | undefined,
+  italic: boolean | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -3958,13 +3960,13 @@ function buildLegend(
   // entirely when no typography knob is pinned so a fresh chart matches
   // Excel's reference serialization byte-for-byte (Excel itself omits
   // the block whenever the legend renders at the theme-default style).
-  // The block currently carries the legend font size and bold flag;
-  // future typography pins (italic / color) will land on the same
+  // The block currently carries the legend font size, bold, and italic
+  // flags; future typography pins (color) will land on the same
   // `<a:defRPr>` slot. The `<a:bodyPr>` carries no rotation attribute
   // — the legend is not rotatable in Excel's UI, mirroring how the
   // axis tick-label `<c:txPr>` slot drops `rot` when only typography
   // knobs are pinned.
-  const txPrXml = buildLegendTxPr(fontSizePt, bold);
+  const txPrXml = buildLegendTxPr(fontSizePt, bold, italic);
   if (txPrXml !== undefined) {
     children.push(txPrXml);
   }
@@ -3974,35 +3976,38 @@ function buildLegend(
 
 /**
  * Build the `<c:txPr>` block that carries the legend's typography pins
- * (currently the font size and bold flag). Returns `undefined` when
- * every input is unset so the caller can elide the element entirely
- * (Excel's reference serialization omits `<c:txPr>` from `<c:legend>`
- * when the legend renders at the theme-default style).
+ * (currently the font size, bold, and italic flags). Returns
+ * `undefined` when every input is unset so the caller can elide the
+ * element entirely (Excel's reference serialization omits `<c:txPr>`
+ * from `<c:legend>` when the legend renders at the theme-default
+ * style).
  *
  * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
  * when the user pins a legend typography knob — `<a:bodyPr/>` (no
  * rotation because the legend is not rotatable), `<a:lstStyle/>` is
  * the empty list-style placeholder the schema requires, and the
- * `<a:p><a:pPr><a:defRPr sz="N" b=".."/></a:pPr><a:endParaRPr/></a:p>`
- * paragraph stub Excel always emits hosts the typography attributes on
- * `<a:defRPr>`. Mirrors the chart-title / axis-title / tick-label
- * `<c:txPr>` slots exactly so a re-parse picks the values off the
- * canonical default-paragraph slot every other typography reader
- * expects.
+ * `<a:p><a:pPr><a:defRPr sz="N" b=".." i=".."/></a:pPr><a:endParaRPr/>
+ * </a:p>` paragraph stub Excel always emits hosts the typography
+ * attributes on `<a:defRPr>`. Mirrors the chart-title / axis-title /
+ * tick-label `<c:txPr>` slots exactly so a re-parse picks the values
+ * off the canonical default-paragraph slot every other typography
+ * reader expects.
  *
- * The bold flag emits a literal `b="1"` / `b="0"` whenever the input
- * is a boolean — `false` pins the OOXML default explicitly, which is
- * functionally identical to absence but lets a clone target override
- * an upstream `b="1"` from a templated chart.
+ * The bold / italic flags emit literal `b="1"` / `b="0"` / `i="1"` /
+ * `i="0"` whenever the input is a boolean — `false` pins the OOXML
+ * default explicitly, which is functionally identical to absence but
+ * lets a clone target override an upstream `1` from a templated chart.
  */
 function buildLegendTxPr(
   fontSizePt: number | undefined,
   bold: boolean | undefined,
+  italic: boolean | undefined,
 ): string | undefined {
-  if (fontSizePt === undefined && bold === undefined) return undefined;
+  if (fontSizePt === undefined && bold === undefined && italic === undefined) return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
+  if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),
@@ -4052,6 +4057,26 @@ function resolveLegendFontSize(chart: SheetChart): number | undefined {
  */
 function resolveLegendBold(chart: SheetChart): boolean | undefined {
   const value = chart.legendBold;
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve `<c:legend><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+ * </a:p></c:txPr></c:legend>` from {@link SheetChart.legendItalic}.
+ *
+ * Returns the italic flag, or `undefined` when the chart leaves the
+ * field unset / passed a non-boolean token. The flag is only
+ * meaningful when the chart actually emits a legend — the caller is
+ * expected to gate the call on the resolved legend visibility.
+ *
+ * Mirrors `resolveTitleItalic` / `resolveAxisTitleItalic` /
+ * `resolveAxisLabelItalic` exactly — only literal `true` / `false`
+ * pass through; non-boolean tokens collapse to `undefined`.
+ */
+function resolveLegendItalic(chart: SheetChart): boolean | undefined {
+  const value = chart.legendItalic;
   if (value === true) return true;
   if (value === false) return false;
   return undefined;

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -5043,6 +5043,239 @@ describe("cloneChart — legendBold", () => {
   });
 });
 
+// ── cloneChart — legendItalic ────────────────────────────────────────
+
+describe("cloneChart — legendItalic", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendItalic by default", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendItalic).toBe(true);
+  });
+
+  it("lets options.legendItalic override the source's value", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendItalic: false,
+    });
+    expect(clone.legendItalic).toBe(false);
+  });
+
+  it("drops the inherited legendItalic when the override is null", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendItalic: null,
+    });
+    expect(clone.legendItalic).toBeUndefined();
+  });
+
+  it("returns undefined legendItalic when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendItalic).toBeUndefined();
+  });
+
+  it("collapses non-boolean overrides to undefined (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendItalic: "yes" as any,
+    });
+    expect(clone.legendItalic).toBeUndefined();
+  });
+
+  it("normalizes a non-boolean source value (typed escape) to undefined", () => {
+    const malformed = source({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendItalic: "yes" as any,
+    });
+    const clone = cloneChart(malformed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendItalic).toBeUndefined();
+  });
+
+  it("carries legendItalic through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendItalic).toBe(true);
+  });
+
+  it("carries legendItalic through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendItalic).toBe(true);
+  });
+
+  it("drops the inherited legendItalic when the resolved legend is hidden", () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendItalic).toBeUndefined();
+  });
+
+  it("drops the legendItalic override when the resolved legend is hidden", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendItalic: true,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendItalic).toBeUndefined();
+  });
+
+  it("retains the legendItalic override when the override re-enables a hidden source legend", () => {
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendItalic: true,
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendItalic).toBe(true);
+  });
+
+  it("composes with legendOverlay and legendEntries on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        legendItalic: true,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendItalic).toBe(true);
+    expect(clone.legendOverlay).toBe(true);
+    expect(clone.legendEntries).toEqual([{ idx: 0, delete: true }]);
+  });
+
+  it("propagates legendItalic into the rendered <c:legend><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('i="1"');
+    expect(parseChart(written)?.legendItalic).toBe(true);
+  });
+
+  it("emits no <c:txPr> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendItalic).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendItalic: false,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('i="0"');
+    expect(legend).not.toContain('i="1"');
+    expect(parseChart(written)?.legendItalic).toBeUndefined();
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:txPr> emitted)", async () => {
+    const clone = cloneChart(source({ legendItalic: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendItalic: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendItalic).toBeUndefined();
+  });
+});
+
 // ── cloneChart — axis lblAlgn ───────────────────────────────────────
 
 describe("cloneChart — axis lblAlgn", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4601,6 +4601,160 @@ describe("writeChart — legendBold", () => {
   });
 });
 
+// ── writeChart — legend italic ───────────────────────────────────────
+
+describe("writeChart — legendItalic", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when legendItalic is unset", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:txPr>");
+    expect(legend).not.toContain("a:defRPr");
+  });
+
+  it("threads legendItalic=true through to <c:legend><c:txPr> as i='1'", () => {
+    const result = writeChart(makeChart({ legendItalic: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('i="1"');
+  });
+
+  it("threads legendItalic=false through as i='0' (explicit non-default)", () => {
+    const result = writeChart(makeChart({ legendItalic: false }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('i="0"');
+  });
+
+  it("places <c:txPr> after <c:overlay> inside <c:legend> (OOXML order)", () => {
+    const result = writeChart(makeChart({ legendItalic: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits <c:txPr> once inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendItalic: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendItalic set", () => {
+    const result = writeChart(makeChart({ legend: false, legendItalic: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendItalic through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendItalic: true }), "Sheet1");
+      expect(legendOf(result.chartXml)).toContain('i="1"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendItalic: true,
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('i="1"');
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendItalic: "yes" as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops null inputs (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendItalic: null as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(makeChart({ legendItalic: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<a:bodyPr/>");
+    expect(legend).toContain("<a:lstStyle/>");
+    expect(legend).toContain('<a:defRPr i="1"/>');
+    expect(legend).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("emits <a:bodyPr/> without a rot attribute (legend is not rotatable)", () => {
+    const result = writeChart(makeChart({ legendItalic: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const bodyPr = legend.match(/<a:bodyPr[^/]*\/>/);
+    expect(bodyPr?.[0]).toBe("<a:bodyPr/>");
+  });
+
+  it("round-trips a legendItalic=true value through parseChart", () => {
+    const written = writeChart(makeChart({ legendItalic: true }), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendItalic).toBe(true);
+  });
+
+  it("collapses an unset legendItalic round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendItalic).toBeUndefined();
+  });
+
+  it("collapses a legendItalic=false round-trip back to undefined (i='0' is OOXML default)", () => {
+    const written = writeChart(makeChart({ legendItalic: false }), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendItalic).toBeUndefined();
+  });
+
+  it("composes with legendOverlay and legendEntries on the same <c:legend>", () => {
+    const result = writeChart(
+      makeChart({
+        legendItalic: true,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('i="1"');
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).toContain("c:legendEntry");
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:legendEntry"));
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:overlay"));
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("survives a writeXlsx round trip — legendItalic lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendItalic: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const legend = chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('i="1"');
+  });
+});
+
 // ── writeChart — data labels showLegendKey ──────────────────────────
 
 describe("writeChart — data labels showLegendKey", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5441,6 +5441,186 @@ describe("parseChart — legendBold", () => {
   });
 });
 
+// ── parseChart — legend italic ───────────────────────────────────────
+
+describe("parseChart — legendItalic", () => {
+  const NS_LI = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendItalic(i: string | undefined): string {
+    const defRPr = i === undefined ? "<a:defRPr/>" : `<a:defRPr i="${i}"/>`;
+    return `<c:chartSpace ${NS_LI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces true when the legend pinned i='1'", () => {
+    expect(parseChart(withLegendItalic("1"))?.legendItalic).toBe(true);
+  });
+
+  it("accepts the OOXML 'true' spelling on i", () => {
+    expect(parseChart(withLegendItalic("true"))?.legendItalic).toBe(true);
+  });
+
+  it("collapses i='0' to undefined (OOXML default — non-italic)", () => {
+    expect(parseChart(withLegendItalic("0"))?.legendItalic).toBeUndefined();
+  });
+
+  it("collapses i='false' to undefined", () => {
+    expect(parseChart(withLegendItalic("false"))?.legendItalic).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the i attribute", () => {
+    expect(parseChart(withLegendItalic(undefined))?.legendItalic).toBeUndefined();
+  });
+
+  it("drops unknown i tokens rather than fabricate a value", () => {
+    expect(parseChart(withLegendItalic("italic"))?.legendItalic).toBeUndefined();
+    expect(parseChart(withLegendItalic(""))?.legendItalic).toBeUndefined();
+    expect(parseChart(withLegendItalic("2"))?.legendItalic).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS_LI}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendItalic).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_LI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendItalic).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> has no <a:p><a:pPr> chain", () => {
+    const xml = `<c:chartSpace ${NS_LI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendItalic).toBeUndefined();
+  });
+
+  it('drops the italic flag when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendItalic).toBeUndefined();
+  });
+
+  it("co-surfaces alongside legendOverlay and other legend fields", () => {
+    const xml = `<c:chartSpace ${NS_LI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:legendEntry>
+        <c:idx val="0"/>
+        <c:delete val="1"/>
+      </c:legendEntry>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="1"/></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("bottom");
+    expect(chart?.legendOverlay).toBe(true);
+    expect(chart?.legendEntries).toEqual([{ idx: 0, delete: true }]);
+    expect(chart?.legendItalic).toBe(true);
+  });
+
+  it("surfaces the italic flag on every chart family that emits a legend", () => {
+    for (const kind of ["lineChart", "barChart", "pieChart", "doughnutChart"]) {
+      const xml = `<c:chartSpace ${NS_LI}>
+  <c:chart>
+    <c:plotArea>
+      <c:${kind}><c:ser><c:idx val="0"/></c:ser></c:${kind}>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.legendItalic).toBe(true);
+    }
+  });
+});
+
 // ── parseChart — data labels showLegendKey ──────────────────────────
 
 describe("parseChart — data labels showLegendKey", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:legend><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:legend>` at the read, write, and clone layers so a template's legend italic pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `legendItalic?: boolean` on `SheetChart` (writer side) and the matching `legendItalic?: boolean` on `Chart` (reader side). Sits on the same `<c:legend>` element as `legend` / `legendOverlay` / `legendEntries`; the writer emits a single `<c:txPr>` block on the legend whenever the field is set. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user pinned a custom legend slant (e.g. italicizing the legend swatch labels for a quote-style dashboard tile) now round-trips that pin through the parse / clone / write loop.

Modeled as a boolean for symmetry with the chart-title `titleItalic` (#253), the axis-title `axisTitleItalic` (#257), and the axis tick-label `labelItalic` (#265): `true` emits `i="1"`; `false` emits the OOXML default `i="0"` explicitly so a clone target can override an upstream `i="1"` from a templated chart; absence collapses to omitting the entire `<c:txPr>` block. The reader collapses the OOXML default `false` to `undefined` so absence and `i="0"` round-trip identically — only an explicit `i="1"` surfaces `true`.

The clone layer follows the standard `boolean | null` override grammar: `undefined` inherits, `null` drops, and a literal `boolean` replaces. Non-boolean overrides (typed escapes from an untyped caller) collapse to `undefined` so the cloned `SheetChart` always carries a value the writer will accept. A hidden legend (`legend === false`) silently drops the inherited / overridden value — there is no `<c:txPr>` slot to host the flag on a hidden legend, so leaking the value into the output would carry a pin Excel never reads.

The `<c:txPr>` block lands after `<c:overlay>` and before the optional `<c:extLst>`, matching the CT_Legend schema sequence (ECMA-376 Part 1, §21.2.2.114). The `<a:bodyPr>` is emitted without a `rot` attribute — the legend is not rotatable in Excel's UI, so the writer keeps the body-properties element minimal and only carries the `<a:defRPr i=".."/>` slot inside the paragraph stub. The flag rides on every chart family that emits a legend (bar / column / line / area / scatter / pie / doughnut).

Refs #136

## Test plan

- [x] \`pnpm test\` passes (5107 tests across 89 files, lint + format + typecheck + vitest)
- [x] \`pnpm build\` succeeds
- [x] New describe blocks: \`parseChart — legendItalic\` (12 cases), \`writeChart — legendItalic\` (16 cases), \`cloneChart — legendItalic\` (17 cases) covering parse, write, end-to-end \`writeXlsx\`, the OOXML default \`false\` collapse, malformed input, hidden-legend scoping, OOXML element ordering, multi-family coverage (bar / column / line / pie / doughnut / area / scatter), and composition with the sibling legend knobs (\`legendOverlay\` / \`legendEntries\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)