### PR TITLE
feat(xlsx): chart data-table strikethrough flag — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1165,6 +1165,48 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   bold?: boolean;
+  /**
+   * Data-table strikethrough flag. Maps to `<c:dTable><c:txPr><a:p>
+   * <a:pPr><a:defRPr strike=".."/></a:pPr></a:p></c:txPr></c:dTable>` —
+   * Excel's "Format Data Table -> Font -> Strikethrough" toggle. The
+   * OOXML attribute is the `ST_TextStrikeType` enumeration on
+   * `CT_TextCharacterProperties` (ECMA-376 Part 1, §21.1.2.3.7); the
+   * writer lands `strike="sngStrike"` (single line — Excel's UI
+   * variant) on the default-paragraph `<a:defRPr>` slot inside the
+   * `<c:dTable><c:txPr>` block so a re-parse picks the flag up off the
+   * canonical slot the OOXML schema exposes.
+   *
+   * Default: omitted — the data table renders without a strikethrough
+   * (no `strike` attribute, matching Excel's reference serialization
+   * for fresh data tables whose typography has not been customized).
+   * Set `true` to emit `strike="sngStrike"` so the table renders with
+   * a single-line strikethrough; explicit `false` collapses to
+   * absence (functionally identical, since the OOXML default
+   * `"noStrike"` is what Excel's UI exposes as "off"; the writer
+   * keeps the surfaced shape consistent with what the UI authors —
+   * `"sngStrike"` only, never `"noStrike"` or `"dblStrike"`).
+   *
+   * The reader surfaces only the boolean shape Excel's UI exposes —
+   * `strike="sngStrike"` collapses to `true`; the OOXML default
+   * `"noStrike"` and the schema's other variant `"dblStrike"` (and
+   * malformed tokens) collapse to `undefined` so absence and
+   * `"noStrike"` round-trip identically through `cloneChart`. The
+   * reader never silently downgrades `"dblStrike"` to a single line on
+   * round-trip; only the UI-default `"sngStrike"` survives the parse.
+   *
+   * Composes independently with the other dataTable typography knobs —
+   * {@link fontSize} / {@link fontColor} / {@link bold} — and the
+   * four boolean toggles. Mirrors the chart-title `titleStrikethrough`,
+   * axis-title `axisTitleStrikethrough`, axis tick-label
+   * `labelStrikethrough`, legend `legendStrikethrough`, and data-label
+   * `dataLabels.strikethrough` knobs — same boolean shape, same OOXML
+   * `<a:defRPr strike=".."/>` mapping — so a caller can thread a
+   * single strikethrough value through every typography-pinning slot.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  strikethrough?: boolean;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -4463,6 +4463,8 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (fontColor !== undefined) out.fontColor = fontColor;
   const bold = parseDataTableBold(el);
   if (bold !== undefined) out.bold = bold;
+  const strikethrough = parseDataTableStrikethrough(el);
+  if (strikethrough !== undefined) out.strikethrough = strikethrough;
   return out;
 }
 
@@ -4500,6 +4502,38 @@ function parseDataTableBold(dTable: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+/**
+ * Pull `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr strike=".."/></a:pPr>
+ * </a:p></c:txPr></c:dTable>` off a data-table block. Returns the
+ * strikethrough flag.
+ *
+ * The OOXML `strike` attribute is the `ST_TextStrikeType`
+ * enumeration on `CT_TextCharacterProperties`. Only
+ * `strike="sngStrike"` (Excel's UI variant — single line) surfaces
+ * `true`; the OOXML default `"noStrike"` and the non-UI variant
+ * `"dblStrike"` (and any malformed token) collapse to `undefined` so
+ * absence and `"noStrike"` round-trip identically through
+ * `cloneChart`. Reporting `"dblStrike"` as `true` would silently
+ * downgrade the choice to a single line on round-trip; the writer
+ * emits only `"sngStrike"`, matching the boolean shape the UI
+ * exposes. Mirrors the chart-title / axis-title / axis tick-label /
+ * legend / data-label strikethrough readers exactly so a parsed value
+ * slots straight back into the writer's emit path.
+ */
+function parseDataTableStrikethrough(dTable: XmlElement): boolean | undefined {
+  const txPr = findChild(dTable, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const raw = defRPr.attrs.strike;
+  if (raw === "sngStrike") return true;
+  return undefined;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1111,6 +1111,7 @@ function resolveDataTable(chart: SheetChart):
       fontSize: number | undefined;
       fontColor: string | undefined;
       bold: boolean | undefined;
+      strikethrough: boolean | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1131,6 +1132,7 @@ function resolveDataTable(chart: SheetChart):
       fontSize: undefined,
       fontColor: undefined,
       bold: undefined,
+      strikethrough: undefined,
     };
   }
 
