### PR TITLE
feat(xlsx): chart title manual layout — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2472,6 +2472,54 @@ export interface SheetChart {
    */
   titleFontFamily?: string;
   /**
+   * Custom chart-title placement inside the chart frame. Maps to
+   * `<c:title><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
+   * </c:title>` — Excel's "Format Chart Title -> Title Options ->
+   * Position -> Custom" knob (the same drag-handle a user sees when
+   * grabbing the title block in Excel's chart editor). The block sits
+   * between `<c:tx>` and `<c:overlay>` per `CT_Title` (ECMA-376 Part 1,
+   * §21.2.2.210).
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} is a
+   * fraction of the chart frame in the range `0..1` — `(0, 0)` is the
+   * upper-left of the chart frame, `(1, 1)` is the lower-right. The
+   * coordinates compose independently with {@link titleOverlay} (the
+   * overlay flag still records whether the title overlaps the plot
+   * area, the manual layout merely overrides where the title block
+   * draws). Out-of-range / non-finite / non-numeric coordinates
+   * collapse to omitting the matching `<c:x>` / `<c:y>` / `<c:w>` /
+   * `<c:h>` slot so a caller can pin only the position
+   * ({@link ChartManualLayout.x} / {@link ChartManualLayout.y}) and
+   * let the title keep its automatic size, only the size
+   * ({@link ChartManualLayout.w} / {@link ChartManualLayout.h}) and
+   * let it keep its automatic anchor, or any combination.
+   *
+   * The writer always emits the matching `<c:xMode>` / `<c:yMode>` /
+   * `<c:wMode>` / `<c:hMode>` children with `val="edge"` (Excel's
+   * reference shape when the user drags the title to a custom
+   * position — the coordinates are absolute fractions of the chart
+   * frame, not deltas from the auto-layout baseline).
+   *
+   * Default: omitted — the title renders at the auto-layout position
+   * Excel computes (above the plot area, horizontally centred). Pin a
+   * {@link ChartManualLayout} to place the title in a specific
+   * quadrant of the chart frame — useful for composing a templated
+   * dashboard whose chart title needs to align with an outer header
+   * row, or a hero chart whose title should sit in a corner the
+   * auto-layout would not pick.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * layout in that case. An empty layout (every coordinate undefined)
+   * collapses to omitting the entire `<c:layout>` block so a fresh
+   * chart matches Excel's reference serialization byte-for-byte.
+   * Mirrors the writer-side {@link legendLayout} so a caller can
+   * thread the same `(x, y, w, h)` 0..1 fractions through both manual-
+   * layout slots without bookkeeping a second type.
+   */
+  titleLayout?: ChartManualLayout;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -6723,6 +6771,33 @@ export interface Chart {
    * {@link SheetChart.titleFontFamily} without transformation.
    */
   titleFontFamily?: string;
+  /**
+   * Custom chart-title placement pulled from `<c:title><c:layout>
+   * <c:manualLayout>...</c:manualLayout></c:layout></c:title>`. Reflects
+   * Excel's "Format Chart Title -> Title Options -> Position -> Custom"
+   * knob — the `(x, y)` anchor and `(w, h)` size of the title block as
+   * fractions of the chart frame in the `0..1` band.
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} surfaces
+   * the literal `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` value when the
+   * source chart pins one; absence / non-numeric / non-finite tokens
+   * collapse to `undefined` on the matching field so absence and a
+   * malformed token round-trip identically through {@link cloneChart}.
+   * The reader accepts both `xMode="edge"` (absolute fraction of the
+   * chart frame) and `xMode="factor"` (delta from auto-layout) and
+   * surfaces the same shape; the writer normalizes to `"edge"` on emit
+   * since that is the form Excel itself emits when the user drags a
+   * title to a custom position.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when every coordinate the source
+   * pinned drops to `undefined` — there is no meaningful layout to
+   * surface in either case. Mirrors the writer-side
+   * {@link SheetChart.titleLayout} so a parsed value slots straight
+   * into {@link cloneChart} without conversion.
+   */
+  titleLayout?: ChartManualLayout;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -607,6 +607,30 @@ export interface CloneChartOptions {
    */
   titleFontFamily?: string | null;
   /**
+   * Override the chart-level title manual layout. `undefined` (or
+   * omitted) inherits the source's parsed `titleLayout`; `null` drops
+   * the inherited layout so the writer falls back to Excel's auto-
+   * layout position (the title renders above the plot area, no
+   * `<c:layout>` block on `<c:title>`); a {@link ChartManualLayout}
+   * replaces it.
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} runs
+   * through the writer-side `0..1` band — out-of-range / non-finite /
+   * non-numeric coordinates collapse to `undefined` on the matching
+   * axis so the cloned `SheetChart` always carries a value the writer
+   * will accept; an override whose every axis dropped collapses to
+   * `undefined` so the writer skips the `<c:layout>` block entirely.
+   *
+   * The override is silently dropped from the cloned `SheetChart` when
+   * the resolved chart renders no title (`title` resolved to `undefined`
+   * or `showTitle === false`) — there is no `<c:title>` block to host
+   * the layout in either case. The grammar mirrors `legendLayout` so
+   * the chart-level manual-layout knobs compose the same way at the
+   * call site.
+   */
+  titleLayout?: ChartManualLayout | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -1981,6 +2005,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.titleFontFamily,
     );
     if (resolvedTitleFontFamily !== undefined) out.titleFontFamily = resolvedTitleFontFamily;
+
+    // `titleLayout` only renders inside `<c:title>` — a clone that
+    // omits the title has no `<c:layout>` slot for the writer to
+    // populate. Same scope rule as the other title knobs:
+    // `undefined` inherits the parsed value (after the writer-side
+    // normalizer drops out-of-range axes), `null` drops it (the writer
+    // emits no `<c:layout>` block, falling back to Excel's auto-
+    // layout position above the plot area), a `ChartManualLayout`
+    // replaces it. An override whose every coordinate dropped on
+    // normalization collapses the entire layout to `undefined` so the
+    // writer skips the `<c:layout>` block. Mirrors the legendLayout
+    // grammar — both manual-layout slots use the same
+    // `ChartManualLayout` shape, so a caller can thread a single
+    // layout value through both call sites.
+    const resolvedTitleLayout = resolveTitleLayout(source.titleLayout, options.titleLayout);
+    if (resolvedTitleLayout !== undefined) out.titleLayout = resolvedTitleLayout;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -3320,6 +3360,38 @@ function normalizeLayoutCoordinate(raw: unknown): number | undefined {
  * the rendered chart.
  */
 function resolveLegendLayout(
+  sourceValue: ChartManualLayout | undefined,
+  override: ChartManualLayout | null | undefined,
+): ChartManualLayout | undefined {
+  if (override === undefined) return normalizeLegendLayout(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendLayout(override);
+}
+
+/**
+ * Resolve a `titleLayout` override.
+ *
+ * `undefined` → inherit the source's parsed `titleLayout` (after
+ *               running it through {@link normalizeLegendLayout} so a
+ *               malformed source value drops cleanly — both manual-
+ *               layout slots share the same normalizer).
+ * `null`      → drop the inherited layout (the writer falls back to
+ *               Excel's auto-layout position above the plot area —
+ *               no `<c:layout>` block on `<c:title>`).
+ * `ChartManualLayout` → replace, after running through
+ *               {@link normalizeLegendLayout}. Coordinates outside the
+ *               `0..1` band collapse on the matching axis so the
+ *               cloned `SheetChart` always carries a value the writer
+ *               will accept; an override whose every axis dropped
+ *               collapses to `undefined` so the writer skips the
+ *               `<c:layout>` block entirely.
+ *
+ * The grammar mirrors `legendLayout` — both manual-layout slots
+ * compose the same way at the call site. Callers should gate the
+ * result on the resolved title visibility — when no title is emitted,
+ * the layout has no slot in the rendered chart.
+ */
+function resolveTitleLayout(
   sourceValue: ChartManualLayout | undefined,
   override: ChartManualLayout | null | undefined,
 ): ChartManualLayout | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -205,6 +205,18 @@ export function parseChart(xml: string): Chart | undefined {
   const titleFontFamily = parseTitleFontFamily(chartEl);
   if (titleFontFamily !== undefined) out.titleFontFamily = titleFontFamily;
 
+  // `<c:title><c:layout><c:manualLayout>` carries Excel's "Format Chart
+  // Title -> Title Options -> Position -> Custom" placement. CT_Title
+  // (ECMA-376 Part 1, §21.2.2.210) places the block between `<c:tx>`
+  // and `<c:overlay>`. The reader surfaces the `<c:x>` / `<c:y>` /
+  // `<c:w>` / `<c:h>` coordinates off the canonical slot; absence of
+  // any meaningful coordinate collapses the field to `undefined` so a
+  // fresh chart and a chart that pinned an out-of-range layout both
+  // round-trip lossless. Same accept-or-drop grammar as
+  // {@link parseLegendLayout}.
+  const titleLayout = parseTitleLayout(chartEl);
+  if (titleLayout !== undefined) out.titleLayout = titleLayout;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -3716,6 +3728,59 @@ function parseLegendLayout(chartEl: XmlElement): ChartManualLayout | undefined {
   const legend = findChild(chartEl, "legend");
   if (!legend) return undefined;
   const layout = findChild(legend, "layout");
+  if (!layout) return undefined;
+  const manual = findChild(layout, "manualLayout");
+  if (!manual) return undefined;
+
+  const out: ChartManualLayout = {};
+  const x = readLayoutCoordinate(findChild(manual, "x"));
+  if (x !== undefined) out.x = x;
+  const y = readLayoutCoordinate(findChild(manual, "y"));
+  if (y !== undefined) out.y = y;
+  const w = readLayoutCoordinate(findChild(manual, "w"));
+  if (w !== undefined) out.w = w;
+  const h = readLayoutCoordinate(findChild(manual, "h"));
+  if (h !== undefined) out.h = h;
+
+  if (out.x === undefined && out.y === undefined && out.w === undefined && out.h === undefined) {
+    return undefined;
+  }
+  return out;
+}
+
+/**
+ * Pull `<c:title><c:layout><c:manualLayout>` off the chart. Reflects
+ * Excel's "Format Chart Title -> Title Options -> Position -> Custom"
+ * knob — the `(x, y)` anchor and `(w, h)` size of the title block as
+ * fractions of the chart frame in the `0..1` band.
+ *
+ * The OOXML schema (`CT_ManualLayout`, ECMA-376 Part 1, §21.2.2.115)
+ * exposes optional `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` children whose
+ * `val` attributes carry an `xsd:double`. The reader admits the
+ * coordinate only when `val` parses to a finite number in the `0..1`
+ * band; out-of-range / non-finite / non-numeric tokens drop to
+ * `undefined` on the matching axis so absence and a malformed token
+ * round-trip identically through {@link cloneChart}.
+ *
+ * Both `<c:xMode val="edge"/>` (absolute fraction of the chart frame)
+ * and `<c:xMode val="factor"/>` (delta from auto-layout) are accepted
+ * — the reader surfaces the same `ChartManualLayout` shape regardless,
+ * since the writer always normalizes to `"edge"` on emit (Excel itself
+ * emits the absolute form when the user drags the title to a custom
+ * position).
+ *
+ * Returns `undefined` whenever the chart omits the `<c:title>` /
+ * `<c:layout>` / `<c:manualLayout>` chain at any link, or when every
+ * coordinate dropped on normalization — the field is omitted entirely
+ * on a clean parse so absence and an empty layout round-trip identically
+ * through the writer. Mirrors {@link parseLegendLayout} so a parsed
+ * value flows through the same `ChartManualLayout` shape regardless of
+ * which manual-layout slot the source chart pinned.
+ */
+function parseTitleLayout(chartEl: XmlElement): ChartManualLayout | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const layout = findChild(title, "layout");
   if (!layout) return undefined;
   const manual = findChild(layout, "manualLayout");
   if (!manual) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -80,6 +80,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleStrike(chart),
         resolveTitleUnderline(chart),
         resolveTitleFontFamily(chart),
+        resolveTitleLayout(chart),
       ),
     );
   }
@@ -283,6 +284,7 @@ function buildTitle(
   strike: boolean | undefined,
   underline: boolean | undefined,
   fontFamily: string | undefined,
+  layout: ResolvedManualLayout | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -403,7 +405,16 @@ function buildTitle(
           u: underlineAttr,
           strike: strikeAttr,
         });
-  return xmlElement("c:title", undefined, [
+  // CT_Title (ECMA-376 Part 1, §21.2.2.210) places the optional
+  // `<c:layout>` between `<c:tx>` and `<c:overlay>`. The writer skips
+  // emission entirely when the caller pinned no coordinates so a fresh
+  // chart matches Excel's reference serialization byte-for-byte (Excel
+  // itself omits the block when the title renders at the auto-layout
+  // position above the plot area). Each axis is independently optional
+  // so the helper drops `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` slots
+  // whose value did not survive normalization.
+  const layoutXml = buildManualLayout(layout);
+  const titleChildren: string[] = [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
         xmlElement(
@@ -425,8 +436,12 @@ function buildTitle(
         ]),
       ]),
     ]),
-    xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }),
-  ]);
+  ];
+  if (layoutXml !== undefined) {
+    titleChildren.push(layoutXml);
+  }
+  titleChildren.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
+  return xmlElement("c:title", undefined, titleChildren);
 }
 
 /**
@@ -5287,6 +5302,31 @@ interface ResolvedManualLayout {
  */
 function resolveLegendLayout(chart: SheetChart): ResolvedManualLayout | undefined {
   return normalizeManualLayout(chart.legendLayout);
+}
+
+/**
+ * Resolve `<c:title><c:layout><c:manualLayout>...</c:manualLayout>
+ * </c:layout></c:title>` from {@link SheetChart.titleLayout}.
+ *
+ * Returns the normalized coordinate set, or `undefined` when every
+ * axis the caller pinned dropped to `undefined` (so the writer can
+ * elide the entire `<c:layout>` block — Excel's reference serialization
+ * omits the element when the title renders at the auto-layout position
+ * above the plot area). The element is only meaningful when the chart
+ * actually emits a title — the caller is expected to gate the call on
+ * the resolved title visibility (showTitle && chart.title).
+ *
+ * Coordinates outside the OOXML `0..1` band, `NaN`, `Infinity`, and
+ * non-numeric inputs all collapse to `undefined` on the matching axis
+ * so the writer drops the matching `<c:x>` / `<c:y>` / `<c:w>` /
+ * `<c:h>` slot rather than emit a token Excel would reject. Mirrors
+ * {@link resolveLegendLayout} — same accept-or-drop grammar, same
+ * `ChartManualLayout` shape — so a caller can thread a single layout
+ * value through both the chart title and the legend without
+ * bookkeeping a second type.
+ */
+function resolveTitleLayout(chart: SheetChart): ResolvedManualLayout | undefined {
+  return normalizeManualLayout(chart.titleLayout);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -20097,3 +20097,266 @@ describe("cloneChart — legendLayout", () => {
     expect(parseChart(written)?.legendLayout).toEqual({ x: 0.2, y: 0.8 });
   });
 });
