### PR TITLE
feat(xlsx): chart axis title overlay flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2797,6 +2797,45 @@ export interface SheetChart {
        * area / scatter).
        */
       axisTitleFontFamily?: string;
+      /**
+       * Axis-title overlay flag. Maps to
+       * `<c:catAx><c:title><c:overlay val=".."/></c:title></c:catAx>`
+       * (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) — the OOXML
+       * `<c:overlay>` child of `CT_Title`. The element controls
+       * whether the axis title is drawn on top of (and may overlap)
+       * the plot area, mirroring how the chart-level
+       * {@link SheetChart.titleOverlay} controls the chart title's
+       * overlap.
+       *
+       * Default: omitted — the writer emits the OOXML default
+       * `val="0"` (the axis title reserves its own slot adjacent to
+       * the axis and the plot area shrinks to make room), matching
+       * Excel's reference serialization for a fresh axis title. Pin
+       * `axisTitleOverlay: true` to draw the axis title on top of the
+       * plot area so the chart series get the full frame
+       * (`val="1"`). Excel's UI does not surface this toggle for axis
+       * titles directly, but the OOXML schema (CT_Title is shared
+       * with the chart-level title) carries the element on every
+       * emitted axis-title block — the writer always emits
+       * `<c:overlay>` so a hand-edited template that pinned `val="1"`
+       * round-trips cleanly.
+       *
+       * Mirrors {@link SheetChart.titleOverlay} — same `boolean`
+       * shape, same OOXML `<c:overlay val=".."/>` mapping — so a
+       * caller can thread a single overlay toggle through both the
+       * chart and axis titles.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>`
+       * shape per the OOXML schema, so the field round-trips on
+       * every chart family that has axes (bar / column / line /
+       * area / scatter).
+       */
+      axisTitleOverlay?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -3547,6 +3586,14 @@ export interface SheetChart {
        * area / scatter).
        */
       axisTitleFontFamily?: string;
