### PR TITLE
feat(xlsx): chart data labels font size — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -654,6 +654,39 @@ export interface ChartDataLabels {
    * out and render labels without the connecting lines.
    */
   showLeaderLines?: boolean;
+  /**
+   * Data-label font size in points (range `1..400`), pinned via
+   * `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+   * </c:txPr></c:dLbls>`. Mirrors Excel's "Format Data Labels -> Font
+   * -> Size" knob — the OOXML attribute is in 100ths of a point on
+   * `CT_TextCharacterProperties`' `sz` slot (ECMA-376 Part 1,
+   * §21.1.2.3.7); the writer holds the value in points and converts
+   * at emit time so a caller can pass the value directly without
+   * doing the multiplication.
+   *
+   * Default: omitted — the data labels render at the theme-default
+   * size (Excel's reference behavior for fresh data labels whose
+   * typography has not been customized; the writer skips the entire
+   * `<c:txPr>` block when no font knob is pinned).
+   *
+   * Out-of-range values (`< 1` or `> 400`) and non-numeric tokens
+   * (typed escapes from an untyped caller — strings, `null`, `NaN`,
+   * `Infinity`) collapse to `undefined` so the writer never emits a
+   * malformed `sz` attribute. Fractional points round to the nearest
+   * half-point (Excel's UI step) — `12.3` → `12.5`, `12.24` → `12`.
+   *
+   * The `<c:txPr>` block lands between `<c:spPr>` and `<c:dLblPos>`,
+   * matching the CT_DLbls schema sequence (ECMA-376 Part 1,
+   * §21.2.2.50). Composes independently with the other dLbls knobs —
+   * {@link position} / {@link separator} / {@link numberFormat} /
+   * {@link showLeaderLines} / the `show*` toggles — so a caller can
+   * pin the font size without touching the rest of the configuration.
+   * Mirrors {@link SheetChart.titleFontSize} /
+   * {@link SheetChart.legendFontSize} — same range, same conversion
+   * factor — so a caller can thread a single point value through every
+   * typography-pinning slot.
+   */
+  fontSize?: number;
 }
 
 /**
@@ -4086,6 +4119,23 @@ export interface ChartDataLabelsInfo {
    * cleanly even when the chart-type element ends up coerced.
    */
   showLeaderLines?: boolean;
+  /**
+   * Data-label font size in points pulled from `<c:dLbls><c:txPr>
+   * <a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr></c:dLbls>`.
+   * The OOXML attribute is in 100ths of a point on
+   * `CT_TextCharacterProperties`' `sz` slot (ECMA-376 Part 1,
+   * §21.1.2.3.7); the reader divides by 100 at parse time so the
+   * surfaced value matches what the user sees in Excel's "Format Data
+   * Labels -> Font -> Size" UI.
+   *
+   * Out-of-range values (`< 1` or `> 400`) and malformed tokens
+   * collapse to `undefined` so absence and a malformed source value
+   * round-trip identically through {@link cloneChart} — only an
+   * in-range `sz` attribute surfaces a numeric value. Mirrors the
+   * writer-side {@link ChartDataLabels.fontSize} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   */
+  fontSize?: number;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2556,10 +2556,18 @@ function parseDataLabelsFontSize(dLbls: XmlElement): number | undefined {
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.sz;
   if (typeof raw !== "string") return undefined;
-  const num = Number.parseInt(raw, 10);
-  if (!Number.isFinite(num)) return undefined;
-  const points = num / 100;
-  if (points < 1 || points > 400) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 100ths of a point to points, rounding to the nearest
+  // 0.5pt to match the granularity Excel's UI exposes. Mirrors the
+  // chart-title / axis-title / tick-label / legend sibling parsers
+  // exactly so a parsed value flows through every typography slot
+  // without bookkeeping the units.
+  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
   return points;
 }
 

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2501,6 +2501,17 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     }
   }
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p></c:txPr>`
+  // — data-label font size pinned via Excel's "Format Data Labels ->
+  // Font -> Size" knob. The OOXML attribute is in 100ths of a point on
+  // `CT_TextCharacterProperties`' `sz` slot; the reader divides by
+  // 100 at parse time so the surfaced value matches what the user
+  // sees in the UI. Out-of-range / malformed tokens collapse to
+  // `undefined` so absence and a malformed source value round-trip
+  // identically through `cloneChart`.
+  const fontSize = parseDataLabelsFontSize(el);
+  if (fontSize !== undefined) out.fontSize = fontSize;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2511,11 +2522,45 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     !out.showLegendKey &&
     out.separator === undefined &&
     out.numberFormat === undefined &&
-    out.showLeaderLines === undefined
+    out.showLeaderLines === undefined &&
+    out.fontSize === undefined
   ) {
     return undefined;
   }
   return out;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+ * </c:txPr></c:dLbls>` off a data-labels block. Returns the font size
