### PR TITLE
feat(xlsx): chart axis tick-label font family — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -3043,6 +3043,48 @@ export interface SheetChart {
        */
       labelStrike?: boolean;
       /**
+       * Axis tick-label font family / typeface. Maps to
+       * `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` ->
+       * `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/>
+       * </a:defRPr></a:pPr></a:p></c:txPr>` — Excel's "Format Axis ->
+       * Number / Font -> Font" picker scoped to the axis's tick
+       * labels. The OOXML `<a:latin typeface=".."/>` element carries
+       * the typeface name (`CT_TextFont`, ECMA-376 Part 1,
+       * §21.1.2.3.7); the writer lands the element on the default-
+       * paragraph `<a:defRPr>` of the axis-level `<c:txPr>` body.
+       *
+       * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+       * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+       * whitespace and emits the trimmed value verbatim (XML-escaped)
+       * so Excel can resolve the named font from the workbook's font
+       * scheme or the host system's installed fonts. Empty /
+       * whitespace-only strings and non-string tokens collapse to
+       * `undefined` so the writer skips the entire `<a:latin>`
+       * element and the tick labels inherit Excel's reference theme
+       * typeface.
+       *
+       * Default: omitted — the tick labels render in Excel's
+       * reference theme typeface (no `<a:latin>` element, the writer
+       * skips the element entirely). Pin a typeface name to render
+       * the labels in that font.
+       *
+       * Composes independently with {@link labelRotation} /
+       * {@link labelFontSize} / {@link labelBold} /
+       * {@link labelItalic} / {@link labelColor} /
+       * {@link labelUnderline} / {@link labelStrike}: all eight knobs
+       * land on the same `<c:txPr>` body, so a single configuration
+       * call threads cleanly through every tick-label knob the
+       * writer exposes.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>`
+       * per the OOXML schema, so the field round-trips on every
+       * chart family that has axes (bar / column / line / area /
+       * scatter). Pie / doughnut have no axes at all, so the field
+       * is silently dropped on those families.
+       */
+      labelFontFamily?: string;
+      /**
        * Reverse the axis plotting order. Maps to
        * `<c:scaling><c:orientation val="maxMin"/></c:scaling>` —
        * Excel's "Categories in reverse order" / "Values in reverse
@@ -3516,6 +3558,13 @@ export interface SheetChart {
        * (no axes at all).
        */
       labelStrike?: boolean;
+      /**
+       * Value-axis tick-label font family / typeface. Same canonical-
+       * slot pair and grammar as {@link SheetChart.axes.x.labelFontFamily} —
+       * the field round-trips on `<c:valAx>` exactly as it does on
+       * `<c:catAx>`. See the X-axis variant for the full semantics.
+       */
+      labelFontFamily?: string;
       /**
        * Hide the entire value axis (line, tick marks, tick labels).
        * Maps to `<c:valAx><c:delete val="1"/></c:valAx>`. Default:
@@ -5181,6 +5230,33 @@ export interface ChartAxisInfo {
    * {@link ChartAxisInfo.axisTitleStrike}) cannot leak in.
    */
   labelStrike?: boolean;
+  /**
+   * Axis tick-label font family / typeface pulled from `<c:catAx>` /
+   * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` ->
+   * `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/>
+   * </a:defRPr></a:pPr></a:p></c:txPr>`. Reflects Excel's "Format
+   * Axis -> Number / Font -> Font" picker scoped to the axis's tick
+   * labels. The OOXML `<a:latin typeface=".."/>` element carries the
+   * typeface name (`CT_TextFont`, ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Reports the trimmed typeface string when the source axis pinned
+   * a non-empty typeface; absence and empty / whitespace-only
+   * `typeface` attributes both collapse to `undefined` so absence
+   * and `<a:latin typeface=""/>` round-trip identically through
+   * {@link cloneChart}. Non-string `typeface` tokens (defensive —
+   * the XML parser only ever surfaces strings) likewise drop to
+   * `undefined`.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>` per
+   * the OOXML schema. Mirrors the writer-side
+   * {@link SheetChart.axes.x.labelFontFamily} so a parsed value slots
+   * straight back into a clone target without transformation. The
+   * lookup is scoped to the axis-level `<c:txPr>` so a stray
+   * `<a:latin>` inside `<c:title>` (surfaced by
+   * {@link ChartAxisInfo.axisTitleFontFamily}) cannot leak in.
+   */
+  labelFontFamily?: string;
   /**
    * Reverse-axis flag pulled from
    * `<c:scaling><c:orientation val=".."/></c:scaling>`. Surfaces `true`

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -1152,6 +1152,29 @@ export interface CloneChartOptions {
        */
       labelStrike?: boolean | null;
       /**
+       * Override `SheetChart.axes.x.labelFontFamily`. `undefined` (or
+       * omitted) inherits the source axis's tick-label typeface;
+       * `null` drops the inherited typeface (the writer falls back to
+       * the OOXML default — no `<a:latin>` element, the labels
+       * inherit the theme typeface); a non-empty string replaces it;
+       * the override is trimmed.
+       *
+       * Empty / whitespace-only strings and non-string overrides
+       * (typed escapes from an untyped caller) collapse to a drop so
+       * the cloned `SheetChart` always carries a value the writer
+       * will accept.
+       *
+       * `<c:txPr>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts since neither has axes. Composes
+       * independently with {@link labelRotation} / {@link labelFontSize} /
+       * {@link labelBold} / {@link labelItalic} / {@link labelColor} /
+       * {@link labelUnderline} / {@link labelStrike}: all eight knobs
+       * land on the same `<c:txPr>` body.
+       */
+      labelFontFamily?: string | null;
+      /**
        * Override the reverse-axis flag. `undefined` (or omitted)
        * inherits the source axis' parsed value; `null` drops it (the
        * writer falls back to the OOXML default `"minMax"` — forward
@@ -1331,6 +1354,8 @@ export interface CloneChartOptions {
       labelUnderline?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.labelStrike}. */
       labelStrike?: boolean | null;
+      /** See {@link CloneChartOptions.axes.x.labelFontFamily}. */
+      labelFontFamily?: string | null;
       /** See {@link CloneChartOptions.axes.x.hidden}. */
       hidden?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.reverse}. */
