### PR TITLE
feat(xlsx): chart data-table italic flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1165,6 +1165,38 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   bold?: boolean;
+  /**
+   * Data-table italic flag. Maps to `<c:dTable><c:txPr><a:p><a:pPr>
+   * <a:defRPr i=".."/></a:pPr></a:p></c:txPr></c:dTable>` — Excel's
+   * "Format Data Table -> Font -> Italic" toggle. The OOXML attribute
+   * is the `xsd:boolean` italic flag on `CT_TextCharacterProperties`
+   * (ECMA-376 Part 1, §21.1.2.3.7); the writer lands `i="1"` (italic)
+   * or `i="0"` (the OOXML default — non-italic) on the default-paragraph
+   * `<a:defRPr>` slot inside the `<c:dTable><c:txPr>` block so a
+   * re-parse picks the flag up off the canonical slot the OOXML schema
+   * exposes.
+   *
+   * Default: omitted — the data table renders non-italic (no `i`
+   * attribute, matching Excel's reference serialization for fresh data
+   * tables whose typography has not been customized; the OOXML default
+   * `0` collapses to absence). Set `true` to emit `i="1"` so the table
+   * renders italic; set `false` explicitly to pin `i="0"` (functionally
+   * identical to omission, but useful when overriding a templated
+   * chart that had italic pinned upstream).
+   *
+   * Composes independently with the other dataTable typography knobs —
+   * {@link fontSize} / {@link fontColor} / {@link bold} — and the four
+   * boolean toggles. Mirrors the chart-title `titleItalic`, axis-title
+   * `axisTitleItalic`, axis tick-label `labelItalic`, legend
+   * `legendItalic`, and data-label `dataLabels.italic` knobs — same
+   * boolean shape, same OOXML `<a:defRPr i=".."/>` mapping — so a
+   * caller can thread a single italic value through every typography-
+   * pinning slot.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  italic?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -4463,6 +4463,8 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (fontColor !== undefined) out.fontColor = fontColor;
   const bold = parseDataTableBold(el);
   if (bold !== undefined) out.bold = bold;
+  const italic = parseDataTableItalic(el);
+  if (italic !== undefined) out.italic = italic;
   return out;
 }
 
@@ -4489,6 +4491,46 @@ function parseDataTableBold(dTable: XmlElement): boolean | undefined {
   const defRPr = findChild(pPr, "defRPr");
   if (!defRPr) return undefined;
   const raw = defRPr.attrs.b;
+  if (typeof raw !== "string") return undefined;
+  switch (raw) {
+    case "1":
+    case "true":
+      return true;
+    case "0":
+    case "false":
+      return false;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pull `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr></a:p>
+ * </c:txPr></c:dTable>` off a data-table block. Returns the italic
+ * flag.
+ *
+ * The OOXML `i` attribute is the `xsd:boolean` italic flag on
+ * `CT_TextCharacterProperties`. An explicit `i="1"` / `"true"`
+ * surfaces `true`; an explicit `i="0"` / `"false"` surfaces `false`
+ * so a templated chart that pinned `i="0"` round-trips literally and
+ * a clone target can override an upstream `i="1"` cleanly. Absence /
+ * malformed tokens collapse to `undefined` so a fresh data table that
+ * never pinned the flag round-trips identically through `cloneChart`.
+ * Mirrors the data-table bold reader (and the chart-title /
+ * axis-title / axis tick-label / legend / data-label italic readers
+ * for the OOXML attribute layout) so a parsed value slots straight
+ * back into the writer's emit path.
+ */
+function parseDataTableItalic(dTable: XmlElement): boolean | undefined {
+  const txPr = findChild(dTable, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.i;
   if (typeof raw !== "string") return undefined;
   switch (raw) {
     case "1":

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1111,6 +1111,7 @@ function resolveDataTable(chart: SheetChart):
       fontSize: number | undefined;
       fontColor: string | undefined;
       bold: boolean | undefined;
+      italic: boolean | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1131,6 +1132,7 @@ function resolveDataTable(chart: SheetChart):
       fontSize: undefined,
       fontColor: undefined,
       bold: undefined,
+      italic: undefined,
     };
   }
 
@@ -1146,6 +1148,7 @@ function resolveDataTable(chart: SheetChart):
     fontSize: resolveDataTableFontSize(raw.fontSize),
     fontColor: resolveDataTableFontColor(raw.fontColor),
     bold: resolveDataTableBold(raw.bold),
+    italic: resolveDataTableItalic(raw.italic),
   };
 }
 
