### PR TITLE
feat(xlsx): chart axis-title border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -4000,6 +4000,70 @@ export interface SheetChart {
        * area / scatter).
        */
       axisTitleFillColor?: string;
+      /**
+       * Axis-title border (line stroke) solid color as a 6-digit RGB
+       * hex string (e.g. `"1F77B4"`). Maps to
+       * `<c:catAx><c:title><c:spPr><a:ln><a:solidFill><a:srgbClr
+       * val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:title></c:catAx>`
+       * (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) — Excel's
+       * "Format Axis Title -> Border -> Solid line -> Color" picker.
+       * The OOXML `<a:srgbClr val=".."/>` carries the 6-character
+       * uppercase hex sRGB color (`CT_SRgbColor` inside the line's
+       * solid fill choice — ECMA-376 Part 1, §20.1.2.3.32 /
+       * §20.1.2.3.24). The `<c:spPr>` slot lives between
+       * `<c:overlay>` and `<c:txPr>` / `<c:extLst>` per CT_Title
+       * (ECMA-376 Part 1, §21.2.2.210); `<a:ln>` follows the optional
+       * `<a:solidFill>` (fill) child inside `<c:spPr>` per
+       * `CT_ShapeProperties` (ECMA-376 Part 1, §20.1.2.3.13).
+       *
+       * Accepts a 6-character hex string with or without a leading
+       * `#`, any case (`"FF0000"`, `"#1070ca"`, `"abcdef"`); the
+       * writer normalizes to the OOXML canonical 6-character
+       * uppercase form (`"FF0000"`, `"1070CA"`, `"ABCDEF"`) so a
+       * re-parse round-trips losslessly. Malformed inputs (wrong
+       * length, non-hex characters, alpha-channel forms like
+       * `"FFAA0080"`, empty / whitespace-only strings, non-string
+       * escapes from an untyped caller) collapse to `undefined` and
+       * the writer omits the `<a:ln>` block — the axis title
+       * inherits the auto-stroke Excel picks from the chart's theme
+       * (typically no visible border, matching Excel's reference
+       * shape byte-for-byte).
+       *
+       * Default: omitted — the title inherits the auto-stroke (no
+       * `<a:ln>` block). Pin a hex color to mirror Excel's "Format
+       * Axis Title -> Border -> Solid line" knob and paint a flat
+       * border around the axis-title block — useful for highlighting
+       * an axis title against a busy theme or framing it like a
+       * dashboard tile.
+       *
+       * Composes independently with {@link axisTitleFillColor} —
+       * the two knobs land on the same `<c:spPr>` block but on
+       * different children (`<a:solidFill>` for the fill, `<a:ln>`
+       * for the stroke), and the writer authors a `<c:spPr>`
+       * whenever either knob is set. A caller can pin one without
+       * the other; pinning both produces a filled axis-title block
+       * with a colored border.
+       *
+       * Patterned / gradient strokes are not modelled — only the
+       * solid sRGB form lands on the wire. Theme-color references
+       * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed
+       * value always carries a literal hex Excel will render
+       * byte-for-byte.
+       *
+       * Silently dropped when the axis renders no title (the
+       * `<c:title>` element is absent in either case) and on `pie` /
+       * `doughnut` charts (no axes at all). Mirrors
+       * {@link SheetChart.titleBorderColor} for axis titles — same
+       * `<c:spPr><a:ln><a:solidFill><a:srgbClr>` slot, same
+       * accept-with-or-without-`#` grammar, distinct host element.
+       *
+       * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+       * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>`
+       * shape per the OOXML schema, so the field round-trips on
+       * every chart family that has axes (bar / column / line /
+       * area / scatter).
+       */
+      axisTitleBorderColor?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -4776,6 +4840,15 @@ export interface SheetChart {
        * See the X-axis variant for the full semantics.
        */
       axisTitleFillColor?: string;
+      /**
+       * Value-axis-title border (line stroke) solid color. Same
+       * canonical `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr
+       * val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:title>` slot
+       * and grammar as {@link SheetChart.axes.x.axisTitleBorderColor}
+       * — the field round-trips on `<c:valAx>` exactly as it does on
+       * `<c:catAx>`. See the X-axis variant for the full semantics.
+       */
+      axisTitleBorderColor?: string;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -6557,6 +6630,52 @@ export interface ChartAxisInfo {
    * whether the source axis was a category or value axis.
    */
   axisTitleFillColor?: string;
+  /**
+   * Axis-title border (line stroke) solid sRGB color pulled from
+   * `<c:catAx><c:title><c:spPr><a:ln><a:solidFill><a:srgbClr
+   * val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:title></c:catAx>`
+   * (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`). Reflects Excel's
+   * "Format Axis Title -> Border -> Solid line -> Color" picker.
+   *
+   * Surfaced as the 6-character uppercase hex string the writer
+   * round-trips (`"FFFF00"` / `"1070CA"`) — the leading `#` is
+   * stripped on read so the value threads straight into the
+   * writer-side {@link SheetChart.axes.x.axisTitleBorderColor}
+   * without transformation. Color picks other than the literal sRGB
+   * form (`<a:schemeClr>` theme references, `<a:hslClr>`,
+   * `<a:sysClr>`, `<a:prstClr>`) collapse to `undefined` — the
+   * reader records only the resolvable RGB triple to keep the round-
+   * trip lossless against {@link cloneChart} -> {@link writeXlsx}.
+   * Non-solid line fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`)
+   * likewise drop to `undefined`. Malformed `val` tokens (wrong
+   * length, non-hex characters) drop to `undefined` rather than
+   * fabricate a value the writer would round-trip into a malformed
+   * `<a:srgbClr>`.
+   *
+   * Independent of {@link ChartAxisInfo.axisTitleColor} (font color
+   * on `<a:defRPr><a:solidFill>`) and
+   * {@link ChartAxisInfo.axisTitleFillColor} (background fill on
+   * `<c:spPr><a:solidFill>`): the stroke lives on `<c:spPr><a:ln>
+   * <a:solidFill>`, the fill lives on `<c:spPr><a:solidFill>`, and
+   * the font color lives on the inner `<a:defRPr><a:solidFill>` —
+   * the three readers walk disjoint paths so a caller can pin all
+   * three knobs without conflict.
+   *
+   * Reported as `undefined` whenever the axis omits `<c:title>`
+   * entirely or when the `<c:spPr><a:ln><a:solidFill><a:srgbClr>`
+   * chain is malformed at any link. Mirrors the chart-level
+   * {@link Chart.titleBorderColor} so a parsed value slots straight
+   * back into the writer-side
+   * {@link SheetChart.axes.x.axisTitleBorderColor} without
+   * transformation.
+   *
+   * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+   * `<c:dateAx>` / `<c:serAx>` all carry the same `<c:title>` shape
+   * per the OOXML schema. The reader surfaces the value on every
+   * axis flavour so a parsed chart preserves the stroke regardless
+   * of whether the source axis was a category or value axis.
+   */
+  axisTitleBorderColor?: string;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -1481,6 +1481,37 @@ export interface CloneChartOptions {
        * slots.
        */
       axisTitleFillColor?: string | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleBorderColor`. `undefined`
+       * (or omitted) inherits the source axis's parsed value; `null`
+       * drops the inherited stroke so the writer falls back to the
+       * theme-default auto-stroke (no `<a:ln>` block on the axis
+       * title, typically no visible border); a 6-character hex string
+       * (with or without a leading `#`, any case) replaces it.
+       *
+       * Malformed overrides (wrong length, non-hex characters,
+       * alpha-channel forms, non-string escapes from an untyped
+       * caller) collapse to a drop so the cloned `SheetChart` always
+       * carries a value the writer will accept.
+       *
+       * `<c:title>` lives on every axis flavour per the OOXML schema,
+       * so the override carries through every chart family that has
+       * axes (bar / column / line / area / scatter). Silently dropped
+       * on `pie` / `doughnut` charts (no axes at all) and on any
+       * axis whose `title` is unset (no `<c:title>` block to host
+       * the stroke). Composes independently with `axisTitleFillColor`
+       * (the background fill on `<c:spPr><a:solidFill>`) and
+       * `axisTitleColor` (the font color on the inner
+       * `<a:defRPr><a:solidFill>`) — the three knobs target different
+       * children of `<c:title>` so a caller can pin all three without
+       * conflict.
+       *
+       * Mirrors the chart-level `titleBorderColor` so a single
+       * configuration call can thread a border color through the
+       * chart title and either axis title without bookkeeping the
+       * canonical OOXML slots.
+       */
+      axisTitleBorderColor?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1825,6 +1856,8 @@ export interface CloneChartOptions {
       axisTitleLayout?: ChartManualLayout | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleFillColor}. */
       axisTitleFillColor?: string | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleBorderColor}. */
+      axisTitleBorderColor?: string | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -4904,6 +4937,30 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleFillColor,
     overrides?.y?.axisTitleFillColor,
   );
+  // `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></a:ln></c:spPr></c:title>` — axis-title border
+  // (line stroke) color. Lives on the axis's `<c:title>` directly per
+  // CT_Title schema, on the same `<c:spPr>` block as the background
+  // fill but on a sibling child (`<a:ln>` for the stroke,
+  // `<a:solidFill>` for the fill). Independent of `axisTitleFillColor`
+  // and `axisTitleColor` (font color on the inner `<a:defRPr>
+  // <a:solidFill>` slot) — the three resolvers walk disjoint paths so
+  // a caller can pin all three knobs without conflict. Malformed
+  // overrides (wrong length, non-hex characters, alpha-channel forms,
+  // empty / whitespace-only strings, non-string escapes from an
+  // untyped caller) collapse to a drop via the normalizer so the
+  // cloned `SheetChart` always carries a value the writer will
+  // accept. Like the other axis-title knobs, the writer drops the
+  // stroke when the matching axis title is unset, so a stray pin on
+  // an axis with no title silently disappears at emit time.
+  const xAxisTitleBorderColor = applyAxisTitleBorderColorOverride(
+    sourceAxes?.x?.axisTitleBorderColor,
+    overrides?.x?.axisTitleBorderColor,
+  );
+  const yAxisTitleBorderColor = applyAxisTitleBorderColorOverride(
+    sourceAxes?.y?.axisTitleBorderColor,
+    overrides?.y?.axisTitleBorderColor,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -5208,6 +5265,17 @@ function resolveAxes(
   // the `<c:spPr>` block entirely when no fill is pinned).
   const xAxisTitleFillColorResolved = xTitle === undefined ? undefined : xAxisTitleFillColor;
   const yAxisTitleFillColorResolved = yTitle === undefined ? undefined : yAxisTitleFillColor;
+  // The axis-title border (line stroke) only renders when the axis
+  // carries a title — drop a stray inherited stroke when the resolved
+  // axis title is unset so the cloned `SheetChart` accurately reflects
+  // what the chart will paint. Symmetric with the writer's title-
+  // presence gate (the per-family axis builder only invokes
+  // `buildAxisTitle` when `opts.xAxisTitle` / `opts.yAxisTitle` is
+  // set, and the writer skips the `<a:ln>` block entirely when no
+  // border is pinned — and skips the entire `<c:spPr>` block when
+  // both the fill and border are absent).
+  const xAxisTitleBorderColorResolved = xTitle === undefined ? undefined : xAxisTitleBorderColor;
+  const yAxisTitleBorderColorResolved = yTitle === undefined ? undefined : yAxisTitleBorderColor;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -5223,6 +5291,7 @@ function resolveAxes(
     xAxisTitleOverlayResolved !== undefined ||
     xAxisTitleLayoutResolved !== undefined ||
     xAxisTitleFillColorResolved !== undefined ||
+    xAxisTitleBorderColorResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -5268,6 +5337,8 @@ function resolveAxes(
     if (xAxisTitleLayoutResolved !== undefined) out.x.axisTitleLayout = xAxisTitleLayoutResolved;
     if (xAxisTitleFillColorResolved !== undefined)
       out.x.axisTitleFillColor = xAxisTitleFillColorResolved;
+    if (xAxisTitleBorderColorResolved !== undefined)
+      out.x.axisTitleBorderColor = xAxisTitleBorderColorResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -5308,6 +5379,7 @@ function resolveAxes(
     yAxisTitleOverlayResolved !== undefined ||
     yAxisTitleLayoutResolved !== undefined ||
     yAxisTitleFillColorResolved !== undefined ||
+    yAxisTitleBorderColorResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -5347,6 +5419,8 @@ function resolveAxes(
     if (yAxisTitleLayoutResolved !== undefined) out.y.axisTitleLayout = yAxisTitleLayoutResolved;
     if (yAxisTitleFillColorResolved !== undefined)
       out.y.axisTitleFillColor = yAxisTitleFillColorResolved;
+    if (yAxisTitleBorderColorResolved !== undefined)
+      out.y.axisTitleBorderColor = yAxisTitleBorderColorResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;
@@ -6051,6 +6125,46 @@ function applyAxisTitleColorOverride(
  * the axis renders no title).
  */
 function applyAxisTitleFillColorOverride(
+  source: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeTitleColor(source);
+  if (override === null) return undefined;
+  return normalizeTitleColor(override);
+}
+
+/**
+ * Resolve an `axisTitleBorderColor` override using the same `undefined`
+ * (inherit) / `null` (drop) / value (replace) grammar as the other
+ * axis helpers. Non-string overrides and malformed hex tokens (typed
+ * escapes from an untyped caller, wrong length, non-hex characters,
+ * alpha-channel forms) collapse to `undefined` via
+ * {@link normalizeTitleColor} so the cloned `SheetChart` always
+ * carries a value the writer will accept. A `null` override always
+ * drops the inherited stroke (the writer falls back to the theme-
+ * default auto-stroke — no `<a:ln>` block on the axis title's
+ * `<c:spPr>`, typically no visible border matching Excel's reference
+ * shape).
+ *
+ * Independent of {@link applyAxisTitleFillColorOverride}: this
+ * resolver targets the axis title's stroke
+ * `<c:spPr><a:ln><a:solidFill>` slot, while the fill targets the
+ * sibling `<c:spPr><a:solidFill>` slot — the two knobs land on
+ * different children of the shared `<c:spPr>` block so a caller can
+ * pin both without conflict. Independent of
+ * {@link applyAxisTitleColorOverride}: the font color targets the
+ * inner `<a:defRPr><a:solidFill>` slot inside `<c:tx><c:rich><a:p>
+ * <a:pPr>` — disjoint from both the fill and the stroke. Mirrors
+ * {@link applyTitleBorderColorOverride} for axis titles — same
+ * accept-with-or-without-`#` hex grammar, distinct host element.
+ *
+ * The caller is expected to additionally gate the resolved value on
+ * the matching axis title's presence so the cloned shape never
+ * carries a stroke that the writer would silently elide (the writer
+ * scopes the stroke emission to `<c:title>`, which is omitted when
+ * the axis renders no title).
+ */
+function applyAxisTitleBorderColorOverride(
   source: string | undefined,
   override: string | null | undefined,
 ): string | undefined {

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -914,6 +914,25 @@ function parseAxisInfo(
   // "Format Axis Title -> Fill" dialog is independent of whether the
   // text body is rich or a formula.
   const axisTitleFillColor = parseAxisTitleFillColor(axis);
+  // `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+  // </a:solidFill></a:ln></c:spPr></c:title>` — axis-title border
+  // (line stroke) color. Sits on the axis's `<c:title>` directly per
+  // CT_Title schema; the `<a:ln>` block lives inside the same
+  // `<c:spPr>` slot as the fill (`<a:solidFill>`), per
+  // CT_ShapeProperties — the reader scopes the lookup to direct
+  // children of the axis's `<c:title>` so a stray `<c:spPr>`
+  // elsewhere (on the plot area, a series, on the legend, on the
+  // chart-level title) cannot leak into this field. Theme references
+  // (`<a:schemeClr>`) and non-solid line fills (`<a:noFill>` /
+  // `<a:gradFill>` / `<a:pattFill>`) all collapse to `undefined` so
+  // a round-trip never fabricates a stroke the writer cannot
+  // reproduce on emit. Independent of `axisTitleFillColor` (which
+  // lives on `<c:spPr><a:solidFill>` — the fill child of the same
+  // `<c:spPr>` block) and `axisTitleColor` (which lives on the
+  // inner `<a:defRPr><a:solidFill>` slot for the font color) — the
+  // three readers walk disjoint paths so a caller can pin all three
+  // knobs without conflict.
+  const axisTitleBorderColor = parseAxisTitleBorderColor(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -1075,6 +1094,7 @@ function parseAxisInfo(
     axisTitleOverlay === undefined &&
     axisTitleLayout === undefined &&
     axisTitleFillColor === undefined &&
+    axisTitleBorderColor === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -1117,6 +1137,7 @@ function parseAxisInfo(
   if (axisTitleOverlay !== undefined) out.axisTitleOverlay = axisTitleOverlay;
   if (axisTitleLayout !== undefined) out.axisTitleLayout = axisTitleLayout;
   if (axisTitleFillColor !== undefined) out.axisTitleFillColor = axisTitleFillColor;
+  if (axisTitleBorderColor !== undefined) out.axisTitleBorderColor = axisTitleBorderColor;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -4797,6 +4818,67 @@ function parseAxisTitleFillColor(axis: XmlElement): string | undefined {
   const spPr = findChild(title, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:title>` off an axis element.
+ * Returns the axis title's line stroke color as a 6-character
+ * uppercase hex string the writer can round-trip via
+ * {@link SheetChart.axes.x.axisTitleBorderColor}. Mirrors
+ * {@link parseTitleBorderColor} for axis titles — same canonical
+ * `<c:spPr><a:ln><a:solidFill><a:srgbClr>` chain, same drop-on-non-
+ * sRGB semantics.
+ *
+ * Returns the 6-character uppercase hex string when the parser walks
+ * the full chain and lands on an `<a:srgbClr val="RRGGBB"/>`. Theme
+ * references (`<a:schemeClr>`), `<a:hslClr>`, `<a:sysClr>`, and
+ * `<a:prstClr>` all collapse to `undefined` — only the literal RGB
+ * triple round-trips losslessly through {@link writeChart}. Non-solid
+ * line fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`) likewise
+ * drop to `undefined` so a round-trip never fabricates a stroke the
+ * writer cannot reproduce on emit. Malformed `val` tokens (wrong
+ * length, non-hex characters) drop to `undefined` rather than
+ * fabricate a value the writer would round-trip into a malformed
+ * `<a:srgbClr>`.
+ *
+ * The lookup is scoped to direct children of the axis's `<c:title>`
+ * so a stray `<c:spPr>` elsewhere on the axis (e.g. on a `<c:txPr>`
+ * tick-label block, or on the axis itself), or on the chart-level
+ * `<c:title>`, cannot leak in. Returns `undefined` whenever the axis
+ * omits the `<c:title>` element or the `<c:spPr><a:ln><a:solidFill>
+ * <a:srgbClr>` chain is malformed at any link.
+ *
+ * Independent of {@link parseAxisTitleFillColor} (the fill on the
+ * same `<c:spPr>` block) and {@link parseAxisTitleColor} (the font
+ * color on the inner `<a:defRPr><a:solidFill>` slot inside
+ * `<c:tx><c:rich><a:p><a:pPr>`) — the three readers walk disjoint
+ * children of the shared `<c:title>` block so a caller can pin all
+ * three knobs without conflict. Unlike {@link parseAxisTitleColor},
+ * the lookup is on `<c:title>` directly rather than gated on
+ * `<c:rich>` so a title authored as a `<c:strRef>` formula reference
+ * can still surface its border color — Excel's "Format Axis Title
+ * -> Border" dialog is independent of whether the text body is rich
+ * or a formula.
+ *
+ * Sits on every axis flavour — `<c:catAx>` / `<c:valAx>` /
+ * `<c:dateAx>` / `<c:serAx>` all share the same `<c:title>` shape
+ * per the OOXML schema. Mirrors the chart-level title border
+ * {@link parseTitleBorderColor} so a parsed value slots straight
+ * into the writer-side {@link SheetChart.axes.x.axisTitleBorderColor}.
+ */
+function parseAxisTitleBorderColor(axis: XmlElement): string | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  const spPr = findChild(title, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1126,6 +1126,19 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // title background with no `<c:spPr>` block).
     xAxisTitleFillColor: normalizeTitleColor(chart.axes?.x?.axisTitleFillColor),
     yAxisTitleFillColor: normalizeTitleColor(chart.axes?.y?.axisTitleFillColor),
+    // `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+    // </a:solidFill></a:ln></c:spPr></c:title>` — axis-title border
+    // (line stroke) color. Same accept-with-or-without-`#` /
+    // case-insensitive hex grammar as the chart-level
+    // `titleBorderColor` knob. Malformed inputs (wrong length,
+    // non-hex characters, alpha-channel forms, empty / whitespace-
+    // only strings, non-string escapes from an untyped caller)
+    // collapse to `undefined` and the writer omits the entire
+    // `<a:ln>` block (Excel's reference serialization for an axis
+    // title that inherits the auto-stroke — typically no visible
+    // border).
+    xAxisTitleBorderColor: normalizeTitleColor(chart.axes?.x?.axisTitleBorderColor),
+    yAxisTitleBorderColor: normalizeTitleColor(chart.axes?.y?.axisTitleBorderColor),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -2352,6 +2365,33 @@ interface AxisRenderOptions {
    * emit semantics as {@link xAxisTitleFillColor}.
    */
   yAxisTitleFillColor: string | undefined;
+  /**
+   * Axis-title border (line stroke) color emitted on the X axis via
+   * `<c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+   * </a:solidFill></a:ln></c:spPr></c:title>`. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (CT_SRgbColor inside the line's solid fill choice —
+   * ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). `undefined`
+   * collapses to omitting the `<a:ln>` block (Excel's reference
+   * serialization for an axis title that inherits the auto-stroke —
+   * typically no visible border); any non-`undefined` value is the
+   * normalized uppercase hex string the writer lands on the title's
+   * `<c:spPr><a:ln>` slot. Composes independently with
+   * {@link xAxisTitleFillColor} — the fill lands on
+   * `<c:spPr><a:solidFill>`, the stroke lands on
+   * `<c:spPr><a:ln><a:solidFill>`; the writer authors a single
+   * `<c:spPr>` whenever either knob is set with children in
+   * CT_ShapeProperties schema order (fill before stroke). Only
+   * meaningful when the axis renders a title — the per-family axis
+   * builders gate the value on the `xAxisTitle` / `yAxisTitle`
+   * field.
+   */
+  xAxisTitleBorderColor: string | undefined;
+  /**
+   * Axis-title border emitted on the Y axis. Same shape and emit
+   * semantics as {@link xAxisTitleBorderColor}.
+   */
+  yAxisTitleBorderColor: string | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -3584,6 +3624,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleOverlay,
         opts.xAxisTitleLayout,
         opts.xAxisTitleFillColor,
+        opts.xAxisTitleBorderColor,
       ),
     );
   catAxChildren.push(
@@ -3662,6 +3703,7 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleOverlay,
         opts.yAxisTitleLayout,
         opts.yAxisTitleFillColor,
+        opts.yAxisTitleBorderColor,
       ),
     );
   valAxChildren.push(
@@ -4041,6 +4083,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleOverlay,
         opts.xAxisTitleLayout,
         opts.xAxisTitleFillColor,
+        opts.xAxisTitleBorderColor,
       ),
     );
   xAxChildren.push(
@@ -4098,6 +4141,7 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleOverlay,
         opts.yAxisTitleLayout,
         opts.yAxisTitleFillColor,
+        opts.yAxisTitleBorderColor,
       ),
     );
   yAxChildren.push(
@@ -4202,6 +4246,7 @@ function buildAxisTitle(
   overlay: boolean,
   layout: ResolvedManualLayout | undefined,
   fillRgbHex: string | undefined,
+  borderRgbHex: string | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -4354,21 +4399,24 @@ function buildAxisTitle(
   titleChildren.push(xmlSelfClose("c:overlay", { val: overlay ? 1 : 0 }));
   // CT_Title (ECMA-376 Part 1, §21.2.2.210) places the optional
   // `<c:spPr>` between `<c:overlay>` and `<c:txPr>` / `<c:extLst>`.
-  // Mirrors `buildTitle`: the writer skips emission entirely when the
-  // caller did not pin a fill color so a fresh axis title matches
-  // Excel's reference shape byte-for-byte (Excel itself omits the
-  // block whenever the title renders at the theme default fill —
-  // typically a transparent title background with no `<c:spPr>`
-  // block). Currently the writer only authors `<a:solidFill>` here
-  // for axis titles; stroke (`<a:ln>`) and other CT_ShapeProperties
-  // children are not modelled at this layer (the chart-level
-  // {@link SheetChart.titleBorderColor} knob lands on `<c:title>` —
-  // the axis-title border counterpart is a separate gap). Distinct
-  // from the `<a:defRPr><a:solidFill>` font-color slot inside
-  // `<c:tx><c:rich>` that {@link SheetChart.axes.x.axisTitleColor}
-  // pins — the two knobs target different children of `<c:title>` so
-  // a caller can pin both without conflict.
-  const titleSpPrXml = buildTitleSpPr(fillRgbHex, undefined);
+  // Mirrors `buildTitle`: the writer skips emission entirely when
+  // neither the fill nor the border color is pinned so a fresh axis
+  // title matches Excel's reference shape byte-for-byte (Excel
+  // itself omits the block whenever the title renders at the theme
+  // defaults — typically a transparent title background with no
+  // visible border, no `<c:spPr>` block). Authors `<a:solidFill>`
+  // for the fill ({@link SheetChart.axes.x.axisTitleFillColor}) and
+  // `<a:ln>` for the stroke
+  // ({@link SheetChart.axes.x.axisTitleBorderColor}) in
+  // CT_ShapeProperties schema order; other CT_ShapeProperties
+  // children (effects, gradient / pattern / picture fills, line
+  // dash / width / compound styles) are not modelled at this layer.
+  // Distinct from the `<a:defRPr><a:solidFill>` font-color slot
+  // inside `<c:tx><c:rich>` that
+  // {@link SheetChart.axes.x.axisTitleColor} pins — the typography
+  // knobs target different children of `<c:title>` so a caller can
+  // pin all three without conflict.
+  const titleSpPrXml = buildTitleSpPr(fillRgbHex, borderRgbHex);
   if (titleSpPrXml !== undefined) titleChildren.push(titleSpPrXml);
   return xmlElement("c:title", undefined, titleChildren);
 }

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -22488,6 +22488,263 @@ describe("cloneChart — axisTitleFillColor", () => {
   });
 });
 
+// ── cloneChart — axisTitleBorderColor ────────────────────────────────
+
+describe("cloneChart — axisTitleBorderColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's X-axis axisTitleBorderColor by default", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("inherits the source's Y-axis axisTitleBorderColor by default", () => {
+    const clone = cloneChart(
+      source({ axes: { y: { title: "USD", axisTitleBorderColor: "00C586" } } }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.y?.axisTitleBorderColor).toBe("00C586");
+    expect(clone.axes?.y?.title).toBe("USD");
+  });
+
+  it("lets options.axes.x.axisTitleBorderColor replace the source's value", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderColor: "1070CA" } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1070CA");
+  });
+
+  it("normalizes a lowercase hex override to uppercase", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderColor: "abcdef" } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("ABCDEF");
+  });
+
+  it("strips a leading '#' on override input", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderColor: "#1070CA" } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1070CA");
+  });
+
+  it("drops the inherited axisTitleBorderColor when the override is null", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderColor: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderColor).toBeUndefined();
+    expect(clone.axes?.x?.title).toBe("Period");
+  });
+
+  it("returns undefined axisTitleBorderColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("replaces an unset source axisTitleBorderColor with the override", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderColor: "1070CA" } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1070CA");
+  });
+
+  it("drops malformed hex overrides (defends against the type guard escaping)", () => {
+    for (const bad of ["", "FFF", "ZZZZZZ", "FF0000FF"]) {
+      const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderColor: bad } },
+      });
+      expect(clone.axes?.x?.axisTitleBorderColor).toBeUndefined();
+    }
+  });
+
+  it("drops non-string overrides (defends against the type guard escaping)", () => {
+    const clone = cloneChart(source({ axes: { x: { title: "Period" } } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      axes: { x: { axisTitleBorderColor: 123 as any } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("normalises a parsed source value that is malformed", () => {
+    const clone = cloneChart(
+      source({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleBorderColor: "ZZZZZZ" as any } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("drops the inherited axisTitleBorderColor when the resolved axis title is dropped", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.title).toBeUndefined();
+    expect(clone.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("drops an override axisTitleBorderColor when no axis title resolves", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderColor: "1F77B4" } },
+    });
+    expect(clone.axes?.x).toBeUndefined();
+  });
+
+  it("preserves the override when the override also pins a title", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { title: "Period", axisTitleBorderColor: "1070CA" } },
+    });
+    expect(clone.axes?.x?.title).toBe("Period");
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1070CA");
+  });
+
+  it("composes independently with axisTitleFillColor on the same axis title", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFillColor: "FFFF00",
+            axisTitleBorderColor: "1F77B4",
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with axisTitleColor (font color slot) on the same axis title", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleColor: "FF0000",
+            axisTitleBorderColor: "1F77B4",
+          },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with the chart-level titleBorderColor", () => {
+    const clone = cloneChart(
+      source({
+        titleBorderColor: "1070CA",
+        axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.titleBorderColor).toBe("1070CA");
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("threads the border through both axes independently on the clone", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "Period", axisTitleBorderColor: "FF0000" },
+          y: { title: "USD", axisTitleBorderColor: "00C586" },
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("FF0000");
+    expect(clone.axes?.y?.axisTitleBorderColor).toBe("00C586");
+  });
+
+  it("survives a writeXlsx round trip — axisTitleBorderColor lands in the cloned chart XML", async () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderColor: "1070CA" } },
+      },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.axes?.x?.axisTitleBorderColor).toBe("1070CA");
+  });
+
+  it("round-trips a parsed axisTitleBorderColor straight back through cloneChart", () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [{ values: "B2:B5", categories: "A2:A5" }],
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── cloneChart — dataLabels.fillColor ───────────────────────────────
 
 describe("cloneChart — dataLabels.fillColor", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -21347,6 +21347,318 @@ describe("writeChart — axisTitleFillColor", () => {
   });
 });
 