+ * in points (`1..400`), or `undefined` when the element is absent /
+ * the chain is malformed at any link / the surfaced value is out of
+ * the supported range.
+ *
+ * The OOXML attribute is in 100ths of a point on
+ * `CT_TextCharacterProperties`' `sz` slot (ECMA-376 Part 1,
+ * §21.1.2.3.7); the reader divides by 100 at parse time so the
+ * surfaced value matches what the user sees in Excel's UI. Mirrors
+ * the chart-title / axis-title / axis tick-label / legend font-size
+ * readers exactly so a parsed value slots straight back into the
+ * writer's emit path.
+ */
+function parseDataLabelsFontSize(dLbls: XmlElement): number | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.sz;
+  if (typeof raw !== "string") return undefined;
+  const num = Number.parseInt(raw, 10);
+  if (!Number.isFinite(num)) return undefined;
+  const points = num / 100;
+  if (points < 1 || points > 400) return undefined;
+  return points;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3837,6 +3837,19 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
     );
   }
 
+  // CT_DLbls schema places `<c:txPr>` between `<c:spPr>` and
+  // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The writer currently
+  // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
+  // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
+  // carries the data-label font size; future typography pins (color,
+  // bold, italic, underline, strikethrough) will land on the same
+  // `<a:defRPr>` slot. The writer skips the entire block when no font
+  // knob is pinned so a fresh chart matches Excel's reference shape.
+  const txPrXml = buildDataLabelsTxPr(resolveDataLabelsFontSize(dl.fontSize));
+  if (txPrXml !== undefined) {
+    children.push(txPrXml);
+  }
+
   if (dl.position) {
     children.push(xmlSelfClose("c:dLblPos", { val: dl.position }));
   }
@@ -3901,6 +3914,56 @@ function resolveDataLabelsNumberFormat(
   const out: ChartAxisNumberFormat = { formatCode };
   if (value.sourceLinked === true) out.sourceLinked = true;
   return out;
+}
+
+/**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+ * </a:p></c:txPr></c:dLbls>` from {@link ChartDataLabels.fontSize}.
+ *
+ * Returns the size in points (`1..400`), or `undefined` when the
+ * caller leaves the field unset / passed an out-of-range or
+ * non-numeric token. Delegates to {@link normalizeTitleFontSize} so
+ * the chart-title / axis-title / axis tick-label / legend / data-label
+ * font-size resolvers share the same range, the same fractional
+ * rounding (Excel's UI step is 0.5pt), and the same OOXML conversion
+ * (100ths of a point at emit time).
+ */
+function resolveDataLabelsFontSize(value: number | undefined): number | undefined {
+  return normalizeTitleFontSize(value);
+}
+
+/**
+ * Build the `<c:txPr>` block that carries a data-label's typography
+ * pins. Returns `undefined` when every input is unset so the caller
+ * can elide the element entirely (Excel's reference serialization
+ * omits `<c:txPr>` from `<c:dLbls>` when the labels render at the
+ * theme-default style).
+ *
+ * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
+ * when the user pins a data-label typography knob — `<a:bodyPr/>` (no
+ * rotation because the data-label rotation is parked in a separate
+ * extension element Excel emits at write time), `<a:lstStyle/>` is
+ * the empty list-style placeholder the schema requires, and the
+ * `<a:p><a:pPr><a:defRPr sz="N"/></a:pPr><a:endParaRPr/></a:p>`
+ * paragraph stub Excel always emits hosts the typography attributes
+ * on `<a:defRPr>`. Mirrors the chart-title / axis-title / axis
+ * tick-label / legend `<c:txPr>` slots exactly so a re-parse picks
+ * the value off the canonical default-paragraph slot every other
+ * typography reader expects.
+ */
+function buildDataLabelsTxPr(fontSizePt: number | undefined): string | undefined {
+  if (fontSizePt === undefined) return undefined;
+  const defRPrAttrs: Record<string, string | number> = {
+    sz: fontSizePt * TITLE_FONT_SZ_PER_POINT,
+  };
+  return xmlElement("c:txPr", undefined, [
+    xmlSelfClose("a:bodyPr"),
+    xmlSelfClose("a:lstStyle"),
+    xmlElement("a:p", undefined, [
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", defRPrAttrs)]),
+      xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
+    ]),
+  ]);
 }
 
 // ── Legend ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -15581,3 +15581,191 @@ describe("cloneChart — axis labelStrike", () => {
     expect(reparsed?.axes?.y?.labelStrike).toBe(true);
   });
 });
