### PR TITLE
feat(xlsx): chart data labels bold flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -723,6 +723,36 @@ export interface ChartDataLabels {
    * thread a single hex string through every typography-pinning slot.
    */
   fontColor?: string;
+  /**
+   * Data-label bold flag. Maps to `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr b=".."/></a:pPr></a:p></c:txPr></c:dLbls>` — Excel's
+   * "Format Data Labels -> Font -> Bold" toggle. The OOXML attribute
+   * is the `xsd:boolean` bold flag on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7); the writer lands `b="1"` (bold)
+   * or `b="0"` (the OOXML default — non-bold) on the
+   * default-paragraph `<a:defRPr>` slot inside the data-label's
+   * `<c:txPr>` block so a re-parse picks the flag up off the
+   * canonical slot the OOXML schema exposes.
+   *
+   * Default: omitted — the data labels render non-bold (no `b`
+   * attribute, matching Excel's reference serialization for fresh
+   * data labels whose typography has not been customized; the OOXML
+   * default `0` collapses to absence). Set `true` to emit `b="1"` so
+   * the labels render bold; set `false` explicitly to pin `b="0"`
+   * (functionally identical to omission, but useful when overriding
+   * a templated chart that had bold pinned upstream).
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Composes
+   * independently with the other dLbls knobs — {@link position} /
+   * {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles. Mirrors the chart-title `titleBold` /
+   * axis-title `axisTitleBold` / axis tick-label `labelBold` / legend
+   * `legendBold` knobs — same boolean shape, same OOXML
+   * `<a:defRPr b=".."/>` mapping — so a caller can thread a single
+   * bold value through every typography-pinning slot.
+   */
+  bold?: boolean;
 }
 
 /**
@@ -4231,6 +4261,20 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   fontColor?: string;
+  /**
+   * Data-label bold flag pulled from `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr b=".."/></a:pPr></a:p></c:txPr></c:dLbls>`. The OOXML
+   * `b` attribute is the `xsd:boolean` bold flag on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `b="0"` round-trip identically — only an explicit `b="1"` surfaces
+   * `true`. Unknown / malformed `b` tokens drop to `undefined` rather
+   * than fabricate a value the writer would never emit. Mirrors the
+   * writer-side {@link ChartDataLabels.bold} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  bold?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2528,6 +2528,14 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const fontColor = parseDataLabelsFontColor(el);
   if (fontColor !== undefined) out.fontColor = fontColor;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p></c:txPr>` —
+  // data-label bold flag pinned via Excel's "Format Data Labels ->
+  // Font -> Bold" toggle. Only an explicit `b="1"` surfaces `true`;
+  // the OOXML default `b="0"` collapses to `undefined` so absence
+  // and `b="0"` round-trip identically through `cloneChart`.
+  const bold = parseDataLabelsBold(el);
+  if (bold !== undefined) out.bold = bold;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2540,7 +2548,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.numberFormat === undefined &&
     out.showLeaderLines === undefined &&
     out.fontSize === undefined &&
-    out.fontColor === undefined
+    out.fontColor === undefined &&
+    out.bold === undefined
   ) {
     return undefined;
   }
@@ -2621,6 +2630,34 @@ function parseDataLabelsFontColor(dLbls: XmlElement): string | undefined {
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;
   return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr></a:p>
+ * </c:txPr></c:dLbls>` off a data-labels block. Returns the bold
+ * flag.
+ *
+ * The OOXML `b` attribute is the `xsd:boolean` bold flag on
+ * `CT_TextCharacterProperties`. Only an explicit `b="1"` (or
+ * `"true"`) surfaces `true`; the OOXML default `0` (and absence /
+ * malformed tokens) collapses to `undefined` so absence and the
+ * default round-trip identically through `cloneChart`. Mirrors the
+ * chart-title / axis-title / axis tick-label / legend bold readers
+ * exactly so a parsed value slots straight back into the writer's
+ * emit path.
+ */
+function parseDataLabelsBold(dLbls: XmlElement): boolean | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.b;
+  if (raw === "1" || raw === "true") return true;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3842,14 +3842,15 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The writer currently
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
-  // carries the data-label font size and font color; future
-  // typography pins (bold, italic, underline, strikethrough) will land
-  // on the same `<a:defRPr>` slot. The writer skips the entire block
-  // when no font knob is pinned so a fresh chart matches Excel's
-  // reference shape.
+  // carries the data-label font size, font color, and bold flag;
+  // future typography pins (italic, underline, strikethrough) will
+  // land on the same `<a:defRPr>` slot. The writer skips the entire
+  // block when no font knob is pinned so a fresh chart matches
+  // Excel's reference shape.
   const txPrXml = buildDataLabelsTxPr(
     resolveDataLabelsFontSize(dl.fontSize),
     resolveDataLabelsFontColor(dl.fontColor),
+    resolveDataLabelsBold(dl.bold),
   );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
