### PR TITLE
feat(xlsx): chart plot-area border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2332,6 +2332,51 @@ export interface SheetChart {
    */
   plotAreaFillColor?: string;
   /**
+   * Plot-area border (stroke) solid color as a 6-digit RGB hex string
+   * (e.g. `"1F77B4"`). Maps to `<c:plotArea><c:spPr><a:ln><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:plotArea>`
+   * — Excel's "Format Plot Area -> Border -> Solid line -> Color"
+   * picker. The OOXML `<a:srgbClr val=".."/>` carries the 6-character
+   * uppercase hex sRGB color (`CT_SRgbColor` inside the line's solid
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The
+   * `<c:spPr>` slot lives at the tail of `<c:plotArea>` per
+   * `CT_PlotArea` (ECMA-376 Part 1, §21.2.2.145), after every chart-type
+   * element / axes / `<c:dTable>`; `<a:ln>` follows the optional
+   * `<a:solidFill>` (fill) child inside `<c:spPr>` per
+   * `CT_ShapeProperties` (ECMA-376 Part 1, §20.1.2.3.13).
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the `<a:ln>` block (Excel's reference serialization for a plot
+   * area that inherits the auto-stroke — typically a translucent gray
+   * border or no border depending on the theme).
+   *
+   * Default: omitted — the plot area inherits the auto-stroke Excel
+   * picks from the chart's theme. Pin a hex color to mirror Excel's
+   * "Format Plot Area -> Border -> Solid line" knob and paint a flat
+   * border around the series band — useful for dashboard tiles where
+   * the plot area should be visually framed against the surrounding
+   * chart frame, or to highlight a series band against a busy theme.
+   *
+   * Composes independently with {@link plotAreaFillColor} — the two
+   * knobs land on the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for the fill, `<a:ln>` for the stroke), and the
+   * writer authors a `<c:spPr>` whenever either knob is set. A caller
+   * can pin one without the other; pinning both produces a filled
+   * plot area with a colored border.
+   *
+   * Patterned / gradient strokes are not modelled — only the solid
+   * sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   * Mirrors `plotAreaFillColor` — same accept-with-or-without-`#` hex
+   * grammar, same `<c:spPr>` host element, but lands on the line
+   * (`<a:ln>`) child rather than the fill (`<a:solidFill>`) child.
+   */
+  plotAreaBorderColor?: string;
+  /**
    * Chart-space (entire chart background) solid fill color as a 6-digit
    * RGB hex string (e.g. `"F2F2F2"`). Maps to `<c:chartSpace><c:spPr>
    * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
@@ -7113,6 +7158,39 @@ export interface Chart {
    * surface the fill from in that case.
    */
   plotAreaFillColor?: string;
+  /**
+   * Plot-area border (stroke) solid color pulled from
+   * `<c:plotArea><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+   * </a:solidFill></a:ln></c:spPr></c:plotArea>`. Reflects Excel's
+   * "Format Plot Area -> Border -> Solid line -> Color" picker. The
+   * OOXML `<a:srgbClr val=".."/>` carries the 6-character uppercase
+   * hex sRGB color (`CT_SRgbColor` inside the line's solid fill choice
+   * — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The `<c:spPr>`
+   * slot lives at the tail of `<c:plotArea>` per `CT_PlotArea`
+   * (ECMA-376 Part 1, §21.2.2.145), after every chart-type element /
+   * axes / `<c:dTable>`; `<a:ln>` follows the optional `<a:solidFill>`
+   * fill child inside `<c:spPr>` per `CT_ShapeProperties` (ECMA-376
+   * Part 1, §20.1.2.3.13).
+   *
+   * Reports the 6-character uppercase hex form when the source chart
+   * pinned a literal `<a:srgbClr>` color on `<a:ln>`; absence,
+   * malformed `val` tokens (wrong length, non-hex characters,
+   * alpha-channel forms), non-solid line fills (`<a:noFill>`,
+   * `<a:gradFill>`, `<a:pattFill>`), and theme-color references
+   * (`<a:schemeClr>`) all collapse to `undefined` so absence and an
+   * unrenderable stroke round-trip identically through
+   * {@link cloneChart}. Mirrors the writer-side
+   * {@link SheetChart.plotAreaBorderColor} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:plotArea>` element at all — there is no `<c:spPr>` slot to
+   * surface the stroke from in that case. Composes independently with
+   * {@link plotAreaFillColor} — the two fields surface from the same
+   * `<c:spPr>` block but on different children (`<a:solidFill>` for
+   * fill, `<a:ln><a:solidFill>` for stroke).
+   */
+  plotAreaBorderColor?: string;
   /**
    * Chart-space (entire chart background) solid fill color pulled
    * from `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/>

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -438,6 +438,31 @@ export interface CloneChartOptions {
    */
   plotAreaFillColor?: string | null;
   /**
+   * Override `SheetChart.plotAreaBorderColor`. `undefined` (or omitted)
+   * inherits the source's parsed `plotAreaBorderColor`; `null` drops
+   * the inherited stroke (the writer falls back to the auto-stroke
+   * Excel picks from the chart's theme — no `<a:ln>` block on the plot
+   * area's `<c:spPr>`); a 6-digit RGB hex string replaces it.
+   *
+   * The override runs through the same sRGB normalizer as the writer —
+   * the leading `#` and case are accepted, then the value collapses to
+   * the OOXML canonical uppercase form. Malformed tokens (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` so the cloned
+   * `SheetChart` drops the field rather than carry a value the writer
+   * would silently elide back to absence.
+   *
+   * The grammar mirrors `plotAreaFillColor` so the chart `<c:spPr>`
+   * knobs compose the same way at the call site. Composes
+   * independently with `plotAreaFillColor` — the two knobs land on
+   * the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for fill, `<a:ln>` for stroke), and the writer
+   * emits `<c:spPr>` whenever either knob is set. Like the fill knob,
+   * the border is never gated on a visibility flag — every chart has
+   * a `<c:plotArea>` element to host the stroke.
+   */
+  plotAreaBorderColor?: string | null;
+  /**
    * Override `SheetChart.chartSpaceFillColor`. `undefined` (or omitted)
    * inherits the source's parsed `chartSpaceFillColor`; `null` drops
    * the inherited fill (the writer emits no `<c:spPr>` block on
@@ -2044,6 +2069,24 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     options.plotAreaFillColor,
   );
   if (resolvedPlotAreaFillColor !== undefined) out.plotAreaFillColor = resolvedPlotAreaFillColor;
+
+  // Plot-area border (stroke) color is independent of the fill — every
+  // chart has a `<c:plotArea>` element to host the `<c:spPr><a:ln>`
+  // slot. `undefined` inherits the source's parsed `plotAreaBorderColor`
+  // (after the writer-side normalizer collapses any malformed token),
+  // `null` drops the inherited stroke (the writer emits no `<a:ln>`
+  // block, the plot area inherits the auto-stroke Excel picks from
+  // the chart's theme), a 6-digit hex string replaces it. Composes
+  // independently with `plotAreaFillColor` — the two knobs share the
+  // `<c:spPr>` host but land on different children (`<a:solidFill>`
+  // for fill, `<a:ln>` for stroke).
+  const resolvedPlotAreaBorderColor = resolvePlotAreaBorderColor(
+    source.plotAreaBorderColor,
+    options.plotAreaBorderColor,
+  );
+  if (resolvedPlotAreaBorderColor !== undefined) {
+    out.plotAreaBorderColor = resolvedPlotAreaBorderColor;
+  }
 
   // Chart-space solid fill color is independent of every visibility
   // flag — every chart has a `<c:chartSpace>` document root to host the
@@ -3794,6 +3837,58 @@ function resolvePlotAreaFillColor(
   if (override === undefined) return normalizePlotAreaFillColor(sourceValue);
   if (override === null) return undefined;
   return normalizePlotAreaFillColor(override);
+}
+
+/**
+ * Normalize a `plotAreaBorderColor` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizePlotAreaBorderColor` — the cloned
+ * shape is guaranteed to round-trip through the writer without
+ * surprise: a leading `#` and any case are accepted, then the value
+ * collapses to the OOXML canonical uppercase form. Malformed inputs
+ * (wrong length, non-hex characters, alpha-channel forms, non-string
+ * escapes from an untyped caller) collapse to `undefined` so the
+ * cloned chart drops the field rather than carry a value the writer
+ * would silently elide back to absence. Mirrors
+ * {@link normalizePlotAreaFillColor} — same hex grammar.
+ */
+function normalizePlotAreaBorderColor(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
+}
+
+/**
+ * Resolve a `plotAreaBorderColor` override.
+ *
+ * `undefined` → inherit the source's parsed `plotAreaBorderColor`
+ *               (after running it through
+ *               {@link normalizePlotAreaBorderColor} so a malformed
+ *               source value drops cleanly).
+ * `null`      → drop the inherited stroke (the writer emits no
+ *               `<a:ln>` block on `<c:plotArea><c:spPr>`, the plot
+ *               area inherits the auto-stroke Excel picks from the
+ *               chart's theme).
+ * `string`    → replace with the normalized 6-character uppercase hex
+ *               form. Malformed overrides collapse to `undefined` via
+ *               the normalizer so the cloned `SheetChart` always
+ *               carries a value the writer will accept.
+ *
+ * The grammar mirrors `plotAreaFillColor` so the chart `<c:spPr>`
+ * knobs compose the same way at the call site. Like the fill knob,
+ * the border is never gated on a visibility flag — every chart has a
+ * `<c:plotArea>` element to host the stroke.
+ */
+function resolvePlotAreaBorderColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizePlotAreaBorderColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizePlotAreaBorderColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -462,6 +462,16 @@ export function parseChart(xml: string): Chart | undefined {
     // round-trip never fabricates a color Excel cannot render.
     const plotAreaFillColor = parsePlotAreaFillColor(plotArea);
     if (plotAreaFillColor !== undefined) out.plotAreaFillColor = plotAreaFillColor;
+
+    // `<c:plotArea><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+    // </a:solidFill></a:ln></c:spPr></c:plotArea>` carries Excel's
+    // "Format Plot Area -> Border -> Solid line -> Color" pin. The
+    // `<a:ln>` block lives inside the same `<c:spPr>` slot as the fill
+    // (`<a:solidFill>`), per CT_ShapeProperties — the reader scopes the
+    // lookup so a stray `<a:ln>` elsewhere (on a series, on an axis)
+    // cannot leak into this field.
+    const plotAreaBorderColor = parsePlotAreaBorderColor(plotArea);
+    if (plotAreaBorderColor !== undefined) out.plotAreaBorderColor = plotAreaBorderColor;
   }
 
   const legend = parseLegend(chartEl);
@@ -4092,6 +4102,50 @@ function parsePlotAreaFillColor(plotArea: XmlElement): string | undefined {
   const spPr = findChild(plotArea, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:plotArea><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+ * </a:solidFill></a:ln></c:spPr></c:plotArea>` off the plot-area block.
+ * Returns the line stroke color as a 6-character uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+ * solid fill choice (`CT_LineProperties`, §20.1.2.3.24) which itself
+ * sits inside `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The
+ * `<c:spPr>` slot lives at the tail of `<c:plotArea>` per
+ * `CT_PlotArea` (§21.2.2.145), after every chart-type element / axes /
+ * `<c:dTable>`.
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid line fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`),
+ * and theme-color references (`<a:schemeClr>`) all collapse to
+ * `undefined` so a chart that pinned a stroke the writer cannot
+ * reproduce on emit drops the field rather than fabricate one Excel
+ * would render differently. Malformed `val` tokens (wrong length,
+ * non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link SheetChart.plotAreaBorderColor} so a
+ * parsed value slots straight into {@link cloneChart} without
+ * conversion. The lookup is scoped to direct children of
+ * `<c:plotArea>` so a stray `<c:spPr>` elsewhere (e.g. on a series,
+ * on an axis, on the `<c:dTable>` block) cannot leak in. Mirrors
+ * {@link parsePlotAreaFillColor} — same `<c:spPr>` host element on
+ * the same `<c:plotArea>` parent — but lands on the line
+ * (`<a:ln><a:solidFill>`) child rather than the fill
+ * (`<a:solidFill>`) child.
+ */
+function parsePlotAreaBorderColor(plotArea: XmlElement): string | undefined {
+  const spPr = findChild(plotArea, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1297,23 +1297,40 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
 
 /**
  * Build the optional `<c:spPr>` block at the tail of `<c:plotArea>`.
- * Currently surfaces only the solid fill color knob
- * ({@link SheetChart.plotAreaFillColor}) — every other `<c:spPr>` child
- * (`<a:ln>` stroke, `<a:effectLst>` effects, gradient / pattern / picture
- * fills) is intentionally not modelled at this layer.
+ * Surfaces the solid fill color knob
+ * ({@link SheetChart.plotAreaFillColor}) and the border (line) color
+ * knob ({@link SheetChart.plotAreaBorderColor}) — every other `<c:spPr>`
+ * child (`<a:effectLst>` effects, gradient / pattern / picture fills,
+ * line dash / width / compound styles) is intentionally not modelled
+ * at this layer.
  *
- * Returns `undefined` when the chart leaves the field unset / passed a
- * malformed token so the writer skips the entire `<c:spPr>` block — an
- * empty `<c:spPr/>` collapses to the inherited theme fill Excel picks
- * anyway, and omitting it keeps untouched chart XML byte-clean.
+ * Returns `undefined` when both fields are unset / malformed so the
+ * writer skips the entire `<c:spPr>` block — an empty `<c:spPr/>`
+ * collapses to the inherited theme fill / stroke Excel picks anyway,
+ * and omitting it keeps untouched chart XML byte-clean. When at least
+ * one knob lands on the wire, the children are emitted in
+ * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
+ * `<a:ln>` (line / stroke).
  */
 function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
   const fillHex = normalizePlotAreaFillColor(chart.plotAreaFillColor);
-  if (fillHex === undefined) return undefined;
-  const solidFill = xmlElement("a:solidFill", undefined, [
-    xmlSelfClose("a:srgbClr", { val: fillHex }),
-  ]);
-  return xmlElement("c:spPr", undefined, [solidFill]);
+  const borderHex = normalizePlotAreaBorderColor(chart.plotAreaBorderColor);
+  if (fillHex === undefined && borderHex === undefined) return undefined;
+
+  const children: string[] = [];
+  if (fillHex !== undefined) {
+    children.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
+    );
+  }
+  if (borderHex !== undefined) {
+    children.push(
+      xmlElement("a:ln", undefined, [
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderHex })]),
+      ]),
+    );
+  }
+  return xmlElement("c:spPr", undefined, children);
 }
 
 /**
@@ -1333,6 +1350,28 @@ function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
  * sRGB grammar.
  */
 function normalizePlotAreaFillColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.plotAreaBorderColor} value for the
+ * `<c:plotArea><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+ * </a:solidFill></a:ln></c:spPr></c:plotArea>` writer slot. Returns
+ * the 6-character uppercase hex form when the input is a valid sRGB
+ * triple (with or without a leading `#`), or `undefined` for any
+ * malformed token — wrong length, non-hex characters, alpha-channel
+ * forms, or non-string escapes from an untyped caller.
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the `<a:ln>` block and the plot area inherits the
+ * auto-stroke Excel picks from the chart's theme (Excel's reference
+ * behavior for a fresh plot area without a custom border). Delegates
+ * to the chart-level {@link normalizeTitleColor} so every `<a:srgbClr>`
+ * fill / line slot shares the same sRGB grammar. Mirrors
+ * {@link normalizePlotAreaFillColor} — same hex grammar, distinct
+ * writer slot (`<a:ln>` rather than `<a:solidFill>`).
+ */
+function normalizePlotAreaBorderColor(value: string | undefined): string | undefined {
   return normalizeTitleColor(value);
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -20926,6 +20926,160 @@ describe("cloneChart — plotAreaFillColor", () => {
     expect(parseChart(written)?.plotAreaFillColor).toBe("1F77B4");
   });
 });
+
+// ── cloneChart — plotAreaBorderColor (line stroke) ──────────────────
+
+describe("cloneChart — plotAreaBorderColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's plotAreaBorderColor by default", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("lets options.plotAreaBorderColor override the source's value", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: "ABCDEF",
+    });
+    expect(clone.plotAreaBorderColor).toBe("ABCDEF");
+  });
+
+  it("drops the inherited plotAreaBorderColor when the override is null", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: null,
+    });
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined plotAreaBorderColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # and lowercase input through the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: "#1f77b4",
+    });
+    expect(clone.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("drops a malformed override (wrong length)", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: "FFF",
+    });
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("drops a malformed override (non-hex characters)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: "GGGGGG",
+    });
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("drops a malformed override (alpha-channel form)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: "FFAA0080",
+    });
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("drops a non-string override (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      plotAreaBorderColor: 0xff_ff_ff as any,
+    });
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ plotAreaBorderColor: "GGGGGG" as any }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("carries plotAreaBorderColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("retains plotAreaBorderColor independently of a hidden legend", () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with plotAreaFillColor (each lands on its own slot)", () => {
+    const clone = cloneChart(
+      source({
+        plotAreaFillColor: "F2F2F2",
+        plotAreaBorderColor: "1F77B4",
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.plotAreaFillColor).toBe("F2F2F2");
+    expect(clone.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("survives a writeXlsx round trip — plotAreaBorderColor lands in the cloned chart XML", async () => {
+    const clone = cloneChart(source({ plotAreaBorderColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderColor: "1F77B4",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.plotAreaBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── cloneChart — axisTitleLayout (manual placement) ─────────────────
 
 describe("cloneChart — axisTitleLayout", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -19667,6 +19667,196 @@ describe("writeChart — plotAreaFillColor", () => {
     expect(reparsed?.plotAreaFillColor).toBe("F2F2F2");
   });
 });
+
+// ── writeChart — plotAreaBorderColor (line stroke) ──────────────────
+
+describe("writeChart — plotAreaBorderColor", () => {
+  function plotAreaOf(xml: string): string {
+    const m = xml.match(/<c:plotArea>[\s\S]*?<\/c:plotArea>/);
+    if (!m) throw new Error("No <c:plotArea> block found in chart XML");
+    return m[0];
+  }
+
+  it("does not emit <c:spPr> when plotAreaBorderColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+    expect(plotArea).not.toContain("<a:ln>");
+  });
+
+  it("emits <c:spPr><a:ln><a:solidFill><a:srgbClr> when plotAreaBorderColor is set", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "1F77B4" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain("<c:spPr>");
+    expect(plotArea).toContain("<a:ln>");
+    expect(plotArea).toContain('<a:srgbClr val="1F77B4"/>');
+    // The border color must land inside <a:ln>, not as a top-level
+    // <a:solidFill> (that slot is reserved for the fill color knob).
+    const lnIdx = plotArea.indexOf("<a:ln>");
+    const srgbIdx = plotArea.indexOf('<a:srgbClr val="1F77B4"/>');
+    expect(srgbIdx).toBeGreaterThan(lnIdx);
+  });
+
+  it("normalizes a leading # and lowercase hex to the canonical uppercase form", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "#1f77b4" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("places <c:spPr> at the tail of <c:plotArea> (CT_PlotArea sequence)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "1F77B4" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    // <c:spPr> must come after every chart-type element / axes / <c:dTable>.
+    // For a column chart that means after <c:barChart>, <c:catAx>, <c:valAx>.
+    const spPrIdx = plotArea.indexOf("<c:spPr>");
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:barChart"));
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:catAx"));
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:valAx"));
+  });
+
+  it("only emits one <c:spPr> inside <c:plotArea>", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "FFAA00" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    const occurrences = plotArea.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads plotAreaBorderColor through every chart family that owns a <c:plotArea>", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, plotAreaBorderColor: "ABCDEF" }), "Sheet1");
+      const plotArea = plotAreaOf(result.chartXml);
+      expect(plotArea).toContain('<a:srgbClr val="ABCDEF"/>');
+      expect(plotArea).toContain("<a:ln>");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        plotAreaBorderColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    expect(plotAreaOf(scatter.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "FFF" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "GGGGGG" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderColor: "FFAA0080" }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops an empty / whitespace-only string", () => {
+    expect(
+      plotAreaOf(writeChart(makeChart({ plotAreaBorderColor: "" }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+    expect(
+      plotAreaOf(writeChart(makeChart({ plotAreaBorderColor: "   " }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ plotAreaBorderColor: 0xff_ff_ff as any }), "Sheet1");
+    expect(plotAreaOf(a.chartXml)).not.toContain("<c:spPr>");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ plotAreaBorderColor: null as any }), "Sheet1");
+    expect(plotAreaOf(b.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("composes independently with plotAreaFillColor — fill and stroke share one <c:spPr>", () => {
+    const result = writeChart(
+      makeChart({
+        plotAreaFillColor: "F2F2F2",
+        plotAreaBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const plotArea = plotAreaOf(result.chartXml);
+    // Single <c:spPr> hosts both knobs.
+    const spPrCount = plotArea.match(/<c:spPr>/g) ?? [];
+    expect(spPrCount).toHaveLength(1);
+    // Fill color lands on the top-level <a:solidFill>.
+    expect(plotArea).toContain('<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>');
+    // Border color lands inside <a:ln>.
+    expect(plotArea).toContain('<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>');
+    // CT_ShapeProperties order: <a:solidFill> precedes <a:ln>.
+    expect(plotArea.indexOf("<a:solidFill>")).toBeLessThan(plotArea.indexOf("<a:ln>"));
+  });
+
+  it("composes independently with plotAreaLayout (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        plotAreaLayout: { x: 0.1, y: 0.15, w: 0.7, h: 0.6 },
+        plotAreaBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<c:x val="0.1"/>');
+    expect(plotArea).toContain('<a:srgbClr val="1F77B4"/>');
+    // Layout precedes spPr per CT_PlotArea sequence.
+    expect(plotArea.indexOf("<c:layout>")).toBeLessThan(plotArea.indexOf("<c:spPr>"));
+  });
+
+  it("round-trips plotAreaBorderColor through parseChart", () => {
+    const written = writeChart(makeChart({ plotAreaBorderColor: "1F77B4" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset plotAreaBorderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("round-trips both fill and border together through parseChart", () => {
+    const written = writeChart(
+      makeChart({ plotAreaFillColor: "F2F2F2", plotAreaBorderColor: "1F77B4" }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaFillColor).toBe("F2F2F2");
+    expect(reparsed?.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("survives a writeXlsx round trip — plotAreaBorderColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            plotAreaBorderColor: "1F77B4",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.plotAreaBorderColor).toBe("1F77B4");
+  });
+});
 // ── writeChart — axisTitleLayout (manual placement) ─────────────────
 
 describe("writeChart — axisTitleLayout", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -19796,6 +19796,142 @@ describe("parseChart — plotAreaFillColor", () => {
   });
 });
 
+// ── parseChart — plotAreaBorderColor (line stroke) ──────────────────
+
+describe("parseChart — plotAreaBorderColor", () => {
+  const NS_PBC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withPlotAreaSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_PBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:plotArea><c:spPr><a:ln><a:solidFill><a:srgbClr> is pinned", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderColor).toBe("ABCDEF");
+  });
+
+  it("surfaces fill and border independently when both are pinned", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>` +
+        `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.plotAreaFillColor).toBe("F2F2F2");
+    expect(parsed?.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the chart has no <c:plotArea>", () => {
+    const xml = `<c:chartSpace ${NS_PBC}><c:chart></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:plotArea> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_PBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no <a:solidFill>", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="12700"/>`);
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln><a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:noFill>", () => {
+    const xml = withPlotAreaSpPr(`<a:ln><a:noFill/></a:ln>`);
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:gradFill>", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (wrong length)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln><a:solidFill><a:srgbClr val="ABC"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (non-hex characters)", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="GGGGGG"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const xml = withPlotAreaSpPr(`<a:ln><a:solidFill><a:srgbClr/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln> on a series <c:spPr> (not the plotArea)", () => {
+    // Series-level <c:spPr><a:ln> must not leak into plotAreaBorderColor.
+    const xml = `<c:chartSpace ${NS_PBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderColor).toBeUndefined();
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── parseChart — axisTitleLayout (manual placement) ─────────────────
 
 describe("parseChart — axisTitleLayout", () => {


### PR DESCRIPTION
## Summary
- Adds `plotAreaBorderColor` knob mapping to `<c:plotArea><c:spPr><a:ln><a:solidFill><a:srgbClr val=\"..\"/></a:solidFill></a:ln></c:spPr></c:plotArea>` — Excel's "Format Plot Area → Border → Solid line → Color" picker.
- Composes independently with `plotAreaFillColor`: the two share the same `<c:spPr>` host on `<c:plotArea>` but land on different children (`<a:solidFill>` for fill, `<a:ln>` for stroke). The writer emits a single `<c:spPr>` whenever either knob is set, in `CT_ShapeProperties` schema order.
- Reader, writer, and clone-through plumbing follows the established hex-color grammar — accepts `#` / case, drops malformed / non-solid / `schemeClr` / alpha-channel forms to `undefined`.

Pivot from the `<a:solidFill>` family (#302–#308) to the `<a:ln>` stroke family on the same `<c:plotArea>` host. First step of stroke knobs (`<c:spPr><a:ln>`) — border width and the legend / title / chartSpace / axisTitle / dataTable / dataLabels border-color counterparts can follow in separate PRs.

## Test plan
- [x] `pnpm vitest run --dir=test` — 89 files / 6671 tests pass (including 47 new tests across `parseChart`, `writeChart`, and `cloneChart`).
- [x] `pnpm build` — succeeds.
- [x] Round-trips covered: writer → reader, writer → `writeXlsx` → packaged `chart1.xml` → reader, plus clone-through with override / null / inheritance / malformed-token / cross-family flatten.
- [x] Composition with `plotAreaFillColor` and `plotAreaLayout` — single `<c:spPr>`, correct child order, layout precedes spPr per `CT_PlotArea`.

Refs #302