### PR TITLE
feat(xlsx): chart data-labels fill color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -891,6 +891,49 @@ export interface ChartDataLabels {
    * {@link strikethrough} / {@link fontSize} / {@link fontColor}.
    */
   fontFamily?: string;
+  /**
+   * Data-labels background fill (solid). Maps to `<c:dLbls><c:spPr>
+   * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
+   * </c:dLbls>` — Excel's "Format Data Labels -> Fill -> Solid fill ->
+   * Color" picker. The OOXML `<c:spPr>` block sits on `CT_DLbls` between
+   * `<c:numFmt>` and `<c:txPr>` per the schema sequence (ECMA-376
+   * Part 1, §21.2.2.50); the `<a:srgbClr val=".."/>` carries the
+   * 6-character uppercase hex sRGB color (`CT_SRgbColor` inside
+   * `CT_ShapeProperties`' fill choice — ECMA-376 Part 1, §20.1.2.3.32 /
+   * §20.1.8.54).
+   *
+   * Accepts a 6-character hex string with or without a leading `#`,
+   * any case (`"FF0000"`, `"#1070ca"`, `"abcdef"`); the writer
+   * normalizes to the OOXML canonical 6-character uppercase form
+   * (`"FF0000"`, `"1070CA"`, `"ABCDEF"`) so a re-parse round-trips
+   * losslessly. Malformed inputs (wrong length, non-hex characters,
+   * alpha-channel forms like `"FFAA0080"`, empty / whitespace-only
+   * strings, non-string escapes from an untyped caller) collapse to
+   * `undefined` and the writer skips the entire `<c:spPr>` block —
+   * the data labels render with no background fill (Excel's reference
+   * shape for fresh data labels whose fill has not been pinned).
+   *
+   * Default: omitted — the data labels render with no `<c:spPr>` block
+   * (Excel's reference serialization for fresh data labels whose fill
+   * has not been customized — typically a transparent label background).
+   *
+   * Distinct from {@link fontColor} (the typography color living on
+   * `<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>`); the two knobs target
+   * different children of `<c:dLbls>` so a caller can pin both without
+   * conflict — {@link fillColor} paints the label box background while
+   * {@link fontColor} paints the text glyphs. Mirrors the chart-title
+   * `titleFillColor` / axis-title `axisTitleFillColor` / plot-area
+   * `plotAreaFillColor` / legend `legendFillColor` knobs — same
+   * accept-with-or-without-`#` hex grammar, same OOXML
+   * `<c:spPr><a:solidFill><a:srgbClr val=".."/>` mapping — so a caller
+   * can thread a single hex string through every fill-pinning slot.
+   * Composes independently with the other dLbls knobs — {@link position}
+   * / {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles / {@link bold} / {@link italic} /
+   * {@link underline} / {@link strikethrough} / {@link fontSize} /
+   * {@link fontColor} / {@link fontFamily}.
+   */
+  fillColor?: string;
 }
 
 /**
@@ -5617,6 +5660,28 @@ export interface ChartDataLabelsInfo {
    * straight into {@link cloneChart} without conversion.
    */
   fontFamily?: string;
+  /**
+   * Data-labels background fill pulled from `<c:dLbls><c:spPr>
+   * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
+   * </c:dLbls>`. The OOXML `<c:spPr>` block sits on `CT_DLbls` between
+   * `<c:numFmt>` and `<c:txPr>` per the schema sequence (ECMA-376
+   * Part 1, §21.2.2.50); the `<a:srgbClr val=".."/>` carries the
+   * 6-character uppercase hex sRGB color (`CT_SRgbColor` inside
+   * `CT_ShapeProperties`' fill choice — ECMA-376 Part 1, §20.1.2.3.32 /
+   * §20.1.8.54).
+   *
+   * Returned as the canonical 6-character uppercase hex string when
+   * the parser walks the full chain and lands on an `<a:srgbClr
+   * val="RRGGBB"/>`. Theme references (`<a:schemeClr>`),
+   * `<a:hslClr>`, `<a:sysClr>`, `<a:prstClr>`, non-solid fills
+   * (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` / `<a:blipFill>`),
+   * and malformed `val` tokens (wrong length, non-hex characters) all
+   * collapse to `undefined` since only the literal RGB triple
+   * round-trips losslessly through {@link writeChart}. Mirrors the
+   * writer-side {@link ChartDataLabels.fillColor} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   */
+  fillColor?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -3003,6 +3003,19 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const fontFamily = parseDataLabelsFontFamily(el);
   if (fontFamily !== undefined) out.fontFamily = fontFamily;
 
