### PR TITLE
feat(xlsx): chart data labels italic flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -753,6 +753,36 @@ export interface ChartDataLabels {
    * bold value through every typography-pinning slot.
    */
   bold?: boolean;
+  /**
+   * Data-label italic flag. Maps to `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:dLbls>` — Excel's
+   * "Format Data Labels -> Font -> Italic" toggle. The OOXML attribute
+   * is the `xsd:boolean` italic flag on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7); the writer lands `i="1"` (italic)
+   * or `i="0"` (the OOXML default — upright) on the default-paragraph
+   * `<a:defRPr>` slot inside the data-label's `<c:txPr>` block so a
+   * re-parse picks the flag up off the canonical slot the OOXML
+   * schema exposes.
+   *
+   * Default: omitted — the data labels render upright (no `i`
+   * attribute, matching Excel's reference serialization for fresh
+   * data labels whose typography has not been customized; the OOXML
+   * default `0` collapses to absence). Set `true` to emit `i="1"` so
+   * the labels render italic; set `false` explicitly to pin `i="0"`
+   * (functionally identical to omission, but useful when overriding
+   * a templated chart that had italic pinned upstream).
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Composes
+   * independently with the other dLbls knobs — {@link position} /
+   * {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles / {@link bold}. Mirrors the chart-title
+   * `titleItalic` / axis-title `axisTitleItalic` / axis tick-label
+   * `labelItalic` / legend `legendItalic` knobs — same boolean shape,
+   * same OOXML `<a:defRPr i=".."/>` mapping — so a caller can thread
+   * a single italic value through every typography-pinning slot.
+   */
+  italic?: boolean;
 }
 
 /**
@@ -4275,6 +4305,20 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   bold?: boolean;
+  /**
+   * Data-label italic flag pulled from `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:dLbls>`. The OOXML
+   * `i` attribute is the `xsd:boolean` italic flag on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * The OOXML default `false` collapses to `undefined` so absence and
+   * `i="0"` round-trip identically — only an explicit `i="1"` surfaces
+   * `true`. Unknown / malformed `i` tokens drop to `undefined` rather
+   * than fabricate a value the writer would never emit. Mirrors the
+   * writer-side {@link ChartDataLabels.italic} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  italic?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2536,6 +2536,14 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const bold = parseDataLabelsBold(el);
   if (bold !== undefined) out.bold = bold;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr>` —
+  // data-label italic flag pinned via Excel's "Format Data Labels ->
+  // Font -> Italic" toggle. Only an explicit `i="1"` surfaces `true`;
+  // the OOXML default `i="0"` collapses to `undefined` so absence
+  // and `i="0"` round-trip identically through `cloneChart`.
+  const italic = parseDataLabelsItalic(el);
+  if (italic !== undefined) out.italic = italic;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2549,7 +2557,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.showLeaderLines === undefined &&
     out.fontSize === undefined &&
     out.fontColor === undefined &&
-    out.bold === undefined
+    out.bold === undefined &&
+    out.italic === undefined
   ) {
     return undefined;
   }
@@ -2656,6 +2665,34 @@ function parseDataLabelsBold(dLbls: XmlElement): boolean | undefined {
   const defRPr = findChild(pPr, "defRPr");
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.b;
+  if (raw === "1" || raw === "true") return true;
+  return undefined;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+ * </c:txPr></c:dLbls>` off a data-labels block. Returns the italic
+ * flag.
+ *
+ * The OOXML `i` attribute is the `xsd:boolean` italic flag on
+ * `CT_TextCharacterProperties`. Only an explicit `i="1"` (or
+ * `"true"`) surfaces `true`; the OOXML default `0` (and absence /
+ * malformed tokens) collapses to `undefined` so absence and the
+ * default round-trip identically through `cloneChart`. Mirrors the
+ * chart-title / axis-title / axis tick-label / legend italic readers
+ * exactly so a parsed value slots straight back into the writer's
+ * emit path.
+ */
+function parseDataLabelsItalic(dLbls: XmlElement): boolean | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.i;
   if (raw === "1" || raw === "true") return true;
   return undefined;
 }

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3842,15 +3842,16 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The writer currently
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
-  // carries the data-label font size, font color, and bold flag;
-  // future typography pins (italic, underline, strikethrough) will
-  // land on the same `<a:defRPr>` slot. The writer skips the entire
-  // block when no font knob is pinned so a fresh chart matches
+  // carries the data-label font size, font color, bold flag, and
+  // italic flag; future typography pins (underline, strikethrough)
+  // will land on the same `<a:defRPr>` slot. The writer skips the
+  // entire block when no font knob is pinned so a fresh chart matches
   // Excel's reference shape.
   const txPrXml = buildDataLabelsTxPr(
     resolveDataLabelsFontSize(dl.fontSize),
     resolveDataLabelsFontColor(dl.fontColor),
     resolveDataLabelsBold(dl.bold),
+    resolveDataLabelsItalic(dl.italic),
   );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
