### PR TITLE
feat(xlsx): chart plot-area fill color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2200,6 +2200,39 @@ export interface SheetChart {
    * </c:layout>`.
    */
   plotAreaLayout?: ChartManualLayout;
+  /**
+   * Plot-area solid fill color as a 6-digit RGB hex string (e.g.
+   * `"F2F2F2"`). Maps to `<c:plotArea><c:spPr><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr></c:plotArea>` —
+   * Excel's "Format Plot Area -> Fill -> Solid fill -> Color" picker.
+   * The OOXML `<a:srgbClr val=".."/>` carries the 6-character uppercase
+   * hex sRGB color (`CT_SRgbColor` inside `CT_ShapeProperties`' fill
+   * choice — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.13). The
+   * `<c:spPr>` slot lives at the tail of `<c:plotArea>` per
+   * `CT_PlotArea` (ECMA-376 Part 1, §21.2.2.145), after every chart-type
+   * element / axes / `<c:dTable>`.
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the entire `<c:spPr>` block (Excel's reference serialization for
+   * a plot area that inherits the auto-fill — typically the chart-frame
+   * background or a translucent white depending on the theme).
+   *
+   * Default: omitted — the plot area inherits the auto-fill Excel
+   * picks from the chart's theme. Pin a hex color to mirror Excel's
+   * "Format Plot Area -> Fill -> Solid fill" knob and paint a flat
+   * background behind the series — useful for dashboard tiles where
+   * the plot area should pick up a brand color or a contrast band
+   * against the surrounding chart frame.
+   *
+   * Patterned / gradient / picture fills are not modelled — only the
+   * solid sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   */
+  plotAreaFillColor?: string;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -6629,6 +6662,32 @@ export interface Chart {
    * conversion.
    */
   plotAreaLayout?: ChartManualLayout;
+  /**
+   * Plot-area solid fill color pulled from `<c:plotArea><c:spPr>
+   * <a:solidFill><a:srgbClr val=".."/></a:solidFill></c:spPr></c:plotArea>`.
+   * Reflects Excel's "Format Plot Area -> Fill -> Solid fill -> Color"
+   * picker. The OOXML `<a:srgbClr val=".."/>` carries the 6-character
+   * uppercase hex sRGB color (`CT_SRgbColor` inside `CT_ShapeProperties`'
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.13). The
+   * `<c:spPr>` slot lives at the tail of `<c:plotArea>` per
+   * `CT_PlotArea` (ECMA-376 Part 1, §21.2.2.145), after every chart-type
+   * element / axes / `<c:dTable>`.
+   *
+   * Reports the 6-character uppercase hex form when the source chart
+   * pinned a literal `<a:srgbClr>` color; absence, malformed `val`
+   * tokens (wrong length, non-hex characters, alpha-channel forms),
+   * non-solid fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`,
+   * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+   * collapse to `undefined` so absence and an unrenderable fill
+   * round-trip identically through {@link cloneChart}. Mirrors the
+   * writer-side {@link SheetChart.plotAreaFillColor} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:plotArea>` element at all — there is no `<c:spPr>` slot to
+   * surface the fill from in that case.
+   */
+  plotAreaFillColor?: string;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -385,6 +385,28 @@ export interface CloneChartOptions {
    * has a `<c:plotArea>` element to host the layout.
    */
   plotAreaLayout?: ChartManualLayout | null;
+  /**
+   * Override `SheetChart.plotAreaFillColor`. `undefined` (or omitted)
+   * inherits the source's parsed `plotAreaFillColor`; `null` drops the
+   * inherited fill (the writer falls back to the auto-fill Excel picks
+   * from the chart's theme — no `<c:spPr>` block on the plot area); a
+   * 6-digit RGB hex string replaces it.
+   *
+   * The override runs through the same sRGB normalizer as the writer —
+   * the leading `#` and case are accepted, then the value collapses to
+   * the OOXML canonical uppercase form. Malformed tokens (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` so the cloned
+   * `SheetChart` drops the field rather than carry a value the writer
+   * would silently elide back to absence.
+   *
+   * The grammar mirrors `titleColor` / `axes.x.axisTitleColor` /
+   * `axes.x.labelColor` so the chart `<a:srgbClr>` knobs compose the
+   * same way at the call site. Unlike the title / axis-title color
+   * knobs, the plot-area fill is never gated on a visibility flag —
+   * every chart has a `<c:plotArea>` element to host the fill.
+   */
+  plotAreaFillColor?: string | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1846,6 +1868,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     options.plotAreaLayout,
   );
   if (resolvedPlotAreaLayout !== undefined) out.plotAreaLayout = resolvedPlotAreaLayout;
+
+  // Plot-area solid fill color is independent of the legend / title
+  // visibility — every chart has a `<c:plotArea>` element to host the
+  // `<c:spPr>` slot. `undefined` inherits the source's parsed
+  // `plotAreaFillColor` (after the writer-side normalizer collapses any
+  // malformed token), `null` drops the inherited fill (the writer
+  // emits no `<c:spPr>` block, the plot area inherits the auto-fill
+  // Excel picks from the chart's theme), a 6-digit hex string replaces
+  // it. Malformed overrides collapse to `undefined` via the normalizer
+  // so the cloned `SheetChart` always carries a value the writer will
+  // accept.
+  const resolvedPlotAreaFillColor = resolvePlotAreaFillColor(
+    source.plotAreaFillColor,
+    options.plotAreaFillColor,
+  );
+  if (resolvedPlotAreaFillColor !== undefined) out.plotAreaFillColor = resolvedPlotAreaFillColor;
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
   if (barGrouping !== undefined && (type === "bar" || type === "column")) {
@@ -3469,6 +3507,56 @@ function resolvePlotAreaLayout(
   if (override === undefined) return normalizeLegendLayout(sourceValue);
   if (override === null) return undefined;
   return normalizeLegendLayout(override);
+}
+
+/**
+ * Normalize a `plotAreaFillColor` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizePlotAreaFillColor` — the cloned shape
+ * is guaranteed to round-trip through the writer without surprise: a
+ * leading `#` and any case are accepted, then the value collapses to
+ * the OOXML canonical uppercase form. Malformed inputs (wrong length,
+ * non-hex characters, alpha-channel forms, non-string escapes from an
+ * untyped caller) collapse to `undefined` so the cloned chart drops
+ * the field rather than carry a value the writer would silently elide
+ * back to absence.
+ */
+function normalizePlotAreaFillColor(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
+}
+
+/**
+ * Resolve a `plotAreaFillColor` override.
+ *
+ * `undefined` → inherit the source's parsed `plotAreaFillColor` (after
+ *               running it through {@link normalizePlotAreaFillColor}
+ *               so a malformed source value drops cleanly).
+ * `null`      → drop the inherited fill (the writer emits no `<c:spPr>`
+ *               block, the plot area inherits the auto-fill Excel
+ *               picks from the chart's theme).
+ * `string`    → replace with the normalized 6-character uppercase hex
+ *               form. Malformed overrides collapse to `undefined` via
+ *               the normalizer so the cloned `SheetChart` always
+ *               carries a value the writer will accept.
+ *
+ * The grammar mirrors `titleColor` / `axes.x.axisTitleColor` /
+ * `axes.x.labelColor` so the chart `<a:srgbClr>` knobs compose the
+ * same way at the call site. Unlike those text-color knobs, the
+ * plot-area fill is never gated on a visibility flag — every chart has
+ * a `<c:plotArea>` element to host the fill.
+ */
+function resolvePlotAreaFillColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizePlotAreaFillColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizePlotAreaFillColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -434,6 +434,18 @@ export function parseChart(xml: string): Chart | undefined {
     // an out-of-range layout both round-trip lossless.
     const plotAreaLayout = parsePlotAreaLayout(plotArea);
     if (plotAreaLayout !== undefined) out.plotAreaLayout = plotAreaLayout;
+
+    // `<c:plotArea><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+    // </c:spPr></c:plotArea>` carries Excel's "Format Plot Area -> Fill ->
+    // Solid fill -> Color" pin. CT_PlotArea places the `<c:spPr>` slot at
+    // the tail of `<c:plotArea>` after every chart-type element / axes /
+    // `<c:dTable>`. The reader surfaces only the literal `<a:srgbClr>`
+    // form so absence, malformed hex tokens, non-solid fills (`<a:noFill>`
+    // / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`), and theme-color
+    // references (`<a:schemeClr>`) all collapse to `undefined` so a
+    // round-trip never fabricates a color Excel cannot render.
+    const plotAreaFillColor = parsePlotAreaFillColor(plotArea);
+    if (plotAreaFillColor !== undefined) out.plotAreaFillColor = plotAreaFillColor;
   }
 
   const legend = parseLegend(chartEl);
@@ -3865,6 +3877,42 @@ function parsePlotAreaLayout(plotArea: XmlElement): ChartManualLayout | undefine
     return undefined;
   }
   return out;
+}
+
+/**
+ * Pull `<c:plotArea><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+ * </c:spPr></c:plotArea>` off the plot area. Returns the plot-area solid
+ * fill color as a 6-character uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the fill choice
+ * of `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The `<c:spPr>` slot
+ * sits at the tail of `<c:plotArea>` per `CT_PlotArea` (§21.2.2.145),
+ * after every chart-type element / axes / `<c:dTable>`.
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` /
+ * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+ * collapse to `undefined` so a chart that pinned a fill the writer
+ * cannot reproduce on emit drops the field rather than fabricate one
+ * Excel would render differently. Malformed `val` tokens (wrong length,
+ * non-hex characters, alpha-channel forms, non-string escapes) likewise
+ * drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link SheetChart.plotAreaFillColor} so a
+ * parsed value slots straight into {@link cloneChart} without
+ * conversion. The lookup is scoped to direct children of `<c:plotArea>`
+ * so a stray `<c:spPr>` elsewhere (e.g. on a series, on an axis, on the
+ * `<c:dTable>` block) cannot leak in.
+ */
+function parsePlotAreaFillColor(plotArea: XmlElement): string | undefined {
+  const spPr = findChild(plotArea, "spPr");
+  if (!spPr) return undefined;
+  const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1150,16 +1150,71 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
 
   // `<c:dTable>` sits inside `<c:plotArea>` after the axes per
   // CT_PlotArea (ECMA-376 Part 1, §21.2.2.145) — between the last
-  // `<c:valAx>` / `<c:catAx>` and the optional `<c:spPr>` that the
-  // writer never emits. Pie / doughnut have no axes at all, so the
-  // OOXML schema places no slot for `<c:dTable>` on those families;
-  // `resolveDataTable` short-circuits them by returning `undefined`.
+  // `<c:valAx>` / `<c:catAx>` and the optional `<c:spPr>` that
+  // `buildPlotAreaSpPr` below emits. Pie / doughnut have no axes at
+  // all, so the OOXML schema places no slot for `<c:dTable>` on those
+  // families; `resolveDataTable` short-circuits them by returning
+  // `undefined`.
   const dTable = resolveDataTable(chart);
   if (dTable !== undefined) {
     children.push(buildDataTable(dTable));
   }
 
+  // `<c:plotArea><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+  // </c:spPr></c:plotArea>` — Excel's "Format Plot Area -> Fill -> Solid
+  // fill -> Color" pin. The slot sits at the tail of `<c:plotArea>` per
+  // `CT_PlotArea` (ECMA-376 Part 1, §21.2.2.145), after every chart-type
+  // element / axes / `<c:dTable>`. The writer emits the block only when
+  // `chart.plotAreaFillColor` normalizes to a literal hex; absence and
+  // every malformed token collapse to no `<c:spPr>` so a fresh chart
+  // matches Excel's reference shape byte-for-byte.
+  const plotAreaSpPr = buildPlotAreaSpPr(chart);
+  if (plotAreaSpPr !== undefined) {
+    children.push(plotAreaSpPr);
+  }
+
   return xmlElement("c:plotArea", undefined, children);
+}
+
+/**
+ * Build the optional `<c:spPr>` block at the tail of `<c:plotArea>`.
+ * Currently surfaces only the solid fill color knob
+ * ({@link SheetChart.plotAreaFillColor}) — every other `<c:spPr>` child
+ * (`<a:ln>` stroke, `<a:effectLst>` effects, gradient / pattern / picture
+ * fills) is intentionally not modelled at this layer.
+ *
+ * Returns `undefined` when the chart leaves the field unset / passed a
+ * malformed token so the writer skips the entire `<c:spPr>` block — an
+ * empty `<c:spPr/>` collapses to the inherited theme fill Excel picks
+ * anyway, and omitting it keeps untouched chart XML byte-clean.
+ */
+function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
+  const fillHex = normalizePlotAreaFillColor(chart.plotAreaFillColor);
+  if (fillHex === undefined) return undefined;
+  const solidFill = xmlElement("a:solidFill", undefined, [
+    xmlSelfClose("a:srgbClr", { val: fillHex }),
+  ]);
+  return xmlElement("c:spPr", undefined, [solidFill]);
+}
+
+/**
+ * Normalize a {@link SheetChart.plotAreaFillColor} value for the
+ * `<c:plotArea><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+ * </c:spPr></c:plotArea>` writer slot. Returns the 6-character uppercase
+ * hex form when the input is a valid sRGB triple (with or without a
+ * leading `#`), or `undefined` for any malformed token — wrong length,
+ * non-hex characters, alpha-channel forms, or non-string escapes from an
+ * untyped caller.
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<c:spPr>` block and the plot area inherits
+ * the auto-fill Excel picks from the chart's theme (Excel's reference
+ * behavior for a fresh plot area without a custom color). Delegates to
+ * the chart-level {@link normalizeTitleColor} so the two share the same
+ * sRGB grammar.
+ */
+function normalizePlotAreaFillColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
 }
 
 // ── Data Table ───────────────────────────────────────────────────────

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -20576,3 +20576,165 @@ describe("cloneChart — plotAreaLayout", () => {
     expect(parseChart(written)?.plotAreaLayout).toEqual({ x: 0.15, y: 0.25 });
   });
 });