+  // `<c:spPr><a:solidFill><a:srgbClr val=".."/></a:solidFill></c:spPr>`
+  // — data-labels background fill pinned via Excel's "Format Data Labels
+  // -> Fill -> Solid fill -> Color" picker. Theme references
+  // (`<a:schemeClr>`), non-solid fills (`<a:noFill>` / `<a:gradFill>` /
+  // `<a:pattFill>` / `<a:blipFill>`), and malformed `val` tokens
+  // collapse to `undefined` since only the literal RGB triple
+  // round-trips losslessly through `writeChart`. Distinct from
+  // `fontColor` (which lives on `<c:txPr><a:p><a:pPr><a:defRPr>
+  // <a:solidFill>`); the two knobs target different children of
+  // `<c:dLbls>` so a caller can pin both without conflict.
+  const fillColor = parseDataLabelsFillColor(el);
+  if (fillColor !== undefined) out.fillColor = fillColor;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -3020,7 +3033,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.italic === undefined &&
     out.underline === undefined &&
     out.strikethrough === undefined &&
-    out.fontFamily === undefined
+    out.fontFamily === undefined &&
+    out.fillColor === undefined
   ) {
     return undefined;
   }
@@ -3260,6 +3274,42 @@ function parseDataLabelsFontFamily(dLbls: XmlElement): string | undefined {
   const trimmed = raw.trim();
   if (trimmed.length === 0) return undefined;
   return trimmed;
+}
+
+/**
+ * Pull `<c:dLbls><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr></c:dLbls>` off a data-labels block. Returns
+ * the 6-character uppercase hex string when the parser walks the full
+ * chain and lands on an `<a:srgbClr val="RRGGBB"/>`. Theme references
+ * (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and `<a:prstClr>`
+ * all collapse to `undefined` — only the literal RGB triple
+ * round-trips losslessly through {@link writeChart}. Non-solid fills
+ * (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`, `<a:blipFill>`)
+ * likewise drop to `undefined` so a round-trip never fabricates a fill
+ * the writer cannot reproduce on emit. Malformed `val` tokens (wrong
+ * length, non-hex characters) drop to `undefined` rather than fabricate
+ * a value the writer would round-trip into a malformed `<a:srgbClr>`.
+ *
+ * The OOXML `<c:spPr>` block sits on `CT_DLbls` between `<c:numFmt>`
+ * and `<c:txPr>` per the schema sequence (ECMA-376 Part 1,
+ * §21.2.2.50). Distinct from {@link parseDataLabelsFontColor}: the
+ * fill lives on `<c:dLbls><c:spPr>`, the font color lives on
+ * `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>` — the two
+ * readers walk disjoint paths so a caller can pin both knobs without
+ * conflict. Mirrors the chart-title fill {@link parseTitleFillColor} /
+ * axis-title fill {@link parseAxisTitleFillColor} / plot-area fill
+ * {@link parsePlotAreaFillColor} / legend fill
+ * {@link parseLegendFillColor} so a parsed value slots straight into
+ * the writer-side {@link ChartDataLabels.fillColor}.
+ */
+function parseDataLabelsFillColor(dLbls: XmlElement): string | undefined {
+  const spPr = findChild(dLbls, "spPr");
+  if (!spPr) return undefined;
+  const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -4825,10 +4825,25 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
     );
   }
 