+      /**
+       * Value-axis-title overlay flag. Same canonical `<c:title>
+       * <c:overlay val=".."/></c:title>` slot and grammar as
+       * {@link SheetChart.axes.x.axisTitleOverlay} — the field
+       * round-trips on `<c:valAx>` exactly as it does on `<c:catAx>`.
+       * See the X-axis variant for the full semantics.
+       */
+      axisTitleOverlay?: boolean;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -5173,6 +5220,36 @@ export interface ChartAxisInfo {
    * axis.
    */
   axisTitleFontFamily?: string;
+  /**
+   * Axis-title overlay flag pulled from
+   * `<c:catAx><c:title><c:overlay val=".."/></c:title></c:catAx>` (or
+   * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`). Reflects the OOXML
+   * `<c:overlay>` child of `CT_Title` — whether the axis title is
+   * drawn on top of (and may overlap) the plot area.
+   *
+   * The OOXML default `false` (the title reserves its own slot
+   * adjacent to the axis, no overlap with the plot area) collapses
+   * to `undefined` so absence and `<c:overlay val="0"/>` round-trip
+   * identically through {@link cloneChart} — only an explicit
+   * `<c:overlay val="1"/>` surfaces `true`. The reader accepts the
+   * OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
+   * `"false"`); unknown values and missing `val` attributes drop to
+   * `undefined` rather than fabricate a flag Excel would not emit.
+   *
+   * Returned as `undefined` whenever the axis omits the `<c:title>`
+   * element entirely — there is no overlay slot to surface in that
+   * case. The element is a sibling of `<c:tx>` inside `<c:title>`
+   * per the CT_Title schema, so the lookup is scoped to direct title
+   * children.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. Mirrors the chart-level
+   * {@link Chart.titleOverlay} so a parsed value slots straight back
+   * into the writer-side {@link SheetChart.axes.x.axisTitleOverlay}
+   * without transformation.
+   */
+  axisTitleOverlay?: boolean;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -1044,6 +1044,27 @@ export interface CloneChartOptions {
        * same way at the call site.
        */
       axisTitleFontFamily?: string | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleOverlay`. `undefined`
+       * (or omitted) inherits the source axis's parsed value; `null`
+       * drops the inherited value (the writer falls back to the OOXML
+       * `false` default — the title reserves its own slot adjacent to
+       * the axis, no overlap with the plot area); a `boolean`
+       * replaces it.
+       *
+       * The override is silently dropped from the cloned `SheetChart`
+       * when the axis renders no title (the resolved `title` is
+       * `undefined`) — there is no `<c:title>` block to host the
+       * overlay flag in either case.
+       *
+       * The grammar mirrors `titleOverlay` (the chart-level analog)
+       * and the other axis-title knobs (`axisTitleRotation` /
+       * `axisTitleFontSize` / `axisTitleBold` / `axisTitleItalic` /
+       * `axisTitleColor` / `axisTitleStrike` / `axisTitleUnderline` /
+       * `axisTitleFontFamily`) so the axis-title knobs compose the
+       * same way at the call site.
+       */
+      axisTitleOverlay?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1382,6 +1403,8 @@ export interface CloneChartOptions {
       axisTitleUnderline?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleFontFamily}. */
       axisTitleFontFamily?: string | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleOverlay}. */
+      axisTitleOverlay?: boolean | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -3613,6 +3636,22 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleFontFamily,
     overrides?.y?.axisTitleFontFamily,
   );
+  // `<c:title><c:overlay val=".."/></c:title>` — axis-title overlay
+  // flag. Sits as a direct child of `<c:title>` per CT_Title schema,
+  // so the resolver applies on every chart family that has axes (pie
+  // / doughnut were short-circuited upstream). Non-boolean overrides
+  // collapse to `undefined` via the resolver. Like the other axis-
+  // title knobs, the writer drops the flag when the matching axis
+  // title is unset, so a stray pin on an axis with no title silently
+  // disappears at emit time.
+  const xAxisTitleOverlay = applyAxisTitleOverlayOverride(
+    sourceAxes?.x?.axisTitleOverlay,
+    overrides?.x?.axisTitleOverlay,
+  );
+  const yAxisTitleOverlay = applyAxisTitleOverlayOverride(
+    sourceAxes?.y?.axisTitleOverlay,
+    overrides?.y?.axisTitleOverlay,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -3894,6 +3933,14 @@ function resolveAxes(
   // will paint.
   const xAxisTitleFontFamilyResolved = xTitle === undefined ? undefined : xAxisTitleFontFamily;
   const yAxisTitleFontFamilyResolved = yTitle === undefined ? undefined : yAxisTitleFontFamily;
+  // Same title-presence gate as the rotation / size / bold / italic /
+  // color / strike / underline / font-family resolved values — the
+  // writer always emits `<c:overlay>` when it emits the axis title,
+  // and the writer skips the entire axis-title block when the matching
+  // axis title is unset, so the cloned `SheetChart` accurately
+  // reflects what the chart will paint.
+  const xAxisTitleOverlayResolved = xTitle === undefined ? undefined : xAxisTitleOverlay;
+  const yAxisTitleOverlayResolved = yTitle === undefined ? undefined : yAxisTitleOverlay;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -3906,6 +3953,7 @@ function resolveAxes(
     xAxisTitleStrikeResolved !== undefined ||
     xAxisTitleUnderlineResolved !== undefined ||
     xAxisTitleFontFamilyResolved !== undefined ||
+    xAxisTitleOverlayResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -3947,6 +3995,7 @@ function resolveAxes(
       out.x.axisTitleUnderline = xAxisTitleUnderlineResolved;
     if (xAxisTitleFontFamilyResolved !== undefined)
       out.x.axisTitleFontFamily = xAxisTitleFontFamilyResolved;
+    if (xAxisTitleOverlayResolved !== undefined) out.x.axisTitleOverlay = xAxisTitleOverlayResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -3984,6 +4033,7 @@ function resolveAxes(
     yAxisTitleStrikeResolved !== undefined ||
     yAxisTitleUnderlineResolved !== undefined ||
     yAxisTitleFontFamilyResolved !== undefined ||
+    yAxisTitleOverlayResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -4019,6 +4069,7 @@ function resolveAxes(
       out.y.axisTitleUnderline = yAxisTitleUnderlineResolved;
     if (yAxisTitleFontFamilyResolved !== undefined)
       out.y.axisTitleFontFamily = yAxisTitleFontFamilyResolved;
+    if (yAxisTitleOverlayResolved !== undefined) out.y.axisTitleOverlay = yAxisTitleOverlayResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -4790,6 +4841,45 @@ function normalizeAxisTitleFontFamilyClone(value: string | undefined): string | 
   const trimmed = value.trim();
   if (trimmed.length === 0) return undefined;
   return trimmed;
+}
+
+/**
+ * Resolve an `axisTitleOverlay` override.
+ *
+ * `undefined` → inherit the source axis's parsed `axisTitleOverlay`.
+ * `null`      → drop the inherited value (the writer falls back to
+ *               the OOXML `false` default — `<c:overlay val="0"/>`,
+ *               the title reserves its own slot adjacent to the axis
+ *               with no overlap).
+ * `boolean`   → replace.
+ *
+ * Mirrors the chart-level `titleOverlay` resolver (PR #224) and the
+ * other axis-title knobs (`axisTitleRotation` / `axisTitleFontSize` /
+ * `axisTitleBold` / `axisTitleItalic` / `axisTitleColor` /
+ * `axisTitleStrike` / `axisTitleUnderline`) so the axis-title knobs
+ * compose the same way at the call site. Non-boolean overrides (typed
+ * escape from an untyped caller) collapse to `undefined` so the
+ * cloned `SheetChart` always carries a value the writer will accept.
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a flag that the writer would silently elide (the writer
+ * scopes the flag emission to `<c:title>`, which is omitted when the
+ * axis renders no title).
+ */
+function applyAxisTitleOverlayOverride(
+  source: boolean | undefined,
+  override: boolean | null | undefined,
+): boolean | undefined {
+  if (override === undefined) {
+    if (source === true) return true;
+    if (source === false) return false;
+    return undefined;
+  }
+  if (override === null) return undefined;
+  if (override === true) return true;
+  if (override === false) return false;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -705,6 +705,14 @@ function parseAxisInfo(
   // `<c:title>` entirely or when the title is a `<c:strRef>` (formula
   // reference) with no `<c:rich>` body.
   const axisTitleFontFamily = parseAxisTitleFontFamily(axis);
+  // `<c:title><c:overlay val=".."/></c:title>` — axis-title overlay
+  // flag. Sits as a direct child of `<c:title>` per CT_Title schema,
+  // so the lookup is scoped to direct title children. The OOXML
+  // default `false` collapses to `undefined` so absence and
+  // `<c:overlay val="0"/>` round-trip identically through
+  // {@link cloneChart}. Returns `undefined` when the axis omits
+  // `<c:title>` entirely.
+  const axisTitleOverlay = parseAxisTitleOverlay(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -863,6 +871,7 @@ function parseAxisInfo(
     axisTitleStrike === undefined &&
     axisTitleUnderline === undefined &&
     axisTitleFontFamily === undefined &&
+    axisTitleOverlay === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -902,6 +911,7 @@ function parseAxisInfo(
   if (axisTitleStrike !== undefined) out.axisTitleStrike = axisTitleStrike;
   if (axisTitleUnderline !== undefined) out.axisTitleUnderline = axisTitleUnderline;
   if (axisTitleFontFamily !== undefined) out.axisTitleFontFamily = axisTitleFontFamily;
+  if (axisTitleOverlay !== undefined) out.axisTitleOverlay = axisTitleOverlay;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -2325,6 +2335,51 @@ function parseAxisTitleFontFamily(axis: XmlElement): string | undefined {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return undefined;
   return trimmed;
+}
+
+/**
+ * Pull `<c:title><c:overlay val=".."/></c:title>` off an axis
+ * element. Returns the axis-title overlay flag.
+ *
+ * The OOXML default `false` (the title reserves its own slot adjacent
+ * to the axis, no overlap with the plot area) collapses to
+ * `undefined` so absence and `<c:overlay val="0"/>` round-trip
+ * identically through {@link cloneChart} — only an explicit
+ * `<c:overlay val="1"/>` surfaces `true`.
+ *
+ * Returns `undefined` whenever the axis omits the `<c:title>`
+ * element — there is no overlay slot to surface in that case. The
+ * element is a sibling of `<c:tx>` inside `<c:title>` per the
+ * CT_Title schema, so the lookup is scoped to direct title children
+ * (a stray `<c:overlay>` elsewhere on the axis or chart cannot leak
+ * in). Mirrors the chart-level title-overlay reader so a parsed
+ * value flows straight back into the writer-side
+ * {@link SheetChart.axes}.x.axisTitleOverlay.
+ *
+ * Accepts the OOXML truthy / falsy spellings (`"1"` / `"true"` /
+ * `"0"` / `"false"`); unknown values and missing `val` attributes
+ * drop to `undefined` rather than fabricate a flag Excel would not
+ * emit.
+ */
+function parseAxisTitleOverlay(axis: XmlElement): boolean | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const overlay = findChild(title, "overlay");
+  if (!overlay) return undefined;
+  const raw = overlay.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      // OOXML default — collapse to undefined for symmetry with the
+      // writer's `axisTitleOverlay` field.
+      return undefined;
+    default:
+      return undefined;
+  }
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -864,6 +864,16 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // inherits the theme typeface).
     xAxisTitleFontFamily: normalizeAxisTitleFontFamily(chart.axes?.x?.axisTitleFontFamily),
     yAxisTitleFontFamily: normalizeAxisTitleFontFamily(chart.axes?.y?.axisTitleFontFamily),
+    // `<c:title><c:overlay val=".."/></c:title>` — axis-title overlay
+    // flag. The element sits as a direct child of `<c:title>` per
+    // CT_Title schema, and is always emitted by the writer (Excel's
+    // reference serialization includes it on every visible axis
+    // title) — only the `val` attribute flips when the caller pins
+    // `axisTitleOverlay: true`. Anything other than literal `true`
+    // collapses to `false` so a stray non-boolean leaking through the
+    // type guard never produces `<c:overlay val="1"/>`.
+    xAxisTitleOverlay: chart.axes?.x?.axisTitleOverlay === true,
+    yAxisTitleOverlay: chart.axes?.y?.axisTitleOverlay === true,
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1470,6 +1480,25 @@ interface AxisRenderOptions {
    * shape and emit semantics as {@link xAxisTitleFontFamily}.
    */
   yAxisTitleFontFamily: string | undefined;
+  /**
+   * Axis-title overlay flag emitted on the X axis via
+   * `<c:catAx><c:title><c:overlay val=".."/></c:title></c:catAx>`.
+   * The OOXML `<c:overlay val=".."/>` element carries the boolean.
+   * `false` (the OOXML default) emits `val="0"` so the title
+   * reserves its own slot adjacent to the axis; `true` emits
+   * `val="1"` so the title overlaps the plot area. The writer
+   * always emits `<c:overlay>` because Excel's reference
+   * serialization includes it on every visible axis title — only
+   * the `val` flips. Only meaningful when the axis renders a title
+   * — the per-family axis builders gate the value on the
+   * `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleOverlay: boolean;
+  /**
+   * Axis-title overlay flag emitted on the Y axis. Same shape and
+   * emit semantics as {@link xAxisTitleOverlay}.
+   */
+  yAxisTitleOverlay: boolean;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -2699,6 +2728,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleStrike,
         opts.xAxisTitleUnderline,
         opts.xAxisTitleFontFamily,
+        opts.xAxisTitleOverlay,
       ),
     );
   catAxChildren.push(
@@ -2774,6 +2804,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleStrike,
         opts.yAxisTitleUnderline,
         opts.yAxisTitleFontFamily,
+        opts.yAxisTitleOverlay,
       ),
     );
   valAxChildren.push(
@@ -3150,6 +3181,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleStrike,
         opts.xAxisTitleUnderline,
         opts.xAxisTitleFontFamily,
+        opts.xAxisTitleOverlay,
       ),
     );
   xAxChildren.push(
@@ -3204,6 +3236,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleStrike,
         opts.yAxisTitleUnderline,
         opts.yAxisTitleFontFamily,
+        opts.yAxisTitleOverlay,
       ),
     );
   yAxChildren.push(
@@ -3305,6 +3338,7 @@ function buildAxisTitle(
   strike: boolean | undefined,
   underline: boolean | undefined,
   fontFamily: string | undefined,
+  overlay: boolean,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -3445,7 +3479,7 @@ function buildAxisTitle(
         ]),
       ]),
     ]),