@@ -1199,6 +1202,23 @@ function resolveDataTableBold(value: boolean | undefined): boolean | undefined {
 }
 
 /**
+ * Resolve `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr i=".."/></a:pPr>
+ * </a:p></c:txPr></c:dTable>` from {@link ChartDataTable.italic}.
+ *
+ * Returns the italic flag, or `undefined` when the caller leaves the
+ * field unset / passed a non-boolean token. Mirrors the chart-title /
+ * axis-title / axis tick-label / legend / data-label italic resolvers
+ * (and the data-table bold resolver) exactly — only literal `true` /
+ * `false` pass through; non-boolean tokens (typed escapes from an
+ * untyped caller) collapse to `undefined`.
+ */
+function resolveDataTableItalic(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
@@ -1222,6 +1242,7 @@ function buildDataTable(table: {
   fontSize: number | undefined;
   fontColor: string | undefined;
   bold: boolean | undefined;
+  italic: boolean | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1234,7 +1255,7 @@ function buildDataTable(table: {
   // Part 1, §21.2.2.54). The writer skips emission entirely when no
   // typography knob is pinned so a fresh chart matches Excel's
   // reference serialization byte-for-byte.
-  const txPrXml = buildDataTableTxPr(table.fontSize, table.fontColor, table.bold);
+  const txPrXml = buildDataTableTxPr(table.fontSize, table.fontColor, table.bold, table.italic);
   if (txPrXml !== undefined) children.push(txPrXml);
   return xmlElement("c:dTable", undefined, children);
 }
@@ -1264,11 +1285,19 @@ function buildDataTableTxPr(
   fontSizePt: number | undefined,
   rgbHex: string | undefined,
   bold: boolean | undefined,
+  italic: boolean | undefined,
 ): string | undefined {
-  if (fontSizePt === undefined && rgbHex === undefined && bold === undefined) return undefined;
+  if (
+    fontSizePt === undefined &&
+    rgbHex === undefined &&
+    bold === undefined &&
+    italic === undefined
+  )
+    return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
+  if (italic !== undefined) defRPrAttrs.i = italic ? 1 : 0;
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-table font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10598,6 +10598,158 @@ describe("cloneChart — data table", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.dataTable?.bold).toBe(true);
   });
+
+  // ── data-table italic ──────────────────────────────────────────
+
+  it("inherits the source's dataTable.italic by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          italic: true,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      italic: true,
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited italic", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, italic: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, italic: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, italic: false });
+  });
+
+  it("drops the inherited italic when override clears the typography pin", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, italic: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited italic when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, italic: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.italic into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          italic: true,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:defRPr i="1"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      italic: true,
+    });
+  });
+
+  it("composes italic with fontSize / fontColor / bold through the clone-through path", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { fontSize: 12, fontColor: "1070CA", bold: true, italic: true },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      fontSize: 12,
+      fontColor: "1070CA",
+      bold: true,
+      italic: true,
+    });
+  });
+
+  it("a parsed dataTable.italic round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, italic: true },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.italic).toBe(true);
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.italic).toBe(true);
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9244,6 +9244,173 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.bold).toBe(true);
   });
