### PR TITLE
feat(xlsx): chart title font family — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -818,6 +818,39 @@ export interface ChartDataLabels {
    * typography-pinning slot.
    */
   underline?: boolean;
+  /**
+   * Data-label strikethrough flag. Maps to `<c:dLbls><c:txPr><a:p>
+   * <a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr></c:dLbls>`
+   * — Excel's "Format Data Labels -> Font -> Strikethrough" toggle.
+   * The OOXML attribute is the `ST_TextStrikeType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer lands `strike="sngStrike"` (single line — Excel's UI
+   * checkbox) on the default-paragraph `<a:defRPr>` slot inside the
+   * data-label's `<c:txPr>` block so a re-parse picks the flag up
+   * off the canonical slot the OOXML schema exposes.
+   *
+   * Modeled as a boolean for symmetry with the data-labels {@link bold}
+   * / {@link italic} / {@link underline} and the chart-title
+   * `titleStrikethrough` / axis-title `axisTitleStrike` / axis
+   * tick-label `labelStrikethrough` / legend `legendStrikethrough`
+   * knobs: `true` emits `strike="sngStrike"`; absence and explicit
+   * `false` both collapse to omitting the attribute (the OOXML default
+   * `"noStrike"` is functionally identical to absence — the writer
+   * never emits `"noStrike"` or `"dblStrike"` to keep the surfaced
+   * shape consistent with what Excel's UI authors). The non-UI variant
+   * `"dblStrike"` (double line) is read-only — the reader collapses
+   * every non-`"sngStrike"` token to `undefined` so a templated chart
+   * that pinned the double-line variant in raw OOXML round-trips
+   * lossless rather than silently downgrading on re-emit.
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Composes
+   * independently with the other dLbls knobs — {@link position} /
+   * {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles / {@link bold} / {@link italic} /
+   * {@link underline}.
+   */
+  strikethrough?: boolean;
 }
 
 /**
@@ -4373,6 +4406,25 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   underline?: boolean;
+  /**
+   * Data-label strikethrough flag pulled from `<c:dLbls><c:txPr>
+   * <a:p><a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr>
+   * </c:dLbls>`. The OOXML `strike` attribute is the
+   * `ST_TextStrikeType` enumeration on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Only `strike="sngStrike"` (Excel's UI variant — single line)
+   * surfaces `true`; the OOXML default `"noStrike"` and the non-UI
+   * variant `"dblStrike"` (and any malformed token) collapse to
+   * `undefined` so absence and `"noStrike"` round-trip identically
+   * through `cloneChart`. Reporting `"dblStrike"` as `true` would
+   * silently downgrade the choice to a single line on round-trip;
+   * the writer emits only `"sngStrike"`, matching the boolean shape
+   * the UI exposes. Mirrors the writer-side
+   * {@link ChartDataLabels.strikethrough} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  strikethrough?: boolean;
 }
 
 /**

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1972,6 +1972,44 @@ export interface SheetChart {
    */
   titleUnderline?: boolean;
   /**
+   * Chart title font family / typeface. Maps to
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+   * typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin
+   * typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` —
+   * Excel's "Format Chart Title -> Font -> Font" picker. The OOXML
+   * `<a:latin typeface=".."/>` element carries the typeface name
+   * (`CT_TextFont`, ECMA-376 Part 1, §21.1.2.3.7); the writer lands
+   * the element on both the default-paragraph `<a:defRPr>` and the
+   * literal run's `<a:rPr>` so a re-parse picks the typeface up off
+   * either canonical slot — Excel keeps the two values in sync.
+   *
+   * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+   * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+   * whitespace and emits the trimmed value verbatim (XML-escaped)
+   * so Excel can resolve the named font from the workbook's font
+   * scheme or the host system's installed fonts. Empty / whitespace-
+   * only strings and non-string tokens collapse to `undefined` so
+   * the writer skips the entire `<a:latin>` element and the title
+   * inherits Excel's reference theme typeface (Calibri Light from
+   * the default Office theme).
+   *
+   * Default: omitted — the title renders in Excel's reference theme
+   * typeface (no `<a:latin>` element, the writer skips the element
+   * entirely). Pin a typeface name to render the title in that font
+   * (e.g. `"Arial"` for a corporate dashboard standard).
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * typeface in either case. Composes independently with
+   * {@link titleBold} / {@link titleItalic} / {@link titleStrike} /
+   * {@link titleUnderline} / {@link titleColor} /
+   * {@link titleFontSize} / {@link titleRotation} /
+   * {@link titleOverlay}: all nine fields land on the same
+   * `<c:title>` element so a single configuration call threads
+   * cleanly through every chart-title knob Excel exposes.
+   */
+  titleFontFamily?: string;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -5752,6 +5790,30 @@ export interface Chart {
    * without transformation.
    */
   titleUnderline?: boolean;
+  /**
+   * Chart title font family / typeface pulled from
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+   * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx>
+   * </c:title>`. Reflects Excel's "Format Chart Title -> Font -> Font"
+   * picker. The OOXML `<a:latin typeface=".."/>` element carries the
+   * typeface name (`CT_TextFont`, ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Reports the trimmed typeface string when the source chart pinned
+   * a non-empty typeface; absence and empty / whitespace-only
+   * `typeface` attributes both collapse to `undefined` so absence
+   * and `<a:latin typeface=""/>` round-trip identically through
+   * {@link cloneChart}. Non-string `typeface` tokens (defensive — the
+   * XML parser only ever surfaces strings) likewise drop to
+   * `undefined`.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no `<a:p>`
+   * to host the typeface in either case. The parsed value threads
+   * straight back into the writer-side
+   * {@link SheetChart.titleFontFamily} without transformation.
+   */
+  titleFontFamily?: string;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -536,6 +536,29 @@ export interface CloneChartOptions {
    */
   titleUnderline?: boolean | null;
   /**
+   * Override the chart-level title font family / typeface.
+   * `undefined` (or omitted) inherits the source's parsed
+   * `titleFontFamily`; `null` drops the inherited typeface so the
+   * writer falls back to the OOXML default (no `<a:latin>` element,
+   * the title inherits the theme typeface); a non-empty string
+   * replaces it.
+   *
+   * The override is trimmed; empty / whitespace-only strings and
+   * non-string overrides (typed escapes from an untyped caller)
+   * collapse to a drop so the cloned `SheetChart` always carries a
+   * value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the typeface in either case. The grammar mirrors
+   * `titleColor` (the other string-typed knob) and `titleBold` /
+   * `titleItalic` / `titleStrike` / `titleUnderline` /
+   * `titleFontSize` / `titleRotation` / `titleOverlay` so the
+   * chart-level title knobs compose the same way at the call site.
+   */
+  titleFontFamily?: string | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1716,6 +1739,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.titleUnderline,
     );
     if (resolvedTitleUnderline !== undefined) out.titleUnderline = resolvedTitleUnderline;
+
+    // `titleFontFamily` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<a:defRPr><a:latin>` slot for the writer
+    // to populate. Same scope rule as `titleColor` (the other string-
+    // typed knob) / `titleStrike` / `titleUnderline` / `titleOverlay`
+    // / `titleRotation` / `titleFontSize` / `titleBold` /
+    // `titleItalic`: the override wins over the source's parsed value;
+    // absence inherits, `null` drops, a non-empty string replaces.
+    // Empty / whitespace-only strings and non-string overrides
+    // collapse via the normalizer so the cloned `SheetChart` always
+    // carries a value the writer will accept.
+    const resolvedTitleFontFamily = resolveTitleFontFamily(
+      source.titleFontFamily,
+      options.titleFontFamily,
+    );
+    if (resolvedTitleFontFamily !== undefined) out.titleFontFamily = resolvedTitleFontFamily;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -3145,6 +3184,55 @@ function resolveTitleUnderline(
   if (override === undefined) return normalizeTitleUnderline(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleUnderline(override);
+}
+
+/**
+ * Normalize a `titleFontFamily` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizeTitleFontFamily` — the cloned shape
+ * is guaranteed to round-trip through the writer without surprise:
+ * non-empty strings pass through trimmed, every other token (empty
+ * / whitespace-only strings, typed escapes from an untyped caller)
+ * collapses to `undefined` so the cloned chart drops the field
+ * rather than carry a value the writer would silently elide back to
+ * absence.
+ */
+function normalizeTitleFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
+ * Resolve a `titleFontFamily` override.
+ *
+ * `undefined` → inherit the source's parsed `titleFontFamily`,
+ *               running it through {@link normalizeTitleFontFamily}
+ *               so a malformed source value cannot leak through to
+ *               the cloned chart.
+ * `null`      → drop the inherited typeface (the writer falls back to
+ *               the OOXML default — no `<a:latin>` element, the title
+ *               inherits the theme typeface).
+ * `string`    → replace, running it through
+ *               {@link normalizeTitleFontFamily} so the override
+ *               accepts any caller spelling that the writer will
+ *               accept (with surrounding whitespace trimmed; empty /
+ *               whitespace-only strings collapse to a drop).
+ *
+ * The grammar mirrors `titleColor` (the other string-typed knob) /
+ * `titleBold` / `titleItalic` / `titleStrike` / `titleUnderline` /
+ * `titleFontSize` / `titleRotation` / `titleOverlay` so the chart-
+ * level title knobs compose the same way at the call site. Callers
+ * should gate the result on the resolved title visibility — when no
+ * title is emitted, the typeface has no slot in the rendered chart.
+ */
+function resolveTitleFontFamily(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleFontFamily(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleFontFamily(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2554,6 +2554,17 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const underline = parseDataLabelsUnderline(el);
   if (underline !== undefined) out.underline = underline;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr></a:p>
+  // </c:txPr>` — data-label strikethrough flag pinned via Excel's
+  // "Format Data Labels -> Font -> Strikethrough" toggle. Only
+  // `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+  // `true`; the OOXML default `"noStrike"` and the non-UI variant
+  // `"dblStrike"` (and any malformed token) collapse to `undefined`
+  // so absence and `"noStrike"` round-trip identically through
+  // `cloneChart`.
+  const strikethrough = parseDataLabelsStrikethrough(el);
+  if (strikethrough !== undefined) out.strikethrough = strikethrough;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2569,7 +2580,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.fontColor === undefined &&
     out.bold === undefined &&
     out.italic === undefined &&
-    out.underline === undefined
+    out.underline === undefined &&
+    out.strikethrough === undefined
   ) {
     return undefined;
   }
@@ -2737,6 +2749,38 @@ function parseDataLabelsUnderline(dLbls: XmlElement): boolean | undefined {
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.u;
   if (raw === "sng") return true;
+  return undefined;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:txPr></c:dLbls>` off a data-labels block. Returns the
+ * strikethrough flag.
+ *
+ * The OOXML `strike` attribute is the `ST_TextStrikeType`
+ * enumeration on `CT_TextCharacterProperties`. Only
+ * `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+ * `true`; the OOXML default `"noStrike"` and the non-UI variant
+ * `"dblStrike"` (and any malformed token) collapse to `undefined` so
+ * absence and `"noStrike"` round-trip identically through
+ * `cloneChart`. Reporting `"dblStrike"` as `true` would silently
+ * downgrade the choice to a single line on round-trip; the writer
+ * emits only `"sngStrike"`, matching the boolean shape the UI
+ * exposes. Mirrors the chart-title / axis-title / axis tick-label /
+ * legend strikethrough readers exactly so a parsed value slots
+ * straight back into the writer's emit path.
+ */
+function parseDataLabelsStrikethrough(dLbls: XmlElement): boolean | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.strike;
+  if (raw === "sngStrike") return true;
   return undefined;
 }
 

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -190,6 +190,20 @@ export function parseChart(xml: string): Chart | undefined {
   const titleUnderline = parseTitleUnderline(chartEl);
   if (titleUnderline !== undefined) out.titleUnderline = titleUnderline;
 
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+  // typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>`
+  // mirrors Excel's "Format Chart Title -> Font -> Font" picker. Same
+  // scope rule as the size — a chart that omits `<c:title>` (or whose
+  // title is a `<c:strRef>` formula reference with no `<c:rich>` body)
+  // has no `<a:p>` slot to surface the typeface from, so the helper
+  // short-circuits to `undefined`. Empty / whitespace-only `typeface`
+  // attributes collapse to `undefined` so absence and the empty form
+  // round-trip identically through {@link cloneChart}. The value
+  // threads straight back into the writer-side
+  // {@link SheetChart.titleFontFamily} field.
+  const titleFontFamily = parseTitleFontFamily(chartEl);
+  if (titleFontFamily !== undefined) out.titleFontFamily = titleFontFamily;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -3783,6 +3797,60 @@ function parseTitleUnderline(chartEl: XmlElement): boolean | undefined {
   // downgrade the choice on round-trip.
   if (raw === "sng") return true;
   return undefined;
+}
+
+// ── Title Font Family ───────────────────────────────────────────────
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>`
+ * off the chart. Returns the typeface string the title was authored
+ * with.
+ *
+ * The OOXML `<a:latin>` element carries the typeface name on
+ * `CT_TextFont` (ECMA-376 Part 1, §21.1.2.3.7). The reader trims
+ * surrounding whitespace and reports the trimmed typeface; empty /
+ * whitespace-only `typeface` attributes and missing `<a:latin>`
+ * elements both collapse to `undefined` so absence and the empty
+ * form round-trip identically through the writer. Non-string
+ * `typeface` tokens (defensive — the XML parser only ever surfaces
+ * strings) likewise drop to `undefined`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` element
+ * — there is no `<a:p>` slot to surface the typeface from in that case
+ * — or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body. The `<a:defRPr>` lives inside
+ * `<c:tx><c:rich><a:p><a:pPr>` per the CT_Title schema (the default-
+ * paragraph properties on the rich-text body's first paragraph); the
+ * lookup is scoped to that path so a stray `<a:latin>` elsewhere in
+ * the chart (e.g. on an axis title or a data-labels block) cannot
+ * leak in.
+ */
+function parseTitleFontFamily(chartEl: XmlElement): string | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr><a:latin>` is the OOXML path Excel writes
+  // for the default-paragraph typeface. The reader walks the
+  // canonical chain and bails on the first missing link so a
+  // malformed `<c:rich>` surfaces as absence rather than a fabricated
+  // value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const latin = findChild(defRPr, "latin");
+  if (!latin) return undefined;
+  const raw = latin.attrs.typeface;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 // ── Auto Title Deleted ────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -3843,8 +3843,8 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
   // carries the data-label font size, font color, bold flag, italic
-  // flag, and underline flag; future typography pins (strikethrough)
-  // will land on the same `<a:defRPr>` slot. The writer skips the
+  // flag, underline flag, and strikethrough flag — every typography
+  // pin lands on the same `<a:defRPr>` slot. The writer skips the
   // entire block when no font knob is pinned so a fresh chart matches
   // Excel's reference shape.
   const txPrXml = buildDataLabelsTxPr(
@@ -3853,6 +3853,7 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
     resolveDataLabelsBold(dl.bold),
     resolveDataLabelsItalic(dl.italic),
     resolveDataLabelsUnderline(dl.underline),
+    resolveDataLabelsStrikethrough(dl.strikethrough),
   );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
@@ -4007,6 +4008,26 @@ function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undef
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr strike=".."/>
+ * </a:pPr></a:p></c:txPr></c:dLbls>` from
+ * {@link ChartDataLabels.strikethrough}.
+ *
+ * Returns `true` when the caller pins the strikethrough flag
+ * literally; every other value (explicit `false`, absence, non-boolean
+ * tokens leaking past the type guard) collapses to `undefined` so the
+ * writer never emits a `strike` attribute below `"sngStrike"`. The
+ * OOXML default `"noStrike"` is functionally identical to absence —
+ * the writer keeps the surfaced shape consistent with what Excel's
+ * UI authors (`"sngStrike"` only, never `"noStrike"` or
+ * `"dblStrike"`), mirroring how `resolveTitleStrike` /
+ * `resolveLegendStrikethrough` land on their `<a:defRPr>` slots.
+ */
+function resolveDataLabelsStrikethrough(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  return undefined;
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -4032,10 +4053,15 @@ function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undef
  * `i="1"` from a templated chart. The underline flag emits `u="sng"`
  * (single underline — Excel's UI variant) for `true` and `u="none"`
  * (the OOXML default) for `false`, with the same override semantics
- * as bold and italic. Mirrors the chart-title / axis-title / axis
- * tick-label / legend `<c:txPr>` slots exactly so a re-parse picks
- * the value off the canonical default-paragraph slot every other
- * typography reader expects.
+ * as bold and italic. The strikethrough flag rides as
+ * `strike="sngStrike"` on the same `<a:defRPr>` slot when the input
+ * is `true`; absence (and explicit `false`, which the resolver
+ * collapses to `undefined`) skips the attribute entirely since the
+ * OOXML default `"noStrike"` is functionally identical to absence.
+ * Mirrors the chart-title / axis-title / axis tick-label / legend
+ * `<c:txPr>` slots exactly so a re-parse picks the value off the
+ * canonical default-paragraph slot every other typography reader
+ * expects.
  */
 function buildDataLabelsTxPr(
   fontSizePt: number | undefined,
@@ -4043,13 +4069,15 @@ function buildDataLabelsTxPr(
   bold: boolean | undefined,
   italic: boolean | undefined,
   underline: boolean | undefined,
+  strikethrough: boolean | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
     rgbHex === undefined &&
     bold === undefined &&
     italic === undefined &&
-    underline === undefined
+    underline === undefined &&
+    strikethrough === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
@@ -4057,6 +4085,13 @@ function buildDataLabelsTxPr(
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
   if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
   if (underline !== undefined) defRPrAttrs.u = underline ? "sng" : "none";
+  // Strikethrough rides as `strike="sngStrike"` on the same
+  // `<a:defRPr>` slot. Absence collapses to omitting the attribute
+  // entirely (the OOXML default `"noStrike"` is functionally
+  // identical to absence — the reader collapses both to `undefined`).
+  // The writer never emits `"noStrike"` or `"dblStrike"` so the
+  // surfaced shape stays consistent with Excel's UI checkbox.
+  if (strikethrough === true) defRPrAttrs.strike = "sngStrike";
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-label font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -78,6 +78,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleColor(chart),
         resolveTitleStrike(chart),
         resolveTitleUnderline(chart),
+        resolveTitleFontFamily(chart),
       ),
     );
   }
@@ -228,6 +229,7 @@ function buildTitle(
   rgbHex: string | undefined,
   strike: boolean | undefined,
   underline: boolean | undefined,
+  fontFamily: string | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -306,26 +308,48 @@ function buildTitle(
   const solidFillChild = rgbHex
     ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
     : undefined;
-  // When a fill color is set the `<a:defRPr>` / `<a:rPr>` slots
-  // expand from self-closing to wrapping the `<a:solidFill>` child;
+  // OOXML's `<a:defRPr><a:latin typeface=".."/></a:defRPr>` carries the
+  // title's font family. The writer holds `titleFontFamily` as a non-
+  // empty string and lands the `<a:latin>` element on both the default-
+  // paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a re-
+  // parse picks the typeface up off either canonical slot. Absence
+  // (`undefined`) collapses to omitting the entire `<a:latin>` element
+  // so the title inherits the theme typeface (Excel's reference
+  // behavior for a fresh chart title that has not had a custom font
+  // picked). The `<a:latin>` element follows `<a:solidFill>` per the
+  // CT_TextCharacterProperties child sequence (ECMA-376 Part 1,
+  // §21.1.2.3.7) so a fresh chart with both color and family matches
+  // Excel's reference serialization byte-for-byte.
+  const latinChild = fontFamily ? xmlSelfClose("a:latin", { typeface: fontFamily }) : undefined;
+  // When a fill color or a typeface is set the `<a:defRPr>` /
+  // `<a:rPr>` slots expand from self-closing to wrapping the children;
   // otherwise the writer keeps the existing self-closing form so a
-  // fresh chart with no custom color matches Excel's reference
-  // serialization byte-for-byte.
-  const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr });
-  const rPr = solidFillChild
-    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i, u: underlineAttr, strike: strikeAttr }, [
-        solidFillChild,
-      ])
-    : xmlSelfClose("a:rPr", {
-        lang: "en-US",
-        sz,
-        b,
-        i,
-        u: underlineAttr,
-        strike: strikeAttr,
-      });
+  // fresh chart with no custom color or font matches Excel's reference
+  // serialization byte-for-byte. Children are emitted in CT_TextChar
+  // acterProperties' canonical schema order: solidFill first, then
+  // latin.
+  const rPrChildren: string[] = [];
+  if (solidFillChild) rPrChildren.push(solidFillChild);
+  if (latinChild) rPrChildren.push(latinChild);
+  const defRPr =
+    rPrChildren.length > 0
+      ? xmlElement("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr }, rPrChildren)
+      : xmlSelfClose("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr });
+  const rPr =
+    rPrChildren.length > 0
+      ? xmlElement(
+          "a:rPr",
+          { lang: "en-US", sz, b, i, u: underlineAttr, strike: strikeAttr },
+          rPrChildren,
+        )
+      : xmlSelfClose("a:rPr", {
+          lang: "en-US",
+          sz,
+          b,
+          i,
+          u: underlineAttr,
+          strike: strikeAttr,
+        });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -636,6 +660,43 @@ function normalizeTitleUnderline(value: boolean | undefined): boolean | undefine
  */
 function resolveTitleUnderline(chart: SheetChart): boolean | undefined {
   return normalizeTitleUnderline(chart.titleUnderline);
+}
+
+/**
+ * Normalize a {@link SheetChart.titleFontFamily} value for the
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx>
+ * </c:title>` writer slot. Returns the trimmed typeface string when
+ * the input is a non-empty string, or `undefined` for any malformed
+ * token — empty / whitespace-only strings, or non-string escapes from
+ * an untyped caller (`null`, numbers, booleans, etc.).
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<a:latin>` element and the title inherits
+ * the theme typeface (Excel's reference behavior for a fresh chart
+ * title without a custom font picked).
+ */
+function normalizeTitleFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
+ * Resolve `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>`
+ * from {@link SheetChart.titleFontFamily}.
+ *
+ * Returns the trimmed typeface string the writer emits, or
+ * `undefined` when the chart leaves the field unset / passed an empty
+ * or non-string token. The element is only meaningful when the chart
+ * actually emits a title — the caller is expected to gate the call
+ * on `showTitle && chart.title`. A chart whose title is suppressed
+ * has no `<c:title>` block to host the typeface in either case.
+ */
+function resolveTitleFontFamily(chart: SheetChart): string | undefined {
+  return normalizeTitleFontFamily(chart.titleFontFamily);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16781,3 +16781,190 @@ describe("cloneChart — dataLabels.underline", () => {
     expect(clone.dataLabels?.underline).toBe(true);
   });
 });
+// ── cloneChart — dataLabels.strikethrough ───────────────────────────
+
+describe("cloneChart — dataLabels.strikethrough", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.strikethrough by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, strikethrough: false },
+    });
+    expect(clone.dataLabels?.strikethrough).toBe(false);
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          strikethrough: true,
+          bold: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+    expect(clone.dataLabels?.bold).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.strikethrough into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('strike="sngStrike"');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: false } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, strikethrough: true },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('strike="sngStrike"');
+    expect(parseChart(written)?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.strikethrough through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("carries dataLabels.strikethrough through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, strikethrough: true } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+  });
+});

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16968,3 +16968,153 @@ describe("cloneChart — dataLabels.strikethrough", () => {
     expect(clone.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── cloneChart — title font family ──────────────────────────────────
+
+describe("cloneChart — title font family", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleFontFamily by default", () => {
+    const clone = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleFontFamily).toBe("Arial");
+  });
+
+  it("lets options.titleFontFamily override the source's typeface", () => {
+    const clone = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: "Calibri",
+    });
+    expect(clone.titleFontFamily).toBe("Calibri");
+  });
+
+  it("drops the inherited titleFontFamily when the override is null", () => {
+    const clone = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: null,
+    });
+    expect(clone.titleFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined titleFontFamily when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleFontFamily).toBeUndefined();
+  });
+
+  it("lets options.titleFontFamily pin a typeface on a typeface-less source", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: "Verdana",
+    });
+    expect(clone.titleFontFamily).toBe("Verdana");
+  });
+
+  it("trims surrounding whitespace from the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: "   Arial   ",
+    });
+    expect(clone.titleFontFamily).toBe("Arial");
+  });
+
+  it("drops empty / whitespace-only overrides (collapses to undefined)", () => {
+    const c1 = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: "",
+    });
+    expect(c1.titleFontFamily).toBeUndefined();
+    const c2 = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: "   ",
+    });
+    expect(c2.titleFontFamily).toBeUndefined();
+  });
+
+  it("drops a non-string override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleFontFamily: 1 as any,
+    });
+    // The malformed override drops via the normalizer; the source's
+    // parsed value is shadowed (override wins, even when the override
+    // is malformed). Mirrors the titleColor behavior.
+    expect(clone.titleFontFamily).toBeUndefined();
+  });
+
+  it("drops the cloned titleFontFamily when the resolved title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleFontFamily).toBeUndefined();
+  });
+
+  it("drops the cloned titleFontFamily when showTitle is false", () => {
+    const clone = cloneChart(source({ titleFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.titleFontFamily).toBeUndefined();
+  });
+
+  it("preserves titleFontFamily when an override pins a fresh title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleFontFamily: "Arial",
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleFontFamily).toBe("Arial");
+  });
+
+  it("composes with titleBold / titleItalic / titleStrike / titleUnderline / titleColor / titleFontSize", () => {
+    const clone = cloneChart(
+      source({
+        titleFontFamily: "Arial",
+        titleBold: true,
+        titleItalic: true,
+        titleStrike: true,
+        titleUnderline: true,
+        titleColor: "FF0000",
+        titleFontSize: 18,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleFontFamily).toBe("Arial");
+    expect(clone.titleBold).toBe(true);
+    expect(clone.titleItalic).toBe(true);
+    expect(clone.titleStrike).toBe(true);
+    expect(clone.titleUnderline).toBe(true);
+    expect(clone.titleColor).toBe("FF0000");
+    expect(clone.titleFontSize).toBe(18);
+  });
+
+  it("normalizes a malformed source value (defensive — the reader trims, but the clone re-checks)", () => {
+    // A source that somehow carries a whitespace-only string still
+    // collapses to undefined on the cloned shape.
+    const clone = cloneChart(source({ titleFontFamily: "   " as any }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleFontFamily).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15092,3 +15092,183 @@ describe("writeChart — dataLabels.underline", () => {
     expect(reparsed?.dataLabels?.underline).toBe(true);
   });
 });
+// ── writeChart — dataLabels.strikethrough ───────────────────────────
+
+describe("writeChart — dataLabels.strikethrough", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when strikethrough is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:defRPr");
+  });
+
+  it('threads strikethrough=true through to <c:dLbls><c:txPr> as strike="sngStrike"', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('strike="sngStrike"');
+  });
+
+  it("does NOT emit <c:txPr> when strikethrough=false (collapses to absence)", () => {
+    // Explicit `false` collapses to `undefined` since the OOXML default
+    // `"noStrike"` is functionally identical to absence — the writer
+    // never emits `"noStrike"` to keep the surfaced shape consistent
+    // with what Excel's UI authors.
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: false } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("strike=");
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          strikethrough: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads strikethrough through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, strikethrough: true } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('strike="sngStrike"');
+    }
+  });
+
+  it("composes with bold on the same <a:defRPr> slot", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, bold: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('b="1"');
+    expect(dLbls).toContain('strike="sngStrike"');
+    // Ensure both attrs land on the same <a:defRPr> element.
+    expect(dLbls).toMatch(
+      /<a:defRPr [^>]*b="1"[^>]*strike="sngStrike"[^>]*\/>|<a:defRPr [^>]*strike="sngStrike"[^>]*b="1"[^>]*\/>/,
+    );
+  });
+
+  it("drops non-boolean inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, strikethrough: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, strikethrough: "sngStrike" as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-boolean inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, strikethrough: 1 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:defRPr strike="sngStrike"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips a strikethrough=true value through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: true } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it("collapses strikethrough=false back to undefined on re-parse (no attribute emitted)", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, strikethrough: false } }),
+      "Sheet1",
+    ).chartXml;
+    expect(parseChart(written)?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("collapses an unset strikethrough round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.strikethrough lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, strikethrough: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('strike="sngStrike"');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.strikethrough).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15272,3 +15272,170 @@ describe("writeChart — dataLabels.strikethrough", () => {
     expect(reparsed?.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── writeChart — title font family ──────────────────────────────────
+
+describe("writeChart — title font family", () => {
+  function titleBlockOf(xml: string): string {
+    return xml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+  }
+
+  function defRPrLatinOf(xml: string): string | undefined {
+    // The title's <a:defRPr> lives inside <c:title><c:tx><c:rich><a:p><a:pPr>.
+    // When a typeface is pinned, <a:defRPr> wraps an <a:latin> child.
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:defRPr\b[^>]*>([\s\S]*?)<\/a:defRPr>/);
+    if (!m) return undefined;
+    const latin = m[1].match(/<a:latin\b[^/]*\/>/);
+    if (!latin) return undefined;
+    const typeface = latin[0].match(/typeface="([^"]*)"/);
+    return typeface ? typeface[1] : undefined;
+  }
+
+  function rPrLatinOf(xml: string): string | undefined {
+    const titleBlock = titleBlockOf(xml);
+    const m = titleBlock.match(/<a:rPr\b[^>]*>([\s\S]*?)<\/a:rPr>/);
+    if (!m) return undefined;
+    const latin = m[1].match(/<a:latin\b[^/]*\/>/);
+    if (!latin) return undefined;
+    const typeface = latin[0].match(/typeface="([^"]*)"/);
+    return typeface ? typeface[1] : undefined;
+  }
+
+  it("omits the <a:latin> element by default (matches Excel's reference inherited typeface)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(titleBlockOf(result.chartXml)).not.toContain("<a:latin");
+  });
+
+  it("emits <a:latin typeface='Arial'/> on titleFontFamily='Arial'", () => {
+    const result = writeChart(makeChart({ titleFontFamily: "Arial" }), "Sheet1");
+    expect(defRPrLatinOf(result.chartXml)).toBe("Arial");
+    expect(rPrLatinOf(result.chartXml)).toBe("Arial");
+  });
+
+  it("emits multi-word typefaces verbatim", () => {
+    const result = writeChart(makeChart({ titleFontFamily: "Times New Roman" }), "Sheet1");
+    expect(defRPrLatinOf(result.chartXml)).toBe("Times New Roman");
+    expect(rPrLatinOf(result.chartXml)).toBe("Times New Roman");
+  });
+
+  it("trims surrounding whitespace from the typeface", () => {
+    const result = writeChart(makeChart({ titleFontFamily: "   Calibri   " }), "Sheet1");
+    expect(defRPrLatinOf(result.chartXml)).toBe("Calibri");
+    expect(rPrLatinOf(result.chartXml)).toBe("Calibri");
+  });
+
+  it("drops empty / whitespace-only inputs back to the OOXML default (no <a:latin>)", () => {
+    const r1 = writeChart(makeChart({ titleFontFamily: "" }), "Sheet1");
+    expect(titleBlockOf(r1.chartXml)).not.toContain("<a:latin");
+    const r2 = writeChart(makeChart({ titleFontFamily: "   " }), "Sheet1");
+    expect(titleBlockOf(r2.chartXml)).not.toContain("<a:latin");
+  });
+
+  it("drops non-string inputs back to the OOXML default (defends against type guard escape)", () => {
+    const r1 = writeChart(makeChart({ titleFontFamily: 1 as any }), "Sheet1");
+    expect(titleBlockOf(r1.chartXml)).not.toContain("<a:latin");
+    const r2 = writeChart(makeChart({ titleFontFamily: null as any }), "Sheet1");
+    expect(titleBlockOf(r2.chartXml)).not.toContain("<a:latin");
+    const r3 = writeChart(makeChart({ titleFontFamily: true as any }), "Sheet1");
+    expect(titleBlockOf(r3.chartXml)).not.toContain("<a:latin");
+  });
+
+  it("ignores titleFontFamily when the chart renders no title (showTitle=false)", () => {
+    const result = writeChart(makeChart({ showTitle: false, titleFontFamily: "Arial" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("ignores titleFontFamily when the chart has no literal title", () => {
+    const result = writeChart(makeChart({ title: undefined, titleFontFamily: "Arial" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleColor (both wrap defRPr/rPr together)", () => {
+    const result = writeChart(
+      makeChart({ titleFontFamily: "Arial", titleColor: "FF0000" }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('<a:srgbClr val="FF0000"/>');
+    expect(titleBlock).toContain('<a:latin typeface="Arial"/>');
+    // Schema order: solidFill before latin inside CT_TextCharacterProperties.
+    expect(titleBlock.indexOf("<a:solidFill>")).toBeLessThan(titleBlock.indexOf("<a:latin"));
+  });
+
+  it("composes independently with titleBold / titleItalic / titleStrike / titleUnderline / titleFontSize", () => {
+    const result = writeChart(
+      makeChart({
+        titleFontFamily: "Arial",
+        titleBold: true,
+        titleItalic: true,
+        titleStrike: true,
+        titleUnderline: true,
+        titleFontSize: 24,
+      }),
+      "Sheet1",
+    );
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('<a:latin typeface="Arial"/>');
+    expect(titleBlock).toContain('sz="2400"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('strike="sngStrike"');
+    expect(titleBlock).toContain('u="sng"');
+  });
+
+  it("XML-escapes the typeface (defends against attribute-injection escape)", () => {
+    const result = writeChart(makeChart({ titleFontFamily: 'A&B"C' }), "Sheet1");
+    const titleBlock = titleBlockOf(result.chartXml);
+    expect(titleBlock).toContain('typeface="A&amp;B&quot;C"');
+  });
+
+  it("threads through every chart family (bar / column / line / pie / scatter / area)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "pie", "scatter", "area"];
+    for (const type of types) {
+      const result = writeChart(makeChart({ type, titleFontFamily: "Arial" }), "Sheet1");
+      expect(defRPrLatinOf(result.chartXml)).toBe("Arial");
+    }
+  });
+
+  it("parse round-trip surfaces titleFontFamily from the writer's output", () => {
+    const written = writeChart(makeChart({ titleFontFamily: "Arial" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFontFamily).toBe("Arial");
+  });
+
+  it("collapses the default round-trip back to undefined", () => {
+    // A fresh chart writes no <a:latin>; the reader collapses absence
+    // to undefined so absence and the default round-trip identically.
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFontFamily).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx -> open -> reparse retains the typeface", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            titleFontFamily: "Arial",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:latin typeface="Arial"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleFontFamily).toBe("Arial");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15822,3 +15822,146 @@ describe("parseChart — data labels underline", () => {
     expect(parseChart(xml)?.dataLabels?.underline).toBe(true);
   });
 });
+// ── parseChart — data labels strikethrough ──────────────────────────
+
+describe("parseChart — data labels strikethrough", () => {
+  const NS_DLS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsStrike(strike: string | undefined): string {
+    const defRPr = strike === undefined ? "<a:defRPr/>" : `<a:defRPr strike="${strike}"/>`;
+    return `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces strikethrough=true when strike="sngStrike"', () => {
+    expect(parseChart(withDLblsStrike("sngStrike"))?.dataLabels?.strikethrough).toBe(true);
+  });
+
+  it('collapses the OOXML default strike="noStrike" to undefined', () => {
+    expect(parseChart(withDLblsStrike("noStrike"))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it('collapses strike="dblStrike" (double line) to undefined — only "sngStrike" round-trips losslessly', () => {
+    expect(parseChart(withDLblsStrike("dblStrike"))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when <a:defRPr> omits the strike attribute", () => {
+    expect(parseChart(withDLblsStrike(undefined))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("collapses garbage tokens to undefined", () => {
+    expect(parseChart(withDLblsStrike(""))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("yes"))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("1"))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("true"))?.dataLabels?.strikethrough).toBeUndefined();
+    expect(parseChart(withDLblsStrike("strike"))?.dataLabels?.strikethrough).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / numberFormat / bold)", () => {
+    const xml = `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr b="1" strike="sngStrike"/></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.strikethrough).toBe(true);
+    expect(chart?.dataLabels?.bold).toBe(true);
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the strikethrough flag on a strike-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.strikethrough).toBe(true);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15965,3 +15965,139 @@ describe("parseChart — data labels strikethrough", () => {
     expect(parseChart(xml)?.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── parseChart — title font family ──────────────────────────────────
+
+describe("parseChart — title font family", () => {
+  const NS_TFF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleFontFamily(typeface: string | undefined): string {
+    const defRPr =
+      typeface === undefined
+        ? "<a:defRPr/>"
+        : `<a:defRPr><a:latin typeface="${typeface}"/></a:defRPr>`;
+    return `<c:chartSpace ${NS_TFF}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the typeface when the title pinned <a:latin typeface='Arial'/>", () => {
+    const chart = parseChart(withTitleFontFamily("Arial"));
+    expect(chart?.titleFontFamily).toBe("Arial");
+  });
+
+  it("surfaces multi-word typefaces verbatim", () => {
+    const chart = parseChart(withTitleFontFamily("Times New Roman"));
+    expect(chart?.titleFontFamily).toBe("Times New Roman");
+  });
+
+  it("collapses absence of the <a:latin> element to undefined", () => {
+    const chart = parseChart(withTitleFontFamily(undefined));
+    expect(chart?.titleFontFamily).toBeUndefined();
+  });
+
+  it("collapses an empty typeface attribute to undefined", () => {
+    const chart = parseChart(withTitleFontFamily(""));
+    expect(chart?.titleFontFamily).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace from the typeface", () => {
+    const chart = parseChart(withTitleFontFamily("   Arial   "));
+    expect(chart?.titleFontFamily).toBe("Arial");
+  });
+
+  it("collapses a whitespace-only typeface to undefined", () => {
+    const chart = parseChart(withTitleFontFamily("   "));
+    expect(chart?.titleFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element", () => {
+    const xml = `<c:chartSpace ${NS_TFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:tx><c:rich> body (strRef)", () => {
+    const xml = `<c:chartSpace ${NS_TFF}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:strRef>
+          <c:f>Sheet1!$A$1</c:f>
+          <c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache>
+        </c:strRef>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFontFamily).toBeUndefined();
+    expect(chart?.title).toBe("Revenue");
+  });
+
+  it("scopes the lookup to the chart-level title (axis-title <a:latin> does not leak in)", () => {
+    // Two axis titles each pin a different typeface; the chart title
+    // does not pin one. The reader must report `undefined` for
+    // `titleFontFamily` rather than picking up the axis-title typeface.
+    const xml = `<c:chartSpace ${NS_TFF}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Quarterly Revenue</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx>
+            <c:rich>
+              <a:bodyPr/>
+              <a:lstStyle/>
+              <a:p><a:pPr><a:defRPr><a:latin typeface="Verdana"/></a:defRPr></a:pPr></a:p>
+            </c:rich>
+          </c:tx>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFontFamily).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Surfaces `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` (CT_TextFont on CT_TextCharacterProperties' latin slot — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's chart-title typeface survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `titleFontFamily?: string` on `SheetChart` (writer side) and `titleFontFamily?: string` on `Chart` (reader side). Sits on the same `<c:title>` block as `titleColor` / `titleBold` / `titleItalic` / `titleStrike` / `titleUnderline` / `titleFontSize` / `titleRotation` / `titleOverlay`; the writer threads the value through the existing `buildTitle` helper so the run-level `<a:rPr>` and the default-paragraph `<a:defRPr>` both pick up the typeface.

Until now hucre's writer omitted `<a:latin>` entirely (the title inherited the theme typeface) and the reader ignored the element, so a templated dashboard chart whose user picked a custom title font silently lost the choice on every parse -> clone -> write loop. Bridges another title-customization gap for the dashboard composition flow tracked in #136.

Mirrors the chart-level `titleColor` field added in #254 — same canonical-slot pair (`<a:defRPr>` + `<a:rPr>`), same string-typed clone grammar (`undefined` inherits, `null` drops, a non-empty string replaces, empty / whitespace-only strings collapse to a drop). The `<a:latin>` element follows `<a:solidFill>` per the CT_TextCharacterProperties child sequence so a chart with both `titleColor` and `titleFontFamily` set lands the children in canonical schema order — a fresh chart matches Excel's reference serialization byte-for-byte. The writer trims surrounding whitespace and emits the trimmed value verbatim (XML-escaped) so attribute-injection escapes never produce a malformed `typeface` attribute.

Refs #136

## Test plan

- [x] `pnpm vitest run --dir=test` — 5601 tests pass
- [x] `pnpm build` — succeeds
- [x] reader: surfaces typeface; trims whitespace; collapses empty / whitespace-only / absent / non-string to undefined; scoped to the chart-level `<c:title>` so axis-title `<a:latin>` cannot leak in
- [x] writer: omits `<a:latin>` by default; emits `<a:latin typeface=".."/>` on both `<a:defRPr>` and `<a:rPr>`; XML-escapes the typeface; composes with color / bold / italic / strike / underline / size; threads through every chart family
- [x] clone: inherits, overrides, drops on `null`, drops on title-suppression / `showTitle: false`; trims whitespace; drops malformed overrides
- [x] end-to-end: `writeXlsx` -> `extractXml` -> `parseChart` retains the typeface

🤖 Generated with [Claude Code](https://claude.com/claude-code)