### PR TITLE
feat(xlsx): chart data labels font family — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -851,6 +851,46 @@ export interface ChartDataLabels {
    * {@link underline}.
    */
   strikethrough?: boolean;
+  /**
+   * Data-label font family / typeface. Maps to `<c:dLbls><c:txPr>
+   * <a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+   * </a:pPr></a:p></c:txPr></c:dLbls>` — Excel's "Format Data Labels
+   * -> Font -> Font" picker. The OOXML `<a:latin typeface=".."/>`
+   * element carries the typeface name (`CT_TextFont`, ECMA-376 Part 1,
+   * §21.1.2.3.7); the writer lands the element on the default-
+   * paragraph `<a:defRPr>` slot inside the data-label's `<c:txPr>`
+   * block so a re-parse picks the typeface up off the canonical slot
+   * the OOXML schema exposes.
+   *
+   * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+   * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+   * whitespace and emits the trimmed value verbatim (XML-escaped) so
+   * Excel can resolve the named font from the workbook's font scheme
+   * or the host system's installed fonts. Empty / whitespace-only
+   * strings and non-string tokens collapse to `undefined` so the
+   * writer skips the entire `<a:latin>` element and the data labels
+   * inherit Excel's reference theme typeface.
+   *
+   * Default: omitted — the data labels render in Excel's reference
+   * theme typeface (no `<a:latin>` element, the writer skips the
+   * element entirely). Pin a typeface name to render the labels in
+   * that font.
+   *
+   * The `<c:txPr>` block lands between `<c:numFmt>` and `<c:dLblPos>`
+   * (CT_DLbls schema, ECMA-376 Part 1, §21.2.2.50). Mirrors
+   * {@link SheetChart.titleFontFamily} /
+   * {@link SheetChart.legendFontFamily} /
+   * {@link SheetChart.axes.x.axisTitleFontFamily} /
+   * {@link SheetChart.axes.x.labelFontFamily} — same accept-and-trim
+   * grammar, same OOXML `<a:latin typeface=".."/>` mapping — so a
+   * caller can thread a single typeface string through every
+   * typography-pinning slot. Composes independently with the other
+   * dLbls knobs — {@link position} / {@link separator} /
+   * {@link numberFormat} / {@link showLeaderLines} / the `show*`
+   * toggles / {@link bold} / {@link italic} / {@link underline} /
+   * {@link strikethrough} / {@link fontSize} / {@link fontColor}.
+   */
+  fontFamily?: string;
 }
 
 /**
@@ -4606,6 +4646,25 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   strikethrough?: boolean;
+  /**
+   * Data-label font family / typeface pulled from `<c:dLbls><c:txPr>
+   * <a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+   * </a:pPr></a:p></c:txPr></c:dLbls>`. Reflects Excel's "Format Data
+   * Labels -> Font -> Font" picker. The OOXML `<a:latin
+   * typeface=".."/>` element carries the typeface name (`CT_TextFont`,
+   * ECMA-376 Part 1, §21.1.2.3.7).
+   *
+   * Reports the trimmed typeface string when the source chart pinned
+   * a non-empty typeface; absence and empty / whitespace-only
+   * `typeface` attributes both collapse to `undefined` so absence
+   * and `<a:latin typeface=""/>` round-trip identically through
+   * {@link cloneChart}. Non-string `typeface` tokens (defensive — the
+   * XML parser only ever surfaces strings) likewise drop to
+   * `undefined`. Mirrors the writer-side
+   * {@link ChartDataLabels.fontFamily} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  fontFamily?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -2712,6 +2712,15 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const strikethrough = parseDataLabelsStrikethrough(el);
   if (strikethrough !== undefined) out.strikethrough = strikethrough;
 
+  // `<c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr>
+  // </a:pPr></a:p></c:txPr>` — data-label font family pinned via
+  // Excel's "Format Data Labels -> Font -> Font" picker. Empty /
+  // whitespace-only `typeface` attributes and missing `<a:latin>`
+  // elements both collapse to `undefined` so absence and the empty
+  // form round-trip identically through the writer.
+  const fontFamily = parseDataLabelsFontFamily(el);
+  if (fontFamily !== undefined) out.fontFamily = fontFamily;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -2728,7 +2737,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.bold === undefined &&
     out.italic === undefined &&
     out.underline === undefined &&
-    out.strikethrough === undefined
+    out.strikethrough === undefined &&
+    out.fontFamily === undefined
   ) {
     return undefined;
   }
@@ -2929,6 +2939,45 @@ function parseDataLabelsStrikethrough(dLbls: XmlElement): boolean | undefined {
   const raw = defRPr.attrs.strike;
   if (raw === "sngStrike") return true;
   return undefined;
+}
+
+/**
+ * Pull `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>` off a
+ * data-labels block. Returns the typeface string the labels were
+ * authored with.
+ *
+ * The OOXML `<a:latin>` element carries the typeface name on
+ * `CT_TextFont` (ECMA-376 Part 1, §21.1.2.3.7). The reader trims
+ * surrounding whitespace and reports the trimmed typeface; empty /
+ * whitespace-only `typeface` attributes and missing `<a:latin>`
+ * elements both collapse to `undefined` so absence and the empty
+ * form round-trip identically through the writer. Non-string
+ * `typeface` tokens (defensive — the XML parser only ever surfaces
+ * strings) likewise drop to `undefined`.
+ *
+ * Returns `undefined` whenever the data-labels block omits `<c:txPr>`
+ * entirely or the canonical `<a:p><a:pPr><a:defRPr><a:latin>` chain
+ * is malformed at any link. Mirrors the chart-title / axis-title /
+ * axis tick-label / legend font family readers exactly so a parsed
+ * value slots straight back into the writer's emit path.
+ */
+function parseDataLabelsFontFamily(dLbls: XmlElement): string | undefined {
+  const txPr = findChild(dLbls, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const latin = findChild(defRPr, "latin");
+  if (!latin) return undefined;
+  const raw = latin.attrs.typeface;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -4054,10 +4054,10 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
   // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
   // carries the data-label font size, font color, bold flag, italic
-  // flag, underline flag, and strikethrough flag — every typography
-  // pin lands on the same `<a:defRPr>` slot. The writer skips the
-  // entire block when no font knob is pinned so a fresh chart matches
-  // Excel's reference shape.
+  // flag, underline flag, strikethrough flag, and font family — every
+  // typography pin lands on the same `<a:defRPr>` slot. The writer
+  // skips the entire block when no font knob is pinned so a fresh
+  // chart matches Excel's reference shape.
   const txPrXml = buildDataLabelsTxPr(
     resolveDataLabelsFontSize(dl.fontSize),
     resolveDataLabelsFontColor(dl.fontColor),
@@ -4065,6 +4065,7 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
     resolveDataLabelsItalic(dl.italic),
     resolveDataLabelsUnderline(dl.underline),
     resolveDataLabelsStrikethrough(dl.strikethrough),
+    resolveDataLabelsFontFamily(dl.fontFamily),
   );
   if (txPrXml !== undefined) {
     children.push(txPrXml);
@@ -4239,6 +4240,25 @@ function resolveDataLabelsStrikethrough(value: boolean | undefined): boolean | u
 }
 
 /**
+ * Resolve `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>` from
+ * {@link ChartDataLabels.fontFamily}.
+ *
+ * Returns the trimmed typeface string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed an
+ * empty / whitespace-only / non-string token. Mirrors the chart-title
+ * / axis-title / axis tick-label / legend font family resolvers
+ * exactly so a single configuration call threads cleanly through
+ * every typography slot Excel exposes.
+ */
+function resolveDataLabelsFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
  * Build the `<c:txPr>` block that carries a data-label's typography
  * pins. Returns `undefined` when every input is unset so the caller
  * can elide the element entirely (Excel's reference serialization
@@ -4281,6 +4301,7 @@ function buildDataLabelsTxPr(
   italic: boolean | undefined,
   underline: boolean | undefined,
   strikethrough: boolean | undefined,
+  fontFamily: string | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
@@ -4288,7 +4309,8 @@ function buildDataLabelsTxPr(
     bold === undefined &&
     italic === undefined &&
     underline === undefined &&
-    strikethrough === undefined
+    strikethrough === undefined &&
+    fontFamily === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
@@ -4312,14 +4334,28 @@ function buildDataLabelsTxPr(
   const solidFillChild = rgbHex
     ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
     : undefined;
-  // When a fill color is set the `<a:defRPr>` slot expands from
-  // self-closing to wrapping the `<a:solidFill>` child; otherwise the
+  // OOXML's `<a:defRPr><a:latin typeface=".."/></a:defRPr>` carries
+  // the data-label font family. The `<a:latin>` element follows
+  // `<a:solidFill>` per the CT_TextCharacterProperties child sequence
+  // (ECMA-376 Part 1, §21.1.2.3.7). Absence (`undefined`) collapses
+  // to omitting the entire `<a:latin>` element so the labels inherit
+  // the theme typeface (Excel's reference behavior for fresh data
+  // labels that have not had a custom font picked).
+  const latinChild = fontFamily ? xmlSelfClose("a:latin", { typeface: fontFamily }) : undefined;
+  // When a fill color or a typeface is set the `<a:defRPr>` slot
+  // expands from self-closing to wrapping the children; otherwise the
   // writer keeps the existing self-closing form so a fresh chart with
-  // no custom color matches Excel's reference serialization
-  // byte-for-byte.
-  const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", defRPrAttrs, [solidFillChild])
-    : xmlSelfClose("a:defRPr", defRPrAttrs);
+  // no custom color or font matches Excel's reference serialization
+  // byte-for-byte. Children are emitted in
+  // CT_TextCharacterProperties' canonical schema order: solidFill
+  // first, then latin.
+  const defRPrChildren: string[] = [];
+  if (solidFillChild) defRPrChildren.push(solidFillChild);
+  if (latinChild) defRPrChildren.push(latinChild);
+  const defRPr =
+    defRPrChildren.length > 0
+      ? xmlElement("a:defRPr", defRPrAttrs, defRPrChildren)
+      : xmlSelfClose("a:defRPr", defRPrAttrs);
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -16969,6 +16969,199 @@ describe("cloneChart — dataLabels.strikethrough", () => {
   });
 });
 
+// ── cloneChart — dataLabels.fontFamily ──────────────────────────────
+
+describe("cloneChart — dataLabels.fontFamily", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.fontFamily by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.fontFamily).toBe("Arial");
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, fontFamily: "Calibri" },
+    });
+    expect(clone.dataLabels?.fontFamily).toBe("Calibri");
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes with the other dLbls fields on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          fontFamily: "Arial",
+          fontColor: "FF0000",
+          bold: true,
+          strikethrough: true,
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.fontFamily).toBe("Arial");
+    expect(clone.dataLabels?.fontColor).toBe("FF0000");
+    expect(clone.dataLabels?.bold).toBe(true);
+    expect(clone.dataLabels?.strikethrough).toBe(true);
+    expect(clone.dataLabels?.showValue).toBe(true);
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("propagates dataLabels.fontFamily into the rendered <c:dLbls><c:txPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:txPr>");
+    expect(written).toContain('<a:latin typeface="Arial"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fontFamily).toBe("Arial");
+  });
+
+  it("emits no <c:dLbls> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, fontFamily: "Calibri" },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<a:latin typeface="Calibri"/>');
+    expect(written).not.toContain('<a:latin typeface="Arial"/>');
+    expect(parseChart(written)?.dataLabels?.fontFamily).toBe("Calibri");
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:dLbls> emitted)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.fontFamily through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.fontFamily).toBe("Arial");
+  });
+
+  it("carries dataLabels.fontFamily through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fontFamily: "Arial" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.fontFamily).toBe("Arial");
+  });
+});
+
 // ── cloneChart — title font family ──────────────────────────────────
 
 describe("cloneChart — title font family", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15273,6 +15273,213 @@ describe("writeChart — dataLabels.strikethrough", () => {
   });
 });
 
