### PR TITLE
feat(xlsx): chart back-wall thickness — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2783,6 +2783,38 @@ export interface SheetChart {
    */
   floorThickness?: number;
   /**
+   * 3-D back-wall thickness, in points. Maps to
+   * `<c:chart><c:backWall><c:thickness val="N"/></c:backWall>` —
+   * Excel's "Format Back Wall -> Back Wall" pane (the `<c:thickness>`
+   * child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.214). Excel renders
+   * the back wall as a flat plate behind the plot area on 3D chart
+   * families; pinning a positive value extrudes the plate to that depth
+   * so the wall reads as a solid slab. Default: omitted — Excel renders
+   * no `<c:backWall>` element on a fresh chart and the per-family
+   * back-wall default (no extrusion) applies.
+   *
+   * The OOXML schema (`ST_Thickness`, `xsd:unsignedInt`) accepts any
+   * non-negative integer; Excel's UI exposes `0..100` under
+   * "Format Back Wall -> Back Wall -> Thickness". Out-of-range or
+   * non-finite inputs drop at write time rather than emit a token
+   * Excel's strict validator would reject. The OOXML default `0`
+   * collapses to `undefined` for symmetry with the writer's
+   * {@link SheetChart.backWallThickness} default — absence and `0` mean
+   * the same thing on roundtrip.
+   *
+   * Although `<c:backWall>` is only meaningful on 3D chart families
+   * (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`) and hucre's
+   * writer authors only 2D families, the OOXML schema accepts the
+   * element on every CT_Chart, so the writer pins it whenever the
+   * caller provides a positive thickness — Excel silently ignores it
+   * on 2D families. Useful primarily for round-tripping a 3D template
+   * chart through {@link cloneChart}. The element sits on `<c:chart>`
+   * between `<c:sideWall>` and `<c:plotArea>` per CT_Chart — `<c:floor>`
+   * /  `<c:sideWall>` / `<c:backWall>` are independent siblings on
+   * `<c:chart>`.
+   */
+  backWallThickness?: number;
+  /**
    * Per-axis configuration rendered alongside the plot area. The `x`
    * axis is the category axis for bar/column/line/area (or the bottom
    * value axis for scatter); the `y` axis is the value axis. Ignored
@@ -7011,6 +7043,29 @@ export interface Chart {
    * lossless.
    */
   floorThickness?: number;
+  /**
+   * 3-D back-wall thickness pulled from
+   * `<c:chart><c:backWall><c:thickness val="N"/></c:backWall>` (the
+   * `<c:thickness>` child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.214).
+   * Reflects Excel's "Format Back Wall -> Back Wall -> Thickness" pin
+   * on 3D chart families.
+   *
+   * Surfaces the integer pinned by the source chart. The OOXML default
+   * `0` (and absence of the element) collapses to `undefined` so absence
+   * and the default round-trip identically through {@link cloneChart} —
+   * only an explicit positive thickness surfaces here. Out-of-range or
+   * unparseable values also drop to `undefined` rather than fabricate a
+   * value the file did not declare.
+   *
+   * The element lives on `<c:chart>` between `<c:sideWall>` and
+   * `<c:plotArea>` per CT_Chart, so the OOXML schema accepts it on every
+   * chart family — though it is only meaningful on 3D families (`bar3D`,
+   * `line3D`, `pie3D`, `area3D`, `surface3D`); a stray element on a 2D
+   * chart still surfaces here so the round-trip through
+   * {@link cloneChart} stays lossless. `<c:floor>` / `<c:sideWall>` /
+   * `<c:backWall>` are independent siblings on `<c:chart>`.
+   */
+  backWallThickness?: number;
 }
 
 // ── Workbook ───────────────────────────────────────────────────────

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -899,6 +899,30 @@ export interface CloneChartOptions {
    */
   floorThickness?: number | null;
   /**
+   * Override `<c:chart><c:backWall><c:thickness val="N"/></c:backWall>`
+   * (the 3-D back-wall extrusion thickness on `CT_Surface`, ECMA-376
+   * Part 1, §21.2.2.31).
+   *
+   * `undefined` (or omitted) inherits the source's parsed
+   * {@link Chart.backWallThickness}. `null` drops the inherited value
+   * so the writer skips `<c:backWall>` entirely — Excel falls back to
+   * its per-family back-wall default (no extrusion). A `number`
+   * replaces it — pass any value in the inclusive `1..100` band
+   * Excel's "Format Back Wall -> Back Wall -> Thickness" pane exposes;
+   * out-of-range, `0`, or non-finite values fall through to absence at
+   * write time rather than emit a token Excel rejects.
+   *
+   * Applies to every chart family — `<c:backWall>` lives on `<c:chart>`
+   * (between `<c:sideWall>` and `<c:plotArea>`), so the OOXML schema
+   * accepts the element on both 2D and 3D families. The toggle is only
+   * meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`,
+   * `surface3D`), but the writer carries a templated value through
+   * every clone so a 3D template chart round-trips losslessly. The
+   * grammar mirrors {@link CloneChartOptions.floorThickness} so the
+   * chart-level numeric knobs compose the same way at the call site.
+   */
+  backWallThickness?: number | null;
+  /**
    * Override `<c:scatterStyle>` (the chart-level XY-scatter preset).
    *
    * `undefined` (or omitted) inherits the source's parsed
@@ -1991,6 +2015,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   );
   if (resolvedFloorThickness !== undefined) out.floorThickness = resolvedFloorThickness;
 
+  // `<c:backWall>` lives on `<c:chart>` directly (between `<c:sideWall>`
+  // and `<c:plotArea>` per CT_Chart), so the OOXML schema accepts it
+  // on every chart family — both 2D and 3D. The toggle is only
+  // meaningful on 3D families, but the resolver applies to every type
+  // so a 3D template chart round-trips losslessly through a clone
+  // (and a 2D clone of a 3D template that happens to inherit the
+  // value silently keeps the element — Excel ignores it on 2D).
+  // Override wins over the source's parsed value, and the grammar
+  // follows the standard `number | null` shape so the chart-level
+  // numeric knobs compose the same way at the call site.
+  const resolvedBackWallThickness = resolveBackWallThickness(
+    source.backWallThickness,
+    options.backWallThickness,
+  );
+  if (resolvedBackWallThickness !== undefined) out.backWallThickness = resolvedBackWallThickness;
+
   // `<c:scatterStyle>` only renders inside `<c:scatterChart>`. Drop the
   // field on every other resolved type so a scatter template flattened
   // to line / column does not leak the preset into a chart kind whose
@@ -2679,6 +2719,33 @@ function resolveView3D(
  * way at the call site.
  */
 function resolveFloorThickness(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return sourceValue;
+  if (override === null) return undefined;
+  return override;
+}
+
+/**
+ * Resolve a `backWallThickness` override.
+ *
+ * `undefined` → inherit the source's parsed `backWallThickness`.
+ * `null`      → drop the inherited value (the writer skips
+ *               `<c:backWall>` entirely — Excel falls back to no
+ *               extrusion).
+ * `number`    → replace. Out-of-range, `0`, or non-finite values still
+ *               surface in the cloned `SheetChart` for symmetry with
+ *               the other override helpers; the writer's
+ *               `buildBackWallThickness` then drops them at emit time
+ *               so a fresh chart matches Excel's reference
+ *               serialization.
+ *
+ * The grammar mirrors `floorThickness` / `upDownBarsGapWidth` /
+ * `gapWidth` / `holeSize` / `firstSliceAng` so the numeric chart-level
+ * knobs compose the same way at the call site.
+ */
+function resolveBackWallThickness(
   sourceValue: number | undefined,
   override: number | null | undefined,
 ): number | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -565,6 +565,17 @@ export function parseChart(xml: string): Chart | undefined {
   const floorThickness = parseFloorThickness(chartEl);
   if (floorThickness !== undefined) out.floorThickness = floorThickness;
 
+  // `<c:backWall>` (CT_Surface, ECMA-376 Part 1, §21.2.2.31) sits on
+  // `<c:chart>` between `<c:sideWall>` and `<c:plotArea>` per CT_Chart.
+  // Like `<c:floor>`, the reader surfaces only the `<c:thickness>`
+  // child here — `<c:spPr>` / `<c:pictureOptions>` / `<c:extLst>`
+  // styling on the back-wall block is not modelled at this layer. The
+  // schema accepts `<c:backWall>` on every CT_Chart even though it is
+  // only meaningful on 3D families, so a stray element on a 2D chart
+  // still surfaces the value for round-trip parity.
+  const backWallThickness = parseBackWallThickness(chartEl);
+  if (backWallThickness !== undefined) out.backWallThickness = backWallThickness;
+
   return out;
 }
 
@@ -4991,6 +5002,56 @@ function parseFloorThickness(chartEl: XmlElement): number | undefined {
   if (n === 0) return undefined;
   // Cap at Excel's UI band ceiling (`100`) — the OOXML schema accepts
   // the full `xsd:unsignedInt` range but Excel's "Format Floor"
+  // dialogue rejects values above 100 with a repair warning. Anything
+  // larger drops here so a corrupt template does not silently rewrite
+  // as an absurd thickness; absence keeps the round-trip stable.
+  if (n > 100) return undefined;
+  return n;
+}
+
+// ── Back Wall Thickness ───────────────────────────────────────────
+
+/**
+ * Pull `<c:chart><c:backWall><c:thickness val=".."/></c:backWall>` off
+ * `<c:chart>`. The `<c:backWall>` element (CT_Surface, ECMA-376 Part 1,
+ * §21.2.2.31) sits on `<c:chart>` between `<c:sideWall>` and
+ * `<c:plotArea>` per CT_Chart and carries an optional `<c:thickness>`
+ * child whose `val` attribute is an `xsd:unsignedInt` — Excel's
+ * "Format Back Wall -> Back Wall -> Thickness" pin on 3D chart families.
+ *
+ * Returns the integer pinned by the source chart. The OOXML default
+ * `0` (and absence of the `<c:thickness>` child or the parent
+ * `<c:backWall>` element) collapses to `undefined` so absence and the
+ * default round-trip identically through {@link cloneChart} — only an
+ * explicit positive thickness surfaces here. Out-of-range or
+ * unparseable values also drop to `undefined` rather than fabricate a
+ * value the file did not declare.
+ *
+ * The `<c:thickness>` element only carries the `val` attribute on
+ * `CT_Thickness` — other back-wall styling (`<c:spPr>`,
+ * `<c:pictureOptions>`, `<c:extLst>`) is not modelled at this layer,
+ * so a stray styling block on the back wall passes through the parse
+ * loop without surfacing.
+ */
+function parseBackWallThickness(chartEl: XmlElement): number | undefined {
+  const backWall = findChild(chartEl, "backWall");
+  if (!backWall) return undefined;
+  const thickness = findChild(backWall, "thickness");
+  if (!thickness) return undefined;
+  const raw = thickness.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  // ST_Thickness is `xsd:unsignedInt` — strict integer regex rejects
+  // fractional / negative / non-numeric tokens.
+  if (!/^\d+$/.test(raw)) return undefined;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return undefined;
+  // Collapse the OOXML default `0` to undefined so absence and the
+  // default round-trip identically through cloneChart — only an
+  // explicit positive thickness surfaces here. Mirrors how the writer
+  // skips emission entirely for `0` / undefined.
+  if (n === 0) return undefined;
+  // Cap at Excel's UI band ceiling (`100`) — the OOXML schema accepts
+  // the full `xsd:unsignedInt` range but Excel's "Format Back Wall"
   // dialogue rejects values above 100 with a repair warning. Anything
   // larger drops here so a corrupt template does not silently rewrite
   // as an absurd thickness; absence keeps the round-trip stable.

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -136,6 +136,22 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
     chartChildren.push(floorXml);
   }
 
+  // `<c:backWall>` (CT_Surface, ECMA-376 Part 1, §21.2.2.31) sits on
+  // `<c:chart>` between `<c:sideWall>` and `<c:plotArea>` per CT_Chart.
+  // The writer pins only the `<c:thickness>` child here — `<c:spPr>`
+  // / `<c:pictureOptions>` / `<c:extLst>` styling on the back-wall
+  // block is not modelled at this layer. Like `<c:floor>`, the schema
+  // accepts `<c:backWall>` on every CT_Chart even though it is only
+  // meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`,
+  // `surface3D`); Excel silently ignores it on 2D families. The writer
+  // skips emission entirely when the caller leaves `backWallThickness`
+  // unset (or pins `0`) so a fresh chart matches Excel's reference
+  // serialization byte-for-byte.
+  const backWallXml = buildBackWallThickness(chart.backWallThickness);
+  if (backWallXml !== undefined) {
+    chartChildren.push(backWallXml);
+  }
+
   // ── Plot Area ──
   chartChildren.push(buildPlotArea(chart, sheetName));
 
@@ -1645,6 +1661,38 @@ function buildFloorThickness(value: number | undefined): string | undefined {
   if (value <= 0) return undefined;
   if (value > 100) return undefined;
   return xmlElement("c:floor", undefined, [xmlSelfClose("c:thickness", { val: value })]);
+}
+
+/**
+ * Serialize {@link SheetChart.backWallThickness} into
+ * `<c:backWall><c:thickness val="N"/></c:backWall>`. Returns
+ * `undefined` when the caller did not opt in (`backWallThickness` is
+ * `undefined`, `0`, non-finite, non-integer, negative, or out of the
+ * Excel UI band `1..100`) so the writer can skip the `<c:backWall>`
+ * element entirely — Excel renders no back-wall extrusion on a fresh
+ * chart and absence matches the reference serialization byte-for-byte.
+ *
+ * The OOXML schema (`ST_Thickness`, `xsd:unsignedInt`) accepts any
+ * non-negative integer, but Excel's "Format Back Wall -> Back Wall ->
+ * Thickness" pane only exposes `0..100` — values above that band
+ * render but trigger Excel's repair dialog. Drop out-of-range and
+ * non-integer inputs rather than emit a token Excel rejects, mirroring
+ * how every other chart-level numeric writer ({@link buildFloorThickness}
+ * / {@link clampView3DInt} / {@link clampHoleSize}) treats its input.
+ *
+ * The element only carries the `<c:thickness>` child — other
+ * `CT_Surface` children (`<c:spPr>`, `<c:pictureOptions>`,
+ * `<c:extLst>`) are not modelled at this layer, so the emitted
+ * `<c:backWall>` block is the minimal shape Excel itself emits when
+ * the user pins a thickness with no other back-wall styling.
+ */
+function buildBackWallThickness(value: number | undefined): string | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value)) return undefined;
+  if (!Number.isInteger(value)) return undefined;
+  if (value <= 0) return undefined;
+  if (value > 100) return undefined;
+  return xmlElement("c:backWall", undefined, [xmlSelfClose("c:thickness", { val: value })]);
 }
 
 interface AxisRenderOptions {

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -12643,6 +12643,250 @@ describe("cloneChart — floorThickness", () => {
   });
 });
 
