### PR TITLE
feat(xlsx): chart legend manual layout — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1616,6 +1616,70 @@ export interface ChartLegendEntry {
 }
 
 /**
+ * Manual placement of a chart sub-element (legend / plot area / title /
+ * data table) inside the chart frame. Maps to OOXML's `<c:manualLayout>`
+ * (`CT_ManualLayout`, ECMA-376 Part 1, §21.2.2.115) — the element block
+ * that backs Excel's "Format <element> -> Position -> Custom" knob and
+ * pins where the element draws inside the chart's drawing area.
+ *
+ * All four coordinates are fractions of the chart frame in the range
+ * `0..1` — `(0, 0)` is the upper-left of the chart frame, `(1, 1)` is
+ * the lower-right; widths / heights are sized as fractions of the chart
+ * frame width / height. Each axis is independently optional so a caller
+ * can pin only the position ({@link x} / {@link y}) and let the element
+ * keep its automatic size, only the size ({@link w} / {@link h}) and
+ * let the element keep its automatic anchor, or any combination.
+ *
+ * The writer always emits the matching `<c:xMode>` / `<c:yMode>` /
+ * `<c:wMode>` / `<c:hMode>` children with `val="edge"` (Excel's "Format
+ * Legend -> Position" reference shape — the coordinates are absolute
+ * fractions of the chart frame, not deltas from the auto-layout
+ * baseline). The reader collapses `val="factor"` (delta from
+ * auto-layout) onto the same shape so a templated chart that pinned
+ * the alternate mode still round-trips through {@link cloneChart}; the
+ * writer normalizes to `"edge"` on emit since Excel itself emits the
+ * absolute form when the user drags an element to a custom position.
+ *
+ * @see {@link SheetChart.legendLayout}
+ * @see {@link Chart.legendLayout}
+ */
+export interface ChartManualLayout {
+  /**
+   * Horizontal anchor as a fraction of the chart frame width. Maps to
+   * `<c:manualLayout><c:x val=".."/></c:manualLayout>`. Range: `0..1`
+   * (`0` is the chart frame's left edge, `1` is the right edge).
+   * Out-of-range / non-finite / non-numeric inputs collapse to
+   * `undefined` so the writer skips the `<c:x>` slot rather than emit a
+   * token Excel would reject.
+   */
+  x?: number;
+  /**
+   * Vertical anchor as a fraction of the chart frame height. Maps to
+   * `<c:manualLayout><c:y val=".."/></c:manualLayout>`. Range: `0..1`
+   * (`0` is the chart frame's top edge, `1` is the bottom edge).
+   * Out-of-range / non-finite / non-numeric inputs collapse to
+   * `undefined` so the writer skips the `<c:y>` slot.
+   */
+  y?: number;
+  /**
+   * Width as a fraction of the chart frame width. Maps to
+   * `<c:manualLayout><c:w val=".."/></c:manualLayout>`. Range: `0..1`
+   * (`0` collapses the element to a hairline, `1` spans the full chart
+   * frame width). Out-of-range / non-finite / non-numeric inputs
+   * collapse to `undefined` so the writer skips the `<c:w>` slot.
+   */
+  w?: number;
+  /**
+   * Height as a fraction of the chart frame height. Maps to
+   * `<c:manualLayout><c:h val=".."/></c:manualLayout>`. Range: `0..1`
+   * (`0` collapses the element to a hairline, `1` spans the full chart
+   * frame height). Out-of-range / non-finite / non-numeric inputs
+   * collapse to `undefined` so the writer skips the `<c:h>` slot.
+   */
+  h?: number;
+}
+
+/**
  * A chart embedded into a worksheet via the drawing layer.
  *
  * Excel anchors charts to cells using the same `xdr:twoCellAnchor`
@@ -2048,6 +2112,49 @@ export interface SheetChart {
    * Excel exposes.
    */
   legendFontFamily?: string;
