### PR TITLE
feat(xlsx): chart data-table font family — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1279,6 +1279,53 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   strikethrough?: boolean;
+  /**
+   * Data-table font family / typeface. Maps to `<c:dTable><c:txPr>
+   * <a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr></a:pPr>
+   * </a:p></c:txPr></c:dTable>` — Excel's "Format Data Table -> Font
+   * -> Font" picker. The OOXML `<a:latin typeface=".."/>` element
+   * carries the typeface name (`CT_TextFont` on
+   * `CT_TextCharacterProperties`' latin slot — ECMA-376 Part 1,
+   * §21.1.2.3.7); the writer lands the element on the default-
+   * paragraph `<a:defRPr>` slot inside the `<c:dTable><c:txPr>` block
+   * so a re-parse picks the typeface up off the canonical slot the
+   * OOXML schema exposes.
+   *
+   * Accepts any non-empty string typeface name (e.g. `"Calibri"`,
+   * `"Arial"`, `"Times New Roman"`); the writer trims surrounding
+   * whitespace and emits the trimmed value verbatim (XML-escaped) so
+   * Excel can resolve the named font from the workbook's font scheme
+   * or the host system's installed fonts. Empty / whitespace-only
+   * strings and non-string tokens collapse to `undefined` so the
+   * writer skips the entire `<a:latin>` element and the data table
+   * inherits Excel's reference theme typeface.
+   *
+   * Default: omitted — the data table renders in Excel's reference
+   * theme typeface (no `<a:latin>` element, the writer skips the
+   * element entirely). Pin a typeface name to render the table in
+   * that font.
+   *
+   * The `<a:latin>` element follows `<a:solidFill>` per the
+   * CT_TextCharacterProperties child sequence so a data-table block
+   * with both `fontColor` and `fontFamily` set lands the children in
+   * canonical schema order — a fresh chart matches Excel's reference
+   * serialization byte-for-byte. Composes independently with the
+   * other dataTable typography knobs — {@link fontSize} /
+   * {@link fontColor} / {@link bold} / {@link italic} /
+   * {@link underline} / {@link strikethrough} — and the four boolean
+   * toggles. Mirrors {@link SheetChart.titleFontFamily} /
+   * {@link SheetChart.legendFontFamily} /
+   * {@link SheetChart.axes.x.axisTitleFontFamily} /
+   * {@link SheetChart.axes.x.labelFontFamily} /
+   * {@link ChartDataLabels.fontFamily} — same accept-and-trim
+   * grammar, same OOXML `<a:latin typeface=".."/>` mapping — so a
+   * caller can thread a single typeface string through every
+   * typography-pinning slot.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  fontFamily?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -4469,6 +4469,8 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (underline !== undefined) out.underline = underline;
   const strikethrough = parseDataTableStrikethrough(el);
   if (strikethrough !== undefined) out.strikethrough = strikethrough;
+  const fontFamily = parseDataTableFontFamily(el);
+  if (fontFamily !== undefined) out.fontFamily = fontFamily;
   return out;
 }
 
@@ -4618,6 +4620,45 @@ function parseDataTableStrikethrough(dTable: XmlElement): boolean | undefined {
   const raw = defRPr.attrs.strike;
   if (raw === "sngStrike") return true;
   return undefined;
+}
+
+/**
+ * Pull `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr></c:dTable>` off
+ * a data-table block. Returns the typeface string the table was
+ * authored with.
+ *
+ * The OOXML `<a:latin>` element carries the typeface name on
+ * `CT_TextFont` (ECMA-376 Part 1, §21.1.2.3.7). The reader trims
+ * surrounding whitespace and reports the trimmed typeface; empty /
+ * whitespace-only `typeface` attributes and missing `<a:latin>`
+ * elements both collapse to `undefined` so absence and the empty
+ * form round-trip identically through the writer. Non-string
+ * `typeface` tokens (defensive — the XML parser only ever surfaces
+ * strings) likewise drop to `undefined`.
+ *
+ * Returns `undefined` whenever the data-table block omits `<c:txPr>`
+ * entirely or the canonical `<a:p><a:pPr><a:defRPr><a:latin>` chain
+ * is malformed at any link. Mirrors the chart-title / axis-title /
+ * axis tick-label / legend / data-label font family readers exactly
+ * so a parsed value slots straight back into the writer's emit path.
+ */
+function parseDataTableFontFamily(dTable: XmlElement): string | undefined {
+  const txPr = findChild(dTable, "txPr");
+  if (!txPr) return undefined;
+  const p = findChild(txPr, "p");
+  if (!p) return undefined;
+  const pPr = findChild(p, "pPr");
+  if (!pPr) return undefined;
+  const defRPr = findChild(pPr, "defRPr");
+  if (!defRPr) return undefined;
+  const latin = findChild(defRPr, "latin");
+  if (!latin) return undefined;
+  const raw = latin.attrs.typeface;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1114,6 +1114,7 @@ function resolveDataTable(chart: SheetChart):
       italic: boolean | undefined;
       underline: boolean | undefined;
       strikethrough: boolean | undefined;
+      fontFamily: string | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1137,6 +1138,7 @@ function resolveDataTable(chart: SheetChart):
       italic: undefined,
       underline: undefined,
       strikethrough: undefined,
+      fontFamily: undefined,
     };
   }
 
