### PR TITLE
feat(xlsx): chart data-table font color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1053,6 +1053,46 @@ export interface ChartDataTable {
   showOutline?: boolean;
   /** Render the legend swatch next to each series row. Default: `true`. */
   showKeys?: boolean;
+  /**
+   * Data-table font size in points (range `1..400`), pinned via
+   * `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+   * </c:txPr></c:dTable>`. Mirrors Excel's "Format Data Table -> Font
+   * -> Size" knob — the OOXML attribute is in 100ths of a point on
+   * `CT_TextCharacterProperties`' `sz` slot (ECMA-376 Part 1,
+   * §21.1.2.3.7); the writer holds the value in points and converts at
+   * emit time so a caller can pass the value directly without doing the
+   * multiplication.
+   *
+   * Default: omitted — the data table renders at the theme-default
+   * size (Excel's reference behavior for fresh data tables whose
+   * typography has not been customized; the writer skips the entire
+   * `<c:txPr>` block when no font knob is pinned).
+   *
+   * Out-of-range values (`< 1` or `> 400`) and non-numeric tokens
+   * (typed escapes from an untyped caller — strings, `null`, `NaN`,
+   * `Infinity`) collapse to `undefined` so the writer never emits a
+   * malformed `sz` attribute. Fractional points round to the nearest
+   * half-point (Excel's UI step) — `12.3` → `12.5`, `12.24` → `12`.
+   *
+   * The `<c:txPr>` block lands after the four required boolean children
+   * (`<c:showHorzBorder>`, `<c:showVertBorder>`, `<c:showOutline>`,
+   * `<c:showKeys>`) per the CT_DTable schema sequence (ECMA-376 Part 1,
+   * §21.2.2.54). Composes independently with the four boolean toggles —
+   * so a caller can pin the font size without touching the rest of the
+   * configuration. Mirrors {@link SheetChart.titleFontSize} /
+   * {@link SheetChart.legendFontSize} / {@link ChartDataLabels.fontSize}
+   * — same range, same fractional rounding, same OOXML conversion
+   * factor — so a caller can thread a single point value through every
+   * typography-pinning slot.
+   *
+   * Only meaningful for chart families with axes (`bar`, `column`,
+   * `line`, `area`, `scatter`) — the OOXML schema places `<c:dTable>`
+   * inside `<c:plotArea>` after the axes, so pie / doughnut have no
+   * slot for it (they have no axes at all). The writer silently drops
+   * the field on those families along with the rest of the data-table
+   * configuration.
+   */
+  fontSize?: number;
 }
 
 /**

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1093,6 +1093,47 @@ export interface ChartDataTable {
    * configuration.
    */
   fontSize?: number;
