### PR TITLE
feat(xlsx): chart data labels strikethrough flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -818,6 +818,39 @@ export interface ChartDataLabels {
    * typography-pinning slot.
    */
   underline?: boolean;
+  /**
+   * Data-label strikethrough flag. Maps to `<c:dLbls><c:txPr><a:p>
+   * <a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr></c:dLbls>`
+   * — Excel's "Format Data Labels -> Font -> Strikethrough" toggle.
+   * The OOXML attribute is the `ST_TextStrikeType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer lands `strike="sngStrike"` (single line — Excel's UI
+   * checkbox) on the default-paragraph `<a:defRPr>` slot inside the
+   * data-label's `<c:txPr>` block so a re-parse picks the flag up
+   * off the canonical slot the OOXML schema exposes.
+   *
+   * Modeled as a boolean for symmetry with the data-labels {@link bold}
+   * / {@link italic} / {@link underline} and the chart-title
+   * `titleStrikethrough` / axis-title `axisTitleStrike` / axis
+   * tick-label `labelStrikethrough` / legend `legendStrikethrough`
+   * knobs: `true` emits `strike="sngStrike"`; absence and explicit
+   * `false` both collapse to omitting the attribute (the OOXML default
+   * `"noStrike"` is functionally identical to absence — the writer
+   * never emits `"noStrike"` or `"dblStrike"` to keep the surfaced
+   * shape consistent with what Excel's UI authors). The non-UI variant
+   * `"dblStrike"` (double line) is read-only — the reader collapses
+   * every non-`"sngStrike"` token to `undefined` so a templated chart
+   * that pinned the double-line variant in raw OOXML round-trips
+   * lossless rather than silently downgrading on re-emit.
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Composes
+   * independently with the other dLbls knobs — {@link position} /
+   * {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles / {@link bold} / {@link italic} /
+   * {@link underline}.
+   */
+  strikethrough?: boolean;
 }
 
 /**
@@ -4373,6 +4406,25 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   underline?: boolean;
+  /**
+   * Data-label strikethrough flag pulled from `<c:dLbls><c:txPr>
+   * <a:p><a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr>
+   * </c:dLbls>`. The OOXML `strike` attribute is the
+   * `ST_TextStrikeType` enumeration on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Only `strike="sngStrike"` (Excel's UI variant — single line)
+   * surfaces `true`; the OOXML default `"noStrike"` and the non-UI
+   * variant `"dblStrike"` (and any malformed token) collapse to
+   * `undefined` so absence and `"noStrike"` round-trip identically
+   * through `cloneChart`. Reporting `"dblStrike"` as `true` would
+   * silently downgrade the choice to a single line on round-trip;
+   * the writer emits only `"sngStrike"`, matching the boolean shape
+   * the UI exposes. Mirrors the writer-side
+   * {@link ChartDataLabels.strikethrough} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  strikethrough?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2554,6 +2554,17 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const underline = parseDataLabelsUnderline(el);
   if (underline !== undefined) out.underline = underline;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr></a:p>
+  // </c:txPr>` — data-label strikethrough flag pinned via Excel's
+  // "Format Data Labels -> Font -> Strikethrough" toggle. Only
+  // `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+  // `true`; the OOXML default `"noStrike"` and the non-UI variant
+  // `"dblStrike"` (and any malformed token) collapse to `undefined`
+  // so absence and `"noStrike"` round-trip identically through
+  // `cloneChart`.
+  const strikethrough = parseDataLabelsStrikethrough(el);
+  if (strikethrough !== undefined) out.strikethrough = strikethrough;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2569,7 +2580,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.fontColor === undefined &&
     out.bold === undefined &&
     out.italic === undefined &&
-    out.underline === undefined
+    out.underline === undefined &&
+    out.strikethrough === undefined
   ) {
     return undefined;
   }
@@ -2737,6 +2749,38 @@ function parseDataLabelsUnderline(dLbls: XmlElement): boolean | undefined {
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.u;
   if (raw === "sng") return true;
+  return undefined;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:txPr></c:dLbls>` off a data-labels block. Returns the
+ * strikethrough flag.
+ *
+ * The OOXML `strike` attribute is the `ST_TextStrikeType`
+ * enumeration on `CT_TextCharacterProperties`. Only
+ * `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+ * `true`; the OOXML default `"noStrike"` and the non-UI variant
+ * `"dblStrike"` (and any malformed token) collapse to `undefined` so
+ * absence and `"noStrike"` round-trip identically through
+ * `cloneChart`. Reporting `"dblStrike"` as `true` would silently
+ * downgrade the choice to a single line on round-trip; the writer
+ * emits only `"sngStrike"`, matching the boolean shape the UI
+ * exposes. Mirrors the chart-title / axis-title / axis tick-label /
+ * legend strikethrough readers exactly so a parsed value slots
+ * straight back into the writer's emit path.
+ */
+function parseDataLabelsStrikethrough(dLbls: XmlElement): boolean | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.strike;
+  if (raw === "sngStrike") return true;
   return undefined;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3843,8 +3843,8 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
   // carries the data-label font size, font color, bold flag, italic