@@ -1146,6 +1148,7 @@ function resolveDataTable(chart: SheetChart):
     fontSize: resolveDataTableFontSize(raw.fontSize),
     fontColor: resolveDataTableFontColor(raw.fontColor),
     bold: resolveDataTableBold(raw.bold),
+    strikethrough: resolveDataTableStrikethrough(raw.strikethrough),
   };
 }
 
@@ -1199,6 +1202,26 @@ function resolveDataTableBold(value: boolean | undefined): boolean | undefined {
 }
 
 /**
+ * Resolve `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr strike=".."/>
+ * </a:pPr></a:p></c:txPr></c:dTable>` from
+ * {@link ChartDataTable.strikethrough}.
+ *
+ * Returns `true` when the caller pins the strikethrough flag literally;
+ * every other value (explicit `false`, absence, non-boolean tokens
+ * leaking past the type guard) collapses to `undefined` so the writer
+ * never emits a `strike` attribute below `"sngStrike"`. The OOXML
+ * default `"noStrike"` is functionally identical to absence — the
+ * writer keeps the surfaced shape consistent with what Excel's UI
+ * authors (`"sngStrike"` only, never `"noStrike"` or `"dblStrike"`),
+ * mirroring how `resolveTitleStrike` / `resolveLegendStrikethrough` /
+ * `resolveDataLabelsStrikethrough` land on their `<a:defRPr>` slots.
+ */
+function resolveDataTableStrikethrough(value: boolean | undefined): boolean | undefined {
+  if (value === true) return true;
+  return undefined;
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
@@ -1222,6 +1245,7 @@ function buildDataTable(table: {
   fontSize: number | undefined;
   fontColor: string | undefined;
   bold: boolean | undefined;
+  strikethrough: boolean | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1234,7 +1258,12 @@ function buildDataTable(table: {
   // Part 1, §21.2.2.54). The writer skips emission entirely when no
   // typography knob is pinned so a fresh chart matches Excel's
   // reference serialization byte-for-byte.
-  const txPrXml = buildDataTableTxPr(table.fontSize, table.fontColor, table.bold);
+  const txPrXml = buildDataTableTxPr(
+    table.fontSize,
+    table.fontColor,
+    table.bold,
+    table.strikethrough,
+  );
   if (txPrXml !== undefined) children.push(txPrXml);
   return xmlElement("c:dTable", undefined, children);
 }
@@ -1264,11 +1293,25 @@ function buildDataTableTxPr(
   fontSizePt: number | undefined,
   rgbHex: string | undefined,
   bold: boolean | undefined,
+  strikethrough: boolean | undefined,
 ): string | undefined {
-  if (fontSizePt === undefined && rgbHex === undefined && bold === undefined) return undefined;
+  if (
+    fontSizePt === undefined &&
+    rgbHex === undefined &&
+    bold === undefined &&
+    strikethrough === undefined
+  )
+    return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
   if (fontSizePt !== undefined) defRPrAttrs.sz = fontSizePt * TITLE_FONT_SZ_PER_POINT;
   if (bold !== undefined) defRPrAttrs.b = bold ? 1 : 0;
+  // Strikethrough rides as `strike="sngStrike"` on the same
+  // `<a:defRPr>` slot. Absence collapses to omitting the attribute
+  // entirely (the OOXML default `"noStrike"` is functionally
+  // identical to absence — the reader collapses both to `undefined`).
+  // The writer never emits `"noStrike"` or `"dblStrike"` so the
+  // surfaced shape stays consistent with Excel's UI checkbox.
+  if (strikethrough === true) defRPrAttrs.strike = "sngStrike";
   // OOXML's `<a:defRPr><a:solidFill><a:srgbClr val="RRGGBB"/>
   // </a:solidFill></a:defRPr>` carries the data-table font color.
   // Absence (`undefined`) collapses to skipping the `<a:solidFill>`

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10598,6 +10598,163 @@ describe("cloneChart — data table", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.dataTable?.bold).toBe(true);
   });
+
+  // ── data-table strikethrough ───────────────────────────────────
+
+  it("inherits the source's dataTable.strikethrough by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          strikethrough: true,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      strikethrough: true,
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited strikethrough", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, strikethrough: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, strikethrough: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, strikethrough: false });
+  });
+
+  it("drops the inherited strikethrough when override clears the typography pin", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, strikethrough: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited strikethrough when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, strikethrough: true },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.strikethrough into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          strikethrough: true,
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:defRPr strike="sngStrike"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      strikethrough: true,
+    });
+  });
+
+  it("composes strikethrough with fontSize / fontColor / bold through the clone-through path", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          fontSize: 12,
+          fontColor: "1070CA",
+          bold: true,
+          strikethrough: true,
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      fontSize: 12,
+      fontColor: "1070CA",
+      bold: true,
+      strikethrough: true,
+    });
+  });
+
+  it("a parsed dataTable.strikethrough round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, strikethrough: true },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.strikethrough).toBe(true);
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.strikethrough).toBe(true);
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -10902,7 +10902,6 @@ describe("cloneChart — data table", () => {
     expect(reparsed?.dataTable?.underline).toBe(true);
   });
 