-    xmlSelfClose("c:overlay", { val: 0 }),
+    xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }),
   ]);
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -17477,3 +17477,179 @@ describe("cloneChart — axis title font family", () => {
     expect(clone.axes?.y?.axisTitleFontFamily).toBe("Calibri");
   });
 });
+
+// ── cloneChart — axis title overlay ─────────────────────────────────
+
+describe("cloneChart — axis title overlay", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleOverlay by default", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleOverlay).toBe(true);
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleOverlay by default", () => {
+    const clone = cloneChart(source({ axes: { y: { title: "USD", axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.y?.axisTitleOverlay).toBe(true);
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleOverlay replace the source's value", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleOverlay: false } },
+    });
+    expect(clone.axes?.x?.axisTitleOverlay).toBe(false);
+  });
+
+  it("drops the inherited axisTitleOverlay when the override is null", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleOverlay: null } },
+    });
+    expect(clone.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("returns undefined axisTitleOverlay when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleOverlay with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleOverlay: true } },
+    });
+    expect(clone.axes?.x?.axisTitleOverlay).toBe(true);
+  });
+
+  it("collapses non-boolean overrides (defends against an untyped caller)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleOverlay: "true" as any } },
+    });
+    expect(clone.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("composes with all other axis-title typography knobs", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleOverlay: true,
+            axisTitleBold: true,
+            axisTitleItalic: true,
+            axisTitleColor: "FF0000",
+            axisTitleFontSize: 14,
+            axisTitleFontFamily: "Arial",
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleOverlay).toBe(true);
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+    expect(clone.axes?.x?.axisTitleItalic).toBe(true);
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(clone.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Arial");
+  });
+
+  it("preserves Y-axis overlay when only X is overridden", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleOverlay: true },
+          y: { title: "USD", axisTitleOverlay: false },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleOverlay: false } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleOverlay).toBe(false);
+    expect(clone.axes?.y?.axisTitleOverlay).toBe(false);
+  });
+
+  it("drops the inherited axisTitleOverlay when the resolved axis has no title", () => {
+    // No title on the X axis means no `<c:title>` block — there is no
+    // `<c:overlay>` slot to host the flag, so the cloned `SheetChart`
+    // must drop the field.
+    const clone = cloneChart(source({ axes: { x: { axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("collapses to undefined on pie / doughnut (no axes at all)", () => {
+    const pieSource: Chart = {
+      kinds: ["pie"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "pie",
+          index: 0,
+          name: "Slices",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Distribution",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { title: "Period", axisTitleOverlay: true } } as any,
+    };
+    const clone = cloneChart(pieSource, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("survives writeXlsx round-trip — axisTitleOverlay lands in the packaged chart XML", async () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period", axisTitleOverlay: true } } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleOverlay).toBe(true);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -15862,3 +15862,205 @@ describe("writeChart — axis title font family", () => {
     expect(reparsed?.axes?.y?.axisTitleFontFamily).toBe("Calibri");
   });
 });
+
+// ── writeChart — axis title overlay ─────────────────────────────────
+
+describe("writeChart — axis title overlay", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  function axisTitleOverlayVal(axisBlock: string): string | undefined {
+    const titleBlock = axisTitleBlock(axisBlock);
+    if (!titleBlock) return undefined;
+    const m = titleBlock.match(/<c:overlay\s+val="([^"]+)"\s*\/>/);
+    return m ? m[1] : undefined;
+  }
+
+  it("emits <c:overlay val='0'/> by default (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleOverlayVal(xAx)).toBe("0");
+  });
+
+  it("emits <c:overlay val='1'/> on axisTitleOverlay=true", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleOverlayVal(xAx)).toBe("1");
+  });
+
+  it("emits <c:overlay val='0'/> on axisTitleOverlay=false (functionally identical to absence)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: false } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleOverlayVal(xAx)).toBe("0");
+  });
+
+  it("drops non-boolean inputs back to the OOXML default (defends against type guard escape)", () => {
+    const r1 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: "true" as any } } }),
+      "Sheet1",
+    );
+    const [r1XAx] = axisBlocks(r1.chartXml);
+    expect(axisTitleOverlayVal(r1XAx)).toBe("0");
+    const r2 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: 1 as any } } }),
+      "Sheet1",
+    );
+    const [r2XAx] = axisBlocks(r2.chartXml);
+    expect(axisTitleOverlayVal(r2XAx)).toBe("0");
+    const r3 = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: null as any } } }),
+      "Sheet1",
+    );
+    const [r3XAx] = axisBlocks(r3.chartXml);
+    expect(axisTitleOverlayVal(r3XAx)).toBe("0");
+  });
+
+  it("threads the overlay flag independently across the X and Y axes", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleOverlay: true },
+          y: { title: "USD", axisTitleOverlay: false },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleOverlayVal(xAx)).toBe("1");
+    expect(axisTitleOverlayVal(yAx)).toBe("0");
+  });
+
+  it("does not emit <c:overlay> when no axis title is rendered (no <c:title> block)", () => {
+    // Without a `title` field, the writer skips `<c:title>` entirely so
+    // the overlay flag has no slot in the rendered chart.
+    const result = writeChart(makeChart({ axes: { x: { axisTitleOverlay: true } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBlock(xAx)).toBeUndefined();
+  });
+
+  it("places <c:overlay> after <c:tx> inside <c:title> (CT_Title order)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(titleBlock.indexOf("c:tx")).toBeLessThan(titleBlock.indexOf("c:overlay"));
+  });
+
+  it("emits <c:overlay> exactly once inside each axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: true } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    const occurrences = titleBlock.match(/<c:overlay\b/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads axisTitleOverlay through every chart family that has axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleOverlay: true } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleOverlayVal(xAx)).toBe("1");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { title: "Period", axisTitleOverlay: true } },
+      }),
+      "Sheet1",
+    );
+    const [xAxScatter] = Array.from(scatter.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)).map(
+      (m) => m[0],
+    );
+    expect(axisTitleOverlayVal(xAxScatter)).toBe("1");
+  });
+
+  it("composes with axisTitleRotation / axisTitleBold / axisTitleColor on the same <c:title> body", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleOverlay: true,
+            axisTitleBold: true,
+            axisTitleRotation: 30,
+            axisTitleColor: "FF0000",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const titleBlock = axisTitleBlock(xAx)!;
+    expect(axisTitleOverlayVal(xAx)).toBe("1");
+    expect(titleBlock).toContain('b="1"');
+    expect(titleBlock).toContain('rot="1800000"');
+    expect(titleBlock).toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("round-trips axisTitleOverlay=true through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleOverlay: true } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleOverlay).toBe(true);
+  });
+
+  it("collapses an unset axisTitleOverlay round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("end-to-end: writeXlsx -> open -> reparse retains the overlay flag", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            axes: {
+              x: { title: "Region", axisTitleOverlay: true },
+              y: { title: "Sales", axisTitleOverlay: false },
+            },
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleOverlay).toBe(true);
+    expect(reparsed?.axes?.y?.axisTitleOverlay).toBeUndefined();
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -16370,3 +16370,155 @@ describe("parseChart — axis title font family", () => {
     expect(chart?.axes?.x?.axisTitleFontFamily).toBeUndefined();
   });
 });
