### PR TITLE
feat(xlsx): chart floor thickness — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2752,6 +2752,37 @@ export interface SheetChart {
    */
   view3D?: ChartView3D;
   /**
+   * 3-D floor thickness, in points. Maps to
+   * `<c:chart><c:floor><c:thickness val="N"/></c:floor>` —
+   * Excel's "Format Floor -> Floor" pane (the `<c:thickness>` child of
+   * `CT_Surface`, ECMA-376 Part 1, §21.2.2.214). Excel renders the
+   * floor as a flat plate beneath the plot area on 3D chart families;
+   * pinning a positive value extrudes the plate to that depth so the
+   * floor reads as a solid slab. Default: omitted — Excel renders no
+   * `<c:floor>` element on a fresh chart and the per-family floor
+   * default (no extrusion) applies.
+   *
+   * The OOXML schema (`ST_Thickness`, `xsd:unsignedInt`) accepts any
+   * non-negative integer; Excel's UI exposes `0..100` under
+   * "Format Floor -> Floor -> Thickness". Out-of-range or non-finite
+   * inputs drop at write time rather than emit a token Excel's strict
+   * validator would reject. The OOXML default `0` collapses to
+   * `undefined` for symmetry with the writer's
+   * {@link SheetChart.floorThickness} default — absence and `0` mean
+   * the same thing on roundtrip.
+   *
+   * Although `<c:floor>` is only meaningful on 3D chart families
+   * (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`) and hucre's
+   * writer authors only 2D families, the OOXML schema accepts the
+   * element on every CT_Chart, so the writer pins it whenever the
+   * caller provides a positive thickness — Excel silently ignores it
+   * on 2D families. Useful primarily for round-tripping a 3D template
+   * chart through {@link cloneChart}. The element sits on `<c:chart>`
+   * between `<c:view3D>` and `<c:sideWall>` / `<c:backWall>` /
+   * `<c:plotArea>` per CT_Chart.
+   */
+  floorThickness?: number;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -6957,6 +6988,29 @@ export interface Chart {
    * lossless.
    */
   view3D?: ChartView3D;
+  /**
+   * 3-D floor thickness pulled from
+   * `<c:chart><c:floor><c:thickness val="N"/></c:floor>` (the
+   * `<c:thickness>` child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.214).
+   * Reflects Excel's "Format Floor -> Floor -> Thickness" pin on 3D
+   * chart families.
+   *
+   * Surfaces the integer pinned by the source chart. The OOXML default
+   * `0` (and absence of the element) collapses to `undefined` so absence
+   * and the default round-trip identically through {@link cloneChart} —
+   * only an explicit positive thickness surfaces here. Out-of-range or
+   * unparseable values also drop to `undefined` rather than fabricate a
+   * value the file did not declare.
+   *
+   * The element lives on `<c:chart>` between `<c:view3D>` and
+   * `<c:sideWall>` / `<c:backWall>` / `<c:plotArea>` per CT_Chart, so
+   * the OOXML schema accepts it on every chart family — though it is
+   * only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`,
+   * `area3D`, `surface3D`); a stray element on a 2D chart still
+   * surfaces here so the round-trip through {@link cloneChart} stays
+   * lossless.
+   */
+  floorThickness?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -874,6 +874,31 @@ export interface CloneChartOptions {
    */
   view3D?: ChartView3D | null;
   /**
+   * Override `<c:chart><c:floor><c:thickness val="N"/></c:floor>`
+   * (the 3-D floor extrusion thickness on `CT_Surface`, ECMA-376
+   * Part 1, §21.2.2.69).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * {@link Chart.floorThickness}. `null` drops the inherited value so
+   * the writer skips `<c:floor>` entirely — Excel falls back to its
+   * per-family floor default (no extrusion). A `number` replaces it —
+   * pass any value in the inclusive `1..100` band Excel's "Format
+   * Floor -> Floor -> Thickness" pane exposes; out-of-range, `0`, or
+   * non-finite values fall through to absence at write time rather
+   * than emit a token Excel rejects.
+   *
+   * Applies to every chart family — `<c:floor>` lives on `<c:chart>`
+   * (between `<c:view3D>` and `<c:plotArea>`), so the OOXML schema
+   * accepts the element on both 2D and 3D families. The toggle is
+   * only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`,
+   * `area3D`, `surface3D`), but the writer carries a templated value
+   * through every clone so a 3D template chart round-trips losslessly.
+   * The grammar mirrors {@link CloneChartOptions.upDownBarsGapWidth}
+   * so the chart-level numeric knobs compose the same way at the call
+   * site.
+   */
+  floorThickness?: number | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -1950,6 +1975,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   const resolvedView3D = resolveView3D(source.view3D, options.view3D);
   if (resolvedView3D !== undefined) out.view3D = resolvedView3D;
 
+  // `<c:floor>` lives on `<c:chart>` directly (between `<c:view3D>`
+  // and `<c:plotArea>` per CT_Chart), so the OOXML schema accepts it
+  // on every chart family — both 2D and 3D. The toggle is only
+  // meaningful on 3D families, but the resolver applies to every type
+  // so a 3D template chart round-trips losslessly through a clone
+  // (and a 2D clone of a 3D template that happens to inherit the
+  // value silently keeps the element — Excel ignores it on 2D).
+  // Override wins over the source's parsed value, and the grammar
+  // follows the standard `number | null` shape so the chart-level
+  // numeric knobs compose the same way at the call site.
+  const resolvedFloorThickness = resolveFloorThickness(
+    source.floorThickness,
+    options.floorThickness,
+  );
+  if (resolvedFloorThickness !== undefined) out.floorThickness = resolvedFloorThickness;
+
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
   // to line / column does not leak the preset into a chart kind whose
@@ -2619,6 +2660,31 @@ function resolveView3D(
   // empty-object shape and emits a bare `<c:view3D/>` shell, mirroring
   // how `resolveProtection` handles the `true` / `{}` forms.
   return { ...override };
+}
+
+/**
+ * Resolve a `floorThickness` override.
+ *
+ * `undefined` → inherit the source's parsed `floorThickness`.
+ * `null`      → drop the inherited value (the writer skips `<c:floor>`
+ *               entirely — Excel falls back to no extrusion).
+ * `number`    → replace. Out-of-range, `0`, or non-finite values still
+ *               surface in the cloned `SheetChart` for symmetry with
+ *               the other override helpers; the writer's
+ *               `buildFloorThickness` then drops them at emit time so
+ *               a fresh chart matches Excel's reference serialization.
+ *
+ * The grammar mirrors `upDownBarsGapWidth` / `gapWidth` / `holeSize` /
+ * `firstSliceAng` so the numeric chart-level knobs compose the same
+ * way at the call site.
+ */
+function resolveFloorThickness(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -553,6 +553,18 @@ export function parseChart(xml: string): Chart | undefined {
   const view3D = parseView3D(chartEl);
   if (view3D !== undefined) out.view3D = view3D;
 
+  // `<c:floor>` (CT_Surface, ECMA-376 Part 1, §21.2.2.69) sits on
+  // `<c:chart>` between `<c:view3D>` and `<c:sideWall>` /
+  // `<c:backWall>` / `<c:plotArea>` per CT_Chart. The reader surfaces
+  // only the `<c:thickness>` child here — `<c:spPr>` / `<c:pictureOptions>`
+  // / `<c:extLst>` styling on the floor block is not modelled at this
+  // layer. Like `<c:view3D>`, the schema accepts `<c:floor>` on every
+  // CT_Chart even though it is only meaningful on 3D families, so a
+  // stray element on a 2D chart still surfaces the value for round-
+  // trip parity.
+  const floorThickness = parseFloorThickness(chartEl);
+  if (floorThickness !== undefined) out.floorThickness = floorThickness;
+
   return out;
 }
 
@@ -4934,6 +4946,56 @@ function parseView3DBoolean(view3D: XmlElement, local: string): boolean | undefi
     default:
       return undefined;
   }
+}
+
+// ── Floor Thickness ───────────────────────────────────────────────
+
+/**
+ * Pull `<c:chart><c:floor><c:thickness val=".."/></c:floor>` off
+ * `<c:chart>`. The `<c:floor>` element (CT_Surface, ECMA-376 Part 1,
+ * §21.2.2.69) sits on `<c:chart>` between `<c:view3D>` and
+ * `<c:sideWall>` / `<c:backWall>` / `<c:plotArea>` per CT_Chart and
+ * carries an optional `<c:thickness>` child whose `val` attribute is
+ * an `xsd:unsignedInt` — Excel's "Format Floor -> Floor -> Thickness"
+ * pin on 3D chart families.
+ *
+ * Returns the integer pinned by the source chart. The OOXML default
+ * `0` (and absence of the `<c:thickness>` child or the parent
+ * `<c:floor>` element) collapses to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart} — only an
+ * explicit positive thickness surfaces here. Out-of-range or
+ * unparseable values also drop to `undefined` rather than fabricate a
+ * value the file did not declare.
+ *
+ * The `<c:thickness>` element only carries the `val` attribute on
+ * `CT_Thickness` — other floor styling (`<c:spPr>`, `<c:pictureOptions>`,
+ * `<c:extLst>`) is not modelled at this layer, so a stray styling
+ * block on the floor passes through the parse loop without surfacing.
+ */
+function parseFloorThickness(chartEl: XmlElement): number | undefined {
+  const floor = findChild(chartEl, "floor");
+  if (!floor) return undefined;
+  const thickness = findChild(floor, "thickness");
+  if (!thickness) return undefined;
+  const raw = thickness.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  // ST_Thickness is `xsd:unsignedInt` — strict integer regex rejects
+  // fractional / negative / non-numeric tokens.
+  if (!/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  // Collapse the OOXML default `0` to undefined so absence and the
+  // default round-trip identically through cloneChart — only an
+  // explicit positive thickness surfaces here. Mirrors how the writer
+  // skips emission entirely for `0` / undefined.
+  if (n === 0) return undefined;
+  // Cap at Excel's UI band ceiling (`100`) — the OOXML schema accepts
+  // the full `xsd:unsignedInt` range but Excel's "Format Floor"
+  // dialogue rejects values above 100 with a repair warning. Anything
+  // larger drops here so a corrupt template does not silently rewrite
+  // as an absurd thickness; absence keeps the round-trip stable.
+  if (n > 100) return undefined;
+  return n;
 }
 
 // ── Vary Colors ────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -119,6 +119,23 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
     chartChildren.push(view3DXml);
   }
 
+  // `<c:floor>` (CT_Surface, ECMA-376 Part 1, §21.2.2.69) sits on
+  // `<c:chart>` between `<c:view3D>` and `<c:sideWall>` /
+  // `<c:backWall>` / `<c:plotArea>` per CT_Chart. The writer pins only
+  // the `<c:thickness>` child here — `<c:spPr>` / `<c:pictureOptions>`
+  // / `<c:extLst>` styling on the floor block is not modelled at this
+  // layer. Like `<c:view3D>`, the schema accepts `<c:floor>` on every
+  // CT_Chart even though it is only meaningful on 3D families
+  // (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`); Excel
+  // silently ignores it on 2D families. The writer skips emission
+  // entirely when the caller leaves `floorThickness` unset (or pins
+  // `0`) so a fresh chart matches Excel's reference serialization
+  // byte-for-byte.
+  const floorXml = buildFloorThickness(chart.floorThickness);
+  if (floorXml !== undefined) {
+    chartChildren.push(floorXml);
+  }
+
   // ── Plot Area ──
   chartChildren.push(buildPlotArea(chart, sheetName));
 
@@ -1595,6 +1612,39 @@ function clampView3DInt(value: number | undefined, min: number, max: number): nu
   if (!Number.isInteger(value)) return undefined;
   if (value < min || value > max) return undefined;
   return value;
+}
+
+/**
+ * Serialize {@link SheetChart.floorThickness} into
+ * `<c:floor><c:thickness val="N"/></c:floor>`. Returns `undefined`
+ * when the caller did not opt in (`floorThickness` is `undefined`,
+ * `0`, non-finite, non-integer, negative, or out of the Excel UI
+ * band `1..100`) so the writer can skip the `<c:floor>` element
+ * entirely — Excel renders no floor extrusion on a fresh chart and
+ * absence matches the reference serialization byte-for-byte.
+ *
+ * The OOXML schema (`ST_Thickness`, `xsd:unsignedInt`) accepts any
+ * non-negative integer, but Excel's "Format Floor -> Floor ->
+ * Thickness" pane only exposes `0..100` — values above that band
+ * render but trigger Excel's repair dialog. Drop out-of-range and
+ * non-integer inputs rather than emit a token Excel rejects, mirroring
+ * how every other chart-level numeric writer ({@link clampView3DInt}
+ * / {@link clampHoleSize} / {@link clampFirstSliceAng}) treats its
+ * input.
+ *
+ * The element only carries the `<c:thickness>` child — other
+ * `CT_Surface` children (`<c:spPr>`, `<c:pictureOptions>`,
+ * `<c:extLst>`) are not modelled at this layer, so the emitted
+ * `<c:floor>` block is the minimal shape Excel itself emits when the
+ * user pins a thickness with no other floor styling.
+ */
+function buildFloorThickness(value: number | undefined): string | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  if (!Number.isInteger(value)) return undefined;
+  if (value <= 0) return undefined;
+  if (value > 100) return undefined;
+  return xmlElement("c:floor", undefined, [xmlSelfClose("c:thickness", { val: value })]);
 }
 
 interface AxisRenderOptions {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -12427,6 +12427,222 @@ describe("cloneChart — view3D", () => {
   });
 });
 