+  /**
+   * Data-table font color. Maps to `<c:dTable><c:txPr><a:p><a:pPr>
+   * <a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+   * </a:defRPr></a:pPr></a:p></c:txPr></c:dTable>` — Excel's "Format
+   * Data Table -> Font -> Font color" picker. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor` inside `CT_TextCharacterProperties`'
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §21.1.2.3.7); the
+   * writer lands the value on the default-paragraph `<a:defRPr>` slot
+   * inside the `<c:dTable><c:txPr>` block so a re-parse picks the
+   * color up off the canonical slot the OOXML schema exposes.
+   *
+   * Accepts the color either with or without a leading `#` and in any
+   * case — `"FF0000"`, `"#FF0000"`, and `"ff0000"` all collapse to the
+   * OOXML uppercase canonical form `"FF0000"`. Malformed inputs (wrong
+   * length, non-hex characters, alpha-channel forms like `"#FF0000FF"`,
+   * non-string escapes from an untyped caller) collapse to `undefined`
+   * so the writer skips the entire `<a:solidFill>` block and the data
+   * table inherits the theme text color (Excel's reference behavior
+   * for fresh data tables that have not had a custom color picked).
+   *
+   * Default: omitted — the data table renders at the theme text color
+   * (no `<a:solidFill>` block, matching Excel's reference
+   * serialization for fresh data tables whose typography has not been
+   * customized).
+   *
+   * The `<c:txPr>` block lands after the four required boolean children
+   * per the CT_DTable schema sequence (ECMA-376 Part 1, §21.2.2.54).
+   * Mirrors the chart-title `titleColor` / axis-title `axisTitleColor`
+   * / axis tick-label `labelColor` / legend `legendFontColor` /
+   * data-label `fontColor` knobs — same accept-with-or-without-`#` hex
+   * grammar, same OOXML `<a:solidFill><a:srgbClr val=".."/>` mapping —
+   * so a caller can thread a single hex string through every
+   * typography-pinning slot. Composes independently with
+   * {@link fontSize} and the four boolean toggles — so a caller can
+   * pin the color without touching the rest of the configuration.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  fontColor?: string;
 }
 
 /**

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -808,9 +808,13 @@ export interface CloneChartOptions {
    * border / outline / key flag to its OOXML default `true`. A
    * {@link ChartDataTable} object replaces the block wholesale (no
    * per-field merge; pass every flag you want preserved). Each
-   * unspecified flag inside the object falls back to `true` at the
-   * writer side because every `<c:dTable>` boolean child is required
-   * on `CT_DTable` and Excel emits all four.
+   * unspecified boolean flag inside the object falls back to `true` at
+   * the writer side because every `<c:dTable>` boolean child is
+   * required on `CT_DTable` and Excel emits all four. The optional
+   * {@link ChartDataTable.fontSize} typography pin survives the
+   * wholesale-replace path along with the four boolean toggles, so a
+   * clone that inherits a templated data-table carries the typography
+   * forward unchanged.
    *
    * Only meaningful when the resolved chart type has axes — `bar`,
    * `column`, `line`, `area`, `scatter`. The field is silently dropped

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -811,10 +811,10 @@ export interface CloneChartOptions {
    * unspecified boolean flag inside the object falls back to `true` at
    * the writer side because every `<c:dTable>` boolean child is
    * required on `CT_DTable` and Excel emits all four. The optional
-   * {@link ChartDataTable.fontSize} typography pin survives the
-   * wholesale-replace path along with the four boolean toggles, so a
-   * clone that inherits a templated data-table carries the typography
-   * forward unchanged.
+   * {@link ChartDataTable.fontSize} / {@link ChartDataTable.fontColor}
+   * typography pins survive the wholesale-replace path along with the
+   * four boolean toggles, so a clone that inherits a templated
+   * data-table carries the typography forward unchanged.
    *
    * Only meaningful when the resolved chart type has axes — `bar`,
    * `column`, `line`, `area`, `scatter`. The field is silently dropped

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -4457,7 +4457,50 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (showOutline !== undefined) out.showOutline = showOutline;
   const showKeys = parseDataTableFlag(el, "showKeys");
   if (showKeys !== undefined) out.showKeys = showKeys;
+  const fontSize = parseDataTableFontSize(el);
+  if (fontSize !== undefined) out.fontSize = fontSize;
   return out;
+}
+
+/**
+ * Pull `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+ * </c:txPr></c:dTable>` off a data-table block. Returns the font size
+ * in points (`1..400`), or `undefined` when the element is absent /
+ * the chain is malformed at any link / the surfaced value is out of
+ * the supported range.
+ *
+ * The OOXML attribute is in 100ths of a point on
+ * `CT_TextCharacterProperties`' `sz` slot (ECMA-376 Part 1,
+ * §21.1.2.3.7); the reader divides by 100 at parse time so the
+ * surfaced value matches what the user sees in Excel's UI. Mirrors
+ * the chart-title / axis-title / axis tick-label / legend / data-label
+ * font-size readers exactly so a parsed value slots straight back into
+ * the writer's emit path.
+ */
+function parseDataTableFontSize(dTable: XmlElement): number | undefined {
+  const txPr = findChild(dTable, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.sz;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed)) return undefined;
+  // Convert from 100ths of a point to points, rounding to the nearest
+  // 0.5pt to match the granularity Excel's UI exposes. Mirrors the
+  // chart-title / axis-title / tick-label / legend / data-label
+  // sibling parsers exactly so a parsed value flows through every
+  // typography slot without bookkeeping the units.
+  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2);
+  const points = halfSteps / 2;
+  if (points < TITLE_FONT_SIZE_MIN_PT || points > TITLE_FONT_SIZE_MAX_PT) return undefined;
+  return points;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -4459,7 +4459,44 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (showKeys !== undefined) out.showKeys = showKeys;
   const fontSize = parseDataTableFontSize(el);
   if (fontSize !== undefined) out.fontSize = fontSize;
+  const fontColor = parseDataTableFontColor(el);
+  if (fontColor !== undefined) out.fontColor = fontColor;
   return out;
+}
+
+/**
+ * Pull `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:txPr></c:dTable>` off a data-table block. Returns the
+ * 6-character uppercase hex string when the parser walks the full
+ * chain and lands on an `<a:srgbClr val="RRGGBB"/>`. Theme references
+ * (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>`
+ * all collapse to `undefined` — only the literal RGB triple round-
+ * trips losslessly through {@link writeChart}. Malformed `val` tokens
+ * (wrong length, non-hex characters) likewise drop to `undefined`
+ * rather than fabricate a value the writer would round-trip into a
+ * malformed `<a:srgbClr>`.
+ *
+ * Returns `undefined` whenever the data-table block omits `<c:txPr>`
+ * entirely or the canonical chain is malformed at any link. Mirrors
+ * the chart-title / axis-title / axis tick-label / legend / data-label
+ * color readers exactly so a parsed value slots straight back into the
+ * writer's emit path.
+ */
+function parseDataTableFontColor(dTable: XmlElement): string | undefined {
+  const txPr = findChild(dTable, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const solidFill = findChild(defRPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1108,6 +1108,7 @@ function resolveDataTable(chart: SheetChart):
       showVertBorder: boolean;
       showOutline: boolean;
       showKeys: boolean;
+      fontSize: number | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1125,6 +1126,7 @@ function resolveDataTable(chart: SheetChart):
       showVertBorder: true,
       showOutline: true,
       showKeys: true,
+      fontSize: undefined,
     };
   }
 
@@ -1137,32 +1139,93 @@ function resolveDataTable(chart: SheetChart):
     showVertBorder: raw.showVertBorder !== false,
     showOutline: raw.showOutline !== false,
     showKeys: raw.showKeys !== false,
+    fontSize: resolveDataTableFontSize(raw.fontSize),
   };
