### PR TITLE
feat(xlsx): chart data-table fill color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1326,6 +1326,57 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   fontFamily?: string;
+  /**
+   * Data-table background fill color as a 6-digit RGB hex string (e.g.
+   * `"F2F2F2"`). Maps to `<c:dTable><c:spPr><a:solidFill><a:srgbClr
+   * val="RRGGBB"/></a:solidFill></c:spPr></c:dTable>` (CT_DTable,
+   * ECMA-376 Part 1, §21.2.2.54) — Excel's "Format Data Table -> Fill
+   * -> Solid fill -> Color" picker (the same dialog the user reaches
+   * by right-clicking the data table grid). The OOXML `<a:srgbClr
+   * val=".."/>` carries the 6-character uppercase hex sRGB color
+   * (`CT_SRgbColor` inside `CT_ShapeProperties`' fill choice — ECMA-376
+   * Part 1, §20.1.2.3.32 / §20.1.2.3.13). The `<c:spPr>` slot lives
+   * after the four required boolean children (`<c:showHorzBorder>`,
+   * `<c:showVertBorder>`, `<c:showOutline>`, `<c:showKeys>`) and before
+   * the optional `<c:txPr>` per CT_DTable — distinct from the typography
+   * `<c:txPr>` block which carries the font color knobs.
+   *
+   * Distinct from {@link fontColor} — the fill color paints the cell
+   * backgrounds of the data table, while the font color tints the
+   * series-name / value text drawn inside those cells. A caller can
+   * pin both knobs (e.g. a brand-color background with white text)
+   * since they land on different host elements (`<c:spPr>` for the
+   * fill, `<c:txPr>` for the typography).
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the entire `<c:spPr>` block (Excel's reference serialization for
+   * a data table that inherits the auto-fill — typically transparent
+   * on top of the plot area).
+   *
+   * Default: omitted — the data table inherits the auto-fill Excel
+   * picks from the workbook theme (typically transparent so the plot
+   * area's fill shows through). Pin a hex color to mirror Excel's
+   * "Format Data Table -> Fill -> Solid fill" knob and paint a flat
+   * background behind the table grid.
+   *
+   * Patterned / gradient / picture fills are not modelled — only the
+   * solid sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   * Mirrors `plotAreaFillColor` / `legendFillColor` / `titleFillColor`
+   * / `chartSpaceFillColor` / `axisTitleFillColor` — same accept-with-
+   * or-without-`#` hex grammar, same OOXML `<c:spPr><a:solidFill>
+   * <a:srgbClr val=".."/></a:solidFill></c:spPr>` mapping — so a
+   * caller can thread a single hex string through every `<c:spPr>`-
+   * based fill slot.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  fillColor?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -5018,6 +5018,8 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (strikethrough !== undefined) out.strikethrough = strikethrough;
   const fontFamily = parseDataTableFontFamily(el);
   if (fontFamily !== undefined) out.fontFamily = fontFamily;
+  const fillColor = parseDataTableFillColor(el);
+  if (fillColor !== undefined) out.fillColor = fillColor;
   return out;
 }
 
@@ -5206,6 +5208,48 @@ function parseDataTableFontFamily(dTable: XmlElement): string | undefined {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return undefined;
   return trimmed;
+}
+
+/**
+ * Pull `<c:dTable><c:spPr><a:solidFill><a:srgbClr val=".."/>
+ * </a:solidFill></c:spPr></c:dTable>` off a data-table block.
+ * Returns the data-table background fill color as a 6-character
+ * uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the fill
+ * choice of `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The
+ * `<c:spPr>` slot sits inside `<c:dTable>` after the four required
+ * boolean children (`<c:showHorzBorder>`, `<c:showVertBorder>`,
+ * `<c:showOutline>`, `<c:showKeys>`) and before the optional
+ * `<c:txPr>` per CT_DTable (ECMA-376 Part 1, §21.2.2.54).
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` /
+ * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+ * collapse to `undefined` so a chart that pinned a fill the writer
+ * cannot reproduce on emit drops the field rather than fabricate one
+ * Excel would render differently. Malformed `val` tokens (wrong
+ * length, non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link ChartDataTable.fillColor} so a parsed
+ * value slots straight into {@link cloneChart} without conversion.
+ * The lookup is scoped to direct children of `<c:dTable>` so a stray
+ * `<c:spPr>` elsewhere (e.g. on `<c:plotArea>` / `<c:legend>` /
+ * `<c:title>` / a series) cannot leak into this field. Mirrors
+ * {@link parsePlotAreaFillColor} / {@link parseLegendFillColor} —
+ * same `<c:spPr><a:solidFill><a:srgbClr>` chain on a different host
+ * element.
+ */
+function parseDataTableFillColor(dTable: XmlElement): string | undefined {
+  const spPr = findChild(dTable, "spPr");
+  if (!spPr) return undefined;
+  const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1397,6 +1397,7 @@ function resolveDataTable(chart: SheetChart):
       underline: boolean | undefined;
       strikethrough: boolean | undefined;
       fontFamily: string | undefined;
+      fillColor: string | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1421,6 +1422,7 @@ function resolveDataTable(chart: SheetChart):
       underline: undefined,
       strikethrough: undefined,
       fontFamily: undefined,
+      fillColor: undefined,
     };
   }
 