+
+// ── cloneChart — data labels fontSize ───────────────────────────────
+
+describe("cloneChart — dataLabels.fontSize", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.fontSize by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.fontSize).toBe(14);
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, fontSize: 18 },
+    });
+    expect(clone.dataLabels?.fontSize).toBe(18);
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          fontSize: 14,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.fontSize).toBe(14);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.fontSize into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('sz="1400"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fontSize).toBe(14);
+  });
+
+  it("emits no <c:txPr> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // The chart has no chart-level dLbls at all in this case.
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, fontSize: 20 },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('sz="2000"');
+    expect(written).not.toContain('sz="1400"');
+    expect(parseChart(written)?.dataLabels?.fontSize).toBe(20);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.fontSize through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.fontSize).toBe(14);
+  });
+
+  it("carries dataLabels.fontSize through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontSize: 14 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.fontSize).toBe(14);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -14003,3 +14003,180 @@ describe("writeChart — axis labelStrike", () => {
     expect(reparsed?.axes?.y?.labelStrike).toBe(true);
   });
 });
+
+// ── writeChart — data labels fontSize ───────────────────────────────
+
+describe("writeChart — dataLabels.fontSize", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when fontSize is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:defRPr");
+  });
+
+  it('threads fontSize=14 through to <c:dLbls><c:txPr> as sz="1400"', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 14 } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('sz="1400"');
+  });
+
+  it("converts fractional points to 100ths-of-a-point at emit time (12.5 → 1250)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 12.5 } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('sz="1250"');
+  });
+
+  it("rounds non-half-step fractional points to the nearest 0.5pt (Excel UI step)", () => {
+    // 12.3 → 12.5, 12.24 → 12 — mirrors the title / axis font-size
+    // resolvers exactly so a single point value threads cleanly
+    // through every typography slot Excel exposes.
+    const a = writeChart(makeChart({ dataLabels: { showValue: true, fontSize: 12.3 } }), "Sheet1");
+    expect(dLblsOf(a.chartXml)).toContain('sz="1250"');
+    const b = writeChart(makeChart({ dataLabels: { showValue: true, fontSize: 12.24 } }), "Sheet1");
+    expect(dLblsOf(b.chartXml)).toContain('sz="1200"');
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          fontSize: 14,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 14 } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads fontSize through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, fontSize: 14 } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('sz="1400"');
+    }
+  });
+
+  it("drops out-of-range font sizes (below 1pt)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 0.5 } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops out-of-range font sizes (above 400pt)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 401 } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-numeric inputs (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fontSize: "14" as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops NaN inputs", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: Number.NaN } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops Infinity inputs", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: Number.POSITIVE_INFINITY } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 14 } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:defRPr sz="1400"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips a fontSize=14 value through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontSize: 14 } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fontSize).toBe(14);
+  });
+
+  it("collapses an unset fontSize round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.fontSize).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.fontSize lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, fontSize: 14 },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('sz="1400"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.fontSize).toBe(14);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -14809,3 +14809,172 @@ describe("parseChart — axis labelStrike", () => {
     });
   });
 });
