### PR TITLE
feat(xlsx): chart data labels underline flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -783,6 +783,41 @@ export interface ChartDataLabels {
    * a single italic value through every typography-pinning slot.
    */
   italic?: boolean;
+  /**
+   * Data-label underline flag. Maps to `<c:dLbls><c:txPr><a:p><a:pPr>
+   * <a:defRPr u=".."/></a:pPr></a:p></c:txPr></c:dLbls>` — Excel's
+   * "Format Data Labels -> Font -> Underline" toggle. The OOXML
+   * attribute is the `ST_TextUnderlineType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer lands `u="sng"` (single underline — Excel's UI checkbox)
+   * or `u="none"` (the OOXML default — no underline) on the
+   * default-paragraph `<a:defRPr>` slot inside the data-label's
+   * `<c:txPr>` block so a re-parse picks the flag up off the
+   * canonical slot the OOXML schema exposes.
+   *
+   * Modeled as a boolean for symmetry with {@link bold} / {@link italic}
+   * / the other `*Underline` knobs across the chart-title, axis-title,
+   * axis tick-label, and legend slots: `true` emits `u="sng"`; `false`
+   * emits `u="none"` explicitly so a clone target can override an
+   * upstream `u="sng"` from a templated chart; absence collapses to
+   * omitting the attribute entirely. The non-UI variant `"dbl"`
+   * (double line) and the sixteen exotic `ST_TextUnderlineType`
+   * tokens (`"words"`, `"heavy"`, `"dotted"`, etc.) are read-only —
+   * the writer emits only `"sng"` / `"none"` to keep the surfaced
+   * shape consistent with what Excel's reference UI authors.
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Composes
+   * independently with the other dLbls knobs — {@link position} /
+   * {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles / {@link bold} / {@link italic}. Mirrors the
+   * chart-title `titleUnderline` / axis-title `axisTitleUnderline` /
+   * axis tick-label `labelUnderline` / legend `legendUnderline` knobs
+   * — same boolean shape, same OOXML `<a:defRPr u=".."/>` mapping —
+   * so a caller can thread a single underline value through every
+   * typography-pinning slot.
+   */
+  underline?: boolean;
 }
 
 /**
@@ -4319,6 +4354,25 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   italic?: boolean;
+  /**
+   * Data-label underline flag pulled from `<c:dLbls><c:txPr><a:p>
+   * <a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr></c:dLbls>`. The
+   * OOXML `u` attribute is the `ST_TextUnderlineType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Only `u="sng"` (Excel's UI variant — single underline) surfaces
+   * `true`; the OOXML default `"none"` (and every other variant the
+   * schema allows — `"dbl"`, `"heavy"`, `"dotted"`, `"dotDash"`,
+   * `"wavy"`, etc.) collapse to `undefined` so absence and `u="none"`
+   * round-trip identically through `cloneChart`. Reporting any
+   * non-`"sng"` underline as `true` would silently downgrade the
+   * choice to a single line on round-trip; the writer emits only
+   * `u="sng"` / `u="none"`, matching the boolean shape the UI
+   * exposes. Mirrors the writer-side
+   * {@link ChartDataLabels.underline} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  underline?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2544,6 +2544,16 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const italic = parseDataLabelsItalic(el);
   if (italic !== undefined) out.italic = italic;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr>` —
+  // data-label underline flag pinned via Excel's "Format Data Labels
+  // -> Font -> Underline" toggle. Only `u="sng"` (Excel's UI variant
+  // — single underline) surfaces `true`; the OOXML default `"none"`
+  // (and every other ST_TextUnderlineType variant) collapse to
+  // `undefined` so absence and `u="none"` round-trip identically
+  // through `cloneChart`.
+  const underline = parseDataLabelsUnderline(el);
+  if (underline !== undefined) out.underline = underline;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2558,7 +2568,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.fontSize === undefined &&
     out.fontColor === undefined &&
     out.bold === undefined &&
-    out.italic === undefined
+    out.italic === undefined &&
+    out.underline === undefined
   ) {
     return undefined;
   }
@@ -2694,6 +2705,38 @@ function parseDataLabelsItalic(dLbls: XmlElement): boolean | undefined {
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.i;
   if (raw === "1" || raw === "true") return true;
+  return undefined;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p>
+ * </c:txPr></c:dLbls>` off a data-labels block. Returns the underline
+ * flag.
+ *
+ * The OOXML `u` attribute is the `ST_TextUnderlineType` enumeration
+ * on `CT_TextCharacterProperties`. Only `u="sng"` (Excel's UI variant
+ * — single underline) surfaces `true`; the OOXML default `"none"`
+ * (and every other variant the schema allows — `"dbl"`, `"heavy"`,
+ * `"dotted"`, `"dotDash"`, `"wavy"`, etc.) collapse to `undefined` so
+ * absence and `u="none"` round-trip identically through `cloneChart`.
+ * Reporting any non-`"sng"` underline as `true` would silently
+ * downgrade the choice to a single line on round-trip; the writer
+ * emits only `u="sng"` / `u="none"`, matching the boolean shape the
+ * UI exposes. Mirrors the chart-title / axis-title / axis tick-label
+ * / legend underline readers exactly so a parsed value slots straight
+ * back into the writer's emit path.
+ */
+function parseDataLabelsUnderline(dLbls: XmlElement): boolean | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.u;
+  if (raw === "sng") return true;
   return undefined;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3842,8 +3842,8 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The writer currently
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
-  // carries the data-label font size, font color, bold flag, and
-  // italic flag; future typography pins (underline, strikethrough)
+  // carries the data-label font size, font color, bold flag, italic
+  // flag, and underline flag; future typography pins (strikethrough)
   // will land on the same `<a:defRPr>` slot. The writer skips the
   // entire block when no font knob is pinned so a fresh chart matches
   // Excel's reference shape.