+}
+
+/**
+ * Resolve `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr sz="N"/></a:pPr></a:p>
+ * </c:txPr></c:dTable>` from {@link ChartDataTable.fontSize}.
+ *
+ * Returns the size in points (`1..400`), or `undefined` when the caller
+ * leaves the field unset / passed an out-of-range or non-numeric token.
+ * Delegates to {@link normalizeTitleFontSize} so the chart-title /
+ * axis-title / axis tick-label / legend / data-label / data-table
+ * font-size resolvers share the same range, the same fractional rounding
+ * (Excel's UI step is 0.5pt), and the same OOXML conversion (100ths of
+ * a point at emit time).
+ */
+function resolveDataTableFontSize(value: number | undefined): number | undefined {
+  return normalizeTitleFontSize(value);
 }
 
 /**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
- * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`.
+ * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
+ * a `fontSize` is pinned the writer emits an additional `<c:txPr>`
+ * block after the four booleans; absence collapses to the existing
+ * four-child shape so a fresh chart with no typography pin matches
+ * Excel's reference serialization byte-for-byte.
  *
- * The writer always emits all four children — the OOXML schema marks
- * them required on `CT_DTable`, and Excel's reference serialization
- * includes every one even when the caller leaves it at the default. The
- * optional `<c:spPr>` / `<c:txPr>` / `<c:extLst>` children are skipped
- * because hucre's data-table model does not surface fill / text styling
- * yet.
+ * The writer always emits all four boolean children — the OOXML schema
+ * marks them required on `CT_DTable`, and Excel's reference
+ * serialization includes every one even when the caller leaves it at
+ * the default. The optional `<c:spPr>` / `<c:extLst>` children are
+ * skipped because hucre's data-table model does not surface fill /
+ * extension styling yet.
  */
 function buildDataTable(table: {
   showHorzBorder: boolean;
   showVertBorder: boolean;
   showOutline: boolean;
   showKeys: boolean;
+  fontSize: number | undefined;
 }): string {
-  return xmlElement("c:dTable", undefined, [
+  const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
     xmlSelfClose("c:showVertBorder", { val: table.showVertBorder ? 1 : 0 }),
     xmlSelfClose("c:showOutline", { val: table.showOutline ? 1 : 0 }),
     xmlSelfClose("c:showKeys", { val: table.showKeys ? 1 : 0 }),
+  ];
+  // CT_DTable schema places `<c:txPr>` after the four required
+  // boolean children, before the optional `<c:extLst>` (ECMA-376
+  // Part 1, §21.2.2.54). The writer skips emission entirely when no
+  // typography knob is pinned so a fresh chart matches Excel's
+  // reference serialization byte-for-byte.
+  const txPrXml = buildDataTableTxPr(table.fontSize);
+  if (txPrXml !== undefined) children.push(txPrXml);
+  return xmlElement("c:dTable", undefined, children);
+}
+
+/**
+ * Build the `<c:txPr>` block that carries a data-table's typography
+ * pins (currently the font size only). Returns `undefined` when every
+ * input is unset so the caller can elide the element entirely (Excel's
+ * reference serialization omits `<c:txPr>` from `<c:dTable>` when the
+ * table renders at the theme-default style).
+ *
+ * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
+ * when the user pins a data-table typography knob — `<a:bodyPr/>`,
+ * `<a:lstStyle/>`, and the `<a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
+ * <a:endParaRPr/></a:p>` paragraph stub Excel always emits hosts the
+ * typography attributes on `<a:defRPr>`. Mirrors the chart-title /
+ * axis-title / tick-label / legend / data-label `<c:txPr>` slots
+ * exactly so a re-parse picks the values off the canonical
+ * default-paragraph slot every other typography reader expects.
+ */
+function buildDataTableTxPr(fontSizePt: number | undefined): string | undefined {
+  if (fontSizePt === undefined) return undefined;
+  const defRPrAttrs: Record<string, string | number> = {
+    sz: fontSizePt * TITLE_FONT_SZ_PER_POINT,
+  };
+  return xmlElement("c:txPr", undefined, [
+    xmlSelfClose("a:bodyPr"),
+    xmlSelfClose("a:lstStyle"),
+    xmlElement("a:p", undefined, [
+      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", defRPrAttrs)]),
+      xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
+    ]),
   ]);
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1109,6 +1109,7 @@ function resolveDataTable(chart: SheetChart):
       showOutline: boolean;
       showKeys: boolean;
       fontSize: number | undefined;
+      fontColor: string | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1127,6 +1128,7 @@ function resolveDataTable(chart: SheetChart):
       showOutline: true,
       showKeys: true,
       fontSize: undefined,
+      fontColor: undefined,
     };
   }
 
