### PR TITLE
feat(xlsx): chart legend font family — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1693,6 +1693,48 @@ export interface SheetChart {
    * exposes.
    */
   legendFontColor?: string;
+  /**
+   * Legend font family / typeface. Maps to `<c:legend><c:txPr><a:p>
+   * <a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr></a:pPr>
+   * </a:p></c:txPr></c:legend>` — Excel's "Format Legend -> Font ->
+   * Font" picker. The OOXML `<a:latin typeface=".."/>` element carries
+   * the typeface name (`CT_TextFont`, ECMA-376 Part 1, §21.1.2.3.7);
+   * the writer lands the element on the default-paragraph
+   * `<a:defRPr>` slot inside the legend's `<c:txPr>` block so a re-
+   * parse picks the typeface up off the canonical slot the OOXML
+   * schema exposes.
+   *
+   * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+   * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+   * whitespace and emits the trimmed value verbatim (XML-escaped) so
+   * Excel can resolve the named font from the workbook's font scheme
+   * or the host system's installed fonts. Empty / whitespace-only
+   * strings and non-string tokens collapse to `undefined` so the
+   * writer skips the entire `<a:latin>` element and the legend
+   * inherits Excel's reference theme typeface.
+   *
+   * Default: omitted — the legend renders in Excel's reference theme
+   * typeface (no `<a:latin>` element, the writer skips the element
+   * entirely). Pin a typeface name to render the legend in that font
+   * (e.g. `"Arial"` for a corporate dashboard standard).
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no `<c:txPr>` slot to host the typeface in
+   * that case. Mirrors {@link titleFontFamily} /
+   * {@link axes.x.axisTitleFontFamily} /
+   * {@link axes.x.labelFontFamily} — same accept-and-trim grammar,
+   * same OOXML `<a:latin typeface=".."/>` mapping — so a caller can
+   * thread a single typeface string through every typography-pinning
+   * slot. Composes independently with {@link legend} /
+   * {@link legendOverlay} / {@link legendEntries} /
+   * {@link legendFontSize} / {@link legendBold} /
+   * {@link legendItalic} / {@link legendUnderline} /
+   * {@link legendStrikethrough} / {@link legendFontColor}: all ten
+   * fields land on the same `<c:legend>` element so a single
+   * configuration call threads cleanly through every legend knob
+   * Excel exposes.
+   */
+  legendFontFamily?: string;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -5803,6 +5845,30 @@ export interface Chart {
    * value slots straight into {@link cloneChart} without conversion.
    */
   legendFontColor?: string;
+  /**
+   * Legend font family / typeface pulled from `<c:legend><c:txPr>
+   * <a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+   * </a:pPr></a:p></c:txPr></c:legend>`. Reflects Excel's "Format
+   * Legend -> Font -> Font" picker. The OOXML `<a:latin
+   * typeface=".."/>` element carries the typeface name (`CT_TextFont`,
+   * ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Reports the trimmed typeface string when the source chart pinned
+   * a non-empty typeface; absence and empty / whitespace-only
+   * `typeface` attributes both collapse to `undefined` so absence and
+   * `<a:latin typeface=""/>` round-trip identically through
+   * {@link cloneChart}. Non-string `typeface` tokens (defensive — the
+   * XML parser only ever surfaces strings) likewise drop to
+   * `undefined`.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:txPr>` slot to surface the typeface from in either case.
+   * Mirrors the writer-side {@link SheetChart.legendFontFamily} so a
+   * parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   */
+  legendFontFamily?: string;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -314,6 +314,27 @@ export interface CloneChartOptions {
    * at the call site.
    */
   legendFontColor?: string | null;
+  /**
+   * Override `SheetChart.legendFontFamily`. `undefined` (or omitted)
+   * inherits the source's parsed `legendFontFamily`; `null` drops the
+   * inherited typeface (the writer emits no `<a:latin>` element on
+   * the legend's `<a:defRPr>`, falling back to the theme typeface);
+   * a non-empty string replaces it. The override is trimmed; empty /
+   * whitespace-only strings and non-string overrides (typed escapes
+   * from an untyped caller) collapse to `undefined` so the cloned
+   * `SheetChart` always carries a value the writer will accept.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved legend is `false` (no `<c:legend>` element will
+   * be emitted) — there is no `<c:txPr>` slot to host the typeface on
+   * a hidden legend, so leaking the value into the output would carry
+   * a pin Excel never reads.
+   *
+   * The grammar mirrors `titleFontFamily` /
+   * `axes.x.axisTitleFontFamily` / `axes.x.labelFontFamily` so the
+   * typography knobs compose the same way at the call site.
+   */
+  legendFontFamily?: string | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1610,6 +1631,17 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.legendFontColor,
     );
     if (resolvedLegendFontColor !== undefined) out.legendFontColor = resolvedLegendFontColor;
+
+    // Same hidden-legend scoping for the font family — `<c:txPr>` is
+    // the shared host element. `undefined` inherits, `null` drops, a
+    // non-empty string replaces. Empty / whitespace-only / non-string
+    // overrides collapse via the normalizer so the cloned
+    // `SheetChart` always carries a value the writer will accept.
+    const resolvedLegendFontFamily = resolveLegendFontFamily(
+      source.legendFontFamily,
+      options.legendFontFamily,
+    );
+    if (resolvedLegendFontFamily !== undefined) out.legendFontFamily = resolvedLegendFontFamily;
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -2911,6 +2943,52 @@ function resolveLegendFontColor(
   if (override === undefined) return normalizeTitleColor(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleColor(override);
+}
+
+/**
+ * Normalize a `legendFontFamily` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizeLegendFontFamily` — non-empty
+ * strings pass through trimmed, every other token (empty /
+ * whitespace-only strings, typed escapes from an untyped caller)
+ * collapses to `undefined` so the cloned chart drops the field
+ * rather than carry a value the writer would silently elide back to
+ * absence.
+ */
+function normalizeLegendFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
+ * Resolve a `legendFontFamily` override.
+ *
+ * `undefined` → inherit the source's parsed `legendFontFamily` (after
+ *               running it through {@link normalizeLegendFontFamily}
+ *               so a malformed source value drops cleanly).
+ * `null`      → drop the inherited typeface (the writer falls back to
+ *               the theme typeface — no `<a:latin>` element on the
+ *               legend's `<a:defRPr>`).
+ * `string`    → replace, after running through
+ *               {@link normalizeLegendFontFamily} so the override
+ *               accepts any caller spelling that the writer will
+ *               accept (with surrounding whitespace trimmed; empty /
+ *               whitespace-only strings collapse to a drop).
+ *
+ * The grammar mirrors `titleFontFamily` /
+ * `axes.x.axisTitleFontFamily` / `axes.x.labelFontFamily` so the
+ * typography knobs compose the same way at the call site. Callers
+ * should gate the result on the resolved legend visibility — when no
+ * legend is emitted, the typeface has no slot in the rendered chart.
+ */
+function resolveLegendFontFamily(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeLegendFontFamily(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendFontFamily(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -477,6 +477,13 @@ export function parseChart(xml: string): Chart | undefined {
     // tokens all collapse to `undefined`.
     const legendFontColor = parseLegendFontColor(chartEl);
     if (legendFontColor !== undefined) out.legendFontColor = legendFontColor;
+
+    // Same scoping for the font family — `<c:txPr>` is the shared host
+    // element. Empty / whitespace-only `typeface` attributes collapse
+    // to `undefined` so absence and the empty form round-trip
+    // identically through the writer.
+    const legendFontFamily = parseLegendFontFamily(chartEl);
+    if (legendFontFamily !== undefined) out.legendFontFamily = legendFontFamily;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -3485,6 +3492,47 @@ function parseLegendFontColor(chartEl: XmlElement): string | undefined {
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;
   return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull the legend font family off the canonical
+ * `<c:legend><c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/>
+ * </a:defRPr></a:pPr></a:p></c:txPr></c:legend>` chain Excel writes
+ * when the user pins a typeface on the legend.
+ *
+ * The OOXML `<a:latin>` element carries the typeface name on
+ * `CT_TextFont` (ECMA-376 Part 1, §21.1.2.3.7). The reader trims
+ * surrounding whitespace and reports the trimmed typeface; empty /
+ * whitespace-only `typeface` attributes and missing `<a:latin>`
+ * elements both collapse to `undefined` so absence and the empty
+ * form round-trip identically through the writer. Non-string
+ * `typeface` tokens (defensive — the XML parser only ever surfaces
+ * strings) likewise drop to `undefined`.
+ *
+ * Returns `undefined` whenever the chart omits the `<c:legend>`
+ * element or the canonical `<c:txPr><a:p><a:pPr><a:defRPr><a:latin>`
+ * chain is malformed at any link. Mirrors the chart-title /
+ * axis-title / axis tick-label font family readers exactly so a
+ * parsed value slots straight back into the writer's emit path.
+ */
+function parseLegendFontFamily(chartEl: XmlElement): string | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const txPr = findChild(legend, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const latin = findChild(defRPr, "latin");
+  if (!latin) return undefined;
+  const raw = latin.attrs.typeface;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -135,6 +135,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendUnderline(chart),
         resolveLegendStrikethrough(chart),
         resolveLegendFontColor(chart),
+        resolveLegendFontFamily(chart),
       ),
     );
   }
@@ -4364,6 +4365,7 @@ function buildLegend(
   underline: boolean | undefined,
   strikethrough: boolean | undefined,
   rgbHex: string | undefined,
+  fontFamily: string | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -4393,11 +4395,19 @@ function buildLegend(
   // Excel's reference serialization byte-for-byte (Excel itself omits
   // the block whenever the legend renders at the theme-default style).
   // The block currently carries the legend font size, bold, italic,
-  // underline, strikethrough, and font color knobs. The `<a:bodyPr>`
-  // carries no rotation attribute — the legend is not rotatable in
-  // Excel's UI, mirroring how the axis tick-label `<c:txPr>` slot
-  // drops `rot` when only typography knobs are pinned.
-  const txPrXml = buildLegendTxPr(fontSizePt, bold, italic, underline, strikethrough, rgbHex);
+  // underline, strikethrough, font color, and font family knobs. The
+  // `<a:bodyPr>` carries no rotation attribute — the legend is not
+  // rotatable in Excel's UI, mirroring how the axis tick-label
+  // `<c:txPr>` slot drops `rot` when only typography knobs are pinned.
+  const txPrXml = buildLegendTxPr(
+    fontSizePt,
+    bold,
+    italic,
+    underline,
+    strikethrough,
+    rgbHex,
+    fontFamily,
+  );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
   }
@@ -4436,6 +4446,7 @@ function buildLegendTxPr(
   underline: boolean | undefined,
   strikethrough: boolean | undefined,
   rgbHex: string | undefined,
+  fontFamily: string | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
@@ -4443,7 +4454,8 @@ function buildLegendTxPr(
     italic === undefined &&
     underline === undefined &&
     strikethrough === undefined &&
-    rgbHex === undefined
+    rgbHex === undefined &&
+    fontFamily === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
@@ -4467,14 +4479,28 @@ function buildLegendTxPr(
   const solidFillChild = rgbHex
     ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
     : undefined;
-  // When a fill color is set the `<a:defRPr>` slot expands from
-  // self-closing to wrapping the `<a:solidFill>` child; otherwise the
+  // OOXML's `<a:defRPr><a:latin typeface=".."/></a:defRPr>` carries
+  // the legend font family. The `<a:latin>` element follows
+  // `<a:solidFill>` per the CT_TextCharacterProperties child sequence
+  // (ECMA-376 Part 1, §21.1.2.3.7). Absence (`undefined`) collapses
+  // to omitting the entire `<a:latin>` element so the legend inherits
+  // the theme typeface (Excel's reference behavior for a fresh legend
+  // that has not had a custom font picked).
+  const latinChild = fontFamily ? xmlSelfClose("a:latin", { typeface: fontFamily }) : undefined;
+  // When a fill color or a typeface is set the `<a:defRPr>` slot
+  // expands from self-closing to wrapping the children; otherwise the
   // writer keeps the existing self-closing form so a fresh legend
-  // with no custom color matches Excel's reference serialization
-  // byte-for-byte.
-  const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", defRPrAttrs, [solidFillChild])
-    : xmlSelfClose("a:defRPr", defRPrAttrs);
+  // with no custom color or font matches Excel's reference
+  // serialization byte-for-byte. Children are emitted in
+  // CT_TextCharacterProperties' canonical schema order: solidFill
+  // first, then latin.
+  const defRPrChildren: string[] = [];
+  if (solidFillChild) defRPrChildren.push(solidFillChild);
+  if (latinChild) defRPrChildren.push(latinChild);
+  const defRPr =
+    defRPrChildren.length > 0
+      ? xmlElement("a:defRPr", defRPrAttrs, defRPrChildren)
+      : xmlSelfClose("a:defRPr", defRPrAttrs);
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),
@@ -4618,6 +4644,46 @@ function resolveLegendStrikethrough(chart: SheetChart): boolean | undefined {
  */
 function resolveLegendFontColor(chart: SheetChart): string | undefined {
   return normalizeTitleColor(chart.legendFontColor);
+}
+
+/**
+ * Normalize a {@link SheetChart.legendFontFamily} value for the
+ * `<c:legend><c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/>
+ * </a:defRPr></a:pPr></a:p></c:txPr></c:legend>` writer slot. Returns
+ * the trimmed typeface string when the input is a non-empty string,
+ * or `undefined` for any malformed token — empty / whitespace-only
+ * strings, or non-string escapes from an untyped caller (`null`,
+ * numbers, booleans, etc.).
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<a:latin>` element and the legend inherits
+ * the theme typeface (Excel's reference behavior for a fresh legend
+ * without a custom font picked).
+ */
+function normalizeLegendFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
+ * Resolve `<c:legend><c:txPr><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr></c:legend>` from
+ * {@link SheetChart.legendFontFamily}.
+ *
+ * Returns the trimmed typeface string the writer emits, or
+ * `undefined` when the chart leaves the field unset / passed an empty
+ * or non-string token. Delegates to {@link normalizeLegendFontFamily}
+ * so the accept-and-trim grammar matches the chart-title /
+ * axis-title / axis tick-label font family resolvers exactly. The
+ * element is only meaningful when the chart actually emits a legend —
+ * the caller is expected to gate the call on the resolved legend
+ * visibility. A chart whose legend is suppressed has no `<c:txPr>`
+ * slot to host the typeface in either case.
+ */
+function resolveLegendFontFamily(chart: SheetChart): string | undefined {
+  return normalizeLegendFontFamily(chart.legendFontFamily);
 }
 
 interface ResolvedLegendEntry {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -6069,6 +6069,267 @@ describe("cloneChart — legendFontColor", () => {
   });
 });
 
+// ── cloneChart — legendFontFamily ───────────────────────────────────
+
+describe("cloneChart — legendFontFamily", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendFontFamily by default", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFontFamily).toBe("Arial");
+  });
+
+  it("lets options.legendFontFamily override the source's value", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontFamily: "Calibri",
+    });
+    expect(clone.legendFontFamily).toBe("Calibri");
+  });
+
+  it("drops the inherited legendFontFamily when the override is null", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontFamily: null,
+    });
+    expect(clone.legendFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined legendFontFamily when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendFontFamily).toBeUndefined();
+  });
+
+  it("trims surrounding whitespace from the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontFamily: "   Verdana   ",
+    });
+    expect(clone.legendFontFamily).toBe("Verdana");
+  });
+
+  it("drops empty / whitespace-only overrides", () => {
+    const c1 = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontFamily: "",
+    });
+    expect(c1.legendFontFamily).toBeUndefined();
+    const c2 = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFontFamily: "   ",
+    });
+    expect(c2.legendFontFamily).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver (drops to undefined)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const clone = cloneChart(source({ legendFontFamily: "   " as any }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFontFamily).toBeUndefined();
+  });
+
+  it("collapses non-string overrides (number leaking past the type guard)", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendFontFamily: 14 as any,
+    });
+    expect(clone.legendFontFamily).toBeUndefined();
+  });
+
+  it("carries legendFontFamily through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendFontFamily).toBe("Arial");
+  });
+
+  it("carries legendFontFamily through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendFontFamily).toBe("Arial");
+  });
+
+  it("drops the inherited legendFontFamily when the resolved legend is hidden", () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendFontFamily).toBeUndefined();
+  });
+
+  it("drops the legendFontFamily override when the resolved legend is hidden", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendFontFamily: "Arial",
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendFontFamily).toBeUndefined();
+  });
+
+  it("retains the legendFontFamily override when the override re-enables a hidden source legend", () => {
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendFontFamily: "Arial",
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendFontFamily).toBe("Arial");
+  });
+
+  it("composes with legendOverlay / legendEntries / legendFontSize / legendUnderline / legendFontColor on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        legendFontFamily: "Arial",
+        legendFontColor: "FF0000",
+        legendUnderline: true,
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendFontFamily).toBe("Arial");
+    expect(clone.legendFontColor).toBe("FF0000");
+    expect(clone.legendUnderline).toBe(true);
+    expect(clone.legendFontSize).toBe(12);
+    expect(clone.legendOverlay).toBe(true);
+    expect(clone.legendEntries).toEqual([{ idx: 0, delete: true }]);
+  });
+
+  it("propagates legendFontFamily into the rendered <c:legend><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('<a:latin typeface="Arial"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFontFamily).toBe("Arial");
+  });
+
+  it("emits no <c:txPr> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendFontFamily).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendFontFamily: "Calibri",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('<a:latin typeface="Calibri"/>');
+    expect(legend).not.toContain('<a:latin typeface="Arial"/>');
+    expect(parseChart(written)?.legendFontFamily).toBe("Calibri");
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:txPr> emitted)", async () => {
+    const clone = cloneChart(source({ legendFontFamily: "Arial" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendFontFamily: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:txPr>");
+    expect(parseChart(written)?.legendFontFamily).toBeUndefined();
+  });
+});
+
 // ── cloneChart — axis lblAlgn ───────────────────────────────────────
 
 describe("cloneChart — axis lblAlgn", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -5325,6 +5325,220 @@ describe("writeChart — legendFontColor", () => {
   });
 });
 
