### PR TITLE
feat(xlsx): chart data-table underline flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1165,6 +1165,45 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   bold?: boolean;
+  /**
+   * Data-table underline flag. Maps to `<c:dTable><c:txPr><a:p><a:pPr>
+   * <a:defRPr u=".."/></a:pPr></a:p></c:txPr></c:dTable>` — Excel's
+   * "Format Data Table -> Font -> Underline" toggle. The OOXML
+   * attribute is the `ST_TextUnderlineType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer lands `u="sng"` (single underline — Excel's UI variant) or
+   * `u="none"` (the OOXML default — non-underlined) on the
+   * default-paragraph `<a:defRPr>` slot inside the `<c:dTable><c:txPr>`
+   * block so a re-parse picks the flag up off the canonical slot the
+   * OOXML schema exposes.
+   *
+   * Default: omitted — the data table renders non-underlined (no `u`
+   * attribute, matching Excel's reference serialization for fresh data
+   * tables whose typography has not been customized; the OOXML default
+   * `"none"` collapses to absence). Set `true` to emit `u="sng"` so
+   * the table renders single-underlined; set `false` explicitly to pin
+   * `u="none"` (functionally identical to omission, but useful when
+   * overriding a templated chart that had underline pinned upstream).
+   *
+   * The reader surfaces only the boolean shape Excel's UI exposes —
+   * `u="sng"` collapses to `true`, `u="none"` collapses to `false`,
+   * and the schema's other variants (`"dbl"`, `"heavy"`, `"dotted"`,
+   * `"dotDash"`, `"wavy"`, etc.) collapse to `undefined` rather than
+   * silently downgrade the choice to a single line on round-trip.
+   *
+   * Composes independently with the other dataTable typography knobs —
+   * {@link fontSize} / {@link fontColor} / {@link bold} — and the
+   * four boolean toggles. Mirrors the chart-title `titleUnderline`,
+   * axis-title `axisTitleUnderline`, axis tick-label `labelUnderline`,
+   * legend `legendUnderline`, and data-label `dataLabels.underline`
+   * knobs — same boolean shape, same OOXML `<a:defRPr u=".."/>`
+   * mapping — so a caller can thread a single underline value through
+   * every typography-pinning slot.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  underline?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -4463,6 +4463,8 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (fontColor !== undefined) out.fontColor = fontColor;
   const bold = parseDataTableBold(el);
   if (bold !== undefined) out.bold = bold;
+  const underline = parseDataTableUnderline(el);
+  if (underline !== undefined) out.underline = underline;
   return out;
 }
 
@@ -4500,6 +4502,46 @@ function parseDataTableBold(dTable: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+/**
+ * Pull `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr></a:p>
+ * </c:txPr></c:dTable>` off a data-table block. Returns the underline
+ * flag.
+ *
+ * The OOXML `u` attribute is the `ST_TextUnderlineType` enumeration
+ * on `CT_TextCharacterProperties`. `u="sng"` (Excel's UI variant —
+ * single underline) surfaces `true`; `u="none"` (the OOXML default)
+ * surfaces `false` so a templated chart that pinned `u="none"`
+ * round-trips literally and a clone target can override an upstream
+ * `u="sng"` cleanly. The schema's other variants (`"dbl"`, `"heavy"`,
+ * `"dotted"`, `"dotDash"`, `"wavy"`, etc.) and absence / malformed
+ * tokens collapse to `undefined` so a fresh data table that never
+ * pinned the flag round-trips identically through `cloneChart`. The
+ * reader never silently downgrades a non-`"sng"` underline to a
+ * single line on round-trip; only the boolean shape Excel's UI
+ * exposes survives the parse.
+ *
+ * Mirrors the data-table bold reader pattern — `true` and `false`
+ * round-trip explicitly so a clone can override either direction —
+ * while the OOXML attribute layout matches the chart-title /
+ * axis-title / axis tick-label / legend / data-label underline
+ * readers exactly so a parsed value slots straight back into the
+ * writer's emit path.
+ */
+function parseDataTableUnderline(dTable: XmlElement): boolean | undefined {
+  const txPr = findChild(dTable, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.u;
+  if (raw === "sng") return true;
+  if (raw === "none") return false;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1111,6 +1111,7 @@ function resolveDataTable(chart: SheetChart):
       fontSize: number | undefined;
       fontColor: string | undefined;
       bold: boolean | undefined;
+      underline: boolean | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1131,6 +1132,7 @@ function resolveDataTable(chart: SheetChart):
       fontSize: undefined,
       fontColor: undefined,
       bold: undefined,
+      underline: undefined,
     };
   }
 
@@ -1146,6 +1148,7 @@ function resolveDataTable(chart: SheetChart):
     fontSize: resolveDataTableFontSize(raw.fontSize),
     fontColor: resolveDataTableFontColor(raw.fontColor),
     bold: resolveDataTableBold(raw.bold),
+    underline: resolveDataTableUnderline(raw.underline),
   };
 }
 
