### PR TITLE
feat(xlsx): chart data labels font color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -687,6 +687,42 @@ export interface ChartDataLabels {
    * typography-pinning slot.
    */
   fontSize?: number;
+  /**
+   * Data-label font color. Maps to `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+   * </a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>` — Excel's "Format
+   * Data Labels -> Font -> Font color" picker. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor` inside `CT_TextCharacterProperties`'
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §21.1.2.3.7); the
+   * writer lands the value on the default-paragraph `<a:defRPr>` slot
+   * inside the `<c:dLbls><c:txPr>` block so a re-parse picks the
+   * color up off the canonical slot the OOXML schema exposes.
+   *
+   * Accepts the color either with or without a leading `#` and in any
+   * case — `"FF0000"`, `"#FF0000"`, and `"ff0000"` all collapse to
+   * the OOXML uppercase canonical form `"FF0000"`. Malformed inputs
+   * (wrong length, non-hex characters, alpha-channel forms like
+   * `"#FF0000FF"`, non-string escapes from an untyped caller)
+   * collapse to `undefined` so the writer skips the entire
+   * `<a:solidFill>` block and the data labels inherit the theme text
+   * color (Excel's reference behavior for fresh data labels that
+   * have not had a custom color picked).
+   *
+   * Default: omitted — the data labels render at the theme text color
+   * (no `<a:solidFill>` block, matching Excel's reference
+   * serialization for fresh data labels whose typography has not been
+   * customized).
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Mirrors the
+   * chart-title `titleColor` / axis-title `axisTitleColor` / axis
+   * tick-label `labelColor` / legend `legendFontColor` knobs — same
+   * accept-with-or-without-`#` hex grammar, same OOXML
+   * `<a:solidFill><a:srgbClr val=".."/>` mapping — so a caller can
+   * thread a single hex string through every typography-pinning slot.
+   */
+  fontColor?: string;
 }
 
 /**
@@ -4176,6 +4212,25 @@ export interface ChartDataLabelsInfo {
    * slots straight into {@link cloneChart} without conversion.
    */
   fontSize?: number;
+  /**
+   * Data-label font color pulled from `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+   * </a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>`. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor` inside `CT_TextCharacterProperties`'
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §21.1.2.3.7).
+   *
+   * Returned as the canonical 6-character uppercase hex string when
+   * the parser walks the full chain and lands on an `<a:srgbClr
+   * val="RRGGBB"/>`. Theme references (`<a:schemeClr>`),
+   * `<a:hslClr>`, `<a:sysClr>`, `<a:prstClr>`, and malformed `val`
+   * tokens (wrong length, non-hex characters) all collapse to
+   * `undefined` since only the literal RGB triple round-trips
+   * losslessly through {@link writeChart}. Mirrors the writer-side
+   * {@link ChartDataLabels.fontColor} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  fontColor?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2519,6 +2519,15 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const fontSize = parseDataLabelsFontSize(el);
   if (fontSize !== undefined) out.fontSize = fontSize;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val=".."/>
+  // </a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>` — data-label
+  // font color pinned via Excel's "Format Data Labels -> Font -> Font
+  // color" picker. Theme references (`<a:schemeClr>`) and malformed
+  // `val` tokens collapse to `undefined` since only the literal RGB
+  // triple round-trips losslessly through `writeChart`.
+  const fontColor = parseDataLabelsFontColor(el);
+  if (fontColor !== undefined) out.fontColor = fontColor;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2530,7 +2539,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.separator === undefined &&
     out.numberFormat === undefined &&
     out.showLeaderLines === undefined &&
-    out.fontSize === undefined
+    out.fontSize === undefined &&
+    out.fontColor === undefined
   ) {
     return undefined;
   }
@@ -2576,6 +2586,41 @@ function parseDataLabelsFontSize(dLbls: XmlElement): number | undefined {
   const points = halfSteps / 2;
   if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
   return points;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:txPr></c:dLbls>` off a data-labels block. Returns the
+ * 6-character uppercase hex string when the parser walks the full
+ * chain and lands on an `<a:srgbClr val="RRGGBB"/>`. Theme references
+ * (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>`
+ * all collapse to `undefined` — only the literal RGB triple
+ * round-trips losslessly through {@link writeChart}. Malformed `val`
+ * tokens (wrong length, non-hex characters) likewise drop to
+ * `undefined` rather than fabricate a value the writer would
+ * round-trip into a malformed `<a:srgbClr>`.
+ *
+ * Returns `undefined` whenever the data-labels block omits `<c:txPr>`
+ * entirely or the canonical chain is malformed at any link. Mirrors
+ * the chart-title / axis-title / axis tick-label / legend color
+ * readers exactly so a parsed value slots straight back into the
+ * writer's emit path.
+ */
+function parseDataLabelsFontColor(dLbls: XmlElement): string | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const solidFill = findChild(defRPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3842,11 +3842,15 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The writer currently
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
-  // carries the data-label font size; future typography pins (color,
-  // bold, italic, underline, strikethrough) will land on the same
-  // `<a:defRPr>` slot. The writer skips the entire block when no font
-  // knob is pinned so a fresh chart matches Excel's reference shape.
-  const txPrXml = buildDataLabelsTxPr(resolveDataLabelsFontSize(dl.fontSize));
+  // carries the data-label font size and font color; future
+  // typography pins (bold, italic, underline, strikethrough) will land
+  // on the same `<a:defRPr>` slot. The writer skips the entire block
+  // when no font knob is pinned so a fresh chart matches Excel's
+  // reference shape.
+  const txPrXml = buildDataLabelsTxPr(
+    resolveDataLabelsFontSize(dl.fontSize),
+    resolveDataLabelsFontColor(dl.fontColor),
+  );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
   }
