### PR TITLE
feat(xlsx): chart legend fill color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2156,6 +2156,53 @@ export interface SheetChart {
    */
   legendLayout?: ChartManualLayout;
   /**
+   * Legend background fill color. Maps to `<c:legend><c:spPr>
+   * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
+   * </c:legend>` (CT_Legend, ECMA-376 Part 1, §21.2.2.114) — Excel's
+   * "Format Legend -> Fill -> Solid fill -> Color" picker (the same
+   * dialog the user reaches by right-clicking the legend background).
+   * The element sits between `<c:overlay>` and `<c:txPr>` per the
+   * CT_Legend schema sequence — distinct from `legendFontColor`,
+   * which lands on the legend's `<c:txPr>` text-character-properties
+   * slot.
+   *
+   * Accepts a 6-character hex sRGB triple with or without a leading
+   * `#` (e.g. `"FFFF00"`, `"#FFFF00"`, `"ffff00"`); the writer
+   * normalizes to OOXML's canonical 6-character uppercase form before
+   * emit. Empty / whitespace-only strings, alpha-channel forms,
+   * non-hex characters, and non-string escapes from an untyped caller
+   * all collapse to `undefined` so the writer skips the entire
+   * `<c:spPr>` block and the legend renders at the theme default fill
+   * (Excel's reference behavior for a fresh legend that has not had a
+   * custom fill picked — typically a transparent background with no
+   * `<c:spPr>` block).
+   *
+   * Default: omitted — the legend renders at the theme default fill
+   * (no `<c:spPr>` block, matching Excel's reference serialization
+   * for a fresh chart legend whose background has not been
+   * customized). Pin a hex color to render the legend background in
+   * that color (e.g. `"FFFF00"` for a highlighted legend on a
+   * dashboard tile, or `"FFFFFF"` for an opaque white legend on a
+   * non-white plot area).
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no slot to host the fill in that case.
+   * Mirrors `plotAreaFillColor` — same accept-with-or-without-`#` hex
+   * grammar, same OOXML `<c:spPr><a:solidFill><a:srgbClr val=".."/>
+   * </a:solidFill></c:spPr>` mapping — so a caller can thread a
+   * single hex string through every `<c:spPr>`-based fill slot.
+   * Composes independently with `legend` / `legendOverlay` /
+   * `legendEntries` / `legendFontSize` / `legendBold` /
+   * `legendItalic` / `legendUnderline` / `legendStrikethrough` /
+   * `legendFontColor` / `legendFontFamily` / `legendLayout`: the fill
+   * lands on the legend's `<c:spPr>` block, the typography knobs on
+   * the legend's `<c:txPr>` block, the layout on the legend's
+   * `<c:layout>` block, and the visibility / position toggles on
+   * `<c:legendPos>` / `<c:overlay>` — every knob targets a different
+   * child of `<c:legend>`.
+   */
+  legendFillColor?: string;
+  /**
    * Custom plot-area placement inside the chart frame. Maps to
    * `<c:plotArea><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
    * </c:plotArea>` — Excel's "Format Plot Area -> Position -> Custom"
@@ -6702,6 +6749,34 @@ export interface Chart {
    * slots straight into {@link cloneChart} without conversion.
    */
   legendLayout?: ChartManualLayout;
+  /**
+   * Legend background fill color pulled from `<c:legend><c:spPr>
+   * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
+   * </c:legend>`. Reflects Excel's "Format Legend -> Fill -> Solid
+   * fill -> Color" picker (the same dialog the user reaches by
+   * right-clicking the legend background). The element sits on
+   * `<c:legend>` between `<c:overlay>` and `<c:txPr>` per the
+   * CT_Legend schema sequence (ECMA-376 Part 1, §21.2.2.114).
+   *
+   * Reports the 6-character uppercase hex string when the source
+   * chart pins a literal `<a:srgbClr val="RRGGBB"/>` fill on the
+   * legend's `<c:spPr>` block. Theme references (`<a:schemeClr>`),
+   * non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` /
+   * `<a:blipFill>`), and the OOXML system / preset color forms
+   * (`<a:sysClr>` / `<a:hslClr>` / `<a:prstClr>`) all collapse to
+   * `undefined` — only the literal RGB triple round-trips losslessly
+   * through {@link writeChart}. Malformed `val` tokens (wrong length,
+   * non-hex characters) likewise drop to `undefined` rather than
+   * fabricate a value the writer would round-trip into a malformed
+   * `<a:srgbClr>`.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:spPr>` slot to surface the fill from in either case. Mirrors
+   * the writer-side {@link SheetChart.legendFillColor} so a parsed
+   * value slots straight into {@link cloneChart} without conversion.
+   */
+  legendFillColor?: string;
   /**
    * Custom plot-area placement pulled from `<c:plotArea><c:layout>
    * <c:manualLayout>...</c:manualLayout></c:layout></c:plotArea>`.

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -363,6 +363,36 @@ export interface CloneChartOptions {
    */
   legendLayout?: ChartManualLayout | null;
   /**
+   * Override `SheetChart.legendFillColor`. `undefined` (or omitted)
+   * inherits the source's parsed `legendFillColor`; `null` drops the
+   * inherited fill (the writer emits no `<c:spPr>` block on
+   * `<c:legend>`, falling back to the theme default — typically a
+   * transparent background); a hex string replaces it. The override
+   * is normalized through the writer-side hex-color path — accepts
+   * `"FFFF00"` / `"#FFFF00"` / `"ffff00"` and collapses malformed
+   * tokens (wrong length, non-hex characters, alpha-channel forms,
+   * empty / whitespace-only strings, non-string escapes from an
+   * untyped caller) to `undefined`. The cloned `SheetChart` always
+   * carries a value the writer will accept; malformed source values
+   * likewise collapse on the resolver path.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved legend is `false` (no `<c:legend>` element will
+   * be emitted) — there is no slot to host the fill on a hidden
+   * legend, so leaking the value into the output would carry a pin
+   * Excel never reads.
+   *
+   * The grammar mirrors `plotAreaFillColor` / `titleColor` /
+   * `axes.x.axisTitleColor` / `axes.x.labelColor` /
+   * `legendFontColor` so the fill / color knobs compose the same way
+   * at the call site. The override lands on the legend's `<c:spPr>`
+   * block and composes independently with `legendFontColor` (which
+   * lands on the legend's `<c:txPr>` block) — the two knobs target
+   * different children of `<c:legend>` so a caller can pin both
+   * without conflict.
+   */
+  legendFillColor?: string | null;
+  /**
    * Override `SheetChart.plotAreaLayout`. `undefined` (or omitted)
    * inherits the source's parsed `plotAreaLayout`; `null` drops the
    * inherited layout (the writer emits the bare `<c:layout/>`
@@ -1857,6 +1887,22 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     // to `undefined` so the writer skips the `<c:layout>` block.
     const resolvedLegendLayout = resolveLegendLayout(source.legendLayout, options.legendLayout);
     if (resolvedLegendLayout !== undefined) out.legendLayout = resolvedLegendLayout;
+
+    // Same hidden-legend scoping for the background fill — `<c:spPr>`
+    // is a direct child of `<c:legend>` per CT_Legend, so a clone whose
+    // legend is hidden has no slot for the fill. `undefined` inherits,
+    // `null` drops, a hex string replaces. The override runs through
+    // the same hex normalizer as the writer so the cloned `SheetChart`
+    // always carries a value the writer will accept; malformed source
+    // values likewise collapse on the resolver path. Composes
+    // independently with `legendFontColor` — the two knobs target
+    // different children of `<c:legend>` (`<c:spPr>` for the fill,
+    // `<c:txPr>` for the font color).
+    const resolvedLegendFillColor = resolveLegendFillColor(
+      source.legendFillColor,
+      options.legendFillColor,
+    );
+    if (resolvedLegendFillColor !== undefined) out.legendFillColor = resolvedLegendFillColor;
   }
 
   // Plot-area manual layout is independent of the legend visibility —
@@ -3431,6 +3477,44 @@ function resolveLegendLayout(
   if (override === undefined) return normalizeLegendLayout(sourceValue);
   if (override === null) return undefined;
   return normalizeLegendLayout(override);
+}
+
+/**
+ * Resolve a `legendFillColor` override.
+ *
+ * `undefined` → inherit the source's parsed `legendFillColor` (after
+ *               running it through {@link normalizeTitleColor} so a
+ *               malformed source value drops cleanly — the hex
+ *               normalizer is purely shape-based and applies
+ *               identically to every `<a:srgbClr val="RRGGBB"/>`
+ *               slot).
+ * `null`      → drop the inherited fill (the writer emits no
+ *               `<c:spPr>` block on `<c:legend>`, falling back to the
+ *               theme default — typically a transparent legend
+ *               background).
+ * `string`    → replace, after running through
+ *               {@link normalizeTitleColor} so the override accepts
+ *               `"FF0000"` / `"#FF0000"` / `"ff0000"` and collapses
+ *               malformed tokens to `undefined`.
+ *
+ * The grammar mirrors `plotAreaFillColor` / `titleColor` /
+ * `axisTitleColor` / `legendFontColor` so the fill / color knobs
+ * compose the same way at the call site. Callers should gate the
+ * result on the resolved legend visibility — when no legend is
+ * emitted, the fill has no slot in the rendered chart.
+ *
+ * Independent of `legendFontColor`: the two knobs target different
+ * children of `<c:legend>` (`<c:spPr>` for the background fill,
+ * `<c:txPr>` for the font color), so a caller can pin both without
+ * conflict.
+ */
+function resolveLegendFillColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -519,6 +519,18 @@ export function parseChart(xml: string): Chart | undefined {
     // that pinned an out-of-range layout both round-trip lossless.
     const legendLayout = parseLegendLayout(chartEl);
     if (legendLayout !== undefined) out.legendLayout = legendLayout;
+
+    // `<c:legend><c:spPr><a:solidFill>` carries Excel's "Format Legend
+    // -> Fill -> Solid fill -> Color" picker. CT_Legend places the
+    // `<c:spPr>` block between `<c:overlay>` and `<c:txPr>`. The
+    // reader surfaces only literal `<a:srgbClr val="RRGGBB"/>` fills;
+    // theme references and non-solid fills (`<a:noFill>` /
+    // `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>` /
+    // `<a:schemeClr>`) drop to `undefined` so a round-trip never
+    // fabricates a fill the writer cannot reproduce on emit. Same
+    // hidden-legend scoping as the typography knobs.
+    const legendFillColor = parseLegendFillColor(chartEl);
+    if (legendFillColor !== undefined) out.legendFillColor = legendFillColor;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -3833,6 +3845,51 @@ function parseLegendLayout(chartEl: XmlElement): ChartManualLayout | undefined {
     return undefined;
   }
   return out;
+}
+
+/**
+ * Pull the legend background fill color off the canonical
+ * `<c:legend><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr></c:legend>` chain Excel writes when the
+ * user pins "Format Legend -> Fill -> Solid fill -> Color".
+ *
+ * Returns the 6-character uppercase hex string when the parser walks
+ * the full chain and lands on an `<a:srgbClr val="RRGGBB"/>`. Theme
+ * references (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and
+ * `<a:prstClr>` all collapse to `undefined` — only the literal RGB
+ * triple round-trips losslessly through {@link writeChart}. Non-solid
+ * fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`, `<a:blipFill>`)
+ * likewise drop to `undefined` so a round-trip never fabricates a
+ * fill the writer cannot reproduce on emit. Malformed `val` tokens
+ * (wrong length, non-hex characters) drop to `undefined` rather than
+ * fabricate a value the writer would round-trip into a malformed
+ * `<a:srgbClr>`.
+ *
+ * The lookup is scoped to direct children of `<c:legend>` so a stray
+ * `<c:spPr>` elsewhere (e.g. on a series or on the legend's
+ * `<c:txPr>` block — the latter is purely text-character-properties,
+ * but a malformed source might place a `<c:spPr>` there in error)
+ * cannot leak in. Returns `undefined` whenever the chart omits the
+ * `<c:legend>` element or the `<c:spPr><a:solidFill><a:srgbClr>`
+ * chain is malformed at any link. Mirrors the chart-title /
+ * axis-title / axis tick-label / legend font color readers exactly
+ * so a parsed value slots straight back into the writer's emit path.
+ *
+ * Independent of {@link parseLegendFontColor}: the fill lives on
+ * `<c:legend><c:spPr>`, the font color lives on
+ * `<c:legend><c:txPr>` — the two readers walk disjoint paths so a
+ * caller can pin both knobs without conflict.
+ */
+function parseLegendFillColor(chartEl: XmlElement): string | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const spPr = findChild(legend, "spPr");
+  if (!spPr) return undefined;
+  const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -189,6 +189,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendFontColor(chart),
         resolveLegendFontFamily(chart),
         resolveLegendLayout(chart),
+        resolveLegendFillColor(chart),
       ),
     );
   }