@@ -3573,6 +3598,22 @@ function resolveAxes(
     sourceAxes?.y?.labelStrike,
     overrides?.y?.labelStrike,
   );
+  // `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+  // </a:pPr></a:p></c:txPr>` shares the same `<c:txPr>` slot as the
+  // rotation / size / bold / italic / color / underline / strike
+  // resolvers above, and the same per-axis scope rule (every axis
+  // flavour carries `<c:txPr>`; pie / doughnut already short-
+  // circuited upstream). Empty / whitespace-only / non-string
+  // overrides collapse to a drop so the cloned `SheetChart` always
+  // carries a value the writer will accept.
+  const xLabelFontFamily = applyLabelFontFamilyOverride(
+    sourceAxes?.x?.labelFontFamily,
+    overrides?.x?.labelFontFamily,
+  );
+  const yLabelFontFamily = applyLabelFontFamilyOverride(
+    sourceAxes?.y?.labelFontFamily,
+    overrides?.y?.labelFontFamily,
+  );
   const xReverse = applyReverseOverride(sourceAxes?.x?.reverse, overrides?.x?.reverse);
   const yReverse = applyReverseOverride(sourceAxes?.y?.reverse, overrides?.y?.reverse);
   // `tickLblSkip` / `tickMarkSkip` only render on category axes