@@ -3934,6 +3938,21 @@ function resolveDataLabelsFontSize(value: number | undefined): number | undefine
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:txPr></c:dLbls>` from {@link ChartDataLabels.fontColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches the chart-title /
+ * axis-title / axis tick-label / legend color resolvers exactly.
+ */
+function resolveDataLabelsFontColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -3945,23 +3964,47 @@ function resolveDataLabelsFontSize(value: number | undefined): number | undefine
  * rotation because the data-label rotation is parked in a separate
  * extension element Excel emits at write time), `<a:lstStyle/>` is
  * the empty list-style placeholder the schema requires, and the
- * `<a:p><a:pPr><a:defRPr sz="N"/></a:pPr><a:endParaRPr/></a:p>`
- * paragraph stub Excel always emits hosts the typography attributes
- * on `<a:defRPr>`. Mirrors the chart-title / axis-title / axis
- * tick-label / legend `<c:txPr>` slots exactly so a re-parse picks
- * the value off the canonical default-paragraph slot every other
- * typography reader expects.
+ * `<a:p><a:pPr><a:defRPr ...><a:solidFill>...</a:solidFill></a:defRPr>
+ * </a:pPr><a:endParaRPr/></a:p>` paragraph stub Excel always emits
+ * hosts the typography attributes on `<a:defRPr>`. The `<a:defRPr>`
+ * element expands from self-closing to wrapping a single
+ * `<a:solidFill>` child when a color is set; otherwise the writer
+ * keeps the existing self-closing form so a fresh chart with no
+ * custom color matches Excel's reference serialization byte-for-byte.
+ * Mirrors the chart-title / axis-title / axis tick-label / legend
+ * `<c:txPr>` slots exactly so a re-parse picks the value off the
+ * canonical default-paragraph slot every other typography reader
+ * expects.
  */
-function buildDataLabelsTxPr(fontSizePt: number | undefined): string | undefined {
-  if (fontSizePt === undefined) return undefined;
-  const defRPrAttrs: Record<string, string | number> = {
-    sz: fontSizePt * TITLE_FONT_SZ_PER_POINT,
-  };
+function buildDataLabelsTxPr(
+  fontSizePt: number | undefined,
+  rgbHex: string | undefined,
+): string | undefined {
+  if (fontSizePt === undefined && rgbHex === undefined) return undefined;
+  const defRPrAttrs: Record<string, string | number> = {};
+  if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></a:defRPr>` carries the data-label font color.
+  // Absence (`undefined`) collapses to skipping the `<a:solidFill>`
+  // child entirely so the labels inherit the theme text color
+  // (Excel's reference behavior for fresh data labels that have not
+  // had a custom color picked).
+  const solidFillChild = rgbHex
+    ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
+    : undefined;
+  // When a fill color is set the `<a:defRPr>` slot expands from
+  // self-closing to wrapping the `<a:solidFill>` child; otherwise the
+  // writer keeps the existing self-closing form so a fresh chart with
+  // no custom color matches Excel's reference serialization
+  // byte-for-byte.
+  const defRPr = solidFillChild
+    ? xmlElement("a:defRPr", defRPrAttrs, [solidFillChild])
+    : xmlSelfClose("a:defRPr", defRPrAttrs);
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),
     xmlElement("a:p", undefined, [
-      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", defRPrAttrs)]),
+      xmlElement("a:pPr", undefined, [defRPr]),
       xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
     ]),
   ]);

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16033,3 +16033,190 @@ describe("cloneChart — dataLabels.fontSize", () => {
     expect(clone.dataLabels?.fontSize).toBe(14);
   });
 });