@@ -1155,6 +1157,7 @@ function resolveDataTable(chart: SheetChart):
     italic: resolveDataTableItalic(raw.italic),
     underline: resolveDataTableUnderline(raw.underline),
     strikethrough: resolveDataTableStrikethrough(raw.strikethrough),
+    fontFamily: resolveDataTableFontFamily(raw.fontFamily),
   };
 }
 
@@ -1264,6 +1267,25 @@ function resolveDataTableStrikethrough(value: boolean | undefined): boolean | un
 }
 
 /**
+ * Resolve `<c:dTable><c:txPr><a:p><a:pPr><a:defRPr><a:latin
+ * typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr></c:dTable>` from
+ * {@link ChartDataTable.fontFamily}.
+ *
+ * Returns the trimmed typeface string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed an
+ * empty / whitespace-only / non-string token. Mirrors the chart-title
+ * / axis-title / axis tick-label / legend / data-label font family
+ * resolvers exactly so a single configuration call threads cleanly
+ * through every typography slot Excel exposes.
+ */
+function resolveDataTableFontFamily(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return trimmed;
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
@@ -1290,6 +1312,7 @@ function buildDataTable(table: {
   italic: boolean | undefined;
   underline: boolean | undefined;
   strikethrough: boolean | undefined;
+  fontFamily: string | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1309,6 +1332,7 @@ function buildDataTable(table: {
     table.italic,
     table.underline,
     table.strikethrough,
+    table.fontFamily,
   );
   if (txPrXml !== undefined) children.push(txPrXml);
   return xmlElement("c:dTable", undefined, children);
@@ -1342,6 +1366,7 @@ function buildDataTableTxPr(
   italic: boolean | undefined,
   underline: boolean | undefined,
   strikethrough: boolean | undefined,
+  fontFamily: string | undefined,
 ): string | undefined {
   if (
     fontSizePt === undefined &&
@@ -1349,7 +1374,8 @@ function buildDataTableTxPr(
     bold === undefined &&
     italic === undefined &&
     underline === undefined &&
-    strikethrough === undefined
+    strikethrough === undefined &&
+    fontFamily === undefined
   )
     return undefined;
   const defRPrAttrs: Record<string, string | number> = {};
@@ -1373,9 +1399,28 @@ function buildDataTableTxPr(
   const solidFillChild = rgbHex
     ? xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: rgbHex })])
     : undefined;
-  const defRPr = solidFillChild
-    ? xmlElement("a:defRPr", defRPrAttrs, [solidFillChild])
-    : xmlSelfClose("a:defRPr", defRPrAttrs);
+  // OOXML's `<a:defRPr><a:latin typeface=".."/></a:defRPr>` carries
+  // the data-table font family. The `<a:latin>` element follows
+  // `<a:solidFill>` per the CT_TextCharacterProperties child sequence
+  // (ECMA-376 Part 1, §21.1.2.3.7). Absence (`undefined`) collapses
+  // to omitting the entire `<a:latin>` element so the data table
+  // inherits the theme typeface (Excel's reference behavior for
+  // fresh data tables that have not had a custom font picked).
+  const latinChild = fontFamily ? xmlSelfClose("a:latin", { typeface: fontFamily }) : undefined;
+  // When a fill color or a typeface is set the `<a:defRPr>` slot
+  // expands from self-closing to wrapping the children; otherwise the
+  // writer keeps the existing self-closing form so a fresh chart with
+  // no custom color or font matches Excel's reference serialization
+  // byte-for-byte. Children are emitted in
+  // CT_TextCharacterProperties' canonical schema order: solidFill
+  // first, then latin.
+  const defRPrChildren: string[] = [];
+  if (solidFillChild) defRPrChildren.push(solidFillChild);
+  if (latinChild) defRPrChildren.push(latinChild);
+  const defRPr =
+    defRPrChildren.length > 0
+      ? xmlElement("a:defRPr", defRPrAttrs, defRPrChildren)
+      : xmlSelfClose("a:defRPr", defRPrAttrs);
   return xmlElement("c:txPr", undefined, [
     xmlSelfClose("a:bodyPr"),
     xmlSelfClose("a:lstStyle"),

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -11058,6 +11058,179 @@ describe("cloneChart — data table", () => {
     const reparsed = parseChart(written);
     expect(reparsed?.dataTable?.strikethrough).toBe(true);
   });
+
+  // ── data-table font family ─────────────────────────────────────
+
+  it("inherits the source's dataTable.fontFamily by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontFamily: "Calibri",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontFamily: "Calibri",
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited fontFamily", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontFamily: "Calibri" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, fontFamily: "Arial" },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, fontFamily: "Arial" });
+  });
+
+  it("drops the inherited fontFamily when override clears the typography pin", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontFamily: "Calibri" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited fontFamily when flattening into a pie clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontFamily: "Calibri" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "pie",
+      },
+    );
+    expect(clone.type).toBe("pie");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops the inherited fontFamily when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fontFamily: "Calibri" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.fontFamily into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontFamily: "Calibri",
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:latin typeface="Calibri"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontFamily: "Calibri",
+    });
+  });
+
+  it("composes fontFamily with fontSize / fontColor / bold / strikethrough through the clone-through path", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          fontSize: 12,
+          fontColor: "1070CA",
+          bold: true,
+          strikethrough: true,
+          fontFamily: "Calibri",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      fontSize: 12,
+      fontColor: "1070CA",
+      bold: true,
+      strikethrough: true,
+      fontFamily: "Calibri",
+    });
+  });
+
+  it("a parsed dataTable.fontFamily round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, fontFamily: "Calibri" },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.fontFamily).toBe("Calibri");
+    const clone = cloneChart(parsed, {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.fontFamily).toBe("Calibri");
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -9758,6 +9758,253 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.strikethrough).toBe(true);
   });