@@ -1440,6 +1442,7 @@ function resolveDataTable(chart: SheetChart):
     underline: resolveDataTableUnderline(raw.underline),
     strikethrough: resolveDataTableStrikethrough(raw.strikethrough),
     fontFamily: resolveDataTableFontFamily(raw.fontFamily),
+    fillColor: resolveDataTableFillColor(raw.fillColor),
   };
 }
 
@@ -1568,6 +1571,25 @@ function resolveDataTableFontFamily(value: string | undefined): string | undefin
 }
 
 /**
+ * Resolve `<c:dTable><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr></c:dTable>` from
+ * {@link ChartDataTable.fillColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches the chart-title /
+ * plot-area / legend / chart-space / axis-title fill color resolvers
+ * exactly. The `<c:spPr>` slot lives between the four required
+ * boolean children and the optional `<c:txPr>` per CT_DTable
+ * (ECMA-376 Part 1, §21.2.2.54), distinct from the `<c:txPr>` block
+ * that carries {@link ChartDataTable.fontColor}.
+ */
+function resolveDataTableFillColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
@@ -1595,6 +1617,7 @@ function buildDataTable(table: {
   underline: boolean | undefined;
   strikethrough: boolean | undefined;
   fontFamily: string | undefined;
+  fillColor: string | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1602,11 +1625,17 @@ function buildDataTable(table: {
     xmlSelfClose("c:showOutline", { val: table.showOutline ? 1 : 0 }),
     xmlSelfClose("c:showKeys", { val: table.showKeys ? 1 : 0 }),
   ];
-  // CT_DTable schema places `<c:txPr>` after the four required
-  // boolean children, before the optional `<c:extLst>` (ECMA-376
-  // Part 1, §21.2.2.54). The writer skips emission entirely when no
-  // typography knob is pinned so a fresh chart matches Excel's
+  // CT_DTable schema places `<c:spPr>` after the four required
+  // boolean children, before `<c:txPr>` and the optional `<c:extLst>`
+  // (ECMA-376 Part 1, §21.2.2.54). The writer skips emission entirely
+  // when no fill knob is pinned so a fresh chart matches Excel's
   // reference serialization byte-for-byte.
+  const spPrXml = buildDataTableSpPr(table.fillColor);
+  if (spPrXml !== undefined) children.push(spPrXml);
+  // CT_DTable schema places `<c:txPr>` after `<c:spPr>` and before
+  // the optional `<c:extLst>` (ECMA-376 Part 1, §21.2.2.54). The writer
+  // skips emission entirely when no typography knob is pinned so a
+  // fresh chart matches Excel's reference serialization byte-for-byte.
   const txPrXml = buildDataTableTxPr(
     table.fontSize,
     table.fontColor,
@@ -1618,6 +1647,31 @@ function buildDataTable(table: {
   );
   if (txPrXml !== undefined) children.push(txPrXml);
   return xmlElement("c:dTable", undefined, children);
+}
+
+/**
+ * Build the optional `<c:spPr>` block inside `<c:dTable>`. Currently
+ * surfaces only the solid fill color knob ({@link
+ * ChartDataTable.fillColor}) — every other `<c:spPr>` child (`<a:ln>`
+ * stroke, `<a:effectLst>` effects, gradient / pattern / picture fills)
+ * is intentionally not modelled at this layer.
+ *
+ * Returns `undefined` when the caller leaves the field unset / passed
+ * a malformed token so the writer skips the entire `<c:spPr>` block —
+ * an empty `<c:spPr/>` collapses to the inherited theme fill Excel
+ * picks anyway, and omitting it keeps untouched chart XML byte-clean.
+ *
+ * Mirrors {@link buildPlotAreaSpPr} / {@link buildChartSpaceSpPr}
+ * but on a distinct host element — the data-table fill paints the
+ * background of the table grid, while the plot-area / chart-space
+ * fills paint the inner band / entire chart frame.
+ */
+function buildDataTableSpPr(fillColor: string | undefined): string | undefined {
+  if (fillColor === undefined) return undefined;
+  const solidFill = xmlElement("a:solidFill", undefined, [
+    xmlSelfClose("a:srgbClr", { val: fillColor }),
+  ]);
+  return xmlElement("c:spPr", undefined, [solidFill]);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -4,7 +4,14 @@ import { parseChart } from "../src/xlsx/chart-reader";
 import { writeChart } from "../src/xlsx/chart-writer";
 import { writeXlsx } from "../src/xlsx/writer";
 import { ZipReader } from "../src/zip/reader";
-import type { Chart, ChartLineStroke, ChartMarker, ChartView3D, SheetChart } from "../src/_types";
+import type {
+  Chart,
+  ChartDataTable,
+  ChartLineStroke,
+  ChartMarker,
+  ChartView3D,
+  SheetChart,
+} from "../src/_types";
 
 const decoder = new TextDecoder("utf-8");
 
@@ -11230,6 +11237,188 @@ describe("cloneChart — data table", () => {
     const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
     const reparsed = parseChart(written);
     expect(reparsed?.dataTable?.fontFamily).toBe("Calibri");
+  });
+
+  // ── data-table fill color ────────────────────────────────────────
+
+  it("inherits the source's dataTable.fillColor by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fillColor: "F2F2F2",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fillColor: "F2F2F2",
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited fillColor", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fillColor: "F2F2F2" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, fillColor: "ABCDEF" },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, fillColor: "ABCDEF" });
+  });
+
+  it("drops the inherited fillColor when override clears the fill pin", () => {
+    // The override is wholesale-replace, not per-field merge — passing
+    // an object without fillColor drops the inherited value.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fillColor: "F2F2F2" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited fillColor when flattening into a pie clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fillColor: "F2F2F2" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "pie",
+      },
+    );
+    expect(clone.type).toBe("pie");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops the inherited fillColor when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fillColor: "F2F2F2" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops the inherited fillColor when override clears the entire dataTable block (null)", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, fillColor: "F2F2F2" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: null,
+      },
+    );
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.fillColor into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fillColor: "1070CA",
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain(
+      '<c:spPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></c:spPr>',
+    );
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fillColor: "1070CA",
+    });
+  });
+
+  it("composes dataTable.fillColor and fontColor through the clone-through path", () => {
+    // The fill (background) and font (foreground text) pins land on
+    // different host elements (<c:spPr> vs <c:txPr>), so a caller can
+    // pin both with no conflict.
+    const clone = cloneChart(
+      source({
+        dataTable: { fillColor: "F2F2F2", fontColor: "1070CA" },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({ fillColor: "F2F2F2", fontColor: "1070CA" });
+  });
+
+  it("a parsed dataTable.fillColor round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, fillColor: "AABBCC" },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.fillColor).toBe("AABBCC");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    // `cloneChart` widens `dataTable` to `boolean | ChartDataTable` so a
+    // type-narrowing assertion lets us probe the object form.
+    expect(typeof clone.dataTable === "object").toBe(true);
+    expect((clone.dataTable as ChartDataTable | undefined)?.fillColor).toBe("AABBCC");
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.dataTable?.fillColor).toBe("AABBCC");
   });
 });
 

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10005,6 +10005,256 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.fontFamily).toBe("Calibri");
   });
