### PR TITLE
feat(xlsx): chart data-labels border color — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -934,6 +934,67 @@ export interface ChartDataLabels {
    * {@link fontColor} / {@link fontFamily}.
    */
   fillColor?: string;
+  /**
+   * Data-labels border (line) color as a 6-digit RGB hex string (e.g.
+   * `"1F77B4"`). Maps to `<c:dLbls><c:spPr><a:ln><a:solidFill>
+   * <a:srgbClr val="RRGGBB"/></a:solidFill></a:ln></c:spPr></c:dLbls>`
+   * (CT_DLbls, ECMA-376 Part 1, §21.2.2.50) — Excel's "Format Data
+   * Labels -> Border -> Solid line -> Color" picker. The OOXML
+   * `<a:srgbClr val=".."/>` carries the 6-character uppercase hex
+   * sRGB color (`CT_SRgbColor` inside `<a:ln>`'s solid fill choice —
+   * ECMA-376 Part 1, §20.1.2.3.32 / §20.1.2.3.24). The `<a:ln>` child
+   * sits inside the `<c:spPr>` block alongside the optional
+   * `<a:solidFill>` fill child, in `CT_ShapeProperties` schema order
+   * (fill before stroke).
+   *
+   * Distinct from {@link fillColor} — the border color paints the
+   * outline around each data label box, while the fill color paints
+   * the label box background. The two knobs share the `<c:spPr>` host
+   * but land on different children (`<a:solidFill>` for the fill,
+   * `<a:ln>` for the stroke), and the writer authors a single
+   * `<c:spPr>` whenever either knob is set. A caller can pin one
+   * without the other; pinning both produces a filled label box with
+   * a colored border.
+   *
+   * Distinct from {@link fontColor} (the typography color living on
+   * `<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>`); the three knobs
+   * target different children of `<c:dLbls>` so a caller can pin all
+   * of them without conflict — {@link fillColor} paints the label box
+   * background, {@link borderColor} paints its outline, and
+   * {@link fontColor} paints the text glyphs.
+   *
+   * Accepts a leading `#` and any case; the writer collapses to the
+   * OOXML canonical uppercase form. Malformed inputs (wrong length,
+   * non-hex characters, alpha-channel forms, non-string escapes from
+   * an untyped caller) collapse to `undefined` and the writer omits
+   * the `<a:ln>` block (Excel's reference serialization for data
+   * labels that inherit the auto-stroke — typically no border).
+   *
+   * Default: omitted — the data labels render with no `<c:spPr>`
+   * border (Excel's reference serialization for fresh data labels
+   * whose border has not been pinned). Pin a hex color to mirror
+   * Excel's "Format Data Labels -> Border -> Solid line" knob and
+   * paint a flat outline around each label — useful for dashboard
+   * tiles where the data labels need to stand out against a busy
+   * plot-area background.
+   *
+   * Patterned / gradient strokes are not modelled — only the solid
+   * sRGB form lands on the wire. Theme-color references
+   * (`<a:schemeClr>`) likewise drop to `undefined` so a parsed value
+   * always carries a literal hex Excel will render byte-for-byte.
+   * Mirrors `plotAreaBorderColor` / `legendBorderColor` /
+   * `titleBorderColor` / `axisTitleBorderColor` /
+   * `dataTableBorderColor` — same accept-with-or-without-`#` hex
+   * grammar, same OOXML `<a:ln><a:solidFill><a:srgbClr val=".."/>
+   * </a:solidFill></a:ln>` mapping — so a caller can thread a single
+   * hex string through every `<a:ln>`-based stroke slot. Composes
+   * independently with the other dLbls knobs — {@link position} /
+   * {@link separator} / {@link numberFormat} / {@link showLeaderLines}
+   * / the `show*` toggles / {@link bold} / {@link italic} /
+   * {@link underline} / {@link strikethrough} / {@link fontSize} /
+   * {@link fontColor} / {@link fontFamily} / {@link fillColor}.
+   */
+  borderColor?: string;
 }
 
 /**
@@ -6010,6 +6071,35 @@ export interface ChartDataLabelsInfo {
    * slots straight into {@link cloneChart} without conversion.
    */
   fillColor?: string;