+
+  // ── data-table font family ─────────────────────────────────────────
+
+  it("does NOT emit <c:txPr> when dataTable.fontFamily is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+    expect(dTableSlice).not.toContain("a:latin");
+  });
+
+  it('threads fontFamily through to <c:dTable><c:txPr> as <a:latin typeface=".."/>', () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "Arial" } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).toContain("<c:txPr>");
+    expect(dTableSlice).toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("trims surrounding whitespace from the input typeface", () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "   Calibri   " } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:latin typeface="Calibri"/>');
+  });
+
+  it("emits a multi-word typeface verbatim", () => {
+    const result = writeChart(
+      makeChart({ dataTable: { fontFamily: "Times New Roman" } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<a:latin typeface="Times New Roman"/>');
+  });
+
+  it("drops empty string fontFamily inputs (no <c:txPr>)", () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "" } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+  });
+
+  it("drops whitespace-only fontFamily inputs (no <c:txPr>)", () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "   " } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string fontFamily inputs (null leaking past the type guard)", () => {
+    const dt = { fontFamily: null } as unknown as { fontFamily: string };
+    const result = writeChart(makeChart({ dataTable: dt }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+  });
+
+  it("drops non-string fontFamily inputs (number leaking past the type guard)", () => {
+    const dt = { fontFamily: 14 } as unknown as { fontFamily: string };
+    const result = writeChart(makeChart({ dataTable: dt }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:txPr>");
+  });
+
+  it("expands <a:defRPr> from self-closing to wrapping <a:latin>", () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "Arial" } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:defRPr><a:latin typeface="Arial"/></a:defRPr>');
+  });
+
+  it("emits solidFill before latin in canonical CT_TextCharacterProperties order", () => {
+    const result = writeChart(
+      makeChart({ dataTable: { fontFamily: "Arial", fontColor: "FF0000" } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain(
+      '<a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr>',
+    );
+  });
+
+  it("co-emits sz, b, strike, the solidFill child, and the latin child on a single <a:defRPr>", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          fontFamily: "Arial",
+          fontColor: "FF0000",
+          fontSize: 14,
+          bold: true,
+          strikethrough: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain(
+      '<a:defRPr sz="1400" b="1" strike="sngStrike"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr>',
+    );
+  });
+
+  it("threads fontFamily through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataTable: { fontFamily: "Verdana" } }),
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('<a:latin typeface="Verdana"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontFamily: "Verdana" },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<a:latin typeface="Verdana"/>');
+  });
+
+  it("silently drops fontFamily on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontFamily: "Arial" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("silently drops fontFamily on doughnut charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "doughnut",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fontFamily: "Arial" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:latin typeface="Arial"/>');
+  });
+
+  it("composes fontFamily with the four boolean toggles independently", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          fontFamily: "Calibri",
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:latin typeface="Calibri"/>');
+  });
+
+  it("only emits <c:txPr> once inside <c:dTable>", () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "Arial" } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    const occurrences = dTableSlice.match(/<c:txPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("emits the standard txPr stub shape (a:bodyPr / a:lstStyle / a:p / a:endParaRPr)", () => {
+    const result = writeChart(makeChart({ dataTable: { fontFamily: "Arial" } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).toContain("<a:bodyPr/>");
+    expect(dTableSlice).toContain("<a:lstStyle/>");
+    expect(dTableSlice).toContain('<a:latin typeface="Arial"/>');
+    expect(dTableSlice).toContain('<a:endParaRPr lang="en-US"/>');
+  });
+
+  it("round-trips a pinned dataTable fontFamily through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fontFamily: "Calibri",
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fontFamily: "Calibri",
+    });
+  });
+
+  it("threads fontFamily end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, fontFamily: "Calibri" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:latin typeface="Calibri"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.fontFamily).toBe("Calibri");
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -10507,6 +10507,214 @@ describe("parseChart — data table", () => {
       strikethrough: true,
     });
   });