@@ -1140,6 +1142,7 @@ function resolveDataTable(chart: SheetChart):
     showOutline: raw.showOutline !== false,
     showKeys: raw.showKeys !== false,
     fontSize: resolveDataTableFontSize(raw.fontSize),
+    fontColor: resolveDataTableFontColor(raw.fontColor),
   };
 }
 
@@ -1160,10 +1163,26 @@ function resolveDataTableFontSize(value: number | undefined): number | undefined
 }
 
 /**
+ * Resolve `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:defRPr></a:pPr></a:p>
+ * </c:txPr></c:dTable>` from {@link ChartDataTable.fontColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches the chart-title /
+ * axis-title / axis tick-label / legend / data-label color resolvers
+ * exactly.
+ */
+function resolveDataTableFontColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
- * a `fontSize` is pinned the writer emits an additional `<c:txPr>`
+ * a typography knob is pinned the writer emits an additional `<c:txPr>`
  * block after the four booleans; absence collapses to the existing
  * four-child shape so a fresh chart with no typography pin matches
  * Excel's reference serialization byte-for-byte.
@@ -1181,6 +1200,7 @@ function buildDataTable(table: {
   showOutline: boolean;
   showKeys: boolean;
   fontSize: number | undefined;
+  fontColor: string | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1193,37 +1213,56 @@ function buildDataTable(table: {
   // Part 1, §21.2.2.54). The writer skips emission entirely when no
   // typography knob is pinned so a fresh chart matches Excel's
   // reference serialization byte-for-byte.
-  const txPrXml = buildDataTableTxPr(table.fontSize);
+  const txPrXml = buildDataTableTxPr(table.fontSize, table.fontColor);
   if (txPrXml !== undefined) children.push(txPrXml);
   return xmlElement("c:dTable", undefined, children);
 }
 
 /**
  * Build the `<c:txPr>` block that carries a data-table's typography
- * pins (currently the font size only). Returns `undefined` when every
- * input is unset so the caller can elide the element entirely (Excel's
- * reference serialization omits `<c:txPr>` from `<c:dTable>` when the
- * table renders at the theme-default style).
+ * pins (currently font size and font color). Returns `undefined` when
+ * every input is unset so the caller can elide the element entirely
+ * (Excel's reference serialization omits `<c:txPr>` from `<c:dTable>`
+ * when the table renders at the theme-default style).
  *
  * The emitted block mirrors the minimal `<c:txPr>` shape Excel writes
  * when the user pins a data-table typography knob — `<a:bodyPr/>`,
  * `<a:lstStyle/>`, and the `<a:p><a:pPr><a:defRPr sz="N"/></a:pPr>
  * <a:endParaRPr/></a:p>` paragraph stub Excel always emits hosts the
- * typography attributes on `<a:defRPr>`. Mirrors the chart-title /
- * axis-title / tick-label / legend / data-label `<c:txPr>` slots
- * exactly so a re-parse picks the values off the canonical
- * default-paragraph slot every other typography reader expects.
+ * typography attributes on `<a:defRPr>`. The `<a:defRPr>` element
+ * expands from self-closing to wrapping a single `<a:solidFill>` child
+ * when a color is set; otherwise the writer keeps the existing
+ * self-closing form so a fresh chart with no custom color matches
+ * Excel's reference serialization byte-for-byte. Mirrors the
+ * chart-title / axis-title / tick-label / legend / data-label
+ * `<c:txPr>` slots exactly so a re-parse picks the values off the
+ * canonical default-paragraph slot every other typography reader
+ * expects.
  */
-function buildDataTableTxPr(fontSizePt: number | undefined): string | undefined {
-  if (fontSizePt === undefined) return undefined;
-  const defRPrAttrs: Record<string, string | number> = {
-    sz: fontSizePt * TITLE_FONT_SZ_PER_POINT,
-  };
+function buildDataTableTxPr(
+  fontSizePt: number | undefined,
+  rgbHex: string | undefined,
+): string | undefined {
+  if (fontSizePt === undefined && rgbHex === undefined) return undefined;
+  const defRPrAttrs: Record<string, string | number> = {};
+  if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
+  // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></a:defRPr>` carries the data-table font color.
+  // Absence (`undefined`) collapses to skipping the `<a:solidFill>`
+  // child entirely so the data table inherits the theme text color
+  // (Excel's reference behavior for fresh data tables that have not
+  // had a custom color picked).
+  const solidFillChild = rgbHex
+    ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
+    : undefined;
+  const defRPr = solidFillChild
+    ? xmlElement("a:defRPr", defRPrAttrs, [solidFillChild])
+    : xmlSelfClose("a:defRPr", defRPrAttrs);
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),
     xmlElement("a:p", undefined, [
-      xmlElement("a:pPr", undefined, [xmlSelfClose("a:defRPr", defRPrAttrs)]),
+      xmlElement("a:pPr", undefined, [defRPr]),
       xmlSelfClose("a:endParaRPr", { lang: "en-US" }),
     ]),
   ]);

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10303,6 +10303,154 @@ describe("cloneChart — data table", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.dataTable?.fontSize).toBe(13);
   });
