### PR TITLE
feat(xlsx): chart data-table border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1420,6 +1420,67 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   fillColor?: string;
+  /**
+   * Data-table border (line) color as a 6-digit RGB hex string (e.g.
+   * `"1F77B4"`). Maps to `<c:dTable><c:spPr><a:ln><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:dTable>`
+   * (CT_DTable, ECMA-376 Part 1, §21.2.2.54) — Excel's "Format Data
+   * Table -> Border -> Solid line -> Color" picker (the same dialog
+   * the user reaches by right-clicking the data table grid). The
+   * OOXML `<a:srgbClr val=".."/>` carries the 6-character uppercase
+   * hex sRGB color (`CT_SRgbColor` inside `<a:ln>`'s solid fill choice
+   * — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The `<a:ln>`
+   * child sits inside the `<c:spPr>` block alongside the optional
+   * `<a:solidFill>` fill child, in `CT_ShapeProperties` schema order
+   * (fill before stroke).
+   *
+   * Distinct from {@link fillColor} — the border color paints the
+   * outline around the data-table block, while the fill color paints
+   * the cell backgrounds inside. The two knobs share the `<c:spPr>`
+   * host but land on different children (`<a:solidFill>` for the
+   * fill, `<a:ln>` for the stroke), and the writer authors a single
+   * `<c:spPr>` whenever either knob is set. A caller can pin one
+   * without the other; pinning both produces a filled data table
+   * with a colored border.
+   *
+   * Distinct from the four boolean toggles ({@link showHorzBorder} /
+   * {@link showVertBorder} / {@link showOutline}) which govern the
+   * inner grid lines and outer outline visibility (rendered with the
+   * theme's automatic stroke). The {@link borderColor} knob colors
+   * the entire `<c:spPr>` outline — Excel applies the color to the
+   * outer border and the grid lines together when the matching
+   * toggles are on.
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the `<a:ln>` block (Excel's reference serialization for a data
+   * table that inherits the auto-stroke — typically the theme's
+   * default line color).
+   *
+   * Default: omitted — the data table inherits the auto-stroke Excel
+   * picks from the workbook theme. Pin a hex color to mirror Excel's
+   * "Format Data Table -> Border -> Solid line" knob and paint a
+   * flat outline around the table grid — useful for dashboard tiles
+   * where the data table should be visually framed against the
+   * surrounding chart frame.
+   *
+   * Patterned / gradient strokes are not modelled — only the solid
+   * sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   * Mirrors `plotAreaBorderColor` / `legendBorderColor` /
+   * `titleBorderColor` / `axisTitleBorderColor` — same accept-with-
+   * or-without-`#` hex grammar, same OOXML `<a:ln><a:solidFill>
+   * <a:srgbClr val=".."/></a:solidFill></a:ln>` mapping — so a
+   * caller can thread a single hex string through every `<a:ln>`-
+   * based stroke slot.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  borderColor?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -5327,6 +5327,8 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (fontFamily !== undefined) out.fontFamily = fontFamily;
   const fillColor = parseDataTableFillColor(el);
   if (fillColor !== undefined) out.fillColor = fillColor;
+  const borderColor = parseDataTableBorderColor(el);
+  if (borderColor !== undefined) out.borderColor = borderColor;
   return out;
 }
 
@@ -5547,12 +5549,64 @@ function parseDataTableFontFamily(dTable: XmlElement): string | undefined {
  * `<c:title>` / a series) cannot leak into this field. Mirrors
  * {@link parsePlotAreaFillColor} / {@link parseLegendFillColor} —
  * same `<c:spPr><a:solidFill><a:srgbClr>` chain on a different host
- * element.
+ * element. Independent of {@link parseDataTableBorderColor}: the fill
+ * lives on `<c:dTable><c:spPr><a:solidFill>`, the stroke lives on
+ * `<c:dTable><c:spPr><a:ln><a:solidFill>` — the two readers walk
+ * disjoint children of the same `<c:spPr>` block so a caller can pin
+ * both knobs without conflict.
  */
 function parseDataTableFillColor(dTable: XmlElement): string | undefined {
   const spPr = findChild(dTable, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:dTable><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:dTable>` off a data-table block.
+ * Returns the data-table border (line) color as a 6-character uppercase
+ * hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+ * solid fill choice (`CT_LineProperties`'s solid fill — §20.1.2.3.24).
+ * The `<a:ln>` slot sits inside the `<c:spPr>` block on `<c:dTable>`
+ * alongside the optional `<a:solidFill>` fill child, in
+ * `CT_ShapeProperties` schema order (fill before stroke). The
+ * `<c:spPr>` itself sits between the four required boolean children
+ * (`<c:showHorzBorder>`, `<c:showVertBorder>`, `<c:showOutline>`,
+ * `<c:showKeys>`) and the optional `<c:txPr>` per CT_DTable
+ * (ECMA-376 Part 1, §21.2.2.54).
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid line fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`),
+ * and theme-color references (`<a:schemeClr>`) all collapse to
+ * `undefined` so a chart that pinned a stroke the writer cannot
+ * reproduce on emit drops the field rather than fabricate one Excel
+ * would render differently. Malformed `val` tokens (wrong length,
+ * non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link ChartDataTable.borderColor} so a
+ * parsed value slots straight into {@link cloneChart} without
+ * conversion. The lookup is scoped to direct children of `<c:dTable>`
+ * so a stray `<c:spPr>` elsewhere (e.g. on `<c:plotArea>` /
+ * `<c:legend>` / `<c:title>` / a series) cannot leak in. Mirrors
+ * {@link parseDataTableFillColor} — same `<c:spPr>` host element on
+ * the same `<c:dTable>` parent — but lands on the line
+ * (`<a:ln><a:solidFill>`) child rather than the fill (`<a:solidFill>`)
+ * child.
+ */
+function parseDataTableBorderColor(dTable: XmlElement): string | undefined {
+  const spPr = findChild(dTable, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1508,6 +1508,7 @@ function resolveDataTable(chart: SheetChart):
       strikethrough: boolean | undefined;
       fontFamily: string | undefined;
       fillColor: string | undefined;
+      borderColor: string | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1533,6 +1534,7 @@ function resolveDataTable(chart: SheetChart):
       strikethrough: undefined,
       fontFamily: undefined,
       fillColor: undefined,
+      borderColor: undefined,
     };
   }
 
@@ -1553,6 +1555,7 @@ function resolveDataTable(chart: SheetChart):
     strikethrough: resolveDataTableStrikethrough(raw.strikethrough),
     fontFamily: resolveDataTableFontFamily(raw.fontFamily),
     fillColor: resolveDataTableFillColor(raw.fillColor),
+    borderColor: resolveDataTableBorderColor(raw.borderColor),
   };
 }
 
