### PR TITLE
feat(xlsx): chart axis-title manual layout — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -3486,6 +3486,58 @@ export interface SheetChart {
        * area / scatter).
        */
       axisTitleOverlay?: boolean;
+      /**
+       * Axis-title manual placement. Maps to
+       * `<c:catAx><c:title><c:layout><c:manualLayout>...</c:manualLayout>
+       * </c:layout></c:title></c:catAx>` (or `<c:valAx>` / `<c:dateAx>` /
+       * `<c:serAx>`) — Excel's "Format Axis Title -> Title Options ->
+       * Position -> Custom" placement, the same drag-handle a user sees
+       * when grabbing the axis-title block in Excel's chart editor.
+       *
+       * The OOXML `CT_ManualLayout` block (ECMA-376 Part 1, §21.2.2.115)
+       * sits inside `CT_Title` between `<c:tx>` and `<c:overlay>` and
+       * carries the title's `(x, y)` anchor and `(w, h)` size as
+       * fractions of the chart frame in the `0..1` band. Each of
+       * {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+       * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} is
+       * independently optional — pin only the position
+       * ({@link ChartManualLayout.x} / {@link ChartManualLayout.y}) and
+       * let the title keep its automatic size, only the size
+       * ({@link ChartManualLayout.w} / {@link ChartManualLayout.h}) and
+       * let it keep its automatic anchor, or any combination.
+       *
+       * Mirrors {@link SheetChart.legendLayout} /
+       * {@link SheetChart.plotAreaLayout} for axis titles — same
+       * {@link ChartManualLayout} shape, same accept-or-drop grammar
+       * (out-of-range / non-finite / non-numeric coordinates collapse
+       * to `undefined` axis-by-axis), same canonical `xMode="edge"`
+       * normalization on emit. The writer always emits
+       * `xMode="edge"` / `yMode="edge"` / `wMode="edge"` /
+       * `hMode="edge"` next to the matching `<c:x>` / `<c:y>` / `<c:w>` /
+       * `<c:h>` slot — `"edge"` is Excel's reference shape when the
+       * user drags an element to a custom position (the coordinates
+       * are absolute fractions of the chart frame, not deltas from
+       * the auto-layout baseline).
+       *
+       * Default: omitted — the writer skips the entire `<c:layout>`
+       * block so the axis title renders at Excel's auto-layout
+       * position (adjacent to the matching axis, with the plot area
+       * shrunk to make room). An empty layout (every coordinate
+       * dropped on normalization) collapses back to no `<c:layout>`
+       * block so a fresh chart matches Excel's reference shape
+       * byte-for-byte.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>`
+       * shape per the OOXML schema, so the field round-trips on
+       * every chart family that has axes (bar / column / line /
+       * area / scatter).
+       */
+      axisTitleLayout?: ChartManualLayout;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -4244,6 +4296,15 @@ export interface SheetChart {
        * See the X-axis variant for the full semantics.
        */
       axisTitleOverlay?: boolean;
+      /**
+       * Value-axis-title manual placement. Same canonical
+       * `<c:title><c:layout><c:manualLayout>...</c:manualLayout>
+       * </c:layout></c:title>` slot and grammar as
+       * {@link SheetChart.axes.x.axisTitleLayout} — the field
+       * round-trips on `<c:valAx>` exactly as it does on `<c:catAx>`.
+       * See the X-axis variant for the full semantics.
+       */
+      axisTitleLayout?: ChartManualLayout;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -5919,6 +5980,47 @@ export interface ChartAxisInfo {
    * without transformation.
    */
   axisTitleOverlay?: boolean;
+  /**
+   * Axis-title manual placement pulled from
+   * `<c:catAx><c:title><c:layout><c:manualLayout>...</c:manualLayout>
+   * </c:layout></c:title></c:catAx>` (or `<c:valAx>` / `<c:dateAx>` /
+   * `<c:serAx>`). Reflects Excel's "Format Axis Title -> Title Options
+   * -> Position -> Custom" placement — the `(x, y)` anchor and
+   * `(w, h)` size of the axis-title block as fractions of the chart
+   * frame in the `0..1` band.
+   *
+   * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+   * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} surfaces
+   * only when the matching `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` child
+   * is present and parses to a finite number in the `0..1` band; out-of-
+   * range / non-finite / non-numeric tokens drop on the matching axis
+   * so absence and a malformed token round-trip identically through
+   * {@link cloneChart}.
+   *
+   * Both `<c:xMode val="edge"/>` (absolute fraction of the chart frame)
+   * and `<c:xMode val="factor"/>` (delta from auto-layout) are accepted
+   * — the reader surfaces the same {@link ChartManualLayout} shape
+   * regardless, since the writer always normalizes to `"edge"` on emit
+   * (Excel itself emits the absolute form when the user drags an
+   * element to a custom position).
+   *
+   * Returned as `undefined` whenever the axis omits the `<c:title>` /
+   * `<c:layout>` / `<c:manualLayout>` chain at any link, or when every
+   * coordinate dropped on normalization — the field is omitted entirely
+   * on a clean parse so absence and an empty layout round-trip
+   * identically through the writer. Mirrors the chart-level
+   * {@link Chart.titleLayout} (when set on the same chart) and
+   * {@link Chart.legendLayout} / {@link Chart.plotAreaLayout} so a
+   * parsed value slots straight back into the writer-side
+   * {@link SheetChart.axes.x.axisTitleLayout} without transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every axis
+   * flavour so a parsed chart preserves the placement regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleLayout?: ChartManualLayout;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -1239,6 +1239,31 @@ export interface CloneChartOptions {
        * same way at the call site.
        */
       axisTitleOverlay?: boolean | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleLayout`. `undefined` (or
+       * omitted) inherits the source axis's parsed `axisTitleLayout`;
+       * `null` drops the inherited layout (the writer falls back to
+       * Excel's auto-layout position — no `<c:layout>` block on the
+       * axis title); a {@link ChartManualLayout} replaces it.
+       *
+       * Each of {@link ChartManualLayout.x} / {@link ChartManualLayout.y} /
+       * {@link ChartManualLayout.w} / {@link ChartManualLayout.h} runs
+       * through the same `0..1` filter as the writer-side
+       * normalization: out-of-range / non-finite / non-numeric tokens
+       * collapse on the matching axis. An override whose every
+       * coordinate dropped collapses to `undefined` so the cloned
+       * `SheetChart` skips the entire `<c:layout>` block.
+       *
+       * The override is silently dropped from the cloned `SheetChart`
+       * when the axis renders no title (the resolved `title` is
+       * `undefined`) — there is no `<c:title>` block to host the
+       * layout in either case.
+       *
+       * The grammar mirrors the chart-level `titleLayout` /
+       * `legendLayout` / `plotAreaLayout` so the four manual-layout
+       * knobs compose the same way at the call site.
+       */
+      axisTitleLayout?: ChartManualLayout | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1579,6 +1604,8 @@ export interface CloneChartOptions {
       axisTitleFontFamily?: string | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleOverlay}. */
       axisTitleOverlay?: boolean | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleLayout}. */
+      axisTitleLayout?: ChartManualLayout | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -4187,6 +4214,25 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleOverlay,
     overrides?.y?.axisTitleOverlay,
   );
+  // `<c:title><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
+  // </c:title>` — axis-title manual placement. Sits inside `<c:title>`
+  // between `<c:tx>` and `<c:overlay>` per CT_Title schema, so the
+  // resolver applies on every chart family that has axes (pie /
+  // doughnut were short-circuited upstream). Out-of-range / non-finite /
+  // non-numeric coordinates collapse on the matching axis via the
+  // resolver; an override whose every coordinate dropped collapses to
+  // `undefined` so the cloned `SheetChart` skips the entire `<c:layout>`
+  // block. Like the other axis-title knobs, the writer drops the layout
+  // when the matching axis title is unset, so a stray pin on an axis
+  // with no title silently disappears at emit time.
+  const xAxisTitleLayout = resolveAxisTitleLayout(
+    sourceAxes?.x?.axisTitleLayout,
+    overrides?.x?.axisTitleLayout,
+  );
+  const yAxisTitleLayout = resolveAxisTitleLayout(
+    sourceAxes?.y?.axisTitleLayout,
+    overrides?.y?.axisTitleLayout,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -4476,6 +4522,12 @@ function resolveAxes(
   // reflects what the chart will paint.
   const xAxisTitleOverlayResolved = xTitle === undefined ? undefined : xAxisTitleOverlay;
   const yAxisTitleOverlayResolved = yTitle === undefined ? undefined : yAxisTitleOverlay;
+  // Same title-presence gate as the other axis-title knobs — the writer
+  // skips the entire `<c:layout>` block (and the surrounding `<c:title>`
+  // element) when the matching axis title is unset, so the cloned
+  // `SheetChart` accurately reflects what the chart will paint.
+  const xAxisTitleLayoutResolved = xTitle === undefined ? undefined : xAxisTitleLayout;
+  const yAxisTitleLayoutResolved = yTitle === undefined ? undefined : yAxisTitleLayout;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -4489,6 +4541,7 @@ function resolveAxes(
     xAxisTitleUnderlineResolved !== undefined ||
     xAxisTitleFontFamilyResolved !== undefined ||
     xAxisTitleOverlayResolved !== undefined ||
+    xAxisTitleLayoutResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -4531,6 +4584,7 @@ function resolveAxes(
     if (xAxisTitleFontFamilyResolved !== undefined)
       out.x.axisTitleFontFamily = xAxisTitleFontFamilyResolved;
     if (xAxisTitleOverlayResolved !== undefined) out.x.axisTitleOverlay = xAxisTitleOverlayResolved;
+    if (xAxisTitleLayoutResolved !== undefined) out.x.axisTitleLayout = xAxisTitleLayoutResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -4569,6 +4623,7 @@ function resolveAxes(
     yAxisTitleUnderlineResolved !== undefined ||
     yAxisTitleFontFamilyResolved !== undefined ||
     yAxisTitleOverlayResolved !== undefined ||
+    yAxisTitleLayoutResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -4605,6 +4660,7 @@ function resolveAxes(
     if (yAxisTitleFontFamilyResolved !== undefined)
       out.y.axisTitleFontFamily = yAxisTitleFontFamilyResolved;
     if (yAxisTitleOverlayResolved !== undefined) out.y.axisTitleOverlay = yAxisTitleOverlayResolved;
+    if (yAxisTitleLayoutResolved !== undefined) out.y.axisTitleLayout = yAxisTitleLayoutResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -5415,6 +5471,43 @@ function applyAxisTitleOverlayOverride(
   if (override === true) return true;
   if (override === false) return false;
   return undefined;
+}
+
+/**
+ * Resolve an `axisTitleLayout` override.
+ *
+ * `undefined` → inherit the source axis's parsed `axisTitleLayout`
+ *               (after running through {@link normalizeLegendLayout}
+ *               so a malformed source value drops cleanly — the
+ *               normalizer is purely shape-based, no host-element
+ *               awareness, so it applies identically to legend /
+ *               plot-area / title / axis-title layouts).
+ * `null`      → drop the inherited layout (the writer falls back to
+ *               Excel's auto-layout position — no `<c:layout>` block
+ *               on the axis title).
+ * `ChartManualLayout` → replace, after running through
+ *               {@link normalizeLegendLayout}. Coordinates outside the
+ *               `0..1` band collapse on the matching axis so the
+ *               cloned `SheetChart` always carries a value the writer
+ *               will accept; an override whose every axis dropped
+ *               collapses to `undefined` so the cloned shape skips
+ *               the entire `<c:layout>` block.
+ *
+ * The grammar mirrors `resolveLegendLayout` / `resolvePlotAreaLayout`
+ * so the manual-layout knobs compose the same way at the call site.
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never carries
+ * a layout that the writer would silently elide (the writer scopes the
+ * `<c:layout>` emission to `<c:title>`, which is omitted when the axis
+ * renders no title).
+ */
+function resolveAxisTitleLayout(
+  sourceValue: ChartManualLayout | undefined,
+  override: ChartManualLayout | null | undefined,
+): ChartManualLayout | undefined {
+  if (override === undefined) return normalizeLegendLayout(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendLayout(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -790,6 +790,23 @@ function parseAxisInfo(
   // {@link cloneChart}. Returns `undefined` when the axis omits
   // `<c:title>` entirely.
   const axisTitleOverlay = parseAxisTitleOverlay(axis);
+  // `<c:title><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
+  // </c:title>` — axis-title manual placement. Sits inside `<c:title>`
+  // between `<c:tx>` and `<c:overlay>` per CT_Title schema (ECMA-376
+  // Part 1, §21.2.2.210), so the lookup is scoped to the `<c:layout>`
+  // child of `<c:title>` (a stray `<c:layout>` elsewhere on the axis
+  // — e.g. on `<c:plotArea>` — cannot leak in). The OOXML
+  // `<c:manualLayout>` block (`CT_ManualLayout`, §21.2.2.115) carries
+  // the `(x, y)` anchor and `(w, h)` size as fractions of the chart
+  // frame in the `0..1` band; out-of-range / non-finite / non-numeric
+  // tokens drop on the matching axis so absence and a malformed token
+  // round-trip identically through {@link cloneChart}. Returns
+  // `undefined` whenever the axis omits the `<c:title>` /
+  // `<c:layout>` / `<c:manualLayout>` chain at any link or when every
+  // coordinate dropped on normalization. Mirrors the chart-level
+  // `legendLayout` / `plotAreaLayout` parsers — same accept-or-drop
+  // grammar, same `xMode="edge"` / `xMode="factor"` admission.
+  const axisTitleLayout = parseAxisTitleLayout(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -949,6 +966,7 @@ function parseAxisInfo(
     axisTitleUnderline === undefined &&
     axisTitleFontFamily === undefined &&
     axisTitleOverlay === undefined &&
+    axisTitleLayout === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -989,6 +1007,7 @@ function parseAxisInfo(
   if (axisTitleUnderline !== undefined) out.axisTitleUnderline = axisTitleUnderline;
   if (axisTitleFontFamily !== undefined) out.axisTitleFontFamily = axisTitleFontFamily;
   if (axisTitleOverlay !== undefined) out.axisTitleOverlay = axisTitleOverlay;
+  if (axisTitleLayout !== undefined) out.axisTitleLayout = axisTitleLayout;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -2457,6 +2476,62 @@ function parseAxisTitleOverlay(axis: XmlElement): boolean | undefined {
     default:
       return undefined;
   }
+}
+
+/**
+ * Pull `<c:title><c:layout><c:manualLayout>` off an axis element.
+ * Reflects Excel's "Format Axis Title -> Title Options -> Position ->
+ * Custom" placement — the `(x, y)` anchor and `(w, h)` size of the
+ * axis-title block as fractions of the chart frame in the `0..1`
+ * band.
+ *
+ * The OOXML schema (`CT_Title`, ECMA-376 Part 1, §21.2.2.210) places
+ * `<c:layout>` inside `<c:title>` between `<c:tx>` and `<c:overlay>`,
+ * and the `<c:manualLayout>` block (`CT_ManualLayout`, §21.2.2.115)
+ * exposes optional `<c:x>` / `<c:y>` / `<c:w>` / `<c:h>` children
+ * whose `val` attributes carry an `xsd:double`. The reader admits
+ * the coordinate only when `val` parses to a finite number in the
+ * `0..1` band; out-of-range / non-finite / non-numeric tokens drop
+ * to `undefined` on the matching axis so absence and a malformed
+ * token round-trip identically through {@link cloneChart}.
+ *
+ * Both `<c:xMode val="edge"/>` (absolute fraction of the chart frame)
+ * and `<c:xMode val="factor"/>` (delta from auto-layout) are accepted
+ * — the reader surfaces the same `ChartManualLayout` shape regardless,
+ * since the writer always normalizes to `"edge"` on emit (Excel itself
+ * emits the absolute form when the user drags an element to a custom
+ * position).
+ *
+ * Returns `undefined` whenever the axis omits the `<c:title>` /
+ * `<c:layout>` / `<c:manualLayout>` chain at any link, or when every
+ * coordinate dropped on normalization — the field is omitted entirely
+ * on a clean parse so absence and an empty layout round-trip
+ * identically through the writer. Mirrors the chart-level
+ * {@link parseLegendLayout} / {@link parsePlotAreaLayout} so the
+ * three layout knobs share parsing semantics.
+ */
+function parseAxisTitleLayout(axis: XmlElement): ChartManualLayout | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const layout = findChild(title, "layout");
+  if (!layout) return undefined;
+  const manual = findChild(layout, "manualLayout");
+  if (!manual) return undefined;
+
+  const out: ChartManualLayout = {};
+  const x = readLayoutCoordinate(findChild(manual, "x"));
+  if (x !== undefined) out.x = x;
+  const y = readLayoutCoordinate(findChild(manual, "y"));
+  if (y !== undefined) out.y = y;
+  const w = readLayoutCoordinate(findChild(manual, "w"));
+  if (w !== undefined) out.w = w;
+  const h = readLayoutCoordinate(findChild(manual, "h"));
+  if (h !== undefined) out.h = h;
+
+  if (out.x === undefined && out.y === undefined && out.w === undefined && out.h === undefined) {
+    return undefined;
+  }
+  return out;
 }
 
 // ── Series ────────────────────────────────────────────────────────

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -954,6 +954,21 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // type guard never produces `<c:overlay val="1"/>`.
     xAxisTitleOverlay: chart.axes?.x?.axisTitleOverlay === true,
     yAxisTitleOverlay: chart.axes?.y?.axisTitleOverlay === true,
+    // `<c:title><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
+    // </c:title>` — axis-title manual placement. The OOXML
+    // `CT_ManualLayout` block (ECMA-376 Part 1, §21.2.2.115) sits
+    // inside `CT_Title` between `<c:tx>` and `<c:overlay>` and carries
+    // the title's `(x, y)` anchor and `(w, h)` size as fractions of
+    // the chart frame in the `0..1` band. Reuses the same
+    // `normalizeManualLayout` helper as the chart-level legend /
+    // plot-area layouts — out-of-range / non-finite / non-numeric
+    // coordinates collapse to `undefined` axis-by-axis, and an empty
+    // layout (every coordinate dropped) collapses to `undefined` so
+    // the writer skips the entire `<c:layout>` block. Only meaningful
+    // when the axis renders a title — the per-family axis builders
+    // gate the value on the `xAxisTitle` / `yAxisTitle` field.
+    xAxisTitleLayout: normalizeManualLayout(chart.axes?.x?.axisTitleLayout),
+    yAxisTitleLayout: normalizeManualLayout(chart.axes?.y?.axisTitleLayout),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1943,6 +1958,27 @@ interface AxisRenderOptions {
    * emit semantics as {@link xAxisTitleOverlay}.
    */
   yAxisTitleOverlay: boolean;
+  /**
+   * Axis-title manual placement emitted on the X axis via
+   * `<c:title><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
+   * </c:title>`. The OOXML `CT_ManualLayout` block (ECMA-376 Part 1,
+   * §21.2.2.115) sits inside `CT_Title` between `<c:tx>` and
+   * `<c:overlay>` and carries the title's `(x, y)` anchor and
+   * `(w, h)` size as fractions of the chart frame in the `0..1` band.
+   * Absence (`undefined`) collapses to omitting the entire `<c:layout>`
+   * block so the axis title renders at Excel's auto-layout position.
+   * Only meaningful when the axis renders a title — the per-family
+   * axis builders gate the value on the `xAxisTitle` / `yAxisTitle`
+   * field. Mirrors the chart-level `titleLayout` / `legendLayout` /
+   * `plotAreaLayout` slots so the four manual-layout knobs share a
+   * normalization grammar (`normalizeManualLayout`).
+   */
+  xAxisTitleLayout: ResolvedManualLayout | undefined;
+  /**
+   * Axis-title manual placement emitted on the Y axis. Same shape
+   * and emit semantics as {@link xAxisTitleLayout}.
+   */
+  yAxisTitleLayout: ResolvedManualLayout | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -3173,6 +3209,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleUnderline,
         opts.xAxisTitleFontFamily,
         opts.xAxisTitleOverlay,
+        opts.xAxisTitleLayout,
       ),
     );
   catAxChildren.push(
@@ -3249,6 +3286,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleUnderline,
         opts.yAxisTitleFontFamily,
         opts.yAxisTitleOverlay,
+        opts.yAxisTitleLayout,
       ),
     );
   valAxChildren.push(
@@ -3626,6 +3664,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleUnderline,
         opts.xAxisTitleFontFamily,
         opts.xAxisTitleOverlay,
+        opts.xAxisTitleLayout,
       ),
     );
   xAxChildren.push(
@@ -3681,6 +3720,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleUnderline,
         opts.yAxisTitleFontFamily,
         opts.yAxisTitleOverlay,
+        opts.yAxisTitleLayout,
       ),
     );
   yAxChildren.push(
@@ -3783,6 +3823,7 @@ function buildAxisTitle(
   underline: boolean | undefined,
   fontFamily: string | undefined,
   overlay: boolean,
+  layout: ResolvedManualLayout | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -3901,7 +3942,14 @@ function buildAxisTitle(
           u: underlineAttr,
           strike: strikeAttr,
         });
-  return xmlElement("c:title", undefined, [
+  // `<c:layout>` sits between `<c:tx>` and `<c:overlay>` per CT_Title
+  // (ECMA-376 Part 1, §21.2.2.210) — the schema sequence is
+  // `<c:tx>?` / `<c:layout>?` / `<c:overlay>?` / `<c:spPr>?` /
+  // `<c:txPr>?`. Skip the entire block when `layout` is `undefined`
+  // (every coordinate either unset or dropped on normalization) so a
+  // fresh axis title matches Excel's reference shape byte-for-byte.
+  const layoutXml = buildManualLayout(layout);
+  const titleChildren: string[] = [
     xmlElement("c:tx", undefined, [
       xmlElement("c:rich", undefined, [
         xmlElement(
@@ -3923,8 +3971,10 @@ function buildAxisTitle(
         ]),
       ]),
     ]),
-    xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }),
-  ]);
+  ];
+  if (layoutXml) titleChildren.push(layoutXml);
+  titleChildren.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
+  return xmlElement("c:title", undefined, titleChildren);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -20576,3 +20576,285 @@ describe("cloneChart — plotAreaLayout", () => {
     expect(parseChart(written)?.plotAreaLayout).toEqual({ x: 0.15, y: 0.25 });
   });
 });
+
+// ── cloneChart — axisTitleLayout (manual placement) ─────────────────
+
+describe("cloneChart — axisTitleLayout", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleLayout by default", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.9 });
+  });
+
+  it("inherits the source's Y-axis axisTitleLayout by default", () => {
+    const clone = cloneChart(
+      source({ axes: { y: { title: "USD", axisTitleLayout: { w: 0.05, h: 0.5 } } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.y?.axisTitleLayout).toEqual({ w: 0.05, h: 0.5 });
+  });
+
+  it("lets options.axes.x.axisTitleLayout replace the source's value", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleLayout: { x: 0.2, y: 0.85, w: 0.4, h: 0.1 } } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ x: 0.2, y: 0.85, w: 0.4, h: 0.1 });
+  });
+
+  it("drops the inherited axisTitleLayout when the override is null", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleLayout: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("returns undefined axisTitleLayout when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleLayout with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleLayout: { x: 0.5, y: 0.85 } } },
+    });
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ x: 0.5, y: 0.85 });
+  });
+
+  it("normalizes out-of-range overrides axis-by-axis", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleLayout: { x: -0.1, y: 1.2, w: 0.4, h: 0.1 } } },
+    });
+    // x and y dropped; w and h survive.
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ w: 0.4, h: 0.1 });
+  });
+
+  it("collapses an override whose every axis dropped to undefined", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.5 } } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: {
+          x: {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            axisTitleLayout: { x: -1 as any, y: 2 as any, w: Number.NaN as any },
+          },
+        },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("drops non-numeric coordinates leaking past the type guard", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleLayout: { x: "0.5" as any, y: 0.4 } } },
+    });
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ y: 0.4 });
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      source({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleLayout: { x: 5 as any, y: -1 as any } } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("drops the cloned axisTitleLayout when the resolved axis title is dropped (title=null)", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("drops the cloned axisTitleLayout when the source axis has no title", () => {
+    // Source axis has axisTitleLayout but no title — the writer would
+    // have skipped <c:title> entirely, so the cloned shape drops the
+    // layout for symmetry. This mirrors the writer's title-presence
+    // gate.
+    const clone = cloneChart(source({ axes: { x: { axisTitleLayout: { x: 0.4, y: 0.9 } } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("preserves axisTitleLayout when an override pins a fresh title on a sourceless axis", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.9 });
+  });
+
+  it("composes with other axis-title knobs on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleLayout: { x: 0.4, y: 0.9 },
+            axisTitleOverlay: true,
+            axisTitleBold: true,
+            axisTitleFontFamily: "Arial",
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.9 });
+    expect(clone.axes?.x?.axisTitleOverlay).toBe(true);
+    expect(clone.axes?.x?.axisTitleBold).toBe(true);
+    expect(clone.axes?.x?.axisTitleFontFamily).toBe("Arial");
+  });
+
+  it("threads axisTitleLayout through every chart family that has axes", () => {
+    for (const t of ["column", "line", "area", "scatter"] as const) {
+      const clone = cloneChart(
+        source({
+          kinds: [t === "column" ? "bar" : t],
+          axes: {
+            x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } },
+          },
+        }),
+        { anchor: { from: { row: 0, col: 0 } }, type: t },
+      );
+      expect(clone.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.9 });
+    }
+  });
+
+  it("drops axisTitleLayout on pie / doughnut flatten (no axes)", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      { anchor: { from: { row: 0, col: 0 } }, type: "doughnut" },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.axes).toBeUndefined();
+  });
+
+  it("propagates axisTitleLayout into the rendered <c:title><c:layout> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.85, w: 0.3, h: 0.1 } },
+          y: { title: "USD", axisTitleLayout: { w: 0.05, h: 0.5 } },
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.85, w: 0.3, h: 0.1 });
+    expect(reparsed?.axes?.y?.axisTitleLayout).toEqual({ w: 0.05, h: 0.5 });
+  });
+
+  it("emits no axis-title <c:layout> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const catAx = written.match(/<c:catAx>[\s\S]*?<\/c:catAx>/)![0];
+    const titleBlock = catAx.match(/<c:title>[\s\S]*?<\/c:title>/)![0];
+    expect(titleBlock).not.toContain("<c:layout>");
+    expect(parseChart(written)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      {
+        anchor: { from: { row: 5, col: 0 } },
+        axes: { x: { axisTitleLayout: { x: 0.2, y: 0.8 } } },
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.axes?.x?.axisTitleLayout).toEqual({ x: 0.2, y: 0.8 });
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -19263,3 +19263,404 @@ describe("writeChart — plotAreaLayout", () => {
     expect(reparsed?.plotAreaLayout).toEqual({ x: 0.1, y: 0.2, w: 0.8, h: 0.6 });
   });
 });
