### PR TITLE
feat(xlsx): chart title border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2880,6 +2880,55 @@ export interface SheetChart {
    */
   titleFillColor?: string;
   /**
+   * Chart title border (stroke) solid color as a 6-digit RGB hex string
+   * (e.g. `"1F77B4"`). Maps to `<c:title><c:spPr><a:ln><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:title>`
+   * — Excel's "Format Chart Title -> Border -> Solid line -> Color"
+   * picker. The OOXML `<a:srgbClr val=".."/>` carries the 6-character
+   * uppercase hex sRGB color (`CT_SRgbColor` inside the line's solid
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The
+   * `<c:spPr>` slot lives between `<c:overlay>` and `<c:txPr>` /
+   * `<c:extLst>` per CT_Title (ECMA-376 Part 1, §21.2.2.210); `<a:ln>`
+   * follows the optional `<a:solidFill>` (fill) child inside `<c:spPr>`
+   * per `CT_ShapeProperties` (ECMA-376 Part 1, §20.1.2.3.13).
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the `<a:ln>` block (Excel's reference serialization for a chart
+   * title that inherits the auto-stroke — typically no border).
+   *
+   * Default: omitted — the title inherits the auto-stroke Excel picks
+   * from the chart's theme (typically no visible border). Pin a hex
+   * color to mirror Excel's "Format Chart Title -> Border -> Solid
+   * line" knob and paint a flat border around the title block —
+   * useful for dashboard tiles where the title should be visually
+   * framed against the chart background, or to highlight the title
+   * against a busy theme.
+   *
+   * Composes independently with {@link titleFillColor} — the two
+   * knobs land on the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for the fill, `<a:ln>` for the stroke), and the
+   * writer authors a `<c:spPr>` whenever either knob is set. A caller
+   * can pin one without the other; pinning both produces a filled
+   * title block with a colored border.
+   *
+   * Patterned / gradient strokes are not modelled — only the solid
+   * sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   *
+   * Silently ignored when no title is rendered (`showTitle === false`
+   * or `title` is absent) — there is no `<c:title>` block to host the
+   * stroke in either case. Mirrors `plotAreaBorderColor` — same
+   * accept-with-or-without-`#` hex grammar, same OOXML `<c:spPr>
+   * <a:ln><a:solidFill><a:srgbClr val=".."/></a:solidFill></a:ln>
+   * </c:spPr>` mapping — so a caller can thread a single hex string
+   * through every `<c:spPr><a:ln>`-based stroke slot.
+   */
+  titleBorderColor?: string;
+  /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
    * the auto-generated title that single-series charts synthesise from
@@ -7564,6 +7613,47 @@ export interface Chart {
    * slots straight into {@link cloneChart} without conversion.
    */
   titleFillColor?: string;
+  /**
+   * Chart title border (stroke) solid color pulled from
+   * `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+   * </a:solidFill></a:ln></c:spPr></c:title>`. Reflects Excel's
+   * "Format Chart Title -> Border -> Solid line -> Color" picker.
+   *
+   * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+   * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+   * solid fill choice (`CT_LineProperties`, §20.1.2.3.24) which itself
+   * sits inside `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The
+   * `<c:spPr>` slot lives between `<c:overlay>` and `<c:txPr>` /
+   * `<c:extLst>` per CT_Title (§21.2.2.210); `<a:ln>` follows the
+   * optional `<a:solidFill>` (fill) child inside `<c:spPr>`.
+   *
+   * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+   * non-solid line fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`),
+   * and theme-color references (`<a:schemeClr>` / `<a:sysClr>` /
+   * `<a:hslClr>` / `<a:prstClr>`) all collapse to `undefined` so a
+   * chart that pinned a stroke the writer cannot reproduce on emit
+   * drops the field rather than fabricate one Excel would render
+   * differently. Malformed `val` tokens (wrong length, non-hex
+   * characters, alpha-channel forms, non-string escapes) likewise
+   * drop to `undefined`.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:title>` element at all, or when the title is a `<c:strRef>`
+   * (formula reference) with no `<c:rich>` body — Excel's "Format
+   * Title -> Border" dialog is still authored against `<c:spPr>` even
+   * when the text body is a formula reference, so the lookup is on
+   * `<c:title>` directly rather than gated on `<c:rich>`. Mirrors the
+   * writer-side {@link SheetChart.titleBorderColor} so a parsed value
+   * slots straight into {@link cloneChart} without conversion.
+   *
+   * Independent of {@link titleFillColor} — the two fields surface
+   * from the same `<c:spPr>` host but on different children
+   * (`<a:solidFill>` for the fill, `<a:ln>` for the stroke), so a
+   * caller can read both simultaneously. Mirrors
+   * {@link plotAreaBorderColor} — same `<a:ln><a:solidFill><a:srgbClr>`
+   * chain on a different host element.
+   */
+  titleBorderColor?: string;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -788,6 +788,35 @@ export interface CloneChartOptions {
    */
   titleFillColor?: string | null;
   /**
+   * Override `SheetChart.titleBorderColor`. `undefined` (or omitted)
+   * inherits the source's parsed `titleBorderColor`; `null` drops the
+   * inherited stroke (the writer emits no `<a:ln>` block on
+   * `<c:title><c:spPr>`, falling back to the theme default — typically
+   * no visible border); a hex string replaces it. The override is
+   * normalized through the writer-side hex-color path — accepts
+   * `"1F77B4"` / `"#1F77B4"` / `"1f77b4"` and collapses malformed
+   * tokens (wrong length, non-hex characters, alpha-channel forms,
+   * empty / whitespace-only strings, non-string escapes from an
+   * untyped caller) to `undefined`. The cloned `SheetChart` always
+   * carries a value the writer will accept; malformed source values
+   * likewise collapse on the resolver path.
+   *
+   * The override is silently dropped from the cloned `SheetChart`
+   * when the resolved chart renders no title (`title` resolved to
+   * `undefined` or `showTitle === false`) — there is no `<c:title>`
+   * block to host the stroke on a hidden title, so leaking the
+   * value into the output would carry a pin Excel never reads.
+   *
+   * The grammar mirrors `plotAreaBorderColor` so the chart `<c:spPr>`
+   * stroke knobs compose the same way at the call site. The override
+   * lands on the title's `<c:spPr><a:ln>` block and composes
+   * independently with `titleFillColor` — the two knobs share the
+   * `<c:spPr>` host but land on different children
+   * (`<a:solidFill>` for fill, `<a:ln>` for stroke), and the writer
+   * authors a `<c:spPr>` whenever either knob resolves to a value.
+   */
+  titleBorderColor?: string | null;
+  /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
    *
@@ -2339,6 +2368,23 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.titleFillColor,
     );
     if (resolvedTitleFillColor !== undefined) out.titleFillColor = resolvedTitleFillColor;
+
+    // `titleBorderColor` only renders inside `<c:title>` — a clone
+    // that omits the title has no `<c:spPr><a:ln>` slot for the writer
+    // to populate. Same scope rule as the typography knobs / title
+    // layout / title fill: the override wins over the source's parsed
+    // value; absence inherits, `null` drops, a hex string replaces.
+    // Malformed overrides collapse via the normalizer so the cloned
+    // `SheetChart` always carries a value the writer will accept;
+    // malformed source values likewise collapse on the resolver path.
+    // Composes independently with `titleFillColor` — the two knobs
+    // share the `<c:spPr>` host but land on different children
+    // (`<a:solidFill>` for fill, `<a:ln>` for stroke).
+    const resolvedTitleBorderColor = resolveTitleBorderColor(
+      source.titleBorderColor,
+      options.titleBorderColor,
+    );
+    if (resolvedTitleBorderColor !== undefined) out.titleBorderColor = resolvedTitleBorderColor;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -4221,6 +4267,43 @@ function resolveTitleColor(
  * color), so a caller can pin both without conflict.
  */
 function resolveTitleFillColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
+}
+
+/**
+ * Resolve a `titleBorderColor` override.
+ *
+ * `undefined` → inherit the source's parsed `titleBorderColor` (after
+ *               running it through {@link normalizeTitleColor} so a
+ *               malformed source value drops cleanly — the hex
+ *               normalizer is purely shape-based and applies
+ *               identically to every `<a:srgbClr val="RRGGBB"/>`
+ *               slot).
+ * `null`      → drop the inherited stroke (the writer emits no
+ *               `<a:ln>` block on `<c:title><c:spPr>`, falling back
+ *               to the theme default — typically no visible border).
+ * `string`    → replace, after running through
+ *               {@link normalizeTitleColor} so the override accepts
+ *               `"1F77B4"` / `"#1F77B4"` / `"1f77b4"` and collapses
+ *               malformed tokens to `undefined`.
+ *
+ * The grammar mirrors `plotAreaBorderColor` / `titleFillColor` so the
+ * chart `<c:spPr>` knobs compose the same way at the call site.
+ * Callers should gate the result on the resolved title visibility —
+ * when no title is emitted, the stroke has no slot in the rendered
+ * chart.
+ *
+ * Independent of `titleFillColor`: the two knobs target different
+ * children of the shared `<c:spPr>` block on `<c:title>`
+ * (`<a:solidFill>` for the fill, `<a:ln>` for the stroke), so a
+ * caller can pin both without conflict.
+ */
+function resolveTitleBorderColor(
   sourceValue: string | undefined,
   override: string | null | undefined,
 ): string | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -233,6 +233,19 @@ export function parseChart(xml: string): Chart | undefined {
   const titleFillColor = parseTitleFillColor(chartEl);
   if (titleFillColor !== undefined) out.titleFillColor = titleFillColor;
 
+  // `<c:title><c:spPr><a:ln><a:solidFill>` carries Excel's "Format
+  // Chart Title -> Border -> Solid line -> Color" picker. The
+  // `<a:ln>` block lives inside the same `<c:spPr>` slot as the fill
+  // (`<a:solidFill>`), per CT_ShapeProperties — the reader scopes the
+  // lookup to direct children of `<c:title>` so a stray `<c:spPr>`
+  // elsewhere (on the plot area, a series, on the legend) cannot
+  // leak into this field. Theme references (`<a:schemeClr>`) and
+  // non-solid line fills (`<a:noFill>` / `<a:gradFill>` /
+  // `<a:pattFill>`) all collapse to `undefined` so a round-trip
+  // never fabricates a stroke the writer cannot reproduce on emit.
+  const titleBorderColor = parseTitleBorderColor(chartEl);
+  if (titleBorderColor !== undefined) out.titleBorderColor = titleBorderColor;
+
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
   // `<c:title>` is present. The element sits on `<c:chart>` directly
@@ -4615,6 +4628,59 @@ function parseTitleFillColor(chartEl: XmlElement): string | undefined {
   const spPr = findChild(title, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:title>` off the chart-level
+ * `<c:title>` block. Returns the title border (line) stroke color as
+ * a 6-character uppercase hex string the writer can round-trip via
+ * {@link SheetChart.titleBorderColor}.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+ * solid fill choice (`CT_LineProperties`, §20.1.2.3.24) which itself
+ * sits inside `<c:spPr>` (`CT_ShapeProperties`, §20.1.2.3.13). The
+ * `<c:spPr>` slot lives between `<c:overlay>` and `<c:txPr>` /
+ * `<c:extLst>` per CT_Title (§21.2.2.210); `<a:ln>` follows the
+ * optional `<a:solidFill>` (fill) child inside `<c:spPr>`.
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid line fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`),
+ * and theme-color references (`<a:schemeClr>`) all collapse to
+ * `undefined` so a chart that pinned a stroke the writer cannot
+ * reproduce on emit drops the field rather than fabricate one Excel
+ * would render differently. Malformed `val` tokens (wrong length,
+ * non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * The lookup is scoped to direct children of `<c:title>` so a stray
+ * `<c:spPr>` elsewhere in the chart (e.g. on the plot area, a
+ * series, or the legend) cannot leak in. Returns `undefined`
+ * whenever the chart omits the `<c:title>` element or the
+ * `<c:spPr><a:ln><a:solidFill><a:srgbClr>` chain is malformed at
+ * any link. Mirrors {@link parsePlotAreaBorderColor} — same
+ * `<a:ln>` chain on a different host element. Independent of
+ * {@link parseTitleFillColor}: the two readers walk disjoint
+ * children of the shared `<c:spPr>` block (`<a:solidFill>` for the
+ * fill, `<a:ln>` for the stroke) so a caller can pin both knobs
+ * without conflict. Unlike {@link parseTitleColor}, the lookup is
+ * on `<c:title>` directly rather than gated on `<c:rich>` so a
+ * title authored as a `<c:strRef>` formula reference can still
+ * surface its border color.
+ */
+function parseTitleBorderColor(chartEl: XmlElement): string | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  const spPr = findChild(title, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -82,6 +82,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleFontFamily(chart),
         resolveTitleLayout(chart),
         resolveTitleFillColor(chart),
+        resolveTitleBorderColor(chart),
       ),
     );
   }
@@ -304,6 +305,7 @@ function buildTitle(
   fontFamily: string | undefined,
   layout: ResolvedManualLayout | undefined,
   fillRgbHex: string | undefined,
+  borderRgbHex: string | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -463,17 +465,20 @@ function buildTitle(
   // CT_Title (ECMA-376 Part 1, §21.2.2.210) places the optional
   // `<c:spPr>` between `<c:overlay>` and `<c:txPr>` / `<c:extLst>`.
   // The writer skips emission entirely when the caller did not pin a
-  // fill color so a fresh chart matches Excel's reference
+  // fill or border color so a fresh chart matches Excel's reference
   // serialization byte-for-byte — Excel itself omits the block
-  // whenever the title renders at the theme default fill (typically a
-  // transparent title background with no `<c:spPr>` block). Currently
-  // the writer only authors `<a:solidFill>` here; stroke (`<a:ln>`)
-  // and other CT_ShapeProperties children are not modelled at this
-  // layer. Distinct from the `<a:defRPr><a:solidFill>` font-color slot
-  // inside `<c:tx><c:rich>` that {@link SheetChart.titleColor} pins —
-  // the two knobs target different children of `<c:title>` so a
-  // caller can pin both without conflict.
-  const titleSpPrXml = buildTitleSpPr(fillRgbHex);
+  // whenever the title renders at the theme defaults (typically a
+  // transparent title background with no visible border, no
+  // `<c:spPr>` block). Authors `<a:solidFill>` for the fill and
+  // `<a:ln>` for the stroke in CT_ShapeProperties schema order;
+  // other CT_ShapeProperties children (effects, gradient / pattern /
+  // picture fills, line dash / width / compound styles) are not
+  // modelled at this layer. Distinct from the `<a:defRPr><a:solidFill>`
+  // font-color slot inside `<c:tx><c:rich>` that
+  // {@link SheetChart.titleColor} pins — the typography knobs target
+  // different children of `<c:title>` so a caller can pin both
+  // without conflict.
+  const titleSpPrXml = buildTitleSpPr(fillRgbHex, borderRgbHex);
   if (titleSpPrXml !== undefined) {
     titleChildren.push(titleSpPrXml);
   }
@@ -482,27 +487,47 @@ function buildTitle(
 
 /**
  * Build the `<c:spPr>` element on `<c:title>` that carries the
- * title's background fill. Returns `undefined` when no fill color is
- * pinned so the caller can elide the entire block — Excel's reference
- * serialization omits `<c:spPr>` from `<c:title>` whenever the title
- * renders at the theme default fill (typically a transparent title
- * background).
+ * title's background fill ({@link SheetChart.titleFillColor}) and /
+ * or border-stroke color ({@link SheetChart.titleBorderColor}).
+ * Returns `undefined` when neither knob is pinned so the caller can
+ * elide the entire block — Excel's reference serialization omits
+ * `<c:spPr>` from `<c:title>` whenever the title renders at the theme
+ * default fill / stroke (typically a transparent title background
+ * with no visible border).
  *
- * The emitted block mirrors the minimal `<c:spPr>` shape Excel writes
- * when the user pins "Format Chart Title -> Fill -> Solid fill ->
- * Color": `<c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
- * </a:solidFill></c:spPr>`. The `val` attribute holds the canonical
- * 6-character uppercase hex form (the writer normalizes the input
- * ahead of this call so a malformed source value never reaches emit).
+ * When at least one knob lands on the wire, the children are emitted
+ * in `CT_ShapeProperties` (ECMA-376 Part 1, §20.1.2.3.13) schema
+ * order: `<a:solidFill>` (fill) first, then `<a:ln>` (line / stroke).
+ * The fill block has the form `<a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill>`; the stroke block has the form `<a:ln><a:solidFill>
+ * <a:srgbClr val="RRGGBB"/></a:solidFill></a:ln>`. The `val`
+ * attribute holds the canonical 6-character uppercase hex form (the
+ * writer normalizes the inputs ahead of this call so malformed source
+ * values never reach emit).
  *
  * Mirrors the plot-area / legend `<c:spPr>` slots so a single hex
- * string threads cleanly through every fill knob the writer authors.
+ * string threads cleanly through every fill / stroke knob the writer
+ * authors.
  */
-function buildTitleSpPr(fillRgbHex: string | undefined): string | undefined {
-  if (fillRgbHex === undefined) return undefined;
-  return xmlElement("c:spPr", undefined, [
-    xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
-  ]);
+function buildTitleSpPr(
+  fillRgbHex: string | undefined,
+  borderRgbHex: string | undefined,
+): string | undefined {
+  if (fillRgbHex === undefined && borderRgbHex === undefined) return undefined;
+  const children: string[] = [];
+  if (fillRgbHex !== undefined) {
+    children.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
+    );
+  }
+  if (borderRgbHex !== undefined) {
+    children.push(
+      xmlElement("a:ln", undefined, [
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
+      ]),
+    );
+  }
+  return xmlElement("c:spPr", undefined, children);
 }
 
 /**
@@ -746,6 +771,33 @@ function resolveTitleColor(chart: SheetChart): string | undefined {
  */
 function resolveTitleFillColor(chart: SheetChart): string | undefined {
   return normalizeTitleColor(chart.titleFillColor);
+}
+
+/**
+ * Resolve `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:title>` from
+ * {@link SheetChart.titleBorderColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the chart leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches every other
+ * `<a:srgbClr>` slot the writer authors. The stroke is only
+ * meaningful when the chart actually emits a title — the caller is
+ * expected to gate the call on `showTitle && chart.title`. A chart
+ * whose title is suppressed has no `<c:title>` block to host the
+ * `<c:spPr>` slot in either case.
+ *
+ * Independent of {@link resolveTitleFillColor}: the stroke lands on
+ * `<c:title><c:spPr><a:ln>`, the fill lands on
+ * `<c:title><c:spPr><a:solidFill>` — the two resolvers target
+ * different children of the shared `<c:spPr>` block so a single
+ * configuration call can pin both. Mirrors
+ * {@link normalizePlotAreaBorderColor} — same hex grammar, distinct
+ * host element (`<c:title>` vs `<c:plotArea>`).
+ */
+function resolveTitleBorderColor(chart: SheetChart): string | undefined {
+  return normalizeTitleColor(chart.titleBorderColor);
 }
 
 /**
@@ -4306,14 +4358,16 @@ function buildAxisTitle(
   // Excel's reference shape byte-for-byte (Excel itself omits the
   // block whenever the title renders at the theme default fill —
   // typically a transparent title background with no `<c:spPr>`
-  // block). Currently the writer only authors `<a:solidFill>` here;
-  // stroke (`<a:ln>`) and other CT_ShapeProperties children are not
-  // modelled at this layer. Distinct from the
-  // `<a:defRPr><a:solidFill>` font-color slot inside `<c:tx><c:rich>`
-  // that {@link SheetChart.axes.x.axisTitleColor} pins — the two knobs
-  // target different children of `<c:title>` so a caller can pin both
-  // without conflict.
-  const titleSpPrXml = buildTitleSpPr(fillRgbHex);
+  // block). Currently the writer only authors `<a:solidFill>` here
+  // for axis titles; stroke (`<a:ln>`) and other CT_ShapeProperties
+  // children are not modelled at this layer (the chart-level
+  // {@link SheetChart.titleBorderColor} knob lands on `<c:title>` —
+  // the axis-title border counterpart is a separate gap). Distinct
+  // from the `<a:defRPr><a:solidFill>` font-color slot inside
+  // `<c:tx><c:rich>` that {@link SheetChart.axes.x.axisTitleColor}
+  // pins — the two knobs target different children of `<c:title>` so
+  // a caller can pin both without conflict.
+  const titleSpPrXml = buildTitleSpPr(fillRgbHex, undefined);
   if (titleSpPrXml !== undefined) titleChildren.push(titleSpPrXml);
   return xmlElement("c:title", undefined, titleChildren);
 }

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -21568,6 +21568,221 @@ describe("cloneChart — titleFillColor", () => {
   });
 });
 
+// ── cloneChart — titleBorderColor (line stroke) ─────────────────────
+
+describe("cloneChart — titleBorderColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's titleBorderColor by default", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("lets options.titleBorderColor override the source's value", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: "ABCDEF",
+    });
+    expect(clone.titleBorderColor).toBe("ABCDEF");
+  });
+
+  it("drops the inherited titleBorderColor when the override is null", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: null,
+    });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined titleBorderColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # in the override hex string", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: "#abcdef",
+    });
+    expect(clone.titleBorderColor).toBe("ABCDEF");
+  });
+
+  it("normalizes a lowercase override hex string to uppercase", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: "ff8800",
+    });
+    expect(clone.titleBorderColor).toBe("FF8800");
+  });
+
+  it("normalizes a malformed source value through the resolver (drops to undefined)", () => {
+    const clone = cloneChart(source({ titleBorderColor: "ZZZ" as string }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("collapses malformed override hex tokens (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: "ZZZZZZ",
+    });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("collapses non-string overrides (number leaking past the type guard)", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      titleBorderColor: 0xff_ff_ff as any,
+    });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("collapses an alpha-channel form override (8 chars)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: "FFAA0080",
+    });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("carries titleBorderColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("carries titleBorderColor through a doughnut flatten (line → doughnut)", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("drops the inherited titleBorderColor when title is dropped (title=null)", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.title).toBeUndefined();
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("drops the titleBorderColor override when showTitle is false", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+      titleBorderColor: "1F77B4",
+    });
+    expect(clone.titleBorderColor).toBeUndefined();
+  });
+
+  it("retains titleBorderColor when override re-introduces a title on a sourceless chart", () => {
+    const noTitle = source();
+    delete noTitle.title;
+    const clone = cloneChart(noTitle, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Replacement",
+      titleBorderColor: "1F77B4",
+    });
+    expect(clone.title).toBe("Replacement");
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with titleFillColor (each lands on its own slot in the clone)", () => {
+    const clone = cloneChart(source({ titleFillColor: "FFFF00", titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleFillColor).toBe("FFFF00");
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with titleColor (font color lands on its own slot)", () => {
+    const clone = cloneChart(source({ titleColor: "FF0000", titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleColor).toBe("FF0000");
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("retains titleBorderColor independently of a hidden legend", () => {
+    const clone = cloneChart(source({ titleBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("survives a writeXlsx round trip — titleBorderColor lands in the cloned chart XML", async () => {
+    const clone = cloneChart(source({ titleBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderColor: "1F77B4",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("round-trips both fill and border together — write → parse → clone", async () => {
+    const written = writeChart(
+      {
+        type: "line",
+        title: "Sales",
+        series: [{ values: "B2:B5", categories: "A2:A5" }],
+        anchor: { from: { row: 0, col: 0 } },
+        titleFillColor: "FFFF00",
+        titleBorderColor: "1F77B4",
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.titleFillColor).toBe("FFFF00");
+    expect(parsed.titleBorderColor).toBe("1F77B4");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.titleFillColor).toBe("FFFF00");
+    expect(clone.titleBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── cloneChart — legendFillColor ─────────────────────────────────────
 
 describe("cloneChart — legendFillColor", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -20446,6 +20446,231 @@ describe("writeChart — titleFillColor", () => {
   });
 });
 
+// ── writeChart — titleBorderColor (line stroke) ──────────────────────
+
+describe("writeChart — titleBorderColor", () => {
+  function titleOf(xml: string): string {
+    // Root chart-level title sits directly inside `<c:chart>`. Anchor
+    // the regex on `<c:chart>` to avoid matching axis titles.
+    const m = xml.match(/<c:chart>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No chart-level <c:title> block found in chart XML");
+    const titleMatch = m[0].match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) throw new Error("No <c:title> in chart subtree");
+    return titleMatch[0];
+  }
+
+  it("does not emit <c:spPr> on <c:title> when titleBorderColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:spPr>");
+    expect(title).not.toContain("<a:ln>");
+  });
+
+  it("emits <c:spPr><a:ln><a:solidFill><a:srgbClr> on <c:title> when titleBorderColor is set", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "1F77B4" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).toContain("<c:spPr>");
+    expect(title).toContain("<a:ln>");
+    expect(title).toContain('<a:srgbClr val="1F77B4"/>');
+    // The border color must land inside <a:ln>, not as a top-level
+    // <a:solidFill> (that slot is reserved for the fill color knob).
+    const lnIdx = title.indexOf("<a:ln>");
+    const srgbIdx = title.indexOf('<a:srgbClr val="1F77B4"/>');
+    expect(srgbIdx).toBeGreaterThan(lnIdx);
+  });
+
+  it("normalizes a leading # and lowercase hex to the canonical uppercase form", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "#1f77b4" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("places <c:spPr> after <c:overlay> on <c:title> (CT_Title sequence)", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "1F77B4" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    const overlayIdx = title.indexOf("<c:overlay");
+    const spPrIdx = title.indexOf("<c:spPr>");
+    expect(overlayIdx).toBeGreaterThan(0);
+    expect(spPrIdx).toBeGreaterThan(overlayIdx);
+  });
+
+  it("only emits one <c:spPr> inside <c:title>", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "FFAA00" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    const occurrences = title.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads titleBorderColor through every chart family that owns a <c:title>", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, titleBorderColor: "ABCDEF" }), "Sheet1");
+      const title = titleOf(result.chartXml);
+      expect(title).toContain('<a:srgbClr val="ABCDEF"/>');
+      expect(title).toContain("<a:ln>");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        titleBorderColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    expect(titleOf(scatter.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "FFF" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "GGGGGG" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(makeChart({ titleBorderColor: "FFAA0080" }), "Sheet1");
+    const title = titleOf(result.chartXml);
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops an empty / whitespace-only string", () => {
+    expect(
+      titleOf(writeChart(makeChart({ titleBorderColor: "" }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+    expect(
+      titleOf(writeChart(makeChart({ titleBorderColor: "   " }), "Sheet1").chartXml),
+    ).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ titleBorderColor: 0xff_ff_ff as any }), "Sheet1");
+    expect(titleOf(a.chartXml)).not.toContain("<c:spPr>");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ titleBorderColor: null as any }), "Sheet1");
+    expect(titleOf(b.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("does not emit any <c:title> at all when no title is rendered (showTitle=false)", () => {
+    const result = writeChart(
+      makeChart({ showTitle: false, title: "", titleBorderColor: "1F77B4" }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:title>");
+  });
+
+  it("composes independently with titleFillColor — fill and stroke share one <c:spPr>", () => {
+    const result = writeChart(
+      makeChart({
+        titleFillColor: "FFFF00",
+        titleBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    // Single <c:spPr> hosts both knobs.
+    const spPrCount = title.match(/<c:spPr>/g) ?? [];
+    expect(spPrCount).toHaveLength(1);
+    // Fill color lands on the top-level <a:solidFill>.
+    expect(title).toContain('<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>');
+    // Border color lands inside <a:ln>.
+    expect(title).toContain('<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>');
+    // CT_ShapeProperties order: fill <a:solidFill> precedes <a:ln>.
+    // (Use the spPr-scoped indices so the title-color font fill on
+    // <a:defRPr> does not skew the comparison.)
+    const spPrIdx = title.indexOf("<c:spPr>");
+    expect(title.indexOf("<a:solidFill>", spPrIdx)).toBeLessThan(title.indexOf("<a:ln>", spPrIdx));
+  });
+
+  it("composes independently with titleColor (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        title: "Hero",
+        titleColor: "FF0000",
+        titleBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    // Font color in <a:defRPr><a:solidFill> slot.
+    expect(title).toMatch(/<a:defRPr[^>]*>\s*<a:solidFill><a:srgbClr val="FF0000"\/>/);
+    // Border color on the title's <c:spPr><a:ln>.
+    expect(title).toContain('<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>');
+    // Font color slot precedes the spPr stroke slot per CT_Title schema.
+    const fontFillPos = title.indexOf('<a:srgbClr val="FF0000"/>');
+    const strokePos = title.indexOf('<a:srgbClr val="1F77B4"/>');
+    expect(fontFillPos).toBeGreaterThan(0);
+    expect(strokePos).toBeGreaterThan(fontFillPos);
+  });
+
+  it("composes independently with titleLayout (layout precedes spPr)", () => {
+    const result = writeChart(
+      makeChart({
+        titleLayout: { x: 0.1, y: 0.05 },
+        titleBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const title = titleOf(result.chartXml);
+    expect(title).toContain('<c:x val="0.1"/>');
+    expect(title).toContain('<a:srgbClr val="1F77B4"/>');
+    // CT_Title sequence: <c:layout> precedes <c:overlay> precedes <c:spPr>.
+    expect(title.indexOf("<c:layout>")).toBeLessThan(title.indexOf("<c:overlay"));
+    expect(title.indexOf("<c:overlay")).toBeLessThan(title.indexOf("<c:spPr>"));
+  });
+
+  it("round-trips titleBorderColor through parseChart", () => {
+    const written = writeChart(makeChart({ titleBorderColor: "1F77B4" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset titleBorderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("round-trips both fill and border together through parseChart", () => {
+    const written = writeChart(
+      makeChart({ titleFillColor: "FFFF00", titleBorderColor: "1F77B4" }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.titleFillColor).toBe("FFFF00");
+    expect(reparsed?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("survives a writeXlsx round trip — titleBorderColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            titleBorderColor: "1F77B4",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── writeChart — legendFillColor ─────────────────────────────────────
 
 describe("writeChart — legendFillColor", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20317,6 +20317,204 @@ describe("parseChart — titleFillColor", () => {
   });
 });
 
+// ── parseChart — titleBorderColor (line stroke) ─────────────────────
+
+describe("parseChart — titleBorderColor", () => {
+  const NS_TBC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_TBC}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:title>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:title><c:spPr><a:ln><a:solidFill><a:srgbClr> is pinned", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBe("ABCDEF");
+  });
+
+  it("surfaces fill and border independently when both are pinned", () => {
+    const xml = withTitleSpPr(
+      `<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>` +
+        `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.titleFillColor).toBe("FFFF00");
+    expect(parsed?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the chart has no <c:title>", () => {
+    const xml = `<c:chartSpace ${NS_TBC}><c:chart><c:plotArea><c:layout/><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart><c:catAx><c:axId val="1"/></c:catAx><c:valAx><c:axId val="2"/></c:valAx></c:plotArea></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_TBC}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+    </c:title>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    const xml = withTitleSpPr(`<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no <a:solidFill>", () => {
+    const xml = withTitleSpPr(`<a:ln w="12700"/>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln><a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:noFill>", () => {
+    const xml = withTitleSpPr(`<a:ln><a:noFill/></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:gradFill>", () => {
+    const xml = withTitleSpPr(
+      `<a:ln><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:pattFill>", () => {
+    const xml = withTitleSpPr(
+      `<a:ln><a:pattFill prst="dkUpDiag"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (wrong length)", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="ABC"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (non-hex characters)", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="GGGGGG"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:srgbClr/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln> on the plot area (not the title)", () => {
+    const xml = `<c:chartSpace ${NS_TBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln> on a series <c:spPr> (not the title)", () => {
+    const xml = `<c:chartSpace ${NS_TBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleBorderColor).toBeUndefined();
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const xml = withTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("surfaces titleBorderColor independently of titleColor (font color slot)", () => {
+    const xml = `<c:chartSpace ${NS_TBC}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p>
+        <a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr>
+        <a:r><a:rPr lang="en-US"/><a:t>Hero</a:t></a:r>
+      </a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+    </c:title>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleColor).toBe("FF0000");
+    expect(chart?.titleBorderColor).toBe("1F77B4");
+  });
+
+  it("surfaces titleBorderColor on a strRef-bodied title (no <c:rich>)", () => {
+    const xml = `<c:chartSpace ${NS_TBC}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:strRef><c:f>Sheet1!$A$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Hero</c:v></c:pt></c:strCache></c:strRef></c:tx>
+      <c:overlay val="0"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+    </c:title>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.titleBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── parseChart — legendFillColor ─────────────────────────────────────
 
 describe("parseChart — legendFillColor", () => {


### PR DESCRIPTION
## Summary
- Adds `titleBorderColor` knob mapping to `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val=\"..\"/></a:solidFill></a:ln></c:spPr></c:title>` — Excel's "Format Chart Title → Border → Solid line → Color" picker.
- Composes independently with `titleFillColor`: the two share the same `<c:spPr>` host on `<c:title>` but land on different children (`<a:solidFill>` for fill, `<a:ln>` for stroke). The writer emits a single `<c:spPr>` whenever either knob is set, in `CT_ShapeProperties` schema order (fill before stroke).
- Reader, writer, and clone-through plumbing follows the established hex-color grammar — accepts `#` / case, drops malformed / non-solid / `schemeClr` / alpha-channel forms to `undefined`. Silently dropped when no title is rendered (`showTitle === false` or `title` is absent — there is no `<c:title>` element to host the slot).

Sibling of the in-flight `legendBorderColor` knob (#310) — same `<a:ln>` pattern, distinct host element (`<c:title>` vs `<c:legend>`). Continues the stroke (`<c:spPr><a:ln>`) family started by #309.

## Test plan
- [x] `pnpm vitest run --dir=test` — 89 files / 6773 tests pass (58 new tests across `parseChart`, `writeChart`, and `cloneChart`).
- [x] `pnpm build` — succeeds.
- [x] Round-trips covered: writer → reader, writer → `writeXlsx` → packaged `chart1.xml` → reader, plus clone-through with override / null / inheritance / malformed-token / cross-family flatten.
- [x] Composition with `titleFillColor`, `titleColor`, and `titleLayout` — single `<c:spPr>`, correct child order (`<a:solidFill>` precedes `<a:ln>`), layout precedes spPr per `CT_Title`.
- [x] Hidden-title scoping verified — `showTitle: false` produces no `<c:title>` element even with the border pinned; `title: null` clone drops the border.
- [x] strRef-bodied title (formula reference, no `<c:rich>` body) still surfaces the border on parse.

Refs #309