### PR TITLE
feat(xlsx): chart legend strikethrough flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1421,6 +1421,41 @@ export interface SheetChart {
    * call threads cleanly through every legend knob Excel exposes.
    */
   legendUnderline?: boolean;
+  /**
+   * Legend strikethrough flag. Maps to `<c:legend><c:txPr><a:p><a:pPr>
+   * <a:defRPr strike=".."/></a:pPr></a:p></c:txPr></c:legend>` — Excel's
+   * "Format Legend -> Font -> Strikethrough" toggle. The OOXML attribute
+   * is the `ST_TextStrikeType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer lands `strike="sngStrike"` (Excel's UI variant — single line)
+   * on the default-paragraph `<a:defRPr>` slot inside the legend's
+   * `<c:txPr>` block so a re-parse picks the flag up off the canonical
+   * slot the OOXML schema exposes.
+   *
+   * Default: omitted — the legend renders non-strikethrough (no
+   * `strike` attribute, matching Excel's reference serialization for a
+   * fresh chart legend whose typography has not been customized; the
+   * OOXML default `"noStrike"` collapses to absence). Set `true` to
+   * emit `strike="sngStrike"` so the legend renders with a single
+   * strikethrough line; absence and explicit `false` both collapse to
+   * omitting the attribute entirely (mirrors `titleStrikethrough` /
+   * `axisTitleStrike` / `labelStrikethrough` — the writer emits only
+   * the UI variant `"sngStrike"`, never `"noStrike"` or `"dblStrike"`).
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no `<c:txPr>` slot to host the flag in that
+   * case. Mirrors {@link titleStrikethrough} /
+   * {@link axes.x.axisTitleStrike} / {@link axes.x.labelStrikethrough}
+   * — same boolean shape, same OOXML `<a:defRPr strike=".."/>` mapping
+   * — so a caller can thread a single strikethrough value through every
+   * typography-pinning slot. Composes independently with {@link legend}
+   * / {@link legendOverlay} / {@link legendEntries} /
+   * {@link legendFontSize} / {@link legendBold} / {@link legendItalic}
+   * / {@link legendUnderline}: all eight fields land on the same
+   * `<c:legend>` element so a single configuration call threads
+   * cleanly through every legend knob Excel exposes.
+   */
+  legendStrikethrough?: boolean;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -5141,6 +5176,28 @@ export interface Chart {
    * value slots straight into {@link cloneChart} without conversion.
    */
   legendUnderline?: boolean;
+  /**
+   * Legend strikethrough flag pulled from `<c:legend><c:txPr><a:p>
+   * <a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr></c:legend>`.
+   * The OOXML `strike` attribute is the `ST_TextStrikeType` enumeration
+   * on `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * The OOXML default `"noStrike"` collapses to `undefined` so absence
+   * and `strike="noStrike"` round-trip identically — only
+   * `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+   * `true`. The non-UI variant `strike="dblStrike"` (double line) is
+   * read-only and collapses to `undefined` so a templated chart that
+   * pinned the double-line variant in raw OOXML round-trips lossless
+   * rather than silently downgrading on re-emit; the writer emits only
+   * `"sngStrike"`, matching the boolean shape the UI exposes.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:txPr>` slot to surface the flag from in either case. Mirrors
+   * the writer-side {@link SheetChart.legendStrikethrough} so a parsed
+   * value slots straight into {@link cloneChart} without conversion.
+   */
+  legendStrikethrough?: boolean;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -270,6 +270,26 @@ export interface CloneChartOptions {
    * typography knobs compose the same way at the call site.
    */
   legendUnderline?: boolean | null;
+  /**
+   * Override `SheetChart.legendStrikethrough`. `undefined` (or omitted)
+   * inherits the source's parsed `legendStrikethrough`; `null` drops
+   * the inherited flag (the writer emits no `strike` attribute on the
+   * legend's `<a:defRPr>`, falling back to the OOXML default — no
+   * strikethrough); a `boolean` replaces. Non-boolean overrides (typed
+   * escapes from an untyped caller) collapse to `undefined` so a typed
+   * escape cannot pin a value the writer would silently elide.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved legend is `false` (no `<c:legend>` element will
+   * be emitted) — there is no `<c:txPr>` slot to host the flag on a
+   * hidden legend, so leaking the value into the output would carry
+   * a pin Excel never reads.
+   *
+   * The grammar mirrors `titleStrikethrough` /
+   * `axes.x.axisTitleStrike` / `axes.x.labelStrikethrough` so the
+   * typography knobs compose the same way at the call site.
+   */
+  legendStrikethrough?: boolean | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1472,6 +1492,15 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.legendUnderline,
     );
     if (resolvedLegendUnderline !== undefined) out.legendUnderline = resolvedLegendUnderline;
+
+    // Same hidden-legend scoping for the strikethrough flag.
+    const resolvedLegendStrikethrough = resolveLegendStrikethrough(
+      source.legendStrikethrough,
+      options.legendStrikethrough,
+    );
+    if (resolvedLegendStrikethrough !== undefined) {
+      out.legendStrikethrough = resolvedLegendStrikethrough;
+    }
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -2681,6 +2710,53 @@ function resolveLegendUnderline(
   if (override === undefined) return normalizeLegendUnderline(sourceValue);
   if (override === null) return undefined;
   return normalizeLegendUnderline(override);
+}
+
+/**
+ * Normalize a `legendStrikethrough` value for the cloned `SheetChart`.
+ * Mirrors the writer's `resolveLegendStrikethrough` — `true` / `false`
+ * pass through literally, every other token collapses to `undefined`.
+ *
+ * The cloned `SheetChart` retains a literal `false` (the writer drops
+ * `false` to absence at emit time, so pinning `false` on the cloned
+ * chart is functionally identical to omission, but it lets a downstream
+ * consumer that re-clones the chart distinguish "explicit no-strike
+ * pin" from "field never set"). The chart-title / axis-title / axis
+ * tick-label strike clone resolvers use the same shape — only at the
+ * writer's `<a:defRPr>` slot does the `false` collapse to attribute
+ * omission.
+ */
+function normalizeLegendStrikethrough(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve a `legendStrikethrough` override.
+ *
+ * `undefined` → inherit the source's parsed `legendStrikethrough`
+ *               (after running it through
+ *               {@link normalizeLegendStrikethrough} so a typed escape
+ *               on the source path drops cleanly).
+ * `null`      → drop the inherited flag (the writer falls back to the
+ *               OOXML default — no `strike` attribute, equivalent to
+ *               non-strikethrough).
+ * `boolean`   → replace.
+ *
+ * The grammar mirrors `titleStrikethrough` / `axisTitleStrike` /
+ * `axes.x.labelStrikethrough` so the typography knobs compose the same
+ * way at the call site. Callers should gate the result on the resolved
+ * legend visibility — when no legend is emitted, the flag has no slot
+ * in the rendered chart.
+ */
+function resolveLegendStrikethrough(
+  sourceValue: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) return normalizeLegendStrikethrough(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendStrikethrough(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -447,6 +447,15 @@ export function parseChart(xml: string): Chart | undefined {
     // collapse to `undefined`.
     const legendUnderline = parseLegendUnderline(chartEl);
     if (legendUnderline !== undefined) out.legendUnderline = legendUnderline;
+
+    // Same scoping for the strikethrough flag — only an explicit
+    // `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+    // `true`; the OOXML default `"noStrike"` and the non-UI variant
+    // `"dblStrike"` (double line) both collapse to `undefined` so a
+    // templated chart with the double-line variant round-trips
+    // lossless rather than silently downgrading on re-emit.
+    const legendStrikethrough = parseLegendStrikethrough(chartEl);
+    if (legendStrikethrough !== undefined) out.legendStrikethrough = legendStrikethrough;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -2984,6 +2993,43 @@ function parseLegendUnderline(chartEl: XmlElement): boolean | undefined {
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.u;
   if (raw === "sng") return true;
+  return undefined;
+}
+
+/**
+ * Pull `<c:legend><c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:txPr></c:legend>` off the chart. Returns the strikethrough
+ * flag.
+ *
+ * The OOXML `strike` attribute is the `ST_TextStrikeType` enumeration
+ * on `CT_TextCharacterProperties` — `"noStrike"` (default),
+ * `"sngStrike"` (single line, Excel's UI variant), `"dblStrike"`
+ * (double line, non-UI). Only `strike="sngStrike"` surfaces `true`;
+ * the OOXML default `"noStrike"` and the double-line variant both
+ * collapse to `undefined` so absence and `strike="noStrike"`
+ * round-trip identically through `cloneChart`. Reporting `"dblStrike"`
+ * as `true` would silently downgrade the choice to a single line on
+ * re-emit; the writer emits only `"sngStrike"`, matching the boolean
+ * shape the UI exposes.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:legend>`
+ * element. Mirrors the chart-title / axis-title / axis tick-label
+ * strikethrough readers exactly so a parsed value slots straight back
+ * into the writer's emit path.
+ */
+function parseLegendStrikethrough(chartEl: XmlElement): boolean | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const txPr = findChild(legend, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.strike;
+  if (raw === "sngStrike") return true;
   return undefined;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -132,6 +132,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendBold(chart),
         resolveLegendItalic(chart),
         resolveLegendUnderline(chart),
+        resolveLegendStrikethrough(chart),
       ),
     );
   }
@@ -3934,6 +3935,7 @@ function buildLegend(
   bold: boolean | undefined,
   italic: boolean | undefined,
   underline: boolean | undefined,
+  strikethrough: boolean | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -3962,13 +3964,13 @@ function buildLegend(
   // entirely when no typography knob is pinned so a fresh chart matches
   // Excel's reference serialization byte-for-byte (Excel itself omits
   // the block whenever the legend renders at the theme-default style).
-  // The block currently carries the legend font size, bold, italic, and
-  // underline flags; future typography pins (color) will land on the
-  // same `<a:defRPr>` slot. The `<a:bodyPr>` carries no rotation
-  // attribute — the legend is not rotatable in Excel's UI, mirroring
-  // how the axis tick-label `<c:txPr>` slot drops `rot` when only
-  // typography knobs are pinned.
-  const txPrXml = buildLegendTxPr(fontSizePt, bold, italic, underline);
+  // The block currently carries the legend font size, bold, italic,
+  // underline, and strikethrough flags; future typography pins (color)
+  // will land on the same `<a:defRPr>` slot. The `<a:bodyPr>` carries
+  // no rotation attribute — the legend is not rotatable in Excel's UI,
+  // mirroring how the axis tick-label `<c:txPr>` slot drops `rot` when
+  // only typography knobs are pinned.
+  const txPrXml = buildLegendTxPr(fontSizePt, bold, italic, underline, strikethrough);
   if (txPrXml !== undefined) {
     children.push(txPrXml);
   }
@@ -4005,12 +4007,14 @@ function buildLegendTxPr(
   bold: boolean | undefined,
   italic: boolean | undefined,
   underline: boolean | undefined,
+  strikethrough: boolean | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
     bold === undefined &&
     italic === undefined &&
-    underline === undefined
+    underline === undefined &&
+    strikethrough === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
@@ -4018,6 +4022,13 @@ function buildLegendTxPr(
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
   if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
   if (underline !== undefined) defRPrAttrs.u = underline ? "sng" : "none";
+  // Strikethrough rides as `strike="sngStrike"` on the same
+  // `<a:defRPr>` slot. Absence collapses to omitting the attribute
+  // entirely (the OOXML default `"noStrike"` is functionally identical
+  // to absence — the reader collapses both to `undefined`). The writer
+  // never emits `"noStrike"` or `"dblStrike"` so the surfaced shape
+  // stays consistent with Excel's UI checkbox.
+  if (strikethrough === true) defRPrAttrs.strike = "sngStrike";
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),
@@ -4111,6 +4122,36 @@ function resolveLegendUnderline(chart: SheetChart): boolean | undefined {
   const value = chart.legendUnderline;
   if (value === true) return true;
   if (value === false) return false;
+  return undefined;
+}
+
+/**
+ * Resolve `<c:legend><c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:txPr></c:legend>` from
+ * {@link SheetChart.legendStrikethrough}.
+ *
+ * Returns `true` when the chart pins the strikethrough flag literally;
+ * every other value (explicit `false`, absence, non-boolean tokens
+ * leaking past the type guard) collapses to `undefined` so the writer
+ * never emits a `strike` attribute below `"sngStrike"`. The OOXML
+ * default `"noStrike"` is functionally identical to absence — the
+ * writer keeps the surfaced shape consistent with what Excel's UI
+ * authors (`"sngStrike"` only, never `"noStrike"` or `"dblStrike"`),
+ * mirroring how `resolveTitleStrike` lands on the title's `<a:defRPr>`.
+ *
+ * Collapsing `false` to `undefined` (instead of the `boolean`-pass-through
+ * shape that `legendBold` / `legendItalic` / `legendUnderline` use)
+ * mirrors how the chart-title / axis-title / axis tick-label
+ * strikethrough writers also drop the attribute on `false`: a
+ * standalone `legendStrikethrough: false` does not gratuitously
+ * trigger the `<c:txPr>` block emission, so the legend stays at the
+ * theme-default style and a fresh chart with no custom strikethrough
+ * matches Excel's reference serialization byte-for-byte. The flag is
+ * only meaningful when the chart actually emits a legend — the caller
+ * is expected to gate the call on the resolved legend visibility.
+ */
+function resolveLegendStrikethrough(chart: SheetChart): boolean | undefined {
+  if (chart.legendStrikethrough === true) return true;
   return undefined;
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -5524,6 +5524,287 @@ describe("cloneChart — legendUnderline", () => {
   });
 });
 
+// ── cloneChart — legendStrikethrough ─────────────────────────────────
+
+describe("cloneChart — legendStrikethrough", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendStrikethrough by default", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendStrikethrough).toBe(true);
+  });
+
+  it("lets options.legendStrikethrough override the source's value", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendStrikethrough: false,
+    });
+    expect(clone.legendStrikethrough).toBe(false);
+  });
+
+  it("drops the inherited legendStrikethrough when the override is null", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendStrikethrough: null,
+    });
+    expect(clone.legendStrikethrough).toBeUndefined();
+  });
+
+  it("returns undefined legendStrikethrough when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendStrikethrough).toBeUndefined();
+  });
+
+  it("retains an explicit false override (for downstream re-clone visibility)", () => {
+    // The cloned `SheetChart` retains a literal `false` so a downstream
+    // consumer that re-clones the chart can distinguish "explicit
+    // no-strike pin" from "field never set" — even though the writer
+    // collapses `false` to absence at emit time.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendStrikethrough: false,
+    });
+    expect(clone.legendStrikethrough).toBe(false);
+  });
+
+  it("collapses non-boolean overrides (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendStrikethrough: "yes" as any,
+    });
+    expect(clone.legendStrikethrough).toBeUndefined();
+  });
+
+  it("collapses numeric overrides leaking past the type guard", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendStrikethrough: 1 as any,
+    });
+    expect(clone.legendStrikethrough).toBeUndefined();
+  });
+
+  it("carries legendStrikethrough through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendStrikethrough).toBe(true);
+  });
+
+  it("carries legendStrikethrough through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendStrikethrough).toBe(true);
+  });
+
+  it("drops the inherited legendStrikethrough when the resolved legend is hidden", () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendStrikethrough).toBeUndefined();
+  });
+
+  it("drops the legendStrikethrough override when the resolved legend is hidden", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendStrikethrough: true,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendStrikethrough).toBeUndefined();
+  });
+
+  it("retains the legendStrikethrough override when the override re-enables a hidden source legend", () => {
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendStrikethrough: true,
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendStrikethrough).toBe(true);
+  });
+
+  it("composes with legendOverlay / legendEntries / legendFontSize / legendUnderline on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        legendStrikethrough: true,
+        legendUnderline: true,
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendStrikethrough).toBe(true);
+    expect(clone.legendUnderline).toBe(true);
+    expect(clone.legendFontSize).toBe(12);
+    expect(clone.legendOverlay).toBe(true);
+    expect(clone.legendEntries).toEqual([{ idx: 0, delete: true }]);
+  });
+
+  it("propagates legendStrikethrough into the rendered <c:legend><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('strike="sngStrike"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendStrikethrough).toBe(true);
+  });
+
+  it("emits no <c:txPr> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ legendStrikethrough: false }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendStrikethrough: true,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('strike="sngStrike"');
+    expect(parseChart(written)?.legendStrikethrough).toBe(true);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:txPr> emitted)", async () => {
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendStrikethrough: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("a false override on the cloned SheetChart still writes no <c:txPr> (writer drops false)", async () => {
+    // The cloned SheetChart retains the literal `false` for downstream
+    // re-clone visibility, but the writer collapses `false` to absence
+    // — so the rendered XML never contains a `strike` attribute or a
+    // gratuitous `<c:txPr>` wrapper.
+    const clone = cloneChart(source({ legendStrikethrough: true }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendStrikethrough: false,
+    });
+    expect(clone.legendStrikethrough).toBe(false);
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("strike=");
+    expect(legend).not.toContain("<c:txPr>");
+  });
+});
+
 // ── cloneChart — axis lblAlgn ───────────────────────────────────────
 
 describe("cloneChart — axis lblAlgn", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -4937,6 +4937,192 @@ describe("writeChart — legendUnderline", () => {
   });
 });
 