+
+  // ── data-table font color ────────────────────────────────────────
+
+  it("inherits the source's dataTable.fontColor by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontColor: "FF6600",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontColor: "FF6600",
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited fontColor", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontColor: "FF6600" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, fontColor: "00AAFF" },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, fontColor: "00AAFF" });
+  });
+
+  it("drops the inherited fontColor when override clears the typography pin", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontColor: "FF6600" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited fontColor when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontColor: "FF6600" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.fontColor into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontColor: "1070CA",
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:srgbClr val="1070CA"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontColor: "1070CA",
+    });
+  });
+
+  it("composes dataTable.fontSize and fontColor through the clone-through path", () => {
+    // Both typography pins survive the inherit-by-default path together.
+    const clone = cloneChart(
+      source({
+        dataTable: { fontSize: 12, fontColor: "1070CA" },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({ fontSize: 12, fontColor: "1070CA" });
+  });
+
+  it("a parsed dataTable.fontColor round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, fontColor: "AABBCC" },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.fontColor).toBe("AABBCC");
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.fontColor).toBe("AABBCC");
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10156,6 +10156,153 @@ describe("cloneChart — data table", () => {
       showKeys: false,
     });
   });
+
+  // ── data-table font size ─────────────────────────────────────────
+
+  it("inherits the source's dataTable.fontSize by default", () => {
+    // The clone-through path should preserve the typography pin
+    // alongside the four boolean toggles when the caller leaves
+    // `options.dataTable` unset.
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontSize: 14,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontSize: 14,
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited fontSize", () => {
+    // Wholesale replace — the override fontSize wins, and the source's
+    // typography pin does not bleed into the clone.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontSize: 14 },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, fontSize: 22 },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, fontSize: 22 });
+  });
+
+  it("drops the inherited fontSize when override clears the typography pin", () => {
+    // Wholesale-replace with no fontSize on the override drops the
+    // inherited typography — the four boolean toggles still emit at
+    // their writer-side defaults via the override block.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontSize: 14 },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited fontSize when flattening into a doughnut clone", () => {
+    // Pie / doughnut have no <c:dTable> slot at all — every dataTable
+    // field is dropped, fontSize included.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontSize: 14 },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.fontSize into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontSize: 16,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:defRPr sz="1600"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontSize: 16,
+    });
+  });
+
+  it("a parsed dataTable.fontSize round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, fontSize: 13 },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.fontSize).toBe(13);
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.fontSize).toBe(13);
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -8916,6 +8916,169 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.fontSize).toBe(11);
   });