+// ── cloneChart — back-wall thickness ────────────────────────────────
+
+describe("cloneChart — backWallThickness", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's backWallThickness by default", () => {
+    const clone = cloneChart(source({ backWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.backWallThickness).toBe(25);
+  });
+
+  it("lets options.backWallThickness replace the inherited value", () => {
+    const clone = cloneChart(source({ backWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      backWallThickness: 50,
+    });
+    expect(clone.backWallThickness).toBe(50);
+  });
+
+  it("drops the inherited backWallThickness when the override is null", () => {
+    // null collapses to absence — the cloned SheetChart drops the
+    // field so the writer skips <c:backWall> entirely on emit. Mirrors
+    // resolveFloorThickness / resolveUpDownBarsGapWidth /
+    // resolveView3D's null grammar.
+    const clone = cloneChart(source({ backWallThickness: 25 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      backWallThickness: null,
+    });
+    expect(clone.backWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined backWallThickness when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.backWallThickness).toBeUndefined();
+  });
+
+  it("carries backWallThickness through a flatten (line → column)", () => {
+    // <c:backWall> lives on <c:chart>, so a chart-type coercion
+    // preserves the pinned value — the element has no axis dependency.
+    const clone = cloneChart(source({ backWallThickness: 35 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.backWallThickness).toBe(35);
+  });
+
+  it("preserves backWallThickness when flattening into a doughnut clone", () => {
+    // Unlike <c:dTable>, <c:backWall> has no axis dependency — it
+    // lives on <c:chart> so pie / doughnut still carry the slot.
+    const clone = cloneChart(source({ backWallThickness: 20 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.backWallThickness).toBe(20);
+  });
+
+  it("preserves backWallThickness when flattening into a pie clone", () => {
+    const clone = cloneChart(source({ backWallThickness: 40 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "pie",
+    });
+    expect(clone.type).toBe("pie");
+    expect(clone.backWallThickness).toBe(40);
+  });
+
+  it("composes independently with view3D and floorThickness (all sit on <c:chart>)", () => {
+    // All three knobs land on <c:chart> directly as independent
+    // siblings — overrides of one should not leak into the others
+    // through the resolver pair.
+    const clone = cloneChart(
+      source({
+        view3D: { rotX: 15, rotY: 20 },
+        floorThickness: 30,
+        backWallThickness: 40,
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+      },
+    );
+    expect(clone.view3D).toEqual({ rotX: 15, rotY: 20 });
+    expect(clone.floorThickness).toBe(30);
+    expect(clone.backWallThickness).toBe(40);
+  });
+
+  it("override does not leak into view3D / floorThickness when fields are pinned independently", () => {
+    // The view3D / floorThickness / backWallThickness resolvers are
+    // independent. Overriding one should not affect the others.
+    const clone = cloneChart(
+      source({
+        view3D: { rotX: 15 },
+        floorThickness: 25,
+        backWallThickness: 30,
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        backWallThickness: 60,
+      },
+    );
+    expect(clone.view3D).toEqual({ rotX: 15 });
+    expect(clone.floorThickness).toBe(25);
+    expect(clone.backWallThickness).toBe(60);
+  });
+
+  it("propagates backWallThickness into the rendered <c:backWall> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ backWallThickness: 45 }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:backWall>");
+    expect(written).toContain('<c:thickness val="45"/>');
+
+    // Re-parsing the rendered chart returns the same value — closes
+    // the template → clone → write → read loop.
+    const reparsed = parseChart(written);
+    expect(reparsed?.backWallThickness).toBe(45);
+  });
+
+  it("propagates the override-drop (null) into absence on roundtrip", async () => {
+    // null on the override drops the inherited value so the writer
+    // skips the element entirely — Excel falls back to no extrusion.
+    // The round-trip closes with no <c:backWall> present in the
+    // rendered file.
+    const clone = cloneChart(source({ backWallThickness: 25 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      backWallThickness: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:backWall");
+    expect(parseChart(written)?.backWallThickness).toBeUndefined();
+  });
+
+  it("override-replace into a positive value emits the new <c:thickness val>", async () => {
+    // The override replaces the inherited value — the writer emits the
+    // override at the canonical slot.
+    const clone = cloneChart(source({ backWallThickness: 10 }), {
+      anchor: { from: { row: 5, col: 0 } },
+      backWallThickness: 75,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:thickness val="75"/>');
+    expect(written).not.toContain('<c:thickness val="10"/>');
+    expect(parseChart(written)?.backWallThickness).toBe(75);
+  });
+
+  it("composes independently with view3D and floorThickness on the writeXlsx roundtrip", async () => {
+    // All three knobs sit on <c:chart>; the round-trip preserves all
+    // three independently.
+    const clone = cloneChart(
+      source({
+        view3D: { rotX: 20, rotY: 30 },
+        floorThickness: 35,
+        backWallThickness: 50,
+      }),
+      {
+        anchor: { from: { row: 5, col: 0 } },
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["Q", "Revenue"],
+            ["Q1", 100],
+            ["Q2", 200],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<c:rotX val="20"/>');
+    expect(written).toContain('<c:rotY val="30"/>');
+    expect(written).toContain('<c:thickness val="35"/>');
+    expect(written).toContain('<c:thickness val="50"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 20, rotY: 30 });
+    expect(reparsed?.floorThickness).toBe(35);
+    expect(reparsed?.backWallThickness).toBe(50);
+  });
+});
+
 // ── cloneChart — axis label rotation ───────────────────────────────
 
 describe("cloneChart — axis labelRotation", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -11447,6 +11447,209 @@ describe("writeChart — floorThickness", () => {
   });
 });
 
+// ── writeChart — back-wall thickness ────────────────────────────────
+
+describe("writeChart — backWallThickness", () => {
+  it("skips <c:backWall> entirely when the field is unset (writer default)", () => {
+    // Excel renders no back-wall extrusion on a fresh chart — the
+    // writer skips the element so the file stays minimal. Absence and
+    // the unset default round-trip identically through cloneChart.
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:backWall");
+  });
+
+  it('emits <c:backWall><c:thickness val="N"/></c:backWall> when backWallThickness is positive', () => {
+    const result = writeChart(makeChart({ backWallThickness: 25 }), "Sheet1");
+    expect(result.chartXml).toContain("<c:backWall>");
+    expect(result.chartXml).toContain('<c:thickness val="25"/>');
+    expect(result.chartXml).toContain("</c:backWall>");
+  });
+
+  it("emits the boundary value 100 (Excel UI band ceiling)", () => {
+    const result = writeChart(makeChart({ backWallThickness: 100 }), "Sheet1");
+    expect(result.chartXml).toContain('<c:thickness val="100"/>');
+  });
+
+  it("emits the minimum positive value 1", () => {
+    const result = writeChart(makeChart({ backWallThickness: 1 }), "Sheet1");
+    expect(result.chartXml).toContain('<c:thickness val="1"/>');
+  });
+
+  it("skips emission when backWallThickness is 0 (the OOXML default)", () => {
+    // The OOXML default `0` matches absence — drop the element so a
+    // fresh chart matches Excel's reference serialization byte-for-byte.
+    const result = writeChart(makeChart({ backWallThickness: 0 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:backWall");
+  });
+
+  it("drops out-of-range values (above the Excel UI ceiling 100) rather than emit", () => {
+    // Excel's UI tops out at 100 — values above the band drop here so
+    // a fresh chart never emits a token Excel's repair dialog would
+    // flag. Mirrors how buildFloorThickness / clampView3DInt /
+    // clampHoleSize handle out-of-range numeric inputs.
+    const result = writeChart(makeChart({ backWallThickness: 500 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:backWall");
+  });
+
+  it("drops negative values (ST_Thickness is xsd:unsignedInt)", () => {
+    const result = writeChart(makeChart({ backWallThickness: -10 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:backWall");
+  });
+
+  it("drops fractional values rather than truncate", () => {
+    // ST_Thickness is `xsd:unsignedInt` — a fractional input drops
+    // rather than silently truncate. Mirrors clampView3DInt's strict
+    // integer check.
+    const result = writeChart(makeChart({ backWallThickness: 25.5 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:backWall");
+  });
+
+  it("drops non-finite values (NaN, Infinity, -Infinity)", () => {
+    expect(
+      writeChart(makeChart({ backWallThickness: Number.NaN }), "Sheet1").chartXml,
+    ).not.toContain("<c:backWall");
+    expect(
+      writeChart(makeChart({ backWallThickness: Number.POSITIVE_INFINITY }), "Sheet1").chartXml,
+    ).not.toContain("<c:backWall");
+    expect(
+      writeChart(makeChart({ backWallThickness: Number.NEGATIVE_INFINITY }), "Sheet1").chartXml,
+    ).not.toContain("<c:backWall");
+  });
+
+  it("drops a non-number backWallThickness rather than emit invalid token", () => {
+    // A non-number leaking through the type guard drops the element —
+    // mirrors how every other chart-level numeric writer treats its
+    // input.
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ backWallThickness: "25" as any }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:backWall");
+  });
+
+  it("places <c:backWall> after <c:floor> and before <c:plotArea> per CT_Chart", () => {
+    // CT_Chart sequence (ECMA-376 Part 1, §21.2.2.4):
+    //   title?, autoTitleDeleted?, pivotFmts?, view3D?, floor?,
+    //   sideWall?, backWall?, plotArea, ...
+    const result = writeChart(
+      makeChart({ view3D: { rotX: 15 }, floorThickness: 25, backWallThickness: 30 }),
+      "Sheet1",
+    );
+    const view3DIdx = result.chartXml.indexOf("<c:view3D");
+    const floorIdx = result.chartXml.indexOf("<c:floor");
+    const backWallIdx = result.chartXml.indexOf("<c:backWall");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(view3DIdx).toBeGreaterThan(-1);
+    expect(floorIdx).toBeGreaterThan(view3DIdx);
+    expect(backWallIdx).toBeGreaterThan(floorIdx);
+    expect(backWallIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("places <c:backWall> after <c:autoTitleDeleted> when <c:view3D> / <c:floor> are absent", () => {
+    // With no view3D / floor pinned, <c:backWall> still slots between
+    // <c:autoTitleDeleted> and <c:plotArea> per CT_Chart.
+    const result = writeChart(makeChart({ backWallThickness: 30 }), "Sheet1");
+    const autoIdx = result.chartXml.indexOf("<c:autoTitleDeleted");
+    const backWallIdx = result.chartXml.indexOf("<c:backWall");
+    const plotAreaIdx = result.chartXml.indexOf("<c:plotArea>");
+    expect(autoIdx).toBeGreaterThan(-1);
+    expect(backWallIdx).toBeGreaterThan(autoIdx);
+    expect(backWallIdx).toBeLessThan(plotAreaIdx);
+  });
+
+  it("only emits <c:backWall> once on a chart that pins it", () => {
+    // Guard against any regression that would double-emit the element.
+    const result = writeChart(makeChart({ backWallThickness: 25 }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:backWall[\s/>]/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads backWallThickness through every chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:backWall> is only meaningful on 3D families but the OOXML
+    // schema accepts it on every CT_Chart. The writer emits it on
+    // every family the caller pins it on — Excel silently ignores it
+    // on 2D families.
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, backWallThickness: 20 }), "Sheet1");
+      expect(result.chartXml).toContain('<c:thickness val="20"/>');
+    }
+    for (const type of ["pie", "doughnut"] as const) {
+      const result = writeChart(
+        {
+          type,
+          series: [{ values: "B2:B4", categories: "A2:A4" }],
+          anchor: { from: { row: 5, col: 0 } },
+          backWallThickness: 20,
+        },
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain('<c:thickness val="20"/>');
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        backWallThickness: 20,
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain('<c:thickness val="20"/>');
+  });
+
+  it("round-trips a positive backWallThickness through parseChart", () => {
+    const written = writeChart(makeChart({ backWallThickness: 35 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.backWallThickness).toBe(35);
+  });
+
+  it("round-trips backWallThickness independently of view3D and floorThickness", () => {
+    // All three knobs sit on <c:chart> as independent siblings — one
+    // should not leak into the others through the writer / reader pair.
+    const written = writeChart(
+      makeChart({
+        view3D: { rotX: 15, rotY: 20 },
+        floorThickness: 30,
+        backWallThickness: 40,
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.view3D).toEqual({ rotX: 15, rotY: 20 });
+    expect(reparsed?.floorThickness).toBe(30);
+    expect(reparsed?.backWallThickness).toBe(40);
+  });
+
+  it("threads backWallThickness through writeXlsx into xl/charts/chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Back Wall Test",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            backWallThickness: 50,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:backWall>");
+    expect(chartXml).toContain('<c:thickness val="50"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.backWallThickness).toBe(50);
+  });
+});
+
 // ── writeChart — axis label rotation ────────────────────────────────
 
 describe("writeChart — axis labelRotation", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -12004,6 +12004,300 @@ describe("parseChart — floorThickness", () => {
   });
 });
 
+// ── parseChart — back-wall thickness ──────────────────────────────
+
+describe("parseChart — backWallThickness", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"`;
+
+  it("surfaces a positive thickness pinned by <c:backWall><c:thickness>", () => {
+    // Excel's "Format Back Wall -> Back Wall -> Thickness" pane writes
+    // `<c:backWall><c:thickness val="N"/></c:backWall>` when the user
+    // pins a non-zero value. The reader surfaces the integer literally
+    // so a clone can replay the exact extrusion depth.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="25"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBe(25);
+  });
+
+  it("collapses the OOXML default 0 to undefined", () => {
+    // The OOXML default `0` (no extrusion) is the writer's default
+    // shape — absence and `0` round-trip identically. Only an explicit
+    // positive thickness surfaces here.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="0"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("surfaces the boundary value 100 (Excel UI band ceiling)", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="100"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBe(100);
+  });
+
+  it("drops out-of-range values rather than fabricate a clamped thickness", () => {
+    // Excel's UI tops out at 100 — a stray value above the band drops
+    // rather than silently rewrite as a different thickness, mirroring
+    // how the other chart-level numeric readers (gapWidth / overlap /
+    // firstSliceAng / view3D children / floor-thickness) handle out-of-
+    // range tokens.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="500"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("drops fractional / non-integer values rather than fabricate floats", () => {
+    // ST_Thickness is `xsd:unsignedInt` — `parseInt` would coerce
+    // "25.5" → 25, but Excel never emits the fractional spelling.
+    // Drop the field so a hand-edited file with a fractional `val`
+    // stays unrecognised rather than silently round-trip a value Excel
+    // would not author.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="25.5"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("drops negative values (ST_Thickness is xsd:unsignedInt)", () => {
+    // The unsigned simple type rejects a leading `-`.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="-10"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("drops a missing val attribute rather than fabricate a value", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("drops non-numeric val tokens rather than coerce", () => {
+    // `parseInt` would coerce "30abc" → 30, but Excel never emits the
+    // mixed spelling. The strict integer regex rejects the token.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="30abc"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined when <c:backWall> is present but <c:thickness> is missing", () => {
+    // CT_Surface's `<c:thickness>` is optional. A `<c:backWall>` block
+    // with only `<c:spPr>` styling carries no thickness pin.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:spPr/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined on a bare <c:backWall/> element", () => {
+    // A self-closing element with no children — same minimal-shape
+    // result as a back wall with `<c:spPr>` only.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall/>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:backWall> element", () => {
+    // Absence is the writer's default — Excel renders no back-wall
+    // extrusion on a fresh chart. The reader surfaces nothing so a
+    // fresh chart and a chart that omits the element round-trip
+    // identically through cloneChart.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBeUndefined();
+  });
+
+  it("surfaces backWallThickness on a 2D chart family (the schema accepts it on every CT_Chart)", () => {
+    // <c:backWall> is only meaningful on 3D families but the OOXML
+    // schema accepts it on every CT_Chart. A stray element on a 2D
+    // chart surfaces here so the round-trip through cloneChart stays
+    // lossless even when the template authors a no-op.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="15"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:lineChart><c:ser><c:idx val="0"/></c:ser></c:lineChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBe(15);
+  });
+
+  it("surfaces backWallThickness on a pie chart (no axes, but the element lives on <c:chart>)", () => {
+    // <c:backWall> lives on <c:chart>, not inside <c:plotArea>, so
+    // axis-shape has no bearing on whether the slot exists. Pie /
+    // doughnut still carry the element when the file pins it.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:backWall>
+      <c:thickness val="10"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:pieChart>
+        <c:varyColors val="1"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:pieChart>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.backWallThickness).toBe(10);
+  });
+
+  it("co-exists with sibling chart-level toggles (view3D, floor)", () => {
+    // The backWallThickness reader should not interfere with sibling
+    // fields parsed off <c:chart> (autoTitleDeleted / view3D /
+    // floorThickness / plotVisOnly / dispBlanksAs). All three of
+    // <c:floor>, <c:sideWall>, and <c:backWall> are independent
+    // siblings on <c:chart>, so the reader pulls them off
+    // independently.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:autoTitleDeleted val="1"/>
+    <c:view3D>
+      <c:rotX val="20"/>
+    </c:view3D>
+    <c:floor>
+      <c:thickness val="30"/>
+    </c:floor>
+    <c:backWall>
+      <c:thickness val="40"/>
+    </c:backWall>
+    <c:plotArea>
+      <c:bar3DChart>
+        <c:barDir val="col"/>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:bar3DChart>
+    </c:plotArea>
+    <c:plotVisOnly val="0"/>
+    <c:dispBlanksAs val="zero"/>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.autoTitleDeleted).toBe(true);
+    expect(chart?.view3D).toEqual({ rotX: 20 });
+    expect(chart?.floorThickness).toBe(30);
+    expect(chart?.backWallThickness).toBe(40);
+    expect(chart?.plotVisOnly).toBe(false);
+    expect(chart?.dispBlanksAs).toBe("zero");
+  });
+});
+
 // ── parseChart — legend entries ────────────────────────────────────
 
 describe("parseChart — legend entries", () => {


### PR DESCRIPTION
## Summary
- Adds `backWallThickness?: number` to `SheetChart` / `Chart`, mapped to `<c:chart><c:backWall><c:thickness val="N"/></c:backWall>` per the `CT_Surface` schema (the `<c:thickness>` child of `CT_Surface`, ECMA-376 Part 1, §21.2.2.31 / §21.2.2.214) — Excel's "Format Back Wall -> Back Wall -> Thickness" pin on 3D chart families.
- Mirrors the `floorThickness` (#295) / `sideWallThickness` (#296) pattern — same OOXML simple-type clamp, same default-collapse contract, same `number | null` clone-through grammar. Closes the 3D-walls trio (floor / side wall / back wall).
- Reader / writer / clone-through all support the new knob; composes independently with `view3D` and `floorThickness` (all three knobs sit on `<c:chart>` as independent siblings).

## Behavioural notes
- **Reader**: surfaces a positive integer pinned by `<c:backWall><c:thickness val="N"/>`; the OOXML default `0` (and absence of `<c:backWall>` / `<c:thickness>`) collapses to `undefined` so absence and the default round-trip identically through `cloneChart`. Out-of-range (`> 100`, the Excel UI band ceiling), negative, fractional, and non-numeric `val` tokens drop to `undefined` rather than fabricate a value the file did not declare.
- **Writer**: emits `<c:backWall><c:thickness val="N"/></c:backWall>` between `<c:floor>` and `<c:plotArea>` per CT_Chart sequence; skips emission when the field is unset, `0`, non-finite, non-integer, negative, or above the Excel UI ceiling `100` so a fresh chart matches Excel's reference serialization byte-for-byte.
- **Clone-through**: `cloneChart`'s new `backWallThickness?: number | null` option mirrors `floorThickness`'s `number | null` shape — `undefined` inherits, `null` drops the inherited value, a number replaces it. Applies to every chart family — `<c:backWall>` lives on `<c:chart>` directly, so the OOXML schema accepts it on every chart family even though it is only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`); useful primarily for round-tripping a 3D template chart through `cloneChart`.

Refs #136

## Test plan
- [x] `pnpm test` (lint + typecheck + 6071 vitest tests, all green)
- [x] `pnpm build` (obuild clean)
- [x] New unit tests cover reader (positive value / 0 / 100 / out-of-range / fractional / negative / missing val / non-numeric / missing thickness child / bare element / absent / 2D family / pie / sibling co-existence with view3D + floor)
- [x] New unit tests cover writer (unset / positive / boundary 100 / minimum 1 / 0 / out-of-range / negative / fractional / non-finite / non-number / element ordering after floor + before plotArea / placement when view3D and floor absent / single occurrence / every chart family / round-trip through parseChart / independence from view3D + floorThickness / writeXlsx end-to-end)
- [x] New unit tests cover cloneChart (inherit / replace / null-drop / undefined absent / flatten line→column / pie / doughnut / compose with view3D + floorThickness / leak guard / writeXlsx round-trip propagate / writeXlsx round-trip null-drop / writeXlsx round-trip override-replace / writeXlsx round-trip multi-knob composition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)