@@ -1700,6 +1703,28 @@ function resolveDataTableFillColor(value: string | undefined): string | undefine
 }
 
 /**
+ * Resolve `<c:dTable><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:dTable>` from
+ * {@link ChartDataTable.borderColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches every other `<a:srgbClr>`
+ * fill / line slot exactly. Composes independently with
+ * {@link ChartDataTable.fillColor} — the two knobs share the same
+ * `<c:spPr>` host on `<c:dTable>` but land on different children
+ * (`<a:solidFill>` for the fill, `<a:ln><a:solidFill>` for the stroke).
+ * Mirrors the chart-title / axis-title / chart-space / plot-area /
+ * legend `<c:spPr>` border slots — same hex grammar, same `<a:ln>`
+ * slot on the `CT_ShapeProperties` schema — but lands on `<c:dTable>`'s
+ * own `<c:spPr>` block.
+ */
+function resolveDataTableBorderColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
  * Serialize a resolved data-table into `<c:dTable>` with its four
  * required boolean children, in the order CT_DTable mandates:
  * `showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`. When
@@ -1728,6 +1753,7 @@ function buildDataTable(table: {
   strikethrough: boolean | undefined;
   fontFamily: string | undefined;
   fillColor: string | undefined;
+  borderColor: string | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1738,9 +1764,9 @@ function buildDataTable(table: {
   // CT_DTable schema places `<c:spPr>` after the four required
   // boolean children, before `<c:txPr>` and the optional `<c:extLst>`
   // (ECMA-376 Part 1, §21.2.2.54). The writer skips emission entirely
-  // when no fill knob is pinned so a fresh chart matches Excel's
-  // reference serialization byte-for-byte.
-  const spPrXml = buildDataTableSpPr(table.fillColor);
+  // when no fill / border knob is pinned so a fresh chart matches
+  // Excel's reference serialization byte-for-byte.
+  const spPrXml = buildDataTableSpPr(table.fillColor, table.borderColor);
   if (spPrXml !== undefined) children.push(spPrXml);
   // CT_DTable schema places `<c:txPr>` after `<c:spPr>` and before
   // the optional `<c:extLst>` (ECMA-376 Part 1, §21.2.2.54). The writer
@@ -1760,28 +1786,46 @@ function buildDataTable(table: {
 }
 
 /**
- * Build the optional `<c:spPr>` block inside `<c:dTable>`. Currently
- * surfaces only the solid fill color knob ({@link
- * ChartDataTable.fillColor}) — every other `<c:spPr>` child (`<a:ln>`
- * stroke, `<a:effectLst>` effects, gradient / pattern / picture fills)
- * is intentionally not modelled at this layer.
+ * Build the optional `<c:spPr>` block inside `<c:dTable>`. Surfaces
+ * the solid fill color knob ({@link ChartDataTable.fillColor}) and
+ * the border (line) color knob ({@link ChartDataTable.borderColor}) —
+ * every other `<c:spPr>` child (`<a:effectLst>` effects, gradient /
+ * pattern / picture fills, line dash / width / compound styles) is
+ * intentionally not modelled at this layer.
  *
- * Returns `undefined` when the caller leaves the field unset / passed
- * a malformed token so the writer skips the entire `<c:spPr>` block —
- * an empty `<c:spPr/>` collapses to the inherited theme fill Excel
- * picks anyway, and omitting it keeps untouched chart XML byte-clean.
+ * Returns `undefined` when both fields are unset / malformed so the
+ * writer skips the entire `<c:spPr>` block — an empty `<c:spPr/>`
+ * collapses to the inherited theme fill / stroke Excel picks anyway,
+ * and omitting it keeps untouched chart XML byte-clean. When at least
+ * one knob lands on the wire, the children are emitted in
+ * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
+ * `<a:ln>` (line / stroke).
  *
  * Mirrors {@link buildPlotAreaSpPr} / {@link buildChartSpaceSpPr}
- * but on a distinct host element — the data-table fill paints the
- * background of the table grid, while the plot-area / chart-space
- * fills paint the inner band / entire chart frame.
+ * but on a distinct host element — the data-table fill / stroke
+ * paint the background and outline of the table grid, while the
+ * plot-area / chart-space variants paint the inner band / entire
+ * chart frame.
  */
-function buildDataTableSpPr(fillColor: string | undefined): string | undefined {
-  if (fillColor === undefined) return undefined;
-  const solidFill = xmlElement("a:solidFill", undefined, [
-    xmlSelfClose("a:srgbClr", { val: fillColor }),
-  ]);
-  return xmlElement("c:spPr", undefined, [solidFill]);
+function buildDataTableSpPr(
+  fillColor: string | undefined,
+  borderColor: string | undefined,
+): string | undefined {
+  if (fillColor === undefined && borderColor === undefined) return undefined;
+  const children: string[] = [];
+  if (fillColor !== undefined) {
+    children.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillColor })]),
+    );
+  }
+  if (borderColor !== undefined) {
+    children.push(
+      xmlElement("a:ln", undefined, [
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderColor })]),
+      ]),
+    );
+  }
+  return xmlElement("c:spPr", undefined, children);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -11420,6 +11420,184 @@ describe("cloneChart — data table", () => {
     const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
     expect(parseChart(written)?.dataTable?.fillColor).toBe("AABBCC");
   });