+
+// ── cloneChart — titleLayout (manual placement) ─────────────────────
+
+describe("cloneChart — titleLayout", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleLayout by default", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleLayout).toEqual({ x: 0.4, y: 0.05 });
+  });
+
+  it("lets options.titleLayout override the source's value", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleLayout: { x: 0.2, y: 0.02, w: 0.3, h: 0.1 },
+    });
+    expect(clone.titleLayout).toEqual({ x: 0.2, y: 0.02, w: 0.3, h: 0.1 });
+  });
+
+  it("drops the inherited titleLayout when the override is null", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleLayout: null,
+    });
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("returns undefined titleLayout when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("normalizes out-of-range overrides axis-by-axis", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleLayout: { x: -0.1, y: 1.2, w: 0.3, h: 0.1 },
+    });
+    // x and y dropped; w and h survive.
+    expect(clone.titleLayout).toEqual({ w: 0.3, h: 0.1 });
+  });
+
+  it("collapses an override whose every axis dropped to undefined", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.5 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      titleLayout: { x: -1 as any, y: 2 as any, w: Number.NaN as any },
+    });
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("drops non-numeric coordinates leaking past the type guard", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      titleLayout: { x: "0.5" as any, y: 0.05 },
+    });
+    expect(clone.titleLayout).toEqual({ y: 0.05 });
+  });
+
+  it("drops a non-object titleLayout (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.5 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      titleLayout: "top" as any,
+    });
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ titleLayout: { x: 5 as any, y: -1 as any } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("carries titleLayout through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleLayout).toEqual({ x: 0.4, y: 0.05 });
+  });
+
+  it("carries titleLayout through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleLayout).toEqual({ x: 0.4, y: 0.05 });
+  });
+
+  it("drops the inherited titleLayout when the resolved title is dropped", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("drops the inherited titleLayout when showTitle is set to false", () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+    });
+    expect(clone.showTitle).toBe(false);
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("drops the titleLayout override when the resolved chart has no title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+      titleLayout: { x: 0.4, y: 0.05 },
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleLayout).toBeUndefined();
+  });
+
+  it("retains the titleLayout override when the override re-enables a missing source title", () => {
+    const clone = cloneChart(source({ title: undefined }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Sales",
+      titleLayout: { x: 0.4, y: 0.05 },
+    });
+    expect(clone.title).toBe("Sales");
+    expect(clone.titleLayout).toEqual({ x: 0.4, y: 0.05 });
+  });
+
+  it("composes with other title knobs on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        titleLayout: { x: 0.4, y: 0.05 },
+        titleFontFamily: "Arial",
+        titleFontSize: 18,
+        titleOverlay: true,
+        titleBold: true,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleLayout).toEqual({ x: 0.4, y: 0.05 });
+    expect(clone.titleFontFamily).toBe("Arial");
+    expect(clone.titleFontSize).toBe(18);
+    expect(clone.titleOverlay).toBe(true);
+    expect(clone.titleBold).toBe(true);
+  });
+
+  it("composes independently with legendLayout (different <c:layout> slots)", () => {
+    const clone = cloneChart(
+      source({
+        titleLayout: { x: 0.4, y: 0.05 },
+        legendLayout: { x: 0.7, y: 0.2 },
+        legend: "right",
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleLayout).toEqual({ x: 0.4, y: 0.05 });
+    expect(clone.legendLayout).toEqual({ x: 0.7, y: 0.2 });
+  });
+
+  it("propagates titleLayout into the rendered <c:title><c:layout> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.35, y: 0.05, w: 0.3, h: 0.1 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const title = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).toContain("<c:layout>");
+    expect(title).toContain("<c:manualLayout>");
+    expect(title).toContain('<c:x val="0.35"/>');
+    expect(title).toContain('<c:y val="0.05"/>');
+    expect(title).toContain('<c:w val="0.3"/>');
+    expect(title).toContain('<c:h val="0.1"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleLayout).toEqual({ x: 0.35, y: 0.05, w: 0.3, h: 0.1 });
+  });
+
+  it("emits no <c:layout> on <c:title> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const title = written.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(title).not.toContain("<c:layout>");
+    expect(parseChart(written)?.titleLayout).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ titleLayout: { x: 0.4, y: 0.05 } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      titleLayout: { x: 0.2, y: 0.02 },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.titleLayout).toEqual({ x: 0.2, y: 0.02 });
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -18661,3 +18661,326 @@ describe("writeChart — legendLayout", () => {
     expect(reparsed?.legendLayout).toEqual({ x: 0.4, y: 0.3 });
   });
 });