+// ── writeChart — axisTitleBorderColor (line stroke) ──────────────────
+
+describe("writeChart — axisTitleBorderColor", () => {
+  function axisBlocks(xml: string): string[] {
+    return Array.from(xml.matchAll(/<c:(catAx|valAx|dateAx)>[\s\S]*?<\/c:\1>/g)).map((m) => m[0]);
+  }
+
+  function axisTitleBlock(axisBlock: string): string | undefined {
+    const m = axisBlock.match(/<c:title>[\s\S]*?<\/c:title>/);
+    return m ? m[0] : undefined;
+  }
+
+  function axisTitleSpPrLnVal(axisBlock: string): string | undefined {
+    const title = axisTitleBlock(axisBlock);
+    if (!title) return undefined;
+    const m = title.match(/<c:spPr>[\s\S]*?<\/c:spPr>/);
+    if (!m) return undefined;
+    const ln = m[0].match(/<a:ln><a:solidFill><a:srgbClr val="([^"]+)"\/><\/a:solidFill><\/a:ln>/);
+    return ln ? ln[1] : undefined;
+  }
+
+  it("does not emit <c:spPr> on the axis title when axisTitleBorderColor is unset", () => {
+    const result = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1");
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("emits <c:spPr><a:ln><a:solidFill><a:srgbClr> on the axis title when axisTitleBorderColor is set", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleSpPrLnVal(xAx)).toBe("1F77B4");
+  });
+
+  it("normalizes a leading # and lowercase hex to canonical uppercase", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "#1f77b4" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(axisTitleSpPrLnVal(xAx)).toBe("1F77B4");
+  });
+
+  it("places <c:spPr> after <c:overlay> on the axis title (CT_Title sequence)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    const overlayIdx = title.indexOf("<c:overlay");
+    const spPrIdx = title.indexOf("<c:spPr>");
+    expect(overlayIdx).toBeGreaterThan(0);
+    expect(spPrIdx).toBeGreaterThan(overlayIdx);
+  });
+
+  it("only emits one <c:spPr> inside the axis title even when both fill and border are set", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFillColor: "FFFF00",
+            axisTitleBorderColor: "1F77B4",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    const occurrences = title.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("emits fill before stroke inside <c:spPr> per CT_ShapeProperties schema order", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFillColor: "FFFF00",
+            axisTitleBorderColor: "1F77B4",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    const fillIdx = title.indexOf('<a:solidFill><a:srgbClr val="FFFF00"/>');
+    const lnIdx = title.indexOf("<a:ln>");
+    expect(fillIdx).toBeGreaterThan(0);
+    expect(lnIdx).toBeGreaterThan(fillIdx);
+  });
+
+  it("threads the border color through both axes independently", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: { title: "Period", axisTitleBorderColor: "FF0000" },
+          y: { title: "USD", axisTitleBorderColor: "00C586" },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx, yAx] = axisBlocks(result.chartXml);
+    expect(axisTitleSpPrLnVal(xAx)).toBe("FF0000");
+    expect(axisTitleSpPrLnVal(yAx)).toBe("00C586");
+  });
+
+  it("threads axisTitleBorderColor through every chart family that has axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, axes: { x: { title: "Period", axisTitleBorderColor: "ABCDEF" } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      expect(axisTitleSpPrLnVal(xAx)).toBe("ABCDEF");
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        axes: { y: { title: "USD", axisTitleBorderColor: "ABCDEF" } },
+      }),
+      "Sheet1",
+    );
+    const blocks = axisBlocks(scatter.chartXml);
+    const yAx = blocks[1];
+    expect(axisTitleSpPrLnVal(yAx)).toBe("ABCDEF");
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "FFF" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "GGGGGG" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "FFAA0080" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("drops an empty / whitespace-only string", () => {
+    for (const bad of ["", "   "]) {
+      const result = writeChart(
+        makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: bad } } }),
+        "Sheet1",
+      );
+      const [xAx] = axisBlocks(result.chartXml);
+      const title = axisTitleBlock(xAx)!;
+      expect(title).not.toContain("<c:spPr>");
+    }
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    const result = writeChart(
+      makeChart({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        axes: { x: { title: "Period", axisTitleBorderColor: 123 as any } },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).not.toContain("<c:spPr>");
+  });
+
+  it("ignores axisTitleBorderColor when the axis renders no title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { axisTitleBorderColor: "1F77B4" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    expect(xAx).not.toContain("<c:title>");
+  });
+
+  it("composes independently with axisTitleColor (each lands on its own slot)", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleColor: "FF0000",
+            axisTitleBorderColor: "1F77B4",
+          },
+        },
+      }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    // Font color in <a:defRPr><a:solidFill> slot.
+    expect(title).toMatch(/<a:defRPr[^>]*>\s*<a:solidFill><a:srgbClr val="FF0000"\/>/);
+    // Border stroke on the title's <c:spPr><a:ln>.
+    expect(title).toContain("<a:ln>");
+    expect(title).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("emits a <c:spPr> when only the border (not the fill) is pinned", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      "Sheet1",
+    );
+    const [xAx] = axisBlocks(result.chartXml);
+    const title = axisTitleBlock(xAx)!;
+    expect(title).toContain("<c:spPr>");
+    // No <a:solidFill> on the spPr (only on the inner <a:ln>).
+    const spPr = title.match(/<c:spPr>[\s\S]*?<\/c:spPr>/)![0];
+    // Strip <a:ln>...</a:ln> first.
+    const lnStripped = spPr.replace(/<a:ln>[\s\S]*?<\/a:ln>/, "");
+    expect(lnStripped).not.toContain("<a:solidFill>");
+  });
+
+  it("round-trips axisTitleBorderColor through parseChart (catAx)", () => {
+    const written = writeChart(
+      makeChart({ axes: { x: { title: "Period", axisTitleBorderColor: "1F77B4" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.title).toBe("Period");
+    expect(reparsed?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("round-trips axisTitleBorderColor through parseChart (valAx)", () => {
+    const written = writeChart(
+      makeChart({ axes: { y: { title: "USD", axisTitleBorderColor: "00C586" } } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.y?.title).toBe("USD");
+    expect(reparsed?.axes?.y?.axisTitleBorderColor).toBe("00C586");
+  });
+
+  it("round-trips fill + border together on the same axis title", () => {
+    const written = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "Period",
+            axisTitleFillColor: "FFFF00",
+            axisTitleBorderColor: "1F77B4",
+          },
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    expect(reparsed?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset axisTitleBorderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ axes: { x: { title: "Period" } } }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — axisTitleBorderColor lands in chart1.xml", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            axes: {
+              x: { title: "Period", axisTitleBorderColor: "1F77B4" },
+              y: { title: "USD", axisTitleBorderColor: "00C586" },
+            },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+    expect(reparsed?.axes?.y?.axisTitleBorderColor).toBe("00C586");
+  });
+});
+
 // ── writeChart — dataLabels.fillColor (solid fill) ───────────────────
 
 describe("writeChart — dataLabels.fillColor", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -21143,6 +21143,283 @@ describe("parseChart — axisTitleFillColor", () => {
   });
 });
 
+// ── parseChart — axisTitleBorderColor (line stroke) ──────────────────
+
+describe("parseChart — axisTitleBorderColor", () => {
+  const NS_ATBC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withCatAxTitleSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr>${spPrBody}</c:spPr>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  function withValAxTitleSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr>${spPrBody}</c:spPr>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB color when <c:title><c:spPr><a:ln><a:solidFill><a:srgbClr> is pinned (catAx)", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+    expect(chart?.axes?.x?.title).toBe("Period");
+  });
+
+  it("surfaces the literal sRGB color on the value axis (valAx)", () => {
+    const chart = parseChart(
+      withValAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="00C586"/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.y?.axisTitleBorderColor).toBe("00C586");
+    expect(chart?.axes?.y?.title).toBe("USD");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBe("ABCDEF");
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("surfaces fill and border independently when both are pinned on the same axis title", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(
+        `<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>` +
+          `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+      ),
+    );
+    expect(chart?.axes?.x?.axisTitleFillColor).toBe("FFFF00");
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the axis omits <c:title>", () => {
+    const xml = `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes).toBeUndefined();
+  });
+
+  it("returns undefined when <c:title> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.title).toBe("Period");
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>`),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no <a:solidFill>", () => {
+    const chart = parseChart(withCatAxTitleSpPr(`<a:ln w="12700"/>`));
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln><a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:ln><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:noFill>", () => {
+    const chart = parseChart(withCatAxTitleSpPr(`<a:ln><a:noFill/></a:ln>`));
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:gradFill>", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(
+        `<a:ln><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill></a:ln>`,
+      ),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> stroke is <a:pattFill>", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(
+        `<a:ln><a:pattFill prst="dkUpDiag"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill></a:ln>`,
+      ),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("drops malformed val tokens (wrong length / non-hex / 8-char alpha form)", () => {
+    expect(
+      parseChart(withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val=""/></a:solidFill></a:ln>`))
+        ?.axes?.x?.axisTitleBorderColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(
+        withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="FFF"/></a:solidFill></a:ln>`),
+      )?.axes?.x?.axisTitleBorderColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(
+        withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="ZZZZZZ"/></a:solidFill></a:ln>`),
+      )?.axes?.x?.axisTitleBorderColor,
+    ).toBeUndefined();
+    // 8-character alpha form (Excel uses <a:alpha> sibling for that).
+    expect(
+      parseChart(
+        withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill></a:ln>`),
+      )?.axes?.x?.axisTitleBorderColor,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const chart = parseChart(
+      withCatAxTitleSpPr(`<a:ln><a:solidFill><a:srgbClr/></a:solidFill></a:ln>`),
+    );
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("does not leak the chart-level title <c:spPr><a:ln> stroke into the axis title border", () => {
+    // Chart-level <c:title> has the spPr/ln; the axis title doesn't.
+    const xml = `<c:chartSpace ${NS_ATBC}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+    </c:title>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.titleBorderColor).toBe("1F77B4");
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+  });
+
+  it("does not leak a stray <a:ln> on a sibling axis (catAx vs valAx scope)", () => {
+    const xml = `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Period</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+      </c:title>
+    </c:catAx>
+    <c:valAx>
+      <c:axId val="2"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>USD</a:t></a:r></a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr><a:ln><a:solidFill><a:srgbClr val="00C586"/></a:solidFill></a:ln></c:spPr>
+      </c:title>
+    </c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBeUndefined();
+    expect(chart?.axes?.y?.axisTitleBorderColor).toBe("00C586");
+  });
+
+  it("surfaces axisTitleBorderColor independently of axisTitleColor (font color slot)", () => {
+    const xml = `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p>
+          <a:pPr><a:defRPr><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr></a:pPr>
+          <a:r><a:rPr lang="en-US"/><a:t>Period</a:t></a:r>
+        </a:p></c:rich></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.axes?.x?.axisTitleColor).toBe("FF0000");
+    expect(chart?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("surfaces axisTitleBorderColor on a strRef-bodied title (no <c:rich>)", () => {
+    const xml = `<c:chartSpace ${NS_ATBC}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx>
+      <c:axId val="1"/>
+      <c:title>
+        <c:tx><c:strRef><c:f>Sheet1!$A$1</c:f><c:strCache><c:ptCount val="1"/><c:pt idx="0"><c:v>Period</c:v></c:pt></c:strCache></c:strRef></c:tx>
+        <c:overlay val="0"/>
+        <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+      </c:title>
+    </c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── parseChart — dataLabelsFillColor ────────────────────────────────
 
 describe("parseChart — dataLabelsFillColor", () => {


### PR DESCRIPTION
## Summary

Adds `axisTitleBorderColor` knob to `SheetChart.axes.x` /
`SheetChart.axes.y` and `ChartAxisInfo`, mapping to
`<c:catAx><c:title><c:spPr><a:ln><a:solidFill><a:srgbClr val=\"RRGGBB\"/></a:solidFill></a:ln></c:spPr></c:title></c:catAx>`
(or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) per `CT_Title` (ECMA-376 Part 1, §21.2.2.210)
— Excel's "Format Axis Title -> Border -> Solid line -> Color" picker. Mirrors
`titleBorderColor` (#311) for axis titles, lands in the same `<a:ln>` family as
`plotAreaBorderColor` (#309) / `legendBorderColor` (#310) but on a per-axis host.

- Composes independently with `axisTitleFillColor` (#306): the two knobs share the
  same `<c:spPr>` host on the axis `<c:title>` but land on different children
  (`<a:solidFill>` for fill, `<a:ln>` for stroke). The writer authors a single
  `<c:spPr>` whenever either knob is set, with children in `CT_ShapeProperties`
  schema order (fill before stroke). Reuses `buildTitleSpPr` so a single hex
  string threads cleanly through every fill / stroke knob the writer authors.
- Reader, writer, and clone-through plumbing follows the established hex-color
  grammar — accepts `#` / case, drops malformed / non-solid / `schemeClr` /
  alpha-channel forms to `undefined`. Silently dropped when no axis title is
  rendered and on `pie` / `doughnut` charts (no axes).
- `cloneChart` threads the field through with the standard `undefined` (inherit) /
  `null` (drop) / value (replace) grammar via `applyAxisTitleBorderColorOverride`.

## Test plan

- [x] Read: `parseChart` surfaces literal `<a:srgbClr>` form on catAx / valAx; drops
  schemeClr / noFill / gradFill / pattFill / malformed val tokens; not gated on
  `<c:rich>` so strRef-bodied titles still surface; chart-level title `<a:ln>` doesn't leak.
- [x] Write: emits `<c:spPr><a:ln>` after `<c:overlay>` per CT_Title schema, single
  `<c:spPr>` even when both fill and border are set, fill emitted before stroke per
  CT_ShapeProperties schema; threads through every chart family with axes (bar, column,
  line, area, scatter); drops malformed inputs to no `<c:spPr>`; round-trips through
  `parseChart` and `writeXlsx`.
- [x] Clone: inherits source value; `null` drops; literal hex replaces; malformed
  overrides drop; composes with `axisTitleFillColor` and `axisTitleColor`; drops
  when resolved axis title is dropped; round-trips through `writeXlsx`.
- [x] All 6880 tests passing, `pnpm tsc --noEmit` clean, `oxfmt` clean on changed files.

Closes #312

Refs #306, #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)