+
+// ── writeChart — axisTitleLayout (manual placement) ─────────────────
+
+describe("writeChart — axisTitleLayout", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  it("does NOT emit <c:layout> on an axis title when axisTitleLayout is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:layout>");
+    expect(title).not.toContain("<c:manualLayout>");
+  });
+
+  it("threads x/y anchor through to <c:layout><c:manualLayout> on the X axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).toContain("<c:layout>");
+    expect(title).toContain("<c:manualLayout>");
+    expect(title).toContain('<c:xMode val="edge"/>');
+    expect(title).toContain('<c:yMode val="edge"/>');
+    expect(title).toContain('<c:x val="0.4"/>');
+    expect(title).toContain('<c:y val="0.9"/>');
+    expect(title).not.toContain("<c:wMode");
+    expect(title).not.toContain("<c:hMode");
+    expect(title).not.toContain("<c:w ");
+    expect(title).not.toContain("<c:h ");
+  });
+
+  it("threads w/h size through to <c:layout><c:manualLayout> on the Y axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { y: { title: "USD", axisTitleLayout: { w: 0.15, h: 0.45 } } } }),
+      "Sheet1",
+    );
+    const [, yAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(yAx)!;
+    expect(title).toContain('<c:wMode val="edge"/>');
+    expect(title).toContain('<c:hMode val="edge"/>');
+    expect(title).toContain('<c:w val="0.15"/>');
+    expect(title).toContain('<c:h val="0.45"/>');
+    expect(title).not.toContain("<c:xMode");
+    expect(title).not.toContain("<c:yMode");
+  });
+
+  it("threads all four coordinates when every axis is pinned", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleLayout: { x: 0.3, y: 0.85, w: 0.4, h: 0.1 } },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).toContain('<c:x val="0.3"/>');
+    expect(title).toContain('<c:y val="0.85"/>');
+    expect(title).toContain('<c:w val="0.4"/>');
+    expect(title).toContain('<c:h val="0.1"/>');
+    // Mode children precede value children inside <c:manualLayout>.
+    const ml = title.match(/<c:manualLayout>[\s\S]*?<\/c:manualLayout>/)![0];
+    expect(ml.indexOf("c:xMode")).toBeLessThan(ml.indexOf("<c:x "));
+    expect(ml.indexOf("c:yMode")).toBeLessThan(ml.indexOf("<c:y "));
+    expect(ml.indexOf("c:wMode")).toBeLessThan(ml.indexOf("<c:w "));
+    expect(ml.indexOf("c:hMode")).toBeLessThan(ml.indexOf("<c:h "));
+  });
+
+  it("places <c:layout> after <c:tx> and before <c:overlay> (CT_Title order)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.5 } } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title.indexOf("c:tx")).toBeLessThan(title.indexOf("c:layout"));
+    expect(title.indexOf("c:layout")).toBeLessThan(title.indexOf("c:overlay"));
+  });
+
+  it("emits <c:layout> exactly once inside each axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.5, y: 0.5 } } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    const occurrences = title.match(/<c:layout\b/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any axis-title <c:layout> when the axis renders no title", () => {
+    // Without a `title` field, the writer skips `<c:title>` entirely so
+    // the layout has no slot in the rendered chart.
+    const result = writeChart(
+      makeChart({ axes: { x: { axisTitleLayout: { x: 0.5, y: 0.5 } } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleBlock(xAx)).toBeUndefined();
+  });
+
+  it("threads axisTitleLayout independently across the X and Y axes", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.9 } },
+          y: { title: "USD", axisTitleLayout: { w: 0.05, h: 0.5 } },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    const xTitle = axisTitleBlock(xAx)!;
+    const yTitle = axisTitleBlock(yAx)!;
+    expect(xTitle).toContain('<c:x val="0.4"/>');
+    expect(xTitle).toContain('<c:y val="0.9"/>');
+    expect(xTitle).not.toContain("<c:w ");
+    expect(yTitle).toContain('<c:w val="0.05"/>');
+    expect(yTitle).toContain('<c:h val="0.5"/>');
+    expect(yTitle).not.toContain("<c:x ");
+  });
+
+  it("threads axisTitleLayout through every chart family that has axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({
+          type,
+          axes: { x: { title: "Period", axisTitleLayout: { x: 0.5, y: 0.9 } } },
+        }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      const title = axisTitleBlock(xAx)!;
+      expect(title).toContain('<c:x val="0.5"/>');
+      expect(title).toContain('<c:y val="0.9"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { x: { title: "Period", axisTitleLayout: { x: 0.5, y: 0.9 } } },
+      }),
+      "Sheet1",
+    );
+    const [xAxScatter] = Array.from(scatter.chartXml.matchAll(/<c:valAx>[\s\S]*?<\/c:valAx>/g)).map(
+      (m) => m[0],
+    );
+    const title = axisTitleBlock(xAxScatter)!;
+    expect(title).toContain('<c:x val="0.5"/>');
+    expect(title).toContain('<c:y val="0.9"/>');
+  });
+
+  it("drops out-of-range coordinates (negative / above 1)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleLayout: { x: -0.1, y: 1.2, w: 0.4, h: 0.1 },
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:xMode");
+    expect(title).not.toContain("<c:yMode");
+    expect(title).not.toContain("<c:x ");
+    expect(title).not.toContain("<c:y ");
+    expect(title).toContain('<c:w val="0.4"/>');
+    expect(title).toContain('<c:h val="0.1"/>');
+  });
+
+  it("accepts the boundary values 0 and 1", () => {
+    const result = writeChart(
+      makeChart({
+        axes: { x: { title: "Period", axisTitleLayout: { x: 0, y: 1, w: 0, h: 1 } } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).toContain('<c:x val="0"/>');
+    expect(title).toContain('<c:y val="1"/>');
+    expect(title).toContain('<c:w val="0"/>');
+    expect(title).toContain('<c:h val="1"/>');
+  });
+
+  it("drops non-finite coordinates (NaN / Infinity)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleLayout: { x: Number.NaN, y: Number.POSITIVE_INFINITY, w: 0.4 },
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:xMode");
+    expect(title).not.toContain("<c:yMode");
+    expect(title).toContain('<c:w val="0.4"/>');
+  });
+
+  it("drops non-numeric coordinates (string leaking past the type guard)", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleLayout: { x: "0.5" as any, y: 0.4 } } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:xMode");
+    expect(title).toContain('<c:y val="0.4"/>');
+  });
+
+  it("collapses an empty layout (every axis dropped) to no <c:layout> block", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleLayout: { x: -1 as any, y: 2 as any } } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:layout>");
+    expect(title).not.toContain("<c:manualLayout>");
+  });
+
+  it("collapses a layout with no coordinates to no <c:layout> block", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleLayout: {} } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:layout>");
+  });
+
+  it("ignores a non-object axisTitleLayout (typed escape from an untyped caller)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ axes: { x: { title: "Period", axisTitleLayout: "custom" as any } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:layout>");
+  });
+
+  it("composes with axisTitleOverlay / axisTitleBold on the same <c:title> body", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleLayout: { x: 0.3, y: 0.9 },
+            axisTitleOverlay: true,
+            axisTitleBold: true,
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).toContain('<c:x val="0.3"/>');
+    expect(title).toContain('<c:overlay val="1"/>');
+    expect(title).toContain('b="1"');
+    // CT_Title order: tx / layout / overlay
+    expect(title.indexOf("c:tx")).toBeLessThan(title.indexOf("c:layout"));
+    expect(title.indexOf("c:layout")).toBeLessThan(title.indexOf("c:overlay"));
+  });
+
+  it("round-trips axisTitleLayout through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        axes: { x: { title: "Period", axisTitleLayout: { x: 0.4, y: 0.85, w: 0.3, h: 0.1 } } },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.85, w: 0.3, h: 0.1 });
+  });
+
+  it("round-trips a partial axisTitleLayout (only x/y) through parseChart", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleLayout: { x: 0.5, y: 0.25 } } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleLayout).toEqual({ x: 0.5, y: 0.25 });
+  });
+
+  it("collapses an unset axisTitleLayout round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("does not surface axisTitleLayout when the axis has no title", () => {
+    const written = writeChart(makeChart({ axes: { x: {} } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — axisTitleLayout lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            axes: {
+              x: { title: "Region", axisTitleLayout: { x: 0.4, y: 0.9 } },
+              y: { title: "USD", axisTitleLayout: { w: 0.05, h: 0.5 } },
+            },
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.9 });
+    expect(reparsed?.axes?.y?.axisTitleLayout).toEqual({ w: 0.05, h: 0.5 });
+  });
+
+  it('normalizes <c:xMode val="factor"/> back to the same shape on parse', () => {
+    // A templated chart that pinned the alternate `factor` mode still
+    // round-trips through parseChart — the writer normalizes to `edge`
+    // on emit, but the reader admits both.
+    const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <c:chart>
+    <c:autoTitleDeleted val="1"/>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:barDir val="col"/>
+        <c:grouping val="clustered"/>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:order val="0"/>
+          <c:val><c:numRef><c:f>Sheet1!$B$2:$B$4</c:f></c:numRef></c:val>
+        </c:ser>
+        <c:axId val="1"/>
+        <c:axId val="2"/>
+      </c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:scaling><c:orientation val="minMax"/></c:scaling>
+        <c:delete val="0"/>
+        <c:axPos val="b"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Region</a:t></a:r></a:p></c:rich></c:tx>
+          <c:layout>
+            <c:manualLayout>
+              <c:xMode val="factor"/>
+              <c:yMode val="factor"/>
+              <c:x val="0.4"/>
+              <c:y val="0.3"/>
+            </c:manualLayout>
+          </c:layout>
+          <c:overlay val="0"/>
+        </c:title>
+        <c:crossAx val="2"/>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/><c:scaling><c:orientation val="minMax"/></c:scaling><c:delete val="0"/><c:axPos val="l"/><c:crossAx val="1"/></c:valAx>
+    </c:plotArea>
+    <c:plotVisOnly val="1"/>
+    <c:dispBlanksAs val="gap"/>
+  </c:chart>
+</c:chartSpace>`;
+    const reparsed = parseChart(xml);
+    expect(reparsed?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.3 });
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -19475,3 +19475,218 @@ describe("parseChart — titleLayout", () => {
     expect(chart?.legendLayout).toEqual({ x: 0.7, y: 0.2 });
   });
 });
+
+// ── parseChart — axisTitleLayout (manual placement) ─────────────────
+
+describe("parseChart — axisTitleLayout", () => {
+  const NS_ATL = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withAxisTitleLayout(body: string, on: "x" | "y" = "x"): string {
+    const xTitle =
+      on === "x"
+        ? `<c:title>
+            <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+            <c:layout><c:manualLayout>${body}</c:manualLayout></c:layout>
+            <c:overlay val="0"/>
+          </c:title>`
+        : "";
+    const yTitle =
+      on === "y"
+        ? `<c:title>
+            <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+            <c:layout><c:manualLayout>${body}</c:manualLayout></c:layout>
+            <c:overlay val="0"/>
+          </c:title>`
+        : "";
+    return `<c:chartSpace ${NS_ATL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      ${xTitle}
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      ${yTitle}
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces every coordinate when all four are pinned on the X axis", () => {
+    const xml = withAxisTitleLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:wMode val="edge"/><c:hMode val="edge"/>
+       <c:x val="0.4"/><c:y val="0.85"/><c:w val="0.3"/><c:h val="0.1"/>`,
+    );
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({
+      x: 0.4,
+      y: 0.85,
+      w: 0.3,
+      h: 0.1,
+    });
+  });
+
+  it("surfaces every coordinate when all four are pinned on the Y axis", () => {
+    const xml = withAxisTitleLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:wMode val="edge"/><c:hMode val="edge"/>
+       <c:x val="0.05"/><c:y val="0.5"/><c:w val="0.05"/><c:h val="0.5"/>`,
+      "y",
+    );
+    expect(parseChart(xml)?.axes?.y?.axisTitleLayout).toEqual({
+      x: 0.05,
+      y: 0.5,
+      w: 0.05,
+      h: 0.5,
+    });
+  });
+
+  it("surfaces a partial layout (only x/y pinned)", () => {
+    const xml = withAxisTitleLayout(
+      `<c:xMode val="edge"/><c:yMode val="edge"/><c:x val="0.5"/><c:y val="0.9"/>`,
+    );
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({ x: 0.5, y: 0.9 });
+  });
+
+  it("surfaces a partial layout (only w/h pinned)", () => {
+    const xml = withAxisTitleLayout(
+      `<c:wMode val="edge"/><c:hMode val="edge"/><c:w val="0.3"/><c:h val="0.1"/>`,
+    );
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({ w: 0.3, h: 0.1 });
+  });
+
+  it('accepts xMode="factor" and surfaces the same shape', () => {
+    const xml = withAxisTitleLayout(
+      `<c:xMode val="factor"/><c:yMode val="factor"/><c:x val="0.4"/><c:y val="0.3"/>`,
+    );
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.3 });
+  });
+
+  it("drops out-of-range coordinates axis-by-axis", () => {
+    const xml = withAxisTitleLayout(
+      `<c:x val="-0.5"/><c:y val="2.0"/><c:w val="0.3"/><c:h val="0.1"/>`,
+    );
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({ w: 0.3, h: 0.1 });
+  });
+
+  it("drops non-numeric coordinates axis-by-axis", () => {
+    const xml = withAxisTitleLayout(`<c:x val="not-a-number"/><c:y val="0.4"/>`);
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({ y: 0.4 });
+  });
+
+  it("collapses an empty <c:manualLayout> to undefined", () => {
+    const xml = withAxisTitleLayout(``);
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("collapses a layout where every coordinate dropped to undefined", () => {
+    const xml = withAxisTitleLayout(`<c:x val="-1"/><c:y val="2"/>`);
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("returns undefined when the axis has no <c:title> element at all", () => {
+    const xml = `<c:chartSpace ${NS_ATL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toBeUndefined();
+    expect(parseChart(xml)?.axes?.y?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:layout> child", () => {
+    const xml = `<c:chartSpace ${NS_ATL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("returns undefined when <c:layout> has no <c:manualLayout> child", () => {
+    const xml = `<c:chartSpace ${NS_ATL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:layout/>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toBeUndefined();
+  });
+
+  it("accepts the boundary values 0 and 1", () => {
+    const xml = withAxisTitleLayout(`<c:x val="0"/><c:y val="1"/><c:w val="0"/><c:h val="1"/>`);
+    expect(parseChart(xml)?.axes?.x?.axisTitleLayout).toEqual({ x: 0, y: 1, w: 0, h: 1 });
+  });
+
+  it("does not leak a chart-level <c:legend><c:layout> into the axis-title layout slot", () => {
+    // A stray legend layout on the same chart must not leak into the
+    // axis-title layout (the lookup is scoped to <c:title> children).
+    const xml = `<c:chartSpace ${NS_ATL}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:layout><c:manualLayout><c:x val="0.5"/><c:y val="0.5"/></c:manualLayout></c:layout>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleLayout).toBeUndefined();
+    expect(chart?.legendLayout).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("surfaces independently on the X and Y axes", () => {
+    const xml = `<c:chartSpace ${NS_ATL}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:layout><c:manualLayout><c:x val="0.4"/><c:y val="0.9"/></c:manualLayout></c:layout>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+        <c:layout><c:manualLayout><c:w val="0.05"/><c:h val="0.5"/></c:manualLayout></c:layout>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.9 });
+    expect(chart?.axes?.y?.axisTitleLayout).toEqual({ w: 0.05, h: 0.5 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `axisTitleLayout?: ChartManualLayout` to `SheetChart.axes.x` / `axes.y` and the parsed `Chart.axes.x` / `axes.y` / `ChartAxisInfo`, mapped to `<c:catAx><c:title><c:layout><c:manualLayout>...</c:layout></c:title></c:catAx>` (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) per `CT_Title` / `CT_ManualLayout` (ECMA-376 Part 1, §21.2.2.210 / §21.2.2.115) — Excel's "Format Axis Title -> Title Options -> Position -> Custom" placement, the same drag-handle a user sees when grabbing the axis-title block in Excel's chart editor.
- Reuses the existing generic `ChartManualLayout` shape introduced for `legendLayout` in #298 and `plotAreaLayout` in #299, so callers thread the same `(x, y, w, h)` 0..1 fractions through axis titles too without bookkeeping a new type. Both X and Y axis titles share the field so a single configuration call composes across category and value axes.
- Writer emits `<c:layout>` between `<c:tx>` and `<c:overlay>` per `CT_Title`; mode children (`<c:xMode>` / `<c:yMode>` / `<c:wMode>` / `<c:hMode>` with `val="edge"`) precede value children per the schema sequence. Out-of-range / non-finite / non-numeric coordinates collapse axis-by-axis through the shared `normalizeManualLayout` helper; an empty layout collapses to no `<c:layout>` block so a fresh chart matches Excel's reference serialization byte-for-byte. The writer gates emission on the matching axis title's presence — a stray pin on an axis without a title silently drops at emit time.
- Reader admits both `xMode="edge"` and `xMode="factor"` and surfaces the same shape; the writer always normalizes to `"edge"` on emit since that is what Excel itself emits when the user drags the title to a custom position. The lookup is scoped to `<c:title>` children so a stray `<c:layout>` elsewhere on the axis (or on `<c:plotArea>` / `<c:legend>`) cannot leak in.
- Clone-through follows the established axis-title-knob grammar (`undefined` inherits, `null` drops, value replaces) and is gated on the resolved axis title's presence — the cloned `SheetChart` drops the field silently when the resolved `title` is `undefined`, symmetric with the writer's title-presence gate. Threads through every chart family that has axes (bar / column / line / area / scatter); pie / doughnut are short-circuited upstream so the field has no slot there.

Refs #299

## Test plan

- [x] `pnpm typecheck` — passes.
- [x] `pnpm lint` — no new errors (existing 45 warnings unchanged, formatting clean).
- [x] `pnpm vitest run --dir=test` — 6276 tests pass (57 new tests across writer / reader / clone-through, including `writeXlsx` round-trip and `xMode="factor"` admission).
- [x] `pnpm build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)