+// ── writeChart — dataLabels.fontFamily ──────────────────────────────
+
+describe("writeChart — dataLabels.fontFamily", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:txPr> when fontFamily is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:txPr>");
+    expect(dLbls).not.toContain("a:latin");
+  });
+
+  it('threads fontFamily through to <c:dLbls><c:txPr> as <a:latin typeface=".."/>', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "Arial" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("trims surrounding whitespace from the input typeface", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "   Calibri   " } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:latin typeface="Calibri"/>');
+  });
+
+  it("emits a multi-word typeface verbatim", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "Times New Roman" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:latin typeface="Times New Roman"/>');
+  });
+
+  it("places <c:txPr> after <c:numFmt> and before <c:dLblPos> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          fontFamily: "Arial",
+          position: "outEnd",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:txPr"));
+    expect(dLbls.indexOf("c:txPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:txPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "Arial" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads fontFamily through every chart family that supports data labels", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, fontFamily: "Verdana" } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain('<a:latin typeface="Verdana"/>');
+    }
+  });
+
+  it("drops empty string inputs", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops whitespace-only inputs", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "   " } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fontFamily: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fontFamily: 14 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:txPr>");
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "Arial" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:bodyPr/>");
+    expect(dLbls).toContain("<a:lstStyle/>");
+    expect(dLbls).toContain('<a:latin typeface="Arial"/>');
+    expect(dLbls).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("expands <a:defRPr> from self-closing to wrapping <a:latin>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "Arial" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<a:defRPr><a:latin typeface="Arial"/></a:defRPr>');
+  });
+
+  it("emits solidFill before latin in canonical CT_TextCharacterProperties order", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, fontFamily: "Arial", fontColor: "FF0000" },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain(
+      '<a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr>',
+    );
+  });
+
+  it("co-emits sz, b, strike, the solidFill child, and the latin child on a single <a:defRPr>", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          fontFamily: "Arial",
+          fontColor: "FF0000",
+          fontSize: 14,
+          bold: true,
+          strikethrough: true,
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('sz="1400"');
+    expect(dLbls).toContain('b="1"');
+    expect(dLbls).toContain('strike="sngStrike"');
+    expect(dLbls).toContain('<a:srgbClr val="FF0000"/>');
+    expect(dLbls).toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("round-trips a fontFamily through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, fontFamily: "Arial" } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fontFamily).toBe("Arial");
+  });
+
+  it("survives a writeXlsx round trip — fontFamily lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, fontFamily: "Calibri" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:latin typeface="Calibri"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.fontFamily).toBe("Calibri");
+  });
+});
+
 // ── writeChart — title font family ──────────────────────────────────
 
 describe("writeChart — title font family", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -15966,6 +15966,157 @@ describe("parseChart — data labels strikethrough", () => {
   });
 });
 
