### PR TITLE
feat(xlsx): chart axis-title fill color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -3714,6 +3714,55 @@ export interface SheetChart {
        * area / scatter).
        */
       axisTitleLayout?: ChartManualLayout;
+      /**
+       * Axis-title background fill (solid). Maps to
+       * `<c:catAx><c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+       * </a:solidFill></c:spPr></c:title></c:catAx>` (or `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>`) — Excel's "Format Axis Title -> Fill
+       * -> Solid fill -> Color" picker. The OOXML `<c:spPr>` block on
+       * `CT_Title` (ECMA-376 Part 1, §21.2.2.210) carries the title's
+       * shape properties and sits between `<c:overlay>` and `<c:txPr>` /
+       * `<c:extLst>` per the schema sequence.
+       *
+       * Accepts a 6-character hex string with or without a leading `#`,
+       * any case (`"FF0000"`, `"#1070ca"`, `"abcdef"`); the writer
+       * normalizes to the OOXML canonical 6-character uppercase form
+       * (`"FF0000"`, `"1070CA"`, `"ABCDEF"`) so a re-parse round-trips
+       * losslessly. Malformed inputs (wrong length, non-hex characters,
+       * alpha-channel forms like `"FFAA0080"`, empty / whitespace-only
+       * strings, non-string escapes from an untyped caller) collapse to
+       * `undefined` and the writer skips the entire `<c:spPr>` block —
+       * the axis title inherits the theme default fill (typically a
+       * transparent title background with no `<c:spPr>` block, matching
+       * Excel's reference shape byte-for-byte).
+       *
+       * Mirrors {@link SheetChart.titleFillColor} for axis titles —
+       * same `<c:spPr><a:solidFill><a:srgbClr>` slot, same accept-
+       * with-or-without-`#` grammar, same drop-on-malformed semantics.
+       * Lands in the same `<c:spPr>` family as
+       * {@link SheetChart.plotAreaFillColor} /
+       * {@link SheetChart.legendFillColor} but on a distinct host
+       * element. Composes independently with
+       * {@link axisTitleColor} (the font color) — the two knobs target
+       * different children of `<c:title>` (`<c:spPr>` for the
+       * background fill, `<c:tx><c:rich><a:p><a:pPr><a:defRPr>
+       * <a:solidFill>` for the font color).
+       *
+       * Default: omitted — no `<c:spPr>` block on the axis title (the
+       * title inherits the theme default fill, matching Excel's
+       * reference shape byte-for-byte).
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all).
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>`
+       * shape per the OOXML schema, so the field round-trips on
+       * every chart family that has axes (bar / column / line /
+       * area / scatter).
+       */
+      axisTitleFillColor?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -4481,6 +4530,15 @@ export interface SheetChart {
        * See the X-axis variant for the full semantics.
        */
       axisTitleLayout?: ChartManualLayout;
+      /**
+       * Value-axis-title background fill (solid). Same canonical
+       * `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+       * </a:solidFill></c:spPr></c:title>` slot and grammar as
+       * {@link SheetChart.axes.x.axisTitleFillColor} — the field
+       * round-trips on `<c:valAx>` exactly as it does on `<c:catAx>`.
+       * See the X-axis variant for the full semantics.
+       */
+      axisTitleFillColor?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -6197,6 +6255,49 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleLayout?: ChartManualLayout;
+  /**
+   * Axis-title background fill (solid sRGB) pulled from
+   * `<c:catAx><c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+   * </a:solidFill></c:spPr></c:title></c:catAx>` (or `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>`). Reflects Excel's "Format Axis Title
+   * -> Fill -> Solid fill -> Color" picker.
+   *
+   * Surfaced as the 6-character uppercase hex string the writer round-
+   * trips (`"FFFF00"` / `"1070CA"`) — the leading `#` is stripped on
+   * read so the value threads straight into the writer-side
+   * {@link SheetChart.axes.x.axisTitleFillColor} without
+   * transformation. Color picks other than the literal sRGB form
+   * (`<a:schemeClr>` theme references, `<a:hslClr>`, `<a:sysClr>`,
+   * `<a:prstClr>`) collapse to `undefined` — the reader records only
+   * the resolvable RGB triple to keep the round-trip lossless against
+   * {@link cloneChart} -> {@link writeXlsx}. Non-solid fills
+   * (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`, `<a:blipFill>`)
+   * likewise drop to `undefined`. Malformed `val` tokens (wrong
+   * length, non-hex characters) drop to `undefined` rather than
+   * fabricate a value the writer would round-trip into a malformed
+   * `<a:srgbClr>`.
+   *
+   * Independent of {@link ChartAxisInfo.axisTitleColor}: the fill
+   * lives on `<c:title><c:spPr>`, the font color lives on
+   * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>` —
+   * the two readers walk disjoint paths so a caller can pin both
+   * knobs without conflict.
+   *
+   * Reported as `undefined` whenever the axis omits `<c:title>`
+   * entirely or when the `<c:spPr><a:solidFill><a:srgbClr>` chain is
+   * malformed at any link. Mirrors the chart-level
+   * {@link Chart.titleFillColor} so a parsed value slots straight
+   * back into the writer-side
+   * {@link SheetChart.axes.x.axisTitleFillColor} without
+   * transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every
+   * axis flavour so a parsed chart preserves the fill regardless of
+   * whether the source axis was a category or value axis.
+   */
+  axisTitleFillColor?: string;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -1373,6 +1373,34 @@ export interface CloneChartOptions {
        * knobs compose the same way at the call site.
        */
       axisTitleLayout?: ChartManualLayout | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleFillColor`. `undefined`
+       * (or omitted) inherits the source axis's parsed value; `null`
+       * drops the inherited fill so the writer falls back to the
+       * theme default fill (no `<c:spPr>` block on the axis title,
+       * typically a transparent title background); a 6-character hex
+       * string (with or without a leading `#`, any case) replaces it.
+       *
+       * Malformed overrides (wrong length, non-hex characters,
+       * alpha-channel forms, non-string escapes from an untyped
+       * caller) collapse to a drop so the cloned `SheetChart` always
+       * carries a value the writer will accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any axis
+       * whose `title` is unset (no `<c:title>` block to host the
+       * fill). Composes independently with `axisTitleColor` (the font
+       * color) — the two knobs target different children of
+       * `<c:title>`.
+       *
+       * Mirrors the chart-level `titleFillColor` so a single
+       * configuration call can thread a fill through the chart title
+       * and either axis title without bookkeeping the canonical OOXML
+       * slots.
+       */
+      axisTitleFillColor?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1715,6 +1743,8 @@ export interface CloneChartOptions {
       axisTitleOverlay?: boolean | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleLayout}. */
       axisTitleLayout?: ChartManualLayout | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleFillColor}. */
+      axisTitleFillColor?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -4592,6 +4622,29 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleLayout,
     overrides?.y?.axisTitleLayout,
   );