+  // `<c:spPr>` sits between `<c:numFmt>` and `<c:txPr>` in the
+  // CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). Currently
+  // the writer only authors `<a:solidFill>` here from
+  // {@link ChartDataLabels.fillColor}; stroke (`<a:ln>`) and other
+  // `CT_ShapeProperties` children are not modelled at this layer. The
+  // builder skips emission entirely when no fill is pinned so a fresh
+  // chart matches Excel's reference shape (no `<c:spPr>` block on a
+  // theme-default data-labels rendering — typically a transparent label
+  // background). Distinct from the `<a:defRPr><a:solidFill>` font-color
+  // slot inside `<c:txPr>` that {@link ChartDataLabels.fontColor} pins
+  // — the two knobs target different children of `<c:dLbls>` so a
+  // caller can pin both without conflict.
+  const spPrXml = buildDataLabelsSpPr(resolveDataLabelsFillColor(dl.fillColor));
+  if (spPrXml !== undefined) {
+    children.push(spPrXml);
+  }
+
   // CT_DLbls schema places `<c:txPr>` between `<c:spPr>` and
-  // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The writer currently
-  // skips `<c:spPr>` (not yet authored), so `<c:txPr>` lands directly
-  // after `<c:numFmt>` and before `<c:dLblPos>`. The block currently
+  // `<c:dLblPos>` (ECMA-376 Part 1, §21.2.2.50). The block currently
   // carries the data-label font size, font color, bold flag, italic
   // flag, underline flag, strikethrough flag, and font family — every
   // typography pin lands on the same `<a:defRPr>` slot. The writer
@@ -5032,6 +5047,50 @@ function resolveDataLabelsFontFamily(value: string | undefined): string | undefi
   const trimmed = value.trim();
   if (trimmed.length === 0) return undefined;
   return trimmed;
+}
+
+/**
+ * Resolve `<c:dLbls><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr></c:dLbls>` from {@link ChartDataLabels.fillColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches the chart-title /
+ * axis-title / plot-area / legend / data-label color resolvers
+ * exactly. Distinct from {@link resolveDataLabelsFontColor}: the fill
+ * lives on `<c:dLbls><c:spPr>`, the font color lives on
+ * `<c:dLbls><c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>` — the two
+ * resolvers feed disjoint slots so a caller can pin both without
+ * conflict.
+ */
+function resolveDataLabelsFillColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
+ * Build the `<c:spPr>` block that carries a data-labels' background
+ * fill. Returns `undefined` when no fill is pinned so the caller can
+ * elide the entire block — Excel's reference serialization omits
+ * `<c:spPr>` from `<c:dLbls>` whenever the labels render at the theme
+ * default fill (typically a transparent label background).
+ *
+ * The emitted block mirrors the minimal `<c:spPr>` shape Excel writes
+ * when the user pins "Format Data Labels -> Fill -> Solid fill ->
+ * Color": `<c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></c:spPr>`. The `val` attribute holds the canonical
+ * 6-character uppercase hex form (the writer normalizes the input
+ * ahead of this call so a malformed source value never reaches emit).
+ *
+ * Mirrors the chart-title / axis-title / plot-area / legend
+ * `<c:spPr>` slots so a single hex string threads cleanly through
+ * every fill knob the writer authors.
+ */
+function buildDataLabelsSpPr(fillRgbHex: string | undefined): string | undefined {
+  if (fillRgbHex === undefined) return undefined;
+  return xmlElement("c:spPr", undefined, [
+    xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
+  ]);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -22127,9 +22127,10 @@ describe("cloneChart — dataLabels.fillColor", () => {
     const parsed = parseChart(written)!;
     expect(parsed.series?.[0]?.dataLabels?.fillColor).toBe("A1B2C3");
     const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
-    expect(clone.series?.[0]?.dataLabels).toBeTruthy();
-    if (clone.series?.[0]?.dataLabels && clone.series[0].dataLabels !== false) {
-      expect(clone.series[0].dataLabels.fillColor).toBe("A1B2C3");
+    const cloneDataLabels = clone.series?.[0]?.dataLabels;
+    expect(cloneDataLabels).toBeTruthy();
+    if (cloneDataLabels) {
+      expect(cloneDataLabels.fillColor).toBe("A1B2C3");
     }
   });
 });

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -21929,3 +21929,207 @@ describe("cloneChart — axisTitleFillColor", () => {
     expect(clone.axes?.x?.axisTitleFillColor).toBe("FFFF00");
   });
 });