@@ -3734,6 +3775,7 @@ function resolveAxes(
     xLabelColor !== undefined ||
     xLabelUnderline !== undefined ||
     xLabelStrike !== undefined ||
+    xLabelFontFamily !== undefined ||
     xReverse !== undefined ||
     xTickLblSkip !== undefined ||
     xTickMarkSkip !== undefined ||
@@ -3772,6 +3814,7 @@ function resolveAxes(
     if (xLabelColor !== undefined) out.x.labelColor = xLabelColor;
     if (xLabelUnderline !== undefined) out.x.labelUnderline = xLabelUnderline;
     if (xLabelStrike !== undefined) out.x.labelStrike = xLabelStrike;
+    if (xLabelFontFamily !== undefined) out.x.labelFontFamily = xLabelFontFamily;
     if (xReverse !== undefined) out.x.reverse = xReverse;
     if (xTickLblSkip !== undefined) out.x.tickLblSkip = xTickLblSkip;
     if (xTickMarkSkip !== undefined) out.x.tickMarkSkip = xTickMarkSkip;
@@ -3807,6 +3850,7 @@ function resolveAxes(
     yLabelColor !== undefined ||
     yLabelUnderline !== undefined ||
     yLabelStrike !== undefined ||
+    yLabelFontFamily !== undefined ||
     yHidden !== undefined ||
     yReverse !== undefined ||
     yCrossesPair.crosses !== undefined ||
@@ -3839,6 +3883,7 @@ function resolveAxes(
     if (yLabelColor !== undefined) out.y.labelColor = yLabelColor;
     if (yLabelUnderline !== undefined) out.y.labelUnderline = yLabelUnderline;
     if (yLabelStrike !== undefined) out.y.labelStrike = yLabelStrike;
+    if (yLabelFontFamily !== undefined) out.y.labelFontFamily = yLabelFontFamily;
     if (yHidden !== undefined) out.y.hidden = yHidden;
     if (yReverse !== undefined) out.y.reverse = yReverse;
     if (yCrossesPair.crosses !== undefined) out.y.crosses = yCrossesPair.crosses;
@@ -4330,6 +4375,48 @@ function applyLabelStrikeOverride(
   if (override === true) return true;
   if (override === false) return false;
   return undefined;
+}
+
+/**
+ * Resolve a `labelFontFamily` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis tick-label typography knobs.
+ *
+ * Empty / whitespace-only strings and non-string overrides (typed
+ * escapes from an untyped caller) collapse to `undefined` via
+ * {@link normalizeLabelFontFamily} so the cloned `SheetChart` always
+ * carries a value the writer will accept. A `null` override always
+ * drops the inherited typeface (the writer falls back to the OOXML
+ * default — no `<a:latin>` element, the labels inherit the theme
+ * typeface).
+ *
+ * The `<c:txPr>` block sits on every axis flavour per the OOXML
+ * schema, so the override applies on every chart family that has
+ * axes. The pie / doughnut short-circuit upstream collapses the
+ * field on those families since neither has axes.
+ */
+function applyLabelFontFamilyOverride(
+  source: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeLabelFontFamily(source);
+  if (override === null) return undefined;
+  return normalizeLabelFontFamily(override);
+}
+
+/**
+ * Normalize a `labelFontFamily` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizeAxisLabelFontFamily` — non-empty
+ * strings pass through trimmed, every other token (empty /
+ * whitespace-only strings, typed escapes from an untyped caller)
+ * collapses to `undefined` so the cloned chart drops the field
+ * rather than carry a value the writer would silently elide.
+ */
+function normalizeLabelFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -749,6 +749,17 @@ function parseAxisInfo(
   // `"sngStrike"`). Surfaced on every axis flavour for symmetry with
   // the writer.
   const labelStrike = parseAxisLabelStrike(axis);
+  // `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+  // </a:pPr></a:p></c:txPr>` — axis tick-label font family. Same
+  // axis-level `<c:txPr>` body scope as the rotation / size / bold /
+  // italic / color / underline / strike readers above. Empty /
+  // whitespace-only `typeface` attributes and missing `<a:latin>`
+  // elements both collapse to `undefined` so absence and the empty
+  // form round-trip identically through the writer. The reader is
+  // scoped to the axis-level `<c:txPr>` so a stray `<a:latin>` inside
+  // `<c:title>` (surfaced by `axisTitleFontFamily`) cannot leak in.
+  // Surfaced on every axis flavour for symmetry with the writer.
+  const labelFontFamily = parseAxisLabelFontFamily(axis);
   // <c:scaling><c:orientation val=".."/></c:scaling> — ST_Orientation
   // accepts "minMax" (default, low → high) and "maxMin" (reversed).
   // The default collapses to undefined so a fresh chart and a chart
@@ -836,6 +847,7 @@ function parseAxisInfo(
     labelBold === undefined &&
     labelItalic === undefined &&
     labelColor === undefined &&
+    labelFontFamily === undefined &&
     labelUnderline === undefined &&
     labelStrike === undefined &&
     reverse === undefined &&
@@ -873,6 +885,7 @@ function parseAxisInfo(
   if (labelBold !== undefined) out.labelBold = labelBold;
   if (labelItalic !== undefined) out.labelItalic = labelItalic;
   if (labelColor !== undefined) out.labelColor = labelColor;
+  if (labelFontFamily !== undefined) out.labelFontFamily = labelFontFamily;
   if (labelUnderline !== undefined) out.labelUnderline = labelUnderline;
   if (labelStrike !== undefined) out.labelStrike = labelStrike;
   if (reverse !== undefined) out.reverse = reverse;
@@ -1481,6 +1494,52 @@ function parseAxisLabelStrike(axis: XmlElement): boolean | undefined {
   // trip.
   if (raw === "sngStrike") return true;
   return undefined;
+}
+
+/**
+ * Pull the axis tick-label font family off the canonical
+ * `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+ * </a:pPr></a:p></c:txPr>` chain Excel writes when the user pins a
+ * typeface on the axis tick labels.
+ *
+ * The OOXML `<a:latin>` element carries the typeface name on
+ * `CT_TextFont` (ECMA-376 Part 1, §21.1.2.3.7). The reader trims
+ * surrounding whitespace and reports the trimmed typeface; empty /
+ * whitespace-only `typeface` attributes and missing `<a:latin>`
+ * elements both collapse to `undefined` so absence and the empty
+ * form round-trip identically through the writer. Non-string
+ * `typeface` tokens (defensive — the XML parser only ever surfaces
+ * strings) likewise drop to `undefined`.
+ *
+ * Returns `undefined` whenever the axis omits `<c:txPr>` entirely or
+ * the canonical `<a:p><a:pPr><a:defRPr><a:latin>` chain is malformed
+ * at any link.
+ *
+ * The `<c:txPr>` element sits on every axis flavour — `<c:catAx>` /
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` all carry the optional
+ * element per the OOXML schema. The reader surfaces the value
+ * regardless of axis flavour so a parsed chart preserves the
+ * typeface for symmetry with the writer-side
+ * {@link SheetChart.axes}.x.labelFontFamily. The lookup is scoped to
+ * the axis-level `<c:txPr>` so a stray `<a:latin>` inside the axis
+ * `<c:title><c:tx><c:rich>` body cannot leak in.
+ */
+function parseAxisLabelFontFamily(axis: XmlElement): string | undefined {
+  const txPr = findChild(axis, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const latin = findChild(defRPr, "latin");
+  if (!latin) return undefined;
+  const raw = latin.attrs.typeface;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 /** Recognized values of `<c:crosses>` per the OOXML `ST_Crosses` enum. */

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -866,6 +866,17 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // Excel's reference non-strikethrough tick labels.
     xLabelStrike: normalizeAxisLabelStrike(chart.axes?.x?.labelStrike),
     yLabelStrike: normalizeAxisLabelStrike(chart.axes?.y?.labelStrike),
+    // `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+    // </a:pPr></a:p></c:txPr>` — axis tick-label font family. The
+    // element shares the same `<c:txPr>` block as the rotation / size
+    // / bold / italic / color / underline / strike slots. The writer
+    // trims surrounding whitespace and emits the trimmed typeface
+    // verbatim. Empty / whitespace-only / non-string tokens collapse
+    // to `undefined` so the writer skips the entire `<a:latin>`
+    // element and a fresh chart inherits Excel's reference theme
+    // typeface.
+    xLabelFontFamily: normalizeAxisLabelFontFamily(chart.axes?.x?.labelFontFamily),
+    yLabelFontFamily: normalizeAxisLabelFontFamily(chart.axes?.y?.labelFontFamily),
     xReverse: chart.axes?.x?.reverse === true,
     yReverse: chart.axes?.y?.reverse === true,
     // `tickLblSkip` / `tickMarkSkip` only round-trip on category axes
@@ -1506,6 +1517,23 @@ interface AxisRenderOptions {
    * and semantics as {@link xLabelStrike}.
    */
   yLabelStrike: boolean | undefined;
+  /**
+   * Tick-label font family / typeface emitted on the X axis via
+   * `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+   * </a:pPr></a:p></c:txPr>`. The OOXML `<a:latin>` element carries
+   * the typeface name on `CT_TextFont`. `undefined` collapses to
+   * omitting the element (Excel's reference serialization for tick
+   * labels that inherit the theme typeface); a non-empty trimmed
+   * string emits `<a:latin typeface=".."/>`. The block is emitted
+   * whenever any tick-label typography knob is set so the OOXML
+   * schema's `<c:txPr>` slot carries every pinned typography knob.
+   */
+  xLabelFontFamily: string | undefined;
+  /**
+   * Tick-label font family / typeface emitted on the Y axis. Same
+   * shape and semantics as {@link xLabelFontFamily}.
+   */
+  yLabelFontFamily: string | undefined;
   xReverse: boolean;
   yReverse: boolean;
   /**
@@ -1937,6 +1965,26 @@ function normalizeAxisLabelStrike(value: boolean | undefined): boolean | undefin
 }
 
 /**
+ * Normalize an axis `labelFontFamily` value for the
+ * `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+ * </a:pPr></a:p></c:txPr>` writer slot. Returns the trimmed typeface
+ * string when the input is a non-empty string, or `undefined` for any
+ * malformed token — empty / whitespace-only strings, or non-string
+ * escapes from an untyped caller (`null`, numbers, booleans, etc.).
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<a:latin>` element and the tick labels
+ * inherit the theme typeface (Excel's reference behavior for a fresh
+ * axis without a custom tick-label font picked).
+ */
+function normalizeAxisLabelFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
  * Build the `<c:txPr>` block that carries an axis tick-label rotation,
  * font size, bold flag, italic flag, font color, underline flag, and /
  * or strikethrough flag. Returns `undefined` when every input is unset
@@ -1995,6 +2043,7 @@ function buildAxisTxPr(
   rgbHex: string | undefined,
   underline: boolean | undefined,
   strike: boolean | undefined,
+  fontFamily: string | undefined,
 ): string | undefined {
   if (
     rotationDeg === undefined &&
@@ -2003,7 +2052,8 @@ function buildAxisTxPr(
     italic === undefined &&
     rgbHex === undefined &&
     underline === undefined &&
-    strike === undefined
+    strike === undefined &&
+    fontFamily === undefined
   )
     return undefined;
   const rot = rotationDeg === undefined ? undefined : rotationDeg * TXPR_ROT_PER_DEGREE;
@@ -2041,14 +2091,28 @@ function buildAxisTxPr(
   const solidFillChild = rgbHex
     ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
     : undefined;
-  // When a fill color is set the `<a:defRPr>` slot expands from
-  // self-closing to wrapping the `<a:solidFill>` child; otherwise the
+  // OOXML's `<a:defRPr><a:latin typeface=".."/></a:defRPr>` carries
+  // the tick-label font family. The `<a:latin>` element follows
+  // `<a:solidFill>` per the CT_TextCharacterProperties child sequence
+  // (ECMA-376 Part 1, §21.1.2.3.7). Absence (`undefined`) collapses to
+  // omitting the entire `<a:latin>` element so the labels inherit the
+  // theme typeface (Excel's reference behavior for a fresh axis that
+  // has not had a custom tick-label font picked).
+  const latinChild = fontFamily ? xmlSelfClose("a:latin", { typeface: fontFamily }) : undefined;
+  // When a fill color or a typeface is set the `<a:defRPr>` slot
+  // expands from self-closing to wrapping the children; otherwise the
   // writer keeps the existing self-closing form so a fresh axis with
-  // no custom color matches Excel's reference serialization byte-for-
-  // byte.
-  const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", { sz, b, i, u, strike: strikeAttr }, [solidFillChild])
-    : xmlSelfClose("a:defRPr", { sz, b, i, u, strike: strikeAttr });
+  // no custom color or font matches Excel's reference serialization
+  // byte-for-byte. Children are emitted in
+  // CT_TextCharacterProperties' canonical schema order: solidFill
+  // first, then latin.
+  const defRPrChildren: string[] = [];
+  if (solidFillChild) defRPrChildren.push(solidFillChild);
+  if (latinChild) defRPrChildren.push(latinChild);
+  const defRPr =
+    defRPrChildren.length > 0
+      ? xmlElement("a:defRPr", { sz, b, i, u, strike: strikeAttr }, defRPrChildren)
+      : xmlSelfClose("a:defRPr", { sz, b, i, u, strike: strikeAttr });
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr", { rot }),
     xmlSelfClose("a:lstStyle"),
@@ -2556,6 +2620,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     opts.xLabelColor,
     opts.xLabelUnderline,
     opts.xLabelStrike,
+    opts.xLabelFontFamily,
   );
   if (xCatAxTxPr) catAxChildren.push(xCatAxTxPr);
   catAxChildren.push(
@@ -2630,6 +2695,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
     opts.yLabelColor,
     opts.yLabelUnderline,
     opts.yLabelStrike,
+    opts.yLabelFontFamily,
   );
   if (yValAxTxPr) valAxChildren.push(yValAxTxPr);
   valAxChildren.push(
@@ -3002,6 +3068,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     opts.xLabelColor,
     opts.xLabelUnderline,
     opts.xLabelStrike,
+    opts.xLabelFontFamily,
   );
   if (xValAxTxPr) xAxChildren.push(xValAxTxPr);
   xAxChildren.push(
@@ -3053,6 +3120,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
     opts.yLabelColor,
     opts.yLabelUnderline,
     opts.yLabelStrike,
+    opts.yLabelFontFamily,
   );
   if (yScatterTxPr) yAxChildren.push(yScatterTxPr);
   yAxChildren.push(

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16968,3 +16968,171 @@ describe("cloneChart — dataLabels.strikethrough", () => {
     expect(clone.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── cloneChart — axis tick-label font family ────────────────────────
+
+describe("cloneChart — axis tick-label font family", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis labelFontFamily by default", () => {
+    const clone = cloneChart(source({ axes: { x: { labelFontFamily: "Arial" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.labelFontFamily).toBe("Arial");
+  });
+
+  it("inherits the source's Y-axis labelFontFamily by default", () => {
+    const clone = cloneChart(source({ axes: { y: { labelFontFamily: "Calibri" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.labelFontFamily).toBe("Calibri");
+  });
+
+  it("lets options.axes.x.labelFontFamily replace the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { labelFontFamily: "Arial" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontFamily: "Calibri" } },
+    });
+    expect(clone.axes?.x?.labelFontFamily).toBe("Calibri");
+  });
+
+  it("drops the inherited labelFontFamily when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { labelFontFamily: "Arial" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontFamily: null } },
+    });
+    expect(clone.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined labelFontFamily when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("replaces an unset source labelFontFamily with the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontFamily: "Verdana" } },
+    });
+    expect(clone.axes?.x?.labelFontFamily).toBe("Verdana");
+  });
+
+  it("trims surrounding whitespace from the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontFamily: "   Arial   " } },
+    });
+    expect(clone.axes?.x?.labelFontFamily).toBe("Arial");
+  });
+
+  it("drops empty / whitespace-only overrides", () => {
+    const c1 = cloneChart(source({ axes: { x: { labelFontFamily: "Arial" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontFamily: "" } },
+    });
+    expect(c1.axes?.x?.labelFontFamily).toBeUndefined();
+    const c2 = cloneChart(source({ axes: { x: { labelFontFamily: "Arial" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { labelFontFamily: "   " } },
+    });
+    expect(c2.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("drops a non-string override (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ axes: { x: { labelFontFamily: "Arial" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { labelFontFamily: 1 as any } },
+    });
+    expect(clone.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("composes with all other tick-label typography knobs", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            labelFontFamily: "Arial",
+            labelBold: true,
+            labelItalic: true,
+            labelStrike: true,
+            labelUnderline: true,
+            labelColor: "FF0000",
+            labelFontSize: 14,
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.labelFontFamily).toBe("Arial");
+    expect(clone.axes?.x?.labelBold).toBe(true);
+    expect(clone.axes?.x?.labelItalic).toBe(true);
+    expect(clone.axes?.x?.labelStrike).toBe(true);
+    expect(clone.axes?.x?.labelUnderline).toBe(true);
+    expect(clone.axes?.x?.labelColor).toBe("FF0000");
+    expect(clone.axes?.x?.labelFontSize).toBe(14);
+  });
+
+  it("normalizes a malformed source value (defensive)", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ axes: { x: { labelFontFamily: "   " as any } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("preserves Y-axis typeface when only X is overridden", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { labelFontFamily: "Arial" },
+          y: { labelFontFamily: "Calibri" },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { labelFontFamily: "Verdana" } },
+      },
+    );
+    expect(clone.axes?.x?.labelFontFamily).toBe("Verdana");
+    expect(clone.axes?.y?.labelFontFamily).toBe("Calibri");
+  });
+
+  it("collapses to undefined on pie / doughnut (no axes at all)", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "pie",
+          index: 0,
+          name: "Slices",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Distribution",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { labelFontFamily: "Arial" } } as any,
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15272,3 +15272,187 @@ describe("writeChart — dataLabels.strikethrough", () => {
     expect(reparsed?.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── writeChart — axis tick-label font family ────────────────────────
+
+describe("writeChart — axis tick-label font family", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function txPrBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:txPr>[\s\S]*?<\/c:txPr>/);
+    return m ? m[0] : undefined;
+  }
+
+  function txPrLatinTypeface(axisBlock: string): string | undefined {
+    const block = txPrBlock(axisBlock);
+    if (!block) return undefined;
+    const latin = block.match(/<a:latin\b[^/]*\/>/);
+    if (!latin) return undefined;
+    const typeface = latin[0].match(/typeface="([^"]*)"/);
+    return typeface ? typeface[1] : undefined;
+  }
+
+  it("omits the entire <c:txPr> by default (no tick-label typography pinned)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const blocks = axisBlocks(result.chartXml);
+    for (const block of blocks) {
+      expect(block).not.toContain("<c:txPr>");
+    }
+  });
+
+  it("emits <a:latin typeface='Arial'/> on labelFontFamily='Arial' (X axis)", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelFontFamily: "Arial" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(txPrLatinTypeface(xAx)).toBe("Arial");
+  });
+
+  it("emits <a:latin> on the value axis (Y axis)", () => {
+    const result = writeChart(makeChart({ axes: { y: { labelFontFamily: "Calibri" } } }), "Sheet1");
+    const blocks = axisBlocks(result.chartXml);
+    const valAx = blocks.find((b) => b.startsWith("<c:valAx>"));
+    expect(valAx).toBeDefined();
+    expect(txPrLatinTypeface(valAx!)).toBe("Calibri");
+  });
+
+  it("emits multi-word typefaces verbatim", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelFontFamily: "Times New Roman" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(txPrLatinTypeface(xAx)).toBe("Times New Roman");
+  });
+
+  it("trims surrounding whitespace", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelFontFamily: "   Calibri   " } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(txPrLatinTypeface(xAx)).toBe("Calibri");
+  });
+
+  it("drops empty / whitespace-only inputs back to no <c:txPr>", () => {
+    const r1 = writeChart(makeChart({ axes: { x: { labelFontFamily: "" } } }), "Sheet1");
+    const [r1XAx] = axisBlocks(r1.chartXml);
+    expect(r1XAx).not.toContain("<c:txPr>");
+    const r2 = writeChart(makeChart({ axes: { x: { labelFontFamily: "   " } } }), "Sheet1");
+    const [r2XAx] = axisBlocks(r2.chartXml);
+    expect(r2XAx).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const r1 = writeChart(makeChart({ axes: { x: { labelFontFamily: 1 as any } } }), "Sheet1");
+    const [r1XAx] = axisBlocks(r1.chartXml);
+    expect(r1XAx).not.toContain("<c:txPr>");
+    const r2 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { labelFontFamily: null as any } } }),
+      "Sheet1",
+    );
+    const [r2XAx] = axisBlocks(r2.chartXml);
+    expect(r2XAx).not.toContain("<c:txPr>");
+  });
+
+  it("XML-escapes the typeface", () => {
+    const result = writeChart(makeChart({ axes: { x: { labelFontFamily: 'A&B"C' } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(txPrBlock(xAx)).toContain('typeface="A&amp;B&quot;C"');
+  });
+
+  it("composes with labelColor (both wrap defRPr together in schema order)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { labelFontFamily: "Arial", labelColor: "FF0000" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const block = txPrBlock(xAx)!;
+    expect(block).toContain('<a:srgbClr val="FF0000"/>');
+    expect(block).toContain('<a:latin typeface="Arial"/>');
+    // Schema order: solidFill before latin inside CT_TextCharacterProperties.
+    expect(block.indexOf("<a:solidFill>")).toBeLessThan(block.indexOf("<a:latin"));
+  });
+
+  it("composes with all other tick-label typography knobs", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            labelFontFamily: "Arial",
+            labelBold: true,
+            labelItalic: true,
+            labelStrike: true,
+            labelUnderline: true,
+            labelFontSize: 14,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const block = txPrBlock(xAx)!;
+    expect(block).toContain('<a:latin typeface="Arial"/>');
+    expect(block).toContain('sz="1400"');
+    expect(block).toContain('b="1"');
+    expect(block).toContain('i="1"');
+    expect(block).toContain('strike="sngStrike"');
+    expect(block).toContain('u="sng"');
+  });
+
+  it("threads through every chart family (bar / column / line / area / scatter)", () => {
+    const types: WriteChartKind[] = ["bar", "column", "line", "area", "scatter"];
+    for (const type of types) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { labelFontFamily: "Arial" } } }),
+        "Sheet1",
+      );
+      const blocks = axisBlocks(result.chartXml);
+      const xAxBlock = blocks[0];
+      expect(txPrLatinTypeface(xAxBlock)).toBe("Arial");
+    }
+  });
+
+  it("parse round-trip surfaces labelFontFamily from the writer's output", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { labelFontFamily: "Arial" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.labelFontFamily).toBe("Arial");
+  });
+
+  it("end-to-end: writeXlsx -> open -> reparse retains the typeface on both axes", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            axes: {
+              x: { labelFontFamily: "Arial" },
+              y: { labelFontFamily: "Calibri" },
+            },
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:latin typeface="Arial"/>');
+    expect(chartXml).toContain('<a:latin typeface="Calibri"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.labelFontFamily).toBe("Arial");
+    expect(reparsed?.axes?.y?.labelFontFamily).toBe("Calibri");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15965,3 +15965,118 @@ describe("parseChart — data labels strikethrough", () => {
     expect(parseChart(xml)?.dataLabels?.strikethrough).toBe(true);
   });
 });
+
+// ── parseChart — axis tick-label font family ────────────────────────
+
+describe("parseChart — axis tick-label font family", () => {
+  const NS_ALFF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxLabelFontFamily(typeface: string | undefined): string {
+    const txPr =
+      typeface === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr><a:latin typeface="${typeface}"/></a:defRPr></a:pPr></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS_ALFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${txPr}
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  function withValAxLabelFontFamily(typeface: string | undefined): string {
+    const txPr =
+      typeface === undefined
+        ? ""
+        : `<c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr><a:latin typeface="${typeface}"/></a:defRPr></a:pPr></a:p></c:txPr>`;
+    return `<c:chartSpace ${NS_ALFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      ${txPr}
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the typeface on a category axis", () => {
+    const chart = parseChart(withCatAxLabelFontFamily("Arial"));
+    expect(chart?.axes?.x?.labelFontFamily).toBe("Arial");
+  });
+
+  it("surfaces the typeface on a value axis", () => {
+    const chart = parseChart(withValAxLabelFontFamily("Calibri"));
+    expect(chart?.axes?.y?.labelFontFamily).toBe("Calibri");
+  });
+
+  it("surfaces multi-word typefaces verbatim", () => {
+    const chart = parseChart(withCatAxLabelFontFamily("Times New Roman"));
+    expect(chart?.axes?.x?.labelFontFamily).toBe("Times New Roman");
+  });
+
+  it("collapses absence of <a:latin> to undefined", () => {
+    const xml = `<c:chartSpace ${NS_ALFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:txPr><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr></a:p></c:txPr>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("collapses an empty typeface attribute to undefined", () => {
+    const chart = parseChart(withCatAxLabelFontFamily(""));
+    expect(chart?.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace from the typeface", () => {
+    const chart = parseChart(withCatAxLabelFontFamily("   Arial   "));
+    expect(chart?.axes?.x?.labelFontFamily).toBe("Arial");
+  });
+
+  it("collapses whitespace-only typefaces to undefined", () => {
+    const chart = parseChart(withCatAxLabelFontFamily("   "));
+    expect(chart?.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when the axis has no <c:txPr>", () => {
+    const chart = parseChart(withCatAxLabelFontFamily(undefined));
+    expect(chart?.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+
+  it("scopes the lookup to the axis-level <c:txPr> (axis-title <a:latin> does not leak in)", () => {
+    // The axis title pins <a:latin>; the tick-label <c:txPr> pins
+    // none. The reader must not pick up the axis-title typeface
+    // for labelFontFamily.
+    const xml = `<c:chartSpace ${NS_ALFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr><a:latin typeface="Verdana"/></a:defRPr></a:pPr></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.labelFontFamily).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Surfaces `<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>` -> `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr>` (CT_TextFont on CT_TextCharacterProperties' latin slot — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's axis tick-label typeface survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `labelFontFamily?: string` on `SheetChart.axes.x|y` (writer side) and on `ChartAxisInfo` (reader side). Sits on the same `<c:txPr>` body as `labelColor` / `labelBold` / `labelItalic` / `labelStrike` / `labelUnderline` / `labelFontSize` / `labelRotation`; the writer threads the value through the existing `buildAxisTxPr` helper.

Mirrors the chart-title `titleFontFamily` (#282) and axis-title `axisTitleFontFamily` (#283) — same canonical-slot grammar, same accept-and-trim shape, same `string | null` clone grammar so a single configuration call threads cleanly through every typeface knob the writer exposes.

The `<a:latin>` element follows `<a:solidFill>` per the CT_TextCharacterProperties child sequence so an axis with both `labelColor` and `labelFontFamily` set lands the children in canonical schema order — a fresh chart matches Excel's reference serialization byte-for-byte. Sits on every axis flavour (`<c:catAx>` / `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) so the field round-trips on every chart family that has axes (bar / column / line / area / scatter); silently dropped on pie / doughnut.

Refs #136

## Test plan

- [x] `pnpm vitest run --dir=test` — 5599 tests pass
- [x] `pnpm build` — succeeds
- [x] reader: surfaces typeface on catAx and valAx; trims whitespace; collapses empty / whitespace-only / absent / non-string to undefined; scoped so axis-title `<c:title><a:latin>` cannot leak in
- [x] writer: omits `<c:txPr>` by default; emits `<a:latin>` inside the `<c:txPr><a:defRPr>`; XML-escapes; composes with color in canonical schema order; composes with bold / italic / strike / underline / size; threads through every chart family
- [x] clone: inherits, overrides, drops on `null`, drops on pie/doughnut; trims whitespace; drops malformed overrides; preserves Y-axis when only X is overridden
- [x] end-to-end: `writeXlsx` -> `extractXml` -> `parseChart` retains the typeface on both axes

🤖 Generated with [Claude Code](https://claude.com/claude-code)