@@ -3852,6 +3852,7 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
     resolveDataLabelsFontColor(dl.fontColor),
     resolveDataLabelsBold(dl.bold),
     resolveDataLabelsItalic(dl.italic),
+    resolveDataLabelsUnderline(dl.underline),
   );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
@@ -3987,6 +3988,25 @@ function resolveDataLabelsItalic(value: boolean | undefined): boolean | undefine
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr>
+ * </a:p></c:txPr></c:dLbls>` from {@link ChartDataLabels.underline}.
+ *
+ * Returns the underline flag, or `undefined` when the caller leaves
+ * the field unset / passed a non-boolean token. Mirrors the
+ * chart-title / axis-title / axis tick-label / legend underline
+ * resolvers exactly — only literal `true` / `false` pass through;
+ * non-boolean tokens (typed escapes from an untyped caller) collapse
+ * to `undefined`. The writer translates `true` into `u="sng"` (Excel's
+ * UI variant — single underline) and `false` into `u="none"` at emit
+ * time.
+ */
+function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -4009,28 +4029,34 @@ function resolveDataLabelsItalic(value: boolean | undefined): boolean | undefine
  * (or `i="1"` / `i="0"`) whenever the input is a boolean — `false`
  * pins the OOXML default explicitly, which is functionally identical
  * to absence but lets a clone target override an upstream `b="1"` /
- * `i="1"` from a templated chart. Mirrors the chart-title /
- * axis-title / axis tick-label / legend `<c:txPr>` slots exactly so
- * a re-parse picks the value off the canonical default-paragraph slot
- * every other typography reader expects.
+ * `i="1"` from a templated chart. The underline flag emits `u="sng"`
+ * (single underline — Excel's UI variant) for `true` and `u="none"`
+ * (the OOXML default) for `false`, with the same override semantics
+ * as bold and italic. Mirrors the chart-title / axis-title / axis
+ * tick-label / legend `<c:txPr>` slots exactly so a re-parse picks
+ * the value off the canonical default-paragraph slot every other
+ * typography reader expects.
  */
 function buildDataLabelsTxPr(
   fontSizePt: number | undefined,
   rgbHex: string | undefined,
   bold: boolean | undefined,
   italic: boolean | undefined,
+  underline: boolean | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
     rgbHex === undefined &&
     bold === undefined &&
-    italic === undefined
+    italic === undefined &&
+    underline === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
   if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
+  if (underline !== undefined) defRPrAttrs.u = underline ? "sng" : "none";
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-label font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16594,3 +16594,190 @@ describe("cloneChart — dataLabels.italic", () => {
     expect(clone.dataLabels?.italic).toBe(true);
   });
 });
+// ── cloneChart — dataLabels.underline ───────────────────────────────
+
+describe("cloneChart — dataLabels.underline", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.underline by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.underline).toBe(true);
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, underline: false },
+    });
+    expect(clone.dataLabels?.underline).toBe(false);
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          underline: true,
+          bold: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.underline).toBe(true);
+    expect(clone.dataLabels?.bold).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.underline into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('u="sng"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.underline).toBe(true);
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: false } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, underline: true },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('u="sng"');
+    expect(parseChart(written)?.dataLabels?.underline).toBe(true);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.underline through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.underline).toBe(true);
+  });
+
+  it("carries dataLabels.underline through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, underline: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.underline).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -14913,3 +14913,182 @@ describe("writeChart — dataLabels.italic", () => {
     expect(reparsed?.dataLabels?.italic).toBe(true);
   });
 });
+// ── writeChart — dataLabels.underline ───────────────────────────────
+
+describe("writeChart — dataLabels.underline", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when underline is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:defRPr");
+  });
+
+  it('threads underline=true through to <c:dLbls><c:txPr> as u="sng"', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, underline: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('u="sng"');
+  });
+
+  it('threads underline=false through as u="none" (explicit OOXML default)', () => {
+    // Explicit `false` pins the OOXML default — functionally identical
+    // to omission, but lets a clone target override an upstream
+    // `u="sng"` from a templated chart.
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, underline: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('u="none"');
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          underline: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, underline: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads underline through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, underline: true } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('u="sng"');
+    }
+  });
+
+  it("composes with bold on the same <a:defRPr> slot", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: true, underline: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('b="1"');
+    expect(dLbls).toContain('u="sng"');
+    // Ensure both attrs land on the same <a:defRPr> element.
+    expect(dLbls).toMatch(
+      /<a:defRPr [^>]*b="1"[^>]*u="sng"[^>]*\/>|<a:defRPr [^>]*u="sng"[^>]*b="1"[^>]*\/>/,
+    );
+  });
+
+  it("drops non-boolean inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, underline: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, underline: "sng" as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, underline: 1 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, underline: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:defRPr u="sng"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips an underline=true value through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, underline: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.underline).toBe(true);
+  });
+
+  it('collapses underline=false back to undefined on re-parse (u="none" is OOXML default)', () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, underline: false } }),
+      "Sheet1",
+    ).chartXml;
+    expect(parseChart(written)?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it("collapses an unset underline round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.underline lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, underline: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('u="sng"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.underline).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15658,3 +15658,167 @@ describe("parseChart — data labels italic", () => {
     expect(parseChart(xml)?.dataLabels?.italic).toBe(true);
   });
 });
+// ── parseChart — data labels underline ──────────────────────────────
+
+describe("parseChart — data labels underline", () => {
+  const NS_DLU = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsUnderline(u: string | undefined): string {
+    const defRPr = u === undefined ? "<a:defRPr/>" : `<a:defRPr u="${u}"/>`;
+    return `<c:chartSpace ${NS_DLU}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces underline=true when u="sng"', () => {
+    expect(parseChart(withDLblsUnderline("sng"))?.dataLabels?.underline).toBe(true);
+  });
+
+  it('collapses the OOXML default u="none" to undefined', () => {
+    expect(parseChart(withDLblsUnderline("none"))?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it('collapses u="dbl" (double underline) to undefined — only "sng" round-trips losslessly', () => {
+    expect(parseChart(withDLblsUnderline("dbl"))?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it("collapses every non-sng ST_TextUnderlineType variant to undefined", () => {
+    for (const variant of [
+      "heavy",
+      "dotted",
+      "dottedHeavy",
+      "dash",
+      "dashHeavy",
+      "dashLong",
+      "dashLongHeavy",
+      "dotDash",
+      "dotDashHeavy",
+      "dotDotDash",
+      "dotDotDashHeavy",
+      "wavy",
+      "wavyHeavy",
+      "wavyDbl",
+      "words",
+    ]) {
+      expect(parseChart(withDLblsUnderline(variant))?.dataLabels?.underline).toBeUndefined();
+    }
+  });
+
+  it("returns undefined when <a:defRPr> omits the u attribute", () => {
+    expect(parseChart(withDLblsUnderline(undefined))?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLU}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it("collapses garbage tokens to undefined", () => {
+    expect(parseChart(withDLblsUnderline(""))?.dataLabels?.underline).toBeUndefined();
+    expect(parseChart(withDLblsUnderline("yes"))?.dataLabels?.underline).toBeUndefined();
+    expect(parseChart(withDLblsUnderline("1"))?.dataLabels?.underline).toBeUndefined();
+    expect(parseChart(withDLblsUnderline("true"))?.dataLabels?.underline).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat / bold)", () => {
+    const xml = `<c:chartSpace ${NS_DLU}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1" u="sng"/></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.underline).toBe(true);
+    expect(chart?.dataLabels?.bold).toBe(true);
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the underline flag on an underline-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLU}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.underline).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p></c:txPr></c:dLbls>` at the read, write, and clone layers so a template's data-labels underline flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `underline?: boolean` on `ChartDataLabels` (writer side) and the matching `underline?: boolean` on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:dLbls>` block as `position` / `numberFormat` / `separator` / `showLeaderLines` / the `show*` toggles / `bold`; the writer threads the value through the shared `buildDataLabelsBody` helper so chart-level and per-series data labels both pick up the typography pin. Bridges another typography-customization gap for the dashboard composition flow tracked in #136 — useful for emphasising key metric data labels on dashboard tiles where the underline visually separates the value from the surrounding context.

Modeled as a boolean for symmetry with the data-labels `bold` (#278) and the chart-title `titleUnderline` (#260), axis-title `axisTitleUnderline` (#262), axis tick-label `labelUnderline` (#267), and legend `legendUnderline` (#272) knobs: `true` emits `u="sng"` (Excel's UI variant — single line), `false` emits `u="none"` explicitly so a clone target can override an upstream `u="sng"` from a templated chart, absence collapses to omitting the attribute entirely. The non-UI variant `"dbl"` (double line) and the sixteen exotic `ST_TextUnderlineType` tokens (`"words"`, `"heavy"`, `"dotted"`, `"dotDash"`, `"wavy"`, etc.) are read-only — the writer emits only `"sng"` / `"none"` to keep the surfaced shape consistent with what Excel's reference UI authors, and the reader collapses every non-`"sng"` token to `undefined` so absence and `u="none"` round-trip identically. Non-boolean inputs (typed escapes from an untyped caller — strings, `null`, numbers) collapse to `undefined` so the writer never emits a malformed `u` attribute.

The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>` inside `<c:dLbls>`, matching the CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The block is skipped entirely when no font knob is pinned so a fresh chart matches Excel's reference shape byte-for-byte. The clone path threads the value through the existing `resolveChartDataLabels` resolver (which spreads the read-side `ChartDataLabelsInfo` into the write-side `ChartDataLabels` shape — they share field semantics), so no chart-clone changes are needed beyond the type addition.

Refs #136

## Test plan

- [x] `pnpm lint` — clean (only pre-existing warnings)
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --dir=test` — full suite green (89 files)
- [x] `pnpm build` — clean
- [x] New parser tests (9): `u="sng"` surfaces `true`; `u="none"` / `u="dbl"` / every non-sng `ST_TextUnderlineType` variant collapse to `undefined`; missing `<c:txPr>` returns `undefined`; garbage tokens collapse; co-surfaces with `bold` / `position` / `numberFormat`
- [x] New writer tests (15): unset omits `<c:txPr>`; `true` emits `u="sng"`; `false` emits `u="none"`; CT_DLbls element ordering after `<c:numFmt>` and before `<c:dLblPos>`; only one `<c:txPr>`; threads through bar/column/line/pie/doughnut/area; composes with `bold` on the same `<a:defRPr>`; non-boolean inputs (`null` / string / number) collapse to omission; emits the standard txPr stub shape; round-trips `true` and collapses `false`/unset back to `undefined`; `writeXlsx` package round-trip
- [x] New clone tests (11): inherits source value; explicit override replaces; `null` drops the inherited block; absence on both sides collapses to `undefined`; composes with other dLbls fields; `writeXlsx` round-trips through `parseChart`; flatten preserves underline through `bar -> line` and `bar -> doughnut`

🤖 Generated with [Claude Code](https://claude.com/claude-code)