+
+// ── cloneChart — dataLabels.fillColor ───────────────────────────────
+
+describe("cloneChart — dataLabels.fillColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.fillColor by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.fillColor).toBe("FFFF00");
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, fillColor: "00C586" },
+    });
+    expect(clone.dataLabels?.fillColor).toBe("00C586");
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes independently with fontColor on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          fillColor: "FFEEDD",
+          fontColor: "112233",
+          position: "outEnd",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.fillColor).toBe("FFEEDD");
+    expect(clone.dataLabels?.fontColor).toBe("112233");
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.showValue).toBe(true);
+  });
+
+  it("propagates dataLabels.fillColor into the rendered <c:dLbls><c:spPr> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:spPr>");
+    expect(written).toContain('<a:srgbClr val="FFFF00"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fillColor).toBe("FFFF00");
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, fillColor: "00C586" },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<a:srgbClr val="00C586"/>');
+    expect(written).not.toContain('<a:srgbClr val="FFFF00"/>');
+    expect(parseChart(written)?.dataLabels?.fillColor).toBe("00C586");
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:spPr> on dLbls)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.fillColor through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.fillColor).toBe("FFFF00");
+  });
+
+  it("carries dataLabels.fillColor through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, fillColor: "FFFF00" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.fillColor).toBe("FFFF00");
+  });
+
+  it("round-trips a parsed dataLabels.fillColor straight back through cloneChart", () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [{ values: "B2:B5", categories: "A2:A5" }],
+        anchor: { from: { row: 0, col: 0 } },
+        dataLabels: { showValue: true, fillColor: "FFFF00" },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.dataLabels?.fillColor).toBe("FFFF00");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels?.fillColor).toBe("FFFF00");
+  });
+
+  it("round-trips a per-series dataLabels.fillColor through cloneChart", async () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [
+          {
+            values: "B2:B5",
+            categories: "A2:A5",
+            dataLabels: { showValue: true, fillColor: "A1B2C3" },
+          },
+        ],
+        anchor: { from: { row: 0, col: 0 } },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.series?.[0]?.dataLabels?.fillColor).toBe("A1B2C3");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.series?.[0]?.dataLabels).toBeTruthy();
+    if (clone.series?.[0]?.dataLabels && clone.series[0].dataLabels !== false) {
+      expect(clone.series[0].dataLabels.fillColor).toBe("A1B2C3");
+    }
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -20681,3 +20681,235 @@ describe("writeChart — axisTitleFillColor", () => {
     expect(reparsed?.axes?.y?.axisTitleFillColor).toBe("00C586");
   });
 });