+  /**
+   * Data-labels border (line) color pulled from `<c:dLbls><c:spPr>
+   * <a:ln><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:ln>
+   * </c:spPr></c:dLbls>`. The OOXML `<c:spPr>` block sits on
+   * `CT_DLbls` between `<c:numFmt>` and `<c:txPr>` per the schema
+   * sequence (ECMA-376 Part 1, §21.2.2.50); the `<a:ln>` child sits
+   * inside the `<c:spPr>` block alongside the optional `<a:solidFill>`
+   * fill child, and the `<a:srgbClr val=".."/>` carries the
+   * 6-character uppercase hex sRGB color (`CT_SRgbColor` inside
+   * `<a:ln>`'s solid fill choice — ECMA-376 Part 1, §20.1.2.3.32 /
+   * §20.1.2.3.24).
+   *
+   * Returned as the canonical 6-character uppercase hex string when
+   * the parser walks the full chain and lands on an `<a:srgbClr
+   * val="RRGGBB"/>`. Theme references (`<a:schemeClr>`),
+   * `<a:hslClr>`, `<a:sysClr>`, `<a:prstClr>`, non-solid line fills
+   * (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`), and malformed
+   * `val` tokens (wrong length, non-hex characters) all collapse to
+   * `undefined` since only the literal RGB triple round-trips
+   * losslessly through {@link writeChart}. Mirrors the writer-side
+   * {@link ChartDataLabels.borderColor} so a parsed value slots
+   * straight into {@link cloneChart} without conversion. Independent
+   * of {@link fillColor}: the fill lives on `<c:dLbls><c:spPr>
+   * <a:solidFill>`, the stroke lives on `<c:dLbls><c:spPr><a:ln>
+   * <a:solidFill>` — the two readers walk disjoint children of the
+   * same `<c:spPr>` block so a caller can pin both knobs without
+   * conflict.
+   */
+  borderColor?: string;
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -3071,6 +3071,19 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const fillColor = parseDataLabelsFillColor(el);
   if (fillColor !== undefined) out.fillColor = fillColor;
 
+  // `<c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/></a:solidFill>
+  // </a:ln></c:spPr>` — data-labels border (line) color pinned via
+  // Excel's "Format Data Labels -> Border -> Solid line -> Color"
+  // picker. Theme references (`<a:schemeClr>`), non-solid line fills
+  // (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`), and malformed
+  // `val` tokens collapse to `undefined` since only the literal RGB
+  // triple round-trips losslessly through `writeChart`. Distinct from
+  // `fillColor` (which lives on `<c:spPr><a:solidFill>`); the two
+  // knobs target different children of the same `<c:spPr>` so a
+  // caller can pin both without conflict.
+  const borderColor = parseDataLabelsBorderColor(el);
+  if (borderColor !== undefined) out.borderColor = borderColor;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -3089,7 +3102,8 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.underline === undefined &&
     out.strikethrough === undefined &&
     out.fontFamily === undefined &&
-    out.fillColor === undefined
+    out.fillColor === undefined &&
+    out.borderColor === undefined
   ) {
     return undefined;
   }