@@ -4930,6 +4931,7 @@ function buildLegend(
   rgbHex: string | undefined,
   fontFamily: string | undefined,
   layout: ResolvedManualLayout | undefined,
+  fillRgbHex: string | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -4965,11 +4967,25 @@ function buildLegend(
 
   children.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
 
-  // CT_Legend sequence places `<c:txPr>` after `<c:overlay>` (and
-  // before the optional `<c:extLst>`). The writer skips emission
-  // entirely when no typography knob is pinned so a fresh chart matches
-  // Excel's reference serialization byte-for-byte (Excel itself omits
-  // the block whenever the legend renders at the theme-default style).
+  // CT_Legend sequence places `<c:spPr>` between `<c:overlay>` and
+  // `<c:txPr>` (ECMA-376 Part 1, §21.2.2.114). The writer skips
+  // emission entirely when the caller did not pin a fill color so a
+  // fresh chart matches Excel's reference serialization byte-for-byte
+  // — Excel itself omits the block whenever the legend renders at the
+  // theme default fill (typically a transparent legend background
+  // with no `<c:spPr>` block). Currently the writer only authors
+  // `<a:solidFill>` here; stroke (`<a:ln>`) and other CT_ShapeProperties
+  // children are not modelled at this layer.
+  const legendSpPrXml = buildLegendSpPr(fillRgbHex);
+  if (legendSpPrXml !== undefined) {
+    children.push(legendSpPrXml);
+  }
+
+  // CT_Legend sequence places `<c:txPr>` after `<c:spPr>` (and before
+  // the optional `<c:extLst>`). The writer skips emission entirely
+  // when no typography knob is pinned so a fresh chart matches Excel's
+  // reference serialization byte-for-byte (Excel itself omits the
+  // block whenever the legend renders at the theme-default style).
   // The block currently carries the legend font size, bold, italic,
   // underline, strikethrough, font color, and font family knobs. The
   // `<a:bodyPr>` carries no rotation attribute — the legend is not
@@ -4989,6 +5005,32 @@ function buildLegend(
   }
 
   return xmlElement("c:legend", undefined, children);
+}
+
+/**
+ * Build the `<c:spPr>` element on `<c:legend>` that carries the
+ * legend's background fill. Returns `undefined` when no fill color is
+ * pinned so the caller can elide the entire block — Excel's reference
+ * serialization omits `<c:spPr>` from `<c:legend>` whenever the legend
+ * renders at the theme default fill (typically a transparent legend
+ * background).
+ *
+ * The emitted block mirrors the minimal `<c:spPr>` shape Excel writes
+ * when the user pins "Format Legend -> Fill -> Solid fill -> Color":
+ * `<c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+ * </c:spPr>`. The `val` attribute holds the canonical 6-character
+ * uppercase hex form (the writer normalizes the input ahead of this
+ * call so a malformed source value never reaches emit).
+ *
+ * Mirrors the chart-title / plot-area / axis-title `<c:spPr>` slots
+ * so a single hex string threads cleanly through every fill knob the
+ * writer authors.
+ */
+function buildLegendSpPr(fillRgbHex: string | undefined): string | undefined {
+  if (fillRgbHex === undefined) return undefined;
+  return xmlElement("c:spPr", undefined, [
+    xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
+  ]);
 }
 
 /**
@@ -5364,6 +5406,31 @@ interface ResolvedManualLayout {
  */
 function resolveLegendLayout(chart: SheetChart): ResolvedManualLayout | undefined {
   return normalizeManualLayout(chart.legendLayout);
+}
+
+/**
+ * Resolve `<c:legend><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr></c:legend>` from
+ * {@link SheetChart.legendFillColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the chart leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches the chart-title /
+ * axis-title / axis tick-label / legend font color resolvers exactly.
+ * The fill is only meaningful when the chart actually emits a
+ * legend — the caller is expected to gate the call on the resolved
+ * legend visibility (`resolveLegendPosition` returning a non-null
+ * value). A chart whose legend is suppressed has no `<c:legend>`
+ * block to host the `<c:spPr>` slot in either case.
+ *
+ * Independent of {@link resolveLegendFontColor}: the fill lands on
+ * `<c:legend><c:spPr>`, the font color lands on
+ * `<c:legend><c:txPr>` — the two resolvers target different children
+ * of `<c:legend>` so a single configuration call can pin both.
+ */
+function resolveLegendFillColor(chart: SheetChart): string | undefined {
+  return normalizeTitleColor(chart.legendFillColor);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -20858,3 +20858,217 @@ describe("cloneChart — axisTitleLayout", () => {
     expect(parseChart(written)?.axes?.x?.axisTitleLayout).toEqual({ x: 0.2, y: 0.8 });
   });
 });