+
+  // ── data-table italic ──────────────────────────────────────────────
+
+  it("skips the i attribute when italic is unset (writer default)", () => {
+    // Absence collapses to omitting the i attribute entirely — the
+    // OOXML default `0` is functionally identical to absence and Excel
+    // itself omits the attribute on a fresh data table.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toMatch(/i="[01]"/);
+  });
+
+  it("emits i='1' when dataTable.italic is true", () => {
+    const result = writeChart(makeChart({ dataTable: { italic: true } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr i="1"/>');
+  });
+
+  it("emits i='0' explicitly when dataTable.italic is false", () => {
+    // Pinning `false` lets a clone target override an upstream `i="1"`
+    // from a templated chart. Functionally identical to absence but
+    // useful for explicit overrides.
+    const result = writeChart(makeChart({ dataTable: { italic: false } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr i="0"/>');
+  });
+
+  it("collapses non-boolean italic escapes to undefined", () => {
+    // Typed escapes from an untyped caller — strings, null, numbers —
+    // drop the field rather than fabricate a malformed i attribute.
+    const dt = { italic: "yes" } as unknown as { italic: boolean };
+    const result = writeChart(makeChart({ dataTable: dt }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+    const dt2 = { italic: 1 } as unknown as { italic: boolean };
+    const result2 = writeChart(makeChart({ dataTable: dt2 }), "Sheet1");
+    const dTableSlice2 = result2.chartXml.slice(
+      result2.chartXml.indexOf("<c:dTable>"),
+      result2.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice2).not.toContain("<c:txPr>");
+  });
+
+  it("composes italic with fontSize / fontColor / bold on the same defRPr slot", () => {
+    // All four typography knobs land on the same <a:defRPr> — the
+    // size, bold, and italic as attributes, the color as the wrapped <a:solidFill>.
+    const result = writeChart(
+      makeChart({
+        dataTable: { fontSize: 14, fontColor: "1070CA", bold: true, italic: true },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain(
+      '<a:defRPr sz="1400" b="1" i="1"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr>',
+    );
+  });
+
+  it("composes italic with fontSize alone (no fontColor) on a self-closing defRPr", () => {
+    const result = writeChart(makeChart({ dataTable: { fontSize: 14, italic: true } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr sz="1400" i="1"/>');
+  });
+
+  it("threads italic through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: { italic: true } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr i="1"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { italic: true },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<a:defRPr i="1"/>');
+  });
+
+  it("silently drops italic on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { italic: true },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:defRPr i="1"/>');
+  });
+
+  it("composes italic with the four boolean toggles independently", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          italic: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:defRPr i="1"/>');
+  });
+
+  it("round-trips a pinned dataTable italic through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          italic: true,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      italic: true,
+    });
+  });
+
+  it("threads italic end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, italic: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:defRPr i="1"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.italic).toBe(true);
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10028,6 +10028,171 @@ describe("parseChart — data table", () => {
       bold: true,
     });
   });
+
+  // ── data-table italic ──────────────────────────────────────────────
+
+  it("surfaces a pinned dataTable.italic from <a:defRPr i='1'/>", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.italic).toBe(true);
+  });
+
+  it("surfaces an explicit i='0' as italic: false", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="0"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.italic).toBe(false);
+  });
+
+  it("accepts the OOXML textual <xsd:boolean> spellings for i", () => {
+    const trueXml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="true"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(trueXml)?.dataTable?.italic).toBe(true);
+    const falseXml = trueXml.replace('i="true"', 'i="false"');
+    expect(parseChart(falseXml)?.dataTable?.italic).toBe(false);
+  });
+
+  it("collapses an unknown i token to undefined", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr i="yes"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.italic).toBeUndefined();
+  });
+
+  it("returns undefined italic when <c:txPr> is missing entirely", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.italic).toBeUndefined();
+  });
+
+  it("returns undefined italic when the i attribute is missing on defRPr", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400" b="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.italic).toBeUndefined();
+    // The fontSize and bold parts still surface.
+    expect(parseChart(xml)?.dataTable?.fontSize).toBe(14);
+    expect(parseChart(xml)?.dataTable?.bold).toBe(true);
+  });
+
+  it("surfaces every typography pin together when all four are pinned", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1600" b="1" i="1"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fontSize: 16,
+      fontColor: "1070CA",
+      bold: true,
+      italic: true,
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `italic?: boolean` to `ChartDataTable`, mapped to `<c:plotArea><c:dTable><c:txPr><a:p><a:pPr><a:defRPr i=\"..\"/></a:pPr></a:p></c:txPr></c:dTable>` per the `CT_DTable` schema.
- Reader / writer / clone-through all support the new knob; mirrors the chart-title `titleItalic`, axis-title `axisTitleItalic`, tick-label `labelItalic`, legend `legendItalic`, and data-label `dataLabels.italic` knobs — same boolean shape, same OOXML `<a:defRPr i=\"..\"/>` mapping.
- Composes independently with `dataTable.fontSize`, `dataTable.fontColor`, `dataTable.bold`, and the four boolean toggles; all typography pins land on the same `<a:defRPr>` slot.
- Silently dropped on pie / doughnut along with the rest of the data-table config (no `<c:dTable>` slot when the chart has no axes).

Stacked on top of #290 (data-table bold), #289 (data-table fontColor), and #288 (data-table fontSize) — the writer / reader / clone helpers extend the same code paths.

Refs #136

## Test plan

- [x] `pnpm test` — lint + typecheck + vitest (5898 tests, all pass; 25 new for this feature)
- [x] `pnpm build` — succeeds
- [x] reader: surfaces `italic` from `<a:defRPr i=\"1\"/>`; accepts the OOXML textual `<xsd:boolean>` spellings; explicit `i=\"0\"` surfaces as `false`; unknown / missing tokens collapse to undefined
- [x] writer: emits `i=\"1\"` for `true`, `i=\"0\"` for `false`, omits attribute entirely for absence; threads through every chart family with axes; silently drops on pie / doughnut
- [x] clone: inherits `italic` by default; wholesale-replace via `options.dataTable: { ... }` overrides cleanly; composes with `fontSize` / `fontColor` / `bold`
- [x] roundtrip: write -> read, parse -> clone -> write -> parse round-trip identical
- [x] end-to-end: `writeXlsx` packaging emits the typography pin into `xl/charts/chart1.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)