+  // `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></c:spPr></c:title>` — axis-title background fill.
+  // Lives on the axis's `<c:title>` directly per CT_Title schema (the
+  // `<c:spPr>` block follows `<c:overlay>` in the schema sequence).
+  // Independent of `axisTitleColor` (which lives on the inner
+  // `<a:defRPr><a:solidFill>` slot for the font color) — the two
+  // resolvers walk disjoint paths so a caller can pin both knobs
+  // without conflict. Malformed overrides (wrong length, non-hex
+  // characters, alpha-channel forms, empty / whitespace-only strings,
+  // non-string escapes from an untyped caller) collapse to a drop via
+  // the normalizer so the cloned `SheetChart` always carries a value
+  // the writer will accept. Like the other axis-title knobs, the
+  // writer drops the fill when the matching axis title is unset, so
+  // a stray pin on an axis with no title silently disappears at emit
+  // time.
+  const xAxisTitleFillColor = applyAxisTitleFillColorOverride(
+    sourceAxes?.x?.axisTitleFillColor,
+    overrides?.x?.axisTitleFillColor,
+  );
+  const yAxisTitleFillColor = applyAxisTitleFillColorOverride(
+    sourceAxes?.y?.axisTitleFillColor,
+    overrides?.y?.axisTitleFillColor,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -4887,6 +4940,15 @@ function resolveAxes(
   // `SheetChart` accurately reflects what the chart will paint.
   const xAxisTitleLayoutResolved = xTitle === undefined ? undefined : xAxisTitleLayout;
   const yAxisTitleLayoutResolved = yTitle === undefined ? undefined : yAxisTitleLayout;
+  // The axis-title background fill only renders when the axis carries
+  // a title — drop a stray inherited fill when the resolved axis title
+  // is unset so the cloned `SheetChart` accurately reflects what the
+  // chart will paint. Symmetric with the writer's title-presence gate
+  // (the per-family axis builder only invokes `buildAxisTitle` when
+  // `opts.xAxisTitle` / `opts.yAxisTitle` is set, and the writer skips
+  // the `<c:spPr>` block entirely when no fill is pinned).
+  const xAxisTitleFillColorResolved = xTitle === undefined ? undefined : xAxisTitleFillColor;
+  const yAxisTitleFillColorResolved = yTitle === undefined ? undefined : yAxisTitleFillColor;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -4901,6 +4963,7 @@ function resolveAxes(
     xAxisTitleFontFamilyResolved !== undefined ||
     xAxisTitleOverlayResolved !== undefined ||
     xAxisTitleLayoutResolved !== undefined ||
+    xAxisTitleFillColorResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -4944,6 +5007,8 @@ function resolveAxes(
       out.x.axisTitleFontFamily = xAxisTitleFontFamilyResolved;
     if (xAxisTitleOverlayResolved !== undefined) out.x.axisTitleOverlay = xAxisTitleOverlayResolved;
     if (xAxisTitleLayoutResolved !== undefined) out.x.axisTitleLayout = xAxisTitleLayoutResolved;
+    if (xAxisTitleFillColorResolved !== undefined)
+      out.x.axisTitleFillColor = xAxisTitleFillColorResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -4983,6 +5048,7 @@ function resolveAxes(
     yAxisTitleFontFamilyResolved !== undefined ||
     yAxisTitleOverlayResolved !== undefined ||
     yAxisTitleLayoutResolved !== undefined ||
+    yAxisTitleFillColorResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -5020,6 +5086,8 @@ function resolveAxes(
       out.y.axisTitleFontFamily = yAxisTitleFontFamilyResolved;
     if (yAxisTitleOverlayResolved !== undefined) out.y.axisTitleOverlay = yAxisTitleOverlayResolved;
     if (yAxisTitleLayoutResolved !== undefined) out.y.axisTitleLayout = yAxisTitleLayoutResolved;
+    if (yAxisTitleFillColorResolved !== undefined)
+      out.y.axisTitleFillColor = yAxisTitleFillColorResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -5691,6 +5759,39 @@ function applyAxisTitleItalicOverride(
  * the axis renders no title).
  */
 function applyAxisTitleColorOverride(
+  source: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(source);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
+}
+
+/**
+ * Resolve an `axisTitleFillColor` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Non-string overrides and malformed hex tokens (typed
+ * escapes from an untyped caller, wrong length, non-hex characters,
+ * alpha-channel forms) collapse to `undefined` via
+ * {@link normalizeTitleColor} so the cloned `SheetChart` always
+ * carries a value the writer will accept. A `null` override always
+ * drops the inherited fill (the writer falls back to the theme
+ * default fill — no `<c:spPr>` block on the axis title, typically a
+ * transparent title background matching Excel's reference shape).
+ *
+ * Independent of {@link applyAxisTitleColorOverride}: this resolver
+ * targets the axis title's background `<c:spPr><a:solidFill>` slot,
+ * while the font color targets the inner `<a:defRPr><a:solidFill>`
+ * inside `<c:tx><c:rich><a:p><a:pPr>` — the two knobs compose
+ * without conflict.
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a fill that the writer would silently elide (the writer
+ * scopes the fill emission to `<c:title>`, which is omitted when
+ * the axis renders no title).
+ */
+function applyAxisTitleFillColorOverride(
   source: string | undefined,
   override: string | null | undefined,
 ): string | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -861,6 +861,25 @@ function parseAxisInfo(
   // `legendLayout` / `plotAreaLayout` parsers — same accept-or-drop
   // grammar, same `xMode="edge"` / `xMode="factor"` admission.
   const axisTitleLayout = parseAxisTitleLayout(axis);
+  // `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></c:spPr></c:title>` — axis-title background fill.
+  // Sits on the axis's `<c:title>` directly per CT_Title schema (the
+  // `<c:spPr>` block follows `<c:overlay>` in the schema sequence,
+  // ECMA-376 Part 1, §21.2.2.210). The reader surfaces only the
+  // literal `<a:srgbClr val="RRGGBB"/>` form; theme references
+  // (`<a:schemeClr>`), non-solid fills (`<a:noFill>` / `<a:gradFill>` /
+  // `<a:pattFill>` / `<a:blipFill>`), and malformed `val` tokens all
+  // collapse to `undefined` so a round-trip never fabricates a fill the
+  // writer cannot reproduce on emit. Independent of `axisTitleColor`
+  // (which lives on the inner `<a:defRPr><a:solidFill>` slot for the
+  // font color) — the two readers walk disjoint paths so a caller can
+  // pin both knobs without conflict. Returns `undefined` when the axis
+  // omits `<c:title>` entirely; unlike `axisTitleColor`, the lookup is
+  // not gated on `<c:rich>` so a title authored as a `<c:strRef>`
+  // formula reference can still surface its background fill — Excel's
+  // "Format Axis Title -> Fill" dialog is independent of whether the
+  // text body is rich or a formula.
+  const axisTitleFillColor = parseAxisTitleFillColor(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -1021,6 +1040,7 @@ function parseAxisInfo(
     axisTitleFontFamily === undefined &&
     axisTitleOverlay === undefined &&
     axisTitleLayout === undefined &&
+    axisTitleFillColor === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -1062,6 +1082,7 @@ function parseAxisInfo(
   if (axisTitleFontFamily !== undefined) out.axisTitleFontFamily = axisTitleFontFamily;
   if (axisTitleOverlay !== undefined) out.axisTitleOverlay = axisTitleOverlay;
   if (axisTitleLayout !== undefined) out.axisTitleLayout = axisTitleLayout;
+  if (axisTitleFillColor !== undefined) out.axisTitleFillColor = axisTitleFillColor;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -4486,6 +4507,62 @@ function parseTitleColor(chartEl: XmlElement): string | undefined {
  */
 function parseTitleFillColor(chartEl: XmlElement): string | undefined {
   const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const spPr = findChild(title, "spPr");
+  if (!spPr) return undefined;
+  const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr></c:title>` off an axis element. Returns the
+ * axis title's solid fill color as a 6-character uppercase hex string
+ * the writer can round-trip via
+ * {@link SheetChart.axes.x.axisTitleFillColor}. Mirrors
+ * {@link parseTitleFillColor} for axis titles — same canonical
+ * `<c:spPr><a:solidFill><a:srgbClr>` chain, same drop-on-non-sRGB
+ * semantics.
+ *
+ * Returns the 6-character uppercase hex string when the parser walks
+ * the full chain and lands on an `<a:srgbClr val="RRGGBB"/>`. Theme
+ * references (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and
+ * `<a:prstClr>` all collapse to `undefined` — only the literal RGB
+ * triple round-trips losslessly through {@link writeChart}. Non-solid
+ * fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`, `<a:blipFill>`)
+ * likewise drop to `undefined` so a round-trip never fabricates a
+ * fill the writer cannot reproduce on emit. Malformed `val` tokens
+ * (wrong length, non-hex characters) drop to `undefined` rather than
+ * fabricate a value the writer would round-trip into a malformed
+ * `<a:srgbClr>`.
+ *
+ * The lookup is scoped to direct children of the axis's `<c:title>`
+ * so a stray `<c:spPr>` elsewhere on the axis (e.g. on a `<c:txPr>`
+ * tick-label block, or on the axis itself) cannot leak in. Returns
+ * `undefined` whenever the axis omits the `<c:title>` element or the
+ * `<c:spPr><a:solidFill><a:srgbClr>` chain is malformed at any link.
+ *
+ * Independent of {@link parseAxisTitleColor}: the fill lives on
+ * `<c:title><c:spPr>`, the font color lives on
+ * `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>` — the
+ * two readers walk disjoint paths so a caller can pin both knobs
+ * without conflict. Unlike {@link parseAxisTitleColor}, the lookup is
+ * on `<c:title>` directly rather than gated on `<c:rich>` so a title
+ * authored as a `<c:strRef>` formula reference can still surface its
+ * background fill — Excel's "Format Axis Title -> Fill" dialog is
+ * independent of whether the text body is rich or a formula.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape
+ * per the OOXML schema. Mirrors the chart-level title fill
+ * {@link parseTitleFillColor} so a parsed value slots straight into
+ * the writer-side {@link SheetChart.axes.x.axisTitleFillColor}.
+ */
+function parseAxisTitleFillColor(axis: XmlElement): string | undefined {
+  const title = findChild(axis, "title");
   if (!title) return undefined;
   const spPr = findChild(title, "spPr");
   if (!spPr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1055,6 +1055,24 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // gate the value on the `xAxisTitle` / `yAxisTitle` field.
     xAxisTitleLayout: normalizeManualLayout(chart.axes?.x?.axisTitleLayout),
     yAxisTitleLayout: normalizeManualLayout(chart.axes?.y?.axisTitleLayout),
+    // `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+    // </a:solidFill></c:spPr></c:title>` — axis-title background fill.
+    // The OOXML `<c:spPr>` block sits on `CT_Title` between
+    // `<c:overlay>` and `<c:txPr>` / `<c:extLst>` (ECMA-376 Part 1,
+    // §21.2.2.210). Mirrors the chart-level `titleFillColor` writer
+    // path so a single hex string threads cleanly through both
+    // call sites; reuses {@link normalizeTitleColor} so the
+    // accept-with-or-without-`#` grammar matches the chart-title
+    // fill / plot-area fill / legend fill resolvers exactly.
+    // Malformed inputs (wrong length, non-hex characters,
+    // alpha-channel forms, empty / whitespace-only strings,
+    // non-string escapes from an untyped caller) collapse to
+    // `undefined` and the writer omits the entire `<c:spPr>` block
+    // (Excel's reference serialization for an axis title that
+    // inherits the theme default fill — typically a transparent
+    // title background with no `<c:spPr>` block).
+    xAxisTitleFillColor: normalizeTitleColor(chart.axes?.x?.axisTitleFillColor),
+    yAxisTitleFillColor: normalizeTitleColor(chart.axes?.y?.axisTitleFillColor),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -2167,6 +2185,27 @@ interface AxisRenderOptions {
    * and emit semantics as {@link xAxisTitleLayout}.
    */
   yAxisTitleLayout: ResolvedManualLayout | undefined;
+  /**
+   * Axis-title background fill emitted on the X axis via
+   * `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+   * </a:solidFill></c:spPr></c:title>`. The OOXML `<a:srgbClr
+   * val=".."/>` carries the 6-character uppercase hex sRGB color
+   * (CT_SRgbColor inside CT_ShapeProperties' fill choice — ECMA-376
+   * Part 1, §20.1.2.3.32 / §20.1.8.54). `undefined` collapses to
+   * omitting the entire `<c:spPr>` block (Excel's reference
+   * serialization for an axis title that inherits the theme default
+   * fill — typically a transparent title background); any
+   * non-`undefined` value is the normalized uppercase hex string the
+   * writer lands on the title's `<c:spPr>` slot. Only meaningful
+   * when the axis renders a title — the per-family axis builders
+   * gate the value on the `xAxisTitle` / `yAxisTitle` field.
+   */
+  xAxisTitleFillColor: string | undefined;
+  /**
+   * Axis-title background fill emitted on the Y axis. Same shape and
+   * emit semantics as {@link xAxisTitleFillColor}.
+   */
+  yAxisTitleFillColor: string | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -3398,6 +3437,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleFontFamily,
         opts.xAxisTitleOverlay,
         opts.xAxisTitleLayout,
+        opts.xAxisTitleFillColor,
       ),
     );
   catAxChildren.push(
@@ -3475,6 +3515,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleFontFamily,
         opts.yAxisTitleOverlay,
         opts.yAxisTitleLayout,
+        opts.yAxisTitleFillColor,
       ),
     );
   valAxChildren.push(
@@ -3853,6 +3894,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleFontFamily,
         opts.xAxisTitleOverlay,
         opts.xAxisTitleLayout,
+        opts.xAxisTitleFillColor,
       ),
     );
   xAxChildren.push(
@@ -3909,6 +3951,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleFontFamily,
         opts.yAxisTitleOverlay,
         opts.yAxisTitleLayout,
+        opts.yAxisTitleFillColor,
       ),
     );
   yAxChildren.push(
@@ -4012,6 +4055,7 @@ function buildAxisTitle(
   fontFamily: string | undefined,
   overlay: boolean,
   layout: ResolvedManualLayout | undefined,
+  fillRgbHex: string | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -4162,6 +4206,22 @@ function buildAxisTitle(
   ];
   if (layoutXml) titleChildren.push(layoutXml);
   titleChildren.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
+  // CT_Title (ECMA-376 Part 1, §21.2.2.210) places the optional
+  // `<c:spPr>` between `<c:overlay>` and `<c:txPr>` / `<c:extLst>`.
+  // Mirrors `buildTitle`: the writer skips emission entirely when the
+  // caller did not pin a fill color so a fresh axis title matches
+  // Excel's reference shape byte-for-byte (Excel itself omits the
+  // block whenever the title renders at the theme default fill —
+  // typically a transparent title background with no `<c:spPr>`
+  // block). Currently the writer only authors `<a:solidFill>` here;
+  // stroke (`<a:ln>`) and other CT_ShapeProperties children are not
+  // modelled at this layer. Distinct from the
+  // `<a:defRPr><a:solidFill>` font-color slot inside `<c:tx><c:rich>`
+  // that {@link SheetChart.axes.x.axisTitleColor} pins — the two knobs
+  // target different children of `<c:title>` so a caller can pin both
+  // without conflict.
+  const titleSpPrXml = buildTitleSpPr(fillRgbHex);
+  if (titleSpPrXml !== undefined) titleChildren.push(titleSpPrXml);
   return xmlElement("c:title", undefined, titleChildren);
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -21683,3 +21683,249 @@ describe("cloneChart — chartSpaceFillColor", () => {
     expect(chartSpaceSpPr).toBeNull();
   });
 });
+
+// ── cloneChart — axisTitleFillColor ──────────────────────────────────
+
+describe("cloneChart — axisTitleFillColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleFillColor by default", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleFillColor by default", () => {
+    const clone = cloneChart(
+      source({ axes: { y: { title: "USD", axisTitleFillColor: "00C586" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.y?.axisTitleFillColor).toBe("00C586");
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleFillColor replace the source's value", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFillColor: "1070CA" } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("1070CA");
+  });
+
+  it("normalizes a lowercase hex override to uppercase", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFillColor: "abcdef" } },
+    });
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("ABCDEF");
+  });
+
+  it("strips a leading '#' on override input", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFillColor: "#1070CA" } },
+    });
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("1070CA");
+  });
+
+  it("drops the inherited axisTitleFillColor when the override is null", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFillColor: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleFillColor).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleFillColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleFillColor with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFillColor: "1070CA" } },
+    });
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("1070CA");
+  });
+
+  it("drops malformed hex overrides (defends against the type guard escaping)", () => {
+    for (const bad of ["", "FFF", "ZZZZZZ", "FF0000FF"]) {
+      const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFillColor: bad } },
+      });
+      expect(clone.axes?.x?.axisTitleFillColor).toBeUndefined();
+    }
+  });
+
+  it("drops non-string overrides (defends against the type guard escaping)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleFillColor: 123 as any } },
+    });
+    expect(clone.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("normalises a parsed source value that is malformed", () => {
+    const clone = cloneChart(
+      source({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleFillColor: "ZZZZZZ" as any } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("drops the inherited axisTitleFillColor when the resolved axis title is dropped", () => {
+    // `title: null` flattens the inherited axis title — no `<c:title>`
+    // block will be emitted, so the inherited fill has no slot in the
+    // rendered axis and the clone collapses it.
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("drops an override axisTitleFillColor when no axis title resolves", () => {
+    // The axis has no source title and the caller did not pin one —
+    // the writer would silently elide the fill either way, so the
+    // clone-side resolver mirrors that by dropping the field.
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleFillColor: "FFFF00" } },
+    });
+    expect(clone.axes?.x).toBeUndefined();
+  });
+
+  it("preserves the override when the override also pins a title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleFillColor: "1070CA" } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("1070CA");
+  });
+
+  it("composes independently with axisTitleColor on the same axis title", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleColor: "FF0000",
+            axisTitleFillColor: "FFFF00",
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+  });
+
+  it("composes independently with the chart-level titleFillColor", () => {
+    const clone = cloneChart(
+      source({
+        titleFillColor: "1070CA",
+        axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleFillColor).toBe("1070CA");
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+  });
+
+  it("threads the fill through both axes independently on the clone", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleFillColor: "FF0000" },
+          y: { title: "USD", axisTitleFillColor: "00C586" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("FF0000");
+    expect(clone.axes?.y?.axisTitleFillColor).toBe("00C586");
+  });
+
+  it("survives a writeXlsx round trip — axisTitleFillColor lands in the cloned chart XML", async () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleFillColor: "1F77B4" } },
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.axes?.x?.axisTitleFillColor).toBe("1F77B4");
+  });
+
+  it("round-trips a parsed axisTitleFillColor straight back through cloneChart", () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [{ values: "B2:B5", categories: "A2:A5" }],
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -20402,3 +20402,282 @@ describe("writeChart — chartSpaceFillColor", () => {
     expect(reparsed?.chartSpaceFillColor).toBe("F2F2F2");
   });
 });