+
+// ── writeChart — titleLayout (manual placement) ─────────────────────
+
+describe("writeChart — titleLayout", () => {
+  function titleOf(xml: string): string {
+    const m = xml.match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No <c:title> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:layout> on <c:title> when titleLayout is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:layout>");
+    expect(title).not.toContain("<c:manualLayout>");
+  });
+
+  it("threads x/y anchor through to <c:title><c:layout><c:manualLayout>", () => {
+    const result = writeChart(makeChart({ titleLayout: { x: 0.4, y: 0.05 } }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).toContain("<c:layout>");
+    expect(title).toContain("<c:manualLayout>");
+    expect(title).toContain('<c:xMode val="edge"/>');
+    expect(title).toContain('<c:yMode val="edge"/>');
+    expect(title).toContain('<c:x val="0.4"/>');
+    expect(title).toContain('<c:y val="0.05"/>');
+    // No w/h pinned -> writer skips those slots and their modes.
+    expect(title).not.toContain("<c:wMode");
+    expect(title).not.toContain("<c:hMode");
+    expect(title).not.toContain("<c:w ");
+    expect(title).not.toContain("<c:h ");
+  });
+
+  it("threads w/h size through to <c:title><c:layout><c:manualLayout>", () => {
+    const result = writeChart(makeChart({ titleLayout: { w: 0.3, h: 0.1 } }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).toContain('<c:wMode val="edge"/>');
+    expect(title).toContain('<c:hMode val="edge"/>');
+    expect(title).toContain('<c:w val="0.3"/>');
+    expect(title).toContain('<c:h val="0.1"/>');
+    expect(title).not.toContain("<c:xMode");
+    expect(title).not.toContain("<c:yMode");
+  });
+
+  it("threads all four coordinates when every axis is pinned", () => {
+    const result = writeChart(
+      makeChart({ titleLayout: { x: 0.35, y: 0.05, w: 0.3, h: 0.1 } }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).toContain('<c:x val="0.35"/>');
+    expect(title).toContain('<c:y val="0.05"/>');
+    expect(title).toContain('<c:w val="0.3"/>');
+    expect(title).toContain('<c:h val="0.1"/>');
+    // Mode children precede value children inside <c:manualLayout>.
+    const ml = title.match(/<c:manualLayout>[\s\S]*?<\/c:manualLayout>/)![0];
+    expect(ml.indexOf("c:xMode")).toBeLessThan(ml.indexOf("<c:x "));
+    expect(ml.indexOf("c:yMode")).toBeLessThan(ml.indexOf("<c:y "));
+    expect(ml.indexOf("c:wMode")).toBeLessThan(ml.indexOf("<c:w "));
+    expect(ml.indexOf("c:hMode")).toBeLessThan(ml.indexOf("<c:h "));
+  });
+
+  it("places <c:layout> after <c:tx> and before <c:overlay> (CT_Title order)", () => {
+    const result = writeChart(makeChart({ titleLayout: { x: 0.5 } }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title.indexOf("c:tx")).toBeLessThan(title.indexOf("c:layout"));
+    expect(title.indexOf("c:layout")).toBeLessThan(title.indexOf("c:overlay"));
+  });
+
+  it("only emits <c:layout> once inside <c:title>", () => {
+    const result = writeChart(makeChart({ titleLayout: { x: 0.4, y: 0.1 } }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    const occurrences = title.match(/<c:layout\b/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:title> when showTitle=false, even with titleLayout set", () => {
+    const result = writeChart(
+      makeChart({ showTitle: false, titleLayout: { x: 0.5, y: 0.5 } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("does not emit any <c:title> when title is absent, even with titleLayout set", () => {
+    const result = writeChart(
+      makeChart({ title: undefined, titleLayout: { x: 0.5, y: 0.5 } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("threads titleLayout through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, titleLayout: { x: 0.4, y: 0.05 } }), "Sheet1");
+      const title = titleOf(result.chartXml);
+      expect(title).toContain('<c:x val="0.4"/>');
+      expect(title).toContain('<c:y val="0.05"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        titleLayout: { x: 0.4, y: 0.05 },
+      }),
+      "Sheet1",
+    );
+    expect(titleOf(scatter.chartXml)).toContain('<c:x val="0.4"/>');
+  });
+
+  it("drops out-of-range coordinates (negative / above 1)", () => {
+    const result = writeChart(
+      makeChart({ titleLayout: { x: -0.1, y: 1.2, w: 0.3, h: 0.1 } }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:xMode");
+    expect(title).not.toContain("<c:yMode");
+    expect(title).not.toContain("<c:x ");
+    expect(title).not.toContain("<c:y ");
+    expect(title).toContain('<c:w val="0.3"/>');
+    expect(title).toContain('<c:h val="0.1"/>');
+  });
+
+  it("accepts the boundary values 0 and 1", () => {
+    const result = writeChart(makeChart({ titleLayout: { x: 0, y: 1, w: 0, h: 1 } }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).toContain('<c:x val="0"/>');
+    expect(title).toContain('<c:y val="1"/>');
+    expect(title).toContain('<c:w val="0"/>');
+    expect(title).toContain('<c:h val="1"/>');
+  });
+
+  it("drops non-finite coordinates (NaN / Infinity)", () => {
+    const result = writeChart(
+      makeChart({ titleLayout: { x: Number.NaN, y: Number.POSITIVE_INFINITY, w: 0.3 } }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:xMode");
+    expect(title).not.toContain("<c:yMode");
+    expect(title).toContain('<c:w val="0.3"/>');
+  });
+
+  it("drops non-numeric coordinates (string leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ titleLayout: { x: "0.4" as any, y: 0.05 } }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:xMode");
+    expect(title).toContain('<c:y val="0.05"/>');
+  });
+
+  it("collapses an empty layout (every axis dropped) to no <c:layout> block", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ titleLayout: { x: -1 as any, y: 2 as any } }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:layout>");
+    expect(title).not.toContain("<c:manualLayout>");
+  });
+
+  it("collapses a layout with no coordinates to no <c:layout> block", () => {
+    const result = writeChart(makeChart({ titleLayout: {} }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:layout>");
+  });
+
+  it("ignores a non-object titleLayout (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ titleLayout: "custom" as any }), "Sheet1");
+    expect(titleOf(result.chartXml)).not.toContain("<c:layout>");
+  });
+
+  it("round-trips titleLayout through parseChart", () => {
+    const written = writeChart(
+      makeChart({ titleLayout: { x: 0.35, y: 0.05, w: 0.3, h: 0.1 } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleLayout).toEqual({ x: 0.35, y: 0.05, w: 0.3, h: 0.1 });
+  });
+
+  it("round-trips a partial titleLayout (only x/y) through parseChart", () => {
+    const written = writeChart(makeChart({ titleLayout: { x: 0.5, y: 0.05 } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleLayout).toEqual({ x: 0.5, y: 0.05 });
+  });
+
+  it("collapses an unset titleLayout round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.titleLayout).toBeUndefined();
+  });
+
+  it("does not surface titleLayout when the chart hides the title", () => {
+    const written = writeChart(makeChart({ showTitle: false })).chartXml ?? "";
+    // Calling writeChart returns chartXml; ensure no <c:title> at all.
+    const written2 = writeChart(makeChart({ showTitle: false }), "Sheet1").chartXml;
+    expect(written2).not.toContain("<c:title>");
+    void written; // suppress unused
+  });
+
+  it("composes with other title knobs on the same <c:title>", () => {
+    const result = writeChart(
+      makeChart({
+        titleLayout: { x: 0.4, y: 0.05 },
+        titleFontSize: 18,
+        titleOverlay: true,
+        titleBold: true,
+      }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).toContain('<c:x val="0.4"/>');
+    expect(title).toContain('sz="1800"');
+    expect(title).toContain('c:overlay val="1"');
+    expect(title).toContain('b="1"');
+    // CT_Title order: tx / layout / overlay
+    expect(title.indexOf("c:tx")).toBeLessThan(title.indexOf("c:layout"));
+    expect(title.indexOf("c:layout")).toBeLessThan(title.indexOf("c:overlay"));
+  });
+
+  it("composes independently with legendLayout (different <c:layout> slots)", () => {
+    const result = writeChart(
+      makeChart({
+        titleLayout: { x: 0.4, y: 0.05 },
+        legendLayout: { x: 0.7, y: 0.2 },
+      }),
+      "Sheet1",
+    );
+    const title = result.chartXml.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    const legend = result.chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(title).toContain('<c:x val="0.4"/>');
+    expect(legend).toContain('<c:x val="0.7"/>');
+    // The two layouts are independent — pinning one does not leak into
+    // the other slot.
+    expect(title).not.toContain('<c:x val="0.7"/>');
+    expect(legend).not.toContain('<c:x val="0.4"/>');
+  });
+
+  it("survives a writeXlsx round trip — titleLayout lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            titleLayout: { x: 0.45, y: 0.02, w: 0.3, h: 0.08 },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleLayout).toEqual({ x: 0.45, y: 0.02, w: 0.3, h: 0.08 });
+  });
+
+  it('normalizes <c:xMode val="factor"/> back to the same shape on parse', () => {
+    // A templated chart that pinned the alternate `factor` mode still
+    // round-trips through parseChart — the writer normalizes to `edge`
+    // on emit, but the reader admits both.
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="0" spcFirstLastPara="1" vertOverflow="ellipsis" wrap="square" anchor="ctr" anchorCtr="1"/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr><a:defRPr sz="1400" b="0"/></a:pPr>
+            <a:r><a:rPr lang="en-US" sz="1400" b="0"/><a:t>Sales</a:t></a:r>
+          </a:p>
+        </c:rich>
+      </c:tx>
+      <c:layout>
+        <c:manualLayout>
+          <c:xMode val="factor"/>
+          <c:yMode val="factor"/>
+          <c:x val="0.45"/>
+          <c:y val="0.02"/>
+        </c:manualLayout>
+      </c:layout>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:autoTitleDeleted val="0"/>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$4</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="b"/><c:crossAx val="2"/></c:catAx>
+      <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1"/>
+    <c:dispBlanksAs val="gap"/>
+  </c:chart>
+</c:chartSpace>`;
+    const reparsed = parseChart(xml);
+    expect(reparsed?.titleLayout).toEqual({ x: 0.45, y: 0.02 });
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -19116,3 +19116,209 @@ describe("parseChart — axis title overlay", () => {
     expect(chart?.axes?.y?.axisTitleOverlay).toBeUndefined();
   });
 });
+
+// ── parseChart — titleLayout (manual placement) ─────────────────────
+
+describe("parseChart — titleLayout", () => {
+  const NS_TL = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleLayout(body: string): string {
+    return `<c:chartSpace ${NS_TL}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="0" spcFirstLastPara="1" vertOverflow="ellipsis" wrap="square" anchor="ctr" anchorCtr="1"/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr><a:defRPr sz="1400" b="0"/></a:pPr>
+            <a:r><a:rPr lang="en-US" sz="1400" b="0"/><a:t>Title</a:t></a:r>
+          </a:p>
+        </c:rich>
+      </c:tx>
+      <c:layout>
+        <c:manualLayout>${body}</c:manualLayout>
+      </c:layout>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces every coordinate when all four are pinned", () => {
+    const xml = withTitleLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:wMode val="edge"/><c:hMode val="edge"/>
+       <c:x val="0.35"/><c:y val="0.05"/><c:w val="0.3"/><c:h val="0.1"/>`,
+    );
+    expect(parseChart(xml)?.titleLayout).toEqual({ x: 0.35, y: 0.05, w: 0.3, h: 0.1 });
+  });
+
+  it("surfaces a partial layout (only x/y pinned)", () => {
+    const xml = withTitleLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:x val="0.5"/><c:y val="0.05"/>`,
+    );
+    expect(parseChart(xml)?.titleLayout).toEqual({ x: 0.5, y: 0.05 });
+  });
+
+  it('accepts xMode="factor" and surfaces the same shape', () => {
+    const xml = withTitleLayout(
+      `<c:xMode val="factor"/><c:yMode val="factor"/><c:x val="0.4"/><c:y val="0.02"/>`,
+    );
+    expect(parseChart(xml)?.titleLayout).toEqual({ x: 0.4, y: 0.02 });
+  });
+
+  it("drops out-of-range coordinates axis-by-axis", () => {
+    const xml = withTitleLayout(
+      `<c:x val="-0.5"/><c:y val="2.0"/><c:w val="0.3"/><c:h val="0.1"/>`,
+    );
+    expect(parseChart(xml)?.titleLayout).toEqual({ w: 0.3, h: 0.1 });
+  });
+
+  it("drops non-numeric coordinates axis-by-axis", () => {
+    const xml = withTitleLayout(`<c:x val="not-a-number"/><c:y val="0.05"/>`);
+    expect(parseChart(xml)?.titleLayout).toEqual({ y: 0.05 });
+  });
+
+  it("collapses an empty <c:manualLayout> to undefined", () => {
+    const xml = withTitleLayout(``);
+    expect(parseChart(xml)?.titleLayout).toBeUndefined();
+  });
+
+  it("collapses a layout where every coordinate dropped to undefined", () => {
+    const xml = withTitleLayout(`<c:x val="-1"/><c:y val="2"/>`);
+    expect(parseChart(xml)?.titleLayout).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:layout> block", () => {
+    const xml = `<c:chartSpace ${NS_TL}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>T</a:t></a:r></a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleLayout).toBeUndefined();
+  });
+
+  it("returns undefined when <c:layout> has no <c:manualLayout> child", () => {
+    const xml = `<c:chartSpace ${NS_TL}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>T</a:t></a:r></a:p></c:rich></c:tx>
+      <c:layout/>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleLayout).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:title> element at all", () => {
+    const xml = `<c:chartSpace ${NS_TL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleLayout).toBeUndefined();
+  });
+
+  it("accepts the boundary values 0 and 1", () => {
+    const xml = withTitleLayout(`<c:x val="0"/><c:y val="1"/><c:w val="0"/><c:h val="1"/>`);
+    expect(parseChart(xml)?.titleLayout).toEqual({ x: 0, y: 1, w: 0, h: 1 });
+  });
+
+  it("co-surfaces alongside titleOverlay / titleFontSize / titleBold", () => {
+    const xml = `<c:chartSpace ${NS_TL}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr rot="0" spcFirstLastPara="1" vertOverflow="ellipsis" wrap="square" anchor="ctr" anchorCtr="1"/>
+          <a:lstStyle/>
+          <a:p>
+            <a:pPr><a:defRPr sz="1800" b="1"/></a:pPr>
+            <a:r><a:rPr lang="en-US" sz="1800" b="1"/><a:t>Bold Title</a:t></a:r>
+          </a:p>
+        </c:rich>
+      </c:tx>
+      <c:layout>
+        <c:manualLayout>
+          <c:xMode val="edge"/><c:yMode val="edge"/>
+          <c:x val="0.4"/><c:y val="0.02"/>
+        </c:manualLayout>
+      </c:layout>
+      <c:overlay val="1"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleLayout).toEqual({ x: 0.4, y: 0.02 });
+    expect(chart?.titleOverlay).toBe(true);
+    expect(chart?.titleFontSize).toBe(18);
+    expect(chart?.titleBold).toBe(true);
+  });
+
+  it("co-surfaces alongside legendLayout (independent <c:layout> slots)", () => {
+    const xml = `<c:chartSpace ${NS_TL}>
+  <c:chart>
+    <c:title>
+      <c:tx>
+        <c:rich>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>T</a:t></a:r></a:p>
+        </c:rich>
+      </c:tx>
+      <c:layout>
+        <c:manualLayout>
+          <c:xMode val="edge"/><c:yMode val="edge"/>
+          <c:x val="0.4"/><c:y val="0.02"/>
+        </c:manualLayout>
+      </c:layout>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:layout>
+        <c:manualLayout>
+          <c:xMode val="edge"/><c:yMode val="edge"/>
+          <c:x val="0.7"/><c:y val="0.2"/>
+        </c:manualLayout>
+      </c:layout>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleLayout).toEqual({ x: 0.4, y: 0.02 });
+    expect(chart?.legendLayout).toEqual({ x: 0.7, y: 0.2 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `titleLayout?: ChartManualLayout` to `SheetChart` / `Chart`, mapped to `<c:title><c:layout><c:manualLayout>` per `CT_Title` / `CT_ManualLayout` (ECMA-376 Part 1, §21.2.2.210 / §21.2.2.115) — Excel's "Format Chart Title -> Title Options -> Position -> Custom" placement (the same drag-handle a user sees when grabbing the title block in Excel's chart editor).
- Reuses the existing generic `ChartManualLayout` shape introduced for `legendLayout` in #298, so callers thread the same `(x, y, w, h)` 0..1 fractions through both manual-layout slots without bookkeeping a second type.
- Writer emits `<c:layout>` between `<c:tx>` and `<c:overlay>` per `CT_Title`; mode children (`<c:xMode>` / `<c:yMode>` / `<c:wMode>` / `<c:hMode>` with `val="edge"`) precede value children per the schema sequence. Out-of-range / non-finite / non-numeric coordinates collapse axis-by-axis; an empty layout collapses to no `<c:layout>` block so a fresh chart matches Excel's reference serialization byte-for-byte.
- Reader admits both `xMode="edge"` and `xMode="factor"` and surfaces the same shape; the writer always normalizes to `"edge"` on emit since that is what Excel itself emits when the user drags the title to a custom position.
- Clone-through follows the established title-knob grammar (`undefined` inherits, `null` drops, value replaces) and is gated on the resolved title visibility — `title` resolved to `undefined` or `showTitle === false` drops the field silently, since there is no `<c:title>` block to host the layout in either case.

Refs #298

## Test plan

- [x] `pnpm typecheck` — passes.
- [x] `pnpm lint` — no new errors (existing 45 warnings unchanged, formatting clean).
- [x] `pnpm vitest run --dir=test` — 6226 tests pass (57 new tests across writer / reader / clone-through, including `writeXlsx` round-trip and `xMode="factor"` admission).
- [x] `pnpm build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)