-
   // ── data-table strikethrough ───────────────────────────────────
 
   it("inherits the source's dataTable.strikethrough by default", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9244,6 +9244,184 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.bold).toBe(true);
   });
+
+  // ── data-table strikethrough ───────────────────────────────────────
+
+  it("skips the strike attribute when strikethrough is unset (writer default)", () => {
+    // Absence collapses to omitting the strike attribute entirely —
+    // the OOXML default `"noStrike"` is functionally identical to
+    // absence and Excel itself omits the attribute on a fresh data
+    // table.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toMatch(/strike="(sngStrike|noStrike|dblStrike)"/);
+  });
+
+  it("emits strike='sngStrike' when dataTable.strikethrough is true", () => {
+    const result = writeChart(makeChart({ dataTable: { strikethrough: true } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr strike="sngStrike"/>');
+  });
+
+  it("collapses dataTable.strikethrough: false to absence (no strike attribute)", () => {
+    // The OOXML default `"noStrike"` is functionally identical to
+    // absence — the writer drops the attribute rather than emit
+    // `"noStrike"` so the round-trip stays consistent with Excel's
+    // UI checkbox.
+    const result = writeChart(makeChart({ dataTable: { strikethrough: false } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain('strike="');
+    // The whole txPr block is skipped because there's no other typography pin.
+    expect(dTableSlice).not.toContain("<c:txPr>");
+  });
+
+  it("collapses non-boolean strikethrough escapes to undefined", () => {
+    // Typed escapes from an untyped caller — strings, null, numbers —
+    // drop the field rather than fabricate a malformed strike attribute.
+    const dt = { strikethrough: "yes" } as unknown as { strikethrough: boolean };
+    const result = writeChart(makeChart({ dataTable: dt }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+    const dt2 = { strikethrough: 1 } as unknown as { strikethrough: boolean };
+    const result2 = writeChart(makeChart({ dataTable: dt2 }), "Sheet1");
+    const dTableSlice2 = result2.chartXml.slice(
+      result2.chartXml.indexOf("<c:dTable>"),
+      result2.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice2).not.toContain("<c:txPr>");
+  });
+
+  it("composes strikethrough with fontSize / fontColor / bold on the same defRPr slot", () => {
+    // All four typography knobs land on the same <a:defRPr> — the
+    // size, bold, and strike as attributes, the color as the wrapped <a:solidFill>.
+    const result = writeChart(
+      makeChart({
+        dataTable: { fontSize: 14, fontColor: "1070CA", bold: true, strikethrough: true },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain(
+      '<a:defRPr sz="1400" b="1" strike="sngStrike"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr>',
+    );
+  });
+
+  it("composes strikethrough with fontSize alone (no fontColor) on a self-closing defRPr", () => {
+    const result = writeChart(
+      makeChart({ dataTable: { fontSize: 14, strikethrough: true } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<a:defRPr sz="1400" strike="sngStrike"/>');
+  });
+
+  it("threads strikethrough through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: { strikethrough: true } }), "Sheet1");
+      expect(result.chartXml).toContain('<a:defRPr strike="sngStrike"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { strikethrough: true },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<a:defRPr strike="sngStrike"/>');
+  });
+
+  it("silently drops strikethrough on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { strikethrough: true },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:defRPr strike="sngStrike"/>');
+  });
+
+  it("composes strikethrough with the four boolean toggles independently", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          strikethrough: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:defRPr strike="sngStrike"/>');
+  });
+
+  it("round-trips a pinned dataTable strikethrough through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          strikethrough: true,
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      strikethrough: true,
+    });
+  });
+
+  it("threads strikethrough end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, strikethrough: true },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:defRPr strike="sngStrike"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.strikethrough).toBe(true);
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9581,7 +9581,6 @@ describe("writeChart — data table", () => {
     expect(reparsed?.dataTable?.underline).toBe(true);
   });
 
-
   // ── data-table strikethrough ───────────────────────────────────────
 
   it("skips the strike attribute when strikethrough is unset (writer default)", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10028,6 +10028,175 @@ describe("parseChart — data table", () => {
       bold: true,
     });
   });
+
+  // ── data-table strikethrough ───────────────────────────────────────
+
+  it("surfaces a pinned dataTable.strikethrough from <a:defRPr strike='sngStrike'/>", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr strike="sngStrike"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.strikethrough).toBe(true);
+  });
+
+  it("collapses an explicit strike='noStrike' to undefined", () => {
+    // The OOXML default `"noStrike"` is functionally identical to
+    // absence — reporting it as `false` would create a silent
+    // round-trip mismatch (the writer emits only `"sngStrike"`).
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr strike="noStrike"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.strikethrough).toBeUndefined();
+  });
+
+  it("collapses the dblStrike variant to undefined", () => {
+    // Reporting `"dblStrike"` as `true` would silently downgrade the
+    // choice to a single line on round-trip. Drop it instead so the
+    // round-trip behaviour is loss-aware.
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr strike="dblStrike"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.strikethrough).toBeUndefined();
+  });
+
+  it("collapses an unknown strike token to undefined", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr strike="weirdStrike"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.strikethrough).toBeUndefined();
+  });
+
+  it("returns undefined strikethrough when <c:txPr> is missing entirely", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.strikethrough).toBeUndefined();
+  });
+
+  it("returns undefined strikethrough when the strike attribute is missing on defRPr", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400" b="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.strikethrough).toBeUndefined();
+    // The fontSize and bold parts still surface.
+    expect(parseChart(xml)?.dataTable?.fontSize).toBe(14);
+    expect(parseChart(xml)?.dataTable?.bold).toBe(true);
+  });
+
+  it("surfaces every typography pin together when all four are pinned", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1600" b="1" strike="sngStrike"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fontSize: 16,
+      fontColor: "1070CA",
+      bold: true,
+      strikethrough: true,
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10339,7 +10339,6 @@ describe("parseChart — data table", () => {
     });
   });
 