+// ── writeChart — legendFontFamily ───────────────────────────────────
+
+describe("writeChart — legendFontFamily", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when legendFontFamily is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:txPr>");
+    expect(legend).not.toContain("a:latin");
+  });
+
+  it('threads legendFontFamily through to <c:legend><c:txPr> as <a:latin typeface=".."/>', () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:txPr>");
+    expect(legend).toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("trims surrounding whitespace from the input typeface", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "   Calibri   " }), "Sheet1");
+    expect(legendOf(result.chartXml)).toContain('<a:latin typeface="Calibri"/>');
+  });
+
+  it("emits a multi-word typeface verbatim", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Times New Roman" }), "Sheet1");
+    expect(legendOf(result.chartXml)).toContain('<a:latin typeface="Times New Roman"/>');
+  });
+
+  it("XML-escapes special characters in the typeface name", () => {
+    const result = writeChart(makeChart({ legendFontFamily: 'Funky "Font" & Co' }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("a:latin");
+    // Quotes and ampersands must be escaped in XML attribute values.
+    expect(legend).not.toContain('typeface="Funky "Font" & Co"');
+  });
+
+  it("places <c:txPr> after <c:overlay> inside <c:legend> (OOXML order)", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits <c:txPr> once inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendFontFamily set", () => {
+    const result = writeChart(makeChart({ legend: false, legendFontFamily: "Arial" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendFontFamily through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendFontFamily: "Verdana" }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('<a:latin typeface="Verdana"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendFontFamily: "Verdana",
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('<a:latin typeface="Verdana"/>');
+  });
+
+  it("drops empty string inputs", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops whitespace-only inputs", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "   " }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs (null leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendFontFamily: null as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs (number leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendFontFamily: 14 as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<a:bodyPr/>");
+    expect(legend).toContain("<a:lstStyle/>");
+    expect(legend).toContain('<a:latin typeface="Arial"/>');
+    expect(legend).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("emits <a:bodyPr/> without a rot attribute (legend is not rotatable)", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const bodyPr = legend.match(/<a:bodyPr[^/]*\/>/);
+    expect(bodyPr?.[0]).toBe("<a:bodyPr/>");
+  });
+
+  it("expands <a:defRPr> from self-closing to wrapping <a:latin>", () => {
+    const result = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:defRPr><a:latin typeface="Arial"/></a:defRPr>');
+  });
+
+  it("emits solidFill before latin in canonical CT_TextCharacterProperties order", () => {
+    const result = writeChart(
+      makeChart({ legendFontFamily: "Arial", legendFontColor: "FF0000" }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain(
+      '<a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr>',
+    );
+  });
+
+  it("round-trips a legendFontFamily through parseChart", () => {
+    const written = writeChart(makeChart({ legendFontFamily: "Arial" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFontFamily).toBe("Arial");
+  });
+
+  it("collapses an unset legendFontFamily round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendFontFamily).toBeUndefined();
+  });
+
+  it("composes with legendOverlay / legendEntries / legendFontSize / legendUnderline / legendFontColor on the same <c:legend>", () => {
+    const result = writeChart(
+      makeChart({
+        legendFontFamily: "Arial",
+        legendFontColor: "1A2B3C",
+        legendUnderline: true,
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:latin typeface="Arial"/>');
+    expect(legend).toContain('<a:srgbClr val="1A2B3C"/>');
+    expect(legend).toContain('u="sng"');
+    expect(legend).toContain('sz="1200"');
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).toContain("c:legendEntry");
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:legendEntry"));
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:overlay"));
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("co-emits sz, u, the solidFill child, and the latin child on a single <a:defRPr>", () => {
+    const result = writeChart(
+      makeChart({
+        legendFontFamily: "Arial",
+        legendFontColor: "FF0000",
+        legendUnderline: true,
+        legendFontSize: 14,
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    // Single <a:defRPr> hosts every typography pin — matches the
+    // canonical title / axis-title / tick-label txPr emission.
+    expect(legend).toContain('sz="1400"');
+    expect(legend).toContain('u="sng"');
+    expect(legend).toContain('<a:srgbClr val="FF0000"/>');
+    expect(legend).toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("survives a writeXlsx round trip — legendFontFamily lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendFontFamily: "Calibri",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const legend = chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('<a:latin typeface="Calibri"/>');
+  });
+});
+
 // ── writeChart — data labels showLegendKey ──────────────────────────
 
 describe("writeChart — data labels showLegendKey", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6210,6 +6210,192 @@ describe("parseChart — legendFontColor", () => {
   });
 });
 
+// ── parseChart — legendFontFamily ───────────────────────────────────
+
+describe("parseChart — legendFontFamily", () => {
+  const NS_LFF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendTypeface(typeface: string | undefined): string {
+    const latin =
+      typeface === undefined
+        ? "<a:defRPr/>"
+        : `<a:defRPr><a:latin typeface="${typeface}"/></a:defRPr>`;
+    return `<c:chartSpace ${NS_LFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr>${latin}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces legendFontFamily as the trimmed typeface string", () => {
+    expect(parseChart(withLegendTypeface("Arial"))?.legendFontFamily).toBe("Arial");
+  });
+
+  it("trims surrounding whitespace from the typeface attribute", () => {
+    expect(parseChart(withLegendTypeface("   Calibri   "))?.legendFontFamily).toBe("Calibri");
+  });
+
+  it("surfaces a multi-word typeface verbatim", () => {
+    expect(parseChart(withLegendTypeface("Times New Roman"))?.legendFontFamily).toBe(
+      "Times New Roman",
+    );
+  });
+
+  it("returns undefined when the legend has no <a:latin> element at all", () => {
+    expect(parseChart(withLegendTypeface(undefined))?.legendFontFamily).toBeUndefined();
+  });
+
+  it("collapses an empty typeface attribute to undefined", () => {
+    expect(parseChart(withLegendTypeface(""))?.legendFontFamily).toBeUndefined();
+  });
+
+  it("collapses a whitespace-only typeface attribute to undefined", () => {
+    expect(parseChart(withLegendTypeface("   "))?.legendFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS_LFF}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_LFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when <c:txPr> has no <a:p><a:pPr><a:defRPr> chain", () => {
+    const xml = `<c:chartSpace ${NS_LFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFontFamily).toBeUndefined();
+  });
+
+  it('drops the typeface when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="Arial"/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendFontFamily).toBeUndefined();
+  });
+
+  it("co-surfaces alongside legendOverlay / legendEntries / legendFontSize / legendUnderline / legendFontColor", () => {
+    const xml = `<c:chartSpace ${NS_LFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:legendEntry>
+        <c:idx val="0"/>
+        <c:delete val="1"/>
+      </c:legendEntry>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400" u="sng"><a:solidFill><a:srgbClr val="123456"/></a:solidFill><a:latin typeface="Verdana"/></a:defRPr></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("bottom");
+    expect(chart?.legendOverlay).toBe(true);
+    expect(chart?.legendEntries).toEqual([{ idx: 0, delete: true }]);
+    expect(chart?.legendFontSize).toBe(14);
+    expect(chart?.legendUnderline).toBe(true);
+    expect(chart?.legendFontColor).toBe("123456");
+    expect(chart?.legendFontFamily).toBe("Verdana");
+  });
+
+  it("surfaces the typeface on every chart family that emits a legend", () => {
+    for (const kind of ["lineChart", "barChart", "pieChart", "doughnutChart"]) {
+      const xml = `<c:chartSpace ${NS_LFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:${kind}><c:ser><c:idx val="0"/></c:ser></c:${kind}>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="Calibri"/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.legendFontFamily).toBe("Calibri");
+    }
+  });
+});
+
 // ── parseChart — data labels showLegendKey ──────────────────────────
 
 describe("parseChart — data labels showLegendKey", () => {


### PR DESCRIPTION
Surfaces `<c:legend><c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=\"..\"/></a:defRPr></a:pPr></a:p></c:txPr></c:legend>` (CT_TextFont on CT_TextCharacterProperties' latin slot — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's legend typeface survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `legendFontFamily?: string` on `SheetChart` (writer side) and on `Chart` (reader side). Sits on the same `<c:txPr>` body as `legendFontColor` / `legendBold` / `legendItalic` / `legendStrikethrough` / `legendUnderline` / `legendFontSize`; the writer threads the value through the existing `buildLegendTxPr` helper.

Mirrors the chart-title `titleFontFamily` (#282), axis-title `axisTitleFontFamily` (#283), and axis tick-label `labelFontFamily` (#284) — same canonical-slot grammar, same accept-and-trim shape, same `string | null` clone grammar so a single configuration call threads cleanly through every typeface knob the writer exposes.

The `<a:latin>` element follows `<a:solidFill>` per the CT_TextCharacterProperties child sequence so a legend with both `legendFontColor` and `legendFontFamily` set lands the children in canonical schema order — a fresh chart matches Excel's reference serialization byte-for-byte. Surfaced on every chart family that emits a legend (bar / column / line / pie / doughnut / area / scatter); silently dropped when `legend === false`.

Refs #136

## Test plan

- [x] `pnpm exec vitest run` — 5726 tests pass (52 new)
- [x] `pnpm test` — lint + typecheck + vitest all pass
- [x] `pnpm build` — succeeds
- [x] reader: surfaces typeface on the legend; trims whitespace; collapses empty / whitespace-only / absent / non-string to undefined; scoped to the legend `<c:txPr>` (no leak from chart-title or axis `<a:latin>`)
- [x] writer: omits `<c:txPr>` by default; emits `<a:latin>` inside the `<c:txPr><a:defRPr>`; XML-escapes; composes with size / bold / italic / underline / strikethrough / color in canonical schema order (solidFill before latin); silently dropped when `legend === false`
- [x] cloneChart: `undefined` inherits, `null` drops, non-empty string replaces; empty / whitespace-only / non-string overrides collapse to a drop; carried through type flatten (line → column / doughnut); dropped when the resolved legend is hidden; survives writeXlsx round-trip