+
+// ── cloneChart — plotAreaFillColor (solid fill) ─────────────────────
+
+describe("cloneChart — plotAreaFillColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's plotAreaFillColor by default", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.plotAreaFillColor).toBe("F2F2F2");
+  });
+
+  it("lets options.plotAreaFillColor override the source's value", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: "ABCDEF",
+    });
+    expect(clone.plotAreaFillColor).toBe("ABCDEF");
+  });
+
+  it("drops the inherited plotAreaFillColor when the override is null", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: null,
+    });
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined plotAreaFillColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # and lowercase input through the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: "#1f77b4",
+    });
+    expect(clone.plotAreaFillColor).toBe("1F77B4");
+  });
+
+  it("drops a malformed override (wrong length)", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: "FFF",
+    });
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("drops a malformed override (non-hex characters)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: "GGGGGG",
+    });
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("drops a malformed override (alpha-channel form)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: "FFAA0080",
+    });
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("drops a non-string override (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      plotAreaFillColor: 0xff_ff_ff as any,
+    });
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ plotAreaFillColor: "GGGGGG" as any }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("carries plotAreaFillColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.plotAreaFillColor).toBe("F2F2F2");
+  });
+
+  it("carries plotAreaFillColor through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.plotAreaFillColor).toBe("F2F2F2");
+  });
+
+  it("retains plotAreaFillColor independently of a hidden legend", () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.plotAreaFillColor).toBe("F2F2F2");
+  });
+
+  it("composes independently with plotAreaLayout (each lands on its own slot)", () => {
+    const clone = cloneChart(
+      source({
+        plotAreaLayout: { x: 0.1, y: 0.2 },
+        plotAreaFillColor: "F2F2F2",
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.plotAreaLayout).toEqual({ x: 0.1, y: 0.2 });
+    expect(clone.plotAreaFillColor).toBe("F2F2F2");
+  });
+
+  it("survives a writeXlsx round trip — plotAreaFillColor lands in the cloned chart XML", async () => {
+    const clone = cloneChart(source({ plotAreaFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaFillColor: "1F77B4",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.plotAreaFillColor).toBe("1F77B4");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -19263,3 +19263,157 @@ describe("writeChart — plotAreaLayout", () => {
     expect(reparsed?.plotAreaLayout).toEqual({ x: 0.1, y: 0.2, w: 0.8, h: 0.6 });
   });
 });
+
+// ── writeChart — plotAreaFillColor (solid fill) ─────────────────────
+
+describe("writeChart — plotAreaFillColor", () => {
+  function plotAreaOf(xml: string): string {
+    const m = xml.match(/<c:plotArea>[\s\S]*?<\/c:plotArea>/);
+    if (!m) throw new Error("No <c:plotArea> block found in chart XML");
+    return m[0];
+  }
+
+  it("does not emit <c:spPr> when plotAreaFillColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+    expect(plotArea).not.toContain("<a:solidFill>");
+  });
+
+  it("emits <c:spPr><a:solidFill><a:srgbClr> when plotAreaFillColor is set", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "F2F2F2" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain("<c:spPr>");
+    expect(plotArea).toContain("<a:solidFill>");
+    expect(plotArea).toContain('<a:srgbClr val="F2F2F2"/>');
+  });
+
+  it("normalizes a leading # and lowercase hex to the canonical uppercase form", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "#1f77b4" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("places <c:spPr> at the tail of <c:plotArea> (CT_PlotArea sequence)", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "F2F2F2" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    // <c:spPr> must come after every chart-type element / axes / <c:dTable>.
+    // For a column chart that means after <c:barChart>, <c:catAx>, <c:valAx>.
+    const spPrIdx = plotArea.indexOf("<c:spPr>");
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:barChart"));
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:catAx"));
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:valAx"));
+  });
+
+  it("only emits one <c:spPr> inside <c:plotArea>", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "FFAA00" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    const occurrences = plotArea.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads plotAreaFillColor through every chart family that owns a <c:plotArea>", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, plotAreaFillColor: "ABCDEF" }), "Sheet1");
+      const plotArea = plotAreaOf(result.chartXml);
+      expect(plotArea).toContain('<a:srgbClr val="ABCDEF"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        plotAreaFillColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    expect(plotAreaOf(scatter.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "FFF" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "GGGGGG" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(makeChart({ plotAreaFillColor: "FFAA0080" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops an empty / whitespace-only string", () => {
+    expect(
+      plotAreaOf(writeChart(makeChart({ plotAreaFillColor: "" }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+    expect(
+      plotAreaOf(writeChart(makeChart({ plotAreaFillColor: "   " }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ plotAreaFillColor: 0xff_ff_ff as any }), "Sheet1");
+    expect(plotAreaOf(a.chartXml)).not.toContain("<c:spPr>");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ plotAreaFillColor: null as any }), "Sheet1");
+    expect(plotAreaOf(b.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("composes independently with plotAreaLayout (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        plotAreaLayout: { x: 0.1, y: 0.15, w: 0.7, h: 0.6 },
+        plotAreaFillColor: "F2F2F2",
+      }),
+      "Sheet1",
+    );
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<c:x val="0.1"/>');
+    expect(plotArea).toContain('<a:srgbClr val="F2F2F2"/>');
+    // Layout precedes spPr per CT_PlotArea sequence.
+    expect(plotArea.indexOf("<c:layout>")).toBeLessThan(plotArea.indexOf("<c:spPr>"));
+  });
+
+  it("round-trips plotAreaFillColor through parseChart", () => {
+    const written = writeChart(makeChart({ plotAreaFillColor: "1F77B4" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaFillColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset plotAreaFillColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — plotAreaFillColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            plotAreaFillColor: "F2F2F2",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.plotAreaFillColor).toBe("F2F2F2");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -19475,3 +19475,116 @@ describe("parseChart — titleLayout", () => {
     expect(chart?.legendLayout).toEqual({ x: 0.7, y: 0.2 });
   });
 });
+
+// ── parseChart — plotAreaFillColor (solid fill) ─────────────────────
+
+describe("parseChart — plotAreaFillColor", () => {
+  const NS_PFC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withPlotAreaSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_PFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:plotArea><c:spPr><a:solidFill><a:srgbClr> is pinned", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBe("F2F2F2");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="abcdef"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBe("ABCDEF");
+  });
+
+  it("returns undefined when the chart has no <c:plotArea>", () => {
+    const xml = `<c:chartSpace ${NS_PFC}><c:chart></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:plotArea> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_PFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:solidFill>", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:schemeClr val="bg1"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:noFill>", () => {
+    const xml = withPlotAreaSpPr(`<a:noFill/>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:gradFill>", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill>`,
+    );
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (wrong length)", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="ABC"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (non-hex characters)", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="GGGGGG"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("ignores a stray <c:spPr> elsewhere on the chart (e.g. on a series)", () => {
+    // Series-level <c:spPr> must not leak into plotAreaFillColor.
+    const xml = `<c:chartSpace ${NS_PFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaFillColor).toBeUndefined();
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaFillColor).toBe("1F77B4");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `plotAreaFillColor?: string` to `SheetChart` and the parsed `Chart`, mapped to `<c:plotArea><c:spPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></c:spPr></c:plotArea>` per `CT_PlotArea` (ECMA-376 Part 1, §21.2.2.145) / `CT_ShapeProperties` (§20.1.2.3.13) / `CT_SRgbColor` (§20.1.2.3.32) — Excel's "Format Plot Area -> Fill -> Solid fill -> Color" picker, the same dialog the user reaches by right-clicking the plot area background. Pivots away from the `<c:layout>` cluster (#298 / #299 / #300 / #301) onto a fresh `<c:spPr>` location.
- Writer emits the `<c:spPr>` block at the tail of `<c:plotArea>` after every chart-type element / axes / `<c:dTable>` per the `CT_PlotArea` schema sequence. Malformed inputs (wrong length, non-hex characters, alpha-channel forms, empty / whitespace-only strings, non-string escapes from an untyped caller) collapse to no `<c:spPr>` so a fresh chart matches Excel's reference shape byte-for-byte. The writer accepts a leading `#` and any case, normalizing to the OOXML canonical 6-character uppercase form.
- Reader surfaces only the literal `<a:srgbClr>` form — non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`) and theme-color references (`<a:schemeClr>`) all drop to `undefined` so a round-trip never fabricates a fill the writer cannot reproduce on emit. The lookup is scoped to direct children of `<c:plotArea>` so a stray `<c:spPr>` elsewhere (e.g. on a series, on the `<c:dTable>` block) cannot leak in.
- Clone-through follows the established srgb-knob grammar (`undefined` inherits, `null` drops, value replaces) and threads through every chart family that owns a `<c:plotArea>` (bar / column / line / area / scatter / pie / doughnut). The override runs through the same hex normalizer as the writer so the cloned `SheetChart` always carries a value the writer will accept; malformed source values likewise collapse on the resolver path.
- Plot-area fill is independent of the legend / title visibility — every chart has a `<c:plotArea>` element to host the slot — and composes cleanly with `plotAreaLayout` (#299) since each lands on a different child of `<c:plotArea>` (the layout block at the head, the fill block at the tail).

Refs #299

## Test plan

- [x] `pnpm vitest run --dir=test` — 6319 tests pass (43 new tests across writer / reader / clone-through, including `writeXlsx` round-trip and the `<a:schemeClr>` / `<a:noFill>` / `<a:gradFill>` non-solid-fill drop paths).
- [x] `pnpm typecheck` — passes.
- [x] `pnpm lint` — no new errors (existing 45 warnings unchanged, formatting clean).
- [x] `pnpm build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)