### PR TITLE
feat(xlsx): chart side-wall thickness — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2752,6 +2752,38 @@ export interface SheetChart {
    */
   view3D?: ChartView3D;
   /**
+   * 3-D side-wall thickness, in points. Maps to
+   * `<c:chart><c:sideWall><c:thickness val="N"/></c:sideWall>` —
+   * Excel's "Format Side Wall -> Side Wall" pane (the `<c:thickness>`
+   * child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.187). Excel
+   * renders the side wall as a flat plate flanking the plot area on
+   * 3D chart families; pinning a positive value extrudes the plate to
+   * that depth so the wall reads as a solid slab. Default: omitted —
+   * Excel renders no `<c:sideWall>` element on a fresh chart and the
+   * per-family side-wall default (no extrusion) applies.
+   *
+   * The OOXML schema (`ST_Thickness`, `xsd:unsignedInt`) accepts any
+   * non-negative integer; Excel's UI exposes `0..100` under
+   * "Format Side Wall -> Side Wall -> Thickness". Out-of-range or
+   * non-finite inputs drop at write time rather than emit a token
+   * Excel's strict validator would reject. The OOXML default `0`
+   * collapses to `undefined` for symmetry with the writer's
+   * {@link SheetChart.sideWallThickness} default — absence and `0`
+   * mean the same thing on roundtrip.
+   *
+   * Although `<c:sideWall>` is only meaningful on 3D chart families
+   * (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`) and hucre's
+   * writer authors only 2D families, the OOXML schema accepts the
+   * element on every CT_Chart, so the writer pins it whenever the
+   * caller provides a positive thickness — Excel silently ignores it
+   * on 2D families. Useful primarily for round-tripping a 3D template
+   * chart through {@link cloneChart}. The element sits on `<c:chart>`
+   * between `<c:floor>` and `<c:backWall>` / `<c:plotArea>` per
+   * CT_Chart; mirrors {@link SheetChart.view3D} as a chart-level 3D
+   * styling knob.
+   */
+  sideWallThickness?: number;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -6957,6 +6989,28 @@ export interface Chart {
    * lossless.
    */
   view3D?: ChartView3D;
+  /**
+   * 3-D side-wall thickness pulled from
+   * `<c:chart><c:sideWall><c:thickness val="N"/></c:sideWall>` (the
+   * `<c:thickness>` child of `CT_Surface`, ECMA-376 Part 1,
+   * §21.2.2.187). Reflects Excel's "Format Side Wall -> Side Wall ->
+   * Thickness" pin on 3D chart families.
+   *
+   * Surfaces the integer pinned by the source chart. The OOXML default
+   * `0` (and absence of the element) collapses to `undefined` so absence
+   * and the default round-trip identically through {@link cloneChart} —
+   * only an explicit positive thickness surfaces here. Out-of-range or
+   * unparseable values also drop to `undefined` rather than fabricate a
+   * value the file did not declare.
+   *
+   * The element lives on `<c:chart>` between `<c:floor>` and
+   * `<c:backWall>` / `<c:plotArea>` per CT_Chart, so the OOXML schema
+   * accepts it on every chart family — though it is only meaningful
+   * on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`,
+   * `surface3D`); a stray element on a 2D chart still surfaces here
+   * so the round-trip through {@link cloneChart} stays lossless.
+   */
+  sideWallThickness?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -874,6 +874,31 @@ export interface CloneChartOptions {
    */
   view3D?: ChartView3D | null;
   /**
+   * Override `<c:chart><c:sideWall><c:thickness val="N"/></c:sideWall>`
+   * (the 3-D side-wall extrusion thickness on `CT_Surface`, ECMA-376
+   * Part 1, §21.2.2.187).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * {@link Chart.sideWallThickness}. `null` drops the inherited value
+   * so the writer skips `<c:sideWall>` entirely — Excel falls back to
+   * its per-family side-wall default (no extrusion). A `number`
+   * replaces it — pass any value in the inclusive `1..100` band
+   * Excel's "Format Side Wall -> Side Wall -> Thickness" pane
+   * exposes; out-of-range, `0`, or non-finite values fall through to
+   * absence at write time rather than emit a token Excel rejects.
+   *
+   * Applies to every chart family — `<c:sideWall>` lives on
+   * `<c:chart>` (between `<c:floor>` and `<c:backWall>` /
+   * `<c:plotArea>`), so the OOXML schema accepts the element on both
+   * 2D and 3D families. The toggle is only meaningful on 3D families
+   * (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`), but the
+   * writer carries a templated value through every clone so a 3D
+   * template chart round-trips losslessly. The grammar mirrors
+   * {@link CloneChartOptions.upDownBarsGapWidth} so the chart-level
+   * numeric knobs compose the same way at the call site.
+   */
+  sideWallThickness?: number | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -1950,6 +1975,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   const resolvedView3D = resolveView3D(source.view3D, options.view3D);
   if (resolvedView3D !== undefined) out.view3D = resolvedView3D;
 
+  // `<c:sideWall>` lives on `<c:chart>` directly (between `<c:floor>`
+  // and `<c:backWall>` / `<c:plotArea>` per CT_Chart), so the OOXML
+  // schema accepts it on every chart family — both 2D and 3D. The
+  // toggle is only meaningful on 3D families, but the resolver applies
+  // to every type so a 3D template chart round-trips losslessly
+  // through a clone (and a 2D clone of a 3D template that happens to
+  // inherit the value silently keeps the element — Excel ignores it
+  // on 2D). Override wins over the source's parsed value, and the
+  // grammar follows the standard `number | null` shape so the chart-
+  // level numeric knobs compose the same way at the call site.
+  const resolvedSideWallThickness = resolveSideWallThickness(
+    source.sideWallThickness,
+    options.sideWallThickness,
+  );
+  if (resolvedSideWallThickness !== undefined) out.sideWallThickness = resolvedSideWallThickness;
+
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
   // to line / column does not leak the preset into a chart kind whose
@@ -2619,6 +2660,33 @@ function resolveView3D(
   // empty-object shape and emits a bare `<c:view3D/>` shell, mirroring
   // how `resolveProtection` handles the `true` / `{}` forms.
   return { ...override };
+}
+
+/**
+ * Resolve a `sideWallThickness` override.
+ *
+ * `undefined` → inherit the source's parsed `sideWallThickness`.
+ * `null`      → drop the inherited value (the writer skips
+ *               `<c:sideWall>` entirely — Excel falls back to no
+ *               extrusion).
+ * `number`    → replace. Out-of-range, `0`, or non-finite values still
+ *               surface in the cloned `SheetChart` for symmetry with
+ *               the other override helpers; the writer's
+ *               `buildSideWallThickness` then drops them at emit time
+ *               so a fresh chart matches Excel's reference
+ *               serialization.
+ *
+ * The grammar mirrors `upDownBarsGapWidth` / `gapWidth` / `holeSize` /
+ * `firstSliceAng` so the numeric chart-level knobs compose the same
+ * way at the call site.
+ */
+function resolveSideWallThickness(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -553,6 +553,18 @@ export function parseChart(xml: string): Chart | undefined {
   const view3D = parseView3D(chartEl);
   if (view3D !== undefined) out.view3D = view3D;
 
+  // `<c:sideWall>` (CT_Surface, ECMA-376 Part 1, §21.2.2.187) sits on
+  // `<c:chart>` between `<c:floor>` and `<c:backWall>` /
+  // `<c:plotArea>` per CT_Chart. The reader surfaces only the
+  // `<c:thickness>` child here — `<c:spPr>` / `<c:pictureOptions>` /
+  // `<c:extLst>` styling on the side-wall block is not modelled at
+  // this layer. Like `<c:view3D>` / `<c:floor>`, the schema accepts
+  // `<c:sideWall>` on every CT_Chart even though it is only
+  // meaningful on 3D families, so a stray element on a 2D chart still
+  // surfaces the value for round-trip parity.
+  const sideWallThickness = parseSideWallThickness(chartEl);
+  if (sideWallThickness !== undefined) out.sideWallThickness = sideWallThickness;
+
   return out;
 }
 
@@ -4934,6 +4946,57 @@ function parseView3DBoolean(view3D: XmlElement, local: string): boolean | undefi
     default:
       return undefined;
   }
+}
+
+// ── Side Wall Thickness ───────────────────────────────────────────
+
+/**
+ * Pull `<c:chart><c:sideWall><c:thickness val=".."/></c:sideWall>` off
+ * `<c:chart>`. The `<c:sideWall>` element (CT_Surface, ECMA-376 Part 1,
+ * §21.2.2.187) sits on `<c:chart>` between `<c:floor>` and
+ * `<c:backWall>` / `<c:plotArea>` per CT_Chart and carries an optional
+ * `<c:thickness>` child whose `val` attribute is an `xsd:unsignedInt` —
+ * Excel's "Format Side Wall -> Side Wall -> Thickness" pin on 3D chart
+ * families.
+ *
+ * Returns the integer pinned by the source chart. The OOXML default
+ * `0` (and absence of the `<c:thickness>` child or the parent
+ * `<c:sideWall>` element) collapses to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart} — only an
+ * explicit positive thickness surfaces here. Out-of-range or
+ * unparseable values also drop to `undefined` rather than fabricate a
+ * value the file did not declare.
+ *
+ * The `<c:thickness>` element only carries the `val` attribute on
+ * `CT_Thickness` — other side-wall styling (`<c:spPr>`,
+ * `<c:pictureOptions>`, `<c:extLst>`) is not modelled at this layer,
+ * so a stray styling block on the wall passes through the parse loop
+ * without surfacing.
+ */
+function parseSideWallThickness(chartEl: XmlElement): number | undefined {
+  const sideWall = findChild(chartEl, "sideWall");
+  if (!sideWall) return undefined;
+  const thickness = findChild(sideWall, "thickness");
+  if (!thickness) return undefined;
+  const raw = thickness.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  // ST_Thickness is `xsd:unsignedInt` — strict integer regex rejects
+  // fractional / negative / non-numeric tokens.
+  if (!/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  // Collapse the OOXML default `0` to undefined so absence and the
+  // default round-trip identically through cloneChart — only an
+  // explicit positive thickness surfaces here. Mirrors how the writer
+  // skips emission entirely for `0` / undefined.
+  if (n === 0) return undefined;
+  // Cap at Excel's UI band ceiling (`100`) — the OOXML schema accepts
+  // the full `xsd:unsignedInt` range but Excel's "Format Side Wall"
+  // dialogue rejects values above 100 with a repair warning. Anything
+  // larger drops here so a corrupt template does not silently rewrite
+  // as an absurd thickness; absence keeps the round-trip stable.
+  if (n > 100) return undefined;
+  return n;
 }
 
 // ── Vary Colors ────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -119,6 +119,23 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
     chartChildren.push(view3DXml);
   }
 
+  // `<c:sideWall>` (CT_Surface, ECMA-376 Part 1, §21.2.2.187) sits on
+  // `<c:chart>` between `<c:floor>` and `<c:backWall>` /
+  // `<c:plotArea>` per CT_Chart. The writer pins only the
+  // `<c:thickness>` child here — `<c:spPr>` / `<c:pictureOptions>` /
+  // `<c:extLst>` styling on the side-wall block is not modelled at
+  // this layer. Like `<c:view3D>`, the schema accepts `<c:sideWall>`
+  // on every CT_Chart even though it is only meaningful on 3D
+  // families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`);
+  // Excel silently ignores it on 2D families. The writer skips
+  // emission entirely when the caller leaves `sideWallThickness`
+  // unset (or pins `0`) so a fresh chart matches Excel's reference
+  // serialization byte-for-byte.
+  const sideWallXml = buildSideWallThickness(chart.sideWallThickness);
+  if (sideWallXml !== undefined) {
+    chartChildren.push(sideWallXml);
+  }
+
   // ── Plot Area ──
   chartChildren.push(buildPlotArea(chart, sheetName));
 
@@ -1595,6 +1612,40 @@ function clampView3DInt(value: number | undefined, min: number, max: number): nu
   if (!Number.isInteger(value)) return undefined;
   if (value < min || value > max) return undefined;
   return value;
+}
+
+/**
+ * Serialize {@link SheetChart.sideWallThickness} into
+ * `<c:sideWall><c:thickness val="N"/></c:sideWall>`. Returns
+ * `undefined` when the caller did not opt in
+ * (`sideWallThickness` is `undefined`, `0`, non-finite, non-integer,
+ * negative, or out of the Excel UI band `1..100`) so the writer can
+ * skip the `<c:sideWall>` element entirely — Excel renders no side-
+ * wall extrusion on a fresh chart and absence matches the reference
+ * serialization byte-for-byte.
+ *
+ * The OOXML schema (`ST_Thickness`, `xsd:unsignedInt`) accepts any
+ * non-negative integer, but Excel's "Format Side Wall -> Side Wall ->
+ * Thickness" pane only exposes `0..100` — values above that band
+ * render but trigger Excel's repair dialog. Drop out-of-range and
+ * non-integer inputs rather than emit a token Excel rejects, mirroring
+ * how every other chart-level numeric writer ({@link clampView3DInt}
+ * / {@link clampHoleSize} / {@link clampFirstSliceAng}) treats its
+ * input.
+ *
+ * The element only carries the `<c:thickness>` child — other
+ * `CT_Surface` children (`<c:spPr>`, `<c:pictureOptions>`,
+ * `<c:extLst>`) are not modelled at this layer, so the emitted
+ * `<c:sideWall>` block is the minimal shape Excel itself emits when
+ * the user pins a thickness with no other side-wall styling.
+ */
+function buildSideWallThickness(value: number | undefined): string | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  if (!Number.isInteger(value)) return undefined;
+  if (value <= 0) return undefined;
+  if (value > 100) return undefined;
+  return xmlElement("c:sideWall", undefined, [xmlSelfClose("c:thickness", { val: value })]);
 }
 
 interface AxisRenderOptions {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -12427,6 +12427,222 @@ describe("cloneChart — view3D", () => {
   });
 });
 