+
+  // ── data-table border color ──────────────────────────────────────
+
+  it("inherits the source's dataTable.borderColor by default", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          borderColor: "1F77B4",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      borderColor: "1F77B4",
+    });
+  });
+
+  it("lets options.dataTable: object override the inherited borderColor", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, borderColor: "1F77B4" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false, borderColor: "ABCDEF" },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false, borderColor: "ABCDEF" });
+  });
+
+  it("drops the inherited borderColor when override clears the border pin", () => {
+    // The override is wholesale-replace, not per-field merge — passing
+    // an object without borderColor drops the inherited value.
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, borderColor: "1F77B4" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: { showVertBorder: false },
+      },
+    );
+    expect(clone.dataTable).toEqual({ showVertBorder: false });
+  });
+
+  it("drops the inherited borderColor when flattening into a pie clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, borderColor: "1F77B4" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "pie",
+      },
+    );
+    expect(clone.type).toBe("pie");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops the inherited borderColor when flattening into a doughnut clone", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, borderColor: "1F77B4" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "doughnut",
+      },
+    );
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("drops the inherited borderColor when override clears the entire dataTable block (null)", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: { showKeys: false, borderColor: "1F77B4" },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        dataTable: null,
+      },
+    );
+    expect(clone.dataTable).toBeUndefined();
+  });
+
+  it("propagates dataTable.borderColor into the rendered <c:dTable> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          borderColor: "1070CA",
+        },
+      }),
+      { anchor: { from: { row: 5, col: 0 } } },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:dTable>");
+    expect(written).toContain('<a:ln><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:ln>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      borderColor: "1070CA",
+    });
+  });
+
+  it("composes dataTable.fillColor and borderColor through the clone-through path", () => {
+    // Fill (background) and border (outline) share the <c:spPr> host
+    // but land on different children (<a:solidFill> vs <a:ln>), so a
+    // caller can pin both with no conflict.
+    const clone = cloneChart(
+      source({
+        dataTable: { fillColor: "F2F2F2", borderColor: "1F77B4" },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataTable).toEqual({ fillColor: "F2F2F2", borderColor: "1F77B4" });
+  });
+
+  it("a parsed dataTable.borderColor round-trips through parseChart -> cloneChart -> writeChart -> parseChart", async () => {
+    const seed: SheetChart = {
+      type: "column",
+      series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+      anchor: { from: { row: 0, col: 0 } },
+      dataTable: { showKeys: false, borderColor: "AABBCC" },
+    };
+    const xml = writeChart(seed, "Sheet1").chartXml;
+    const parsed = parseChart(xml)!;
+    expect(parsed.dataTable?.borderColor).toBe("AABBCC");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(typeof clone.dataTable === "object").toBe(true);
+    expect((clone.dataTable as ChartDataTable | undefined)?.borderColor).toBe("AABBCC");
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.dataTable?.borderColor).toBe("AABBCC");
+  });
 });
 
 // ── cloneChart — chart-space protection ──────────────────────────────

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -10255,6 +10255,316 @@ describe("writeChart — data table", () => {
     const reparsed = parseChart(chartXml);
     expect(reparsed?.dataTable?.fillColor).toBe("AABBCC");
   });