@@ -3361,6 +3375,52 @@ function parseDataLabelsFillColor(dLbls: XmlElement): string | undefined {
   const spPr = findChild(dLbls, "spPr");
   if (!spPr) return undefined;
   const solidFill = findChild(spPr, "solidFill");
+  if (!solidFill) return undefined;
+  const srgbClr = findChild(solidFill, "srgbClr");
+  if (!srgbClr) return undefined;
+  return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull `<c:dLbls><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:dLbls>` off a data-labels block.
+ * Returns the data-labels border (line) color as a 6-character
+ * uppercase hex string.
+ *
+ * The OOXML `<a:srgbClr>` element carries the literal sRGB color
+ * (`CT_SRgbColor`, ECMA-376 Part 1, §20.1.2.3.32) inside the line's
+ * solid fill choice (`CT_LineProperties`'s solid fill — §20.1.2.3.24).
+ * The `<a:ln>` slot sits inside the `<c:spPr>` block on `<c:dLbls>`
+ * alongside the optional `<a:solidFill>` fill child, in
+ * `CT_ShapeProperties` schema order (fill before stroke). The
+ * `<c:spPr>` itself sits between `<c:numFmt>` and `<c:txPr>` per
+ * CT_DLbls (ECMA-376 Part 1, §21.2.2.50).
+ *
+ * The reader surfaces only the literal `<a:srgbClr>` form — absence,
+ * non-solid line fills (`<a:noFill>` / `<a:gradFill>` / `<a:pattFill>`),
+ * and theme-color references (`<a:schemeClr>`) all collapse to
+ * `undefined` so a chart that pinned a stroke the writer cannot
+ * reproduce on emit drops the field rather than fabricate one Excel
+ * would render differently. Malformed `val` tokens (wrong length,
+ * non-hex characters, alpha-channel forms, non-string escapes)
+ * likewise drop to `undefined`.
+ *
+ * Mirrors the writer-side {@link ChartDataLabels.borderColor} so a
+ * parsed value slots straight into {@link cloneChart} without
+ * conversion. The lookup is scoped to direct children of `<c:dLbls>`
+ * so a stray `<c:spPr>` elsewhere (e.g. on `<c:plotArea>` /
+ * `<c:legend>` / `<c:title>` / a series) cannot leak in. Mirrors
+ * {@link parseDataLabelsFillColor} — same `<c:spPr>` host element on
+ * the same `<c:dLbls>` parent — but lands on the line
+ * (`<a:ln><a:solidFill>`) child rather than the fill (`<a:solidFill>`)
+ * child.
+ */
+function parseDataLabelsBorderColor(dLbls: XmlElement): string | undefined {
+  const spPr = findChild(dLbls, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const solidFill = findChild(ln, "solidFill");
   if (!solidFill) return undefined;
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -5066,18 +5066,26 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   }
 
   // `<c:spPr>` sits between `<c:numFmt>` and `<c:txPr>` in the
-  // CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). Currently
-  // the writer only authors `<a:solidFill>` here from
-  // {@link ChartDataLabels.fillColor}; stroke (`<a:ln>`) and other
-  // `CT_ShapeProperties` children are not modelled at this layer. The
-  // builder skips emission entirely when no fill is pinned so a fresh
-  // chart matches Excel's reference shape (no `<c:spPr>` block on a
-  // theme-default data-labels rendering — typically a transparent label
-  // background). Distinct from the `<a:defRPr><a:solidFill>` font-color
-  // slot inside `<c:txPr>` that {@link ChartDataLabels.fontColor} pins
-  // — the two knobs target different children of `<c:dLbls>` so a
-  // caller can pin both without conflict.
-  const spPrXml = buildDataLabelsSpPr(resolveDataLabelsFillColor(dl.fillColor));
+  // CT_DLbls schema sequence (ECMA-376 Part 1, §21.2.2.50). The writer
+  // authors `<a:solidFill>` here from {@link ChartDataLabels.fillColor}
+  // and `<a:ln>` here from {@link ChartDataLabels.borderColor}; other
+  // `CT_ShapeProperties` children (gradient / pattern fills, line dash
+  // / width / compound styles, `<a:effectLst>` effects) are not
+  // modelled at this layer. The builder skips emission entirely when
+  // no fill / border is pinned so a fresh chart matches Excel's
+  // reference shape (no `<c:spPr>` block on a theme-default data-
+  // labels rendering — typically a transparent label background with
+  // no border). When at least one knob lands on the wire, the children
+  // are emitted in `CT_ShapeProperties` schema order: `<a:solidFill>`
+  // (fill) then `<a:ln>` (line / stroke). Distinct from the
+  // `<a:defRPr><a:solidFill>` font-color slot inside `<c:txPr>` that
+  // {@link ChartDataLabels.fontColor} pins — the three knobs target
+  // different children of `<c:dLbls>` so a caller can pin them all
+  // without conflict.
+  const spPrXml = buildDataLabelsSpPr(
+    resolveDataLabelsFillColor(dl.fillColor),
+    resolveDataLabelsBorderColor(dl.borderColor),
+  );
   if (spPrXml !== undefined) {
     children.push(spPrXml);
   }
@@ -5309,28 +5317,77 @@ function resolveDataLabelsFillColor(value: string | undefined): string | undefin
 }
 
 /**
- * Build the `<c:spPr>` block that carries a data-labels' background
- * fill. Returns `undefined` when no fill is pinned so the caller can
- * elide the entire block — Excel's reference serialization omits
- * `<c:spPr>` from `<c:dLbls>` whenever the labels render at the theme
- * default fill (typically a transparent label background).
+ * Resolve `<c:dLbls><c:spPr><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr></c:dLbls>` from
+ * {@link ChartDataLabels.borderColor}.
+ *
+ * Returns the 6-character uppercase hex string the writer emits, or
+ * `undefined` when the caller leaves the field unset / passed a
+ * malformed token. Delegates to {@link normalizeTitleColor} so the
+ * accept-with-or-without-`#` grammar matches every other `<a:srgbClr>`
+ * fill / line slot exactly. Composes independently with
+ * {@link ChartDataLabels.fillColor} — the two knobs share the same
+ * `<c:spPr>` host on `<c:dLbls>` but land on different children
+ * (`<a:solidFill>` for the fill, `<a:ln><a:solidFill>` for the
+ * stroke). Mirrors the chart-title / axis-title / chart-space /
+ * plot-area / legend / data-table `<c:spPr>` border slots — same hex
+ * grammar, same `<a:ln>` slot on the `CT_ShapeProperties` schema —
+ * but lands on `<c:dLbls>`'s own `<c:spPr>` block.
+ */
+function resolveDataLabelsBorderColor(value: string | undefined): string | undefined {
+  return normalizeTitleColor(value);
+}
+
+/**
+ * Build the optional `<c:spPr>` block inside `<c:dLbls>`. Surfaces the
+ * solid fill color knob ({@link ChartDataLabels.fillColor}) and the
+ * border (line) color knob ({@link ChartDataLabels.borderColor}) —
+ * every other `<c:spPr>` child (`<a:effectLst>` effects, gradient /
+ * pattern / picture fills, line dash / width / compound styles) is
+ * intentionally not modelled at this layer.
+ *
+ * Returns `undefined` when both fields are unset / malformed so the
+ * writer skips the entire `<c:spPr>` block — an empty `<c:spPr/>`
+ * collapses to the inherited theme fill / stroke Excel picks anyway,
+ * and omitting it keeps untouched chart XML byte-clean. When at least
+ * one knob lands on the wire, the children are emitted in
+ * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
+ * `<a:ln>` (line / stroke).
  *
  * The emitted block mirrors the minimal `<c:spPr>` shape Excel writes
  * when the user pins "Format Data Labels -> Fill -> Solid fill ->
+ * Color" and / or "Format Data Labels -> Border -> Solid line ->
  * Color": `<c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
- * </a:solidFill></c:spPr>`. The `val` attribute holds the canonical
- * 6-character uppercase hex form (the writer normalizes the input
- * ahead of this call so a malformed source value never reaches emit).
+ * </a:solidFill><a:ln><a:solidFill><a:srgbClr val="RRGGBB"/>
+ * </a:solidFill></a:ln></c:spPr>`. The `val` attribute holds the
+ * canonical 6-character uppercase hex form (the writer normalizes the
+ * input ahead of this call so a malformed source value never reaches
+ * emit).
  *
- * Mirrors the chart-title / axis-title / plot-area / legend
- * `<c:spPr>` slots so a single hex string threads cleanly through
- * every fill knob the writer authors.
+ * Mirrors {@link buildLegendSpPr} / {@link buildDataTableSpPr} but
+ * on a distinct host element — the data-labels fill / stroke paint
+ * the background and outline of each label box, while the legend /
+ * data-table variants paint a different chart-frame element.
  */
-function buildDataLabelsSpPr(fillRgbHex: string | undefined): string | undefined {
-  if (fillRgbHex === undefined) return undefined;
-  return xmlElement("c:spPr", undefined, [
-    xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
-  ]);
+function buildDataLabelsSpPr(
+  fillRgbHex: string | undefined,
+  borderRgbHex: string | undefined,
+): string | undefined {
+  if (fillRgbHex === undefined && borderRgbHex === undefined) return undefined;
+  const children: string[] = [];
+  if (fillRgbHex !== undefined) {
+    children.push(
+      xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
+    );
+  }
+  if (borderRgbHex !== undefined) {
+    children.push(
+      xmlElement("a:ln", undefined, [
+        xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
+      ]),
+    );
+  }
+  return xmlElement("c:spPr", undefined, children);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -23128,6 +23128,249 @@ describe("cloneChart — dataLabels.fillColor", () => {
   });
 });
 
+// ── cloneChart — dataLabels.borderColor ─────────────────────────────
+
+describe("cloneChart — dataLabels.borderColor", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "bar",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's chart-level dataLabels.borderColor by default", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("lets options.dataLabels override the source's value (replaces the whole block)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: { showValue: true, borderColor: "00C586" },
+    });
+    expect(clone.dataLabels?.borderColor).toBe("00C586");
+  });
+
+  it("drops the inherited dataLabels block when the override is null", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      dataLabels: null,
+    });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("returns undefined dataLabels when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels).toBeUndefined();
+  });
+
+  it("composes independently with fillColor on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          fillColor: "FFEEDD",
+          borderColor: "112233",
+          position: "outEnd",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.fillColor).toBe("FFEEDD");
+    expect(clone.dataLabels?.borderColor).toBe("112233");
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.showValue).toBe(true);
+  });
+
+  it("composes independently with fontColor on the cloned SheetChart", () => {
+    const clone = cloneChart(
+      source({
+        dataLabels: {
+          showValue: true,
+          borderColor: "FFEEDD",
+          fontColor: "112233",
+          position: "outEnd",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.dataLabels?.borderColor).toBe("FFEEDD");
+    expect(clone.dataLabels?.fontColor).toBe("112233");
+    expect(clone.dataLabels?.position).toBe("outEnd");
+    expect(clone.dataLabels?.showValue).toBe(true);
+  });
+
+  it("propagates dataLabels.borderColor into the rendered <c:dLbls><c:spPr><a:ln> on writeXlsx roundtrip", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain("<c:spPr>");
+    expect(written).toContain("<a:ln>");
+    expect(written).toContain('<a:srgbClr val="1F77B4"/>');
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("an explicit override beats the source value through writeXlsx", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: { showValue: true, borderColor: "00C586" },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).toContain('<a:srgbClr val="00C586"/>');
+    expect(written).not.toContain('<a:srgbClr val="1F77B4"/>');
+    expect(parseChart(written)?.dataLabels?.borderColor).toBe("00C586");
+  });
+
+  it("a null override drops the source value through writeXlsx (no <c:spPr> on dLbls)", async () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 5, col: 0 } },
+      dataLabels: null,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(written).not.toContain("<c:dLbls>");
+    expect(parseChart(written)?.dataLabels).toBeUndefined();
+  });
+
+  it("carries dataLabels.borderColor through a flatten (bar → line)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "line",
+    });
+    expect(clone.type).toBe("line");
+    expect(clone.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("carries dataLabels.borderColor through a doughnut flatten (bar → doughnut)", () => {
+    const clone = cloneChart(source({ dataLabels: { showValue: true, borderColor: "1F77B4" } }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "doughnut",
+    });
+    expect(clone.type).toBe("doughnut");
+    expect(clone.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("round-trips a parsed dataLabels.borderColor straight back through cloneChart", () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [{ values: "B2:B5", categories: "A2:A5" }],
+        anchor: { from: { row: 0, col: 0 } },
+        dataLabels: { showValue: true, borderColor: "1F77B4" },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.dataLabels?.borderColor).toBe("1F77B4");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("round-trips fillColor + borderColor together through cloneChart", () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [{ values: "B2:B5", categories: "A2:A5" }],
+        anchor: { from: { row: 0, col: 0 } },
+        dataLabels: { showValue: true, fillColor: "FFEEDD", borderColor: "1F77B4" },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.dataLabels?.fillColor).toBe("FFEEDD");
+    expect(parsed.dataLabels?.borderColor).toBe("1F77B4");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.dataLabels?.fillColor).toBe("FFEEDD");
+    expect(clone.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("round-trips a per-series dataLabels.borderColor through cloneChart", () => {
+    const written = writeChart(
+      {
+        type: "column",
+        title: "Sales",
+        series: [
+          {
+            values: "B2:B5",
+            categories: "A2:A5",
+            dataLabels: { showValue: true, borderColor: "A1B2C3" },
+          },
+        ],
+        anchor: { from: { row: 0, col: 0 } },
+      },
+      "Sheet1",
+    ).chartXml;
+    const parsed = parseChart(written)!;
+    expect(parsed.series?.[0]?.dataLabels?.borderColor).toBe("A1B2C3");
+    const clone = cloneChart(parsed, { anchor: { from: { row: 0, col: 0 } } });
+    const cloneDataLabels = clone.series?.[0]?.dataLabels;
+    expect(cloneDataLabels).toBeTruthy();
+    if (cloneDataLabels) {
+      expect(cloneDataLabels.borderColor).toBe("A1B2C3");
+    }
+  });
+});
+
 // ── cloneChart — legendBorderColor (line stroke) ────────────────────
 
 describe("cloneChart — legendBorderColor", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -22202,6 +22202,292 @@ describe("writeChart — dataLabels.fillColor", () => {
   });
 });
 
+// ── writeChart — dataLabels.borderColor (line stroke) ───────────────
+
+describe("writeChart — dataLabels.borderColor", () => {
+  function dLblsOf(xml: string): string {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    if (!m) throw new Error("No <c:dLbls> block found in chart XML");
+    return m[0];
+  }
+
+  it("does NOT emit <c:spPr> on <c:dLbls> when borderColor is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1");
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).not.toContain("<c:spPr>");
+    expect(dLbls).not.toContain("<a:ln>");
+  });
+
+  it("emits <c:spPr><a:ln><a:solidFill><a:srgbClr> when borderColor is set", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "1F77B4" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).toContain("<a:ln>");
+    expect(dLbls).toContain('<a:srgbClr val="1F77B4"/>');
+    // The border color must land inside <a:ln>, not as a top-level
+    // <a:solidFill> (that slot is reserved for the fill color knob).
+    const lnIdx = dLbls.indexOf("<a:ln>");
+    const lnEndIdx = dLbls.indexOf("</a:ln>");
+    expect(lnIdx).toBeGreaterThan(-1);
+    expect(lnEndIdx).toBeGreaterThan(lnIdx);
+    expect(dLbls.slice(lnIdx, lnEndIdx)).toContain('<a:srgbClr val="1F77B4"/>');
+  });
+
+  it("normalizes a leading # in the input hex string", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "#1070CA" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:srgbClr val="1070CA"/>');
+  });
+
+  it("normalizes a lowercase hex string to the OOXML uppercase canonical form", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "abcdef" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("places <c:spPr> after <c:numFmt> and before <c:txPr> inside <c:dLbls> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          borderColor: "FFEEDD",
+          fontColor: "112233",
+          numberFormat: { formatCode: "0.00" },
+        },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:numFmt")).toBeLessThan(dLbls.indexOf("c:spPr"));
+    expect(dLbls.indexOf("c:spPr")).toBeLessThan(dLbls.indexOf("c:txPr"));
+  });
+
+  it("places <c:spPr> before <c:dLblPos> (CT_DLbls order)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, borderColor: "112233", position: "outEnd" },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls.indexOf("c:spPr")).toBeLessThan(dLbls.indexOf("c:dLblPos"));
+  });
+
+  it("only emits <c:spPr> once inside <c:dLbls>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "112233" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    const occurrences = dLbls.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads borderColor through every chart family that emits dLbls", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(
+        makeChart({ type, dataLabels: { showValue: true, borderColor: "445566" } }),
+        "Sheet1",
+      );
+      const dLbls = dLblsOf(result.chartXml);
+      expect(dLbls).toContain("<c:spPr>");
+      expect(dLbls).toContain("<a:ln>");
+      expect(dLbls).toContain('<a:srgbClr val="445566"/>');
+    }
+  });
+
+  it("composes independently with fillColor on the same <c:spPr> in CT_ShapeProperties order", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, fillColor: "FFEEDD", borderColor: "112233" },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).toContain("<a:solidFill>");
+    expect(dLbls).toContain("<a:ln>");
+    expect(dLbls).toContain('<a:srgbClr val="FFEEDD"/>');
+    expect(dLbls).toContain('<a:srgbClr val="112233"/>');
+    // Fill must precede stroke on the same <c:spPr> per CT_ShapeProperties
+    // schema order — the fill color comes first, then the border color.
+    expect(dLbls.indexOf('<a:srgbClr val="FFEEDD"/>')).toBeLessThan(
+      dLbls.indexOf('<a:srgbClr val="112233"/>'),
+    );
+    expect(dLbls.indexOf("<a:solidFill>")).toBeLessThan(dLbls.indexOf("<a:ln>"));
+  });
+
+  it("composes independently with fontColor (different children of <c:dLbls>)", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, borderColor: "FFEEDD", fontColor: "112233" },
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).toContain("<c:txPr>");
+    expect(dLbls).toContain('<a:srgbClr val="FFEEDD"/>');
+    expect(dLbls).toContain('<a:srgbClr val="112233"/>');
+  });
+
+  it("drops malformed hex inputs (wrong length)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "FF00" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops malformed hex inputs (non-hex characters)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "ZZZZZZ" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops alpha-channel hex forms", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "#FF0000FF" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops empty / whitespace-only string inputs", () => {
+    expect(
+      dLblsOf(
+        writeChart(makeChart({ dataLabels: { showValue: true, borderColor: "" } }), "Sheet1")
+          .chartXml,
+      ),
+    ).not.toContain("<c:spPr>");
+    expect(
+      dLblsOf(
+        writeChart(makeChart({ dataLabels: { showValue: true, borderColor: "   " } }), "Sheet1")
+          .chartXml,
+      ),
+    ).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string inputs (null leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, borderColor: null as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-string inputs (number leaking past the type guard)", () => {
+    const result = writeChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      makeChart({ dataLabels: { showValue: true, borderColor: 0xff0000 as any } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("does not emit <c:txPr> when only borderColor is set (typography slot stays empty)", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "ABCDEF" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr>");
+    expect(dLbls).not.toContain("<c:txPr>");
+  });
+
+  it("does not emit <a:solidFill> as a sibling of <a:ln> when only borderColor is set", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "ABCDEF" } }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<c:spPr><a:ln>");
+  });
+
+  it("threads borderColor through a per-series dLbls block", () => {
+    const result = writeChart(
+      makeChart({
+        series: [
+          {
+            name: "Revenue",
+            values: "B2:B4",
+            categories: "A2:A4",
+            dataLabels: { showValue: true, borderColor: "ABCDEF" },
+          },
+        ],
+      }),
+      "Sheet1",
+    );
+    const dLbls = dLblsOf(result.chartXml);
+    expect(dLbls).toContain("<a:ln>");
+    expect(dLbls).toContain('<a:srgbClr val="ABCDEF"/>');
+  });
+
+  it("round-trips a borderColor through parseChart", () => {
+    const written = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "FF8800" } }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.borderColor).toBe("FF8800");
+  });
+
+  it("round-trips fillColor + borderColor together through parseChart", () => {
+    const written = writeChart(
+      makeChart({
+        dataLabels: { showValue: true, fillColor: "FF8800", borderColor: "1F77B4" },
+      }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.dataLabels?.fillColor).toBe("FF8800");
+    expect(reparsed?.dataLabels?.borderColor).toBe("1F77B4");
+  });
+
+  it("collapses an unset borderColor round-trip back to undefined", () => {
+    const written = writeChart(makeChart({ dataLabels: { showValue: true } }), "Sheet1").chartXml;
+    expect(parseChart(written)?.dataLabels?.borderColor).toBeUndefined();
+  });
+
+  it("survives a writeXlsx round trip — dataLabels.borderColor lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            dataLabels: { showValue: true, borderColor: "0F0F0F" },
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    expect(chartXml).toContain('<a:srgbClr val="0F0F0F"/>');
+    expect(chartXml).toContain("<a:ln>");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.dataLabels?.borderColor).toBe("0F0F0F");
+  });
+});
+
 // ── writeChart — legendBorderColor (line stroke) ────────────────────
 
 describe("writeChart — legendBorderColor", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -21841,6 +21841,245 @@ describe("parseChart — dataLabelsFillColor", () => {
   });
 });
 