+// ── cloneChart — side-wall thickness ─────────────────────────────────
+
+describe("cloneChart — sideWallThickness", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's sideWallThickness by default", () => {
+    const clone = cloneChart(source({ sideWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.sideWallThickness).toBe(25);
+  });
+
+  it("lets options.sideWallThickness replace the inherited value", () => {
+    const clone = cloneChart(source({ sideWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      sideWallThickness: 50,
+    });
+    expect(clone.sideWallThickness).toBe(50);
+  });
+
+  it("drops the inherited sideWallThickness when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:sideWall> entirely on emit. Mirrors
+    // resolveUpDownBarsGapWidth / resolveView3D's null grammar.
+    const clone = cloneChart(source({ sideWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      sideWallThickness: null,
+    });
+    expect(clone.sideWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined sideWallThickness when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.sideWallThickness).toBeUndefined();
+  });
+
+  it("carries sideWallThickness through a flatten (line → column)", () => {
+    // <c:sideWall> lives on <c:chart>, so a chart-type coercion
+    // preserves the pinned value — the element has no axis dependency.
+    const clone = cloneChart(source({ sideWallThickness: 35 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.sideWallThickness).toBe(35);
+  });
+
+  it("preserves sideWallThickness when flattening into a doughnut clone", () => {
+    // Unlike <c:dTable>, <c:sideWall> has no axis dependency — it
+    // lives on <c:chart> so pie / doughnut still carry the slot.
+    const clone = cloneChart(source({ sideWallThickness: 20 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.sideWallThickness).toBe(20);
+  });
+
+  it("preserves sideWallThickness when flattening into a pie clone", () => {
+    const clone = cloneChart(source({ sideWallThickness: 40 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.sideWallThickness).toBe(40);
+  });
+
+  it("composes independently with view3D (both sit on <c:chart>)", () => {
+    // Both knobs land on <c:chart> directly — one should not leak into
+    // the other through the resolver pair.
+    const clone = cloneChart(source({ view3D: { rotX: 15, rotY: 20 }, sideWallThickness: 30 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.view3D).toEqual({ rotX: 15, rotY: 20 });
+    expect(clone.sideWallThickness).toBe(30);
+  });
+
+  it("override does not leak into view3D when both fields are pinned independently", () => {
+    // The view3D resolver and the sideWallThickness resolver are
+    // independent. Overriding one should not affect the other.
+    const clone = cloneChart(source({ view3D: { rotX: 15 }, sideWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      sideWallThickness: 60,
+    });
+    expect(clone.view3D).toEqual({ rotX: 15 });
+    expect(clone.sideWallThickness).toBe(60);
+  });
+
+  it("propagates sideWallThickness into the rendered <c:sideWall> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ sideWallThickness: 45 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:sideWall>");
+    expect(written).toContain('<c:thickness val="45"/>');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.sideWallThickness).toBe(45);
+  });
+
+  it("propagates the override-drop (null) into absence on roundtrip", async () => {
+    // null on the override drops the inherited value so the writer
+    // skips the element entirely — Excel falls back to no extrusion.
+    // The round-trip closes with no <c:sideWall> present in the
+    // rendered file.
+    const clone = cloneChart(source({ sideWallThickness: 25 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      sideWallThickness: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:sideWall");
+    expect(parseChart(written)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("override-replace into a positive value emits the new <c:thickness val>", async () => {
+    // The override replaces the inherited value — the writer emits the
+    // override at the canonical slot.
+    const clone = cloneChart(source({ sideWallThickness: 10 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      sideWallThickness: 75,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:thickness val="75"/>');
+    expect(written).not.toContain('<c:thickness val="10"/>');
+    expect(parseChart(written)?.sideWallThickness).toBe(75);
+  });
+
+  it("composes independently with view3D on the writeXlsx roundtrip", async () => {
+    // Both knobs sit on <c:chart>; the round-trip preserves both.
+    const clone = cloneChart(source({ view3D: { rotX: 20, rotY: 30 }, sideWallThickness: 50 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:rotX val="20"/>');
+    expect(written).toContain('<c:rotY val="30"/>');
+    expect(written).toContain('<c:thickness val="50"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 20, rotY: 30 });
+    expect(reparsed?.sideWallThickness).toBe(50);
+  });
+});
+
 // ── cloneChart — axis label rotation ───────────────────────────────
 
 describe("cloneChart — axis labelRotation", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -11254,6 +11254,199 @@ describe("writeChart — view3D", () => {
   });
 });
 
+// ── writeChart — side-wall thickness ─────────────────────────────────
+
+describe("writeChart — sideWallThickness", () => {
+  it("skips <c:sideWall> entirely when the field is unset (writer default)", () => {
+    // Excel renders no side-wall extrusion on a fresh chart — the
+    // writer skips the element so the file stays minimal. Absence and
+    // the unset default round-trip identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:sideWall");
+  });
+
+  it('emits <c:sideWall><c:thickness val="N"/></c:sideWall> when sideWallThickness is positive', () => {
+    const result = writeChart(makeChart({ sideWallThickness: 25 }), "Sheet1");
+    expect(result.chartXml).toContain("<c:sideWall>");
+    expect(result.chartXml).toContain('<c:thickness val="25"/>');
+    expect(result.chartXml).toContain("</c:sideWall>");
+  });
+
+  it("emits the boundary value 100 (Excel UI band ceiling)", () => {
+    const result = writeChart(makeChart({ sideWallThickness: 100 }), "Sheet1");
+    expect(result.chartXml).toContain('<c:thickness val="100"/>');
+  });
+
+  it("emits the minimum positive value 1", () => {
+    const result = writeChart(makeChart({ sideWallThickness: 1 }), "Sheet1");
+    expect(result.chartXml).toContain('<c:thickness val="1"/>');
+  });
+
+  it("skips emission when sideWallThickness is 0 (the OOXML default)", () => {
+    // The OOXML default `0` matches absence — drop the element so a
+    // fresh chart matches Excel's reference serialization byte-for-byte.
+    const result = writeChart(makeChart({ sideWallThickness: 0 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:sideWall");
+  });
+
+  it("drops out-of-range values (above the Excel UI ceiling 100) rather than emit", () => {
+    // Excel's UI tops out at 100 — values above the band drop here so
+    // a fresh chart never emits a token Excel's repair dialog would
+    // flag. Mirrors how clampView3DInt / clampHoleSize handle out-of-
+    // range numeric inputs.
+    const result = writeChart(makeChart({ sideWallThickness: 500 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:sideWall");
+  });
+
+  it("drops negative values (ST_Thickness is xsd:unsignedInt)", () => {
+    const result = writeChart(makeChart({ sideWallThickness: -10 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:sideWall");
+  });
+
+  it("drops fractional values rather than truncate", () => {
+    // ST_Thickness is `xsd:unsignedInt` — a fractional input drops
+    // rather than silently truncate. Mirrors clampView3DInt's strict
+    // integer check.
+    const result = writeChart(makeChart({ sideWallThickness: 25.5 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:sideWall");
+  });
+
+  it("drops non-finite values (NaN, Infinity, -Infinity)", () => {
+    expect(
+      writeChart(makeChart({ sideWallThickness: Number.NaN }), "Sheet1").chartXml,
+    ).not.toContain("<c:sideWall");
+    expect(
+      writeChart(makeChart({ sideWallThickness: Number.POSITIVE_INFINITY }), "Sheet1").chartXml,
+    ).not.toContain("<c:sideWall");
+    expect(
+      writeChart(makeChart({ sideWallThickness: Number.NEGATIVE_INFINITY }), "Sheet1").chartXml,
+    ).not.toContain("<c:sideWall");
+  });
+
+  it("drops a non-number sideWallThickness rather than emit invalid token", () => {
+    // A non-number leaking through the type guard drops the element —
+    // mirrors how every other chart-level numeric writer treats its
+    // input.
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ sideWallThickness: "25" as any }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:sideWall");
+  });
+
+  it("places <c:sideWall> after <c:view3D> and before <c:plotArea> per CT_Chart", () => {
+    // CT_Chart sequence (ECMA-376 Part 1, §21.2.2.4):
+    //   title?, autoTitleDeleted?, pivotFmts?, view3D?, floor?,
+    //   sideWall?, backWall?, plotArea, ...
+    const result = writeChart(makeChart({ view3D: { rotX: 15 }, sideWallThickness: 25 }), "Sheet1");
+    const view3DIdx = result.chartXml.indexOf("<c:view3D");
+    const sideWallIdx = result.chartXml.indexOf("<c:sideWall");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(view3DIdx).toBeGreaterThan(-1);
+    expect(sideWallIdx).toBeGreaterThan(view3DIdx);
+    expect(sideWallIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("places <c:sideWall> after <c:autoTitleDeleted> when <c:view3D> is absent", () => {
+    // With no view3D pinned, <c:sideWall> still slots between
+    // <c:autoTitleDeleted> and <c:plotArea> per CT_Chart.
+    const result = writeChart(makeChart({ sideWallThickness: 30 }), "Sheet1");
+    const autoIdx = result.chartXml.indexOf("<c:autoTitleDeleted");
+    const sideWallIdx = result.chartXml.indexOf("<c:sideWall");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(autoIdx).toBeGreaterThan(-1);
+    expect(sideWallIdx).toBeGreaterThan(autoIdx);
+    expect(sideWallIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("only emits <c:sideWall> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ sideWallThickness: 25 }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:sideWall[\s/>]/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads sideWallThickness through every chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:sideWall> is only meaningful on 3D families but the OOXML
+    // schema accepts it on every CT_Chart. The writer emits it on
+    // every family the caller pins it on — Excel silently ignores it
+    // on 2D families.
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, sideWallThickness: 20 }), "Sheet1");
+      expect(result.chartXml).toContain('<c:thickness val="20"/>');
+    }
+    for (const type of ["pie", "doughnut"] as const) {
+      const result = writeChart(
+        {
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4" }],
+          anchor: { from: { row: 5, col: 0 } },
+          sideWallThickness: 20,
+        },
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('<c:thickness val="20"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        sideWallThickness: 20,
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<c:thickness val="20"/>');
+  });
+
+  it("round-trips a positive sideWallThickness through parseChart", () => {
+    const written = writeChart(makeChart({ sideWallThickness: 35 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.sideWallThickness).toBe(35);
+  });
+
+  it("round-trips sideWallThickness independently of view3D", () => {
+    // Both knobs sit on <c:chart> — one should not leak into the other
+    // through the writer / reader pair.
+    const written = writeChart(
+      makeChart({ view3D: { rotX: 15, rotY: 20 }, sideWallThickness: 40 }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 15, rotY: 20 });
+    expect(reparsed?.sideWallThickness).toBe(40);
+  });
+
+  it("threads sideWallThickness through writeXlsx into xl/charts/chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Side Wall Test",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            sideWallThickness: 50,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:sideWall>");
+    expect(chartXml).toContain('<c:thickness val="50"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.sideWallThickness).toBe(50);
+  });
+});
+
 // ── writeChart — axis label rotation ────────────────────────────────
 
 describe("writeChart — axis labelRotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -11718,6 +11718,292 @@ describe("parseChart — view3D", () => {
   });
 });
 
+// ── parseChart — side-wall thickness ──────────────────────────────
+
+describe("parseChart — sideWallThickness", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a positive thickness pinned by <c:sideWall><c:thickness>", () => {
+    // Excel's "Format Side Wall -> Side Wall -> Thickness" pane writes
+    // `<c:sideWall><c:thickness val="N"/></c:sideWall>` when the user
+    // pins a non-zero value. The reader surfaces the integer literally
+    // so a clone can replay the exact extrusion depth.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="25"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBe(25);
+  });
+
+  it("collapses the OOXML default 0 to undefined", () => {
+    // The OOXML default `0` (no extrusion) is the writer's default
+    // shape — absence and `0` round-trip identically. Only an explicit
+    // positive thickness surfaces here.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="0"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("surfaces the boundary value 100 (Excel UI band ceiling)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="100"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBe(100);
+  });
+
+  it("drops out-of-range values rather than fabricate a clamped thickness", () => {
+    // Excel's UI tops out at 100 — a stray value above the band drops
+    // rather than silently rewrite as a different thickness, mirroring
+    // how the other chart-level numeric readers (gapWidth / overlap /
+    // firstSliceAng / view3D children) handle out-of-range tokens.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="500"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("drops fractional / non-integer values rather than fabricate floats", () => {
+    // ST_Thickness is `xsd:unsignedInt` — `parseInt` would coerce
+    // "25.5" → 25, but Excel never emits the fractional spelling.
+    // Drop the field so a hand-edited file with a fractional `val`
+    // stays unrecognised rather than silently round-trip a value Excel
+    // would not author.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="25.5"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("drops negative values (ST_Thickness is xsd:unsignedInt)", () => {
+    // The unsigned simple type rejects a leading `-`.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="-10"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("drops a missing val attribute rather than fabricate a value", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("drops non-numeric val tokens rather than coerce", () => {
+    // `parseInt` would coerce "30abc" → 30, but Excel never emits the
+    // mixed spelling. The strict integer regex rejects the token.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="30abc"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined when <c:sideWall> is present but <c:thickness> is missing", () => {
+    // CT_Surface's `<c:thickness>` is optional. A `<c:sideWall>` block
+    // with only `<c:spPr>` styling carries no thickness pin.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:spPr/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined on a bare <c:sideWall/> element", () => {
+    // A self-closing element with no children — same minimal-shape
+    // result as a side wall with `<c:spPr>` only.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall/>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:sideWall> element", () => {
+    // Absence is the writer's default — Excel renders no side-wall
+    // extrusion on a fresh chart. The reader surfaces nothing so a
+    // fresh chart and a chart that omits the element round-trip
+    // identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBeUndefined();
+  });
+
+  it("surfaces sideWallThickness on a 2D chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:sideWall> is only meaningful on 3D families but the OOXML
+    // schema accepts it on every CT_Chart. A stray element on a 2D
+    // chart surfaces here so the round-trip through cloneChart stays
+    // lossless even when the template authors a no-op.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="15"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBe(15);
+  });
+
+  it("surfaces sideWallThickness on a pie chart (no axes, but the element lives on <c:chart>)", () => {
+    // <c:sideWall> lives on <c:chart>, not inside <c:plotArea>, so
+    // axis-shape has no bearing on whether the slot exists. Pie /
+    // doughnut still carry the element when the file pins it.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:sideWall>
+      <c:thickness val="10"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:pieChart>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.sideWallThickness).toBe(10);
+  });
+
+  it("co-exists with sibling chart-level toggles", () => {
+    // The sideWallThickness reader should not interfere with sibling
+    // fields parsed off <c:chart> (autoTitleDeleted / view3D /
+    // plotVisOnly / dispBlanksAs).
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:autoTitleDeleted val="1"/>
+    <c:view3D>
+      <c:rotX val="20"/>
+    </c:view3D>
+    <c:sideWall>
+      <c:thickness val="40"/>
+    </c:sideWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.autoTitleDeleted).toBe(true);
+    expect(chart?.view3D).toEqual({ rotX: 20 });
+    expect(chart?.sideWallThickness).toBe(40);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+  });
+});
+
 // ── parseChart — legend entries ────────────────────────────────────
 
 describe("parseChart — legend entries", () => {


### PR DESCRIPTION
## Summary

- Adds `sideWallThickness?: number` to `SheetChart` / `Chart`, mapped to `<c:chart><c:sideWall><c:thickness val=\"N\"/></c:sideWall>` per the `CT_Surface` schema (the `<c:thickness>` child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.187 / §21.2.2.69) — Excel's "Format Side Wall -> Side Wall -> Thickness" pin on 3D chart families.
- Reader / writer / clone-through all support the new knob; mirrors the `floorThickness` pattern (#295) — same OOXML simple-type clamp, same default-collapse contract, same `number | null` clone-through grammar.
- Reader: surfaces a positive integer pinned by `<c:sideWall><c:thickness val=\"N\"/>`; the OOXML default `0` (and absence of `<c:sideWall>` / `<c:thickness>`) collapses to `undefined` so absence and the default round-trip identically through `cloneChart`. Out-of-range (`> 100`, the Excel UI band ceiling), negative, fractional, and non-numeric `val` tokens drop to `undefined` rather than fabricate a value the file did not declare.
- Writer: emits `<c:sideWall><c:thickness val=\"N\"/></c:sideWall>` between `<c:view3D>` and `<c:plotArea>` per CT_Chart sequence; skips emission when the field is unset, `0`, non-finite, non-integer, negative, or above the Excel UI ceiling `100` so a fresh chart matches Excel's reference serialization byte-for-byte.
- Clone-through: `cloneChart`'s new `sideWallThickness?: number | null` option mirrors `upDownBarsGapWidth` / `floorThickness`'s `number | null` shape — `undefined` inherits, `null` drops the inherited value, a number replaces it.
- Applies to every chart family — `<c:sideWall>` lives on `<c:chart>` directly, so the OOXML schema accepts it on every chart family even though it is only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`); useful primarily for round-tripping a 3D template chart through `cloneChart`. Composes independently with `view3D` and `floorThickness` (all three knobs sit on `<c:chart>`).

The candidate list on issue #136 calls out `<c:sideWall>` thickness as a 3D-walls Phase 2 round-trip gap (the floor/walls family). This is the side-wall slice of that scope (just the `<c:thickness>` child; `<c:spPr>` / `<c:pictureOptions>` / `<c:extLst>` styling on the side-wall block is not modelled at this layer); `<c:backWall>` follows the same shape and remains a separately-scoped follow-up.

Refs #136

## Test plan

- [x] \`pnpm vitest run --dir=test\` — all 6027 tests pass (44 new for this feature: 14 reader + 17 writer + 13 clone-through)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm build\` — succeeds (\`obuild\` finishes without errors)
- [x] \`pnpm lint\` — no new warnings/errors
- [x] reader: surfaces positive integer values from \`<c:sideWall><c:thickness>\`; collapses default \`0\` and absence to \`undefined\`; drops out-of-range / fractional / negative / non-numeric \`val\` tokens; surfaces the value on every chart family (2D and 3D) and on pie / doughnut (no axes); co-exists with sibling chart-level toggles (\`autoTitleDeleted\`, \`view3D\`, \`plotVisOnly\`, \`dispBlanksAs\`)
- [x] writer: emits \`<c:sideWall><c:thickness val=\"N\"/></c:sideWall>\` for positive values in \`1..100\`; skips emission for unset / \`0\` / out-of-range / non-finite / non-integer / negative / non-number inputs; places \`<c:sideWall>\` after \`<c:view3D>\` (or \`<c:autoTitleDeleted>\` if no view3D) and before \`<c:plotArea>\` per CT_Chart sequence; threads through every chart family; only emits once per chart
- [x] clone: inheritance, override, drop-on-null all behave like the other chart-level numeric knobs; carries through chart-type flatten (line → column / pie / doughnut); composes independently with \`view3D\`; round-trip through \`parseChart\` -> \`cloneChart\` -> \`writeChart\` -> \`parseChart\` preserves the thickness; round-trip through \`writeXlsx\` lands the value in \`xl/charts/chart1.xml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)