+
+  // ── data-table border color ────────────────────────────────────────
+
+  it("skips <c:spPr> when borderColor is unset (writer default)", () => {
+    // The OOXML default for the data-table is no <c:spPr> at all — the
+    // table inherits the auto-stroke Excel picks from the workbook theme.
+    // Absence collapses to no <c:spPr> block.
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).not.toContain("<c:spPr>");
+    expect(dTableSlice).not.toContain("<a:ln>");
+  });
+
+  it("emits <c:spPr><a:ln><a:solidFill><a:srgbClr> when borderColor is set", () => {
+    const result = writeChart(makeChart({ dataTable: { borderColor: "1F77B4" } }), "Sheet1");
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(dTableSlice).toContain("<c:spPr>");
+    expect(dTableSlice).toContain("<a:ln>");
+    expect(dTableSlice).toContain('<a:srgbClr val="1F77B4"/>');
+    // The border color must land inside <a:ln>, not as a top-level
+    // <a:solidFill> (that slot is reserved for the fill color knob).
+    const lnIdx = dTableSlice.indexOf("<a:ln>");
+    const srgbIdx = dTableSlice.indexOf('<a:srgbClr val="1F77B4"/>');
+    expect(srgbIdx).toBeGreaterThan(lnIdx);
+  });
+
+  it("normalizes a leading # and lowercase hex on borderColor to canonical uppercase", () => {
+    const result = writeChart(makeChart({ dataTable: { borderColor: "#1f77b4" } }), "Sheet1");
+    expect(result.chartXml).toContain('<a:ln><a:solidFill><a:srgbClr val="1F77B4"/>');
+  });
+
+  it("collapses malformed borderColor inputs to undefined", () => {
+    // Wrong length, non-hex characters, alpha-channel forms, and
+    // non-string escapes all drop the field rather than fabricate a
+    // value the writer would round-trip into a malformed <a:srgbClr>.
+    const wrong = writeChart(makeChart({ dataTable: { borderColor: "FF00" } }), "Sheet1");
+    const wrongDT = wrong.chartXml.slice(
+      wrong.chartXml.indexOf("<c:dTable>"),
+      wrong.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(wrongDT).not.toContain("<c:spPr>");
+    const nonHex = writeChart(makeChart({ dataTable: { borderColor: "ZZZZZZ" } }), "Sheet1");
+    const nonHexDT = nonHex.chartXml.slice(
+      nonHex.chartXml.indexOf("<c:dTable>"),
+      nonHex.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(nonHexDT).not.toContain("<c:spPr>");
+    const alpha = writeChart(makeChart({ dataTable: { borderColor: "#FF0000FF" } }), "Sheet1");
+    const alphaDT = alpha.chartXml.slice(
+      alpha.chartXml.indexOf("<c:dTable>"),
+      alpha.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(alphaDT).not.toContain("<c:spPr>");
+    const empty = writeChart(makeChart({ dataTable: { borderColor: "" } }), "Sheet1");
+    const emptyDT = empty.chartXml.slice(
+      empty.chartXml.indexOf("<c:dTable>"),
+      empty.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(emptyDT).not.toContain("<c:spPr>");
+    const nonString = {
+      borderColor: 123 as unknown as string,
+    } as { borderColor: string };
+    const numeric = writeChart(makeChart({ dataTable: nonString }), "Sheet1");
+    const numericDT = numeric.chartXml.slice(
+      numeric.chartXml.indexOf("<c:dTable>"),
+      numeric.chartXml.indexOf("</c:dTable>"),
+    );
+    expect(numericDT).not.toContain("<c:spPr>");
+  });
+
+  it("orders <c:spPr> after the four boolean children and before <c:txPr> (with borderColor)", () => {
+    // CT_DTable schema sequence places spPr after the four required
+    // boolean children and before <c:txPr> (ECMA-376 Part 1, §21.2.2.54).
+    const result = writeChart(
+      makeChart({
+        dataTable: { borderColor: "1070CA", fontColor: "FF6600" },
+      }),
+      "Sheet1",
+    );
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    const showKeysIdx = dTableSlice.indexOf("<c:showKeys");
+    const spPrIdx = dTableSlice.indexOf("<c:spPr>");
+    const txPrIdx = dTableSlice.indexOf("<c:txPr>");
+    expect(showKeysIdx).toBeGreaterThanOrEqual(0);
+    expect(spPrIdx).toBeGreaterThan(showKeysIdx);
+    expect(txPrIdx).toBeGreaterThan(spPrIdx);
+  });
+
+  it("composes fillColor and borderColor on the same <c:spPr> in CT_ShapeProperties order", () => {
+    // CT_ShapeProperties places <a:solidFill> before <a:ln>. The two
+    // knobs share one <c:spPr> host on <c:dTable>; pinning both
+    // produces a filled data table with a colored border.
+    const result = writeChart(
+      makeChart({
+        dataTable: { fillColor: "F2F2F2", borderColor: "1F77B4" },
+      }),
+      "Sheet1",
+    );
+    const dTableSlice = result.chartXml.slice(
+      result.chartXml.indexOf("<c:dTable>"),
+      result.chartXml.indexOf("</c:dTable>"),
+    );
+    // Single <c:spPr> hosts both knobs.
+    const spPrCount = dTableSlice.match(/<c:spPr>/g) ?? [];
+    expect(spPrCount).toHaveLength(1);
+    // Fill color lands on the top-level <a:solidFill>.
+    expect(dTableSlice).toContain('<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>');
+    // Border color lands inside <a:ln>.
+    expect(dTableSlice).toContain(
+      '<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>',
+    );
+    // CT_ShapeProperties order: <a:solidFill> precedes <a:ln>.
+    const spPrBlock = dTableSlice.match(/<c:spPr>[\s\S]*?<\/c:spPr>/)?.[0] ?? "";
+    expect(spPrBlock.indexOf("<a:solidFill>")).toBeLessThan(spPrBlock.indexOf("<a:ln>"));
+  });
+
+  it("composes borderColor independently with the four boolean toggles and typography knobs", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: false,
+          showVertBorder: true,
+          showOutline: false,
+          showKeys: true,
+          borderColor: "00FF00",
+          fontColor: "FF0000",
+          bold: true,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).toContain('<c:showHorzBorder val="0"/>');
+    expect(result.chartXml).toContain('<c:showVertBorder val="1"/>');
+    expect(result.chartXml).toContain('<c:showOutline val="0"/>');
+    expect(result.chartXml).toContain('<c:showKeys val="1"/>');
+    expect(result.chartXml).toContain('<a:ln><a:solidFill><a:srgbClr val="00FF00"/>');
+    expect(result.chartXml).toContain('<a:srgbClr val="FF0000"/>');
+    expect(result.chartXml).toContain('b="1"');
+  });
+
+  it("threads borderColor through every chart family with axes", () => {
+    for (const type of ["bar", "column", "line", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataTable: { borderColor: "1070CA" } }),
+        "Sheet1",
+      );
+      expect(result.chartXml).toContain(
+        '<a:ln><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:ln>',
+      );
+    }
+    const scatter = writeChart(
+      {
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { borderColor: "1070CA" },
+      },
+      "Sheet1",
+    );
+    expect(scatter.chartXml).toContain(
+      '<a:ln><a:solidFill><a:srgbClr val="1070CA"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("silently drops borderColor on pie charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { borderColor: "FF0000" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("silently drops borderColor on doughnut charts (no <c:dTable> slot at all)", () => {
+    const result = writeChart(
+      {
+        type: "doughnut",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        anchor: { from: { row: 5, col: 0 } },
+        dataTable: { borderColor: "FF0000" },
+      },
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable");
+    expect(result.chartXml).not.toContain('<a:srgbClr val="FF0000"/>');
+  });
+
+  it("round-trips a pinned dataTable borderColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: false,
+          showOutline: true,
+          showKeys: false,
+          borderColor: "F2F2F2",
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: false,
+      showOutline: true,
+      showKeys: false,
+      borderColor: "F2F2F2",
+    });
+  });
+
+  it("round-trips both fillColor and borderColor together through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          fillColor: "F2F2F2",
+          borderColor: "1F77B4",
+        },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.fillColor).toBe("F2F2F2");
+    expect(reparsed?.dataTable?.borderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset borderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataTable: true }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataTable?.borderColor).toBeUndefined();
+  });
+
+  it("does not leak the dataTable borderColor into plotArea or legend border slots", () => {
+    // The borderColor lives on <c:dTable><c:spPr>, distinct from
+    // <c:plotArea><c:spPr> (plotAreaBorderColor) and <c:legend><c:spPr>
+    // (legendBorderColor). The reader scopes the lookup to direct
+    // children of <c:dTable> so a stray write here cannot leak into
+    // the sibling fields.
+    const written = writeChart(
+      makeChart({ dataTable: { borderColor: "ABCDEF" } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataTable?.borderColor).toBe("ABCDEF");
+    expect(reparsed?.plotAreaBorderColor).toBeUndefined();
+    expect(reparsed?.legendBorderColor).toBeUndefined();
+  });
+
+  it("composes dataTable.borderColor with plotAreaBorderColor on different host elements", () => {
+    // The two knobs land on different <c:spPr> blocks — the data-table
+    // border outlines the table grid, the plot-area border outlines
+    // the inner band that hosts the series. A caller can pin both
+    // with no conflict.
+    const written = writeChart(
+      makeChart({
+        plotAreaBorderColor: "111111",
+        dataTable: { borderColor: "222222" },
+      }),
+      "Sheet1",
+    ).chartXml;
+    expect(written).toContain('<a:srgbClr val="111111"/>');
+    expect(written).toContain('<a:srgbClr val="222222"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaBorderColor).toBe("111111");
+    expect(reparsed?.dataTable?.borderColor).toBe("222222");
+  });
+
+  it("threads borderColor end-to-end through writeXlsx packaging", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Dashboard",
+        rows: [
+          ["Quarter", "Revenue"],
+          ["Q1", 10],
+          ["Q2", 20],
+          ["Q3", 30],
+        ],
+        charts: [
+          {
+            type: "column",
+            series: [{ name: "Revenue", values: "B2:B4", categories: "A2:A4" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataTable: { showKeys: true, borderColor: "AABBCC" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain("<c:dTable>");
+    expect(chartXml).toContain('<a:ln><a:solidFill><a:srgbClr val="AABBCC"/></a:solidFill></a:ln>');
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataTable?.borderColor).toBe("AABBCC");
+  });
 });
 
 // ── writeChart — chart-space protection ──────────────────────────────

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -11258,6 +11258,212 @@ describe("parseChart — data table", () => {
       bold: true,
     });
   });
+
+  // ── data-table border color (parseDataTableBorderColor) ────────────
+
+  it("surfaces a pinned dataTable.borderColor from <c:spPr><a:ln><a:solidFill><a:srgbClr val='RRGGBB'/>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.borderColor).toBe("1F77B4");
+  });
+
+  it("uppercases a lower-case srgbClr val on the <c:dTable><c:spPr><a:ln> slot", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.borderColor).toBe("ABCDEF");
+  });
+
+  it("surfaces undefined when <a:ln> is absent on the <c:dTable><c:spPr> block", () => {
+    // Only a fill knob — no <a:ln> child means no border color to
+    // surface. The reader walks disjoint children of <c:spPr> so
+    // absence of <a:ln> drops borderColor to undefined while keeping
+    // fillColor intact.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataTable?.borderColor).toBeUndefined();
+    expect(chart?.dataTable?.fillColor).toBe("F2F2F2");
+  });
+
+  it("surfaces undefined when <c:spPr> is absent on <c:dTable> for borderColor", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart>
+      <c:barDir val="col"/>
+      <c:ser><c:idx val="0"/></c:ser>
+    </c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.borderColor).toBeUndefined();
+  });
+
+  it("collapses malformed borderColor srgbClr val tokens to undefined", () => {
+    const wrongLen = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCD"/></a:solidFill></a:ln></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(wrongLen)?.dataTable?.borderColor).toBeUndefined();
+    const nonHex = wrongLen.replace('val="ABCD"', 'val="ZZZZZZ"');
+    expect(parseChart(nonHex)?.dataTable?.borderColor).toBeUndefined();
+    const alpha = wrongLen.replace('val="ABCD"', 'val="FF0000FF"');
+    expect(parseChart(alpha)?.dataTable?.borderColor).toBeUndefined();
+  });
+
+  it("collapses theme-color <a:schemeClr> references to undefined for borderColor", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr><a:ln><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln></c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable?.borderColor).toBeUndefined();
+  });
+
+  it("collapses non-solid line fills to undefined (noFill / gradFill / pattFill)", () => {
+    const head = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>`;
+    const tail = `</c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    const noFill = `${head}<c:spPr><a:ln><a:noFill/></a:ln></c:spPr>${tail}`;
+    expect(parseChart(noFill)?.dataTable?.borderColor).toBeUndefined();
+    const gradFill = `${head}<c:spPr><a:ln><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FF0000"/></a:gs></a:gsLst></a:gradFill></a:ln></c:spPr>${tail}`;
+    expect(parseChart(gradFill)?.dataTable?.borderColor).toBeUndefined();
+    const pattFill = `${head}<c:spPr><a:ln><a:pattFill prst="dkDnDiag"><a:fgClr><a:srgbClr val="FF0000"/></a:fgClr></a:pattFill></a:ln></c:spPr>${tail}`;
+    expect(parseChart(pattFill)?.dataTable?.borderColor).toBeUndefined();
+  });
+
+  it("does not leak a sibling plotArea / legend <a:ln> into dataTable.borderColor", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+    </c:dTable>
+    <c:spPr><a:ln><a:solidFill><a:srgbClr val="111111"/></a:solidFill></a:ln></c:spPr>
+  </c:plotArea>
+  <c:legend><c:spPr><a:ln><a:solidFill><a:srgbClr val="222222"/></a:solidFill></a:ln></c:spPr></c:legend></c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataTable?.borderColor).toBeUndefined();
+    expect(chart?.plotAreaBorderColor).toBe("111111");
+    expect(chart?.legendBorderColor).toBe("222222");
+  });
+
+  it("composes dataTable.fillColor and borderColor from a single <c:spPr> block", () => {
+    // The fill and stroke share the <c:spPr> host but land on
+    // different children — the reader walks disjoint children so a
+    // caller can pin both knobs without conflict.
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart><c:plotArea>
+    <c:barChart><c:barDir val="col"/><c:ser><c:idx val="0"/></c:ser></c:barChart>
+    <c:catAx><c:axId val="1"/></c:catAx>
+    <c:valAx><c:axId val="2"/></c:valAx>
+    <c:dTable>
+      <c:showHorzBorder val="1"/>
+      <c:showVertBorder val="1"/>
+      <c:showOutline val="1"/>
+      <c:showKeys val="1"/>
+      <c:spPr>
+        <a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>
+        <a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>
+      </c:spPr>
+    </c:dTable>
+  </c:plotArea></c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataTable).toEqual({
+      showHorzBorder: true,
+      showVertBorder: true,
+      showOutline: true,
+      showKeys: true,
+      fillColor: "F2F2F2",
+      borderColor: "1F77B4",
+    });
+  });
 });
 
 // ── parseChart — chart-space protection ──────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `borderColor` knob on `ChartDataTable`, mapping to `<c:plotArea><c:dTable><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/></a:solidFill></a:ln></c:spPr></c:dTable>` — Excel's "Format Data Table -> Border -> Solid line -> Color" picker.