+// ── parseChart — data labels fontFamily ─────────────────────────────
+
+describe("parseChart — data labels fontFamily", () => {
+  const NS_DLFF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsTypeface(typeface: string | undefined): string {
+    const defRPr =
+      typeface === undefined
+        ? "<a:defRPr/>"
+        : `<a:defRPr><a:latin typeface="${typeface}"/></a:defRPr>`;
+    return `<c:chartSpace ${NS_DLFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr>${defRPr}</a:pPr><a:endParaRPr lang="en-US"/></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces fontFamily as the trimmed typeface string", () => {
+    expect(parseChart(withDLblsTypeface("Arial"))?.dataLabels?.fontFamily).toBe("Arial");
+  });
+
+  it("trims surrounding whitespace from the typeface attribute", () => {
+    expect(parseChart(withDLblsTypeface("   Calibri   "))?.dataLabels?.fontFamily).toBe("Calibri");
+  });
+
+  it("surfaces a multi-word typeface verbatim", () => {
+    expect(parseChart(withDLblsTypeface("Times New Roman"))?.dataLabels?.fontFamily).toBe(
+      "Times New Roman",
+    );
+  });
+
+  it("returns undefined when the dLbls block has no <a:latin> element at all", () => {
+    expect(parseChart(withDLblsTypeface(undefined))?.dataLabels?.fontFamily).toBeUndefined();
+  });
+
+  it("collapses an empty typeface attribute to undefined", () => {
+    expect(parseChart(withDLblsTypeface(""))?.dataLabels?.fontFamily).toBeUndefined();
+  });
+
+  it("collapses a whitespace-only typeface attribute to undefined", () => {
+    expect(parseChart(withDLblsTypeface("   "))?.dataLabels?.fontFamily).toBeUndefined();
+  });
+
+  it("returns undefined when the dLbls block has no <c:txPr> body", () => {
+    const xml = `<c:chartSpace ${NS_DLFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fontFamily).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other dLbls typography fields (sz / strike / fontColor / fontFamily)", () => {
+    const xml = `<c:chartSpace ${NS_DLFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr sz="1400" b="1" strike="sngStrike"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:latin typeface="Verdana"/></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.fontFamily).toBe("Verdana");
+    expect(chart?.dataLabels?.fontSize).toBe(14);
+    expect(chart?.dataLabels?.bold).toBe(true);
+    expect(chart?.dataLabels?.strikethrough).toBe(true);
+    expect(chart?.dataLabels?.fontColor).toBe("FF0000");
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+  });
+
+  it("surfaces the typeface on a font-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLFF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:latin typeface="Calibri"/></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fontFamily).toBe("Calibri");
+  });
+});
+
 // ── parseChart — title font family ──────────────────────────────────
 
 describe("parseChart — title font family", () => {


### PR DESCRIPTION
Surfaces `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=\"..\"/></a:defRPr></a:pPr></a:p></c:txPr></c:dLbls>` (CT_TextFont on CT_TextCharacterProperties' latin slot — ECMA-376 Part 1, §21.1.2.3.7) at the read, write, and clone layers so a template's data-label typeface survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `fontFamily?: string` on `ChartDataLabels` (writer side) and on `ChartDataLabelsInfo` (reader side). Sits on the same `<c:txPr>` body as `fontColor` / `fontSize` / `bold` / `italic` / `underline` / `strikethrough`; the writer threads the value through the existing `buildDataLabelsTxPr` helper.

Mirrors the chart-title `titleFontFamily` (#282), axis-title `axisTitleFontFamily` (#283), axis tick-label `labelFontFamily` (#284), and legend `legendFontFamily` (#285) — same canonical-slot grammar, same accept-and-trim shape so a single configuration call threads cleanly through every typeface knob the writer exposes.

The `<a:latin>` element follows `<a:solidFill>` per the CT_TextCharacterProperties child sequence so a data-labels block with both `fontColor` and `fontFamily` set lands the children in canonical schema order — a fresh chart matches Excel's reference serialization byte-for-byte. Surfaced on every chart family that emits data labels (bar / column / line / pie / doughnut / area / scatter); cloning is automatic via the existing whole-`dataLabels`-block clone resolver.

Refs #136

## Test plan

- [x] `pnpm exec vitest run` — all tests pass (38 new)
- [x] `pnpm test` — lint + typecheck + vitest all pass
- [x] `pnpm build` — succeeds
- [x] reader: surfaces typeface on the data-labels block; trims whitespace; collapses empty / whitespace-only / absent / non-string to undefined
- [x] writer: omits `<c:txPr>` by default; emits `<a:latin>` inside `<c:dLbls><c:txPr><a:defRPr>`; XML-escapes; composes with size / color / bold / italic / underline / strikethrough in canonical schema order (solidFill before latin); CT_DLbls schema-correct ordering (numFmt → txPr → dLblPos)
- [x] cloneChart: inherits via existing whole-`dataLabels` resolver; survives writeXlsx round-trip; `null` override drops; explicit override beats source; carries through type flatten (bar → line / doughnut)