-
   // ── data-table strikethrough ───────────────────────────────────────
 
   it("surfaces a pinned dataTable.strikethrough from <a:defRPr strike='sngStrike'/>", () => {


### PR DESCRIPTION
## Summary

- Adds `strikethrough?: boolean` to `ChartDataTable`, mapped to `<c:plotArea><c:dTable><c:txPr><a:p><a:pPr><a:defRPr strike=\"..\"/></a:pPr></a:p></c:txPr></c:dTable>` per the `CT_DTable` schema.
- Reader / writer / clone-through all support the new knob; mirrors the chart-title `titleStrikethrough`, axis-title `axisTitleStrikethrough`, tick-label `labelStrikethrough`, legend `legendStrikethrough`, and data-label `dataLabels.strikethrough` knobs — same boolean shape, same OOXML `<a:defRPr strike=\"..\"/>` mapping.
- The reader surfaces only the boolean shape Excel's UI exposes — `strike=\"sngStrike\"` collapses to `true`; `\"noStrike\"`, `\"dblStrike\"`, and malformed tokens collapse to `undefined` so the round-trip never silently downgrades a double strikethrough to a single line.
- The writer emits `strike=\"sngStrike\"` for `true` only, and skips the attribute entirely for `false` / absence (the OOXML default `\"noStrike\"` is functionally identical to absence).
- Composes independently with `dataTable.fontSize`, `dataTable.fontColor`, `dataTable.bold`, and the four boolean toggles; all typography pins land on the same `<a:defRPr>` slot.
- Silently dropped on pie / doughnut along with the rest of the data-table config (no `<c:dTable>` slot when the chart has no axes).

Stacked on top of #290 (data-table bold), #289 (data-table fontColor), and #288 (data-table fontSize); sibling to the parallel italic / underline PRs (#291 / #292) — the writer / reader / clone helpers extend the same code paths.

Refs #136

## Test plan

- [x] `pnpm test` — lint + typecheck + vitest (5898 tests, all pass; 25 new for this feature)
- [x] `pnpm build` — succeeds
- [x] reader: surfaces `strikethrough` from `<a:defRPr strike=\"sngStrike\"/>`; explicit `\"noStrike\"`, `\"dblStrike\"`, and malformed tokens collapse to undefined
- [x] writer: emits `strike=\"sngStrike\"` for `true`, skips entirely for `false` and absence; threads through every chart family with axes; silently drops on pie / doughnut
- [x] clone: inherits `strikethrough` by default; wholesale-replace via `options.dataTable: { ... }` overrides cleanly; composes with `fontSize` / `fontColor` / `bold`
- [x] roundtrip: write -> read, parse -> clone -> write -> parse round-trip identical
- [x] end-to-end: `writeXlsx` packaging emits the typography pin into `xl/charts/chart1.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)