- Completes the `<a:ln>` stroke family for major chart-frame hosts: plotArea (#309), legend (#310), title (#311), axisTitle (#312), and now dataTable.
- Composes independently with the existing `fillColor` knob — both share one `<c:spPr>` on `<c:dTable>` and land on different children (`<a:solidFill>` for fill, `<a:ln>` for stroke), emitted in `CT_ShapeProperties` schema order (fill before stroke).
- Reader, writer, and clone-through plumbing follows the established hex-color grammar: accepts `#` / case, drops malformed / non-solid / `schemeClr` / alpha-channel forms to `undefined`. Silently dropped on `pie` / `doughnut` (no `<c:dTable>` slot) along with the rest of the data-table configuration.

Refs #312

## Test plan

- [x] `pnpm vitest run --dir=test test/charts-write.test.ts test/charts.test.ts test/chart-clone.test.ts` — 4446 passed
- [x] `pnpm vitest run --dir=test` — 6854 passed (all 89 test files)
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] `oxfmt --check` on changed files — clean
- [x] Reader: pinned `<a:ln>`, lowercase normalization, absence, malformed length / non-hex / alpha / schemeClr / non-solid line fills, isolation from sibling `<c:plotArea>` / `<c:legend>` `<a:ln>`, fill+border composition in a single `<c:spPr>`.
- [x] Writer: skip `<c:spPr>` when unset, emit when set, normalize, malformed → drop, ordering after the four required boolean children and before `<c:txPr>`, threads through every chart family with axes, drops on pie / doughnut, fill+border composition in canonical schema order, no leak between sibling host elements, `writeXlsx` end-to-end.
- [x] Clone: inherit by default, wholesale replace via override, drop via `null` / `false` / object without the knob, drop on flatten to pie / doughnut, end-to-end through `cloneChart -> writeChart -> parseChart` round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)