### PR TITLE
feat(xlsx): chart-space border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2516,6 +2516,53 @@ export interface SheetChart {
    * through every `<c:spPr>`-based fill slot.
    */
   chartSpaceFillColor?: string;
+  /**
+   * Chart-space (entire chart frame) border (stroke) solid color as a
+   * 6-digit RGB hex string (e.g. `"1F77B4"`). Maps to `<c:chartSpace>
+   * <c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+   * </a:ln></c:spPr></c:chartSpace>` — Excel's "Format Chart Area ->
+   * Border -> Solid line -> Color" picker (the same dialog the user
+   * reaches by right-clicking the chart's outer frame). The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor` inside the line's solid fill choice —
+   * ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The `<c:spPr>`
+   * slot lives at the tail of `<c:chartSpace>` per CT_ChartSpace
+   * (§21.2.2.29); `<a:ln>` follows the optional `<a:solidFill>` (fill)
+   * child inside `<c:spPr>` per `CT_ShapeProperties` (§20.1.2.3.13).
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the `<a:ln>` block (Excel's reference serialization for a chart
+   * area that inherits the auto-stroke — typically a translucent gray
+   * border or no border depending on the theme).
+   *
+   * Default: omitted — the chart inherits the auto-stroke Excel picks
+   * from the workbook theme. Pin a hex color to mirror Excel's
+   * "Format Chart Area -> Border -> Solid line" knob and paint a flat
+   * border around the entire chart frame — useful for dashboard tiles
+   * where the chart should be visually framed against the surrounding
+   * sheet cells.
+   *
+   * Composes independently with {@link chartSpaceFillColor} — the two
+   * knobs land on the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for the fill, `<a:ln>` for the stroke), and the
+   * writer authors a `<c:spPr>` whenever either knob is set. A caller
+   * can pin one without the other; pinning both produces a filled
+   * chart frame with a colored border.
+   *
+   * Patterned / gradient strokes are not modelled — only the solid
+   * sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   * Mirrors `plotAreaBorderColor` / `legendBorderColor` /
+   * `titleBorderColor` — same accept-with-or-without-`#` hex grammar,
+   * same OOXML `<a:ln><a:solidFill><a:srgbClr val=".."/>
+   * </a:solidFill></a:ln>` mapping — so a caller can thread a single
+   * hex string through every `<a:ln>`-based stroke slot.
+   */
+  chartSpaceBorderColor?: string;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -7420,6 +7467,41 @@ export interface Chart {
    * of which `<c:spPr>`-based fill slot the source chart pinned.
    */
   chartSpaceFillColor?: string;
+  /**
+   * Chart-space (entire chart frame) border (stroke) color pulled
+   * from `<c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+   * </a:solidFill></a:ln></c:spPr></c:chartSpace>`. Reflects Excel's
+   * "Format Chart Area -> Border -> Solid line -> Color" picker — the
+   * stroke that paints the outer border of the entire chart frame.
+   * The OOXML `<a:srgbClr val=".."/>` carries the 6-character
+   * uppercase hex sRGB color (`CT_SRgbColor` inside the line's solid
+   * fill choice — ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The
+   * `<c:spPr>` slot lives at the tail of `<c:chartSpace>` per
+   * CT_ChartSpace (§21.2.2.29); `<a:ln>` follows the optional
+   * `<a:solidFill>` (fill) child inside `<c:spPr>` per
+   * `CT_ShapeProperties` (§20.1.2.3.13).
+   *
+   * Reports the 6-character uppercase hex form when the source chart
+   * pinned a literal `<a:srgbClr>` color; absence, malformed `val`
+   * tokens (wrong length, non-hex characters, alpha-channel forms),
+   * non-solid line fills (`<a:noFill>`, `<a:gradFill>`, `<a:pattFill>`,
+   * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+   * collapse to `undefined` so absence and an unrenderable stroke
+   * round-trip identically through {@link cloneChart}. Mirrors the
+   * writer-side {@link SheetChart.chartSpaceBorderColor} so a parsed
+   * value slots straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:chartSpace><c:spPr>` block at all — there is no `<a:ln>` slot
+   * to surface the stroke from in that case. Composes independently
+   * with {@link chartSpaceFillColor} — the two fields surface from the
+   * same `<c:spPr>` block but on different children (`<a:solidFill>`
+   * for fill, `<a:ln><a:solidFill>` for stroke). The lookup is scoped
+   * to direct children of `<c:chartSpace>` so a stray `<c:spPr>`
+   * elsewhere (e.g. on `<c:plotArea>` / `<c:legend>` / `<c:title>` /
+   * a series) cannot leak into this field.
+   */
+  chartSpaceBorderColor?: string;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -515,6 +515,31 @@ export interface CloneChartOptions {
    * so a caller can pin both without conflict.
    */
   chartSpaceFillColor?: string | null;
+  /**
+   * Override `SheetChart.chartSpaceBorderColor`. `undefined` (or
+   * omitted) inherits the source's parsed `chartSpaceBorderColor`;
+   * `null` drops the inherited stroke (the writer emits no `<a:ln>`
+   * block on `<c:chartSpace>`'s `<c:spPr>`, falling back to the auto-
+   * stroke Excel picks from the workbook theme — typically a
+   * translucent gray border or no border depending on the theme); a
+   * 6-digit RGB hex string replaces it.
+   *
+   * The override runs through the same sRGB normalizer as the writer —
+   * the leading `#` and case are accepted, then the value collapses to
+   * the OOXML canonical uppercase form. Malformed tokens (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` so the cloned
+   * `SheetChart` drops the field rather than carry a value the writer
+   * would silently elide back to absence.
+   *
+   * Composes independently with `chartSpaceFillColor` — the two knobs
+   * land on the same `<c:spPr>` block but on different children
+   * (`<a:solidFill>` for fill, `<a:ln>` for stroke), and the writer
+   * emits `<c:spPr>` whenever either knob is set. Like the fill knob,
+   * the border is never gated on a visibility flag — every chart has
+   * a `<c:chartSpace>` document root to host the stroke.
+   */
+  chartSpaceBorderColor?: string | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -2181,6 +2206,25 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   );
   if (resolvedChartSpaceFillColor !== undefined) {
     out.chartSpaceFillColor = resolvedChartSpaceFillColor;
+  }
+
+  // Chart-space border (stroke) color is independent of every visibility
+  // flag — every chart has a `<c:chartSpace>` document root to host the
+  // `<c:spPr>` slot. `undefined` inherits the source's parsed
+  // `chartSpaceBorderColor` (after the writer-side normalizer collapses
+  // any malformed token), `null` drops the inherited stroke (the writer
+  // emits no `<a:ln>` block — the chart inherits the auto-stroke Excel
+  // picks from the workbook theme), a 6-digit hex string replaces it.
+  // Malformed overrides collapse to `undefined` via the normalizer so
+  // the cloned `SheetChart` always carries a value the writer will
+  // accept. Composes independently with `chartSpaceFillColor` — the two
+  // knobs land on different children of the same `<c:spPr>` block.
+  const resolvedChartSpaceBorderColor = resolveChartSpaceBorderColor(
+    source.chartSpaceBorderColor,
+    options.chartSpaceBorderColor,
+  );
+  if (resolvedChartSpaceBorderColor !== undefined) {
+    out.chartSpaceBorderColor = resolvedChartSpaceBorderColor;
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -4069,6 +4113,59 @@ function resolveChartSpaceFillColor(
   if (override === undefined) return normalizeChartSpaceFillColor(sourceValue);
   if (override === null) return undefined;
   return normalizeChartSpaceFillColor(override);
+}
+
+/**
+ * Normalize a `chartSpaceBorderColor` value for the cloned `SheetChart`.
+ * Mirrors the writer's `normalizeChartSpaceBorderColor` (which itself
+ * delegates to the chart-title / plot-area / legend hex normalizer) —
+ * the cloned shape is guaranteed to round-trip through the writer
+ * without surprise: a leading `#` and any case are accepted, then the
+ * value collapses to the OOXML canonical uppercase form. Malformed
+ * inputs (wrong length, non-hex characters, alpha-channel forms,
+ * non-string escapes from an untyped caller) collapse to `undefined`
+ * so the cloned chart drops the field rather than carry a value the
+ * writer would silently elide back to absence.
+ */
+function normalizeChartSpaceBorderColor(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  const hex = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (hex.length !== 6) return undefined;
+  if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+  return hex.toUpperCase();
+}
+
+/**
+ * Resolve a `chartSpaceBorderColor` override.
+ *
+ * `undefined` → inherit the source's parsed `chartSpaceBorderColor`
+ *               (after running it through
+ *               {@link normalizeChartSpaceBorderColor} so a malformed
+ *               source value drops cleanly).
+ * `null`      → drop the inherited stroke (the writer emits no
+ *               `<a:ln>` block on `<c:chartSpace>`'s `<c:spPr>`, the
+ *               chart inherits the auto-stroke Excel picks from the
+ *               workbook theme).
+ * `string`    → replace with the normalized 6-character uppercase hex
+ *               form. Malformed overrides collapse to `undefined` via
+ *               the normalizer so the cloned `SheetChart` always
+ *               carries a value the writer will accept.
+ *
+ * The grammar mirrors `plotAreaBorderColor` / `legendBorderColor` /
+ * `titleBorderColor` so the chart `<a:ln>` stroke knobs compose the
+ * same way at the call site. Unlike the title / legend variants, the
+ * chart-space border is never gated on a visibility flag — every chart
+ * has a `<c:chartSpace>` document root to host the stroke.
+ */
+function resolveChartSpaceBorderColor(
+  sourceValue: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return normalizeChartSpaceBorderColor(sourceValue);
+  if (override === null) return undefined;
+  return normalizeChartSpaceBorderColor(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -711,6 +711,17 @@ export function parseChart(xml: string): Chart | undefined {
   const chartSpaceFillColor = parseChartSpaceFillColor(chartSpace);
   if (chartSpaceFillColor !== undefined) out.chartSpaceFillColor = chartSpaceFillColor;
 
+  // `<c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+  // </a:solidFill></a:ln></c:spPr></c:chartSpace>` carries Excel's
+  // "Format Chart Area -> Border -> Solid line -> Color" pin (the outer
+  // border around the entire chart frame, distinct from the inner
+  // `<c:plotArea>` stroke). The reader surfaces only the literal
+  // `<a:srgbClr>` form so absence, malformed hex tokens, non-solid line
+  // fills, and theme-color references all collapse to `undefined` so a
+  // round-trip never fabricates a stroke Excel cannot render.
+  const chartSpaceBorderColor = parseChartSpaceBorderColor(chartSpace);
+  if (chartSpaceBorderColor !== undefined) out.chartSpaceBorderColor = chartSpaceBorderColor;
+
   return out;
 }
 
@@ -4311,6 +4322,51 @@ function parseChartSpaceFillColor(chartSpace: XmlElement): string | undefined {
   const spPr = findChild(chartSpace, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+ * </a:solidFill></a:ln></c:spPr></c:chartSpace>` off the chart-space
+ * document root. Returns the entire chart frame's border (stroke)
+ * color as a 6-character uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+ * solid fill choice (`CT_LineProperties`' `<a:solidFill>` child —
+ * §20.1.2.3.24). The `<a:ln>` slot follows the optional
+ * `<a:solidFill>` (fill) child inside `<c:spPr>` per
+ * `CT_ShapeProperties` (§20.1.2.3.13). The `<c:spPr>` slot itself
+ * sits at the tail of `<c:chartSpace>` per CT_ChartSpace (§21.2.2.29).
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid line fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>` /
+ * `<a:blipFill>`), and theme-color references (`<a:schemeClr>`) all
+ * collapse to `undefined` so a chart that pinned a stroke the writer
+ * cannot reproduce on emit drops the field rather than fabricate one
+ * Excel would render differently. Malformed `val` tokens (wrong
+ * length, non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link SheetChart.chartSpaceBorderColor} so
+ * a parsed value slots straight into {@link cloneChart} without
+ * conversion. The lookup is scoped to direct children of
+ * `<c:chartSpace>` so a stray `<c:spPr>` elsewhere (e.g. on
+ * `<c:plotArea>` / `<c:legend>` / `<c:title>` / a series) cannot leak
+ * into this field. Mirrors {@link parsePlotAreaBorderColor} /
+ * {@link parseLegendBorderColor} / {@link parseTitleBorderColor} —
+ * same `<c:spPr><a:ln><a:solidFill><a:srgbClr>` chain on a different
+ * host element.
+ */
+function parseChartSpaceBorderColor(chartSpace: XmlElement): string | undefined {
+  const spPr = findChild(chartSpace, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1430,29 +1430,45 @@ function normalizePlotAreaBorderColor(value: string | undefined): string | undef
 
 /**
  * Build the optional `<c:spPr>` block at the tail of `<c:chartSpace>`
- * (the document root). Currently surfaces only the solid fill color
- * knob ({@link SheetChart.chartSpaceFillColor}) — every other
- * `<c:spPr>` child (`<a:ln>` stroke, `<a:effectLst>` effects, gradient
- * / pattern / picture fills) is intentionally not modelled at this
- * layer.
+ * (the document root). Surfaces the solid fill color knob
+ * ({@link SheetChart.chartSpaceFillColor}) and the border (line) color
+ * knob ({@link SheetChart.chartSpaceBorderColor}) — every other
+ * `<c:spPr>` child (`<a:effectLst>` effects, gradient / pattern /
+ * picture fills, line dash / width / compound styles) is intentionally
+ * not modelled at this layer.
  *
- * Returns `undefined` when the chart leaves the field unset / passed a
- * malformed token so the writer skips the entire `<c:spPr>` block — an
- * empty `<c:spPr/>` collapses to the inherited theme fill Excel picks
- * anyway, and omitting it keeps untouched chart XML byte-clean.
+ * Returns `undefined` when both fields are unset / malformed so the
+ * writer skips the entire `<c:spPr>` block — an empty `<c:spPr/>`
+ * collapses to the inherited theme fill / stroke Excel picks anyway,
+ * and omitting it keeps untouched chart XML byte-clean. When at least
+ * one knob lands on the wire, the children are emitted in
+ * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
+ * `<a:ln>` (line / stroke).
  *
  * Mirrors {@link buildPlotAreaSpPr} but on a distinct host element —
- * the chart-space fill paints the entire chart frame (title slot,
- * legend slot, axis label margins, plot area together), while the
- * plot-area fill paints only the inner band that hosts the series.
+ * the chart-space fill / stroke paints the entire chart frame (title
+ * slot, legend slot, axis label margins, plot area together), while
+ * the plot-area knobs paint only the inner band that hosts the series.
  */
 function buildChartSpaceSpPr(chart: SheetChart): string | undefined {
   const fillHex = normalizeChartSpaceFillColor(chart.chartSpaceFillColor);
-  if (fillHex === undefined) return undefined;
-  const solidFill = xmlElement("a:solidFill", undefined, [
-    xmlSelfClose("a:srgbClr", { val: fillHex }),
-  ]);
-  return xmlElement("c:spPr", undefined, [solidFill]);
+  const borderHex = normalizeChartSpaceBorderColor(chart.chartSpaceBorderColor);
+  if (fillHex === undefined && borderHex === undefined) return undefined;
+
+  const children: string[] = [];
+  if (fillHex !== undefined) {
+    children.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
+    );
+  }
+  if (borderHex !== undefined) {
+    children.push(
+      xmlElement("a:ln", undefined, [
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderHex })]),
+      ]),
+    );
+  }
+  return xmlElement("c:spPr", undefined, children);
 }
 
 /**
@@ -1472,6 +1488,28 @@ function buildChartSpaceSpPr(chart: SheetChart): string | undefined {
  * fill slot shares the same sRGB grammar.
  */
 function normalizeChartSpaceFillColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
+ * Normalize a {@link SheetChart.chartSpaceBorderColor} value for the
+ * `<c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/>
+ * </a:solidFill></a:ln></c:spPr></c:chartSpace>` writer slot. Returns
+ * the 6-character uppercase hex form when the input is a valid sRGB
+ * triple (with or without a leading `#`), or `undefined` for any
+ * malformed token — wrong length, non-hex characters, alpha-channel
+ * forms, or non-string escapes from an untyped caller.
+ *
+ * Absence and malformed tokens both collapse to `undefined` so the
+ * writer skips the `<a:ln>` block and the chart inherits the auto-
+ * stroke Excel picks from the workbook theme (Excel's reference
+ * behavior for a fresh chart without a custom border). Delegates to
+ * the chart-level {@link normalizeTitleColor} so every `<a:srgbClr>`
+ * fill / line slot shares the same sRGB grammar. Mirrors
+ * {@link normalizeChartSpaceFillColor} — same hex grammar, distinct
+ * writer slot (`<a:ln>` rather than `<a:solidFill>`).
+ */
+function normalizeChartSpaceBorderColor(value: string | undefined): string | undefined {
   return normalizeTitleColor(value);
 }
 

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -22242,6 +22242,202 @@ describe("cloneChart — chartSpaceFillColor", () => {
   });
 });
 
+// ── cloneChart — chartSpaceBorderColor (entire chart border) ────────
+
+describe("cloneChart — chartSpaceBorderColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chartSpaceBorderColor by default", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("lets options.chartSpaceBorderColor override the source's value", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "ABCDEF",
+    });
+    expect(clone.chartSpaceBorderColor).toBe("ABCDEF");
+  });
+
+  it("drops the inherited chartSpaceBorderColor when the override is null", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: null,
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined chartSpaceBorderColor when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("normalizes a leading # in the override hex string", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "#1f77b4",
+    });
+    expect(clone.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("normalizes a lowercase override hex string to uppercase", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "ff8800",
+    });
+    expect(clone.chartSpaceBorderColor).toBe("FF8800");
+  });
+
+  it("normalizes a malformed source value through the resolver (drops to undefined)", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "ZZZ" as string }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("collapses malformed override hex tokens (wrong length)", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "FFF",
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("collapses malformed override hex tokens (non-hex characters)", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "GGGGGG",
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("collapses alpha-channel override hex tokens", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "FFAA0080",
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("collapses non-string overrides (number leaking past the type guard)", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      chartSpaceBorderColor: 0xff_ff_ff as any,
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("collapses an empty string override", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "ABCDEF" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderColor: "",
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("carries chartSpaceBorderColor through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with chartSpaceFillColor (both inherited from source)", () => {
+    const clone = cloneChart(
+      source({ chartSpaceFillColor: "F2F2F2", chartSpaceBorderColor: "1F77B4" }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+    expect(clone.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("composes independently with chartSpaceFillColor (override only the border)", () => {
+    const clone = cloneChart(
+      source({ chartSpaceFillColor: "F2F2F2", chartSpaceBorderColor: "1F77B4" }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        chartSpaceBorderColor: "ABCDEF",
+      },
+    );
+    expect(clone.chartSpaceFillColor).toBe("F2F2F2");
+    expect(clone.chartSpaceBorderColor).toBe("ABCDEF");
+  });
+
+  it("propagates chartSpaceBorderColor into the rendered <c:chartSpace><c:spPr><a:ln> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const chartSpaceSpPr = written.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    expect(chartSpaceSpPr).not.toBeNull();
+    expect(chartSpaceSpPr![1]).toContain("<a:ln>");
+    expect(chartSpaceSpPr![1]).toContain('<a:srgbClr val="1F77B4"/>');
+
+    const reparsed = parseChart(written);
+    expect(reparsed?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("a null override drops the inherited stroke on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ chartSpaceBorderColor: "1F77B4" }), {
+      anchor: { from: { row: 5, col: 0 } },
+      chartSpaceBorderColor: null,
+    });
+    expect(clone.chartSpaceBorderColor).toBeUndefined();
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const chartSpaceSpPr = written.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    expect(chartSpaceSpPr).toBeNull();
+  });
+});
+
 // ── cloneChart — axisTitleFillColor ──────────────────────────────────
 
 describe("cloneChart — axisTitleFillColor", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -21068,6 +21068,207 @@ describe("writeChart — chartSpaceFillColor", () => {
   });
 });
 
+// ── writeChart — chartSpaceBorderColor (entire chart border) ────────
+
+describe("writeChart — chartSpaceBorderColor", () => {
+  // The chart-space `<c:spPr>` lives at the tail of `<c:chartSpace>`,
+  // not inside `<c:chart>`. The writer never emits `<c:plotArea>` /
+  // `<c:legend>` / `<c:title>` `<c:spPr>` blocks unless the matching
+  // knob is pinned, so when only `chartSpaceBorderColor` is set the
+  // chart XML carries exactly one `<c:spPr>` — the chart-space block.
+  function chartSpaceSpPrOf(xml: string): string | undefined {
+    const m = xml.match(/<\/c:chart>\s*(<c:spPr>[\s\S]*?<\/c:spPr>)/);
+    return m ? m[1] : undefined;
+  }
+
+  it("does NOT emit <c:spPr> on <c:chartSpace> when chartSpaceBorderColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it('threads chartSpaceBorderColor through to <c:chartSpace><c:spPr><a:ln> as <a:srgbClr val="RRGGBB"/>', () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "1F77B4" }), "Sheet1");
+    const spPr = chartSpaceSpPrOf(result.chartXml);
+    expect(spPr).toBeDefined();
+    expect(spPr).toContain("<a:ln>");
+    expect(spPr).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("normalizes a leading # in the input hex string", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "#1F77B4" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("normalizes a lowercase hex string to the OOXML uppercase canonical form", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "abcdef" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("places <c:spPr> after </c:chart> per CT_ChartSpace sequence", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "1F77B4" }), "Sheet1");
+    const xml = result.chartXml;
+    const chartCloseIdx = xml.indexOf("</c:chart>");
+    const spPrIdx = xml.indexOf("<c:spPr>", chartCloseIdx);
+    expect(chartCloseIdx).toBeGreaterThan(0);
+    expect(spPrIdx).toBeGreaterThan(chartCloseIdx);
+  });
+
+  it("only emits one <c:spPr> at the chart-space level", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "FFAA00" }), "Sheet1");
+    const occurrences = result.chartXml.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads chartSpaceBorderColor through every chart family", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, chartSpaceBorderColor: "ABCDEF" }), "Sheet1");
+      expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        chartSpaceBorderColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    expect(chartSpaceSpPrOf(scatter.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("drops a malformed hex (wrong length)", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "FFF" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops a malformed hex (non-hex characters)", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "GGGGGG" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops an alpha-channel form (8 chars)", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "FFAA0080" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops empty / whitespace-only strings", () => {
+    expect(
+      chartSpaceSpPrOf(writeChart(makeChart({ chartSpaceBorderColor: "" }), "Sheet1").chartXml),
+    ).toBeUndefined();
+    expect(
+      chartSpaceSpPrOf(writeChart(makeChart({ chartSpaceBorderColor: "   " }), "Sheet1").chartXml),
+    ).toBeUndefined();
+  });
+
+  it("drops non-string escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ chartSpaceBorderColor: 0xff_ff_ff as any }), "Sheet1");
+    expect(chartSpaceSpPrOf(a.chartXml)).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ chartSpaceBorderColor: null as any }), "Sheet1");
+    expect(chartSpaceSpPrOf(b.chartXml)).toBeUndefined();
+  });
+
+  it("emits a minimal <c:spPr> block with just <a:ln> when only the border is pinned", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderColor: "ABCDEF" }), "Sheet1");
+    const spPr = chartSpaceSpPrOf(result.chartXml);
+    expect(spPr).toBe(
+      '<c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>',
+    );
+  });
+
+  it("composes with chartSpaceFillColor — both children inside the same <c:spPr> block in CT_ShapeProperties order", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceFillColor: "F2F2F2",
+        chartSpaceBorderColor: "1F77B4",
+      }),
+      "Sheet1",
+    );
+    const spPr = chartSpaceSpPrOf(result.chartXml);
+    expect(spPr).toBe(
+      '<c:spPr><a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln></c:spPr>',
+    );
+  });
+
+  it("composes independently with plotAreaBorderColor (each lands on its own host)", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceBorderColor: "1F77B4",
+        plotAreaBorderColor: "ABCDEF",
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const plotAreaMatch = xml.match(/<c:plotArea>[\s\S]*?<\/c:plotArea>/);
+    expect(plotAreaMatch).not.toBeNull();
+    expect(plotAreaMatch![0]).toContain('<a:srgbClr val="ABCDEF"/>');
+    expect(plotAreaMatch![0]).not.toContain('<a:srgbClr val="1F77B4"/>');
+    expect(chartSpaceSpPrOf(xml)).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("composes with legendBorderColor and titleBorderColor (each on a distinct host)", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceBorderColor: "111111",
+        legendBorderColor: "222222",
+      }),
+      "Sheet1",
+    );
+    const xml = result.chartXml;
+    const legend = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/)![0];
+    expect(legend).toContain('<a:srgbClr val="222222"/>');
+    expect(legend).not.toContain("111111");
+    expect(chartSpaceSpPrOf(xml)).toContain('<a:srgbClr val="111111"/>');
+  });
+
+  it("round-trips chartSpaceBorderColor through parseChart", () => {
+    const written = writeChart(makeChart({ chartSpaceBorderColor: "1F77B4" }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("round-trips chartSpaceBorderColor + chartSpaceFillColor together", () => {
+    const written = writeChart(
+      makeChart({ chartSpaceFillColor: "F2F2F2", chartSpaceBorderColor: "1F77B4" }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.chartSpaceFillColor).toBe("F2F2F2");
+    expect(reparsed?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset chartSpaceBorderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — chartSpaceBorderColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            chartSpaceBorderColor: "1F77B4",
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── writeChart — axisTitleFillColor (solid fill) ─────────────────────
 
 describe("writeChart — axisTitleFillColor", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20884,6 +20884,174 @@ describe("parseChart — chartSpaceFillColor", () => {
   });
 });
 
+// ── parseChart — chartSpaceBorderColor (entire chart border) ────────
+
+describe("parseChart — chartSpaceBorderColor", () => {
+  const NS_CSB = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withChartSpaceSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_CSB}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+  <c:spPr>${spPrBody}</c:spPr>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the literal sRGB stroke when <c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr> is pinned", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("normalizes lowercase hex to canonical uppercase form", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBe("ABCDEF");
+  });
+
+  it("admits a leading # on the val attribute", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="#1F77B4"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the chartSpace has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_CSB}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln> child", () => {
+    const xml = withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="000000"/></a:solidFill>`);
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no <a:solidFill>", () => {
+    const xml = withChartSpaceSpPr(`<a:ln><a:noFill/></a:ln>`);
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln><a:solidFill> uses <a:schemeClr> (theme reference)", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> uses <a:gradFill>", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:gradFill><a:gsLst><a:gs pos="0"><a:srgbClr val="FFFFFF"/></a:gs></a:gsLst></a:gradFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> uses <a:pattFill>", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:pattFill prst="pct5"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (wrong length)", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="ABC"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is malformed (non-hex characters)", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="GGGGGG"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("returns undefined when the val attribute is missing", () => {
+    const xml = withChartSpaceSpPr(`<a:ln><a:solidFill><a:srgbClr/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("drops alpha-channel hex forms", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("does not leak a stray <c:spPr> from <c:plotArea> into chartSpaceBorderColor", () => {
+    const xml = `<c:chartSpace ${NS_CSB}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    // The plot-area stroke is a different field; the chart-space stroke is absent.
+    expect(chart?.plotAreaBorderColor).toBe("ABCDEF");
+    expect(chart?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("does not leak a stray <c:spPr> from <c:legend> into chartSpaceBorderColor", () => {
+    const xml = `<c:chartSpace ${NS_CSB}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr><a:ln><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legendBorderColor).toBe("ABCDEF");
+    expect(chart?.chartSpaceBorderColor).toBeUndefined();
+  });
+
+  it("composes independently with chartSpaceFillColor — same <c:spPr> block, distinct children", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill><a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const chart = parseChart(xml);
+    expect(chart?.chartSpaceFillColor).toBe("F2F2F2");
+    expect(chart?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("surfaces the stroke independently when only <a:ln> is pinned (no <a:solidFill> sibling)", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const chart = parseChart(xml);
+    expect(chart?.chartSpaceFillColor).toBeUndefined();
+    expect(chart?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+});
+
 // ── parseChart — axisTitleFillColor ──────────────────────────────────
 
 describe("parseChart — axisTitleFillColor", () => {


### PR DESCRIPTION
## Summary

Adds a `chartSpaceBorderColor` knob on `SheetChart` that maps to
`<c:chartSpace><c:spPr><a:ln><a:solidFill><a:srgbClr val=\"...\"/></a:solidFill></a:ln></c:spPr>`
— Excel's "Format Chart Area -> Border -> Solid line -> Color" picker.
This is the stroke counterpart of `chartSpaceFillColor` (#305) and
completes the chart-space `<c:spPr>` slot.

- **Reader**: scoped to direct children of `<c:chartSpace>` so a stray
  `<c:spPr>` on `<c:plotArea>` / `<c:legend>` / `<c:title>` cannot leak.
  Drops absence, malformed hex, non-solid line fills, and theme-color
  references to `undefined`.
- **Writer**: composes inside the same `<c:spPr>` block as
  `chartSpaceFillColor`; children land in `CT_ShapeProperties` schema
  order (`<a:solidFill>` then `<a:ln>`). When only the border is set,
  the writer emits a minimal `<c:spPr>` with just `<a:ln>`.
- **Clone**: inherit / override / null-drop / normalize, mirroring the
  existing border-color sibling fields (`plotAreaBorderColor`,
  `legendBorderColor`, `titleBorderColor`).

## Test plan

- [x] `pnpm vitest run --dir=test test/charts.test.ts -t \"chartSpaceBorderColor\"` — 17 reader cases pass
- [x] `pnpm vitest run --dir=test test/charts-write.test.ts -t \"chartSpaceBorderColor\"` — 20 writer cases pass
- [x] `pnpm vitest run --dir=test test/chart-clone.test.ts -t \"chartSpaceBorderColor\"` — 17 clone cases pass
- [x] `pnpm vitest run --dir=test` — full suite (6874 tests) passes
- [x] `pnpm build` — green

Refs #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)