### PR TITLE
feat(xlsx): chart axis title font family — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2712,6 +2712,53 @@ export interface SheetChart {
        * family that has axes (bar / column / line / area / scatter).
        */
       axisTitleUnderline?: boolean;
+      /**
+       * Axis title font family / typeface. Maps to
+       * `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` ->
+       * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+       * typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin
+       * typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` —
+       * Excel's "Format Axis Title -> Font -> Font" picker. The OOXML
+       * `<a:latin typeface=".."/>` element carries the typeface name
+       * (`CT_TextFont`, ECMA-376 Part 1, §21.1.2.3.7); the writer
+       * lands the element on both the default-paragraph `<a:defRPr>`
+       * and the literal run's `<a:rPr>` so a re-parse picks the
+       * typeface up off either canonical slot — Excel keeps the two
+       * values in sync.
+       *
+       * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+       * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+       * whitespace and emits the trimmed value verbatim (XML-escaped)
+       * so Excel can resolve the named font from the workbook's font
+       * scheme or the host system's installed fonts. Empty /
+       * whitespace-only strings and non-string tokens collapse to
+       * `undefined` so the writer skips the entire `<a:latin>`
+       * element and the title inherits Excel's reference theme
+       * typeface (Calibri Light from the default Office theme).
+       *
+       * Mirrors {@link SheetChart.titleFontFamily} for axis titles —
+       * same canonical-slot pair, same drop-on-empty semantics, same
+       * `string | null` clone grammar so a single configuration call
+       * threads cleanly through both the chart title and either axis
+       * title without bookkeeping the canonical OOXML slots. Mirrors
+       * {@link axisTitleRotation} / {@link axisTitleFontSize} /
+       * {@link axisTitleBold} / {@link axisTitleItalic} /
+       * {@link axisTitleColor} / {@link axisTitleStrike} /
+       * {@link axisTitleUnderline} for the same `<c:title>` body, so
+       * all eight axis-title typography knobs compose freely on the
+       * same axis.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>`
+       * shape per the OOXML schema, so the field round-trips on
+       * every chart family that has axes (bar / column / line /
+       * area / scatter).
+       */
+      axisTitleFontFamily?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3373,6 +3420,53 @@ export interface SheetChart {
        * block to host the flag).
        */
       axisTitleUnderline?: boolean;
+      /**
+       * Axis title font family / typeface. Maps to
+       * `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` ->
+       * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+       * typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin
+       * typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` —
+       * Excel's "Format Axis Title -> Font -> Font" picker. The OOXML
+       * `<a:latin typeface=".."/>` element carries the typeface name
+       * (`CT_TextFont`, ECMA-376 Part 1, §21.1.2.3.7); the writer
+       * lands the element on both the default-paragraph `<a:defRPr>`
+       * and the literal run's `<a:rPr>` so a re-parse picks the
+       * typeface up off either canonical slot — Excel keeps the two
+       * values in sync.
+       *
+       * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+       * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+       * whitespace and emits the trimmed value verbatim (XML-escaped)
+       * so Excel can resolve the named font from the workbook's font
+       * scheme or the host system's installed fonts. Empty /
+       * whitespace-only strings and non-string tokens collapse to
+       * `undefined` so the writer skips the entire `<a:latin>`
+       * element and the title inherits Excel's reference theme
+       * typeface (Calibri Light from the default Office theme).
+       *
+       * Mirrors {@link SheetChart.titleFontFamily} for axis titles —
+       * same canonical-slot pair, same drop-on-empty semantics, same
+       * `string | null` clone grammar so a single configuration call
+       * threads cleanly through both the chart title and either axis
+       * title without bookkeeping the canonical OOXML slots. Mirrors
+       * {@link axisTitleRotation} / {@link axisTitleFontSize} /
+       * {@link axisTitleBold} / {@link axisTitleItalic} /
+       * {@link axisTitleColor} / {@link axisTitleStrike} /
+       * {@link axisTitleUnderline} for the same `<c:title>` body, so
+       * all eight axis-title typography knobs compose freely on the
+       * same axis.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>`
+       * shape per the OOXML schema, so the field round-trips on
+       * every chart family that has axes (bar / column / line /
+       * area / scatter).
+       */
+      axisTitleFontFamily?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -4957,6 +5051,41 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleUnderline?: boolean;
+  /**
+   * Axis title font family / typeface pulled from `<c:catAx>` /
+   * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` ->
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+   * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx>
+   * </c:title>`. Reflects Excel's "Format Axis Title -> Font ->
+   * Font" picker. The OOXML `<a:latin typeface=".."/>` element
+   * carries the typeface name (`CT_TextFont`, ECMA-376 Part 1,
+   * §21.1.2.3.7).
+   *
+   * Reports the trimmed typeface string when the source axis pinned
+   * a non-empty typeface; absence and empty / whitespace-only
+   * `typeface` attributes both collapse to `undefined` so absence
+   * and `<a:latin typeface=""/>` round-trip identically through
+   * {@link cloneChart}. Non-string `typeface` tokens (defensive —
+   * the XML parser only ever surfaces strings) likewise drop to
+   * `undefined`.
+   *
+   * Reported as `undefined` whenever the source axis has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — there is no
+   * `<a:p>` to host the typeface in either case. Mirrors the
+   * chart-level {@link Chart.titleFontFamily} so a parsed value
+   * slots straight back into the writer-side
+   * {@link SheetChart.axes.x.axisTitleFontFamily} without
+   * transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every
+   * axis flavour so a parsed chart preserves the typeface
+   * regardless of whether the source axis was a category or value
+   * axis.
+   */
+  axisTitleFontFamily?: string;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -995,6 +995,32 @@ export interface CloneChartOptions {
        * compose the same way at the call site.
        */
       axisTitleUnderline?: boolean | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleFontFamily`. `undefined`
+       * (or omitted) inherits the source axis's parsed typeface;
+       * `null` drops the inherited typeface so the writer falls back
+       * to the OOXML default (no `<a:latin>` element, the title
+       * inherits the theme typeface). A non-empty string replaces
+       * it; the override is trimmed.
+       *
+       * Empty / whitespace-only strings and non-string overrides
+       * (typed escapes from an untyped caller) collapse to a drop so
+       * the cloned `SheetChart` always carries a value the writer
+       * will accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any
+       * axis whose `title` is unset (no `<c:title>` block to host
+       * the typeface). The grammar mirrors `titleFontFamily` (the
+       * chart-level analog) and `axisTitleColor` (the other string-
+       * typed knob) / `axisTitleRotation` / `axisTitleFontSize` /
+       * `axisTitleBold` / `axisTitleItalic` / `axisTitleStrike` /
+       * `axisTitleUnderline` so the axis-title knobs compose the
+       * same way at the call site.
+       */
+      axisTitleFontFamily?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1308,6 +1334,8 @@ export interface CloneChartOptions {
       axisTitleStrike?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleUnderline}. */
       axisTitleUnderline?: boolean | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleFontFamily}. */
+      axisTitleFontFamily?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -3452,6 +3480,26 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleUnderline,
     overrides?.y?.axisTitleUnderline,
   );
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+  // typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>` —
+  // axis title font family. Sits on the same `<c:title>` body as
+  // `axisTitleRotation` / `axisTitleFontSize` / `axisTitleBold` /
+  // `axisTitleItalic` / `axisTitleColor` / `axisTitleStrike` /
+  // `axisTitleUnderline`, so the resolver applies on every chart
+  // family that has axes (pie / doughnut were short-circuited
+  // upstream). Empty / whitespace-only / non-string overrides collapse
+  // to `undefined` so the writer omits the `<a:latin>` element. Like
+  // the other axis-title knobs, the writer drops the typeface when
+  // the matching axis title is unset, so a stray pin on an axis with
+  // no title silently disappears at emit time.
+  const xAxisTitleFontFamily = applyAxisTitleFontFamilyOverride(
+    sourceAxes?.x?.axisTitleFontFamily,
+    overrides?.x?.axisTitleFontFamily,
+  );
+  const yAxisTitleFontFamily = applyAxisTitleFontFamilyOverride(
+    sourceAxes?.y?.axisTitleFontFamily,
+    overrides?.y?.axisTitleFontFamily,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -3710,6 +3758,13 @@ function resolveAxes(
   // `opts.xAxisTitle` / `opts.yAxisTitle` is set).
   const xAxisTitleUnderlineResolved = xTitle === undefined ? undefined : xAxisTitleUnderline;
   const yAxisTitleUnderlineResolved = yTitle === undefined ? undefined : yAxisTitleUnderline;
+  // Same title-presence gate as the rotation / size / bold / italic /
+  // color / strike / underline resolved values — the writer skips the
+  // entire `<a:latin>` element when the matching axis title is unset,
+  // so the cloned `SheetChart` accurately reflects what the chart
+  // will paint.
+  const xAxisTitleFontFamilyResolved = xTitle === undefined ? undefined : xAxisTitleFontFamily;
+  const yAxisTitleFontFamilyResolved = yTitle === undefined ? undefined : yAxisTitleFontFamily;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -3721,6 +3776,7 @@ function resolveAxes(
     xAxisTitleColorResolved !== undefined ||
     xAxisTitleStrikeResolved !== undefined ||
     xAxisTitleUnderlineResolved !== undefined ||
+    xAxisTitleFontFamilyResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -3759,6 +3815,8 @@ function resolveAxes(
     if (xAxisTitleStrikeResolved !== undefined) out.x.axisTitleStrike = xAxisTitleStrikeResolved;
     if (xAxisTitleUnderlineResolved !== undefined)
       out.x.axisTitleUnderline = xAxisTitleUnderlineResolved;
+    if (xAxisTitleFontFamilyResolved !== undefined)
+      out.x.axisTitleFontFamily = xAxisTitleFontFamilyResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -3794,6 +3852,7 @@ function resolveAxes(
     yAxisTitleColorResolved !== undefined ||
     yAxisTitleStrikeResolved !== undefined ||
     yAxisTitleUnderlineResolved !== undefined ||
+    yAxisTitleFontFamilyResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -3826,6 +3885,8 @@ function resolveAxes(
     if (yAxisTitleStrikeResolved !== undefined) out.y.axisTitleStrike = yAxisTitleStrikeResolved;
     if (yAxisTitleUnderlineResolved !== undefined)
       out.y.axisTitleUnderline = yAxisTitleUnderlineResolved;
+    if (yAxisTitleFontFamilyResolved !== undefined)
+      out.y.axisTitleFontFamily = yAxisTitleFontFamilyResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -4510,6 +4571,50 @@ function applyAxisTitleUnderlineOverride(
   if (override === undefined) return normalizeTitleUnderline(source);
   if (override === null) return undefined;
   return normalizeTitleUnderline(override);
+}
+
+/**
+ * Resolve an `axisTitleFontFamily` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis-title typography knobs.
+ *
+ * Empty / whitespace-only strings and non-string overrides (typed
+ * escapes from an untyped caller) collapse to `undefined` via
+ * {@link normalizeTitleFontFamily} so the cloned `SheetChart` always
+ * carries a value the writer will accept. A `null` override always
+ * drops the inherited typeface (the writer falls back to the OOXML
+ * default — no `<a:latin>` element, the title inherits the theme
+ * typeface).
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a typeface that the writer would silently elide (the
+ * writer scopes the element emission to `<c:title>`, which is omitted
+ * when the axis renders no title).
+ */
+function applyAxisTitleFontFamilyOverride(
+  source: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeAxisTitleFontFamilyClone(source);
+  if (override === null) return undefined;
+  return normalizeAxisTitleFontFamilyClone(override);
+}
+
+/**
+ * Normalize an `axisTitleFontFamily` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizeAxisTitleFontFamily` — the cloned
+ * shape is guaranteed to round-trip through the writer without
+ * surprise: non-empty strings pass through trimmed, every other token
+ * (empty / whitespace-only strings, typed escapes from an untyped
+ * caller) collapses to `undefined` so the cloned chart drops the
+ * field rather than carry a value the writer would silently elide.
+ */
+function normalizeAxisTitleFontFamilyClone(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -679,6 +679,18 @@ function parseAxisInfo(
   // title is a `<c:strRef>` (formula reference) with no `<c:rich>`
   // body.
   const axisTitleUnderline = parseAxisTitleUnderline(axis);
+  // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+  // typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>` —
+  // axis-title font family. Same `<c:title>` body scope as
+  // `axisTitleColor` / `axisTitleStrike` / `axisTitleUnderline`, so a
+  // stray `<a:latin>` elsewhere on the axis (e.g. on the tick-label
+  // `<c:txPr>`) cannot leak in. Empty / whitespace-only `typeface`
+  // attributes and missing `<a:latin>` elements both collapse to
+  // `undefined` so absence and the empty form round-trip identically
+  // through the writer. Returns `undefined` when the axis omits
+  // `<c:title>` entirely or when the title is a `<c:strRef>` (formula
+  // reference) with no `<c:rich>` body.
+  const axisTitleFontFamily = parseAxisTitleFontFamily(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -825,6 +837,7 @@ function parseAxisInfo(
     axisTitleColor === undefined &&
     axisTitleStrike === undefined &&
     axisTitleUnderline === undefined &&
+    axisTitleFontFamily === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -862,6 +875,7 @@ function parseAxisInfo(
   if (axisTitleColor !== undefined) out.axisTitleColor = axisTitleColor;
   if (axisTitleStrike !== undefined) out.axisTitleStrike = axisTitleStrike;
   if (axisTitleUnderline !== undefined) out.axisTitleUnderline = axisTitleUnderline;
+  if (axisTitleFontFamily !== undefined) out.axisTitleFontFamily = axisTitleFontFamily;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -2178,6 +2192,66 @@ function parseAxisTitleUnderline(axis: XmlElement): boolean | undefined {
   // downgrade the choice on round-trip.
   if (raw === "sng") return true;
   return undefined;
+}
+
+/**
+ * Pull `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>`
+ * off the axis. Returns the typeface string the title was authored
+ * with.
+ *
+ * The OOXML `<a:latin>` element carries the typeface name on
+ * `CT_TextFont` (ECMA-376 Part 1, §21.1.2.3.7). The reader trims
+ * surrounding whitespace and reports the trimmed typeface; empty /
+ * whitespace-only `typeface` attributes and missing `<a:latin>`
+ * elements both collapse to `undefined` so absence and the empty
+ * form round-trip identically through the writer. Non-string
+ * `typeface` tokens (defensive — the XML parser only ever surfaces
+ * strings) likewise drop to `undefined`.
+ *
+ * Mirrors the chart-level title typeface {@link parseTitleFontFamily} —
+ * same canonical-slot pair (`<a:defRPr>` carries the default-paragraph
+ * typeface, which the writer keeps in sync with the literal run's
+ * `<a:rPr>` so the reader only needs to consult one of the two
+ * slots). The lookup is scoped to the axis title's `<c:rich>` body
+ * so a stray `<a:latin>` elsewhere on the axis (e.g. on the
+ * tick-label `<c:txPr>`) cannot leak in.
+ *
+ * Returns `undefined` whenever the axis omits `<c:title>` entirely
+ * or when the title is a `<c:strRef>` (formula reference) with no
+ * `<c:rich>` body — there is no `<a:p>` slot to surface the
+ * typeface from in either case.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape
+ * per the OOXML schema. The parsed value slots straight into the
+ * writer-side {@link SheetChart.axes}.x.axisTitleFontFamily.
+ */
+function parseAxisTitleFontFamily(axis: XmlElement): string | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const tx = findChild(title, "tx");
+  if (!tx) return undefined;
+  const rich = findChild(tx, "rich");
+  if (!rich) return undefined;
+  // `<a:p><a:pPr><a:defRPr><a:latin>` is the OOXML path Excel writes
+  // for the default-paragraph typeface. The reader walks the
+  // canonical chain and bails on the first missing link so a
+  // malformed `<c:rich>` surfaces as absence rather than a fabricated
+  // value.
+  const p = findChild(rich, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const latin = findChild(defRPr, "latin");
+  if (!latin) return undefined;
+  const raw = latin.attrs.typeface;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -789,6 +789,20 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // non-underlined axis title).
     xAxisTitleUnderline: normalizeAxisTitleUnderline(chart.axes?.x?.axisTitleUnderline),
     yAxisTitleUnderline: normalizeAxisTitleUnderline(chart.axes?.y?.axisTitleUnderline),
+    // `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+    // typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin
+    // typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` —
+    // axis-title font family. The OOXML `<a:latin typeface=".."/>`
+    // element carries the typeface name on `CT_TextFont` (ECMA-376
+    // Part 1, §21.1.2.3.7) and the slot lives on every axis flavour.
+    // Normalize the caller's string input — non-empty strings pass
+    // through trimmed, every other token (empty / whitespace-only
+    // strings, typed escapes from an untyped caller) collapses to
+    // `undefined` and the writer skips the entire `<a:latin>` element
+    // (Excel's reference serialization for an axis title that
+    // inherits the theme typeface).
+    xAxisTitleFontFamily: normalizeAxisTitleFontFamily(chart.axes?.x?.axisTitleFontFamily),
+    yAxisTitleFontFamily: normalizeAxisTitleFontFamily(chart.axes?.y?.axisTitleFontFamily),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1363,6 +1377,27 @@ interface AxisRenderOptions {
    * and emit semantics as {@link xAxisTitleUnderline}.
    */
   yAxisTitleUnderline: boolean | undefined;
+  /**
+   * Axis-title font family / typeface emitted on the X axis via
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+   * typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin
+   * typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>`.
+   * The OOXML `<a:latin typeface=".."/>` element carries the
+   * typeface name on `CT_TextFont`. `undefined` collapses to
+   * omitting the element (Excel's reference serialization for an
+   * axis title that inherits the theme typeface); a non-empty
+   * trimmed string emits `<a:latin typeface=".."/>` on both the
+   * default-paragraph `<a:defRPr>` and the literal run's `<a:rPr>`.
+   * Only meaningful when the axis renders a title — the per-family
+   * axis builders gate the value on the `xAxisTitle` / `yAxisTitle`
+   * field.
+   */
+  xAxisTitleFontFamily: string | undefined;
+  /**
+   * Axis-title font family / typeface emitted on the Y axis. Same
+   * shape and emit semantics as {@link xAxisTitleFontFamily}.
+   */
+  yAxisTitleFontFamily: string | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -2538,6 +2573,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleColor,
         opts.xAxisTitleStrike,
         opts.xAxisTitleUnderline,
+        opts.xAxisTitleFontFamily,
       ),
     );
   catAxChildren.push(
@@ -2611,6 +2647,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleColor,
         opts.yAxisTitleStrike,
         opts.yAxisTitleUnderline,
+        opts.yAxisTitleFontFamily,
       ),
     );
   valAxChildren.push(
@@ -2985,6 +3022,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleColor,
         opts.xAxisTitleStrike,
         opts.xAxisTitleUnderline,
+        opts.xAxisTitleFontFamily,
       ),
     );
   xAxChildren.push(
@@ -3037,6 +3075,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleColor,
         opts.yAxisTitleStrike,
         opts.yAxisTitleUnderline,
+        opts.yAxisTitleFontFamily,
       ),
     );
   yAxChildren.push(
@@ -3136,6 +3175,7 @@ function buildAxisTitle(
   rgbHex: string | undefined,
   strike: boolean | undefined,
   underline: boolean | undefined,
+  fontFamily: string | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -3213,26 +3253,47 @@ function buildAxisTitle(
   const solidFillChild = rgbHex
     ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
     : undefined;
-  // When a fill color is set the `<a:defRPr>` / `<a:rPr>` slots
-  // expand from self-closing to wrapping the `<a:solidFill>` child;
-  // otherwise the writer keeps the existing self-closing form so a
-  // fresh axis title with no custom color matches Excel's reference
-  // serialization byte-for-byte.
-  const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr });
-  const rPr = solidFillChild
-    ? xmlElement("a:rPr", { lang: "en-US", sz, b, i, u: underlineAttr, strike: strikeAttr }, [
-        solidFillChild,
-      ])
-    : xmlSelfClose("a:rPr", {
-        lang: "en-US",
-        sz,
-        b,
-        i,
-        u: underlineAttr,
-        strike: strikeAttr,
-      });
+  // OOXML's `<a:defRPr><a:latin typeface=".."/></a:defRPr>` carries the
+  // axis title's font family. Mirrors the chart-level `buildTitle`
+  // typeface emit: `axisTitleFontFamily` lands on both the default-
+  // paragraph `<a:defRPr>` and the literal run's `<a:rPr>` so a
+  // re-parse picks the typeface up off either canonical slot. Absence
+  // (`undefined`) collapses to omitting the entire `<a:latin>` element
+  // so the title inherits the theme typeface (Excel's reference
+  // behavior for a fresh axis title that has not had a custom font
+  // picked). The `<a:latin>` element follows `<a:solidFill>` per the
+  // CT_TextCharacterProperties child sequence (ECMA-376 Part 1,
+  // §21.1.2.3.7).
+  const latinChild = fontFamily ? xmlSelfClose("a:latin", { typeface: fontFamily }) : undefined;
+  // When a fill color or a typeface is set the `<a:defRPr>` /
+  // `<a:rPr>` slots expand from self-closing to wrapping the
+  // children; otherwise the writer keeps the existing self-closing
+  // form so a fresh axis title with no custom color or font matches
+  // Excel's reference serialization byte-for-byte. Children are
+  // emitted in CT_TextCharacterProperties' canonical schema order:
+  // solidFill first, then latin.
+  const rPrChildren: string[] = [];
+  if (solidFillChild) rPrChildren.push(solidFillChild);
+  if (latinChild) rPrChildren.push(latinChild);
+  const defRPr =
+    rPrChildren.length > 0
+      ? xmlElement("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr }, rPrChildren)
+      : xmlSelfClose("a:defRPr", { sz, b, i, u: underlineAttr, strike: strikeAttr });
+  const rPr =
+    rPrChildren.length > 0
+      ? xmlElement(
+          "a:rPr",
+          { lang: "en-US", sz, b, i, u: underlineAttr, strike: strikeAttr },
+          rPrChildren,
+        )
+      : xmlSelfClose("a:rPr", {
+          lang: "en-US",
+          sz,
+          b,
+          i,
+          u: underlineAttr,
+          strike: strikeAttr,
+        });
   return xmlElement("c:title", undefined, [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
@@ -3374,6 +3435,27 @@ function normalizeAxisTitleStrike(value: boolean | undefined): boolean | undefin
  */
 function normalizeAxisTitleUnderline(value: boolean | undefined): boolean | undefined {
   return normalizeTitleUnderline(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.axes}.x.axisTitleFontFamily value for
+ * the `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:rich></c:tx></c:title>`
+ * writer slot inside an axis. Returns the trimmed typeface string
+ * when the input is a non-empty string, or `undefined` for any
+ * malformed token — empty / whitespace-only strings, or non-string
+ * escapes from an untyped caller (`null`, numbers, booleans, etc.).
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<a:latin>` element and the axis title
+ * inherits the theme typeface (Excel's reference behavior for a
+ * fresh axis title without a custom font picked).
+ */
+function normalizeAxisTitleFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 // ── Series ───────────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16968,3 +16968,194 @@ describe("cloneChart — dataLabels.strikethrough", () => {
     expect(clone.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── cloneChart — axis title font family ─────────────────────────────
+
+describe("cloneChart — axis title font family", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleFontFamily by default", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Arial");
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleFontFamily by default", () => {
+    const clone = cloneChart(
+      source({ axes: { y: { title: "USD", axisTitleFontFamily: "Calibri" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.y?.axisTitleFontFamily).toBe("Calibri");
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleFontFamily replace the source's value", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFontFamily: "Calibri" } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Calibri");
+  });
+
+  it("drops the inherited axisTitleFontFamily when the override is null", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFontFamily: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleFontFamily when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleFontFamily with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontFamily: "Verdana" } },
+    });
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Verdana");
+  });
+
+  it("trims surrounding whitespace from the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFontFamily: "   Arial   " } },
+    });
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Arial");
+  });
+
+  it("drops empty / whitespace-only overrides", () => {
+    const c1 = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFontFamily: "" } },
+      },
+    );
+    expect(c1.axes?.x?.axisTitleFontFamily).toBeUndefined();
+    const c2 = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFontFamily: "   " } },
+      },
+    );
+    expect(c2.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("drops a non-string override (defends against an untyped caller)", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { axisTitleFontFamily: 1 as any } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("drops the cloned axisTitleFontFamily when the resolved axis title is dropped (title=null)", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("preserves axisTitleFontFamily when an override pins a fresh title on a sourceless axis", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Arial");
+  });
+
+  it("composes with all other axis-title typography knobs", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFontFamily: "Arial",
+            axisTitleBold: true,
+            axisTitleItalic: true,
+            axisTitleStrike: true,
+            axisTitleUnderline: true,
+            axisTitleColor: "FF0000",
+            axisTitleFontSize: 16,
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Arial");
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+    expect(clone.axes?.x?.axisTitleStrike).toBe(true);
+    expect(clone.axes?.x?.axisTitleUnderline).toBe(true);
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(16);
+  });
+
+  it("normalizes a malformed source value (defensive)", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ axes: { x: { title: "Period", axisTitleFontFamily: "   " as any } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("preserves Y-axis typeface when only X is overridden", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleFontFamily: "Arial" },
+          y: { title: "USD", axisTitleFontFamily: "Calibri" },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFontFamily: "Verdana" } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Verdana");
+    expect(clone.axes?.y?.axisTitleFontFamily).toBe("Calibri");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15272,3 +15272,242 @@ describe("writeChart — dataLabels.strikethrough", () => {
     expect(reparsed?.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── writeChart — axis title font family ─────────────────────────────
+
+describe("writeChart — axis title font family", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  function axisTitleDefRPrLatin(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    // Match the defRPr (which wraps <a:latin> when set)
+    const defRPrMatch = titleBlock.match(/<a:defRPr\b[^>]*>([\s\S]*?)<\/a:defRPr>/);
+    if (!defRPrMatch) return undefined;
+    const latin = defRPrMatch[1].match(/<a:latin\b[^/]*\/>/);
+    if (!latin) return undefined;
+    const typeface = latin[0].match(/typeface="([^"]*)"/);
+    return typeface ? typeface[1] : undefined;
+  }
+
+  function axisTitleRPrLatin(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    const rPrMatch = titleBlock.match(/<a:rPr\b[^>]*>([\s\S]*?)<\/a:rPr>/);
+    if (!rPrMatch) return undefined;
+    const latin = rPrMatch[1].match(/<a:latin\b[^/]*\/>/);
+    if (!latin) return undefined;
+    const typeface = latin[0].match(/typeface="([^"]*)"/);
+    return typeface ? typeface[1] : undefined;
+  }
+
+  it("omits the <a:latin> element by default (matches Excel's reference inherited typeface)", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx);
+    expect(titleBlock).not.toContain("<a:latin");
+  });
+
+  it("emits <a:latin typeface='Arial'/> on axisTitleFontFamily='Arial'", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrLatin(xAx)).toBe("Arial");
+    expect(axisTitleRPrLatin(xAx)).toBe("Arial");
+  });
+
+  it("emits multi-word typefaces verbatim", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: "Times New Roman" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrLatin(xAx)).toBe("Times New Roman");
+  });
+
+  it("trims surrounding whitespace from the typeface", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: "   Calibri   " } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleDefRPrLatin(xAx)).toBe("Calibri");
+  });
+
+  it("drops empty / whitespace-only inputs back to the OOXML default", () => {
+    const r1 = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: "" } } }),
+      "Sheet1",
+    );
+    const [r1XAx] = axisBlocks(r1.chartXml);
+    expect(axisTitleBlock(r1XAx)).not.toContain("<a:latin");
+    const r2 = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: "   " } } }),
+      "Sheet1",
+    );
+    const [r2XAx] = axisBlocks(r2.chartXml);
+    expect(axisTitleBlock(r2XAx)).not.toContain("<a:latin");
+  });
+
+  it("drops non-string inputs back to the OOXML default", () => {
+    const r1 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: 1 as any } } }),
+      "Sheet1",
+    );
+    const [r1XAx] = axisBlocks(r1.chartXml);
+    expect(axisTitleBlock(r1XAx)).not.toContain("<a:latin");
+    const r2 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: null as any } } }),
+      "Sheet1",
+    );
+    const [r2XAx] = axisBlocks(r2.chartXml);
+    expect(axisTitleBlock(r2XAx)).not.toContain("<a:latin");
+  });
+
+  it("ignores axisTitleFontFamily when the axis renders no title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { axisTitleFontFamily: "Arial" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("emits the typeface on a value axis (Y axis)", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { title: "Revenue", axisTitleFontFamily: "Arial" } } }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(result.chartXml);
+    const valAx = blocks.find((b) => b.startsWith("<c:valAx>"));
+    expect(valAx).toBeDefined();
+    expect(axisTitleDefRPrLatin(valAx!)).toBe("Arial");
+  });
+
+  it("XML-escapes the typeface", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: 'A&B"C' } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBlock(xAx)).toContain('typeface="A&amp;B&quot;C"');
+  });
+
+  it("composes with axisTitleColor (both wrap defRPr/rPr together in schema order)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFontFamily: "Arial",
+            axisTitleColor: "FF0000",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock).toContain('<a:srgbClr val="FF0000"/>');
+    expect(titleBlock).toContain('<a:latin typeface="Arial"/>');
+    // Schema order: solidFill before latin inside CT_TextCharacterProperties.
+    expect(titleBlock.indexOf("<a:solidFill>")).toBeLessThan(titleBlock.indexOf("<a:latin"));
+  });
+
+  it("composes with all other axis-title typography knobs", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFontFamily: "Arial",
+            axisTitleBold: true,
+            axisTitleItalic: true,
+            axisTitleStrike: true,
+            axisTitleUnderline: true,
+            axisTitleFontSize: 16,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock).toContain('<a:latin typeface="Arial"/>');
+    expect(titleBlock).toContain('sz="1600"');
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('i="1"');
+    expect(titleBlock).toContain('strike="sngStrike"');
+    expect(titleBlock).toContain('u="sng"');
+  });
+
+  it("threads through every chart family (bar / column / line / area / scatter)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "area", "scatter"];
+    for (const type of types) {
+      const result = writeChart(
+        makeChart({
+          type,
+          axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } },
+        }),
+        "Sheet1",
+      );
+      const blocks = axisBlocks(result.chartXml);
+      expect(blocks.length).toBeGreaterThan(0);
+      // Find the X axis (catAx for bar/column/line/area, valAx for scatter).
+      const xAxBlock = blocks[0];
+      expect(axisTitleDefRPrLatin(xAxBlock)).toBe("Arial");
+    }
+  });
+
+  it("parse round-trip surfaces axisTitleFontFamily from the writer's output", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFontFamily: "Arial" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleFontFamily).toBe("Arial");
+  });
+
+  it("end-to-end: writeXlsx -> open -> reparse retains the typeface", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            axes: {
+              x: { title: "Region", axisTitleFontFamily: "Arial" },
+              y: { title: "Sales", axisTitleFontFamily: "Calibri" },
+            },
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:latin typeface="Arial"/>');
+    expect(chartXml).toContain('<a:latin typeface="Calibri"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleFontFamily).toBe("Arial");
+    expect(reparsed?.axes?.y?.axisTitleFontFamily).toBe("Calibri");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15965,3 +15965,157 @@ describe("parseChart — data labels strikethrough", () => {
     expect(parseChart(xml)?.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── parseChart — axis title font family ─────────────────────────────
+
+describe("parseChart — axis title font family", () => {
+  const NS_ATFF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitleFontFamily(typeface: string | undefined): string {
+    const defRPr =
+      typeface === undefined
+        ? "<a:defRPr/>"
+        : `<a:defRPr><a:latin typeface="${typeface}"/></a:defRPr>`;
+    return `<c:chartSpace ${NS_ATFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  function withValAxTitleFontFamily(typeface: string | undefined): string {
+    const defRPr =
+      typeface === undefined
+        ? "<a:defRPr/>"
+        : `<a:defRPr><a:latin typeface="${typeface}"/></a:defRPr>`;
+    return `<c:chartSpace ${NS_ATFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr>${defRPr}</a:pPr><a:r><a:t>Revenue</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the typeface on a category axis", () => {
+    const chart = parseChart(withCatAxTitleFontFamily("Arial"));
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBe("Arial");
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("surfaces the typeface on a value axis", () => {
+    const chart = parseChart(withValAxTitleFontFamily("Calibri"));
+    expect(chart?.axes?.y?.axisTitleFontFamily).toBe("Calibri");
+    expect(chart?.axes?.y?.title).toBe("Revenue");
+  });
+
+  it("surfaces multi-word typefaces verbatim", () => {
+    const chart = parseChart(withCatAxTitleFontFamily("Times New Roman"));
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBe("Times New Roman");
+  });
+
+  it("collapses absence of <a:latin> to undefined", () => {
+    const chart = parseChart(withCatAxTitleFontFamily(undefined));
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("collapses an empty typeface attribute to undefined", () => {
+    const chart = parseChart(withCatAxTitleFontFamily(""));
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace from the typeface", () => {
+    const chart = parseChart(withCatAxTitleFontFamily("   Arial   "));
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBe("Arial");
+  });
+
+  it("collapses whitespace-only typefaces to undefined", () => {
+    const chart = parseChart(withCatAxTitleFontFamily("   "));
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when the axis has no title at all", () => {
+    const xml = `<c:chartSpace ${NS_ATFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
+    expect(chart?.axes?.y?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when the title is a strRef (no rich body)", () => {
+    const xml = `<c:chartSpace ${NS_ATFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx>
+          <c:strRef><c:f>Sheet1!$A$1</c:f></c:strRef>
+        </c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+
+  it("scopes the lookup to the axis title (tick-label <a:latin> does not leak in)", () => {
+    // The tick-label <c:txPr> pins a typeface; the axis title pins
+    // none. The reader must not pick up the tick-label typeface for
+    // axisTitleFontFamily.
+    const xml = `<c:chartSpace ${NS_ATFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="Verdana"/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Surfaces `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` -> `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr></a:pPr><a:r><a:rPr><a:latin typeface=".."/></a:rPr></a:r></a:p></c:rich></c:tx></c:title>` (CT_TextFont on CT_TextCharacterProperties' latin slot — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's axis-title typeface survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `axisTitleFontFamily?: string` on `SheetChart.axes.x|y` (writer side) and on `ChartAxisInfo` (reader side). Sits on the same `<c:title>` body as `axisTitleColor` / `axisTitleBold` / `axisTitleItalic` / `axisTitleStrike` / `axisTitleUnderline` / `axisTitleFontSize` / `axisTitleRotation`; the writer threads the value through the existing `buildAxisTitle` helper so the run-level `<a:rPr>` and the default-paragraph `<a:defRPr>` both pick up the typeface.

Mirrors the chart-level `titleFontFamily` field (#282) — same canonical-slot pair, same accept-and-trim grammar, same `string | null` clone grammar so a single configuration call threads cleanly through both the chart title and either axis title without bookkeeping the canonical OOXML slots.

The `<a:latin>` element follows `<a:solidFill>` per the CT_TextCharacterProperties child sequence so an axis title with both `axisTitleColor` and `axisTitleFontFamily` set lands the children in canonical schema order — a fresh chart matches Excel's reference serialization byte-for-byte. Sits on every axis flavour (`<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) so the field round-trips on every chart family that has axes (bar / column / line / area / scatter); silently dropped on pie / doughnut.

Refs #136

## Test plan

- [x] `pnpm vitest run --dir=test` — 5602 tests pass
- [x] `pnpm build` — succeeds
- [x] reader: surfaces typeface on catAx and valAx; trims whitespace; collapses empty / whitespace-only / absent / non-string to undefined; scoped so tick-label `<c:txPr><a:latin>` cannot leak in
- [x] writer: omits `<a:latin>` by default; emits on both `<a:defRPr>` and `<a:rPr>`; XML-escapes; composes with color in canonical schema order; composes with bold / italic / strike / underline / size; threads through every chart family
- [x] clone: inherits, overrides, drops on `null`, drops on title-suppression; trims whitespace; drops malformed overrides; preserves Y-axis when only X is overridden
- [x] end-to-end: `writeXlsx` -> `extractXml` -> `parseChart` retains the typeface on both axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)