+
+  // ── data-table fill color ──────────────────────────────────────────
+
+  it("skips <c:spPr> when fillColor is unset (writer default)", () => {
+    // The OOXML default for the data-table is no <c:spPr> at all — the
+    // table inherits the auto-fill Excel picks from the workbook theme.
+    // Absence collapses to no <c:spPr> block.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:spPr>");
+  });
+
+  it("emits <c:spPr><a:solidFill><a:srgbClr val='FF0000'/></a:solidFill></c:spPr> when fillColor is 'FF0000'", () => {
+    const result = writeChart(makeChart({ dataTable: { fillColor: "FF0000" } }), "Sheet1");
+    expect(result.chartXml).toContain(
+      '<c:spPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></c:spPr>',
+    );
+  });
+
+  it("accepts the fillColor with a leading '#' and lowercases input", () => {
+    // Mirrors the chart-title / plot-area / legend / chart-space /
+    // axis-title fill resolvers — the leading `#` is stripped and the
+    // hex is uppercased.
+    const result = writeChart(makeChart({ dataTable: { fillColor: "#abc123" } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:srgbClr val="ABC123"/>');
+  });
+
+  it("collapses malformed fillColor inputs to undefined", () => {
+    // Wrong length, non-hex characters, alpha-channel forms, and
+    // non-string escapes all drop the field rather than fabricate a
+    // value the writer would round-trip into a malformed <a:srgbClr>.
+    const wrong = writeChart(makeChart({ dataTable: { fillColor: "FF00" } }), "Sheet1");
+    const wrongDT = wrong.chartXml.slice(
+      wrong.chartXml.indexOf("<c:dTable>"),
+      wrong.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(wrongDT).not.toContain("<c:spPr>");
+    const nonHex = writeChart(makeChart({ dataTable: { fillColor: "ZZZZZZ" } }), "Sheet1");
+    const nonHexDT = nonHex.chartXml.slice(
+      nonHex.chartXml.indexOf("<c:dTable>"),
+      nonHex.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(nonHexDT).not.toContain("<c:spPr>");
+    const alpha = writeChart(makeChart({ dataTable: { fillColor: "#FF0000FF" } }), "Sheet1");
+    const alphaDT = alpha.chartXml.slice(
+      alpha.chartXml.indexOf("<c:dTable>"),
+      alpha.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(alphaDT).not.toContain("<c:spPr>");
+    const empty = writeChart(makeChart({ dataTable: { fillColor: "" } }), "Sheet1");
+    const emptyDT = empty.chartXml.slice(
+      empty.chartXml.indexOf("<c:dTable>"),
+      empty.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(emptyDT).not.toContain("<c:spPr>");
+    const nonString = {
+      fillColor: 123 as unknown as string,
+    } as { fillColor: string };
+    const numeric = writeChart(makeChart({ dataTable: nonString }), "Sheet1");
+    const numericDT = numeric.chartXml.slice(
+      numeric.chartXml.indexOf("<c:dTable>"),
+      numeric.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(numericDT).not.toContain("<c:spPr>");
+  });
+
+  it("orders <c:spPr> after the four boolean children and before <c:txPr>", () => {
+    // CT_DTable schema sequence places spPr after the four required
+    // boolean children and before <c:txPr> (ECMA-376 Part 1, §21.2.2.54).
+    const result = writeChart(
+      makeChart({
+        dataTable: { fillColor: "1070CA", fontColor: "FF6600" },
+      }),
+      "Sheet1",
+    );
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    const showKeysIdx = dTableSlice.indexOf("<c:showKeys");
+    const spPrIdx = dTableSlice.indexOf("<c:spPr>");
+    const txPrIdx = dTableSlice.indexOf("<c:txPr>");
+    expect(showKeysIdx).toBeGreaterThanOrEqual(0);
+    expect(spPrIdx).toBeGreaterThan(showKeysIdx);
+    expect(txPrIdx).toBeGreaterThan(spPrIdx);
+  });
+
+  it("composes fillColor independently with the four boolean toggles and typography knobs", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          fillColor: "00FF00",
+          fontColor: "FF0000",
+          bold: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:srgbClr val="00FF00"/>');
+    expect(result.chartXml).toContain('<a:srgbClr val="FF0000"/>');
+    expect(result.chartXml).toContain('b="1"');
+  });
+
+  it("threads fillColor through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(makeChart({ type, dataTable: { fillColor: "1070CA" } }), "Sheet1");
+      expect(result.chartXml).toContain(
+        '<c:spPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></c:spPr>',
+      );
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fillColor: "1070CA" },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain(
+      '<c:spPr><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></c:spPr>',
+    );
+  });
+
+  it("silently drops fillColor on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fillColor: "FF0000" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("silently drops fillColor on doughnut charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "doughnut",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { fillColor: "FF0000" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("round-trips a pinned dataTable fillColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          fillColor: "F2F2F2",
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      fillColor: "F2F2F2",
+    });
+  });
+
+  it("does not leak the dataTable fillColor into plotArea or chartSpace fill slots", () => {
+    // The fillColor lives on <c:dTable><c:spPr>, which is distinct from
+    // <c:plotArea><c:spPr> (plotAreaFillColor) and <c:chartSpace><c:spPr>
+    // (chartSpaceFillColor). The reader scopes the lookup to direct
+    // children of <c:dTable> so a stray write here cannot leak into the
+    // sibling fields.
+    const written = writeChart(
+      makeChart({ dataTable: { fillColor: "ABCDEF" } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.fillColor).toBe("ABCDEF");
+    expect(reparsed?.plotAreaFillColor).toBeUndefined();
+    expect(reparsed?.chartSpaceFillColor).toBeUndefined();
+  });
+
+  it("composes dataTable.fillColor with plotAreaFillColor on different host elements", () => {
+    // The two knobs land on different <c:spPr> blocks — the data-table
+    // fill paints the table grid background, the plot-area fill paints
+    // the inner band that hosts the series. A caller can pin both with
+    // no conflict.
+    const written = writeChart(
+      makeChart({
+        plotAreaFillColor: "111111",
+        dataTable: { fillColor: "222222" },
+      }),
+      "Sheet1",
+    ).chartXml;
+    expect(written).toContain('<a:srgbClr val="111111"/>');
+    expect(written).toContain('<a:srgbClr val="222222"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaFillColor).toBe("111111");
+    expect(reparsed?.dataTable?.fillColor).toBe("222222");
+  });
+
+  it("threads fillColor end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, fillColor: "AABBCC" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain(
+      '<c:spPr><a:solidFill><a:srgbClr val="AABBCC"/></a:solidFill></c:spPr>',
+    );
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.fillColor).toBe("AABBCC");
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -11051,6 +11051,213 @@ describe("parseChart — data table", () => {
       fontFamily: "Calibri",
     });
   });
+
+  // ── data-table fill color (parseDataTableFillColor) ────────────────
+
+  it("surfaces a pinned dataTable.fillColor from <c:spPr><a:solidFill><a:srgbClr val='RRGGBB'/>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fillColor).toBe("F2F2F2");
+  });
+
+  it("uppercases a lower-case srgbClr val on the <c:dTable><c:spPr> slot", () => {
+    // The reader collapses any case to OOXML canonical uppercase so a
+    // parsed value flows directly into cloneChart without conversion.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fillColor).toBe("ABCDEF");
+  });
+
+  it("surfaces undefined when <c:spPr> is absent on <c:dTable>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fillColor).toBeUndefined();
+  });
+
+  it("collapses malformed srgbClr val tokens to undefined", () => {
+    // Wrong length (4 hex chars) and non-hex chars both drop the field.
+    const wrongLen = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="ABCD"/></a:solidFill></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(wrongLen)?.dataTable?.fillColor).toBeUndefined();
+    const nonHex = wrongLen.replace('val="ABCD"', 'val="ZZZZZZ"');
+    expect(parseChart(nonHex)?.dataTable?.fillColor).toBeUndefined();
+  });
+
+  it("collapses an alpha-channel srgbClr val to undefined", () => {
+    // The OOXML schema places alpha on <a:alpha>, not on the val token,
+    // so an 8-char val token is malformed for srgbClr.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fillColor).toBeUndefined();
+  });
+
+  it("collapses theme-color <a:schemeClr> references to undefined", () => {
+    // Theme references cannot round-trip losslessly to <a:srgbClr> so
+    // the reader drops them rather than fabricate a value Excel would
+    // render differently.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.fillColor).toBeUndefined();
+  });
+
+  it("collapses non-solid fills to undefined (noFill / gradFill / pattFill / blipFill)", () => {
+    const head = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>`;
+    const tail = `</c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const noFill = `${head}<c:spPr><a:noFill/></c:spPr>${tail}`;
+    expect(parseChart(noFill)?.dataTable?.fillColor).toBeUndefined();
+    const gradFill = `${head}<c:spPr><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs></a:gsLst></a:gradFill></c:spPr>${tail}`;
+    expect(parseChart(gradFill)?.dataTable?.fillColor).toBeUndefined();
+    const pattFill = `${head}<c:spPr><a:pattFill prst="dkDnDiag"><a:fgClr><a:srgbClr val="FF0000"/></a:fgClr></a:pattFill></c:spPr>${tail}`;
+    expect(parseChart(pattFill)?.dataTable?.fillColor).toBeUndefined();
+    const blipFill = `${head}<c:spPr><a:blipFill><a:blip/></a:blipFill></c:spPr>${tail}`;
+    expect(parseChart(blipFill)?.dataTable?.fillColor).toBeUndefined();
+  });
+
+  it("does not leak a sibling plotArea / chartSpace <c:spPr> into dataTable.fillColor", () => {
+    // The reader scopes the lookup to direct children of <c:dTable> so
+    // a stray <c:spPr> on <c:plotArea> / <c:chartSpace> cannot leak in.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+    <c:spPr><a:solidFill><a:srgbClr val="111111"/></a:solidFill></c:spPr>
+  </c:plotArea></c:chart>
+  <c:spPr><a:solidFill><a:srgbClr val="222222"/></a:solidFill></c:spPr>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataTable?.fillColor).toBeUndefined();
+    expect(chart?.plotAreaFillColor).toBe("111111");
+    expect(chart?.chartSpaceFillColor).toBe("222222");
+  });
+
+  it("composes dataTable.fillColor with the four boolean toggles and typography knobs in a single dTable block", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="0"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="0"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill></c:spPr>
+      <c:txPr>
+        <a:bodyPr/>
+        <a:lstStyle/>
+        <a:p><a:pPr><a:defRPr b="1"><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:defRPr></a:pPr><a:endParaRPr lang="en-US"/></a:p>
+      </c:txPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: false,
+      showVertBorder: true,
+      showOutline: false,
+      showKeys: true,
+      fillColor: "F2F2F2",
+      fontColor: "1070CA",
+      bold: true,
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────


### PR DESCRIPTION
## Summary

Adds `fillColor?: string` on `ChartDataTable`, mapped to `<c:dTable><c:spPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></c:spPr></c:dTable>` per CT_DTable (ECMA-376 Part 1, §21.2.2.54) — Excel's "Format Data Table -> Fill -> Solid fill -> Color" picker. Joins the same `<c:spPr>` family as `plotAreaFillColor` (#302), `legendFillColor` (#303), `titleFillColor` (#304), `chartSpaceFillColor` (#305), and `axisTitleFillColor` (#306) but on the data-table host element, painting the cell-grid backgrounds beneath the series-name / value text.

- **Writer** — emits `<c:spPr>` after the four required boolean children (`<c:showHorzBorder>`, `<c:showVertBorder>`, `<c:showOutline>`, `<c:showKeys>`) and before the optional `<c:txPr>` per the CT_DTable schema sequence; malformed tokens (wrong length, non-hex, alpha-channel, empty / non-string) collapse to no `<c:spPr>` so a fresh data table matches Excel's reference shape byte-for-byte; accepts a leading `#` and any case, normalizing to the OOXML canonical 6-character uppercase form.
- **Reader** — surfaces only the literal `<a:srgbClr>` form on `<c:dTable><c:spPr>`; non-solid fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`) and theme references (`<a:schemeClr>`) all drop to `undefined`. Lookup is scoped to direct children of `<c:dTable>` so a stray `<c:spPr>` on `<c:plotArea>` / `<c:chartSpace>` cannot leak in.
- **Clone-through** — inherits via the existing wholesale-replace path on the `dataTable` object — `undefined` (or omitted) inherits, `null` drops, an object replaces. Pie / doughnut clones drop the field along with the rest of the data-table block because the OOXML schema places `<c:dTable>` inside `<c:plotArea>` alongside the axes and pie / doughnut have no axes at all.
- **Independent of `plotAreaFillColor` / `chartSpaceFillColor`** — the data-table fill paints the cell-grid backgrounds, while the plot-area / chart-space fills paint the inner band / entire chart frame. A caller can pin all three with no conflict since each `<c:spPr>` block lands on a different host element. The fill knob is also independent of the `<c:txPr>` typography knobs (fontColor, bold, italic, etc.) — fill paints the background, typography tints the text drawn over it, so a caller can pin both without conflict.

31 new tests across writer / reader / clone-through (writer 13, reader 9, clone 9), including a `writeXlsx` round-trip, the `<a:schemeClr>` / `<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>` non-solid-fill drop paths, schema-order verification (`<c:spPr>` between booleans and `<c:txPr>`), and isolation tests that confirm a stray plot-area / chart-space `<c:spPr>` does not leak into this field.

Refs #136

## Test plan

- [x] \`pnpm vitest run\` (all 6570 tests pass — 31 new vs. 6539 baseline)
- [x] \`pnpm typecheck\` (clean)
- [x] \`pnpm build\` (clean)
- [x] \`pnpm lint\` (no new errors; 45 pre-existing warnings only; oxfmt clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)