+
+// ── parseChart — data labels fontSize ───────────────────────────────
+
+describe("parseChart — data labels fontSize", () => {
+  const NS_DLF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsTxPr(sz: string | undefined): string {
+    const defRPr = sz === undefined ? "<a:defRPr/>" : `<a:defRPr sz="${sz}"/>`;
+    return `<c:chartSpace ${NS_DLF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces fontSize=14 when sz="1400" (100ths of a point)', () => {
+    const chart = parseChart(withDLblsTxPr("1400"));
+    expect(chart?.dataLabels?.fontSize).toBe(14);
+  });
+
+  it("surfaces a half-point integer-based fractional size (1450 → 14.5)", () => {
+    const chart = parseChart(withDLblsTxPr("1450"));
+    expect(chart?.dataLabels?.fontSize).toBe(14.5);
+  });
+
+  it("returns undefined when <a:defRPr> omits the sz attribute", () => {
+    const chart = parseChart(withDLblsTxPr(undefined));
+    expect(chart?.dataLabels?.fontSize).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.fontSize).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:dLbls> element at all", () => {
+    const xml = `<c:chartSpace ${NS_DLF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels).toBeUndefined();
+  });
+
+  it("collapses out-of-range sz values (below 100) to undefined", () => {
+    expect(parseChart(withDLblsTxPr("50"))?.dataLabels?.fontSize).toBeUndefined();
+    expect(parseChart(withDLblsTxPr("0"))?.dataLabels?.fontSize).toBeUndefined();
+  });
+
+  it("collapses out-of-range sz values (above 40000) to undefined", () => {
+    expect(parseChart(withDLblsTxPr("40100"))?.dataLabels?.fontSize).toBeUndefined();
+    expect(parseChart(withDLblsTxPr("999999"))?.dataLabels?.fontSize).toBeUndefined();
+  });
+
+  it("collapses malformed sz tokens (non-numeric) to undefined", () => {
+    expect(parseChart(withDLblsTxPr(""))?.dataLabels?.fontSize).toBeUndefined();
+    expect(parseChart(withDLblsTxPr("abc"))?.dataLabels?.fontSize).toBeUndefined();
+    expect(parseChart(withDLblsTxPr("12pt"))?.dataLabels?.fontSize).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat)", () => {
+    const xml = `<c:chartSpace ${NS_DLF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.fontSize).toBe(14);
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the fontSize on a fontSize-only dLbls block (no other show* toggles)", () => {
+    // Even when no other dataLabels field is set, a fontSize-only
+    // <c:txPr> block surfaces a record so the cloned chart preserves
+    // the typography intent.
+    const xml = `<c:chartSpace ${NS_DLF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr sz="1600"/></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fontSize).toBe(16);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr sz=\"N\"/></a:pPr></a:p></c:txPr></c:dLbls>` at the read, write, and clone layers so a template's data-labels font size survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `fontSize?: number` on `ChartDataLabels` (writer side) and the matching `fontSize?: number` on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:dLbls>` block as `position` / `numberFormat` / `separator` / `showLeaderLines` / the `show*` toggles; the writer threads the value through the shared `buildDataLabelsBody` helper so chart-level and per-series data labels both pick up the typography pin. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user pinned a custom data-labels font size (e.g. larger labels for emphasis on the \"primary\" KPI tile) now round-trips that value through the parse / clone / write loop.

Mirrors the chart-title `titleFontSize` (#251), the axis-title `axisTitleFontSize` (#255), the axis tick-label `labelFontSize` (#263), and the legend `legendFontSize` (#269) exactly — same range (`1..400` points), same fractional rounding (Excel's UI step is 0.5pt — `12.3` → `12.5`, `12.24` → `12`), same OOXML conversion factor (×100 at emit time, ÷100 at parse time). Out-of-range values and non-numeric tokens (typed escapes from an untyped caller — strings, `null`, `NaN`, `Infinity`) collapse to `undefined` so the writer never emits a malformed `sz` attribute and absence + malformed source value round-trip identically through `cloneChart`.

The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>` inside `<c:dLbls>`, matching the CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The block is skipped entirely when no font knob is pinned so a fresh chart matches Excel's reference shape byte-for-byte (Excel itself omits `<c:txPr>` from `<c:dLbls>` when the labels render at the theme-default style). The clone path threads the value through the existing `resolveChartDataLabels` resolver (which spreads the read-side `ChartDataLabelsInfo` into the write-side `ChartDataLabels` shape — they share field semantics). Future typography pins (color, bold, italic, underline, strikethrough) will land on the same `<a:defRPr>` slot.

Refs #136

## Test plan

- [x] `pnpm test` passes (5336 tests across 89 files, lint + format + typecheck + vitest)
- [x] `pnpm build` succeeds
- [x] New describe blocks: `parseChart — data labels fontSize` (10 cases), `writeChart — dataLabels.fontSize` (17 cases), `cloneChart — dataLabels.fontSize` (12 cases) covering parse, write, end-to-end `writeXlsx`, fractional rounding, out-of-range / NaN / Infinity drops, malformed input drops, OOXML element ordering (`<c:numFmt>` -> `<c:txPr>` -> `<c:dLblPos>`), multi-family coverage (bar / column / line / pie / doughnut / area), composition with the sibling dLbls knobs (`position` / `numberFormat` / `separator` / `show*` toggles), and the standard `null`-drop / explicit-replace clone grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)