+
+// ── cloneChart — dataLabels.fontColor ───────────────────────────────
+
+describe("cloneChart — dataLabels.fontColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.fontColor by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.fontColor).toBe("FF0000");
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, fontColor: "00FF00" },
+    });
+    expect(clone.dataLabels?.fontColor).toBe("00FF00");
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          fontColor: "FF0000",
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.fontColor).toBe("FF0000");
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.fontColor into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('<a:srgbClr val="FF0000"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fontColor).toBe("FF0000");
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, fontColor: "00FF00" },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<a:srgbClr val="00FF00"/>');
+    expect(written).not.toContain('<a:srgbClr val="FF0000"/>');
+    expect(parseChart(written)?.dataLabels?.fontColor).toBe("00FF00");
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.fontColor through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.fontColor).toBe("FF0000");
+  });
+
+  it("carries dataLabels.fontColor through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontColor: "FF0000" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.fontColor).toBe("FF0000");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -14382,3 +14382,197 @@ describe("writeChart — dataLabels.fontSize", () => {
     expect(reparsed?.dataLabels?.fontSize).toBe(14);
   });
 });
+
+// ── writeChart — dataLabels.fontColor ───────────────────────────────
+
+describe("writeChart — dataLabels.fontColor", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when fontColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:solidFill");
+  });
+
+  it('threads fontColor through to <c:dLbls><c:txPr> as <a:srgbClr val="RRGGBB"/>', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "FF0000" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("normalizes a leading # in the input hex string", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "#00FF00" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:srgbClr val="00FF00"/>');
+  });
+
+  it("normalizes a lowercase hex string to the OOXML uppercase canonical form", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "abcdef" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          fontColor: "112233",
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "112233" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads fontColor through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, fontColor: "445566" } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('<a:srgbClr val="445566"/>');
+    }
+  });
+
+  it("drops malformed hex inputs (wrong length)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "FF00" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops malformed hex inputs (non-hex characters)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "ZZZZZZ" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops alpha-channel hex forms", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "#FF0000FF" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops empty string inputs", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fontColor: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fontColor: 0xff0000 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "ABCDEF" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:srgbClr val="ABCDEF"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("expands <a:defRPr> from self-closing to wrapping <a:solidFill>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "ABCDEF" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:defRPr><a:solidFill>");
+    expect(dLbls).toContain("</a:solidFill></a:defRPr>");
+  });
+
+  it("round-trips a fontColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontColor: "FF8800" } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fontColor).toBe("FF8800");
+  });
+
+  it("collapses an unset fontColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.fontColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.fontColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, fontColor: "0F0F0F" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:srgbClr val="0F0F0F"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.fontColor).toBe("0F0F0F");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15181,3 +15181,187 @@ describe("parseChart — data labels fontSize", () => {
     expect(parseChart(xml)?.dataLabels?.fontSize).toBe(16);
   });
 });