+
+  // ── data-table font family ─────────────────────────────────────────
+
+  it("surfaces a pinned dataTable.fontFamily from <a:latin typeface='..'/>", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="Arial"/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBe("Arial");
+  });
+
+  it("trims surrounding whitespace from the parsed typeface", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="   Calibri   "/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBe("Calibri");
+  });
+
+  it("collapses an empty typeface attribute to undefined", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface=""/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBeUndefined();
+  });
+
+  it("collapses a whitespace-only typeface attribute to undefined", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="   "/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBeUndefined();
+  });
+
+  it("returns undefined fontFamily when <a:latin> is missing on defRPr", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400" b="1"/></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBeUndefined();
+    // The fontSize and bold parts still surface.
+    expect(parseChart(xml)?.dataTable?.fontSize).toBe(14);
+    expect(parseChart(xml)?.dataTable?.bold).toBe(true);
+  });
+
+  it("returns undefined fontFamily when <c:txPr> is missing entirely", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBeUndefined();
+  });
+
+  it("returns undefined fontFamily when the typeface attribute is missing on <a:latin>", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBeUndefined();
+  });
+
+  it("surfaces a multi-word typeface verbatim", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:latin typeface="Times New Roman"/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fontFamily).toBe("Times New Roman");
+  });
+
+  it("surfaces every typography pin together when fontSize, fontColor, bold, strikethrough, and fontFamily are pinned", () => {
+    const xml = `<c:chartSpace ${NS} xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <c:chart><c:plotArea>
+    <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1600" b="1" strike="sngStrike"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill><a:latin typeface="Calibri"/></a:defRPr></a:pPr></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fontSize: 16,
+      fontColor: "1070CA",
+      bold: true,
+      strikethrough: true,
+      fontFamily: "Calibri",
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `fontFamily?: string` to `ChartDataTable`, mapped to `<c:plotArea><c:dTable><c:txPr><a:p><a:pPr><a:defRPr><a:latin typeface=".."/></a:defRPr></a:pPr></a:p></c:txPr></c:dTable>` per the `CT_DTable` schema (the `<a:latin>` element on `CT_TextFont` inside `CT_TextCharacterProperties`' latin slot, ECMA-376 Part 1, §21.1.2.3.7).
- Reader / writer / clone-through all support the new knob; mirrors the chart-title `titleFontFamily` (#282), axis-title `axisTitleFontFamily` (#283), axis tick-label `labelFontFamily` (#284), legend `legendFontFamily` (#285), and data-label `dataLabels.fontFamily` (#286) — same accept-and-trim grammar, same OOXML `<a:latin typeface=".."/>` mapping.
- The reader trims surrounding whitespace and reports the trimmed typeface; empty / whitespace-only `typeface` attributes and missing `<a:latin>` elements both collapse to `undefined` so absence and the empty form round-trip identically through the writer.
- The writer trims the input and emits the trimmed value verbatim (XML-escaped); empty / whitespace-only strings and non-string tokens collapse to `undefined` so the writer skips the entire `<a:latin>` element and the data table inherits the theme typeface.
- Children are emitted in canonical CT_TextCharacterProperties order (`<a:solidFill>` first, then `<a:latin>`) so a data-table block with both `fontColor` and `fontFamily` set lands the children in schema order — a fresh chart matches Excel's reference serialization byte-for-byte.
- Composes independently with `dataTable.fontSize`, `dataTable.fontColor`, `dataTable.bold`, `dataTable.italic`, `dataTable.underline`, `dataTable.strikethrough`, and the four boolean toggles; all typography pins land on the same `<a:defRPr>` slot.
- Silently dropped on pie / doughnut along with the rest of the data-table config (no `<c:dTable>` slot when the chart has no axes).

Stacked on top of #293 (data-table strikethrough), #292 (data-table underline), #291 (data-table italic), #290 (data-table bold), #289 (data-table fontColor), and #288 (data-table fontSize); completes the data-table typography knob set.

Refs #136

## Test plan

- [x] `pnpm test` — lint + typecheck + vitest (5983 tests, all pass; 49 new for this feature)
- [x] `pnpm build` — succeeds
- [x] reader: surfaces `fontFamily` from `<a:latin typeface=".."/>`; trims whitespace; empty / whitespace-only `typeface`, missing `<a:latin>`, missing `<c:txPr>`, and missing `typeface` attributes collapse to undefined
- [x] writer: emits `<a:latin typeface=".."/>` on the default-paragraph slot; trims whitespace; empty / whitespace-only strings and non-string tokens drop without emitting `<c:txPr>`; expands `<a:defRPr>` from self-closing to wrapping when a typeface is set; emits `solidFill` before `latin` in canonical order
- [x] clone: inheritance, override, and drop-on-flatten-to-pie/doughnut all behave like the other data-table typography knobs; round-trip through `parseChart` -> `cloneChart` -> `writeChart` -> `parseChart` preserves the typeface

🤖 Generated with [Claude Code](https://claude.com/claude-code)