@@ -3970,6 +3971,22 @@ function resolveDataLabelsBold(value: boolean | undefined): boolean | undefined 
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+ * </a:p></c:txPr></c:dLbls>` from {@link ChartDataLabels.italic}.
+ *
+ * Returns the italic flag, or `undefined` when the caller leaves the
+ * field unset / passed a non-boolean token. Mirrors the chart-title /
+ * axis-title / axis tick-label / legend italic resolvers exactly —
+ * only literal `true` / `false` pass through; non-boolean tokens
+ * (typed escapes from an untyped caller) collapse to `undefined`.
+ */
+function resolveDataLabelsItalic(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -3988,11 +4005,12 @@ function resolveDataLabelsBold(value: boolean | undefined): boolean | undefined 
  * `<a:solidFill>` child when a color is set; otherwise the writer
  * keeps the existing self-closing form so a fresh chart with no
  * custom color matches Excel's reference serialization byte-for-byte.
- * The bold flag emits a literal `b="1"` / `b="0"` whenever the input
- * is a boolean — `false` pins the OOXML default explicitly, which is
- * functionally identical to absence but lets a clone target override
- * an upstream `b="1"` from a templated chart. Mirrors the chart-title
- * / axis-title / axis tick-label / legend `<c:txPr>` slots exactly so
+ * The bold and italic flags each emit a literal `b="1"` / `b="0"`
+ * (or `i="1"` / `i="0"`) whenever the input is a boolean — `false`
+ * pins the OOXML default explicitly, which is functionally identical
+ * to absence but lets a clone target override an upstream `b="1"` /
+ * `i="1"` from a templated chart. Mirrors the chart-title /
+ * axis-title / axis tick-label / legend `<c:txPr>` slots exactly so
  * a re-parse picks the value off the canonical default-paragraph slot
  * every other typography reader expects.
  */
@@ -4000,11 +4018,19 @@ function buildDataLabelsTxPr(
   fontSizePt: number | undefined,
   rgbHex: string | undefined,
   bold: boolean | undefined,
+  italic: boolean | undefined,
 ): string | undefined {
-  if (fontSizePt === undefined && rgbHex === undefined && bold === undefined) return undefined;
+  if (
+    fontSizePt === undefined &&
+    rgbHex === undefined &&
+    bold === undefined &&
+    italic === undefined
+  )
+    return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
+  if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-label font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16406,3 +16406,191 @@ describe("cloneChart — dataLabels.bold", () => {
     expect(clone.dataLabels?.bold).toBe(true);
   });
 });
+
+// ── cloneChart — dataLabels.italic ──────────────────────────────────
+
+describe("cloneChart — dataLabels.italic", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.italic by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.italic).toBe(true);
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, italic: false },
+    });
+    expect(clone.dataLabels?.italic).toBe(false);
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          italic: true,
+          bold: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.italic).toBe(true);
+    expect(clone.dataLabels?.bold).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.italic into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('i="1"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.italic).toBe(true);
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: false } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, italic: true },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('i="1"');
+    expect(parseChart(written)?.dataLabels?.italic).toBe(true);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.italic through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.italic).toBe(true);
+  });
+
+  it("carries dataLabels.italic through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, italic: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.italic).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -14733,3 +14733,183 @@ describe("writeChart — dataLabels.bold", () => {
     expect(reparsed?.dataLabels?.bold).toBe(true);
   });
 });
+
+// ── writeChart — dataLabels.italic ──────────────────────────────────
+
+describe("writeChart — dataLabels.italic", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when italic is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:defRPr");
+  });
+
+  it('threads italic=true through to <c:dLbls><c:txPr> as i="1"', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, italic: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('i="1"');
+  });
+
+  it('threads italic=false through as i="0" (explicit OOXML default)', () => {
+    // Explicit `false` pins the OOXML default — functionally identical
+    // to omission, but lets a clone target override an upstream
+    // `i="1"` from a templated chart.
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, italic: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('i="0"');
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          italic: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, italic: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads italic through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, italic: true } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('i="1"');
+    }
+  });
+
+  it("composes with bold on the same <a:defRPr> slot", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: true, italic: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('b="1"');
+    expect(dLbls).toContain('i="1"');
+    // Ensure both attrs land on the same <a:defRPr> element.
+    expect(dLbls).toMatch(
+      /<a:defRPr [^>]*b="1"[^>]*i="1"[^>]*\/>|<a:defRPr [^>]*i="1"[^>]*b="1"[^>]*\/>/,
+    );
+  });
+
+  it("drops non-boolean inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, italic: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, italic: "yes" as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, italic: 1 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, italic: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:defRPr i="1"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips a italic=true value through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, italic: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.italic).toBe(true);
+  });
+
+  it('collapses italic=false back to undefined on re-parse (i="0" is OOXML default)', () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, italic: false } }),
+      "Sheet1",
+    ).chartXml;
+    expect(parseChart(written)?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it("collapses an unset italic round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.italic lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, italic: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('i="1"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.italic).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15511,3 +15511,150 @@ describe("parseChart — data labels bold", () => {
     expect(parseChart(xml)?.dataLabels?.bold).toBe(true);
   });
 });
+
+// ── parseChart — data labels italic ─────────────────────────────────
+
+describe("parseChart — data labels italic", () => {
+  const NS_DLI = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsItalic(i: string | undefined): string {
+    const defRPr = i === undefined ? "<a:defRPr/>" : `<a:defRPr i="${i}"/>`;
+    return `<c:chartSpace ${NS_DLI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces italic=true when i="1"', () => {
+    expect(parseChart(withDLblsItalic("1"))?.dataLabels?.italic).toBe(true);
+  });
+
+  it('surfaces italic=true when i="true" (less common but valid)', () => {
+    expect(parseChart(withDLblsItalic("true"))?.dataLabels?.italic).toBe(true);
+  });
+
+  it('collapses the OOXML default i="0" to undefined', () => {
+    expect(parseChart(withDLblsItalic("0"))?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it('collapses i="false" to undefined (matches the OOXML default)', () => {
+    expect(parseChart(withDLblsItalic("false"))?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the i attribute", () => {
+    expect(parseChart(withDLblsItalic(undefined))?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it("collapses garbage / unknown i tokens to undefined", () => {
+    expect(parseChart(withDLblsItalic(""))?.dataLabels?.italic).toBeUndefined();
+    expect(parseChart(withDLblsItalic("yes"))?.dataLabels?.italic).toBeUndefined();
+    expect(parseChart(withDLblsItalic("2"))?.dataLabels?.italic).toBeUndefined();
+    expect(parseChart(withDLblsItalic("italic"))?.dataLabels?.italic).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat / bold)", () => {
+    const xml = `<c:chartSpace ${NS_DLI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1" i="1"/></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.italic).toBe(true);
+    expect(chart?.dataLabels?.bold).toBe(true);
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the italic flag on an italic-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLI}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.italic).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:dLbls>` at the read, write, and clone layers so a template's data-labels italic flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `italic?: boolean` on `ChartDataLabels` (writer side) and the matching `italic?: boolean` on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:dLbls>` block as `position` / `numberFormat` / `separator` / `showLeaderLines` / the `show*` toggles / `bold`; the writer threads the value through the shared `buildDataLabelsBody` helper so chart-level and per-series data labels both pick up the typography pin. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — a templated dashboard chart whose user pinned italic data labels (e.g. for emphasis on a quote-style KPI tile) now round-trips that flag through the parse / clone / write loop.

Mirrors the chart-title `titleItalic` (#253), the axis-title `axisTitleItalic` (#257), the axis tick-label `labelItalic` (#265), the legend `legendItalic` (#271), and the data-labels `bold` (#278) exactly: `true` emits `i="1"`; `false` emits the OOXML default `i="0"` explicitly so a clone target can override an upstream `i="1"` from a templated chart; absence collapses to omitting the attribute entirely. The reader collapses the OOXML default `0` (and absence) to `undefined` so absence and `i="0"` round-trip identically — only an explicit `i="1"` surfaces `true`. Non-boolean inputs (typed escapes from an untyped caller — strings, `null`, numbers) collapse to `undefined` so the writer never emits a malformed `i` attribute.

The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>` inside `<c:dLbls>`, matching the CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The block is skipped entirely when no font knob is pinned so a fresh chart matches Excel's reference shape byte-for-byte. The clone path threads the value through the existing `resolveChartDataLabels` resolver (which spreads the read-side `ChartDataLabelsInfo` into the write-side `ChartDataLabels` shape — they share field semantics), so no chart-clone changes are needed beyond the type addition.

Refs #136

## Test plan

- [x] `pnpm lint` — clean (only pre-existing warnings)
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --dir=test` — 5495 passing across 89 files
- [x] `pnpm build` — clean
- [x] New parser tests cover: `i="1"` / `i="true"` surface `true`; `i="0"` / `i="false"` / absence collapse to `undefined`; missing `<c:txPr>` returns `undefined`; garbage tokens collapse; co-surfaces with `bold` / `position` / `numberFormat`
- [x] New writer tests cover: unset omits `<c:txPr>`; `true` emits `i="1"`; `false` emits `i="0"`; CT_DLbls element ordering after `<c:numFmt>` and before `<c:dLblPos>`; only one `<c:txPr>`; threads through bar/column/line/pie/doughnut/area; composes with `bold` on the same `<a:defRPr>`; non-boolean inputs (`null` / string / number) collapse to omission; emits the standard txPr stub shape; round-trips `true` and collapses `false`/unset back to `undefined`; `writeXlsx` package round-trip
- [x] New clone tests cover: inherits source value; explicit override replaces; `null` drops the inherited block; absence on both sides collapses to `undefined`; composes with other dLbls fields; `writeXlsx` round-trips through `parseChart`; flatten preserves italic through `bar -> line` and `bar -> doughnut`

🤖 Generated with [Claude Code](https://claude.com/claude-code)