+
+  // ── data-table font color ──────────────────────────────────────────
+
+  it("skips <c:txPr> when fontColor is unset (writer default)", () => {
+    // The OOXML default for the data-table is no <c:txPr> at all — the
+    // table renders at the theme text color. Absence collapses to no
+    // <a:solidFill> block.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<a:solidFill>");
+  });
+
+  it("emits <a:solidFill><a:srgbClr val='FF0000'/> when dataTable.fontColor is 'FF0000'", () => {
+    const result = writeChart(makeChart({ dataTable: { fontColor: "FF0000" } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:srgbClr val="FF0000"/>');
+    expect(result.chartXml).toContain("<a:solidFill>");
+    // The defRPr expands from self-closing to wrapping the solidFill.
+    expect(result.chartXml).toMatch(/<a:defRPr><a:solidFill>/);
+  });
+
+  it("accepts the color with a leading '#' and lowercases input", () => {
+    // Mirrors the chart-title / axis-title / tick-label / legend /
+    // data-label color resolvers — the leading `#` is stripped and the
+    // hex is uppercased.
+    const result = writeChart(makeChart({ dataTable: { fontColor: "#abc123" } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:srgbClr val="ABC123"/>');
+  });
+
+  it("collapses malformed fontColor inputs to undefined", () => {
+    // Wrong length, non-hex characters, alpha-channel forms, and
+    // non-string escapes all drop the field rather than fabricate a
+    // value the writer would round-trip into a malformed <a:srgbClr>.
+    const wrong = writeChart(makeChart({ dataTable: { fontColor: "FF00" } }), "Sheet1");
+    expect(wrong.chartXml).not.toContain("<a:solidFill>");
+    const nonHex = writeChart(makeChart({ dataTable: { fontColor: "ZZZZZZ" } }), "Sheet1");
+    expect(nonHex.chartXml).not.toContain("<a:solidFill>");
+    const alpha = writeChart(makeChart({ dataTable: { fontColor: "#FF0000FF" } }), "Sheet1");
+    expect(alpha.chartXml).not.toContain("<a:solidFill>");
+    const empty = writeChart(makeChart({ dataTable: { fontColor: "" } }), "Sheet1");
+    expect(empty.chartXml).not.toContain("<a:solidFill>");
+    const nonString = {
+      fontColor: 123 as unknown as string,
+    } as { fontColor: string };
+    const numeric = writeChart(makeChart({ dataTable: nonString }), "Sheet1");
+    expect(numeric.chartXml).not.toContain("<a:solidFill>");
+  });
+
+  it("emits the txPr block with both fontSize and fontColor on the same defRPr slot", () => {
+    // Both knobs land on the same <a:defRPr> — the size as the `sz`
+    // attribute, the color as the wrapped <a:solidFill> child.
+    const result = writeChart(
+      makeChart({ dataTable: { fontSize: 12, fontColor: "1070CA" } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain(
+      '<a:defRPr sz="1200"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr>',
+    );
+  });
+
+  it("threads fontColor through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: { fontColor: "1070CA" } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:srgbClr val="1070CA"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontColor: "1070CA" },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<a:srgbClr val="1070CA"/>');
+  });
+
+  it("silently drops fontColor on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontColor: "FF0000" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("composes fontColor with the four boolean toggles independently", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          fontColor: "00FF00",
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:srgbClr val="00FF00"/>');
+  });
+
+  it("round-trips a pinned dataTable fontColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontColor: "FF6600",
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontColor: "FF6600",
+    });
+  });
+
+  it("threads fontColor end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, fontColor: "AABBCC" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:srgbClr val="AABBCC"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.fontColor).toBe("AABBCC");
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -8720,6 +8720,202 @@ describe("writeChart — data table", () => {
       showKeys: false,
     });
   });
+
+  // ── data-table font size ───────────────────────────────────────────
+
+  it("skips <c:txPr> inside <c:dTable> when fontSize is unset", () => {
+    // The OOXML default for the data-table is no `<c:txPr>` at all —
+    // the table renders at the theme-default size. The writer matches
+    // that shape so a fresh chart with no typography pin emits the
+    // four-child variant only.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+  });
+
+  it("emits <c:txPr> with sz=2400 when dataTable.fontSize is 24", () => {
+    // The OOXML attribute is in 100ths of a point — the writer
+    // multiplies the caller-facing point value by 100 at emit time.
+    const result = writeChart(makeChart({ dataTable: { fontSize: 24 } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr sz="2400"/>');
+  });
+
+  it("emits the txPr block in CT_DTable schema order (after the four boolean children)", () => {
+    // CT_DTable: showHorzBorder?, showVertBorder?, showOutline?,
+    // showKeys?, spPr?, txPr?, extLst? — the txPr block sits after the
+    // four boolean children, before the optional extLst.
+    const result = writeChart(makeChart({ dataTable: { fontSize: 14 } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    const keysIdx = dTableSlice.indexOf("c:showKeys");
+    const txPrIdx = dTableSlice.indexOf("<c:txPr>");
+    expect(keysIdx).toBeGreaterThan(-1);
+    expect(txPrIdx).toBeGreaterThan(keysIdx);
+  });
+
+  it("rounds fractional points to the nearest half-point (Excel UI step)", () => {
+    // 12.3 → 12.5pt → sz=1250; 12.24 → 12pt → sz=1200. Mirrors the
+    // chart-title / axis-title / tick-label / legend / data-label
+    // half-point rounding.
+    const half = writeChart(makeChart({ dataTable: { fontSize: 12.3 } }), "Sheet1").chartXml;
+    expect(half).toContain('<a:defRPr sz="1250"/>');
+    const whole = writeChart(makeChart({ dataTable: { fontSize: 12.24 } }), "Sheet1").chartXml;
+    expect(whole).toContain('<a:defRPr sz="1200"/>');
+  });
+
+  it("collapses out-of-range fontSize values to undefined", () => {
+    // Values < 1 or > 400 fall outside the OOXML supported range. The
+    // writer drops the field rather than emit a token Excel rejects.
+    const tooSmall = writeChart(makeChart({ dataTable: { fontSize: 0 } }), "Sheet1").chartXml;
+    expect(tooSmall).not.toContain("<c:txPr>");
+    const tooBig = writeChart(makeChart({ dataTable: { fontSize: 401 } }), "Sheet1").chartXml;
+    expect(tooBig).not.toContain("<c:txPr>");
+  });
+
+  it("collapses non-numeric fontSize escapes to undefined", () => {
+    // Typed escapes from an untyped caller — strings, NaN, Infinity —
+    // drop the field rather than fabricate a malformed sz attribute.
+    const dt = { fontSize: Number.NaN } as unknown as { fontSize: number };
+    const result = writeChart(makeChart({ dataTable: dt }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:txPr>");
+    const dt2 = { fontSize: Number.POSITIVE_INFINITY } as unknown as { fontSize: number };
+    const result2 = writeChart(makeChart({ dataTable: dt2 }), "Sheet1");
+    expect(result2.chartXml).not.toContain("<c:txPr>");
+    const dt3 = { fontSize: "20" } as unknown as { fontSize: number };
+    const result3 = writeChart(makeChart({ dataTable: dt3 }), "Sheet1");
+    expect(result3.chartXml).not.toContain("<c:txPr>");
+  });
+
+  it("emits the boundary fontSize values 1 and 400 verbatim", () => {
+    const min = writeChart(makeChart({ dataTable: { fontSize: 1 } }), "Sheet1").chartXml;
+    expect(min).toContain('<a:defRPr sz="100"/>');
+    const max = writeChart(makeChart({ dataTable: { fontSize: 400 } }), "Sheet1").chartXml;
+    expect(max).toContain('<a:defRPr sz="40000"/>');
+  });
+
+  it("composes fontSize with the four boolean toggles independently", () => {
+    // Each typography knob lands on the txPr block; the four boolean
+    // toggles continue to land on their dedicated child elements.
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          fontSize: 16,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:defRPr sz="1600"/>');
+  });
+
+  it("threads fontSize through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: { fontSize: 12 } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr sz="1200"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontSize: 12 },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<a:defRPr sz="1200"/>');
+  });
+
+  it("silently drops fontSize on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontSize: 14 },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:defRPr sz="1400"/>');
+  });
+
+  it("round-trips a pinned dataTable fontSize through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontSize: 18.5,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontSize: 18.5,
+    });
+  });
+
+  it("collapses an unset fontSize round-trip to undefined on the dataTable", () => {
+    // The four boolean children still surface (they're required on
+    // CT_DTable), but the fontSize field drops out because no txPr
+    // block is emitted.
+    const written = writeChart(makeChart({ dataTable: true }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+    });
+    expect(reparsed?.dataTable?.fontSize).toBeUndefined();
+  });
+
+  it("threads fontSize end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, fontSize: 11 },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:defRPr sz="1100"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.fontSize).toBe(11);
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9507,6 +9507,189 @@ describe("parseChart — data table", () => {
     const xml = `<c:chartSpace ${NS}><c:chart></c:chart></c:chartSpace>`;
     expect(parseChart(xml)?.dataTable).toBeUndefined();
   });
+
+  // ── data-table font size ───────────────────────────────────────────
+
+  it("surfaces a pinned dataTable.fontSize from <c:txPr><a:p><a:pPr><a:defRPr sz='..'/>", () => {
+    // The OOXML attribute is in 100ths of a point; the reader divides
+    // by 100 at parse time so the surfaced value matches what the user
+    // sees in Excel's UI. Mirrors the chart-title / axis-title /
+    // tick-label / legend / data-label font-size readers exactly.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1800"/></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fontSize: 18,
+    });
+  });
+
+  it("rounds a fractional sz to the nearest 0.5pt (Excel UI step)", () => {
+    // sz="1230" → 12.3pt → 12.5pt (rounded to half-step). Mirrors the
+    // chart-title / tick-label / legend / data-label half-step rounding.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1230"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontSize).toBe(12.5);
+  });
+
+  it("collapses an out-of-range sz to undefined fontSize (chart with the four flags only)", () => {
+    // sz="0" → 0pt is below the OOXML supported range. The reader drops
+    // the field rather than surface a value Excel would reject.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="0"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+    });
+  });
+
+  it("collapses a non-numeric sz token to undefined fontSize", () => {
+    // sz="garbage" can't be parsed as an integer. The reader drops the
+    // field rather than fabricate a value the file did not pin.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="garbage"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontSize).toBeUndefined();
+  });
+
+  it("returns undefined fontSize when <c:txPr> is missing entirely", () => {
+    // The OOXML default for the data-table is no <c:txPr> at all — the
+    // table renders at the theme-default size. The reader collapses
+    // absence to undefined so a fresh chart and a chart that omits the
+    // typography pin round-trip identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontSize).toBeUndefined();
+  });
+
+  it("returns undefined fontSize when <c:txPr> is present but the chain is broken", () => {
+    // Each link of `<c:txPr><a:p><a:pPr><a:defRPr sz="..">` must be
+    // present for the reader to surface a value. Missing the inner
+    // <a:pPr> drops the field rather than fabricate one.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontSize).toBeUndefined();
+  });
+
+  it("surfaces the boundary fontSize values 1 and 400 verbatim", () => {
+    // sz="100" → 1pt; sz="40000" → 400pt. Both lie at the edge of the
+    // supported range and round-trip literally.
+    const minXml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="100"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(minXml)?.dataTable?.fontSize).toBe(1);
+    const maxXml = minXml.replace('sz="100"', 'sz="40000"');
+    expect(parseChart(maxXml)?.dataTable?.fontSize).toBe(400);
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -9690,6 +9690,181 @@ describe("parseChart — data table", () => {
     const maxXml = minXml.replace('sz="100"', 'sz="40000"');
     expect(parseChart(maxXml)?.dataTable?.fontSize).toBe(400);
   });
+
+  // ── data-table font color ──────────────────────────────────────────
+
+  it("surfaces a pinned dataTable.fontColor from <a:solidFill><a:srgbClr val='RRGGBB'/>", () => {
+    // The OOXML <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+    // chain lands on the default-paragraph <a:defRPr> slot inside
+    // <c:dTable><c:txPr>. Mirrors the chart-title / axis-title /
+    // tick-label / legend / data-label color readers exactly.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontColor).toBe("1070CA");
+  });
+
+  it("uppercases a lowercase srgbClr val on parse", () => {
+    // The reader normalises the hex to the OOXML uppercase canonical
+    // form so a re-emit lands on the same byte sequence Excel writes.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontColor).toBe("ABCDEF");
+  });
+
+  it("collapses a malformed srgbClr val to undefined", () => {
+    // Wrong length, non-hex characters, missing val all drop the field
+    // rather than surface a value Excel would reject.
+    const wrongLen = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF00"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(wrongLen)?.dataTable?.fontColor).toBeUndefined();
+
+    const nonHex = wrongLen.replace('val="FF00"', 'val="ZZZZZZ"');
+    expect(parseChart(nonHex)?.dataTable?.fontColor).toBeUndefined();
+  });
+
+  it("collapses theme references (a:schemeClr) to undefined fontColor", () => {
+    // Only the literal <a:srgbClr> RGB triple round-trips; theme
+    // references collapse to undefined (writer can't round-trip them).
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:solidFill><a:schemeClr val="dk1"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontColor).toBeUndefined();
+  });
+
+  it("returns undefined fontColor when <c:txPr> is missing entirely", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontColor).toBeUndefined();
+  });
+
+  it("returns undefined fontColor when the chain has no <a:solidFill>", () => {
+    // The <a:defRPr> exists but carries no <a:solidFill> child — the
+    // reader collapses to undefined rather than fabricate a default.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontColor).toBeUndefined();
+    // The fontSize part still surfaces.
+    expect(parseChart(xml)?.dataTable?.fontSize).toBe(14);
+  });
+
+  it("surfaces both fontSize and fontColor when both are pinned", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1600"><a:solidFill><a:srgbClr val="123456"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fontSize: 16,
+      fontColor: "123456",
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `fontColor?: string` to `ChartDataTable`, mapped to `<c:plotArea><c:dTable><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val=".."/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr></c:dTable>` per the `CT_DTable` schema (the `<c:txPr>` child after the four required boolean children, before the optional `<c:extLst>`).
- Reader / writer / clone-through all support the new knob; mirrors the chart-title `titleColor`, axis-title `axisTitleColor`, tick-label `labelColor`, legend `legendFontColor`, and data-label `dataLabels.fontColor` knobs — same accept-with-or-without-`#` hex grammar, same OOXML `<a:solidFill><a:srgbClr val=".."/>` mapping.
- Composes independently with `dataTable.fontSize` and the four boolean toggles; both typography pins land on the same `<a:defRPr>` slot.
- Silently dropped on pie / doughnut along with the rest of the data-table config (no `<c:dTable>` slot when the chart has no axes).

Stacked on top of #288 (data-table fontSize) — the writer / reader / clone helpers extend the same code paths.

Refs #136

## Test plan

- [x] `pnpm test` — lint + typecheck + vitest (5848 tests, all pass; 24 new for this feature)
- [x] `pnpm build` — succeeds
- [x] reader: surfaces `fontColor` from `<a:srgbClr val="RRGGBB"/>`; uppercases lowercase input; collapses wrong-length / non-hex / theme-reference / missing-link inputs to undefined
- [x] writer: emits `<a:solidFill><a:srgbClr val=".."/>` inside the `<c:txPr>` block when pinned; skips `<a:solidFill>` when unset; threads through every chart family with axes; silently drops on pie / doughnut
- [x] clone: inherits `fontColor` by default; wholesale-replace via `options.dataTable: { ... }` overrides cleanly; `null` / `false` / pie-coercion drop the typography pin alongside the rest of the data table; composes with `fontSize`
- [x] roundtrip: write -> read, parse -> clone -> write -> parse round-trip identical
- [x] end-to-end: `writeXlsx` packaging emits the typography pin into `xl/charts/chart1.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)