+// ── parseChart — dataLabelsBorderColor (line stroke) ────────────────
+
+describe("parseChart — dataLabelsBorderColor", () => {
+  const NS_DLBC = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_DLBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:spPr>${spPrBody}</c:spPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces borderColor as the canonical 6-character uppercase hex", () => {
+    expect(
+      parseChart(
+        withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`),
+      )?.dataLabels?.borderColor,
+    ).toBe("1F77B4");
+  });
+
+  it("normalizes a lowercase srgbClr val to the OOXML uppercase canonical form", () => {
+    expect(
+      parseChart(
+        withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`),
+      )?.dataLabels?.borderColor,
+    ).toBe("ABCDEF");
+  });
+
+  it("returns undefined when the dLbls block has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_DLBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.borderColor).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln> child (fillColor-only block)", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:solidFill><a:srgbClr val="FFEEDD"/></a:solidFill>`))?.dataLabels
+        ?.borderColor,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> exists but lacks a solid fill", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:ln><a:noFill/></a:ln>`))?.dataLabels?.borderColor,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the chart has no <c:dLbls> element at all", () => {
+    const xml = `<c:chartSpace ${NS_DLBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels).toBeUndefined();
+  });
+
+  it("collapses theme references (<a:schemeClr>) inside <a:ln> to undefined", () => {
+    expect(
+      parseChart(
+        withDLblsSpPr(`<a:ln><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:ln>`),
+      )?.dataLabels?.borderColor,
+    ).toBeUndefined();
+  });
+
+  it("collapses non-solid line fills (<a:gradFill>) to undefined", () => {
+    expect(
+      parseChart(
+        withDLblsSpPr(`<a:ln><a:gradFill><a:gsLst/><a:lin ang="0" scaled="1"/></a:gradFill></a:ln>`),
+      )?.dataLabels?.borderColor,
+    ).toBeUndefined();
+  });
+
+  it("collapses pattern line fills (<a:pattFill>) to undefined", () => {
+    expect(
+      parseChart(
+        withDLblsSpPr(
+          `<a:ln><a:pattFill prst="pct5"><a:fgClr><a:srgbClr val="000000"/></a:fgClr><a:bgClr><a:srgbClr val="FFFFFF"/></a:bgClr></a:pattFill></a:ln>`,
+        ),
+      )?.dataLabels?.borderColor,
+    ).toBeUndefined();
+  });
+
+  it("collapses malformed val tokens (wrong length / non-hex / alpha) to undefined", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val=""/></a:solidFill></a:ln>`))
+        ?.dataLabels?.borderColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="FF00"/></a:solidFill></a:ln>`))
+        ?.dataLabels?.borderColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(
+        withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="FF0000FF"/></a:solidFill></a:ln>`),
+      )?.dataLabels?.borderColor,
+    ).toBeUndefined();
+    expect(
+      parseChart(withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="ZZZZZZ"/></a:solidFill></a:ln>`))
+        ?.dataLabels?.borderColor,
+    ).toBeUndefined();
+  });
+
+  it("co-surfaces alongside fillColor on the same <c:spPr>", () => {
+    const chart = parseChart(
+      withDLblsSpPr(
+        `<a:solidFill><a:srgbClr val="FFEEDD"/></a:solidFill><a:ln><a:solidFill><a:srgbClr val="112233"/></a:solidFill></a:ln>`,
+      ),
+    );
+    expect(chart?.dataLabels?.fillColor).toBe("FFEEDD");
+    expect(chart?.dataLabels?.borderColor).toBe("112233");
+  });
+
+  it("co-surfaces alongside the other dLbls fields (showVal / position / fontColor)", () => {
+    const xml = `<c:chartSpace ${NS_DLBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:numFmt formatCode="0.00" sourceLinked="0"/>
+          <c:spPr><a:ln><a:solidFill><a:srgbClr val="445566"/></a:solidFill></a:ln></c:spPr>
+          <c:txPr>
+            <a:bodyPr/>
+            <a:lstStyle/>
+            <a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr val="112233"/></a:solidFill></a:defRPr></a:pPr></a:p>
+          </c:txPr>
+          <c:dLblPos val="outEnd"/>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="1"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.dataLabels?.borderColor).toBe("445566");
+    expect(chart?.dataLabels?.fontColor).toBe("112233");
+    expect(chart?.dataLabels?.position).toBe("outEnd");
+    expect(chart?.dataLabels?.showValue).toBe(true);
+    expect(chart?.dataLabels?.numberFormat).toEqual({ formatCode: "0.00" });
+  });
+
+  it("surfaces the borderColor on a borderColor-only dLbls block (no other show* toggles)", () => {
+    const xml = `<c:chartSpace ${NS_DLBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser><c:idx val="0"/></c:ser>
+        <c:dLbls>
+          <c:spPr><a:ln><a:solidFill><a:srgbClr val="00FF00"/></a:solidFill></a:ln></c:spPr>
+          <c:showLegendKey val="0"/>
+          <c:showVal val="0"/>
+          <c:showCatName val="0"/>
+          <c:showSerName val="0"/>
+          <c:showPercent val="0"/>
+          <c:showBubbleSize val="0"/>
+        </c:dLbls>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.dataLabels?.borderColor).toBe("00FF00");
+  });
+
+  it("surfaces borderColor on a per-series <c:dLbls> block", () => {
+    const xml = `<c:chartSpace ${NS_DLBC}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:dLbls>
+            <c:spPr><a:ln><a:solidFill><a:srgbClr val="A1B2C3"/></a:solidFill></a:ln></c:spPr>
+            <c:showLegendKey val="0"/>
+            <c:showVal val="1"/>
+            <c:showCatName val="0"/>
+            <c:showSerName val="0"/>
+            <c:showPercent val="0"/>
+            <c:showBubbleSize val="0"/>
+          </c:dLbls>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.series?.[0]?.dataLabels?.borderColor).toBe("A1B2C3");
+  });
+});
+
 // ── parseChart — legendBorderColor (line stroke) ────────────────────
 
 describe("parseChart — legendBorderColor", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -21871,17 +21871,15 @@ describe("parseChart — dataLabelsBorderColor", () => {
 
   it("surfaces borderColor as the canonical 6-character uppercase hex", () => {
     expect(
-      parseChart(
-        withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`),
-      )?.dataLabels?.borderColor,
+      parseChart(withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`))
+        ?.dataLabels?.borderColor,
     ).toBe("1F77B4");
   });
 
   it("normalizes a lowercase srgbClr val to the OOXML uppercase canonical form", () => {
     expect(
-      parseChart(
-        withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`),
-      )?.dataLabels?.borderColor,
+      parseChart(withDLblsSpPr(`<a:ln><a:solidFill><a:srgbClr val="abcdef"/></a:solidFill></a:ln>`))
+        ?.dataLabels?.borderColor,
     ).toBe("ABCDEF");
   });
 
@@ -21947,7 +21945,9 @@ describe("parseChart — dataLabelsBorderColor", () => {
   it("collapses non-solid line fills (<a:gradFill>) to undefined", () => {
     expect(
       parseChart(
-        withDLblsSpPr(`<a:ln><a:gradFill><a:gsLst/><a:lin ang="0" scaled="1"/></a:gradFill></a:ln>`),
+        withDLblsSpPr(
+          `<a:ln><a:gradFill><a:gsLst/><a:lin ang="0" scaled="1"/></a:gradFill></a:ln>`,
+        ),
       )?.dataLabels?.borderColor,
     ).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- Adds `borderColor` knob on `ChartDataLabels`, mapping to `<c:dLbls><c:spPr><a:ln><a:solidFill><a:srgbClr val=".."/></a:solidFill></a:ln></c:spPr></c:dLbls>` — Excel's "Format Data Labels -> Border -> Solid line -> Color" picker.
- Completes the `<a:ln>` family for chart-frame elements that already carry a fill counterpart, mirroring `plotAreaBorderColor` (#309) / `legendBorderColor` (#310) / `titleBorderColor` (#311) / `axisTitleBorderColor` (#312) / data-table `borderColor` (#313).
- Composes independently with the existing `fillColor` knob (different children of the same `<c:spPr>`, emitted in CT_ShapeProperties schema order — fill before stroke) and with `fontColor` (different child of `<c:dLbls>` entirely).
- Reader, writer, and clone-through plumbing follows the established hex-color grammar — accepts `#` / case, drops malformed / non-solid / `schemeClr` / alpha-channel forms to `undefined`. Works on every chart family that emits `<c:dLbls>` (bar / column / line / area / pie / doughnut). Per-series `<c:dLbls>` blocks carry the field the same way the chart-level block does.

## Test plan

- [x] `pnpm vitest run --dir=test` (6965 tests pass)
- [x] `pnpm build` (clean)
- [x] Round-trip: write → parseChart → cloneChart preserves `borderColor`
- [x] fill+border composition on same `<c:spPr>` in canonical order verified
- [x] Malformed / non-solid / theme / alpha rejection verified
- [x] Per-series and chart-level propagation verified
- [x] End-to-end `writeXlsx` packaging verified

Refs #313

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>