+
+// ── cloneChart — legendFillColor ─────────────────────────────────────
+
+describe("cloneChart — legendFillColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendFillColor by default", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFillColor).toBe("FFFF00");
+  });
+
+  it("lets options.legendFillColor override the source's value", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFillColor: "00FF00",
+    });
+    expect(clone.legendFillColor).toBe("00FF00");
+  });
+
+  it("drops the inherited legendFillColor when the override is null", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFillColor: null,
+    });
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("returns undefined legendFillColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # in the override hex string", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFillColor: "#abcdef",
+    });
+    expect(clone.legendFillColor).toBe("ABCDEF");
+  });
+
+  it("normalizes a lowercase override hex string to uppercase", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFillColor: "ff8800",
+    });
+    expect(clone.legendFillColor).toBe("FF8800");
+  });
+
+  it("normalizes a malformed source value through the resolver (drops to undefined)", () => {
+    const clone = cloneChart(source({ legendFillColor: "ZZZ" as string }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("collapses malformed override hex tokens (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendFillColor: "ZZZZZZ",
+    });
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("collapses non-string overrides (number leaking past the type guard)", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendFillColor: 0xff0000 as any,
+    });
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("carries legendFillColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendFillColor).toBe("FFFF00");
+  });
+
+  it("carries legendFillColor through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.legendFillColor).toBe("FFFF00");
+  });
+
+  it("drops the inherited legendFillColor when the resolved legend is hidden", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("drops the legendFillColor override when the resolved legend is hidden", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+      legendFillColor: "FFFF00",
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendFillColor).toBeUndefined();
+  });
+
+  it("retains the legendFillColor override when the override re-enables a hidden source legend", () => {
+    const clone = cloneChart(source({ legend: false }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: "top",
+      legendFillColor: "FFFF00",
+    });
+    expect(clone.legend).toBe("top");
+    expect(clone.legendFillColor).toBe("FFFF00");
+  });
+
+  it("composes independently with legendFontColor — distinct slots inside <c:legend>", () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00", legendFontColor: "000000" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendFillColor).toBe("FFFF00");
+    expect(clone.legendFontColor).toBe("000000");
+  });
+
+  it("composes with legendOverlay / legendEntries / legendLayout / legendFontFamily on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        legendFillColor: "FFFF00",
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+        legendLayout: { x: 0.1, y: 0.2 },
+        legendFontFamily: "Arial",
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendFillColor).toBe("FFFF00");
+    expect(clone.legendOverlay).toBe(true);
+    expect(clone.legendEntries).toEqual([{ idx: 0, delete: true }]);
+    expect(clone.legendLayout).toEqual({ x: 0.1, y: 0.2 });
+    expect(clone.legendFontFamily).toBe("Arial");
+  });
+
+  it("propagates legendFillColor into the rendered <c:legend><c:spPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ legendFillColor: "FFFF00" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:spPr>");
+    expect(legend).toContain('<a:srgbClr val="FFFF00"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFillColor).toBe("FFFF00");
+  });
+
+  it("emits no <c:spPr> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const legend = written.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).not.toContain("<c:spPr>");
+    expect(parseChart(written)?.legendFillColor).toBeUndefined();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -19664,3 +19664,204 @@ describe("writeChart — axisTitleLayout", () => {
     expect(reparsed?.axes?.x?.axisTitleLayout).toEqual({ x: 0.4, y: 0.3 });
   });
 });