@@ -1199,6 +1202,25 @@ function resolveDataTableBold(value: boolean | undefined): boolean | undefined {
 }
 
 /**
+ * Resolve `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr u=".."/></a:pPr>
+ * </a:p></c:txPr></c:dTable>` from {@link ChartDataTable.underline}.
+ *
+ * Returns the underline flag, or `undefined` when the caller leaves
+ * the field unset / passed a non-boolean token. Mirrors the
+ * chart-title / axis-title / axis tick-label / legend / data-label
+ * underline resolvers exactly — only literal `true` / `false` pass
+ * through; non-boolean tokens (typed escapes from an untyped caller)
+ * collapse to `undefined`. The writer translates `true` into
+ * `u="sng"` (Excel's UI variant — single underline) and `false` into
+ * `u="none"` at emit time.
+ */
+function resolveDataTableUnderline(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  if (value === false) return false;
+  return undefined;
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
@@ -1222,6 +1244,7 @@ function buildDataTable(table: {
   fontSize: number | undefined;
   fontColor: string | undefined;
   bold: boolean | undefined;
+  underline: boolean | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1234,7 +1257,7 @@ function buildDataTable(table: {
   // Part 1, §21.2.2.54). The writer skips emission entirely when no
   // typography knob is pinned so a fresh chart matches Excel's
   // reference serialization byte-for-byte.
-  const txPrXml = buildDataTableTxPr(table.fontSize, table.fontColor, table.bold);
+  const txPrXml = buildDataTableTxPr(table.fontSize, table.fontColor, table.bold, table.underline);
   if (txPrXml !== undefined) children.push(txPrXml);
   return xmlElement("c:dTable", undefined, children);
 }
@@ -1264,11 +1287,19 @@ function buildDataTableTxPr(
   fontSizePt: number | undefined,
   rgbHex: string | undefined,
   bold: boolean | undefined,
+  underline: boolean | undefined,
 ): string | undefined {
-  if (fontSizePt === undefined && rgbHex === undefined && bold === undefined) return undefined;
+  if (
+    fontSizePt === undefined &&
+    rgbHex === undefined &&
+    bold === undefined &&
+    underline === undefined
+  )
+    return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
+  if (underline !== undefined) defRPrAttrs.u = underline ? "sng" : "none";
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-table font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10598,6 +10598,158 @@ describe("cloneChart — data table", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.dataTable?.bold).toBe(true);
   });
+
+  // ── data-table underline ───────────────────────────────────────
+
+  it("inherits the source's dataTable.underline by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          underline: true,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      underline: true,
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited underline", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, underline: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, underline: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, underline: false });
+  });
+
+  it("drops the inherited underline when override clears the typography pin", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, underline: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited underline when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, underline: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.underline into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          underline: true,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:defRPr u="sng"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      underline: true,
+    });
+  });
+
+  it("composes underline with fontSize / fontColor / bold through the clone-through path", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { fontSize: 12, fontColor: "1070CA", bold: true, underline: true },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      fontSize: 12,
+      fontColor: "1070CA",
+      bold: true,
+      underline: true,
+    });
+  });
+
+  it("a parsed dataTable.underline round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, underline: true },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.underline).toBe(true);
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.underline).toBe(true);
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9244,6 +9244,176 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.bold).toBe(true);
   });