+
+// ── parseChart — data labels fontColor ──────────────────────────────
+
+describe("parseChart — data labels fontColor", () => {
+  const NS_DLC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsColor(srgbVal: string | undefined): string {
+    const fill =
+      srgbVal === undefined
+        ? "<a:defRPr/>"
+        : `<a:defRPr><a:solidFill><a:srgbClr val="${srgbVal}"/></a:solidFill></a:defRPr>`;
+    return `<c:chartSpace ${NS_DLC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${fill}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces fontColor as the canonical 6-character uppercase hex", () => {
+    expect(parseChart(withDLblsColor("FF0000"))?.dataLabels?.fontColor).toBe("FF0000");
+  });
+
+  it("normalizes a lowercase srgbClr val to the OOXML uppercase canonical form", () => {
+    expect(parseChart(withDLblsColor("ff8800"))?.dataLabels?.fontColor).toBe("FF8800");
+  });
+
+  it("returns undefined when the dLbls block has no <a:solidFill>", () => {
+    expect(parseChart(withDLblsColor(undefined))?.dataLabels?.fontColor).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fontColor).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:dLbls> element at all", () => {
+    const xml = `<c:chartSpace ${NS_DLC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels).toBeUndefined();
+  });
+
+  it("collapses theme references (<a:schemeClr>) to undefined — only literal RGB round-trips", () => {
+    const xml = `<c:chartSpace ${NS_DLC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fontColor).toBeUndefined();
+  });
+
+  it("collapses malformed val tokens (wrong length, non-hex characters) to undefined", () => {
+    expect(parseChart(withDLblsColor(""))?.dataLabels?.fontColor).toBeUndefined();
+    expect(parseChart(withDLblsColor("FF00"))?.dataLabels?.fontColor).toBeUndefined();
+    expect(parseChart(withDLblsColor("FF0000FF"))?.dataLabels?.fontColor).toBeUndefined();
+    expect(parseChart(withDLblsColor("ZZZZZZ"))?.dataLabels?.fontColor).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat)", () => {
+    const xml = `<c:chartSpace ${NS_DLC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="123456"/></a:solidFill></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.fontColor).toBe("123456");
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the fontColor on a fontColor-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fontColor).toBe("00FF00");
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>` at the read, write, and clone layers so a template's data-labels font color survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `fontColor?: string` on `ChartDataLabels` (writer side) and the matching `fontColor?: string` on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:dLbls>` block as `position` / `numberFormat` / `separator` / `showLeaderLines` / the `show*` toggles; the writer threads the value through the shared `buildDataLabelsBody` helper so chart-level and per-series data labels both pick up the typography pin. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user tinted the data labels (e.g. a high-contrast hex on a dark-background dashboard tile) now round-trips that color through the parse / clone / write loop.

Mirrors the chart-title `titleColor` (#254), the axis-title `axisTitleColor` (#258), the axis tick-label `labelColor` (#266), and the legend `legendFontColor` exactly — same accept-with-or-without-`#` hex grammar (`\"FF0000\"` / `\"#FF0000\"` / `\"ff0000\"` all collapse to the OOXML uppercase canonical form `\"FF0000\"`). Malformed inputs (wrong length, non-hex characters, alpha-channel forms like `\"#FF0000FF\"`, non-string escapes from an untyped caller) collapse to `undefined` so the writer skips the entire `<a:solidFill>` block and the labels inherit the theme text color (Excel's reference behavior for fresh data labels that have not had a custom color picked). Theme references (`<a:schemeClr>`) and preset color tokens drop on the reader side too — only the literal RGB triple round-trips losslessly through the writer.

The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>` inside `<c:dLbls>`, matching the CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The block is skipped entirely when no font knob is pinned so a fresh chart matches Excel's reference shape byte-for-byte (Excel itself omits `<c:txPr>` from `<c:dLbls>` when the labels render at the theme-default style). The clone path threads the value through the existing `resolveChartDataLabels` resolver (which spreads the read-side `ChartDataLabelsInfo` into the write-side `ChartDataLabels` shape — they share field semantics). Future typography pins (size, bold, italic, underline, strikethrough) will land on the same `<a:defRPr>` slot.

Refs #136

## Test plan

- [x] `pnpm test` passes (5337 tests across 89 files, lint + format + typecheck + vitest)
- [x] `pnpm build` succeeds
- [x] New describe blocks: `parseChart — data labels fontColor` (9 cases), `writeChart — dataLabels.fontColor` (18 cases), `cloneChart — dataLabels.fontColor` (11 cases) covering parse, write, end-to-end `writeXlsx`, hex normalization (`#`-prefix / case folding), `<a:schemeClr>` / preset-color collapse, malformed input drops, OOXML element ordering (`<c:numFmt>` -> `<c:txPr>` -> `<c:dLblPos>`), multi-family coverage (bar / column / line / pie / doughnut / area), composition with the sibling dLbls knobs (`position` / `numberFormat` / `separator` / `show*` toggles), and the standard `null`-drop / explicit-replace clone grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)