+
+// ── writeChart — axisTitleFillColor (solid fill) ─────────────────────
+
+describe("writeChart — axisTitleFillColor", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  function axisTitleSpPrFillVal(axisBlock: string): string | undefined {
+    const title = axisTitleBlock(axisBlock);
+    if (!title) return undefined;
+    // Match the spPr block that sits directly under <c:title>.
+    const m = title.match(/<c:spPr>[\s\S]*?<\/c:spPr>/);
+    if (!m) return undefined;
+    const fill = m[0].match(/<a:solidFill><a:srgbClr val="([^"]+)"\/><\/a:solidFill>/);
+    return fill ? fill[1] : undefined;
+  }
+
+  it("does not emit <c:spPr> on the axis title when axisTitleFillColor is unset", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("emits <c:spPr><a:solidFill><a:srgbClr> on the axis title when axisTitleFillColor is set", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleSpPrFillVal(xAx)).toBe("FFFF00");
+  });
+
+  it("normalizes a leading # and lowercase hex to canonical uppercase", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "#1f77b4" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleSpPrFillVal(xAx)).toBe("1F77B4");
+  });
+
+  it("places <c:spPr> after <c:overlay> on the axis title (CT_Title sequence)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "FFFF00" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    const overlayIdx = title.indexOf("<c:overlay");
+    const spPrIdx = title.indexOf("<c:spPr>");
+    expect(overlayIdx).toBeGreaterThan(0);
+    expect(spPrIdx).toBeGreaterThan(overlayIdx);
+  });
+
+  it("only emits one <c:spPr> inside the axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "FFAA00" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    const occurrences = title.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads the fill color through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleFillColor: "FF0000" },
+          y: { title: "USD", axisTitleFillColor: "00C586" },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleSpPrFillVal(xAx)).toBe("FF0000");
+    expect(axisTitleSpPrFillVal(yAx)).toBe("00C586");
+  });
+
+  it("threads axisTitleFillColor through every chart family that has axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleFillColor: "ABCDEF" } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleSpPrFillVal(xAx)).toBe("ABCDEF");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleFillColor: "ABCDEF" } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    const yAx = blocks[1];
+    expect(axisTitleSpPrFillVal(yAx)).toBe("ABCDEF");
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "FFF" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "GGGGGG" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "FFAA0080" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops an empty / whitespace-only string", () => {
+    for (const bad of ["", "   "]) {
+      const result = writeChart(
+        makeChart({ axes: { x: { title: "Period", axisTitleFillColor: bad } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      const title = axisTitleBlock(xAx)!;
+      expect(title).not.toContain("<c:spPr>");
+    }
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleFillColor: 123 as any } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("ignores axisTitleFillColor when the axis renders no title", () => {
+    // No title means no `<c:title>` block — there is no slot for the
+    // fill in either case.
+    const result = writeChart(
+      makeChart({ axes: { x: { axisTitleFillColor: "FF0000" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with axisTitleColor (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleColor: "FF0000",
+            axisTitleFillColor: "FFFF00",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    // Font color in <a:defRPr><a:solidFill> slot.
+    expect(title).toMatch(/<a:defRPr[^>]*>\s*<a:solidFill><a:srgbClr val="FF0000"\/>/);
+    // Background fill on the title's <c:spPr>.
+    expect(title).toContain('<a:srgbClr val="FFFF00"/>');
+    // Font color slot precedes the spPr fill slot per CT_Title schema.
+    const fontFillPos = title.indexOf('<a:srgbClr val="FF0000"/>');
+    const bgFillPos = title.indexOf('<a:srgbClr val="FFFF00"/>');
+    expect(fontFillPos).toBeGreaterThan(0);
+    expect(bgFillPos).toBeGreaterThan(fontFillPos);
+  });
+
+  it("composes independently with axisTitleLayout (layout precedes spPr)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleLayout: { x: 0.1, y: 0.05 },
+            axisTitleFillColor: "FFFF00",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).toContain('<c:x val="0.1"/>');
+    expect(title).toContain('<a:srgbClr val="FFFF00"/>');
+    // CT_Title sequence: <c:layout> precedes <c:overlay> precedes <c:spPr>.
+    expect(title.indexOf("<c:layout>")).toBeLessThan(title.indexOf("<c:overlay"));
+    expect(title.indexOf("<c:overlay")).toBeLessThan(title.indexOf("<c:spPr>"));
+  });
+
+  it("round-trips axisTitleFillColor through parseChart (catAx)", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleFillColor: "1F77B4" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleFillColor).toBe("1F77B4");
+  });
+
+  it("round-trips axisTitleFillColor through parseChart (valAx)", () => {
+    const written = writeChart(
+      makeChart({ axes: { y: { title: "USD", axisTitleFillColor: "00C586" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.title).toBe("USD");
+    expect(reparsed?.axes?.y?.axisTitleFillColor).toBe("00C586");
+  });
+
+  it("collapses an unset axisTitleFillColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — axisTitleFillColor lands in chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleFillColor: "FFFF00" },
+              y: { title: "USD", axisTitleFillColor: "00C586" },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    expect(reparsed?.axes?.y?.axisTitleFillColor).toBe("00C586");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20342,3 +20342,262 @@ describe("parseChart — chartSpaceFillColor", () => {
     expect(chart?.chartSpaceFillColor).toBe("F2F2F2");
   });
 });
+
+// ── parseChart — axisTitleFillColor ──────────────────────────────────
+
+describe("parseChart — axisTitleFillColor", () => {
+  const NS_ATFC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitleSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr>${spPrBody}</c:spPr>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  function withValAxTitleSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr>${spPrBody}</c:spPr>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:title><c:spPr><a:solidFill><a:srgbClr> is pinned (catAx)", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>`),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("surfaces the literal sRGB color on the value axis (valAx)", () => {
+    const chart = parseChart(
+      withValAxTitleSpPr(`<a:solidFill><a:srgbClr val="00C586"/></a:solidFill>`),
+    );
+    expect(chart?.axes?.y?.axisTitleFillColor).toBe("00C586");
+    expect(chart?.axes?.y?.title).toBe("USD");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="abcdef"/></a:solidFill>`),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBe("ABCDEF");
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill>`),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:solidFill>", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="000000"/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:solidFill><a:schemeClr val="bg1"/></a:solidFill>`),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:noFill>", () => {
+    const chart = parseChart(withCatAxTitleSpPr(`<a:noFill/>`));
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:gradFill>", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(
+        `<a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill>`,
+      ),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("returns undefined when fill is <a:pattFill>", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(
+        `<a:pattFill prst="dkUpDiag"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill>`,
+      ),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("drops malformed val tokens (wrong length / non-hex / 8-char alpha form)", () => {
+    expect(
+      parseChart(withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val=""/></a:solidFill>`))?.axes?.x
+        ?.axisTitleFillColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="FFF"/></a:solidFill>`))?.axes?.x
+        ?.axisTitleFillColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="ZZZZZZ"/></a:solidFill>`))?.axes
+        ?.x?.axisTitleFillColor,
+    ).toBeUndefined();
+    // 8-character alpha form (Excel uses <a:alpha> sibling for that).
+    expect(
+      parseChart(withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill>`))?.axes
+        ?.x?.axisTitleFillColor,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const chart = parseChart(withCatAxTitleSpPr(`<a:solidFill><a:srgbClr/></a:solidFill>`));
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("does not leak the chart-level title <c:spPr> fill into the axis title fill", () => {
+    // Chart-level <c:title> has the spPr; the axis title doesn't.
+    const xml = `<c:chartSpace ${NS_ATFC}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+      <c:spPr><a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill></c:spPr>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleFillColor).toBe("FFFF00");
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+  });
+
+  it("does not leak a stray <c:spPr> on a sibling axis (catAx vs valAx scope)", () => {
+    // The valAx has spPr at the title — catAx should not pick it up.
+    const xml = `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr><a:solidFill><a:srgbClr val="00C586"/></a:solidFill></c:spPr>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleFillColor).toBeUndefined();
+    expect(chart?.axes?.y?.axisTitleFillColor).toBe("00C586");
+  });
+
+  it("surfaces axisTitleFillColor independently of axisTitleColor (font color slot)", () => {
+    const xml = `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p>
+          <a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr>
+          <a:r><a:rPr lang="en-US"/><a:t>Period</a:t></a:r>
+        </a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr><a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill></c:spPr>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(chart?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+  });
+
+  it("surfaces axisTitleFillColor on a strRef-bodied title (no <c:rich>)", () => {
+    // Fill lookup is on `<c:title>` directly, not gated on `<c:rich>` —
+    // a title authored as a formula reference still surfaces its fill.
+    const xml = `<c:chartSpace ${NS_ATFC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef><c:f>Sheet1!$A$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache></c:strRef></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr><a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill></c:spPr>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `axisTitleFillColor?: string` to `SheetChart.axes.x` / `SheetChart.axes.y` and `ChartAxisInfo`, mapped to `<c:catAx><c:title><c:spPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></c:spPr></c:title></c:catAx>` (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) per `CT_Title` (ECMA-376 Part 1, §21.2.2.210) — Excel's "Format Axis Title -> Fill -> Solid fill -> Color" picker. Mirrors `titleFillColor` (#304) for axis titles, lands in the same `<c:spPr>` family as `plotAreaFillColor` (#302) / `legendFillColor` (#303) but on a per-axis host.

- **Writer** — emits `<c:spPr>` after `<c:overlay>` on the axis `<c:title>` per the CT_Title sequence; reuses the existing `buildTitleSpPr` helper so a single hex string threads cleanly through both the chart title and the axis-title fill paths. Malformed tokens (wrong length, non-hex, alpha-channel, empty / non-string) collapse to no `<c:spPr>` so a fresh axis title matches Excel's reference shape byte-for-byte; accepts a leading `#` and any case, normalizing to the OOXML canonical 6-character uppercase form.
- **Reader** — surfaces only the literal `<a:srgbClr>` form on `<c:title><c:spPr>`; non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`) and theme references (`<a:schemeClr>`) all drop to `undefined`. Lookup is on `<c:title>` directly rather than gated on `<c:rich>` so a `strRef`-bodied axis title can still surface its background fill.
- **Clone-through** — `undefined` inherits, `null` drops, value replaces via `applyAxisTitleFillColorOverride`. Threads through every chart family that has axes (bar / column / line / area / scatter); silently dropped on `pie` / `doughnut` (no axes) and on any axis whose `title` resolves unset.
- **Independent of `axisTitleColor`** — the two knobs target different children of `<c:title>` (`<c:spPr>` background vs `<c:tx><c:rich><a:p><a:pPr><a:defRPr><a:solidFill>` font), so a caller can pin both without conflict.

55 new tests across reader (17), writer (19), and clone-through (19), including end-to-end `writeXlsx` packaging on both X and Y axes, the `<a:schemeClr>` / `<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` non-solid-fill drop paths, the strRef-bodied title fill path, and cross-axis isolation (catAx vs valAx scope).

Refs #304

## Test plan

- [x] \`pnpm vitest run --dir=test\` (all 6537 tests pass)
- [x] \`pnpm typecheck\` (clean)
- [x] \`pnpm build\` (clean)
- [x] \`pnpm lint\` (no new errors; pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)