+
+  // ── data-table underline ───────────────────────────────────────────
+
+  it("skips the u attribute when underline is unset (writer default)", () => {
+    // Absence collapses to omitting the u attribute entirely — the
+    // OOXML default `"none"` is functionally identical to absence
+    // and Excel itself omits the attribute on a fresh data table.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toMatch(/u="(sng|none)"/);
+  });
+
+  it("emits u='sng' when dataTable.underline is true", () => {
+    const result = writeChart(makeChart({ dataTable: { underline: true } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr u="sng"/>');
+  });
+
+  it("emits u='none' explicitly when dataTable.underline is false", () => {
+    // Pinning `false` lets a clone target override an upstream `u="sng"`
+    // from a templated chart. Functionally identical to absence but
+    // useful for explicit overrides.
+    const result = writeChart(makeChart({ dataTable: { underline: false } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr u="none"/>');
+  });
+
+  it("collapses non-boolean underline escapes to undefined", () => {
+    // Typed escapes from an untyped caller — strings, null, numbers —
+    // drop the field rather than fabricate a malformed u attribute.
+    const dt = { underline: "yes" } as unknown as { underline: boolean };
+    const result = writeChart(makeChart({ dataTable: dt }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+    const dt2 = { underline: 1 } as unknown as { underline: boolean };
+    const result2 = writeChart(makeChart({ dataTable: dt2 }), "Sheet1");
+    const dTableSlice2 = result2.chartXml.slice(
+      result2.chartXml.indexOf("<c:dTable>"),
+      result2.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice2).not.toContain("<c:txPr>");
+  });
+
+  it("composes underline with fontSize / fontColor / bold on the same defRPr slot", () => {
+    // All four typography knobs land on the same <a:defRPr> — the
+    // size, bold, and underline as attributes, the color as the wrapped <a:solidFill>.
+    const result = writeChart(
+      makeChart({
+        dataTable: { fontSize: 14, fontColor: "1070CA", bold: true, underline: true },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain(
+      '<a:defRPr sz="1400" b="1" u="sng"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr>',
+    );
+  });
+
+  it("composes underline with fontSize alone (no fontColor) on a self-closing defRPr", () => {
+    const result = writeChart(
+      makeChart({ dataTable: { fontSize: 14, underline: true } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<a:defRPr sz="1400" u="sng"/>');
+  });
+
+  it("threads underline through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: { underline: true } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr u="sng"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { underline: true },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<a:defRPr u="sng"/>');
+  });
+
+  it("silently drops underline on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { underline: true },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:defRPr u="sng"/>');
+  });
+
+  it("composes underline with the four boolean toggles independently", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          underline: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:defRPr u="sng"/>');
+  });
+
+  it("round-trips a pinned dataTable underline through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          underline: true,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      underline: true,
+    });
+  });
+
+  it("threads underline end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, underline: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:defRPr u="sng"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.underline).toBe(true);
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10028,6 +10028,152 @@ describe("parseChart — data table", () => {
       bold: true,
     });
   });
+
+  // ── data-table underline ───────────────────────────────────────────
+
+  it("surfaces a pinned dataTable.underline from <a:defRPr u='sng'/>", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr u="sng"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.underline).toBe(true);
+  });
+
+  it("surfaces an explicit u='none' as underline: false", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr u="none"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.underline).toBe(false);
+  });
+
+  it("collapses non-Excel-UI underline variants to undefined", () => {
+    // The OOXML schema allows `dbl`, `heavy`, `dotted`, `dotDash`,
+    // `wavy`, etc. The reader collapses them all to undefined rather
+    // than silently downgrade the choice to a single underline.
+    for (const variant of ["dbl", "heavy", "dotted", "dotDash", "wavy", "dash"]) {
+      const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr u="${variant}"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+      expect(parseChart(xml)?.dataTable?.underline).toBeUndefined();
+    }
+  });
+
+  it("returns undefined underline when <c:txPr> is missing entirely", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.underline).toBeUndefined();
+  });
+
+  it("returns undefined underline when the u attribute is missing on defRPr", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400" b="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.underline).toBeUndefined();
+    // The fontSize and bold parts still surface.
+    expect(parseChart(xml)?.dataTable?.fontSize).toBe(14);
+    expect(parseChart(xml)?.dataTable?.bold).toBe(true);
+  });
+
+  it("surfaces every typography pin together when all four are pinned", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1600" b="1" u="sng"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fontSize: 16,
+      fontColor: "1070CA",
+      bold: true,
+      underline: true,
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `underline?: boolean` to `ChartDataTable`, mapped to `<c:plotArea><c:dTable><c:txPr><a:p><a:pPr><a:defRPr u=\"..\"/></a:pPr></a:p></c:txPr></c:dTable>` per the `CT_DTable` schema.
- Reader / writer / clone-through all support the new knob; mirrors the chart-title `titleUnderline`, axis-title `axisTitleUnderline`, tick-label `labelUnderline`, legend `legendUnderline`, and data-label `dataLabels.underline` knobs — same boolean shape, same OOXML `<a:defRPr u=\"..\"/>` mapping.
- The reader surfaces only the boolean shape Excel's UI exposes — `u=\"sng\"` collapses to `true`, `u=\"none\"` collapses to `false`, schema's other variants (`\"dbl\"`, `\"heavy\"`, `\"dotted\"`, `\"dotDash\"`, `\"wavy\"`, etc.) collapse to `undefined`.
- Composes independently with `dataTable.fontSize`, `dataTable.fontColor`, `dataTable.bold`, and the four boolean toggles; all typography pins land on the same `<a:defRPr>` slot.
- Silently dropped on pie / doughnut along with the rest of the data-table config (no `<c:dTable>` slot when the chart has no axes).

Stacked on top of #290 (data-table bold), #289 (data-table fontColor), and #288 (data-table fontSize); sibling to the parallel italic PR (#291) — the writer / reader / clone helpers extend the same code paths.

Refs #136

## Test plan

- [x] `pnpm test` — lint + typecheck + vitest (5897 tests, all pass; 24 new for this feature)
- [x] `pnpm build` — succeeds
- [x] reader: surfaces `underline` from `<a:defRPr u=\"sng\"/>`; explicit `u=\"none\"` surfaces as `false`; non-Excel-UI variants and unknown / missing tokens collapse to undefined
- [x] writer: emits `u=\"sng\"` for `true`, `u=\"none\"` for `false`, omits attribute entirely for absence; threads through every chart family with axes; silently drops on pie / doughnut
- [x] clone: inherits `underline` by default; wholesale-replace via `options.dataTable: { ... }` overrides cleanly; composes with `fontSize` / `fontColor` / `bold`
- [x] roundtrip: write -> read, parse -> clone -> write -> parse round-trip identical
- [x] end-to-end: `writeXlsx` packaging emits the typography pin into `xl/charts/chart1.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)