+// ── cloneChart — floor thickness ─────────────────────────────────────
+
+describe("cloneChart — floorThickness", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's floorThickness by default", () => {
+    const clone = cloneChart(source({ floorThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.floorThickness).toBe(25);
+  });
+
+  it("lets options.floorThickness replace the inherited value", () => {
+    const clone = cloneChart(source({ floorThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      floorThickness: 50,
+    });
+    expect(clone.floorThickness).toBe(50);
+  });
+
+  it("drops the inherited floorThickness when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:floor> entirely on emit. Mirrors
+    // resolveUpDownBarsGapWidth / resolveView3D's null grammar.
+    const clone = cloneChart(source({ floorThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      floorThickness: null,
+    });
+    expect(clone.floorThickness).toBeUndefined();
+  });
+
+  it("returns undefined floorThickness when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.floorThickness).toBeUndefined();
+  });
+
+  it("carries floorThickness through a flatten (line → column)", () => {
+    // <c:floor> lives on <c:chart>, so a chart-type coercion preserves
+    // the pinned value — the element has no axis dependency.
+    const clone = cloneChart(source({ floorThickness: 35 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.floorThickness).toBe(35);
+  });
+
+  it("preserves floorThickness when flattening into a doughnut clone", () => {
+    // Unlike <c:dTable>, <c:floor> has no axis dependency — it lives
+    // on <c:chart> so pie / doughnut still carry the slot.
+    const clone = cloneChart(source({ floorThickness: 20 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.floorThickness).toBe(20);
+  });
+
+  it("preserves floorThickness when flattening into a pie clone", () => {
+    const clone = cloneChart(source({ floorThickness: 40 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.floorThickness).toBe(40);
+  });
+
+  it("composes independently with view3D (both sit on <c:chart>)", () => {
+    // Both knobs land on <c:chart> directly — one should not leak into
+    // the other through the resolver pair.
+    const clone = cloneChart(source({ view3D: { rotX: 15, rotY: 20 }, floorThickness: 30 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.view3D).toEqual({ rotX: 15, rotY: 20 });
+    expect(clone.floorThickness).toBe(30);
+  });
+
+  it("override does not leak into view3D when both fields are pinned independently", () => {
+    // The view3D resolver and the floorThickness resolver are
+    // independent. Overriding one should not affect the other.
+    const clone = cloneChart(source({ view3D: { rotX: 15 }, floorThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      floorThickness: 60,
+    });
+    expect(clone.view3D).toEqual({ rotX: 15 });
+    expect(clone.floorThickness).toBe(60);
+  });
+
+  it("propagates floorThickness into the rendered <c:floor> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ floorThickness: 45 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:floor>");
+    expect(written).toContain('<c:thickness val="45"/>');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.floorThickness).toBe(45);
+  });
+
+  it("propagates the override-drop (null) into absence on roundtrip", async () => {
+    // null on the override drops the inherited value so the writer
+    // skips the element entirely — Excel falls back to no extrusion.
+    // The round-trip closes with no <c:floor> present in the rendered
+    // file.
+    const clone = cloneChart(source({ floorThickness: 25 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      floorThickness: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:floor");
+    expect(parseChart(written)?.floorThickness).toBeUndefined();
+  });
+
+  it("override-replace into a positive value emits the new <c:thickness val>", async () => {
+    // The override replaces the inherited value — the writer emits the
+    // override at the canonical slot.
+    const clone = cloneChart(source({ floorThickness: 10 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      floorThickness: 75,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:thickness val="75"/>');
+    expect(written).not.toContain('<c:thickness val="10"/>');
+    expect(parseChart(written)?.floorThickness).toBe(75);
+  });
+
+  it("composes independently with view3D on the writeXlsx roundtrip", async () => {
+    // Both knobs sit on <c:chart>; the round-trip preserves both.
+    const clone = cloneChart(source({ view3D: { rotX: 20, rotY: 30 }, floorThickness: 50 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:rotX val="20"/>');
+    expect(written).toContain('<c:rotY val="30"/>');
+    expect(written).toContain('<c:thickness val="50"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 20, rotY: 30 });
+    expect(reparsed?.floorThickness).toBe(50);
+  });
+});
+
 // ── cloneChart — axis label rotation ───────────────────────────────
 
 describe("cloneChart — axis labelRotation", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -11254,6 +11254,199 @@ describe("writeChart — view3D", () => {
   });
 });
 
+// ── writeChart — floor thickness ─────────────────────────────────────
+
+describe("writeChart — floorThickness", () => {
+  it("skips <c:floor> entirely when the field is unset (writer default)", () => {
+    // Excel renders no floor extrusion on a fresh chart — the writer
+    // skips the element so the file stays minimal. Absence and the
+    // unset default round-trip identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:floor");
+  });
+
+  it('emits <c:floor><c:thickness val="N"/></c:floor> when floorThickness is positive', () => {
+    const result = writeChart(makeChart({ floorThickness: 25 }), "Sheet1");
+    expect(result.chartXml).toContain("<c:floor>");
+    expect(result.chartXml).toContain('<c:thickness val="25"/>');
+    expect(result.chartXml).toContain("</c:floor>");
+  });
+
+  it("emits the boundary value 100 (Excel UI band ceiling)", () => {
+    const result = writeChart(makeChart({ floorThickness: 100 }), "Sheet1");
+    expect(result.chartXml).toContain('<c:thickness val="100"/>');
+  });
+
+  it("emits the minimum positive value 1", () => {
+    const result = writeChart(makeChart({ floorThickness: 1 }), "Sheet1");
+    expect(result.chartXml).toContain('<c:thickness val="1"/>');
+  });
+
+  it("skips emission when floorThickness is 0 (the OOXML default)", () => {
+    // The OOXML default `0` matches absence — drop the element so a
+    // fresh chart matches Excel's reference serialization byte-for-byte.
+    const result = writeChart(makeChart({ floorThickness: 0 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:floor");
+  });
+
+  it("drops out-of-range values (above the Excel UI ceiling 100) rather than emit", () => {
+    // Excel's UI tops out at 100 — values above the band drop here so
+    // a fresh chart never emits a token Excel's repair dialog would
+    // flag. Mirrors how clampView3DInt / clampHoleSize handle out-of-
+    // range numeric inputs.
+    const result = writeChart(makeChart({ floorThickness: 500 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:floor");
+  });
+
+  it("drops negative values (ST_Thickness is xsd:unsignedInt)", () => {
+    const result = writeChart(makeChart({ floorThickness: -10 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:floor");
+  });
+
+  it("drops fractional values rather than truncate", () => {
+    // ST_Thickness is `xsd:unsignedInt` — a fractional input drops
+    // rather than silently truncate. Mirrors clampView3DInt's strict
+    // integer check.
+    const result = writeChart(makeChart({ floorThickness: 25.5 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:floor");
+  });
+
+  it("drops non-finite values (NaN, Infinity, -Infinity)", () => {
+    expect(writeChart(makeChart({ floorThickness: Number.NaN }), "Sheet1").chartXml).not.toContain(
+      "<c:floor",
+    );
+    expect(
+      writeChart(makeChart({ floorThickness: Number.POSITIVE_INFINITY }), "Sheet1").chartXml,
+    ).not.toContain("<c:floor");
+    expect(
+      writeChart(makeChart({ floorThickness: Number.NEGATIVE_INFINITY }), "Sheet1").chartXml,
+    ).not.toContain("<c:floor");
+  });
+
+  it("drops a non-number floorThickness rather than emit invalid token", () => {
+    // A non-number leaking through the type guard drops the element —
+    // mirrors how every other chart-level numeric writer treats its
+    // input.
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ floorThickness: "25" as any }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:floor");
+  });
+
+  it("places <c:floor> after <c:view3D> and before <c:plotArea> per CT_Chart", () => {
+    // CT_Chart sequence (ECMA-376 Part 1, §21.2.2.4):
+    //   title?, autoTitleDeleted?, pivotFmts?, view3D?, floor?,
+    //   sideWall?, backWall?, plotArea, ...
+    const result = writeChart(makeChart({ view3D: { rotX: 15 }, floorThickness: 25 }), "Sheet1");
+    const view3DIdx = result.chartXml.indexOf("<c:view3D");
+    const floorIdx = result.chartXml.indexOf("<c:floor");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(view3DIdx).toBeGreaterThan(-1);
+    expect(floorIdx).toBeGreaterThan(view3DIdx);
+    expect(floorIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("places <c:floor> after <c:autoTitleDeleted> when <c:view3D> is absent", () => {
+    // With no view3D pinned, <c:floor> still slots between
+    // <c:autoTitleDeleted> and <c:plotArea> per CT_Chart.
+    const result = writeChart(makeChart({ floorThickness: 30 }), "Sheet1");
+    const autoIdx = result.chartXml.indexOf("<c:autoTitleDeleted");
+    const floorIdx = result.chartXml.indexOf("<c:floor");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(autoIdx).toBeGreaterThan(-1);
+    expect(floorIdx).toBeGreaterThan(autoIdx);
+    expect(floorIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("only emits <c:floor> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ floorThickness: 25 }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:floor[\s/>]/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads floorThickness through every chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:floor> is only meaningful on 3D families but the OOXML schema
+    // accepts it on every CT_Chart. The writer emits it on every
+    // family the caller pins it on — Excel silently ignores it on 2D
+    // families.
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, floorThickness: 20 }), "Sheet1");
+      expect(result.chartXml).toContain('<c:thickness val="20"/>');
+    }
+    for (const type of ["pie", "doughnut"] as const) {
+      const result = writeChart(
+        {
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4" }],
+          anchor: { from: { row: 5, col: 0 } },
+          floorThickness: 20,
+        },
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('<c:thickness val="20"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        floorThickness: 20,
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<c:thickness val="20"/>');
+  });
+
+  it("round-trips a positive floorThickness through parseChart", () => {
+    const written = writeChart(makeChart({ floorThickness: 35 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.floorThickness).toBe(35);
+  });
+
+  it("round-trips floorThickness independently of view3D", () => {
+    // Both knobs sit on <c:chart> — one should not leak into the other
+    // through the writer / reader pair.
+    const written = writeChart(
+      makeChart({ view3D: { rotX: 15, rotY: 20 }, floorThickness: 40 }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 15, rotY: 20 });
+    expect(reparsed?.floorThickness).toBe(40);
+  });
+
+  it("threads floorThickness through writeXlsx into xl/charts/chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Floor Test",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            floorThickness: 50,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:floor>");
+    expect(chartXml).toContain('<c:thickness val="50"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.floorThickness).toBe(50);
+  });
+});
+
 // ── writeChart — axis label rotation ────────────────────────────────
 
 describe("writeChart — axis labelRotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -11718,6 +11718,292 @@ describe("parseChart — view3D", () => {
   });
 });
 
+// ── parseChart — floor thickness ──────────────────────────────────
+
+describe("parseChart — floorThickness", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a positive thickness pinned by <c:floor><c:thickness>", () => {
+    // Excel's "Format Floor -> Floor -> Thickness" pane writes
+    // `<c:floor><c:thickness val="N"/></c:floor>` when the user pins a
+    // non-zero value. The reader surfaces the integer literally so a
+    // clone can replay the exact extrusion depth.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="25"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBe(25);
+  });
+
+  it("collapses the OOXML default 0 to undefined", () => {
+    // The OOXML default `0` (no extrusion) is the writer's default
+    // shape — absence and `0` round-trip identically. Only an explicit
+    // positive thickness surfaces here.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="0"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("surfaces the boundary value 100 (Excel UI band ceiling)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="100"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBe(100);
+  });
+
+  it("drops out-of-range values rather than fabricate a clamped thickness", () => {
+    // Excel's UI tops out at 100 — a stray value above the band drops
+    // rather than silently rewrite as a different thickness, mirroring
+    // how the other chart-level numeric readers (gapWidth / overlap /
+    // firstSliceAng / view3D children) handle out-of-range tokens.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="500"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("drops fractional / non-integer values rather than fabricate floats", () => {
+    // ST_Thickness is `xsd:unsignedInt` — `parseInt` would coerce
+    // "25.5" → 25, but Excel never emits the fractional spelling.
+    // Drop the field so a hand-edited file with a fractional `val`
+    // stays unrecognised rather than silently round-trip a value Excel
+    // would not author.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="25.5"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("drops negative values (ST_Thickness is xsd:unsignedInt)", () => {
+    // The unsigned simple type rejects a leading `-`.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="-10"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("drops a missing val attribute rather than fabricate a value", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("drops non-numeric val tokens rather than coerce", () => {
+    // `parseInt` would coerce "30abc" → 30, but Excel never emits the
+    // mixed spelling. The strict integer regex rejects the token.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="30abc"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("returns undefined when <c:floor> is present but <c:thickness> is missing", () => {
+    // CT_Surface's `<c:thickness>` is optional. A `<c:floor>` block
+    // with only `<c:spPr>` styling carries no thickness pin.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:spPr/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("returns undefined on a bare <c:floor/> element", () => {
+    // A self-closing element with no children — same minimal-shape
+    // result as a floor with `<c:spPr>` only.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor/>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:floor> element", () => {
+    // Absence is the writer's default — Excel renders no floor
+    // extrusion on a fresh chart. The reader surfaces nothing so a
+    // fresh chart and a chart that omits the element round-trip
+    // identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBeUndefined();
+  });
+
+  it("surfaces floorThickness on a 2D chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:floor> is only meaningful on 3D families but the OOXML schema
+    // accepts it on every CT_Chart. A stray element on a 2D chart
+    // surfaces here so the round-trip through cloneChart stays
+    // lossless even when the template authors a no-op.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="15"/>
+    </c:floor>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBe(15);
+  });
+
+  it("surfaces floorThickness on a pie chart (no axes, but the element lives on <c:chart>)", () => {
+    // <c:floor> lives on <c:chart>, not inside <c:plotArea>, so
+    // axis-shape has no bearing on whether the slot exists. Pie /
+    // doughnut still carry the element when the file pins it.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:floor>
+      <c:thickness val="10"/>
+    </c:floor>
+    <c:plotArea>
+      <c:pieChart>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.floorThickness).toBe(10);
+  });
+
+  it("co-exists with sibling chart-level toggles", () => {
+    // The floorThickness reader should not interfere with sibling
+    // fields parsed off <c:chart> (autoTitleDeleted / view3D / plotVisOnly /
+    // dispBlanksAs).
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:autoTitleDeleted val="1"/>
+    <c:view3D>
+      <c:rotX val="20"/>
+    </c:view3D>
+    <c:floor>
+      <c:thickness val="40"/>
+    </c:floor>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.autoTitleDeleted).toBe(true);
+    expect(chart?.view3D).toEqual({ rotX: 20 });
+    expect(chart?.floorThickness).toBe(40);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+  });
+});
+
 // ── parseChart — legend entries ────────────────────────────────────
 
 describe("parseChart — legend entries", () => {


### PR DESCRIPTION
## Summary

- Adds `floorThickness?: number` to `SheetChart` / `Chart`, mapped to `<c:chart><c:floor><c:thickness val=\"N\"/></c:floor>` per the `CT_Surface` schema (the `<c:thickness>` child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.214 / §21.2.2.69) — Excel's "Format Floor -> Floor -> Thickness" pin on 3D chart families.
- Reader / writer / clone-through all support the new knob; mirrors the chart-level `holeSize` / `firstSliceAng` / `upDownBarsGapWidth` numeric grammar — same OOXML simple-type clamp, same default-collapse contract, same `number | null` clone-through grammar.
- Reader: surfaces a positive integer pinned by `<c:floor><c:thickness val=\"N\"/>`; the OOXML default `0` (and absence of `<c:floor>` / `<c:thickness>`) collapses to `undefined` so absence and the default round-trip identically through `cloneChart`. Out-of-range (`> 100`, the Excel UI band ceiling), negative, fractional, and non-numeric `val` tokens drop to `undefined` rather than fabricate a value the file did not declare.
- Writer: emits `<c:floor><c:thickness val=\"N\"/></c:floor>` between `<c:view3D>` and `<c:plotArea>` per CT_Chart sequence; skips emission when the field is unset, `0`, non-finite, non-integer, negative, or above the Excel UI ceiling `100` so a fresh chart matches Excel's reference serialization byte-for-byte.
- Clone-through: `cloneChart`'s new `floorThickness?: number | null` option mirrors `upDownBarsGapWidth`'s `number | null` shape — `undefined` inherits, `null` drops the inherited value, a number replaces it.
- Applies to every chart family — `<c:floor>` lives on `<c:chart>` directly, so the OOXML schema accepts it on every chart family even though it is only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`); useful primarily for round-tripping a 3D template chart through `cloneChart`. Composes independently with `view3D` (both knobs sit on `<c:chart>`).

The candidate list on issue #136 explicitly mentions `<c:floor>` thickness as a 3D-wall round-trip gap — this is Phase 1 of that scope (just the `<c:thickness>` child; `<c:spPr>` / `<c:pictureOptions>` / `<c:extLst>` styling on the floor block is not modelled at this layer).

Refs #136

## Test plan

- [x] `pnpm vitest run --dir=test` — all 6027 tests pass (44 new for this feature: 14 reader + 17 writer + 13 clone-through)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — succeeds (`obuild` finishes without errors)
- [x] `pnpm lint` — no new warnings/errors
- [x] reader: surfaces positive integer values from `<c:floor><c:thickness>`; collapses default `0` and absence to `undefined`; drops out-of-range / fractional / negative / non-numeric `val` tokens; surfaces the value on every chart family (2D and 3D) and on pie / doughnut (no axes); co-exists with sibling chart-level toggles (`autoTitleDeleted`, `view3D`, `plotVisOnly`, `dispBlanksAs`)
- [x] writer: emits `<c:floor><c:thickness val=\"N\"/></c:floor>` for positive values in `1..100`; skips emission for unset / `0` / out-of-range / non-finite / non-integer / negative / non-number inputs; places `<c:floor>` after `<c:view3D>` (or `<c:autoTitleDeleted>` if no view3D) and before `<c:plotArea>` per CT_Chart sequence; threads through every chart family; only emits once per chart
- [x] clone: inheritance, override, drop-on-null all behave like the other chart-level numeric knobs; carries through chart-type flatten (line → column / pie / doughnut); composes independently with `view3D`; round-trip through `parseChart` -> `cloneChart` -> `writeChart` -> `parseChart` preserves the thickness; round-trip through `writeXlsx` lands the value in `xl/charts/chart1.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)