+  /**
+   * Custom legend placement inside the chart frame. Maps to
+   * `<c:legend><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
+   * </c:legend>` — Excel's "Format Legend -> Position -> Custom" knob.
+   * The block sits between `<c:legendEntry>` and `<c:overlay>` per
+   * `CT_Legend` (ECMA-376 Part 1, §21.2.2.114).
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} is a
+   * fraction of the chart frame in the range `0..1` — `(0, 0)` is the
+   * upper-left of the chart frame, `(1, 1)` is the lower-right. The
+   * coordinates compose independently with {@link legend} (the legend
+   * still picks up its `<c:legendPos>` orientation hint, the manual
+   * layout merely overrides where the legend block draws). Out-of-range
+   * / non-finite / non-numeric coordinates collapse to omitting the
+   * matching `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` slot so a caller can
+   * pin only the position ({@link ChartManualLayout.x} /
+   * {@link ChartManualLayout.y}) and let the legend keep its automatic
+   * size, only the size ({@link ChartManualLayout.w} /
+   * {@link ChartManualLayout.h}) and let it keep its automatic anchor,
+   * or any combination.
+   *
+   * The writer always emits the matching `<c:xMode>` / `<c:yMode>` /
+   * `<c:wMode>` / `<c:hMode>` children with `val="edge"` (Excel's
+   * reference shape when the user drags the legend to a custom
+   * position — the coordinates are absolute fractions of the chart
+   * frame, not deltas from the auto-layout baseline).
+   *
+   * Default: omitted — the legend renders at the auto-layout position
+   * Excel computes from the chart's dimensions and the resolved
+   * `<c:legendPos>` orientation. Pin a {@link ChartManualLayout} to
+   * place the legend in a specific quadrant of the chart frame —
+   * useful for composing a templated dashboard whose legend needs to
+   * align with neighbouring tiles, or a hero chart whose legend should
+   * sit in a corner the auto-layout would not pick.
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no slot to host the layout in that case. An
+   * empty layout (every coordinate undefined) collapses to omitting the
+   * entire `<c:layout>` block so a fresh chart matches Excel's
+   * reference serialization byte-for-byte.
+   */
+  legendLayout?: ChartManualLayout;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -6373,6 +6480,33 @@ export interface Chart {
    * conversion.
    */
   legendFontFamily?: string;
+  /**
+   * Custom legend placement pulled from `<c:legend><c:layout>
+   * <c:manualLayout>...</c:manualLayout></c:layout></c:legend>`.
+   * Reflects Excel's "Format Legend -> Position -> Custom" knob — the
+   * `(x, y)` anchor and `(w, h)` size of the legend block as fractions
+   * of the chart frame in the `0..1` band.
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} surfaces
+   * the literal `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` value when the
+   * source chart pins one; absence / non-numeric / non-finite tokens
+   * collapse to `undefined` on the matching field so absence and a
+   * malformed token round-trip identically through {@link cloneChart}.
+   * The reader accepts both `xMode="edge"` (absolute fraction of the
+   * chart frame) and `xMode="factor"` (delta from auto-layout) and
+   * surfaces the same shape; the writer normalizes to `"edge"` on emit
+   * since that is the form Excel itself emits when the user drags a
+   * legend to a custom position.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false`, the
+   * source chart has no `<c:legend>` element at all, or every
+   * coordinate the source pinned drops to `undefined` — there is no
+   * meaningful layout to surface in any of those cases. Mirrors the
+   * writer-side {@link SheetChart.legendLayout} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   */
+  legendLayout?: ChartManualLayout;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,7 @@ export type {
   ChartLineAreaGrouping,
   ChartLineDashStyle,
   ChartLineStroke,
+  ChartManualLayout,
   ChartMarker,
   ChartMarkerSymbol,
   ChartProtection,

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -29,6 +29,7 @@ import type {
   ChartKind,
   ChartLegendEntry,
   ChartLineStroke,
+  ChartManualLayout,
   ChartMarker,
   ChartProtection,
   ChartScatterStyle,
@@ -335,6 +336,32 @@ export interface CloneChartOptions {
    * typography knobs compose the same way at the call site.
    */
   legendFontFamily?: string | null;
+  /**
+   * Override `SheetChart.legendLayout`. `undefined` (or omitted)
+   * inherits the source's parsed `legendLayout`; `null` drops the
+   * inherited layout (the writer emits no `<c:layout>` block on the
+   * legend, falling back to Excel's auto-layout position); a
+   * {@link ChartManualLayout} replaces it.
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} runs
+   * through the writer-side normalizer — coordinates outside the
+   * `0..1` band, `NaN`, `Infinity`, and non-numeric overrides all
+   * collapse to omitting the matching `<c:x>` / `<c:y>` / `<c:w>` /
+   * `<c:h>` slot so the cloned `SheetChart` always carries a value the
+   * writer will accept. An override whose every coordinate dropped on
+   * normalization collapses the entire layout to `undefined` so the
+   * writer skips the `<c:layout>` block entirely.
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved legend is `false` (no `<c:legend>` element will be
+   * emitted) — there is no slot to host the layout on a hidden legend,
+   * so leaking the value into the output would carry a pin Excel never
+   * reads. The grammar mirrors `legendOverlay` / `legendEntries` /
+   * `legendFontSize` so the legend knobs compose the same way at the
+   * call site.
+   */
+  legendLayout?: ChartManualLayout | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1744,6 +1771,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.legendFontFamily,
     );
     if (resolvedLegendFontFamily !== undefined) out.legendFontFamily = resolvedLegendFontFamily;
+
+    // Same hidden-legend scoping for the manual layout — `<c:layout>`
+    // lives inside `<c:legend>` per CT_Legend, so a clone whose legend
+    // is hidden has no slot for the placement. `undefined` inherits the
+    // parsed value (after the writer-side normalizer drops out-of-range
+    // axes), `null` drops it (the writer emits no `<c:layout>` block,
+    // falling back to Excel's auto-layout position), a
+    // `ChartManualLayout` replaces it. An override whose every
+    // coordinate dropped on normalization collapses the entire layout
+    // to `undefined` so the writer skips the `<c:layout>` block.
+    const resolvedLegendLayout = resolveLegendLayout(source.legendLayout, options.legendLayout);
+    if (resolvedLegendLayout !== undefined) out.legendLayout = resolvedLegendLayout;
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -3218,6 +3257,75 @@ function resolveLegendFontFamily(
   if (override === undefined) return normalizeLegendFontFamily(sourceValue);
   if (override === null) return undefined;
   return normalizeLegendFontFamily(override);
+}
+
+/**
+ * Normalize a {@link ChartManualLayout} for the cloned `SheetChart`.
+ * Drops every axis whose input is non-numeric / non-finite / outside
+ * the `0..1` band; returns `undefined` when every axis dropped so the
+ * cloned shape elides the field entirely (mirrors the writer-side
+ * normalization so a parsed value flows through {@link cloneChart}
+ * without bookkeeping the units). Coordinates outside the `0..1` band
+ * collapse rather than clamp — same accept-or-drop grammar as
+ * `titleFontSize` / `axisTitleFontSize` / `legendFontSize`.
+ */
+function normalizeLegendLayout(
+  value: ChartManualLayout | undefined,
+): ChartManualLayout | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const out: ChartManualLayout = {};
+  const x = normalizeLayoutCoordinate(value.x);
+  if (x !== undefined) out.x = x;
+  const y = normalizeLayoutCoordinate(value.y);
+  if (y !== undefined) out.y = y;
+  const w = normalizeLayoutCoordinate(value.w);
+  if (w !== undefined) out.w = w;
+  const h = normalizeLayoutCoordinate(value.h);
+  if (h !== undefined) out.h = h;
+  if (out.x === undefined && out.y === undefined && out.w === undefined && out.h === undefined) {
+    return undefined;
+  }
+  return out;
+}
+
+/** Filter a single coordinate to a finite number in the `0..1` band. */
+function normalizeLayoutCoordinate(raw: unknown): number | undefined {
+  if (typeof raw !== "number") return undefined;
+  if (!Number.isFinite(raw)) return undefined;
+  if (raw < 0 || raw > 1) return undefined;
+  return raw;
+}
+
+/**
+ * Resolve a `legendLayout` override.
+ *
+ * `undefined` → inherit the source's parsed `legendLayout` (after
+ *               running it through {@link normalizeLegendLayout} so a
+ *               malformed source value drops cleanly).
+ * `null`      → drop the inherited layout (the writer falls back to
+ *               Excel's auto-layout position — no `<c:layout>` block
+ *               on the legend).
+ * `ChartManualLayout` → replace, after running through
+ *               {@link normalizeLegendLayout}. Coordinates outside the
+ *               `0..1` band collapse on the matching axis so the
+ *               cloned `SheetChart` always carries a value the writer
+ *               will accept; an override whose every axis dropped
+ *               collapses to `undefined` so the writer skips the
+ *               `<c:layout>` block entirely.
+ *
+ * The grammar mirrors `legendOverlay` / `legendEntries` /
+ * `legendFontSize` so the legend knobs compose the same way at the
+ * call site. Callers should gate the result on the resolved legend
+ * visibility — when no legend is emitted, the layout has no slot in
+ * the rendered chart.
+ */
+function resolveLegendLayout(
+  sourceValue: ChartManualLayout | undefined,
+  override: ChartManualLayout | null | undefined,
+): ChartManualLayout | undefined {
+  if (override === undefined) return normalizeLegendLayout(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendLayout(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -36,6 +36,7 @@ import type {
   ChartLineAreaGrouping,
   ChartLineDashStyle,
   ChartLineStroke,
+  ChartManualLayout,
   ChartMarker,
   ChartMarkerSymbol,
   ChartProtection,
@@ -484,6 +485,16 @@ export function parseChart(xml: string): Chart | undefined {
     // identically through the writer.
     const legendFontFamily = parseLegendFontFamily(chartEl);
     if (legendFontFamily !== undefined) out.legendFontFamily = legendFontFamily;
+
+    // `<c:legend><c:layout><c:manualLayout>` carries Excel's "Format
+    // Legend -> Position -> Custom" placement. CT_Legend places the
+    // block between `<c:legendEntry>` and `<c:overlay>`. The reader
+    // surfaces the `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` coordinates
+    // off the canonical slot; absence of any meaningful coordinate
+    // collapses the field to `undefined` so a fresh chart and a chart
+    // that pinned an out-of-range layout both round-trip lossless.
+    const legendLayout = parseLegendLayout(chartEl);
+    if (legendLayout !== undefined) out.legendLayout = legendLayout;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -3672,6 +3683,77 @@ function parseLegendFontFamily(chartEl: XmlElement): string | undefined {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return undefined;
   return trimmed;
+}
+
+/**
+ * Pull `<c:legend><c:layout><c:manualLayout>` off the chart. Reflects
+ * Excel's "Format Legend -> Position -> Custom" knob — the `(x, y)`
+ * anchor and `(w, h)` size of the legend block as fractions of the
+ * chart frame in the `0..1` band.
+ *
+ * The OOXML schema (`CT_ManualLayout`, ECMA-376 Part 1, §21.2.2.115)
+ * exposes optional `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` children whose
+ * `val` attributes carry an `xsd:double`. The reader admits the
+ * coordinate only when `val` parses to a finite number in the `0..1`
+ * band; out-of-range / non-finite / non-numeric tokens drop to
+ * `undefined` on the matching axis so absence and a malformed token
+ * round-trip identically through {@link cloneChart}.
+ *
+ * Both `<c:xMode val="edge"/>` (absolute fraction of the chart frame)
+ * and `<c:xMode val="factor"/>` (delta from auto-layout) are accepted
+ * — the reader surfaces the same `ChartManualLayout` shape regardless,
+ * since the writer always normalizes to `"edge"` on emit (Excel itself
+ * emits the absolute form when the user drags an element to a custom
+ * position).
+ *
+ * Returns `undefined` whenever the chart omits the `<c:legend>` /
+ * `<c:layout>` / `<c:manualLayout>` chain at any link, or when every
+ * coordinate dropped on normalization — the field is omitted entirely
+ * on a clean parse so absence and an empty layout round-trip identically
+ * through the writer.
+ */
+function parseLegendLayout(chartEl: XmlElement): ChartManualLayout | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const layout = findChild(legend, "layout");
+  if (!layout) return undefined;
+  const manual = findChild(layout, "manualLayout");
+  if (!manual) return undefined;
+
+  const out: ChartManualLayout = {};
+  const x = readLayoutCoordinate(findChild(manual, "x"));
+  if (x !== undefined) out.x = x;
+  const y = readLayoutCoordinate(findChild(manual, "y"));
+  if (y !== undefined) out.y = y;
+  const w = readLayoutCoordinate(findChild(manual, "w"));
+  if (w !== undefined) out.w = w;
+  const h = readLayoutCoordinate(findChild(manual, "h"));
+  if (h !== undefined) out.h = h;
+
+  if (out.x === undefined && out.y === undefined && out.w === undefined && out.h === undefined) {
+    return undefined;
+  }
+  return out;
+}
+
+/**
+ * Parse a single `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` element off a
+ * `<c:manualLayout>` block. Returns the `val` attribute as a finite
+ * number in the `0..1` band; everything else (missing element, missing
+ * attribute, non-numeric / non-finite / out-of-range token) collapses
+ * to `undefined` so the matching axis on {@link parseLegendLayout}'s
+ * return value is omitted.
+ */
+function readLayoutCoordinate(el: XmlElement | undefined): number | undefined {
+  if (!el) return undefined;
+  const raw = el.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 0 || parsed > 1) return undefined;
+  return parsed;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -21,6 +21,7 @@ import type {
   ChartDisplayBlanksAs,
   ChartLineDashStyle,
   ChartLineStroke,
+  ChartManualLayout,
   ChartMarker,
   ChartMarkerSymbol,
   ChartProtection,
@@ -186,6 +187,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendStrikethrough(chart),
         resolveLegendFontColor(chart),
         resolveLegendFontFamily(chart),
+        resolveLegendLayout(chart),
       ),
     );
   }
@@ -4850,18 +4852,18 @@ function buildLegend(
   strikethrough: boolean | undefined,
   rgbHex: string | undefined,
   fontFamily: string | undefined,
+  layout: ResolvedManualLayout | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
   // CT_Legend sequence places `<c:legendEntry>` after `<c:legendPos>`
   // and before `<c:layout>` / `<c:overlay>` (ECMA-376 Part 1,
-  // §21.2.2.114). The writer never emits `<c:layout>` here, so the
-  // entries collapse straight onto `<c:overlay>`. Each entry is emitted
-  // with both `<c:idx>` and `<c:delete>` so a re-parse sees the
-  // canonical shape — Excel itself emits `<c:delete val="1"/>` whenever
-  // the action is "Hide legend entry", and the writer mirrors that even
-  // for the OOXML default `false` value (an explicit `<c:delete val="0"/>`
-  // round-trips cleanly through `parseChart`).
+  // §21.2.2.114). Each entry is emitted with both `<c:idx>` and
+  // `<c:delete>` so a re-parse sees the canonical shape — Excel itself
+  // emits `<c:delete val="1"/>` whenever the action is "Hide legend
+  // entry", and the writer mirrors that even for the OOXML default
+  // `false` value (an explicit `<c:delete val="0"/>` round-trips
+  // cleanly through `parseChart`).
   for (const entry of entries) {
     children.push(
       xmlElement("c:legendEntry", undefined, [
@@ -4869,6 +4871,19 @@ function buildLegend(
         xmlSelfClose("c:delete", { val: entry.delete ? 1 : 0 }),
       ]),
     );
+  }
+
+  // CT_Legend sequence places `<c:layout>` between `<c:legendEntry>`
+  // and `<c:overlay>` per ECMA-376 Part 1, §21.2.2.114. The writer
+  // skips emission entirely when the caller pinned no coordinates so a
+  // fresh chart matches Excel's reference serialization byte-for-byte
+  // (Excel itself omits the block when the legend renders at the
+  // auto-layout position). Each axis is independently optional so the
+  // helper drops `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` slots whose
+  // value did not survive normalization.
+  const layoutXml = buildManualLayout(layout);
+  if (layoutXml !== undefined) {
+    children.push(layoutXml);
   }
 
   children.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
@@ -5234,6 +5249,124 @@ function resolveLegendEntries(chart: SheetChart): ResolvedLegendEntry[] {
  */
 function resolveLegendOverlay(chart: SheetChart): boolean {
   return chart.legendOverlay === true;
+}
+
+// ── Manual Layout ────────────────────────────────────────────────────
+
+/**
+ * Normalized `<c:manualLayout>` coordinate set after the writer runs
+ * the caller's input through the `0..1` range filter. Each axis is
+ * independently optional — a caller can pin only the position
+ * (`x` / `y`) and let the element keep its automatic size, only the
+ * size (`w` / `h`) and let it keep its automatic anchor, or any
+ * combination.
+ */
+interface ResolvedManualLayout {
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+}
+
+/**
+ * Resolve `<c:legend><c:layout><c:manualLayout>...</c:manualLayout>
+ * </c:layout></c:legend>` from {@link SheetChart.legendLayout}.
+ *
+ * Returns the normalized coordinate set, or `undefined` when every
+ * axis the caller pinned dropped to `undefined` (so the writer can
+ * elide the entire `<c:layout>` block — Excel's reference
+ * serialization omits the element when the legend renders at the
+ * auto-layout position). The element is only meaningful when the chart
+ * actually emits a legend — the caller is expected to gate the call on
+ * the resolved legend visibility.
+ *
+ * Coordinates outside the OOXML `0..1` band, `NaN`, `Infinity`, and
+ * non-numeric inputs all collapse to `undefined` on the matching axis
+ * so the writer drops the matching `<c:x>` / `<c:y>` / `<c:w>` /
+ * `<c:h>` slot rather than emit a token Excel would reject.
+ */
+function resolveLegendLayout(chart: SheetChart): ResolvedManualLayout | undefined {
+  return normalizeManualLayout(chart.legendLayout);
+}
+
+/**
+ * Normalize a {@link ChartManualLayout} into the writer's emit-ready
+ * shape. Drops every axis whose input is non-numeric / non-finite /
+ * out of the `0..1` band; returns `undefined` when every axis dropped
+ * so the caller can elide the entire `<c:layout>` block.
+ *
+ * The accept-and-clamp grammar matches the OOXML `CT_ManualLayout`
+ * schema — `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` carry `xsd:double`
+ * values in the `0..1` band per Excel's reference serialization. The
+ * normalizer does not silently clamp out-of-range inputs to the
+ * endpoints — it drops them outright, mirroring how `titleFontSize` /
+ * `axisTitleFontSize` / `legendFontSize` collapse out-of-range numbers
+ * rather than emit a token Excel would reject.
+ */
+function normalizeManualLayout(
+  raw: ChartManualLayout | undefined,
+): ResolvedManualLayout | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const out: ResolvedManualLayout = {};
+  const x = normalizeLayoutCoordinate(raw.x);
+  if (x !== undefined) out.x = x;
+  const y = normalizeLayoutCoordinate(raw.y);
+  if (y !== undefined) out.y = y;
+  const w = normalizeLayoutCoordinate(raw.w);
+  if (w !== undefined) out.w = w;
+  const h = normalizeLayoutCoordinate(raw.h);
+  if (h !== undefined) out.h = h;
+  if (out.x === undefined && out.y === undefined && out.w === undefined && out.h === undefined) {
+    return undefined;
+  }
+  return out;
+}
+
+/**
+ * Normalize a single `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` coordinate.
+ * Accepts a finite number in the `0..1` band; everything else drops to
+ * `undefined`.
+ */
+function normalizeLayoutCoordinate(raw: unknown): number | undefined {
+  if (typeof raw !== "number") return undefined;
+  if (!Number.isFinite(raw)) return undefined;
+  if (raw < 0 || raw > 1) return undefined;
+  return raw;
+}
+
+/**
+ * Build the `<c:layout><c:manualLayout>...</c:manualLayout></c:layout>`
+ * block for a resolved layout. Returns `undefined` when the input is
+ * `undefined` so the caller can elide the entire block.
+ *
+ * The writer always emits the `<c:xMode>` / `<c:yMode>` / `<c:wMode>` /
+ * `<c:hMode>` children with `val="edge"` whenever the matching `<c:x>` /
+ * `<c:y>` / `<c:w>` / `<c:h>` slot is present — `"edge"` is Excel's
+ * reference shape when the user drags an element to a custom position
+ * (the coordinates are absolute fractions of the chart frame, not
+ * deltas from the auto-layout baseline). The `"factor"` form (delta
+ * from auto-layout) is read on parse but normalized to `"edge"` on
+ * emit so a re-parse after a clone-through stays canonical.
+ *
+ * The OOXML `CT_ManualLayout` sequence places the mode children before
+ * the value children: `<c:layoutTarget>?` / `<c:xMode>?` / `<c:yMode>?`
+ * / `<c:wMode>?` / `<c:hMode>?` / `<c:x>?` / `<c:y>?` / `<c:w>?` /
+ * `<c:h>?` (ECMA-376 Part 1, §21.2.2.115). The writer emits in that
+ * order so a re-parse sees the canonical shape.
+ */
+function buildManualLayout(layout: ResolvedManualLayout | undefined): string | undefined {
+  if (!layout) return undefined;
+  const children: string[] = [];
+  if (layout.x !== undefined) children.push(xmlSelfClose("c:xMode", { val: "edge" }));
+  if (layout.y !== undefined) children.push(xmlSelfClose("c:yMode", { val: "edge" }));
+  if (layout.w !== undefined) children.push(xmlSelfClose("c:wMode", { val: "edge" }));
+  if (layout.h !== undefined) children.push(xmlSelfClose("c:hMode", { val: "edge" }));
+  if (layout.x !== undefined) children.push(xmlSelfClose("c:x", { val: layout.x }));
+  if (layout.y !== undefined) children.push(xmlSelfClose("c:y", { val: layout.y }));
+  if (layout.w !== undefined) children.push(xmlSelfClose("c:w", { val: layout.w }));
+  if (layout.h !== undefined) children.push(xmlSelfClose("c:h", { val: layout.h }));
+  if (children.length === 0) return undefined;
+  return xmlElement("c:layout", undefined, [xmlElement("c:manualLayout", undefined, children)]);
 }
 
 // ── Display Blanks As ────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -19858,3 +19858,242 @@ describe("cloneChart — axis title overlay", () => {
     expect(reparsed?.axes?.x?.axisTitleOverlay).toBe(true);
   });
 });
+
+// ── cloneChart — legendLayout (manual placement) ─────────────────────
+
+describe("cloneChart — legendLayout", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendLayout by default", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.7, y: 0.1 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendLayout).toEqual({ x: 0.7, y: 0.1 });
+  });
+
+  it("lets options.legendLayout override the source's value", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.7, y: 0.1 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendLayout: { x: 0.2, y: 0.8, w: 0.3, h: 0.15 },
+    });
+    expect(clone.legendLayout).toEqual({ x: 0.2, y: 0.8, w: 0.3, h: 0.15 });
+  });
+
+  it("drops the inherited legendLayout when the override is null", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.7, y: 0.1 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendLayout: null,
+    });
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("returns undefined legendLayout when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("normalizes out-of-range overrides axis-by-axis", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendLayout: { x: -0.1, y: 1.2, w: 0.4, h: 0.5 },
+    });
+    // x and y dropped; w and h survive.
+    expect(clone.legendLayout).toEqual({ w: 0.4, h: 0.5 });
+  });
+
+  it("collapses an override whose every axis dropped to undefined", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.5 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendLayout: { x: -1 as any, y: 2 as any, w: Number.NaN as any },
+    });
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("drops non-numeric coordinates leaking past the type guard", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendLayout: { x: "0.5" as any, y: 0.4 },
+    });
+    expect(clone.legendLayout).toEqual({ y: 0.4 });
+  });
+
+  it("drops a non-object legendLayout (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.5 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendLayout: "right" as any,
+    });
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ legendLayout: { x: 5 as any, y: -1 as any } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("carries legendLayout through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.6, y: 0.2 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendLayout).toEqual({ x: 0.6, y: 0.2 });
+  });
+
+  it("carries legendLayout through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.6, y: 0.2 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendLayout).toEqual({ x: 0.6, y: 0.2 });
+  });
+
+  it("drops the inherited legendLayout when the resolved legend is hidden", () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.6, y: 0.2 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("drops the legendLayout override when the resolved legend is hidden", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendLayout: { x: 0.6, y: 0.2 },
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendLayout).toBeUndefined();
+  });
+
+  it("retains the legendLayout override when the override re-enables a hidden source legend", () => {
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendLayout: { x: 0.6, y: 0.2 },
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendLayout).toEqual({ x: 0.6, y: 0.2 });
+  });
+
+  it("composes with other legend knobs on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        legendLayout: { x: 0.6, y: 0.2 },
+        legendFontFamily: "Arial",
+        legendFontSize: 12,
+        legendOverlay: true,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendLayout).toEqual({ x: 0.6, y: 0.2 });
+    expect(clone.legendFontFamily).toBe("Arial");
+    expect(clone.legendFontSize).toBe(12);
+    expect(clone.legendOverlay).toBe(true);
+  });
+
+  it("propagates legendLayout into the rendered <c:legend><c:layout> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.65, y: 0.15, w: 0.3, h: 0.4 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:layout>");
+    expect(legend).toContain("<c:manualLayout>");
+    expect(legend).toContain('<c:x val="0.65"/>');
+    expect(legend).toContain('<c:y val="0.15"/>');
+    expect(legend).toContain('<c:w val="0.3"/>');
+    expect(legend).toContain('<c:h val="0.4"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendLayout).toEqual({ x: 0.65, y: 0.15, w: 0.3, h: 0.4 });
+  });
+
+  it("emits no <c:layout> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:layout>");
+    expect(parseChart(written)?.legendLayout).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ legendLayout: { x: 0.7, y: 0.1 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      legendLayout: { x: 0.2, y: 0.8 },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.legendLayout).toEqual({ x: 0.2, y: 0.8 });
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -18359,3 +18359,305 @@ describe("writeChart — axis title overlay", () => {
     expect(reparsed?.axes?.y?.axisTitleOverlay).toBeUndefined();
   });
 });