@@ -3953,6 +3954,22 @@ function resolveDataLabelsFontColor(value: string | undefined): string | undefin
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr b=".."/></a:pPr>
+ * </a:p></c:txPr></c:dLbls>` from {@link ChartDataLabels.bold}.
+ *
+ * Returns the bold flag, or `undefined` when the caller leaves the
+ * field unset / passed a non-boolean token. Mirrors the chart-title /
+ * axis-title / axis tick-label / legend bold resolvers exactly —
+ * only literal `true` / `false` pass through; non-boolean tokens
+ * (typed escapes from an untyped caller) collapse to `undefined`.
+ */
+function resolveDataLabelsBold(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -3971,18 +3988,23 @@ function resolveDataLabelsFontColor(value: string | undefined): string | undefin
  * `<a:solidFill>` child when a color is set; otherwise the writer
  * keeps the existing self-closing form so a fresh chart with no
  * custom color matches Excel's reference serialization byte-for-byte.
- * Mirrors the chart-title / axis-title / axis tick-label / legend
- * `<c:txPr>` slots exactly so a re-parse picks the value off the
- * canonical default-paragraph slot every other typography reader
- * expects.
+ * The bold flag emits a literal `b="1"` / `b="0"` whenever the input
+ * is a boolean — `false` pins the OOXML default explicitly, which is
+ * functionally identical to absence but lets a clone target override
+ * an upstream `b="1"` from a templated chart. Mirrors the chart-title
+ * / axis-title / axis tick-label / legend `<c:txPr>` slots exactly so
+ * a re-parse picks the value off the canonical default-paragraph slot
+ * every other typography reader expects.
  */
 function buildDataLabelsTxPr(
   fontSizePt: number | undefined,
   rgbHex: string | undefined,
+  bold: boolean | undefined,
 ): string | undefined {
-  if (fontSizePt === undefined && rgbHex === undefined) return undefined;
+  if (fontSizePt === undefined && rgbHex === undefined && bold === undefined) return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-label font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16220,3 +16220,189 @@ describe("cloneChart — dataLabels.fontColor", () => {
     expect(clone.dataLabels?.fontColor).toBe("FF0000");
   });
 });
+
+// ── cloneChart — dataLabels.bold ────────────────────────────────────
+
+describe("cloneChart — dataLabels.bold", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.bold by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.bold).toBe(true);
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, bold: false },
+    });
+    expect(clone.dataLabels?.bold).toBe(false);
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          bold: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.bold).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.bold into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('b="1"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.bold).toBe(true);
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: false } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, bold: true },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('b="1"');
+    expect(parseChart(written)?.dataLabels?.bold).toBe(true);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.bold through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.bold).toBe(true);
+  });
+
+  it("carries dataLabels.bold through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, bold: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.bold).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -14576,3 +14576,160 @@ describe("writeChart — dataLabels.fontColor", () => {
     expect(reparsed?.dataLabels?.fontColor).toBe("0F0F0F");
   });
 });
+
+// ── writeChart — dataLabels.bold ────────────────────────────────────
+
+describe("writeChart — dataLabels.bold", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when bold is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:defRPr");
+  });
+
+  it('threads bold=true through to <c:dLbls><c:txPr> as b="1"', () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true, bold: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('b="1"');
+  });
+
+  it('threads bold=false through as b="0" (explicit OOXML default)', () => {
+    // Explicit `false` pins the OOXML default — functionally identical
+    // to omission, but lets a clone target override an upstream
+    // `b="1"` from a templated chart.
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('b="0"');
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          bold: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true, bold: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads bold through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, bold: true } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('b="1"');
+    }
+  });
+
+  it("drops non-boolean inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, bold: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, bold: "yes" as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, bold: 1 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true, bold: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:defRPr b="1"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips a bold=true value through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.bold).toBe(true);
+  });
+
+  it('collapses bold=false back to undefined on re-parse (b="0" is OOXML default)', () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: false } }),
+      "Sheet1",
+    ).chartXml;
+    expect(parseChart(written)?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it("collapses an unset bold round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.bold lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, bold: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('b="1"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.bold).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15365,3 +15365,149 @@ describe("parseChart — data labels fontColor", () => {
     expect(parseChart(xml)?.dataLabels?.fontColor).toBe("00FF00");
   });
 });
+
+// ── parseChart — data labels bold ───────────────────────────────────
+
+describe("parseChart — data labels bold", () => {
+  const NS_DLB = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsBold(b: string | undefined): string {
+    const defRPr = b === undefined ? "<a:defRPr/>" : `<a:defRPr b="${b}"/>`;
+    return `<c:chartSpace ${NS_DLB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces bold=true when b="1"', () => {
+    expect(parseChart(withDLblsBold("1"))?.dataLabels?.bold).toBe(true);
+  });
+
+  it('surfaces bold=true when b="true" (less common but valid)', () => {
+    expect(parseChart(withDLblsBold("true"))?.dataLabels?.bold).toBe(true);
+  });
+
+  it('collapses the OOXML default b="0" to undefined', () => {
+    expect(parseChart(withDLblsBold("0"))?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it('collapses b="false" to undefined (matches the OOXML default)', () => {
+    expect(parseChart(withDLblsBold("false"))?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the b attribute", () => {
+    expect(parseChart(withDLblsBold(undefined))?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it("collapses garbage / unknown b tokens to undefined", () => {
+    expect(parseChart(withDLblsBold(""))?.dataLabels?.bold).toBeUndefined();
+    expect(parseChart(withDLblsBold("yes"))?.dataLabels?.bold).toBeUndefined();
+    expect(parseChart(withDLblsBold("2"))?.dataLabels?.bold).toBeUndefined();
+    expect(parseChart(withDLblsBold("bold"))?.dataLabels?.bold).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat)", () => {
+    const xml = `<c:chartSpace ${NS_DLB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1"/></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.bold).toBe(true);
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the bold flag on a bold-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1"/></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.bold).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr b=\"..\"/></a:pPr></a:p></c:txPr></c:dLbls>` at the read, write, and clone layers so a template's data-labels bold flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `bold?: boolean` on `ChartDataLabels` (writer side) and the matching `bold?: boolean` on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:dLbls>` block as `position` / `numberFormat` / `separator` / `showLeaderLines` / the `show*` toggles; the writer threads the value through the shared `buildDataLabelsBody` helper so chart-level and per-series data labels both pick up the typography pin. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user pinned bold data labels (e.g. for emphasis on a \"primary\" KPI tile) now round-trips that flag through the parse / clone / write loop.

Mirrors the chart-title `titleBold` (#252), the axis-title `axisTitleBold` (#256), the axis tick-label `labelBold` (#264), and the legend `legendBold` (#270) exactly: `true` emits `b=\"1\"`; `false` emits the OOXML default `b=\"0\"` explicitly so a clone target can override an upstream `b=\"1\"` from a templated chart; absence collapses to omitting the attribute entirely. The reader collapses the OOXML default `0` (and absence) to `undefined` so absence and `b=\"0\"` round-trip identically — only an explicit `b=\"1\"` surfaces `true`. Non-boolean inputs (typed escapes from an untyped caller — strings, `null`, numbers) collapse to `undefined` so the writer never emits a malformed `b` attribute.

The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>` inside `<c:dLbls>`, matching the CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The block is skipped entirely when no font knob is pinned so a fresh chart matches Excel's reference shape byte-for-byte (Excel itself omits `<c:txPr>` from `<c:dLbls>` when the labels render at the theme-default style). The clone path threads the value through the existing `resolveChartDataLabels` resolver (which spreads the read-side `ChartDataLabelsInfo` into the write-side `ChartDataLabels` shape — they share field semantics). Future typography pins (size, color, italic, underline, strikethrough) will land on the same `<a:defRPr>` slot.

Refs #136

## Test plan

- [x] `pnpm test` passes (5385 tests across 89 files, lint + format + typecheck + vitest)
- [x] `pnpm build` succeeds
- [x] New describe blocks: `parseChart — data labels bold` (9 cases), `writeChart — dataLabels.bold` (15 cases), `cloneChart — dataLabels.bold` (11 cases) covering parse, write, end-to-end `writeXlsx`, the OOXML default `0` collapse, malformed input drops, OOXML element ordering (`<c:numFmt>` -> `<c:txPr>` -> `<c:dLblPos>`), multi-family coverage (bar / column / line / pie / doughnut / area), composition with the sibling dLbls knobs (`position` / `numberFormat` / `separator` / `show*` toggles), and the standard `null`-drop / explicit-replace clone grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)