### PR TITLE
feat(xlsx): chart legend border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2297,6 +2297,55 @@ export interface SheetChart {
    */
   legendFillColor?: string;
   /**
+   * Legend border (stroke) solid color as a 6-digit RGB hex string
+   * (e.g. `"1F77B4"`). Maps to `<c:legend><c:spPr><a:ln><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:legend>`
+   * (CT_Legend, ECMA-376 Part 1, §21.2.2.114) — Excel's "Format Legend
+   * -> Border -> Solid line -> Color" picker. The OOXML `<a:srgbClr
+   * val=".."/>` carries the 6-character uppercase hex sRGB color
+   * (`CT_SRgbColor` inside the line's solid fill choice — ECMA-376
+   * Part 1, §20.1.2.3.32 / §20.1.2.3.24). The `<c:spPr>` slot sits
+   * between `<c:overlay>` and `<c:txPr>` per the CT_Legend schema
+   * sequence; `<a:ln>` follows the optional `<a:solidFill>` (fill)
+   * child inside `<c:spPr>` per `CT_ShapeProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.13).
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the `<a:ln>` block (Excel's reference serialization for a legend
+   * that inherits the auto-stroke — typically a translucent gray
+   * border or no border depending on the theme).
+   *
+   * Default: omitted — the legend inherits the auto-stroke Excel picks
+   * from the chart's theme. Pin a hex color to mirror Excel's "Format
+   * Legend -> Border -> Solid line" knob and paint a flat border around
+   * the legend block — useful for dashboard tiles where the legend
+   * should be visually framed against the surrounding chart frame, or
+   * to highlight a legend against a busy theme.
+   *
+   * Composes independently with {@link legendFillColor} — the two knobs
+   * land on the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for the fill, `<a:ln>` for the stroke), and the
+   * writer authors a `<c:spPr>` whenever either knob is set. A caller
+   * can pin one without the other; pinning both produces a filled
+   * legend with a colored border.
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no slot to host the stroke in that case.
+   * Mirrors `plotAreaBorderColor` — same accept-with-or-without-`#`
+   * hex grammar, same `<c:spPr>` host element on a different parent
+   * (`<c:legend>` rather than `<c:plotArea>`), but lands on the line
+   * (`<a:ln>`) child rather than the fill (`<a:solidFill>`) child.
+   *
+   * Patterned / gradient strokes are not modelled — only the solid
+   * sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   */
+  legendBorderColor?: string;
+  /**
    * Custom plot-area placement inside the chart frame. Maps to
    * `<c:plotArea><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
    * </c:plotArea>` — Excel's "Format Plot Area -> Position -> Custom"
@@ -7123,6 +7172,38 @@ export interface Chart {
    * value slots straight into {@link cloneChart} without conversion.
    */
   legendFillColor?: string;
+  /**
+   * Legend border (stroke) solid color pulled from `<c:legend><c:spPr>
+   * <a:ln><a:solidFill><a:srgbClr val=".."/></a:solidFill></a:ln>
+   * </c:spPr></c:legend>`. Reflects Excel's "Format Legend -> Border
+   * -> Solid line -> Color" picker. The OOXML `<a:srgbClr val=".."/>`
+   * carries the 6-character uppercase hex sRGB color (`CT_SRgbColor`
+   * inside the line's solid fill choice — ECMA-376 Part 1, §20.1.2.3.32
+   * / §20.1.2.3.24). The `<c:spPr>` slot sits between `<c:overlay>` and
+   * `<c:txPr>` per the CT_Legend schema sequence (ECMA-376 Part 1,
+   * §21.2.2.114); `<a:ln>` follows the optional `<a:solidFill>` (fill)
+   * child inside `<c:spPr>` per `CT_ShapeProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.13).
+   *
+   * Reports the 6-character uppercase hex form when the source chart
+   * pinned a literal `<a:srgbClr>` color on `<a:ln>`; absence,
+   * malformed `val` tokens (wrong length, non-hex characters,
+   * alpha-channel forms), non-solid line fills (`<a:noFill>`,
+   * `<a:gradFill>`, `<a:pattFill>`), and theme-color references
+   * (`<a:schemeClr>`) all collapse to `undefined` so absence and an
+   * unrenderable stroke round-trip identically through
+   * {@link cloneChart}. Mirrors the writer-side
+   * {@link SheetChart.legendBorderColor} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:spPr>` slot to surface the stroke from in either case. Composes
+   * independently with {@link legendFillColor} — the two fields surface
+   * from the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for fill, `<a:ln><a:solidFill>` for stroke).
+   */
+  legendBorderColor?: string;
   /**
    * Custom plot-area placement pulled from `<c:plotArea><c:layout>
    * <c:manualLayout>...</c:manualLayout></c:layout></c:plotArea>`.

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -393,6 +393,32 @@ export interface CloneChartOptions {
    */
   legendFillColor?: string | null;
   /**
+   * Override `SheetChart.legendBorderColor`. `undefined` (or omitted)
+   * inherits the source's parsed `legendBorderColor`; `null` drops the
+   * inherited stroke (the writer falls back to the auto-stroke Excel
+   * picks from the chart's theme — no `<a:ln>` block on the legend's
+   * `<c:spPr>`); a 6-digit RGB hex string replaces it.
+   *
+   * The override runs through the same sRGB normalizer as the writer —
+   * the leading `#` and case are accepted, then the value collapses to
+   * the OOXML canonical uppercase form. Malformed tokens (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` so the cloned
+   * `SheetChart` drops the field rather than carry a value the writer
+   * would silently elide back to absence.
+   *
+   * The grammar mirrors `legendFillColor` so the legend `<c:spPr>`
+   * knobs compose the same way at the call site. Composes
+   * independently with `legendFillColor` — the two knobs land on the
+   * same `<c:spPr>` block but on different children (`<a:solidFill>`
+   * for fill, `<a:ln>` for stroke), and the writer emits `<c:spPr>`
+   * whenever either knob is set. The override is silently dropped from
+   * the cloned `SheetChart` when the resolved legend is `false` (no
+   * `<c:legend>` element will be emitted) — there is no slot to host
+   * the stroke on a hidden legend.
+   */
+  legendBorderColor?: string | null;
+  /**
    * Override `SheetChart.plotAreaLayout`. `undefined` (or omitted)
    * inherits the source's parsed `plotAreaLayout`; `null` drops the
    * inherited layout (the writer emits the bare `<c:layout/>`
@@ -2012,6 +2038,25 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.legendFillColor,
     );
     if (resolvedLegendFillColor !== undefined) out.legendFillColor = resolvedLegendFillColor;
+
+    // Same hidden-legend scoping for the border (line) stroke —
+    // `<a:ln>` lives inside `<c:legend><c:spPr>` per CT_ShapeProperties,
+    // so a clone whose legend is hidden has no slot for the stroke.
+    // `undefined` inherits the source's parsed `legendBorderColor`
+    // (after the writer-side normalizer collapses any malformed token),
+    // `null` drops the inherited stroke (the writer emits no `<a:ln>`
+    // block, the legend inherits the auto-stroke Excel picks from the
+    // chart's theme), a 6-digit hex string replaces it. Composes
+    // independently with `legendFillColor` — the two knobs share the
+    // `<c:spPr>` host but land on different children (`<a:solidFill>`
+    // for fill, `<a:ln>` for stroke).
+    const resolvedLegendBorderColor = resolveLegendBorderColor(
+      source.legendBorderColor,
+      options.legendBorderColor,
+    );
+    if (resolvedLegendBorderColor !== undefined) {
+      out.legendBorderColor = resolvedLegendBorderColor;
+    }
   }
 
   // Plot-area manual layout is independent of the legend visibility —
@@ -3673,6 +3718,42 @@ function resolveLegendLayout(
  * conflict.
  */
 function resolveLegendFillColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
+}
+
+/**
+ * Resolve a `legendBorderColor` override.
+ *
+ * `undefined` → inherit the source's parsed `legendBorderColor` (after
+ *               running it through {@link normalizeTitleColor} so a
+ *               malformed source value drops cleanly — the hex
+ *               normalizer is purely shape-based and applies
+ *               identically to every `<a:srgbClr val="RRGGBB"/>`
+ *               slot).
+ * `null`      → drop the inherited stroke (the writer emits no
+ *               `<a:ln>` block on `<c:legend><c:spPr>`, the legend
+ *               inherits the auto-stroke Excel picks from the chart's
+ *               theme).
+ * `string`    → replace with the normalized 6-character uppercase hex
+ *               form. Malformed overrides collapse to `undefined` via
+ *               the normalizer so the cloned `SheetChart` always
+ *               carries a value the writer will accept.
+ *
+ * The grammar mirrors `legendFillColor` so the legend `<c:spPr>` knobs
+ * compose the same way at the call site. Callers should gate the
+ * result on the resolved legend visibility — when no legend is
+ * emitted, the stroke has no slot in the rendered chart.
+ *
+ * Independent of `legendFillColor`: the two knobs target different
+ * children of `<c:legend><c:spPr>` (`<a:solidFill>` for fill,
+ * `<a:ln>` for stroke), so a caller can pin both without conflict.
+ */
+function resolveLegendBorderColor(
   sourceValue: string | undefined,
   override: string | null | undefined,
 ): string | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -559,6 +559,17 @@ export function parseChart(xml: string): Chart | undefined {
     // hidden-legend scoping as the typography knobs.
     const legendFillColor = parseLegendFillColor(chartEl);
     if (legendFillColor !== undefined) out.legendFillColor = legendFillColor;
+
+    // `<c:legend><c:spPr><a:ln><a:solidFill>` carries Excel's "Format
+    // Legend -> Border -> Solid line -> Color" picker. The `<a:ln>`
+    // block lives inside the same `<c:spPr>` slot as the fill
+    // (`<a:solidFill>`), per CT_ShapeProperties — the reader scopes
+    // the lookup so a stray `<a:ln>` elsewhere (on a series, on an
+    // axis, on the legend's `<c:txPr>` block) cannot leak into this
+    // field. Same hidden-legend scoping as the fill / typography
+    // knobs.
+    const legendBorderColor = parseLegendBorderColor(chartEl);
+    if (legendBorderColor !== undefined) out.legendBorderColor = legendBorderColor;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -3999,6 +4010,55 @@ function parseLegendFillColor(chartEl: XmlElement): string | undefined {
   const spPr = findChild(legend, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:legend><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:legend>` off the legend block.
+ * Returns the line stroke color as a 6-character uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+ * solid fill choice (`CT_LineProperties`, §20.1.2.3.24) which itself
+ * sits inside `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The
+ * `<c:spPr>` slot lives between `<c:overlay>` and `<c:txPr>` per
+ * CT_Legend (ECMA-376 Part 1, §21.2.2.114).
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid line fills (`<a:noFill>` / `<a:gradFill>` /
+ * `<a:pattFill>`), and theme-color references (`<a:schemeClr>`) all
+ * collapse to `undefined` so a chart that pinned a stroke the writer
+ * cannot reproduce on emit drops the field rather than fabricate one
+ * Excel would render differently. Malformed `val` tokens (wrong
+ * length, non-hex characters, alpha-channel forms, non-string
+ * escapes) likewise drop to `undefined`.
+ *
+ * The lookup is scoped to direct children of `<c:legend>` so a stray
+ * `<c:spPr>` elsewhere (e.g. on a series, on an axis, on the legend's
+ * `<c:txPr>` block) cannot leak in. Returns `undefined` whenever the
+ * chart omits the `<c:legend>` element or the `<c:spPr><a:ln>
+ * <a:solidFill><a:srgbClr>` chain is malformed at any link. Mirrors
+ * the writer-side {@link SheetChart.legendBorderColor} so a parsed
+ * value slots straight into {@link cloneChart} without conversion.
+ *
+ * Independent of {@link parseLegendFillColor}: the stroke lives on
+ * `<c:legend><c:spPr><a:ln><a:solidFill>`, the fill lives on
+ * `<c:legend><c:spPr><a:solidFill>` — the two readers walk disjoint
+ * children of the same `<c:spPr>` block so a caller can pin both
+ * knobs without conflict.
+ */
+function parseLegendBorderColor(chartEl: XmlElement): string | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const spPr = findChild(legend, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -191,6 +191,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendFontFamily(chart),
         resolveLegendLayout(chart),
         resolveLegendFillColor(chart),
+        resolveLegendBorderColor(chart),
       ),
     );
   }
@@ -5292,6 +5293,7 @@ function buildLegend(
   fontFamily: string | undefined,
   layout: ResolvedManualLayout | undefined,
   fillRgbHex: string | undefined,
+  borderRgbHex: string | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -5329,14 +5331,17 @@ function buildLegend(
 
   // CT_Legend sequence places `<c:spPr>` between `<c:overlay>` and
   // `<c:txPr>` (ECMA-376 Part 1, §21.2.2.114). The writer skips
-  // emission entirely when the caller did not pin a fill color so a
-  // fresh chart matches Excel's reference serialization byte-for-byte
-  // — Excel itself omits the block whenever the legend renders at the
-  // theme default fill (typically a transparent legend background
-  // with no `<c:spPr>` block). Currently the writer only authors
-  // `<a:solidFill>` here; stroke (`<a:ln>`) and other CT_ShapeProperties
-  // children are not modelled at this layer.
-  const legendSpPrXml = buildLegendSpPr(fillRgbHex);
+  // emission entirely when the caller did not pin a fill / border
+  // color so a fresh chart matches Excel's reference serialization
+  // byte-for-byte — Excel itself omits the block whenever the legend
+  // renders at the theme default fill / stroke (typically a transparent
+  // legend background with no `<c:spPr>` block). The writer authors
+  // `<a:solidFill>` (fill) and `<a:ln>` (stroke) here in
+  // `CT_ShapeProperties` schema order; other `CT_ShapeProperties`
+  // children (`<a:effectLst>` effects, gradient / pattern / picture
+  // fills, line dash / width / compound styles) are not modelled at
+  // this layer.
+  const legendSpPrXml = buildLegendSpPr(fillRgbHex, borderRgbHex);
   if (legendSpPrXml !== undefined) {
     children.push(legendSpPrXml);
   }
@@ -5369,28 +5374,48 @@ function buildLegend(
 
 /**
  * Build the `<c:spPr>` element on `<c:legend>` that carries the
- * legend's background fill. Returns `undefined` when no fill color is
- * pinned so the caller can elide the entire block — Excel's reference
- * serialization omits `<c:spPr>` from `<c:legend>` whenever the legend
- * renders at the theme default fill (typically a transparent legend
- * background).
+ * legend's background fill and / or border (line stroke) colors.
+ * Returns `undefined` when no knob is pinned so the caller can elide
+ * the entire block — Excel's reference serialization omits `<c:spPr>`
+ * from `<c:legend>` whenever the legend renders at the theme default
+ * fill / stroke (typically a transparent legend background with no
+ * `<c:spPr>` block).
  *
  * The emitted block mirrors the minimal `<c:spPr>` shape Excel writes
- * when the user pins "Format Legend -> Fill -> Solid fill -> Color":
+ * when the user pins "Format Legend -> Fill -> Solid fill -> Color"
+ * and / or "Format Legend -> Border -> Solid line -> Color":
  * `<c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+ * <a:ln><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:ln>
  * </c:spPr>`. The `val` attribute holds the canonical 6-character
  * uppercase hex form (the writer normalizes the input ahead of this
- * call so a malformed source value never reaches emit).
+ * call so a malformed source value never reaches emit). When at least
+ * one knob lands on the wire, the children are emitted in
+ * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
+ * `<a:ln>` (line / stroke).
  *
  * Mirrors the chart-title / plot-area / axis-title `<c:spPr>` slots
- * so a single hex string threads cleanly through every fill knob the
- * writer authors.
+ * so a single hex string threads cleanly through every fill / stroke
+ * knob the writer authors.
  */
-function buildLegendSpPr(fillRgbHex: string | undefined): string | undefined {
-  if (fillRgbHex === undefined) return undefined;
-  return xmlElement("c:spPr", undefined, [
-    xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
-  ]);
+function buildLegendSpPr(
+  fillRgbHex: string | undefined,
+  borderRgbHex: string | undefined,
+): string | undefined {
+  if (fillRgbHex === undefined && borderRgbHex === undefined) return undefined;
+  const children: string[] = [];
+  if (fillRgbHex !== undefined) {
+    children.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
+    );
+  }
+  if (borderRgbHex !== undefined) {
+    children.push(
+      xmlElement("a:ln", undefined, [
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
+      ]),
+    );
+  }
+  return xmlElement("c:spPr", undefined, children);
 }
 
 /**
@@ -5791,6 +5816,34 @@ function resolveLegendLayout(chart: SheetChart): ResolvedManualLayout | undefine
  */
 function resolveLegendFillColor(chart: SheetChart): string | undefined {
   return normalizeTitleColor(chart.legendFillColor);
+}
+
+/**
+ * Resolve `<c:legend><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:legend>` from
+ * {@link SheetChart.legendBorderColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the chart leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches every other `<a:srgbClr>`
+ * fill / line slot exactly. The stroke is only meaningful when the
+ * chart actually emits a legend — the caller is expected to gate the
+ * call on the resolved legend visibility (`resolveLegendPosition`
+ * returning a non-null value). A chart whose legend is suppressed has
+ * no `<c:legend>` block to host the `<c:spPr>` slot in either case.
+ *
+ * Independent of {@link resolveLegendFillColor}: the fill lands on
+ * `<c:legend><c:spPr><a:solidFill>`, the stroke lands on
+ * `<c:legend><c:spPr><a:ln><a:solidFill>` — the two resolvers feed
+ * disjoint children of `<c:spPr>` so a single configuration call can
+ * pin both. Mirrors the chart-title / axis-title / chart-space /
+ * plot-area `<c:spPr>` slots — same hex grammar, same `<a:ln>` slot
+ * on the `CT_ShapeProperties` schema — but lands on `<c:legend>`'s
+ * own `<c:spPr>` block.
+ */
+function resolveLegendBorderColor(chart: SheetChart): string | undefined {
+  return normalizeTitleColor(chart.legendBorderColor);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -22323,3 +22323,148 @@ describe("cloneChart — dataLabels.fillColor", () => {
     }
   });
 });
+
+// ── cloneChart — legendBorderColor (line stroke) ────────────────────
+
+describe("cloneChart — legendBorderColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendBorderColor by default", () => {
+    const clone = cloneChart(source({ legendBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("lets options.legendBorderColor override the source's value", () => {
+    const clone = cloneChart(source({ legendBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: "ABCDEF",
+    });
+    expect(clone.legendBorderColor).toBe("ABCDEF");
+  });
+
+  it("drops the inherited legendBorderColor when the override is null", () => {
+    const clone = cloneChart(source({ legendBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: null,
+    });
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined legendBorderColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # and lowercase input through the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: "#1f77b4",
+    });
+    expect(clone.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("drops a malformed override (wrong length)", () => {
+    const clone = cloneChart(source({ legendBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: "FFF",
+    });
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("drops a malformed override (non-hex characters)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: "GGGGGG",
+    });
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("drops a malformed override (alpha-channel form)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: "FFAA0080",
+    });
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("drops a non-string override (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendBorderColor: 0xff_ff_ff as any,
+    });
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ legendBorderColor: "GGGGGG" as any }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendBorderColor).toBeUndefined();
+  });
+
+  it("carries legendBorderColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with legendFillColor (each lands on its own slot)", () => {
+    const clone = cloneChart(
+      source({
+        legendFillColor: "F2F2F2",
+        legendBorderColor: "1F77B4",
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendFillColor).toBe("F2F2F2");
+    expect(clone.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("survives a writeXlsx round trip — legendBorderColor lands in the cloned chart XML", async () => {
+    const clone = cloneChart(source({ legendBorderColor: "F2F2F2" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderColor: "1F77B4",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.legendBorderColor).toBe("1F77B4");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -21164,3 +21164,197 @@ describe("writeChart — dataLabels.fillColor", () => {
     expect(reparsed?.dataLabels?.fillColor).toBe("0F0F0F");
   });
 });
+
+// ── writeChart — legendBorderColor (line stroke) ────────────────────
+
+describe("writeChart — legendBorderColor", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does not emit <c:spPr> when legendBorderColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:spPr>");
+    expect(legend).not.toContain("<a:ln>");
+  });
+
+  it("emits <c:spPr><a:ln><a:solidFill><a:srgbClr> when legendBorderColor is set", () => {
+    const result = writeChart(makeChart({ legendBorderColor: "1F77B4" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:spPr>");
+    expect(legend).toContain("<a:ln>");
+    expect(legend).toContain('<a:srgbClr val="1F77B4"/>');
+    // The border color must land inside <a:ln>, not as a top-level
+    // <a:solidFill> (that slot is reserved for the fill color knob).
+    const lnIdx = legend.indexOf("<a:ln>");
+    const srgbIdx = legend.indexOf('<a:srgbClr val="1F77B4"/>');
+    expect(srgbIdx).toBeGreaterThan(lnIdx);
+  });
+
+  it("normalizes a leading # and lowercase hex to the canonical uppercase form", () => {
+    const result = writeChart(makeChart({ legendBorderColor: "#1f77b4" }), "Sheet1");
+    expect(legendOf(result.chartXml)).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("places <c:spPr> after <c:overlay> and before <c:txPr> inside <c:legend>", () => {
+    const result = writeChart(
+      makeChart({ legendBorderColor: "112233", legendFontColor: "445566" }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:spPr"));
+    expect(legend.indexOf("c:spPr")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits one <c:spPr> inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendBorderColor: "FFAA00" }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads legendBorderColor through every chart family that emits a legend", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendBorderColor: "ABCDEF" }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('<a:srgbClr val="ABCDEF"/>');
+      expect(legend).toContain("<a:ln>");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendBorderColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendBorderColor set", () => {
+    const result = writeChart(
+      makeChart({ legend: false, legendBorderColor: "1F77B4" }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:legend>");
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(makeChart({ legendBorderColor: "FFF" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(makeChart({ legendBorderColor: "GGGGGG" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(makeChart({ legendBorderColor: "FFAA0080" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops an empty / whitespace-only string", () => {
+    expect(
+      legendOf(writeChart(makeChart({ legendBorderColor: "" }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+    expect(
+      legendOf(writeChart(makeChart({ legendBorderColor: "   " }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ legendBorderColor: 0xff_ff_ff as any }), "Sheet1");
+    expect(legendOf(a.chartXml)).not.toContain("<c:spPr>");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ legendBorderColor: null as any }), "Sheet1");
+    expect(legendOf(b.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("composes independently with legendFillColor — fill and stroke share one <c:spPr>", () => {
+    const result = writeChart(
+      makeChart({
+        legendFillColor: "F2F2F2",
+        legendBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    // Single <c:spPr> hosts both knobs.
+    const spPrCount = legend.match(/<c:spPr>/g) ?? [];
+    expect(spPrCount).toHaveLength(1);
+    // Fill color lands on the top-level <a:solidFill>.
+    expect(legend).toContain('<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>');
+    // Border color lands inside <a:ln>.
+    expect(legend).toContain('<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>');
+    // CT_ShapeProperties order: <a:solidFill> precedes <a:ln>.
+    const spPrBlock = legend.match(/<c:spPr>[\s\S]*?<\/c:spPr>/)?.[0] ?? "";
+    expect(spPrBlock.indexOf("<a:solidFill>")).toBeLessThan(spPrBlock.indexOf("<a:ln>"));
+  });
+
+  it("composes independently with legendLayout (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        legendLayout: { x: 0.1, y: 0.15, w: 0.7, h: 0.6 },
+        legendBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<c:x val="0.1"/>');
+    expect(legend).toContain('<a:srgbClr val="1F77B4"/>');
+    // Layout precedes spPr per CT_Legend sequence.
+    expect(legend.indexOf("<c:layout>")).toBeLessThan(legend.indexOf("<c:spPr>"));
+  });
+
+  it("round-trips legendBorderColor through parseChart", () => {
+    const written = writeChart(makeChart({ legendBorderColor: "1F77B4" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset legendBorderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("round-trips both fill and border together through parseChart", () => {
+    const written = writeChart(
+      makeChart({ legendFillColor: "F2F2F2", legendBorderColor: "1F77B4" }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendFillColor).toBe("F2F2F2");
+    expect(reparsed?.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("survives a writeXlsx round trip — legendBorderColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendBorderColor: "1F77B4",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.legendBorderColor).toBe("1F77B4");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -21235,10 +21235,7 @@ describe("writeChart — legendBorderColor", () => {
   });
 
   it("does not emit any <c:legend> when legend=false, even with legendBorderColor set", () => {
-    const result = writeChart(
-      makeChart({ legend: false, legendBorderColor: "1F77B4" }),
-      "Sheet1",
-    );
+    const result = writeChart(makeChart({ legend: false, legendBorderColor: "1F77B4" }), "Sheet1");
     expect(result.chartXml).not.toContain("<c:legend>");
   });
 

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -21023,3 +21023,171 @@ describe("parseChart — dataLabelsFillColor", () => {
     expect(chart?.series?.[0]?.dataLabels?.fillColor).toBe("A1B2C3");
   });
 });
+
+// ── parseChart — legendBorderColor (line stroke) ────────────────────
+
+describe("parseChart — legendBorderColor", () => {
+  const NS_LBC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_LBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:legend><c:spPr><a:ln><a:solidFill><a:srgbClr> is pinned", () => {
+    const xml = withLegendSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const xml = withLegendSpPr(`<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.legendBorderColor).toBe("ABCDEF");
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const xml = withLegendSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("surfaces fill and border independently when both are pinned", () => {
+    const xml = withLegendSpPr(
+      `<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>` +
+        `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.legendFillColor).toBe("F2F2F2");
+    expect(parsed?.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the chart has no <c:legend>", () => {
+    const xml = `<c:chartSpace ${NS_LBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_LBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    const xml = withLegendSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`);
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no <a:solidFill>", () => {
+    const xml = withLegendSpPr(`<a:ln w="12700"/>`);
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln><a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const xml = withLegendSpPr(
+      `<a:ln><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:noFill>", () => {
+    const xml = withLegendSpPr(`<a:ln><a:noFill/></a:ln>`);
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:gradFill>", () => {
+    const xml = withLegendSpPr(
+      `<a:ln><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (wrong length)", () => {
+    const xml = withLegendSpPr(`<a:ln><a:solidFill><a:srgbClr val="ABC"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (non-hex characters)", () => {
+    const xml = withLegendSpPr(`<a:ln><a:solidFill><a:srgbClr val="GGGGGG"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const xml = withLegendSpPr(`<a:ln><a:solidFill><a:srgbClr/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+
+  it('drops the border when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendBorderColor).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln> on a series <c:spPr> (not the legend)", () => {
+    // Series-level <c:spPr><a:ln> must not leak into legendBorderColor.
+    const xml = `<c:chartSpace ${NS_LBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `legendBorderColor` knob mapping to `<c:legend><c:spPr><a:ln><a:solidFill><a:srgbClr val=\"..\"/></a:solidFill></a:ln></c:spPr></c:legend>` — Excel's "Format Legend → Border → Solid line → Color" picker.
- Composes independently with `legendFillColor`: the two share the same `<c:spPr>` host on `<c:legend>` but land on different children (`<a:solidFill>` for fill, `<a:ln>` for stroke). The writer emits a single `<c:spPr>` whenever either knob is set, in `CT_ShapeProperties` schema order.
- Reader, writer, and clone-through plumbing follows the established hex-color grammar — accepts `#` / case, drops malformed / non-solid / `schemeClr` / alpha-channel forms to `undefined`. Silently dropped when `legend === false` (no `<c:legend>` element to host the slot).

Sibling of the in-flight `plotAreaBorderColor` knob — same `<a:ln>` pattern, distinct host element (`<c:legend>` vs `<c:plotArea>`). Continues the stroke (`<c:spPr><a:ln>`) family started by #309.

## Test plan
- [x] `pnpm vitest run --dir=test` — 89 files / 6716 tests pass (45 new tests across `parseChart`, `writeChart`, and `cloneChart`).
- [x] `pnpm build` — succeeds.
- [x] Round-trips covered: writer → reader, writer → `writeXlsx` → packaged `chart1.xml` → reader, plus clone-through with override / null / inheritance / malformed-token / cross-family flatten.
- [x] Composition with `legendFillColor` and `legendLayout` — single `<c:spPr>`, correct child order (`<a:solidFill>` precedes `<a:ln>`), layout precedes spPr per `CT_Legend`.
- [x] Hidden-legend scoping verified — `legend: false` produces no `<c:legend>` element even with the border pinned; legend `<c:delete val=\"1\"/>` drops the parsed value.

Refs #309