+
+// ── writeChart — dataLabels.fillColor (solid fill) ───────────────────
+
+describe("writeChart — dataLabels.fillColor", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:spPr> on <c:dLbls> when fillColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:spPr>");
+  });
+
+  it('threads fillColor through to <c:dLbls><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>', () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "FFFF00" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).toContain('<a:srgbClr val="FFFF00"/>');
+    expect(dLbls).toContain("<c:spPr><a:solidFill><a:srgbClr");
+  });
+
+  it("normalizes a leading # in the input hex string", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "#1070CA" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:srgbClr val="1070CA"/>');
+  });
+
+  it("normalizes a lowercase hex string to the OOXML uppercase canonical form", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "abcdef" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("places <c:spPr> after <c:numFmt> and before <c:txPr> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          fillColor: "FFEEDD",
+          fontColor: "112233",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:spPr"));
+    expect(dLbls.indexOf("c:spPr")).toBeLessThan(dLbls.indexOf("c:txPr"));
+  });
+
+  it("places <c:spPr> before <c:dLblPos> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, fillColor: "112233", position: "outEnd" },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:spPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:spPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "112233" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads fillColor through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, fillColor: "445566" } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain("<c:spPr>");
+      expect(dLbls).toContain('<a:srgbClr val="445566"/>');
+    }
+  });
+
+  it("composes independently with fontColor (different children of <c:dLbls>)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, fillColor: "FFEEDD", fontColor: "112233" },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('<a:srgbClr val="FFEEDD"/>');
+    expect(dLbls).toContain('<a:srgbClr val="112233"/>');
+  });
+
+  it("drops malformed hex inputs (wrong length)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "FF00" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops malformed hex inputs (non-hex characters)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "ZZZZZZ" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops alpha-channel hex forms", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "#FF0000FF" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops empty / whitespace-only string inputs", () => {
+    expect(
+      dLblsOf(
+        writeChart(makeChart({ dataLabels: { showValue: true, fillColor: "" } }), "Sheet1").chartXml,
+      ),
+    ).not.toContain("<c:spPr>");
+    expect(
+      dLblsOf(
+        writeChart(makeChart({ dataLabels: { showValue: true, fillColor: "   " } }), "Sheet1")
+          .chartXml,
+      ),
+    ).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fillColor: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, fillColor: 0xff0000 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("does not emit <c:txPr> when only fillColor is set (typography slot stays empty)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "ABCDEF" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).not.toContain("<c:txPr>");
+  });
+
+  it("threads fillColor through a per-series dLbls block", () => {
+    const result = writeChart(
+      makeChart({
+        series: [
+          {
+            name: "Revenue",
+            values: "B2:B4",
+            categories: "A2:A4",
+            dataLabels: { showValue: true, fillColor: "ABCDEF" },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("round-trips a fillColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, fillColor: "FF8800" } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fillColor).toBe("FF8800");
+  });
+
+  it("collapses an unset fillColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.fillColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.fillColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, fillColor: "0F0F0F" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:srgbClr val="0F0F0F"/>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.fillColor).toBe("0F0F0F");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -20815,7 +20815,8 @@ describe("writeChart — dataLabels.fillColor", () => {
   it("drops empty / whitespace-only string inputs", () => {
     expect(
       dLblsOf(
-        writeChart(makeChart({ dataLabels: { showValue: true, fillColor: "" } }), "Sheet1").chartXml,
+        writeChart(makeChart({ dataLabels: { showValue: true, fillColor: "" } }), "Sheet1")
+          .chartXml,
       ),
     ).not.toContain("<c:spPr>");
     expect(

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20601,3 +20601,208 @@ describe("parseChart — axisTitleFillColor", () => {
     expect(parseChart(xml)?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
   });
 });
+
+// ── parseChart — dataLabelsFillColor ────────────────────────────────
+
+describe("parseChart — dataLabelsFillColor", () => {
+  const NS_DLFC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_DLFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:spPr>${spPrBody}</c:spPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces fillColor as the canonical 6-character uppercase hex", () => {
+    expect(parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>`))?.dataLabels?.fillColor).toBe(
+      "FFFF00",
+    );
+  });
+
+  it("normalizes a lowercase srgbClr val to the OOXML uppercase canonical form", () => {
+    expect(parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="abcdef"/></a:solidFill>`))?.dataLabels?.fillColor).toBe(
+      "ABCDEF",
+    );
+  });
+
+  it("returns undefined when the dLbls block has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_DLFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fillColor).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:dLbls> element at all", () => {
+    const xml = `<c:chartSpace ${NS_DLFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels).toBeUndefined();
+  });
+
+  it("collapses theme references (<a:schemeClr>) to undefined — only literal RGB round-trips", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:schemeClr val="accent1"/></a:solidFill>`))?.dataLabels?.fillColor,
+    ).toBeUndefined();
+  });
+
+  it("collapses non-solid fills (<a:noFill>) to undefined", () => {
+    expect(parseChart(withDLblsSpPr(`<a:noFill/>`))?.dataLabels?.fillColor).toBeUndefined();
+  });
+
+  it("collapses gradient fills (<a:gradFill>) to undefined", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:gradFill><a:gsLst/><a:lin ang="0" scaled="1"/></a:gradFill>`))?.dataLabels
+        ?.fillColor,
+    ).toBeUndefined();
+  });
+
+  it("collapses pattern fills (<a:pattFill>) to undefined", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:pattFill prst="pct5"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill>`))
+        ?.dataLabels?.fillColor,
+    ).toBeUndefined();
+  });
+
+  it("collapses malformed val tokens (wrong length / non-hex / alpha) to undefined", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val=""/></a:solidFill>`))?.dataLabels?.fillColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FF00"/></a:solidFill>`))?.dataLabels?.fillColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill>`))?.dataLabels?.fillColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="ZZZZZZ"/></a:solidFill>`))?.dataLabels?.fillColor,
+    ).toBeUndefined();
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / fontColor)", () => {
+    const xml = `<c:chartSpace ${NS_DLFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:spPr><a:solidFill><a:srgbClr val="FFEEDD"/></a:solidFill></c:spPr>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="112233"/></a:solidFill></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.fillColor).toBe("FFEEDD");
+    expect(chart?.dataLabels?.fontColor).toBe("112233");
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the fillColor on a fillColor-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:spPr><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></c:spPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.fillColor).toBe("00FF00");
+  });
+
+  it("surfaces fillColor on a per-series <c:dLbls> block", () => {
+    const xml = `<c:chartSpace ${NS_DLFC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:dLbls>
+            <c:spPr><a:solidFill><a:srgbClr val="A1B2C3"/></a:solidFill></c:spPr>
+            <c:showLegendKey val="0"/>
+            <c:showVal val="1"/>
+            <c:showCatName val="0"/>
+            <c:showSerName val="0"/>
+            <c:showPercent val="0"/>
+            <c:showBubbleSize val="0"/>
+          </c:dLbls>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0]?.dataLabels?.fillColor).toBe("A1B2C3");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20631,15 +20631,17 @@ describe("parseChart — dataLabelsFillColor", () => {
   }
 
   it("surfaces fillColor as the canonical 6-character uppercase hex", () => {
-    expect(parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>`))?.dataLabels?.fillColor).toBe(
-      "FFFF00",
-    );
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>`))?.dataLabels
+        ?.fillColor,
+    ).toBe("FFFF00");
   });
 
   it("normalizes a lowercase srgbClr val to the OOXML uppercase canonical form", () => {
-    expect(parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="abcdef"/></a:solidFill>`))?.dataLabels?.fillColor).toBe(
-      "ABCDEF",
-    );
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="abcdef"/></a:solidFill>`))?.dataLabels
+        ?.fillColor,
+    ).toBe("ABCDEF");
   });
 
   it("returns undefined when the dLbls block has no <c:spPr>", () => {
@@ -20682,7 +20684,8 @@ describe("parseChart — dataLabelsFillColor", () => {
 
   it("collapses theme references (<a:schemeClr>) to undefined — only literal RGB round-trips", () => {
     expect(
-      parseChart(withDLblsSpPr(`<a:solidFill><a:schemeClr val="accent1"/></a:solidFill>`))?.dataLabels?.fillColor,
+      parseChart(withDLblsSpPr(`<a:solidFill><a:schemeClr val="accent1"/></a:solidFill>`))
+        ?.dataLabels?.fillColor,
     ).toBeUndefined();
   });
 
@@ -20692,30 +20695,37 @@ describe("parseChart — dataLabelsFillColor", () => {
 
   it("collapses gradient fills (<a:gradFill>) to undefined", () => {
     expect(
-      parseChart(withDLblsSpPr(`<a:gradFill><a:gsLst/><a:lin ang="0" scaled="1"/></a:gradFill>`))?.dataLabels
-        ?.fillColor,
+      parseChart(withDLblsSpPr(`<a:gradFill><a:gsLst/><a:lin ang="0" scaled="1"/></a:gradFill>`))
+        ?.dataLabels?.fillColor,
     ).toBeUndefined();
   });
 
   it("collapses pattern fills (<a:pattFill>) to undefined", () => {
     expect(
-      parseChart(withDLblsSpPr(`<a:pattFill prst="pct5"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill>`))
-        ?.dataLabels?.fillColor,
+      parseChart(
+        withDLblsSpPr(
+          `<a:pattFill prst="pct5"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill>`,
+        ),
+      )?.dataLabels?.fillColor,
     ).toBeUndefined();
   });
 
   it("collapses malformed val tokens (wrong length / non-hex / alpha) to undefined", () => {
     expect(
-      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val=""/></a:solidFill>`))?.dataLabels?.fillColor,
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val=""/></a:solidFill>`))?.dataLabels
+        ?.fillColor,
     ).toBeUndefined();
     expect(
-      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FF00"/></a:solidFill>`))?.dataLabels?.fillColor,
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FF00"/></a:solidFill>`))?.dataLabels
+        ?.fillColor,
     ).toBeUndefined();
     expect(
-      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill>`))?.dataLabels?.fillColor,
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill>`))
+        ?.dataLabels?.fillColor,
     ).toBeUndefined();
     expect(
-      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="ZZZZZZ"/></a:solidFill>`))?.dataLabels?.fillColor,
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="ZZZZZZ"/></a:solidFill>`))?.dataLabels
+        ?.fillColor,
     ).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

- Add `fillColor?: string` to `ChartDataLabels` (write) and `ChartDataLabelsInfo` (read), mapped to `<c:dLbls><c:spPr><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></c:spPr></c:dLbls>` per `CT_DLbls` (ECMA-376 Part 1, §21.2.2.50) — Excel's "Format Data Labels -> Fill -> Solid fill -> Color" picker.
- Writer emits `<c:spPr>` between `<c:numFmt>` and `<c:txPr>` per the CT_DLbls schema sequence; reuses `normalizeTitleColor` so the accept-with-or-without-`#` hex grammar matches every other fill resolver. Reader surfaces only the literal `<a:srgbClr>` form — non-solid fills (`noFill` / `gradFill` / `pattFill` / `blipFill`) and theme references (`schemeClr`) collapse to `undefined` so a round-trip never fabricates a fill the writer cannot reproduce.
- `cloneChart` threads the field through automatically via the existing `{...sourceLabels}` spread in `resolveChartDataLabels` / `resolveSeriesDataLabels` — composes independently with `fontColor` (different children of `<c:dLbls>`).

Mirrors the `<c:spPr><a:solidFill>` family progress: #302 plotArea, #303 legend, #304 title, #305 chartSpace, #306 axisTitle, #307 dataTable.

## Test plan

- [x] `pnpm vitest run --dir=test` (6638 passed; 44 new tests across read, write, clone-through, and `writeXlsx` round-trip)
- [x] `pnpm build` (obuild — clean)
- [x] Reader: literal sRGB / lowercase normalization / no-spPr / no-dLbls / theme `schemeClr` / non-solid `noFill` / `gradFill` / `pattFill` / malformed val / co-surfacing with other dLbls fields / per-series dLbls block
- [x] Writer: omit when unset / threading / `#`-prefix / case normalization / CT_DLbls element ordering relative to `numFmt` / `txPr` / `dLblPos` / malformed input drops / per-series dLbls / round-trip via `parseChart` and `writeXlsx`
- [x] Clone: inherit / replace / null-drop / flatten across families / round-trip from `parseChart`

Refs #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)