+
+// ── writeChart — legendLayout (manual placement) ────────────────────
+
+describe("writeChart — legendLayout", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:layout> when legendLayout is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:layout>");
+    expect(legend).not.toContain("<c:manualLayout>");
+  });
+
+  it("threads x/y anchor through to <c:layout><c:manualLayout>", () => {
+    const result = writeChart(makeChart({ legendLayout: { x: 0.7, y: 0.1 } }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:layout>");
+    expect(legend).toContain("<c:manualLayout>");
+    expect(legend).toContain('<c:xMode val="edge"/>');
+    expect(legend).toContain('<c:yMode val="edge"/>');
+    expect(legend).toContain('<c:x val="0.7"/>');
+    expect(legend).toContain('<c:y val="0.1"/>');
+    // No w/h pinned -> writer skips those slots and their modes.
+    expect(legend).not.toContain("<c:wMode");
+    expect(legend).not.toContain("<c:hMode");
+    expect(legend).not.toContain("<c:w ");
+    expect(legend).not.toContain("<c:h ");
+  });
+
+  it("threads w/h size through to <c:layout><c:manualLayout>", () => {
+    const result = writeChart(makeChart({ legendLayout: { w: 0.25, h: 0.5 } }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<c:wMode val="edge"/>');
+    expect(legend).toContain('<c:hMode val="edge"/>');
+    expect(legend).toContain('<c:w val="0.25"/>');
+    expect(legend).toContain('<c:h val="0.5"/>');
+    expect(legend).not.toContain("<c:xMode");
+    expect(legend).not.toContain("<c:yMode");
+  });
+
+  it("threads all four coordinates when every axis is pinned", () => {
+    const result = writeChart(
+      makeChart({ legendLayout: { x: 0.6, y: 0.2, w: 0.3, h: 0.4 } }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<c:x val="0.6"/>');
+    expect(legend).toContain('<c:y val="0.2"/>');
+    expect(legend).toContain('<c:w val="0.3"/>');
+    expect(legend).toContain('<c:h val="0.4"/>');
+    // Mode children precede value children inside <c:manualLayout>.
+    const ml = legend.match(/<c:manualLayout>[\s\S]*?<\/c:manualLayout>/)![0];
+    expect(ml.indexOf("c:xMode")).toBeLessThan(ml.indexOf("<c:x "));
+    expect(ml.indexOf("c:yMode")).toBeLessThan(ml.indexOf("<c:y "));
+    expect(ml.indexOf("c:wMode")).toBeLessThan(ml.indexOf("<c:w "));
+    expect(ml.indexOf("c:hMode")).toBeLessThan(ml.indexOf("<c:h "));
+  });
+
+  it("places <c:layout> after <c:legendPos> and before <c:overlay> (CT_Legend order)", () => {
+    const result = writeChart(makeChart({ legendLayout: { x: 0.5 } }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:layout"));
+    expect(legend.indexOf("c:layout")).toBeLessThan(legend.indexOf("c:overlay"));
+  });
+
+  it("places <c:layout> after <c:legendEntry> when both are set (CT_Legend order)", () => {
+    const result = writeChart(
+      makeChart({
+        legendLayout: { x: 0.5 },
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:layout"));
+    expect(legend.indexOf("c:layout")).toBeLessThan(legend.indexOf("c:overlay"));
+  });
+
+  it("only emits <c:layout> once inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendLayout: { x: 0.5, y: 0.5 } }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:layout\b/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendLayout set", () => {
+    const result = writeChart(
+      makeChart({ legend: false, legendLayout: { x: 0.5, y: 0.5 } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:legend>");
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendLayout through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendLayout: { x: 0.7, y: 0.2 } }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('<c:x val="0.7"/>');
+      expect(legend).toContain('<c:y val="0.2"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendLayout: { x: 0.7, y: 0.2 },
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('<c:x val="0.7"/>');
+  });
+
+  it("drops out-of-range coordinates (negative / above 1)", () => {
+    const result = writeChart(
+      makeChart({ legendLayout: { x: -0.1, y: 1.2, w: 0.5, h: 0.5 } }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    // x and y dropped; w and h survive.
+    expect(legend).not.toContain("<c:xMode");
+    expect(legend).not.toContain("<c:yMode");
+    expect(legend).not.toContain("<c:x ");
+    expect(legend).not.toContain("<c:y ");
+    expect(legend).toContain('<c:w val="0.5"/>');
+    expect(legend).toContain('<c:h val="0.5"/>');
+  });
+
+  it("accepts the boundary values 0 and 1", () => {
+    const result = writeChart(makeChart({ legendLayout: { x: 0, y: 1, w: 0, h: 1 } }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<c:x val="0"/>');
+    expect(legend).toContain('<c:y val="1"/>');
+    expect(legend).toContain('<c:w val="0"/>');
+    expect(legend).toContain('<c:h val="1"/>');
+  });
+
+  it("drops non-finite coordinates (NaN / Infinity)", () => {
+    const result = writeChart(
+      makeChart({ legendLayout: { x: Number.NaN, y: Number.POSITIVE_INFINITY, w: 0.5 } }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:xMode");
+    expect(legend).not.toContain("<c:yMode");
+    expect(legend).toContain('<c:w val="0.5"/>');
+  });
+
+  it("drops non-numeric coordinates (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ legendLayout: { x: "0.5" as any, y: 0.4 } }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:xMode");
+    expect(legend).toContain('<c:y val="0.4"/>');
+  });
+
+  it("collapses an empty layout (every axis dropped) to no <c:layout> block", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ legendLayout: { x: -1 as any, y: 2 as any } }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:layout>");
+    expect(legend).not.toContain("<c:manualLayout>");
+  });
+
+  it("collapses a layout with no coordinates to no <c:layout> block", () => {
+    const result = writeChart(makeChart({ legendLayout: {} }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:layout>");
+  });
+
+  it("ignores a non-object legendLayout (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendLayout: "custom" as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:layout>");
+  });
+
+  it("round-trips legendLayout through parseChart", () => {
+    const written = writeChart(
+      makeChart({ legendLayout: { x: 0.65, y: 0.15, w: 0.3, h: 0.4 } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendLayout).toEqual({ x: 0.65, y: 0.15, w: 0.3, h: 0.4 });
+  });
+
+  it("round-trips a partial legendLayout (only x/y) through parseChart", () => {
+    const written = writeChart(makeChart({ legendLayout: { x: 0.5, y: 0.25 } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendLayout).toEqual({ x: 0.5, y: 0.25 });
+  });
+
+  it("collapses an unset legendLayout round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendLayout).toBeUndefined();
+  });
+
+  it("does not surface legendLayout when the chart hides the legend", () => {
+    const written = writeChart(makeChart({ legend: false }), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendLayout).toBeUndefined();
+  });
+
+  it("composes with other legend knobs on the same <c:legend>", () => {
+    const result = writeChart(
+      makeChart({
+        legendLayout: { x: 0.6, y: 0.2 },
+        legendFontSize: 12,
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<c:x val="0.6"/>');
+    expect(legend).toContain('sz="1200"');
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).toContain("c:legendEntry");
+    // CT_Legend order: legendPos / legendEntry / layout / overlay / txPr
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:legendEntry"));
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:layout"));
+    expect(legend.indexOf("c:layout")).toBeLessThan(legend.indexOf("c:overlay"));
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("survives a writeXlsx round trip — legendLayout lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendLayout: { x: 0.75, y: 0.1, w: 0.2, h: 0.5 },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.legendLayout).toEqual({ x: 0.75, y: 0.1, w: 0.2, h: 0.5 });
+  });
+
+  it('normalizes <c:xMode val="factor"/> back to the same shape on parse', () => {
+    // A templated chart that pinned the alternate `factor` mode still
+    // round-trips through parseChart — the writer normalizes to `edge`
+    // on emit, but the reader admits both.
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>
+    <c:autoTitleDeleted val="1"/>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$4</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+      <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:layout>
+        <c:manualLayout>
+          <c:xMode val="factor"/>
+          <c:yMode val="factor"/>
+          <c:x val="0.4"/>
+          <c:y val="0.3"/>
+        </c:manualLayout>
+      </c:layout>
+      <c:overlay val="0"/>
+    </c:legend>
+    <c:plotVisOnly val="1"/>
+    <c:dispBlanksAs val="gap"/>
+  </c:chart>
+</c:chartSpace>`;
+    const reparsed = parseChart(xml);
+    expect(reparsed?.legendLayout).toEqual({ x: 0.4, y: 0.3 });
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -6396,6 +6396,189 @@ describe("parseChart — legendFontFamily", () => {
   });
 });
 
+// ── parseChart — legendLayout (manual placement) ────────────────────
+
+describe("parseChart — legendLayout", () => {
+  const NS_LL = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withManualLayout(body: string): string {
+    return `<c:chartSpace ${NS_LL}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:layout>
+        <c:manualLayout>${body}</c:manualLayout>
+      </c:layout>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces every coordinate when all four are pinned", () => {
+    const xml = withManualLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:wMode val="edge"/><c:hMode val="edge"/>
+       <c:x val="0.65"/><c:y val="0.15"/><c:w val="0.3"/><c:h val="0.4"/>`,
+    );
+    expect(parseChart(xml)?.legendLayout).toEqual({ x: 0.65, y: 0.15, w: 0.3, h: 0.4 });
+  });
+
+  it("surfaces a partial layout (only x/y pinned)", () => {
+    const xml = withManualLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:x val="0.5"/><c:y val="0.25"/>`,
+    );
+    expect(parseChart(xml)?.legendLayout).toEqual({ x: 0.5, y: 0.25 });
+  });
+
+  it('accepts xMode="factor" and surfaces the same shape', () => {
+    // The reader admits both `factor` (delta from auto-layout) and
+    // `edge` (absolute fraction) — the writer normalizes to `edge` on
+    // emit, but a templated chart with `factor` still round-trips.
+    const xml = withManualLayout(
+      `<c:xMode val="factor"/><c:yMode val="factor"/><c:x val="0.4"/><c:y val="0.3"/>`,
+    );
+    expect(parseChart(xml)?.legendLayout).toEqual({ x: 0.4, y: 0.3 });
+  });
+
+  it("drops out-of-range coordinates axis-by-axis", () => {
+    const xml = withManualLayout(
+      `<c:x val="-0.5"/><c:y val="2.0"/><c:w val="0.5"/><c:h val="0.5"/>`,
+    );
+    expect(parseChart(xml)?.legendLayout).toEqual({ w: 0.5, h: 0.5 });
+  });
+
+  it("drops non-numeric coordinates axis-by-axis", () => {
+    const xml = withManualLayout(`<c:x val="not-a-number"/><c:y val="0.5"/>`);
+    expect(parseChart(xml)?.legendLayout).toEqual({ y: 0.5 });
+  });
+
+  it("collapses an empty <c:manualLayout> to undefined", () => {
+    const xml = withManualLayout(``);
+    expect(parseChart(xml)?.legendLayout).toBeUndefined();
+  });
+
+  it("collapses a layout where every coordinate dropped to undefined", () => {
+    const xml = withManualLayout(`<c:x val="-1"/><c:y val="2"/>`);
+    expect(parseChart(xml)?.legendLayout).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:layout> block", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendLayout).toBeUndefined();
+  });
+
+  it("returns undefined when <c:layout> has no <c:manualLayout> child", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:layout/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendLayout).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendLayout).toBeUndefined();
+  });
+
+  it('drops the layout when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:layout><c:manualLayout><c:x val="0.5"/></c:manualLayout></c:layout>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendLayout).toBeUndefined();
+  });
+
+  it("accepts the boundary values 0 and 1", () => {
+    const xml = withManualLayout(`<c:x val="0"/><c:y val="1"/><c:w val="0"/><c:h val="1"/>`);
+    expect(parseChart(xml)?.legendLayout).toEqual({ x: 0, y: 1, w: 0, h: 1 });
+  });
+
+  it("co-surfaces alongside legendOverlay / legendEntries / legendFontSize", () => {
+    const xml = `<c:chartSpace ${NS_LL}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="b"/>
+      <c:legendEntry>
+        <c:idx val="0"/>
+        <c:delete val="1"/>
+      </c:legendEntry>
+      <c:layout>
+        <c:manualLayout>
+          <c:xMode val="edge"/>
+          <c:yMode val="edge"/>
+          <c:x val="0.6"/>
+          <c:y val="0.2"/>
+        </c:manualLayout>
+      </c:layout>
+      <c:overlay val="1"/>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr sz="1400"/></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe("bottom");
+    expect(chart?.legendOverlay).toBe(true);
+    expect(chart?.legendEntries).toEqual([{ idx: 0, delete: true }]);
+    expect(chart?.legendFontSize).toBe(14);
+    expect(chart?.legendLayout).toEqual({ x: 0.6, y: 0.2 });
+  });
+});
+
 // ── parseChart — data labels showLegendKey ──────────────────────────
 
 describe("parseChart — data labels showLegendKey", () => {


### PR DESCRIPTION
## Summary

- Adds `legendLayout?: ChartManualLayout` to `SheetChart` / `Chart`, mapped to `<c:legend><c:layout><c:manualLayout>` per `CT_Legend` / `CT_ManualLayout` (ECMA-376 Part 1, §21.2.2.114 / §21.2.2.115) — Excel's "Format Legend -> Position -> Custom" placement.
- New generic `ChartManualLayout` shape exposes optional `x` / `y` / `w` / `h` coordinates as fractions of the chart frame in the `0..1` band; each axis is independently optional so callers can pin only the position, only the size, or any combination.
- Reader / writer / clone-through all support the new knob with the established `legendOverlay` / `legendEntries` / `legendFontSize` grammar (`undefined` inherits, `null` drops, a value replaces); hidden-legend scoping drops the field silently.
- Writer emits `<c:layout>` between `<c:legendEntry>` and `<c:overlay>` per `CT_Legend`; mode children (`<c:xMode>` / `<c:yMode>` / `<c:wMode>` / `<c:hMode>` with `val="edge"`) precede value children per the schema sequence. Out-of-range / non-finite / non-numeric coordinates collapse axis-by-axis; an empty layout collapses to no `<c:layout>` block so a fresh chart matches Excel's reference serialization byte-for-byte.
- Reader admits both `xMode="edge"` (absolute) and `xMode="factor"` (delta from auto-layout) and surfaces the same shape; the writer always normalizes to `"edge"` on emit since that is what Excel itself emits when the user drags the legend to a custom position.
- `ChartManualLayout` is exported from the package root so future PRs that add manual placement on the plot area / title / data table can reuse the same generic type.

## Test plan

- [x] `pnpm typecheck` — passes.
- [x] `pnpm lint` — no new errors (existing warnings unchanged).
- [x] `pnpm vitest run --dir=test` — 6169 tests pass (54 new tests across writer / reader / clone-through, including the full `writeXlsx` round-trip).
- [x] `pnpm build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)