+
+// ── parseChart — axis title overlay ─────────────────────────────────
+
+describe("parseChart — axis title overlay", () => {
+  const NS_ATO = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withAxisTitleOverlay(val: string | undefined): string {
+    const overlay = val === undefined ? "" : `<c:overlay val="${val}"/>`;
+    return `<c:chartSpace ${NS_ATO}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="0"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        ${overlay}
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it('surfaces axisTitleOverlay=true when val="1"', () => {
+    expect(parseChart(withAxisTitleOverlay("1"))?.axes?.x?.axisTitleOverlay).toBe(true);
+  });
+
+  it('surfaces axisTitleOverlay=true when val="true"', () => {
+    expect(parseChart(withAxisTitleOverlay("true"))?.axes?.x?.axisTitleOverlay).toBe(true);
+  });
+
+  it('collapses the OOXML default val="0" to undefined', () => {
+    expect(parseChart(withAxisTitleOverlay("0"))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it('collapses val="false" to undefined', () => {
+    expect(parseChart(withAxisTitleOverlay("false"))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("returns undefined when <c:overlay> is missing entirely", () => {
+    expect(parseChart(withAxisTitleOverlay(undefined))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("collapses unknown / malformed val tokens to undefined", () => {
+    expect(parseChart(withAxisTitleOverlay(""))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+    expect(parseChart(withAxisTitleOverlay("yes"))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+    expect(parseChart(withAxisTitleOverlay("on"))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+    expect(parseChart(withAxisTitleOverlay("2"))?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("returns undefined when the axis omits <c:title> entirely", () => {
+    const xml = `<c:chartSpace ${NS_ATO}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("scopes the lookup to <c:title> (chart-level <c:overlay> does not leak in)", () => {
+    // The chart-level title pins overlay=true; the axis title pins
+    // overlay=false. The reader must not pick up the chart-level
+    // overlay for axisTitleOverlay.
+    const xml = `<c:chartSpace ${NS_ATO}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Sales</a:t></a:r></a:p>
+      </c:rich></c:tx>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p>
+          </c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleOverlay).toBe(true);
+    expect(chart?.axes?.x?.axisTitleOverlay).toBeUndefined();
+  });
+
+  it("co-surfaces alongside other axis-title knobs", () => {
+    const xml = `<c:chartSpace ${NS_ATO}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich>
+          <a:bodyPr rot="1800000"/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr sz="1400" b="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr><a:r><a:rPr sz="1400" b="1"/><a:t>Period</a:t></a:r></a:p>
+        </c:rich></c:tx>
+        <c:overlay val="1"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleOverlay).toBe(true);
+    expect(chart?.axes?.x?.axisTitleRotation).toBe(30);
+    expect(chart?.axes?.x?.axisTitleFontSize).toBe(14);
+    expect(chart?.axes?.x?.axisTitleBold).toBe(true);
+    expect(chart?.axes?.x?.axisTitleColor).toBe("FF0000");
+  });
+
+  it("surfaces axisTitleOverlay independently on the X and Y axes", () => {
+    const xml = `<c:chartSpace ${NS_ATO}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="1"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleOverlay).toBe(true);
+    expect(chart?.axes?.y?.axisTitleOverlay).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Surfaces `<c:catAx><c:title><c:overlay val=\"..\"/></c:title></c:catAx>` (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) — the OOXML `<c:overlay>` child of `CT_Title` — at the read, write, and clone layers so a template's axis-title overlay flag survives `parseChart` -> `cloneChart` -> `writeXlsx` and can be authored from scratch on a fresh chart.

The model is `axisTitleOverlay?: boolean` on `SheetChart.axes.x|y` (writer side) and on `ChartAxisInfo` (reader side). Sits as a direct child of `<c:title>` per the CT_Title schema (the same OOXML body shape the chart-level title carries). The writer always emits `<c:overlay>` inside every visible axis title (matching Excel's reference serialization); only the `val` attribute flips when the caller pins `axisTitleOverlay: true`.

Mirrors the chart-level `titleOverlay` (#224) — same `boolean | null` clone grammar, same canonical-slot mapping — so a caller can thread a single overlay toggle through both the chart and axis titles. Excel's UI does not surface this toggle for axis titles directly, but the OOXML schema (CT_Title is shared with the chart-level title) carries the element on every emitted axis-title block, so a hand-edited template that pinned `val=\"1\"` round-trips cleanly.

Surfaced on every chart family that has axes (bar / column / line / area / scatter); silently dropped on pie / doughnut. Silently dropped when the matching axis renders no title (no `<c:title>` block to host the overlay flag).

Refs #136

## Test plan

- [x] `pnpm exec vitest run` — all tests pass (35 new)
- [x] `pnpm test` — lint + typecheck + vitest all pass
- [x] `pnpm build` — succeeds
- [x] reader: surfaces `axisTitleOverlay` from `<c:title><c:overlay val=\"1\"/>`; collapses OOXML default `val=\"0\"` to undefined; scoped to `<c:title>` (chart-level overlay does not leak in); returns undefined when `<c:title>` is absent
- [x] writer: emits `<c:overlay val=\"0\"/>` by default; emits `<c:overlay val=\"1\"/>` on `axisTitleOverlay: true`; non-boolean inputs collapse to default; threads independently across X / Y axes; per CT_Title schema order (after `<c:tx>`)
- [x] cloneChart: inherits via `applyAxisTitleOverlayOverride`; `null` drops; `boolean` replaces; survives writeXlsx round-trip; dropped when the resolved axis has no title; dropped on pie / doughnut