### PR TITLE
feat(xlsx): chart-space fill color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2280,6 +2280,54 @@ export interface SheetChart {
    * always carries a literal hex Excel will render byte-for-byte.
    */
   plotAreaFillColor?: string;
+  /**
+   * Chart-space (entire chart background) solid fill color as a 6-digit
+   * RGB hex string (e.g. `"F2F2F2"`). Maps to `<c:chartSpace><c:spPr>
+   * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
+   * </c:chartSpace>` (CT_ChartSpace, ECMA-376 Part 1, §21.2.2.29) —
+   * Excel's "Format Chart Area -> Fill -> Solid fill -> Color" picker
+   * (the same dialog the user reaches by right-clicking the chart's
+   * outer frame). The OOXML `<a:srgbClr val=".."/>` carries the
+   * 6-character uppercase hex sRGB color (`CT_SRgbColor` inside
+   * `CT_ShapeProperties`' fill choice — ECMA-376 Part 1, §20.1.2.3.32 /
+   * §20.1.2.3.13). The `<c:spPr>` slot lives at the tail of
+   * `<c:chartSpace>` per CT_ChartSpace, after `<c:chart>` /
+   * `<c:externalData>` / `<c:printSettings>` / `<c:userShapes>` and
+   * before the optional `<c:txPr>` / `<c:extLst>`.
+   *
+   * Distinct from {@link plotAreaFillColor} — the plot area is the
+   * inner band that hosts the series, while chartSpace covers the full
+   * frame including the title slot, the legend slot, the axis label
+   * margins, and the plot area itself. A caller can pin both knobs
+   * (e.g. an off-white frame and a brand-color plot area) since the
+   * two `<c:spPr>` blocks land on different host elements.
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the entire `<c:spPr>` block (Excel's reference serialization for
+   * a chart that inherits the auto-fill — typically opaque white from
+   * the workbook theme).
+   *
+   * Default: omitted — the chart inherits the auto-fill Excel picks
+   * from the workbook theme. Pin a hex color to mirror Excel's
+   * "Format Chart Area -> Fill -> Solid fill" knob and paint a flat
+   * background behind the entire chart — useful for dashboard tiles
+   * where the chart frame should pick up a brand color or contrast
+   * with the surrounding sheet cells.
+   *
+   * Patterned / gradient / picture fills are not modelled — only the
+   * solid sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   * Mirrors `plotAreaFillColor` / `legendFillColor` / `titleFillColor`
+   * — same accept-with-or-without-`#` hex grammar, same OOXML
+   * `<c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+   * </c:spPr>` mapping — so a caller can thread a single hex string
+   * through every `<c:spPr>`-based fill slot.
+   */
+  chartSpaceFillColor?: string;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -6865,6 +6913,40 @@ export interface Chart {
    * surface the fill from in that case.
    */
   plotAreaFillColor?: string;
+  /**
+   * Chart-space (entire chart background) solid fill color pulled
+   * from `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/>
+   * </a:solidFill></c:spPr></c:chartSpace>`. Reflects Excel's
+   * "Format Chart Area -> Fill -> Solid fill -> Color" picker — the
+   * fill that paints the entire chart frame (title slot, legend slot,
+   * axis label margins, and plot area together). The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor` inside `CT_ShapeProperties`' fill
+   * choice — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.13). The
+   * `<c:spPr>` slot lives at the tail of `<c:chartSpace>` per
+   * CT_ChartSpace (§21.2.2.29), after `<c:chart>` and the optional
+   * `<c:externalData>` / `<c:printSettings>` / `<c:userShapes>` and
+   * before the optional `<c:txPr>` / `<c:extLst>`.
+   *
+   * Reports the 6-character uppercase hex form when the source chart
+   * pinned a literal `<a:srgbClr>` color; absence, malformed `val`
+   * tokens (wrong length, non-hex characters, alpha-channel forms),
+   * non-solid fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`,
+   * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+   * collapse to `undefined` so absence and an unrenderable fill
+   * round-trip identically through {@link cloneChart}. Mirrors the
+   * writer-side {@link SheetChart.chartSpaceFillColor} so a parsed
+   * value slots straight into {@link cloneChart} without conversion.
+   *
+   * Distinct from {@link plotAreaFillColor} — the lookup is scoped to
+   * direct children of `<c:chartSpace>` (the document root) so a
+   * stray `<c:spPr>` on `<c:plotArea>` / `<c:legend>` / `<c:title>`
+   * cannot leak into this field. Mirrors the chart-title /
+   * plot-area / legend `<c:spPr>` slots — same accept-or-drop grammar
+   * — so a parsed value flows through the same hex shape regardless
+   * of which `<c:spPr>`-based fill slot the source chart pinned.
+   */
+  chartSpaceFillColor?: string;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -437,6 +437,33 @@ export interface CloneChartOptions {
    * every chart has a `<c:plotArea>` element to host the fill.
    */
   plotAreaFillColor?: string | null;
+  /**
+   * Override `SheetChart.chartSpaceFillColor`. `undefined` (or omitted)
+   * inherits the source's parsed `chartSpaceFillColor`; `null` drops
+   * the inherited fill (the writer emits no `<c:spPr>` block on
+   * `<c:chartSpace>`, falling back to the auto-fill Excel picks from
+   * the workbook theme — typically opaque white); a 6-digit RGB hex
+   * string replaces it.
+   *
+   * The override runs through the same sRGB normalizer as the writer —
+   * the leading `#` and case are accepted, then the value collapses to
+   * the OOXML canonical uppercase form. Malformed tokens (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` so the cloned
+   * `SheetChart` drops the field rather than carry a value the writer
+   * would silently elide back to absence.
+   *
+   * The grammar mirrors `plotAreaFillColor` / `legendFillColor` /
+   * `titleColor` so the chart `<a:srgbClr>` fill / color knobs compose
+   * the same way at the call site. Unlike the title / legend color
+   * knobs, the chart-space fill is never gated on a visibility flag —
+   * every chart has a `<c:chartSpace>` document root to host the fill.
+   * Composes independently with `plotAreaFillColor` — the two knobs
+   * land on different host elements (`<c:chartSpace>` for the entire
+   * frame, `<c:plotArea>` for the inner band that hosts the series),
+   * so a caller can pin both without conflict.
+   */
+  chartSpaceFillColor?: string | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -1957,6 +1984,27 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     options.plotAreaFillColor,
   );
   if (resolvedPlotAreaFillColor !== undefined) out.plotAreaFillColor = resolvedPlotAreaFillColor;
+
+  // Chart-space solid fill color is independent of every visibility
+  // flag — every chart has a `<c:chartSpace>` document root to host the
+  // `<c:spPr>` slot. `undefined` inherits the source's parsed
+  // `chartSpaceFillColor` (after the writer-side normalizer collapses
+  // any malformed token), `null` drops the inherited fill (the writer
+  // emits no `<c:spPr>` block on `<c:chartSpace>`, the chart inherits
+  // the auto-fill Excel picks from the workbook theme — typically
+  // opaque white), a 6-digit hex string replaces it. Malformed
+  // overrides collapse to `undefined` via the normalizer so the cloned
+  // `SheetChart` always carries a value the writer will accept.
+  // Composes independently with `plotAreaFillColor` — the two knobs
+  // land on different host elements (`<c:chartSpace>` for the entire
+  // frame, `<c:plotArea>` for the inner band that hosts the series).
+  const resolvedChartSpaceFillColor = resolveChartSpaceFillColor(
+    source.chartSpaceFillColor,
+    options.chartSpaceFillColor,
+  );
+  if (resolvedChartSpaceFillColor !== undefined) {
+    out.chartSpaceFillColor = resolvedChartSpaceFillColor;
+  }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
   if (barGrouping !== undefined && (type === "bar" || type === "column")) {
@@ -3668,6 +3716,59 @@ function resolvePlotAreaFillColor(
   if (override === undefined) return normalizePlotAreaFillColor(sourceValue);
   if (override === null) return undefined;
   return normalizePlotAreaFillColor(override);
+}
+
+/**
+ * Normalize a `chartSpaceFillColor` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizeChartSpaceFillColor` (which itself
+ * delegates to the chart-title / plot-area / legend hex normalizer) —
+ * the cloned shape is guaranteed to round-trip through the writer
+ * without surprise: a leading `#` and any case are accepted, then the
+ * value collapses to the OOXML canonical uppercase form. Malformed
+ * inputs (wrong length, non-hex characters, alpha-channel forms,
+ * non-string escapes from an untyped caller) collapse to `undefined`
+ * so the cloned chart drops the field rather than carry a value the
+ * writer would silently elide back to absence.
+ */
+function normalizeChartSpaceFillColor(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
+}
+
+/**
+ * Resolve a `chartSpaceFillColor` override.
+ *
+ * `undefined` → inherit the source's parsed `chartSpaceFillColor`
+ *               (after running it through
+ *               {@link normalizeChartSpaceFillColor} so a malformed
+ *               source value drops cleanly).
+ * `null`      → drop the inherited fill (the writer emits no
+ *               `<c:spPr>` block on `<c:chartSpace>`, the chart
+ *               inherits the auto-fill Excel picks from the workbook
+ *               theme).
+ * `string`    → replace with the normalized 6-character uppercase hex
+ *               form. Malformed overrides collapse to `undefined` via
+ *               the normalizer so the cloned `SheetChart` always
+ *               carries a value the writer will accept.
+ *
+ * The grammar mirrors `plotAreaFillColor` / `legendFillColor` /
+ * `titleColor` so the chart `<a:srgbClr>` fill / color knobs compose
+ * the same way at the call site. Unlike the title / legend variants,
+ * the chart-space fill is never gated on a visibility flag — every
+ * chart has a `<c:chartSpace>` document root to host the fill.
+ */
+function resolveChartSpaceFillColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeChartSpaceFillColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizeChartSpaceFillColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -647,6 +647,20 @@ export function parseChart(xml: string): Chart | undefined {
   const backWallThickness = parseBackWallThickness(chartEl);
   if (backWallThickness !== undefined) out.backWallThickness = backWallThickness;
 
+  // `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+  // </c:spPr></c:chartSpace>` carries Excel's "Format Chart Area -> Fill
+  // -> Solid fill -> Color" pin (the entire chart background, distinct
+  // from the inner `<c:plotArea>` slot). CT_ChartSpace places the
+  // `<c:spPr>` slot at the tail of the document root, after `<c:chart>`
+  // / `<c:externalData>` / `<c:printSettings>` / `<c:userShapes>`. The
+  // reader surfaces only the literal `<a:srgbClr>` form so absence,
+  // malformed hex tokens, non-solid fills (`<a:noFill>` /
+  // `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`), and theme-color
+  // references (`<a:schemeClr>`) all collapse to `undefined` so a
+  // round-trip never fabricates a color Excel cannot render.
+  const chartSpaceFillColor = parseChartSpaceFillColor(chartSpace);
+  if (chartSpaceFillColor !== undefined) out.chartSpaceFillColor = chartSpaceFillColor;
+
   return out;
 }
 
@@ -4039,6 +4053,48 @@ function parsePlotAreaLayout(plotArea: XmlElement): ChartManualLayout | undefine
  */
 function parsePlotAreaFillColor(plotArea: XmlElement): string | undefined {
   const spPr = findChild(plotArea, "spPr");
+  if (!spPr) return undefined;
+  const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/>
+ * </a:solidFill></c:spPr></c:chartSpace>` off the chart-space document
+ * root. Returns the entire chart background's solid fill color as a
+ * 6-character uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the fill
+ * choice of `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The
+ * `<c:spPr>` slot sits at the tail of `<c:chartSpace>` per
+ * CT_ChartSpace (§21.2.2.29), after `<c:chart>` / `<c:externalData>` /
+ * `<c:printSettings>` / `<c:userShapes>` and before the optional
+ * `<c:txPr>` / `<c:extLst>`.
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` /
+ * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+ * collapse to `undefined` so a chart that pinned a fill the writer
+ * cannot reproduce on emit drops the field rather than fabricate one
+ * Excel would render differently. Malformed `val` tokens (wrong
+ * length, non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link SheetChart.chartSpaceFillColor} so a
+ * parsed value slots straight into {@link cloneChart} without
+ * conversion. The lookup is scoped to direct children of
+ * `<c:chartSpace>` so a stray `<c:spPr>` elsewhere (e.g. on
+ * `<c:plotArea>` / `<c:legend>` / `<c:title>` / a series) cannot leak
+ * into this field. Mirrors {@link parsePlotAreaFillColor} /
+ * {@link parseLegendFillColor} — same `<c:spPr><a:solidFill>
+ * <a:srgbClr>` chain on a different host element.
+ */
+function parseChartSpaceFillColor(chartSpace: XmlElement): string | undefined {
+  const spPr = findChild(chartSpace, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
   if (!solidFill) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -253,6 +253,22 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
   }
   chartSpaceChildren.push(chartElement);
 
+  // `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+  // </c:spPr></c:chartSpace>` — Excel's "Format Chart Area -> Fill ->
+  // Solid fill -> Color" pin (the same dialog the user reaches by
+  // right-clicking the chart's outer frame). The slot sits at the tail
+  // of `<c:chartSpace>` per CT_ChartSpace (ECMA-376 Part 1, §21.2.2.29),
+  // after `<c:chart>` / `<c:externalData>` / `<c:printSettings>` /
+  // `<c:userShapes>` and before the optional `<c:txPr>` / `<c:extLst>`.
+  // The writer emits the block only when `chart.chartSpaceFillColor`
+  // normalizes to a literal hex; absence and every malformed token
+  // collapse to no `<c:spPr>` so a fresh chart matches Excel's
+  // reference shape byte-for-byte.
+  const chartSpaceSpPrXml = buildChartSpaceSpPr(chart);
+  if (chartSpaceSpPrXml !== undefined) {
+    chartSpaceChildren.push(chartSpaceSpPrXml);
+  }
+
   const chartXml = xmlDocument(
     "c:chartSpace",
     {
@@ -1230,6 +1246,53 @@ function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
  * sRGB grammar.
  */
 function normalizePlotAreaFillColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
+ * Build the optional `<c:spPr>` block at the tail of `<c:chartSpace>`
+ * (the document root). Currently surfaces only the solid fill color
+ * knob ({@link SheetChart.chartSpaceFillColor}) — every other
+ * `<c:spPr>` child (`<a:ln>` stroke, `<a:effectLst>` effects, gradient
+ * / pattern / picture fills) is intentionally not modelled at this
+ * layer.
+ *
+ * Returns `undefined` when the chart leaves the field unset / passed a
+ * malformed token so the writer skips the entire `<c:spPr>` block — an
+ * empty `<c:spPr/>` collapses to the inherited theme fill Excel picks
+ * anyway, and omitting it keeps untouched chart XML byte-clean.
+ *
+ * Mirrors {@link buildPlotAreaSpPr} but on a distinct host element —
+ * the chart-space fill paints the entire chart frame (title slot,
+ * legend slot, axis label margins, plot area together), while the
+ * plot-area fill paints only the inner band that hosts the series.
+ */
+function buildChartSpaceSpPr(chart: SheetChart): string | undefined {
+  const fillHex = normalizeChartSpaceFillColor(chart.chartSpaceFillColor);
+  if (fillHex === undefined) return undefined;
+  const solidFill = xmlElement("a:solidFill", undefined, [
+    xmlSelfClose("a:srgbClr", { val: fillHex }),
+  ]);
+  return xmlElement("c:spPr", undefined, [solidFill]);
+}
+
+/**
+ * Normalize a {@link SheetChart.chartSpaceFillColor} value for the
+ * `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+ * </c:spPr></c:chartSpace>` writer slot. Returns the 6-character
+ * uppercase hex form when the input is a valid sRGB triple (with or
+ * without a leading `#`), or `undefined` for any malformed token —
+ * wrong length, non-hex characters, alpha-channel forms, or non-string
+ * escapes from an untyped caller.
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the entire `<c:spPr>` block and the chart inherits
+ * the auto-fill Excel picks from the workbook theme (Excel's reference
+ * behavior for a fresh chart without a custom frame color). Delegates
+ * to the chart-level {@link normalizeTitleColor} so every `<a:srgbClr>`
+ * fill slot shares the same sRGB grammar.
+ */
+function normalizeChartSpaceFillColor(value: string | undefined): string | undefined {
   return normalizeTitleColor(value);
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -21232,3 +21232,248 @@ describe("cloneChart — legendFillColor", () => {
     expect(parseChart(written)?.legendFillColor).toBeUndefined();
   });
 });
+
+// ── cloneChart — chartSpaceFillColor (entire chart background) ──────
+
+describe("cloneChart — chartSpaceFillColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chartSpaceFillColor by default", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+  });
+
+  it("lets options.chartSpaceFillColor override the source's value", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "ABCDEF",
+    });
+    expect(clone.chartSpaceFillColor).toBe("ABCDEF");
+  });
+
+  it("drops the inherited chartSpaceFillColor when the override is null", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: null,
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined chartSpaceFillColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # in the override hex string", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "#1f77b4",
+    });
+    expect(clone.chartSpaceFillColor).toBe("1F77B4");
+  });
+
+  it("normalizes a lowercase override hex string to uppercase", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "ff8800",
+    });
+    expect(clone.chartSpaceFillColor).toBe("FF8800");
+  });
+
+  it("normalizes a malformed source value through the resolver (drops to undefined)", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "ZZZ" as string }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("collapses malformed override hex tokens (wrong length)", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "FFF",
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("collapses malformed override hex tokens (non-hex characters)", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "GGGGGG",
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("collapses alpha-channel override hex tokens", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "FFAA0080",
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("collapses non-string overrides (number leaking past the type guard)", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      chartSpaceFillColor: 0xff_ff_ff as any,
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("collapses an empty string override", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceFillColor: "",
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("collapses a malformed source value when the override is undefined", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "GGGGGG" as any }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("carries chartSpaceFillColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+  });
+
+  it("carries chartSpaceFillColor through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+  });
+
+  it("retains chartSpaceFillColor independently of a hidden legend", () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+  });
+
+  it("composes independently with plotAreaFillColor on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({ chartSpaceFillColor: "F2F2F2", plotAreaFillColor: "ABCDEF" }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+    expect(clone.plotAreaFillColor).toBe("ABCDEF");
+  });
+
+  it("composes independently with legendFillColor and titleFillColor on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        chartSpaceFillColor: "111111",
+        legendFillColor: "222222",
+        legend: "right",
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.chartSpaceFillColor).toBe("111111");
+    expect(clone.legendFillColor).toBe("222222");
+  });
+
+  it("propagates chartSpaceFillColor into the rendered <c:chartSpace><c:spPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    // The chart-space-level <c:spPr> sits after </c:chart>.
+    const chartSpaceSpPr = written.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    expect(chartSpaceSpPr).not.toBeNull();
+    expect(chartSpaceSpPr![1]).toContain('<a:srgbClr val="F2F2F2"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.chartSpaceFillColor).toBe("F2F2F2");
+  });
+
+  it("emits no <c:spPr> on <c:chartSpace> when both source and override are absent (round-trips to undefined)", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const chartSpaceSpPr = written.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    expect(chartSpaceSpPr).toBeNull();
+    expect(parseChart(written)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("a null override drops the inherited fill on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ chartSpaceFillColor: "F2F2F2" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      chartSpaceFillColor: null,
+    });
+    expect(clone.chartSpaceFillColor).toBeUndefined();
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const chartSpaceSpPr = written.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    expect(chartSpaceSpPr).toBeNull();
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -20018,3 +20018,199 @@ describe("writeChart — legendFillColor", () => {
     expect(legend).toContain('<a:srgbClr val="0F0F0F"/>');
   });
 });
+
+// ── writeChart — chartSpaceFillColor (entire chart background) ──────
+
+describe("writeChart — chartSpaceFillColor", () => {
+  // The chart-space `<c:spPr>` lives at the tail of `<c:chartSpace>`,
+  // not inside `<c:chart>`. The writer never emits `<c:plotArea>` /
+  // `<c:legend>` / `<c:title>` `<c:spPr>` blocks unless the matching
+  // knob is pinned, so when only `chartSpaceFillColor` is set the
+  // chart XML carries exactly one `<c:spPr>` — the chart-space block.
+  function chartSpaceSpPrOf(xml: string): string | undefined {
+    // Match the trailing <c:spPr> block that sits as a direct child of
+    // <c:chartSpace> (i.e. after </c:chart>).
+    const m = xml.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    return m ? m[1] : undefined;
+  }
+
+  it("does NOT emit <c:spPr> on <c:chartSpace> when chartSpaceFillColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it('threads chartSpaceFillColor through to <c:chartSpace><c:spPr> as <a:srgbClr val="RRGGBB"/>', () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "F2F2F2" }), "Sheet1");
+    const spPr = chartSpaceSpPrOf(result.chartXml);
+    expect(spPr).toBeDefined();
+    expect(spPr).toContain("<a:solidFill>");
+    expect(spPr).toContain('<a:srgbClr val="F2F2F2"/>');
+  });
+
+  it("normalizes a leading # in the input hex string", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "#1F77B4" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("normalizes a lowercase hex string to the OOXML uppercase canonical form", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "abcdef" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("places <c:spPr> after </c:chart> per CT_ChartSpace sequence", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "F2F2F2" }), "Sheet1");
+    const xml = result.chartXml;
+    const chartCloseIdx = xml.indexOf("</c:chart>");
+    // Find the chart-space-level <c:spPr>: it sits after </c:chart>
+    // (every plot-area / legend / title <c:spPr> would land before
+    // </c:chart>). For a chart with no other fill knobs pinned the
+    // first <c:spPr> in the document is the chart-space one.
+    const spPrIdx = xml.indexOf("<c:spPr>", chartCloseIdx);
+    expect(chartCloseIdx).toBeGreaterThan(0);
+    expect(spPrIdx).toBeGreaterThan(chartCloseIdx);
+  });
+
+  it("only emits one <c:spPr> at the chart-space level", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "FFAA00" }), "Sheet1");
+    // For a chart with no plot-area / legend / title fill knobs set,
+    // the only <c:spPr> in the document is the chart-space one.
+    const occurrences = result.chartXml.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads chartSpaceFillColor through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, chartSpaceFillColor: "ABCDEF" }), "Sheet1");
+      expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        chartSpaceFillColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    expect(chartSpaceSpPrOf(scatter.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "FFF" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "GGGGGG" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "FFAA0080" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops empty / whitespace-only strings", () => {
+    expect(
+      chartSpaceSpPrOf(writeChart(makeChart({ chartSpaceFillColor: "" }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      chartSpaceSpPrOf(writeChart(makeChart({ chartSpaceFillColor: "   " }), "Sheet1").chartXml),
+    ).toBeUndefined();
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ chartSpaceFillColor: 0xff_ff_ff as any }), "Sheet1");
+    expect(chartSpaceSpPrOf(a.chartXml)).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ chartSpaceFillColor: null as any }), "Sheet1");
+    expect(chartSpaceSpPrOf(b.chartXml)).toBeUndefined();
+  });
+
+  it("emits a minimal <c:spPr> block (single solidFill child)", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "ABCDEF" }), "Sheet1");
+    const spPr = chartSpaceSpPrOf(result.chartXml);
+    expect(spPr).toBe('<c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>');
+  });
+
+  it("composes independently with plotAreaFillColor (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceFillColor: "F2F2F2",
+        plotAreaFillColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    // Two distinct <c:spPr> blocks: one inside <c:plotArea>, one on <c:chartSpace>.
+    const occurrences = xml.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(2);
+    const plotAreaMatch = xml.match(/<c:plotArea>[\s\S]*?<\/c:plotArea>/);
+    expect(plotAreaMatch).not.toBeNull();
+    expect(plotAreaMatch![0]).toContain('<a:srgbClr val="ABCDEF"/>');
+    expect(plotAreaMatch![0]).not.toContain('<a:srgbClr val="F2F2F2"/>');
+    expect(chartSpaceSpPrOf(xml)).toContain('<a:srgbClr val="F2F2F2"/>');
+  });
+
+  it("composes with legendFillColor and titleFillColor (each on a distinct host)", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceFillColor: "111111",
+        legendFillColor: "222222",
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const legend = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('<a:srgbClr val="222222"/>');
+    expect(legend).not.toContain("111111");
+    expect(chartSpaceSpPrOf(xml)).toContain('<a:srgbClr val="111111"/>');
+  });
+
+  it("places <c:spPr> after <c:chart> in the chart-space sequence", () => {
+    const result = writeChart(makeChart({ chartSpaceFillColor: "F2F2F2" }), "Sheet1");
+    const xml = result.chartXml;
+    // Verify ordering: the chart-space-level <c:spPr> sits after </c:chart>.
+    const chartCloseIdx = xml.indexOf("</c:chart>");
+    // No <c:spPr> after </c:chart> would mean we put it before, which would be wrong.
+    const spPrAfter = xml.indexOf("<c:spPr>", chartCloseIdx);
+    expect(spPrAfter).toBeGreaterThan(chartCloseIdx);
+  });
+
+  it("round-trips chartSpaceFillColor through parseChart", () => {
+    const written = writeChart(makeChart({ chartSpaceFillColor: "1F77B4" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.chartSpaceFillColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset chartSpaceFillColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — chartSpaceFillColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            chartSpaceFillColor: "F2F2F2",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.chartSpaceFillColor).toBe("F2F2F2");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20011,3 +20011,164 @@ describe("parseChart — legendFillColor", () => {
     expect(chart?.legendFontColor).toBe("000000");
   });
 });
+
+// ── parseChart — chartSpaceFillColor (entire chart background) ──────
+
+describe("parseChart — chartSpaceFillColor", () => {
+  const NS_CSF = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withChartSpaceSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_CSF}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+  <c:spPr>${spPrBody}</c:spPr>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:chartSpace><c:spPr><a:solidFill><a:srgbClr> is pinned", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBe("F2F2F2");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="abcdef"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBe("ABCDEF");
+  });
+
+  it("returns undefined when the chartSpace has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_CSF}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:solidFill>", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:schemeClr val="bg1"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:noFill>", () => {
+    const xml = withChartSpaceSpPr(`<a:noFill/>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:gradFill>", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill>`,
+    );
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:pattFill>", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:pattFill prst="pct5"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill>`,
+    );
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:blipFill>", () => {
+    const xml = withChartSpaceSpPr(`<a:blipFill><a:blip r:embed="rId1"/><a:stretch/></a:blipFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (wrong length)", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="ABC"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (non-hex characters)", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="GGGGGG"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("drops alpha-channel hex forms", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceFillColor).toBe("1F77B4");
+  });
+
+  it("does not leak a stray <c:spPr> from <c:plotArea> into chartSpaceFillColor", () => {
+    const xml = `<c:chartSpace ${NS_CSF}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    // The plot-area fill is a different field; the chartSpace fill is absent.
+    expect(chart?.plotAreaFillColor).toBe("ABCDEF");
+    expect(chart?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("does not leak a stray <c:spPr> from <c:legend> into chartSpaceFillColor", () => {
+    const xml = `<c:chartSpace ${NS_CSF}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legendFillColor).toBe("ABCDEF");
+    expect(chart?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("composes independently with plotAreaFillColor — distinct <c:spPr> blocks at distinct hosts", () => {
+    const xml = `<c:chartSpace ${NS_CSF}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></c:spPr>
+    </c:plotArea>
+  </c:chart>
+  <c:spPr><a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill></c:spPr>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.plotAreaFillColor).toBe("ABCDEF");
+    expect(chart?.chartSpaceFillColor).toBe("F2F2F2");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `chartSpaceFillColor?: string` on `SheetChart` and the parsed `Chart`, mapped to `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></c:spPr></c:chartSpace>` per CT_ChartSpace (ECMA-376 Part 1, §21.2.2.29) — Excel's \"Format Chart Area -> Fill -> Solid fill -> Color\" picker. Joins the same `<c:spPr>` family as `plotAreaFillColor` (#302), `legendFillColor` (#303), and `titleFillColor` (#304) but on the document-root host element, painting the entire chart frame (title slot, legend slot, axis label margins, plot area together) rather than the inner band.

- **Writer** — emits `<c:spPr>` after `<c:chart>` per the CT_ChartSpace sequence (after `<c:chart>` / `<c:externalData>` / `<c:printSettings>` / `<c:userShapes>` and before the optional `<c:txPr>` / `<c:extLst>`); malformed tokens (wrong length, non-hex, alpha-channel, empty / non-string) collapse to no `<c:spPr>` so a fresh chart matches Excel's reference shape byte-for-byte; accepts a leading `#` and any case, normalizing to the OOXML canonical 6-character uppercase form.
- **Reader** — surfaces only the literal `<a:srgbClr>` form on `<c:chartSpace><c:spPr>`; non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`) and theme references (`<a:schemeClr>`) all drop to `undefined`. Lookup is scoped to direct children of `<c:chartSpace>` so a stray `<c:spPr>` on `<c:plotArea>` / `<c:legend>` / `<c:title>` cannot leak in.
- **Clone-through** — `undefined` inherits, `null` drops, value replaces. Independent of every visibility flag — every chart has a `<c:chartSpace>` document root to host the fill. Composes independently with `plotAreaFillColor`, `legendFillColor`, and `titleFillColor` since each lands on a different host element.
- **Independent of `plotAreaFillColor`** — the chart-space slot paints the entire chart frame (including the title slot, legend slot, and axis label margins), while the plot-area slot paints only the inner band that hosts the series. A caller can pin both with no conflict.

57 new tests across writer / reader / clone-through (writer 17, reader 17, clone 23), including a `writeXlsx` round-trip, the `<a:schemeClr>` / `<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>` non-solid-fill drop paths, and isolation tests that confirm a stray plot-area / legend `<c:spPr>` does not leak into this field.

Refs #302

## Test plan

- [x] \`pnpm vitest run --dir=test\` (all 6487 tests pass)
- [x] \`pnpm typecheck\` (clean)
- [x] \`pnpm build\` (clean)
- [x] \`pnpm lint\` (no new errors; 45 pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)