-  // flag, and underline flag; future typography pins (strikethrough)
-  // will land on the same `<a:defRPr>` slot. The writer skips the
+  // flag, underline flag, and strikethrough flag — every typography
+  // pin lands on the same `<a:defRPr>` slot. The writer skips the
   // entire block when no font knob is pinned so a fresh chart matches
   // Excel's reference shape.
   const txPrXml = buildDataLabelsTxPr(
@@ -3853,6 +3853,7 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
     resolveDataLabelsBold(dl.bold),
     resolveDataLabelsItalic(dl.italic),
     resolveDataLabelsUnderline(dl.underline),
+    resolveDataLabelsStrikethrough(dl.strikethrough),
   );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
@@ -4007,6 +4008,26 @@ function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undef
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr strike=".."/>
+ * </a:pPr></a:p></c:txPr></c:dLbls>` from
+ * {@link ChartDataLabels.strikethrough}.
+ *
+ * Returns `true` when the caller pins the strikethrough flag
+ * literally; every other value (explicit `false`, absence, non-boolean
+ * tokens leaking past the type guard) collapses to `undefined` so the
+ * writer never emits a `strike` attribute below `"sngStrike"`. The
+ * OOXML default `"noStrike"` is functionally identical to absence —
+ * the writer keeps the surfaced shape consistent with what Excel's
+ * UI authors (`"sngStrike"` only, never `"noStrike"` or
+ * `"dblStrike"`), mirroring how `resolveTitleStrike` /
+ * `resolveLegendStrikethrough` land on their `<a:defRPr>` slots.
+ */
+function resolveDataLabelsStrikethrough(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  return undefined;
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -4032,10 +4053,15 @@ function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undef
  * `i="1"` from a templated chart. The underline flag emits `u="sng"`
  * (single underline — Excel's UI variant) for `true` and `u="none"`
  * (the OOXML default) for `false`, with the same override semantics
- * as bold and italic. Mirrors the chart-title / axis-title / axis
- * tick-label / legend `<c:txPr>` slots exactly so a re-parse picks
- * the value off the canonical default-paragraph slot every other
- * typography reader expects.
+ * as bold and italic. The strikethrough flag rides as
+ * `strike="sngStrike"` on the same `<a:defRPr>` slot when the input
+ * is `true`; absence (and explicit `false`, which the resolver
+ * collapses to `undefined`) skips the attribute entirely since the
+ * OOXML default `"noStrike"` is functionally identical to absence.
+ * Mirrors the chart-title / axis-title / axis tick-label / legend
+ * `<c:txPr>` slots exactly so a re-parse picks the value off the
+ * canonical default-paragraph slot every other typography reader
+ * expects.
  */
 function buildDataLabelsTxPr(
   fontSizePt: number | undefined,
@@ -4043,13 +4069,15 @@ function buildDataLabelsTxPr(
   bold: boolean | undefined,
   italic: boolean | undefined,
   underline: boolean | undefined,
+  strikethrough: boolean | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
     rgbHex === undefined &&
     bold === undefined &&
     italic === undefined &&
-    underline === undefined
+    underline === undefined &&
+    strikethrough === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
@@ -4057,6 +4085,13 @@ function buildDataLabelsTxPr(
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
   if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
   if (underline !== undefined) defRPrAttrs.u = underline ? "sng" : "none";
+  // Strikethrough rides as `strike="sngStrike"` on the same
+  // `<a:defRPr>` slot. Absence collapses to omitting the attribute
+  // entirely (the OOXML default `"noStrike"` is functionally
+  // identical to absence — the reader collapses both to `undefined`).
+  // The writer never emits `"noStrike"` or `"dblStrike"` so the
+  // surfaced shape stays consistent with Excel's UI checkbox.
+  if (strikethrough === true) defRPrAttrs.strike = "sngStrike";
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-label font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16781,3 +16781,190 @@ describe("cloneChart — dataLabels.underline", () => {
     expect(clone.dataLabels?.underline).toBe(true);
   });
 });
+// ── cloneChart — dataLabels.strikethrough ───────────────────────────
+
+describe("cloneChart — dataLabels.strikethrough", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.strikethrough by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, strikethrough: false },
+    });
+    expect(clone.dataLabels?.strikethrough).toBe(false);
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          strikethrough: true,
+          bold: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+    expect(clone.dataLabels?.bold).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.strikethrough into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('strike="sngStrike"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: false } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, strikethrough: true },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('strike="sngStrike"');
+    expect(parseChart(written)?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.strikethrough through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("carries dataLabels.strikethrough through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15092,3 +15092,183 @@ describe("writeChart — dataLabels.underline", () => {
     expect(reparsed?.dataLabels?.underline).toBe(true);
   });
 });
+// ── writeChart — dataLabels.strikethrough ───────────────────────────
+
+describe("writeChart — dataLabels.strikethrough", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when strikethrough is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:defRPr");
+  });
+
+  it('threads strikethrough=true through to <c:dLbls><c:txPr> as strike="sngStrike"', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('strike="sngStrike"');
+  });
+
+  it("does NOT emit <c:txPr> when strikethrough=false (collapses to absence)", () => {
+    // Explicit `false` collapses to `undefined` since the OOXML default
+    // `"noStrike"` is functionally identical to absence — the writer
+    // never emits `"noStrike"` to keep the surfaced shape consistent
+    // with what Excel's UI authors.
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("strike=");
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          strikethrough: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads strikethrough through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, strikethrough: true } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('strike="sngStrike"');
+    }
+  });
+
+  it("composes with bold on the same <a:defRPr> slot", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('b="1"');
+    expect(dLbls).toContain('strike="sngStrike"');
+    // Ensure both attrs land on the same <a:defRPr> element.
+    expect(dLbls).toMatch(
+      /<a:defRPr [^>]*b="1"[^>]*strike="sngStrike"[^>]*\/>|<a:defRPr [^>]*strike="sngStrike"[^>]*b="1"[^>]*\/>/,
+    );
+  });
+
+  it("drops non-boolean inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, strikethrough: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, strikethrough: "sngStrike" as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, strikethrough: 1 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:defRPr strike="sngStrike"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips a strikethrough=true value through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("collapses strikethrough=false back to undefined on re-parse (no attribute emitted)", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: false } }),
+      "Sheet1",
+    ).chartXml;
+    expect(parseChart(written)?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("collapses an unset strikethrough round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.strikethrough lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, strikethrough: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('strike="sngStrike"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.strikethrough).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15822,3 +15822,146 @@ describe("parseChart — data labels underline", () => {
     expect(parseChart(xml)?.dataLabels?.underline).toBe(true);
   });
 });
+// ── parseChart — data labels strikethrough ──────────────────────────
+
+describe("parseChart — data labels strikethrough", () => {
+  const NS_DLS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsStrike(strike: string | undefined): string {
+    const defRPr = strike === undefined ? "<a:defRPr/>" : `<a:defRPr strike="${strike}"/>`;
+    return `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces strikethrough=true when strike="sngStrike"', () => {
+    expect(parseChart(withDLblsStrike("sngStrike"))?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it('collapses the OOXML default strike="noStrike" to undefined', () => {
+    expect(parseChart(withDLblsStrike("noStrike"))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it('collapses strike="dblStrike" (double line) to undefined — only "sngStrike" round-trips losslessly', () => {
+    expect(parseChart(withDLblsStrike("dblStrike"))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the strike attribute", () => {
+    expect(parseChart(withDLblsStrike(undefined))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("collapses garbage tokens to undefined", () => {
+    expect(parseChart(withDLblsStrike(""))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("yes"))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("1"))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("true"))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("strike"))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat / bold)", () => {
+    const xml = `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1" strike="sngStrike"/></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.strikethrough).toBe(true);
+    expect(chart?.dataLabels?.bold).toBe(true);
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the strikethrough flag on a strike-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.strikethrough).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr></c:dLbls>` at the read, write, and clone layers so a template's data-labels strikethrough flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `strikethrough?: boolean` on `ChartDataLabels` (writer side) and the matching `strikethrough?: boolean` on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:dLbls>` block as `position` / `numberFormat` / `separator` / `showLeaderLines` / the `show*` toggles / `bold`; the writer threads the value through the shared `buildDataLabelsBody` helper so chart-level and per-series data labels both pick up the typography pin. Bridges another typography-customization gap for the dashboard composition flow tracked in #136.

Modeled as a boolean for symmetry with the data-labels `bold` (#278) and the chart-title `titleStrikethrough` (#259), axis-title `axisTitleStrike` (#261), axis tick-label `labelStrikethrough` (#268), and legend `legendStrikethrough` (#273) knobs: `true` emits `strike="sngStrike"` (Excel's UI variant — single line); absence and explicit `false` both collapse to omitting the attribute (the OOXML default `"noStrike"` is functionally identical to absence — the writer never emits `"noStrike"` or `"dblStrike"` to keep the surfaced shape consistent with what Excel's UI authors). The non-UI variant `"dblStrike"` (double line) is read-only — the reader collapses every non-`"sngStrike"` token to `undefined` so a templated chart that pinned the double-line variant in raw OOXML round-trips lossless rather than silently downgrading on re-emit. Non-boolean inputs (typed escapes from an untyped caller — strings, `null`, numbers) collapse to `undefined` so the writer never emits a malformed `strike` attribute.

The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>` inside `<c:dLbls>`, matching the CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The block is skipped entirely when no font knob is pinned so a fresh chart matches Excel's reference shape byte-for-byte. The clone path threads the value through the existing `resolveChartDataLabels` resolver (which spreads the read-side `ChartDataLabelsInfo` into the write-side `ChartDataLabels` shape — they share field semantics), so no chart-clone changes are needed beyond the type addition.

Refs #136

## Test plan

- [x] `pnpm lint` — clean (only pre-existing warnings)
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --dir=test` — full suite green (89 files)
- [x] `pnpm build` — clean
- [x] New parser tests (8): `strike="sngStrike"` surfaces `true`; `strike="noStrike"` / `strike="dblStrike"` / absence collapse to `undefined`; missing `<c:txPr>` returns `undefined`; garbage tokens collapse; co-surfaces with `bold` / `position` / `numberFormat`
- [x] New writer tests (15): unset omits `<c:txPr>`; `true` emits `strike="sngStrike"`; `false` collapses to absence (no `<c:txPr>` emitted); CT_DLbls element ordering after `<c:numFmt>` and before `<c:dLblPos>`; only one `<c:txPr>`; threads through bar/column/line/pie/doughnut/area; composes with `bold` on the same `<a:defRPr>`; non-boolean inputs (`null` / string / number) collapse to omission; emits the standard txPr stub shape; round-trips `true` and collapses `false`/unset back to `undefined`; `writeXlsx` package round-trip
- [x] New clone tests (11): inherits source value; explicit override replaces; `null` drops the inherited block; absence on both sides collapses to `undefined`; composes with other dLbls fields; `writeXlsx` round-trips through `parseChart`; flatten preserves strikethrough through `bar -> line` and `bar -> doughnut`

🤖 Generated with [Claude Code](https://claude.com/claude-code)