+
+// ── writeChart — legendFillColor ─────────────────────────────────────
+
+describe("writeChart — legendFillColor", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:spPr> when legendFillColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:spPr>");
+    expect(legend).not.toContain("a:solidFill");
+  });
+
+  it('threads legendFillColor through to <c:legend><c:spPr> as <a:srgbClr val="RRGGBB"/>', () => {
+    const result = writeChart(makeChart({ legendFillColor: "FFFF00" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:spPr>");
+    expect(legend).toContain("<a:solidFill>");
+    expect(legend).toContain('<a:srgbClr val="FFFF00"/>');
+  });
+
+  it("normalizes a leading # in the input hex string", () => {
+    const result = writeChart(makeChart({ legendFillColor: "#00FF00" }), "Sheet1");
+    expect(legendOf(result.chartXml)).toContain('<a:srgbClr val="00FF00"/>');
+  });
+
+  it("normalizes a lowercase hex string to the OOXML uppercase canonical form", () => {
+    const result = writeChart(makeChart({ legendFillColor: "abcdef" }), "Sheet1");
+    expect(legendOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("places <c:spPr> after <c:overlay> and before <c:txPr> inside <c:legend>", () => {
+    const result = writeChart(
+      makeChart({ legendFillColor: "112233", legendFontColor: "445566" }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:spPr"));
+    expect(legend.indexOf("c:spPr")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits <c:spPr> once inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendFillColor: "112233" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendFillColor set", () => {
+    const result = writeChart(makeChart({ legend: false, legendFillColor: "FFFF00" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+    expect(result.chartXml.match(/<c:legend\b/g)).toBeNull();
+  });
+
+  it("threads legendFillColor through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendFillColor: "445566" }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('<a:srgbClr val="445566"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendFillColor: "445566",
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('<a:srgbClr val="445566"/>');
+  });
+
+  it("drops malformed hex inputs (wrong length)", () => {
+    const result = writeChart(makeChart({ legendFillColor: "FF00" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops malformed hex inputs (non-hex characters)", () => {
+    const result = writeChart(makeChart({ legendFillColor: "ZZZZZZ" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops alpha-channel hex forms", () => {
+    const result = writeChart(makeChart({ legendFillColor: "#FF0000FF" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops empty string inputs", () => {
+    const result = writeChart(makeChart({ legendFillColor: "" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops whitespace-only inputs", () => {
+    const result = writeChart(makeChart({ legendFillColor: "   " }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string inputs (null leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendFillColor: null as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string inputs (number leaking past the type guard)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = writeChart(makeChart({ legendFillColor: 0xff0000 as any }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("emits a minimal <c:spPr> block (single solidFill child)", () => {
+    const result = writeChart(makeChart({ legendFillColor: "ABCDEF" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:spPr><a:solidFill><a:srgbClr");
+    expect(legend).toContain("</a:solidFill></c:spPr>");
+    // No stroke (`<a:ln>`) or other CT_ShapeProperties children.
+    expect(legend.match(/<c:spPr>[\s\S]*?<\/c:spPr>/)?.[0]).toContain(
+      '<c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>',
+    );
+  });
+
+  it("composes independently with legendFontColor — fill on <c:spPr>, font color on <c:txPr>", () => {
+    const result = writeChart(
+      makeChart({ legendFillColor: "FFFF00", legendFontColor: "000000" }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:spPr>");
+    expect(legend).toContain("<c:txPr>");
+    // The fill color lives on c:spPr's solidFill, the font color on
+    // a:defRPr's solidFill — both are a:srgbClr but at distinct hosts.
+    const spPr = legend.match(/<c:spPr>[\s\S]*?<\/c:spPr>/)?.[0] ?? "";
+    expect(spPr).toContain('<a:srgbClr val="FFFF00"/>');
+    expect(spPr).not.toContain("000000");
+    const txPr = legend.match(/<c:txPr>[\s\S]*?<\/c:txPr>/)?.[0] ?? "";
+    expect(txPr).toContain('<a:srgbClr val="000000"/>');
+    expect(txPr).not.toContain("FFFF00");
+  });
+
+  it("composes with legendOverlay / legendEntries / legendLayout on the same <c:legend>", () => {
+    const result = writeChart(
+      makeChart({
+        legendFillColor: "1A2B3C",
+        legendOverlay: true,
+        legendEntries: [{ idx: 0, delete: true }],
+        legendLayout: { x: 0.1, y: 0.2 },
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:srgbClr val="1A2B3C"/>');
+    expect(legend).toContain('c:overlay val="1"');
+    expect(legend).toContain("c:legendEntry");
+    expect(legend).toContain("c:manualLayout");
+    // Element ordering inside <c:legend>: legendPos, legendEntry, layout, overlay, spPr, txPr
+    expect(legend.indexOf("c:legendPos")).toBeLessThan(legend.indexOf("c:legendEntry"));
+    expect(legend.indexOf("c:legendEntry")).toBeLessThan(legend.indexOf("c:layout"));
+    expect(legend.indexOf("c:layout")).toBeLessThan(legend.indexOf("c:overlay"));
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:spPr"));
+  });
+
+  it("round-trips a legendFillColor through parseChart", () => {
+    const written = writeChart(makeChart({ legendFillColor: "FF8800" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFillColor).toBe("FF8800");
+  });
+
+  it("collapses an unset legendFillColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendFillColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — legendFillColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendFillColor: "0F0F0F",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const legend = chartXml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain("<c:spPr>");
+    expect(legend).toContain('<a:srgbClr val="0F0F0F"/>');
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -19690,3 +19690,211 @@ describe("parseChart — axisTitleLayout", () => {
     expect(chart?.axes?.y?.axisTitleLayout).toEqual({ w: 0.05, h: 0.5 });
   });
 });
+
+// ── parseChart — legendFillColor ─────────────────────────────────────
+
+describe("parseChart — legendFillColor", () => {
+  const NS_LFB = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendFill(srgbVal: string | undefined): string {
+    const spPr =
+      srgbVal === undefined
+        ? ""
+        : `<c:spPr><a:solidFill><a:srgbClr val="${srgbVal}"/></a:solidFill></c:spPr>`;
+    return `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      ${spPr}
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces legendFillColor as the canonical 6-character uppercase hex", () => {
+    expect(parseChart(withLegendFill("FFFF00"))?.legendFillColor).toBe("FFFF00");
+  });
+
+  it("normalizes a lowercase srgbClr val to the OOXML uppercase canonical form", () => {
+    expect(parseChart(withLegendFill("ff8800"))?.legendFillColor).toBe("FF8800");
+  });
+
+  it("normalizes a leading # in the srgbClr val to the bare hex form", () => {
+    expect(parseChart(withLegendFill("#abcdef"))?.legendFillColor).toBe("ABCDEF");
+  });
+
+  it("returns undefined when the legend has no <c:spPr> block at all", () => {
+    expect(parseChart(withLegendFill(undefined))?.legendFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:legend> element at all", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:solidFill> child", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    // The <a:solidFill> here is nested inside <a:ln> (stroke), not a
+    // direct child of <c:spPr> — the reader should ignore it.
+    expect(parseChart(xml)?.legendFillColor).toBeUndefined();
+  });
+
+  it('drops the fill when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendFillColor).toBeUndefined();
+  });
+
+  it("collapses theme references (<a:schemeClr>) to undefined — only literal RGB round-trips", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFillColor).toBeUndefined();
+  });
+
+  it("collapses <a:noFill> to undefined (non-solid fill)", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:noFill/></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFillColor).toBeUndefined();
+  });
+
+  it("collapses <a:gradFill> to undefined (non-solid fill)", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs></a:gsLst></a:gradFill></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFillColor).toBeUndefined();
+  });
+
+  it("drops malformed <a:srgbClr val/> tokens (wrong length)", () => {
+    expect(parseChart(withLegendFill("FF00"))?.legendFillColor).toBeUndefined();
+  });
+
+  it("drops malformed <a:srgbClr val/> tokens (non-hex characters)", () => {
+    expect(parseChart(withLegendFill("ZZZZZZ"))?.legendFillColor).toBeUndefined();
+  });
+
+  it("drops alpha-channel hex forms in <a:srgbClr val/>", () => {
+    expect(parseChart(withLegendFill("FF0000FF"))?.legendFillColor).toBeUndefined();
+  });
+
+  it("does not leak a stray <c:spPr> from a series into legendFillColor", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendFillColor).toBeUndefined();
+  });
+
+  it("composes independently with legendFontColor — distinct paths inside <c:legend>", () => {
+    const xml = `<c:chartSpace ${NS_LFB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill></c:spPr>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:defRPr></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legendFillColor).toBe("FFFF00");
+    expect(chart?.legendFontColor).toBe("000000");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `legendFillColor?: string` to `SheetChart` and the parsed `Chart`, mapped to `<c:legend><c:spPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></c:spPr></c:legend>` per `CT_Legend` (ECMA-376 Part 1, §21.2.2.114) / `CT_ShapeProperties` (§20.1.2.3.13) / `CT_SRgbColor` (§20.1.2.3.32) — Excel's "Format Legend -> Fill -> Solid fill -> Color" picker, the same dialog the user reaches by right-clicking the legend background. Continues the `<c:spPr>` family started by `plotAreaFillColor` (#302) but lands on a distinct host element.
- Writer emits the `<c:spPr>` block between `<c:overlay>` and `<c:txPr>` on `<c:legend>` per the CT_Legend schema sequence. Malformed inputs (wrong length, non-hex characters, alpha-channel forms, empty / whitespace-only strings, non-string escapes from an untyped caller) collapse to no `<c:spPr>` so a fresh chart matches Excel's reference shape byte-for-byte. The writer accepts a leading `#` and any case, normalizing to the OOXML canonical 6-character uppercase form.
- Reader surfaces only the literal `<a:srgbClr>` form on `<c:legend><c:spPr>` — non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`) and theme references (`<a:schemeClr>`) all drop to `undefined` so a round-trip never fabricates a fill the writer cannot reproduce on emit. The lookup is scoped to direct children of `<c:legend>` so a stray `<c:spPr>` elsewhere (e.g. on a series) cannot leak in.
- Clone-through follows the established srgb-knob grammar (`undefined` inherits, `null` drops, value replaces) and threads through every chart family that owns a `<c:legend>` (bar / column / line / area / scatter / pie / doughnut). The override runs through the same hex normalizer as the writer so the cloned `SheetChart` always carries a value the writer will accept; malformed source values likewise collapse on the resolver path. Same hidden-legend scoping as the typography knobs — `legend === false` drops the field cleanly.
- The fill is independent of `legendFontColor`: the two knobs target different children of `<c:legend>` (`<c:spPr>` for the background fill, `<c:txPr>` for the font color), so a caller can pin both without conflict. Composes cleanly with `legendOverlay` / `legendEntries` / `legendLayout` / `legendFontFamily` and the bold / italic / underline / strikethrough / font-size knobs.

Refs #302

## Test plan

- [x] `pnpm test` (lint + typecheck + vitest) — 6387 tests pass (54 new tests across writer / reader / clone-through, including `writeXlsx` round-trip and the `<a:schemeClr>` / `<a:noFill>` / `<a:gradFill>` non-solid-fill drop paths).
- [x] `pnpm typecheck` — passes.
- [x] `pnpm lint` — no new errors (existing 45 warnings unchanged, formatting clean).
- [x] `pnpm build` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)