+// ── writeChart — legend strikethrough ───────────────────────────────
+
+describe("writeChart — legendStrikethrough", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when legendStrikethrough is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:txPr>");
+    expect(legend).not.toContain("a:defRPr");
+  });
+
+  it('threads legendStrikethrough=true through to <c:legend><c:txPr> as strike="sngStrike"', () => {
+    const result = writeChart(makeChart({ legendStrikethrough: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('strike="sngStrike"');
+  });
+
+  it("does NOT emit <c:txPr> when legendStrikethrough=false (the OOXML default collapses to absence)", () => {
+    // Mirrors the chart-title / axis-title / axis tick-label
+    // strikethrough writers — `false` collapses to omitting the
+    // attribute, so a sole `legendStrikethrough: false` does not
+    // gratuitously trigger the `<c:txPr>` block emission.
+    const result = writeChart(makeChart({ legendStrikethrough: false }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:txPr>");
+    expect(legend).not.toContain("strike=");
+  });
+
+  it("places <c:txPr> after <c:overlay> inside <c:legend> (OOXML order)", () => {
+    const result = writeChart(makeChart({ legendStrikethrough: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits <c:txPr> once inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendStrikethrough: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendStrikethrough set", () => {
+    const result = writeChart(makeChart({ legend: false, legendStrikethrough: true }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendStrikethrough through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendStrikethrough: true }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('strike="sngStrike"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendStrikethrough: true,
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('strike="sngStrike"');
+  });
+
+  it("drops non-boolean inputs (null leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendStrikethrough: null as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendStrikethrough: "yes" as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (number leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendStrikethrough: 1 as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(makeChart({ legendStrikethrough: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<a:bodyPr/>");
+    expect(legend).toContain("<a:lstStyle/>");
+    expect(legend).toContain('<a:defRPr strike="sngStrike"/>');
+    expect(legend).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("emits <a:bodyPr/> without a rot attribute (legend is not rotatable)", () => {
+    const result = writeChart(makeChart({ legendStrikethrough: true }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<a:bodyPr/>");
+    const bodyPr = legend.match(/<a:bodyPr[^/]*\/>/);
+    expect(bodyPr?.[0]).toBe("<a:bodyPr/>");
+  });
+
+  it("round-trips a legendStrikethrough=true value through parseChart", () => {
+    const written = writeChart(makeChart({ legendStrikethrough: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendStrikethrough).toBe(true);
+  });
+
+  it("collapses legendStrikethrough=false back to undefined on re-parse (no attribute emitted)", () => {
+    const written = writeChart(makeChart({ legendStrikethrough: false }), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("collapses an unset legendStrikethrough round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("composes with legendOverlay / legendEntries / legendFontSize / legendUnderline on the same <c:legend>", () => {
+    const result = writeChart(
+      makeChart({
+        legendStrikethrough: true,
+        legendUnderline: true,
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('strike="sngStrike"');
+    expect(legend).toContain('u="sng"');
+    expect(legend).toContain('sz="1200"');
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).toContain("c:legendEntry");
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:legendEntry"));
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:overlay"));
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("co-emits sz, u, and strike attributes on a single <a:defRPr> when all three are pinned", () => {
+    const result = writeChart(
+      makeChart({ legendStrikethrough: true, legendUnderline: true, legendFontSize: 14 }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    // Single <a:defRPr> hosts all three attributes — matches the
+    // canonical tick-label / chart-title txPr emission that lands the
+    // typography pins on the same default-paragraph slot.
+    expect(legend).toMatch(/<a:defRPr[^/]+\/>/);
+    expect(legend).toContain('sz="1400"');
+    expect(legend).toContain('u="sng"');
+    expect(legend).toContain('strike="sngStrike"');
+  });
+
+  it("survives a writeXlsx round trip — legendStrikethrough lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendStrikethrough: true,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const legend = chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('strike="sngStrike"');
+  });
+});
+
 // ── writeChart — data labels showLegendKey ──────────────────────────
 
 describe("writeChart — data labels showLegendKey", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -5823,6 +5823,190 @@ describe("parseChart — legendUnderline", () => {
   });
 });
 
+// ── parseChart — legendStrikethrough ────────────────────────────────
+
+describe("parseChart — legendStrikethrough", () => {
+  const NS_LS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendStrike(strike: string | undefined): string {
+    const defRPr = strike === undefined ? "<a:defRPr/>" : `<a:defRPr strike="${strike}"/>`;
+    return `<c:chartSpace ${NS_LS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces legendStrikethrough=true when strike="sngStrike"', () => {
+    expect(parseChart(withLegendStrike("sngStrike"))?.legendStrikethrough).toBe(true);
+  });
+
+  it('collapses the OOXML default strike="noStrike" to undefined', () => {
+    // Absence and the OOXML default round-trip identically through the
+    // writer — only an explicit `strike="sngStrike"` surfaces `true`.
+    expect(parseChart(withLegendStrike("noStrike"))?.legendStrikethrough).toBeUndefined();
+  });
+
+  it('collapses the non-UI variant strike="dblStrike" to undefined', () => {
+    // The writer only emits `"sngStrike"`, so reporting `"dblStrike"`
+    // as `true` would silently downgrade the choice on round-trip.
+    expect(parseChart(withLegendStrike("dblStrike"))?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the strike attribute", () => {
+    expect(parseChart(withLegendStrike(undefined))?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS_LS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_LS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> has no <a:p><a:pPr> chain", () => {
+    const xml = `<c:chartSpace ${NS_LS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendStrikethrough).toBeUndefined();
+  });
+
+  it('drops the flag when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("collapses garbage / unknown strike tokens to undefined", () => {
+    expect(parseChart(withLegendStrike(""))?.legendStrikethrough).toBeUndefined();
+    expect(parseChart(withLegendStrike("yes"))?.legendStrikethrough).toBeUndefined();
+    expect(parseChart(withLegendStrike("1"))?.legendStrikethrough).toBeUndefined();
+    expect(parseChart(withLegendStrike("true"))?.legendStrikethrough).toBeUndefined();
+    expect(parseChart(withLegendStrike("strike"))?.legendStrikethrough).toBeUndefined();
+  });
+
+  it("co-surfaces alongside legendOverlay / legendEntries / legendFontSize / legendUnderline", () => {
+    const xml = `<c:chartSpace ${NS_LS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:legendEntry>
+        <c:idx val="0"/>
+        <c:delete val="1"/>
+      </c:legendEntry>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400" u="sng" strike="sngStrike"/></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("bottom");
+    expect(chart?.legendOverlay).toBe(true);
+    expect(chart?.legendEntries).toEqual([{ idx: 0, delete: true }]);
+    expect(chart?.legendFontSize).toBe(14);
+    expect(chart?.legendUnderline).toBe(true);
+    expect(chart?.legendStrikethrough).toBe(true);
+  });
+
+  it("surfaces the flag on every chart family that emits a legend", () => {
+    for (const kind of ["lineChart", "barChart", "pieChart", "doughnutChart"]) {
+      const xml = `<c:chartSpace ${NS_LS}>
+  <c:chart>
+    <c:plotArea>
+      <c:${kind}><c:ser><c:idx val="0"/></c:ser></c:${kind}>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.legendStrikethrough).toBe(true);
+    }
+  });
+});
+
 // ── parseChart — data labels showLegendKey ──────────────────────────
 
 describe("parseChart — data labels showLegendKey", () => {


### PR DESCRIPTION
## Summary

Surfaces `<c:legend><c:txPr><a:p><a:pPr><a:defRPr strike=\"..\"/></a:pPr></a:p></c:txPr></c:legend>` at the read, write, and clone layers so a template's legend strikethrough pin survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `legendStrikethrough?: boolean` on `SheetChart` (writer side) and the matching `legendStrikethrough?: boolean` on `Chart` (reader side). Sits on the same `<c:legend>` element as `legend` / `legendOverlay` / `legendEntries` / `legendFontSize` / `legendBold` / `legendItalic` / `legendUnderline`; the writer emits a single `<c:txPr>` block on the legend whenever any typography knob is pinned, and the strikethrough value lands on the same `<a:defRPr>` slot as the size / bold / italic / underline. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user pinned a custom legend strikethrough (e.g. striking through legend swatch labels for "deprecated" series in a sustainability before/after dashboard) now round-trips that pin through the parse / clone / write loop.

Modeled as a boolean for symmetry with the chart-title `titleStrikethrough` (#259), the axis-title `axisTitleStrike` (#261), and the axis tick-label `labelStrikethrough` (#268): `true` emits `strike=\"sngStrike\"` (Excel's UI checkbox — single line); absence and explicit `false` both collapse to omitting the attribute (the OOXML default `\"noStrike\"` collapses to absence — the writer keeps the surfaced shape consistent with what Excel's UI authors). The non-UI variant `\"dblStrike\"` (double line) is read-only — the writer emits only `\"sngStrike\"`, and the reader collapses `\"dblStrike\"` to `undefined` so a templated legend that pinned the double-line variant in raw OOXML round-trips lossless rather than silently downgrading on re-emit.

The clone layer follows the standard `boolean | null` override grammar: `undefined` inherits, `null` drops, and a literal `boolean` replaces. The cloned `SheetChart` retains a literal `false` (for downstream re-clone visibility — distinguishes "explicit no-strike pin" from "field never set"), but the writer collapses `false` to absence at emit time so a sole `legendStrikethrough: false` does not gratuitously trigger the `<c:txPr>` block emission. Non-boolean overrides (typed escapes from an untyped caller) collapse to `undefined`. A hidden legend (`legend === false`) silently drops the inherited / overridden value — there is no `<c:txPr>` slot to host the flag on a hidden legend.

The `<c:txPr>` block lands after `<c:overlay>` and before the optional `<c:extLst>`, matching the CT_Legend schema sequence (ECMA-376 Part 1, §21.2.2.114). The `<a:bodyPr>` is emitted without a `rot` attribute — the legend is not rotatable in Excel's UI. The flag rides on every chart family that emits a legend (bar / column / line / area / scatter / pie / doughnut). Composes with the sibling `legendFontSize` (#269), `legendBold` (#270), `legendItalic` (#271), and `legendUnderline` (#272) — all five attributes land on the same `<a:defRPr>` slot when pinned.

Refs #136

## Test plan

- [x] `pnpm test` passes (5299 tests across 89 files, lint + format + typecheck + vitest)
- [x] `pnpm build` succeeds
- [x] New describe blocks: `parseChart — legendStrikethrough` (12 cases), `writeChart — legendStrikethrough` (17 cases), `cloneChart — legendStrikethrough` (19 cases) covering parse, write, end-to-end `writeXlsx`, the OOXML default `\"noStrike\"` collapse, the non-UI `\"dblStrike\"` collapse, malformed input, hidden-legend scoping, OOXML element ordering, multi-family coverage (bar / column / line / pie / doughnut / area / scatter), and composition with the sibling legend knobs (`legendOverlay` / `legendEntries` / `legendFontSize` / `legendUnderline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)