### PR TITLE
feat(xlsx): chart plot-area border width — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2530,6 +2530,44 @@ export interface SheetChart {
    */
   plotAreaBorderColor?: string;
   /**
+   * Plot-area border (stroke) thickness in points (e.g. `1.5`). Maps to
+   * the `w` attribute on `<c:plotArea><c:spPr><a:ln w="EMU">` — Excel's
+   * "Format Plot Area -> Border -> Width" spinner. The OOXML `w`
+   * attribute carries the stroke width in EMU (English Metric Units;
+   * `1 pt = 12 700 EMU`) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24). The writer multiplies the input by 12 700 and rounds
+   * to the nearest integer because the schema types `w` as `xsd:int`.
+   *
+   * Accepts any finite number; values are clamped to the `0.25..13.5`
+   * pt band Excel's UI exposes (the same band used by the series
+   * stroke knob `series[i].stroke.width`) and snapped to the
+   * 0.25 pt grid so a parsed-then-written width does not drift across
+   * round-trips. Non-finite / non-numeric / `NaN` values collapse to
+   * `undefined` and the writer omits the `w` attribute (the line keeps
+   * Excel's auto-thickness — typically 0.75 pt).
+   *
+   * Default: omitted — the plot-area border inherits Excel's
+   * auto-thickness. Pin a value to thicken the border around the series
+   * band (a hairline at 0.25 pt, a heavy frame at several points) or to
+   * match the stroke width of neighboring chart tiles.
+   *
+   * Composes independently with {@link plotAreaBorderColor} — the
+   * width attribute lands on the same `<a:ln>` element as the color's
+   * `<a:solidFill>` child, but the writer authors `<a:ln>` whenever
+   * either knob is set. A caller can pin a width without a color (the
+   * border picks Excel's auto-color), pin a color without a width (the
+   * border picks Excel's auto-thickness), or pin both. Setting only the
+   * width is valid Excel UI — the user can drag the "Width" spinner
+   * without picking a custom color.
+   *
+   * Mirrors the series-line stroke width grammar (`series[i].stroke.width`)
+   * and shares the same clamp / snap behavior so width values compose
+   * the same way at the call site. The OOXML `w` attribute is also used
+   * for axis lines and other strokes — this knob covers only the
+   * plot-area border slot.
+   */
+  plotAreaBorderWidth?: number;
+  /**
    * Chart-space (entire chart background) solid fill color as a 6-digit
    * RGB hex string (e.g. `"F2F2F2"`). Maps to `<c:chartSpace><c:spPr>
    * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
@@ -7613,6 +7651,33 @@ export interface Chart {
    * fill, `<a:ln><a:solidFill>` for stroke).
    */
   plotAreaBorderColor?: string;
+  /**
+   * Plot-area border (stroke) thickness in points pulled from the `w`
+   * attribute on `<c:plotArea><c:spPr><a:ln w="EMU">`. Reflects Excel's
+   * "Format Plot Area -> Border -> Width" spinner. The OOXML `w`
+   * attribute stores the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24); the reader divides by 12 700 and snaps the result
+   * to the 0.25 pt grid Excel's UI exposes so a parsed-then-cloned
+   * width does not drift across round-trips.
+   *
+   * Reports the point value clamped to the `0.25..13.5` pt band Excel
+   * accepts in the UI when the source chart pinned a finite, positive
+   * `w` attribute. Absence (no `<a:ln>` or `<a:ln>` without a `w`
+   * attribute), zero, negative, and non-numeric `w` values all collapse
+   * to `undefined` so absence and an unrenderable width round-trip
+   * identically through {@link cloneChart}. Mirrors the writer-side
+   * {@link SheetChart.plotAreaBorderWidth} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:plotArea>` element at all — there is no `<c:spPr>` slot to
+   * surface the stroke from in that case. Composes independently with
+   * {@link plotAreaBorderColor} — both fields surface from the same
+   * `<a:ln>` element but on a different slot (the color child versus
+   * the width attribute).
+   */
+  plotAreaBorderWidth?: number;
   /**
    * Chart-space (entire chart background) solid fill color pulled
    * from `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/>

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -489,6 +489,31 @@ export interface CloneChartOptions {
    */
   plotAreaBorderColor?: string | null;
   /**
+   * Override `SheetChart.plotAreaBorderWidth`. `undefined` (or omitted)
+   * inherits the source's parsed `plotAreaBorderWidth`; `null` drops
+   * the inherited width (the writer emits `<a:ln>` without a `w`
+   * attribute, the line keeps Excel's auto-thickness — typically
+   * 0.75 pt); a finite point value (e.g. `1.5`) replaces it.
+   *
+   * The override runs through the same clamp / snap as the writer —
+   * values are clamped to the `0.25..13.5` pt band Excel's UI exposes
+   * and snapped to the 0.25 pt grid so a parsed-then-written width does
+   * not drift across round-trips. Non-finite / non-numeric tokens
+   * (`NaN`, `Infinity`, strings, `null` from an untyped caller) collapse
+   * to `undefined` so the cloned `SheetChart` drops the field rather
+   * than carry a value the writer would silently elide back to absence.
+   *
+   * Composes independently with `plotAreaBorderColor` — both knobs land
+   * on the same `<a:ln>` element but on a different slot (the color's
+   * `<a:solidFill>` child versus the line's `w` attribute). A caller
+   * can pin a width without a color (the border picks Excel's
+   * auto-color), pin a color without a width (the border picks Excel's
+   * auto-thickness), or pin both. Like the color knob, the width is
+   * never gated on a visibility flag — every chart has a `<c:plotArea>`
+   * element to host the stroke.
+   */
+  plotAreaBorderWidth?: number | null;
+  /**
    * Override `SheetChart.chartSpaceFillColor`. `undefined` (or omitted)
    * inherits the source's parsed `chartSpaceFillColor`; `null` drops
    * the inherited fill (the writer emits no `<c:spPr>` block on
@@ -2218,6 +2243,23 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   );
   if (resolvedPlotAreaBorderColor !== undefined) {
     out.plotAreaBorderColor = resolvedPlotAreaBorderColor;
+  }
+
+  // Plot-area border thickness composes independently with the border
+  // color — both lands on the same `<a:ln>` element but on a different
+  // attribute (color is `<a:solidFill><a:srgbClr>`, width is the `w`
+  // attribute on `<a:ln>`). `undefined` inherits the source's parsed
+  // `plotAreaBorderWidth` (after the writer-side clamp collapses any
+  // malformed token), `null` drops the inherited width (the writer
+  // emits `<a:ln>` without the `w` attribute, the line keeps Excel's
+  // auto-thickness), a finite point value replaces it. Malformed
+  // overrides collapse to `undefined` via the normalizer.
+  const resolvedPlotAreaBorderWidth = resolvePlotAreaBorderWidth(
+    source.plotAreaBorderWidth,
+    options.plotAreaBorderWidth,
+  );
+  if (resolvedPlotAreaBorderWidth !== undefined) {
+    out.plotAreaBorderWidth = resolvedPlotAreaBorderWidth;
   }
 
   // Chart-space solid fill color is independent of every visibility
@@ -4093,6 +4135,58 @@ function resolvePlotAreaBorderColor(
   if (override === undefined) return normalizePlotAreaBorderColor(sourceValue);
   if (override === null) return undefined;
   return normalizePlotAreaBorderColor(override);
+}
+
+/**
+ * Normalize a `plotAreaBorderWidth` value for the cloned `SheetChart`.
+ * Mirrors the writer's `clampStrokeWidthPt` — values are clamped to the
+ * `0.25..13.5` pt band Excel's UI exposes and snapped to the 0.25 pt
+ * grid so a parsed-then-cloned-then-written width does not drift across
+ * round-trips (Excel rounds in the UI anyway). Non-finite / non-numeric
+ * tokens (`NaN`, `Infinity`, strings, `null` from an untyped caller)
+ * collapse to `undefined` so the cloned chart drops the field rather
+ * than carry a value the writer would silently elide back to absence.
+ */
+function normalizePlotAreaBorderWidth(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const snapped = Math.round(value * 4) / 4;
+  if (snapped < PLOT_AREA_BORDER_WIDTH_MIN_PT) return PLOT_AREA_BORDER_WIDTH_MIN_PT;
+  if (snapped > PLOT_AREA_BORDER_WIDTH_MAX_PT) return PLOT_AREA_BORDER_WIDTH_MAX_PT;
+  return snapped;
+}
+
+const PLOT_AREA_BORDER_WIDTH_MIN_PT = 0.25;
+const PLOT_AREA_BORDER_WIDTH_MAX_PT = 13.5;
+
+/**
+ * Resolve a `plotAreaBorderWidth` override.
+ *
+ * `undefined` → inherit the source's parsed `plotAreaBorderWidth`
+ *               (after running it through
+ *               {@link normalizePlotAreaBorderWidth} so a malformed
+ *               source value drops cleanly).
+ * `null`      → drop the inherited width (the writer emits `<a:ln>`
+ *               without a `w` attribute, the line keeps Excel's
+ *               auto-thickness).
+ * `number`    → replace with the clamped / snapped point value.
+ *               Non-finite / non-numeric overrides collapse to
+ *               `undefined` via the normalizer so the cloned
+ *               `SheetChart` always carries a value the writer will
+ *               accept.
+ *
+ * The grammar mirrors the series-line stroke width so the chart
+ * `<a:ln w=..>` knobs compose the same way at the call site. Like the
+ * border-color knob, the width is never gated on a visibility flag —
+ * every chart has a `<c:plotArea>` element to host the stroke.
+ */
+function resolvePlotAreaBorderWidth(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizePlotAreaBorderWidth(sourceValue);
+  if (override === null) return undefined;
+  return normalizePlotAreaBorderWidth(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -485,6 +485,18 @@ export function parseChart(xml: string): Chart | undefined {
     // cannot leak into this field.
     const plotAreaBorderColor = parsePlotAreaBorderColor(plotArea);
     if (plotAreaBorderColor !== undefined) out.plotAreaBorderColor = plotAreaBorderColor;
+
+    // `<c:plotArea><c:spPr><a:ln w="EMU">` carries Excel's "Format Plot
+    // Area -> Border -> Width" pin. The OOXML `w` attribute stores the
+    // stroke width in English Metric Units (1 pt = 12 700 EMU) per
+    // CT_LineProperties (ECMA-376 Part 1, §20.1.2.3.24); the reader
+    // converts back to points and clamps to the same 0.25..13.5 pt band
+    // Excel's UI exposes so a template carrying an exotic width still
+    // round-trips through the writer's clamp. Scoped to the plot-area's
+    // `<c:spPr>` so a stray `<a:ln w=..>` elsewhere (series stroke,
+    // axis line) cannot leak into this field.
+    const plotAreaBorderWidth = parsePlotAreaBorderWidth(plotArea);
+    if (plotAreaBorderWidth !== undefined) out.plotAreaBorderWidth = plotAreaBorderWidth;
   }
 
   const legend = parseLegend(chartEl);
@@ -4305,6 +4317,44 @@ function parsePlotAreaBorderColor(plotArea: XmlElement): string | undefined {
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;
   return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull the `w` attribute off `<c:plotArea><c:spPr><a:ln w="EMU"/>` and
+ * return the stroke width in points after clamping to the
+ * `0.25..13.5` pt band Excel's UI exposes. The OOXML `w` attribute
+ * carries the stroke width in English Metric Units (1 pt = 12 700 EMU)
+ * per `CT_LineProperties` (ECMA-376 Part 1, §20.1.2.3.24); the reader
+ * snaps the result to the 0.25 pt grid so a parsed-then-written width
+ * does not drift across round-trips (Excel rounds in the UI anyway).
+ *
+ * Returns `undefined` when there is no `<c:spPr><a:ln w=..>` slot, when
+ * the attribute is missing, when the value cannot be parsed as a finite
+ * positive number, or when it parses to zero (Excel's "no border"
+ * marker — the writer-side knob does not model that state). Mirrors
+ * the writer-side {@link SheetChart.plotAreaBorderWidth} so a parsed
+ * value slots straight into {@link cloneChart} without conversion.
+ *
+ * The lookup is scoped to direct children of `<c:plotArea>` so a stray
+ * `<a:ln w=..>` elsewhere (on a series stroke, on an axis line) cannot
+ * leak in. Mirrors {@link parsePlotAreaBorderColor} — same `<c:spPr>`
+ * host on the same `<c:plotArea>` parent — but lands on the `w`
+ * attribute rather than the `<a:solidFill><a:srgbClr>` color child.
+ */
+function parsePlotAreaBorderWidth(plotArea: XmlElement): number | undefined {
+  const spPr = findChild(plotArea, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const wAttr = ln.attrs.w;
+  if (typeof wAttr !== "string") return undefined;
+  const emu = Number.parseFloat(wAttr);
+  if (!Number.isFinite(emu) || emu <= 0) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const pt = Math.round((emu / EMU_PER_PT) * 4) / 4;
+  if (pt < STROKE_WIDTH_MIN_PT) return STROKE_WIDTH_MIN_PT;
+  if (pt > STROKE_WIDTH_MAX_PT) return STROKE_WIDTH_MAX_PT;
+  return pt;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -1364,24 +1364,31 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
 /**
  * Build the optional `<c:spPr>` block at the tail of `<c:plotArea>`.
  * Surfaces the solid fill color knob
- * ({@link SheetChart.plotAreaFillColor}) and the border (line) color
- * knob ({@link SheetChart.plotAreaBorderColor}) — every other `<c:spPr>`
+ * ({@link SheetChart.plotAreaFillColor}), the border (line) color
+ * knob ({@link SheetChart.plotAreaBorderColor}) and the border width
+ * knob ({@link SheetChart.plotAreaBorderWidth}) — every other `<c:spPr>`
  * child (`<a:effectLst>` effects, gradient / pattern / picture fills,
- * line dash / width / compound styles) is intentionally not modelled
- * at this layer.
+ * line dash / compound styles) is intentionally not modelled at this
+ * layer.
  *
- * Returns `undefined` when both fields are unset / malformed so the
+ * Returns `undefined` when every field is unset / malformed so the
  * writer skips the entire `<c:spPr>` block — an empty `<c:spPr/>`
  * collapses to the inherited theme fill / stroke Excel picks anyway,
  * and omitting it keeps untouched chart XML byte-clean. When at least
  * one knob lands on the wire, the children are emitted in
  * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
- * `<a:ln>` (line / stroke).
+ * `<a:ln>` (line / stroke). The width knob lands on the `w` attribute
+ * of `<a:ln>` (EMU; 1 pt = 12 700 EMU), authored together with the
+ * border-color child so a stroke-only or color-only chart still emits a
+ * single `<a:ln>` block.
  */
 function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
   const fillHex = normalizePlotAreaFillColor(chart.plotAreaFillColor);
   const borderHex = normalizePlotAreaBorderColor(chart.plotAreaBorderColor);
-  if (fillHex === undefined && borderHex === undefined) return undefined;
+  const borderWidthPt = clampStrokeWidthPt(chart.plotAreaBorderWidth);
+  if (fillHex === undefined && borderHex === undefined && borderWidthPt === undefined) {
+    return undefined;
+  }
 
   const children: string[] = [];
   if (fillHex !== undefined) {
@@ -1389,11 +1396,23 @@ function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
     );
   }
-  if (borderHex !== undefined) {
-    children.push(
-      xmlElement("a:ln", undefined, [
+  if (borderHex !== undefined || borderWidthPt !== undefined) {
+    const lnAttrs: Record<string, string | number> = {};
+    if (borderWidthPt !== undefined) {
+      // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
+      // the nearest integer because the schema types `w` as `xsd:int`.
+      lnAttrs.w = Math.round(borderWidthPt * EMU_PER_PT);
+    }
+    const lnChildren: string[] = [];
+    if (borderHex !== undefined) {
+      lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderHex })]),
-      ]),
+      );
+    }
+    children.push(
+      lnChildren.length === 0
+        ? xmlSelfClose("a:ln", lnAttrs)
+        : xmlElement("a:ln", Object.keys(lnAttrs).length > 0 ? lnAttrs : undefined, lnChildren),
     );
   }
   return xmlElement("c:spPr", undefined, children);

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -21258,6 +21258,167 @@ describe("cloneChart — plotAreaBorderColor", () => {
   });
 });
 
+// ── cloneChart — plotAreaBorderWidth (line stroke thickness) ─────────
+
+describe("cloneChart — plotAreaBorderWidth", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      ...extra,
+    };
+  }
+
+  it("inherits the source's plotAreaBorderWidth by default", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("lets options.plotAreaBorderWidth override the source's value", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: 2.5,
+    });
+    expect(clone.plotAreaBorderWidth).toBe(2.5);
+  });
+
+  it("drops the inherited plotAreaBorderWidth when the override is null", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: null,
+    });
+    expect(clone.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined plotAreaBorderWidth when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("snaps the override to the 0.25 pt grid (1.4 → 1.5)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: 1.4,
+    });
+    expect(clone.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("clamps the override below the minimum (0.1 → 0.25)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: 0.1,
+    });
+    expect(clone.plotAreaBorderWidth).toBe(0.25);
+  });
+
+  it("clamps the override above the maximum (50 → 13.5)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: 50,
+    });
+    expect(clone.plotAreaBorderWidth).toBe(13.5);
+  });
+
+  it("drops a NaN override", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: Number.NaN,
+    });
+    expect(clone.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("drops an Infinity override", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: Number.POSITIVE_INFINITY,
+    });
+    expect(clone.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("drops a non-number override (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      plotAreaBorderWidth: "1.5" as any,
+    });
+    expect(clone.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ plotAreaBorderWidth: Number.NaN as any }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("carries plotAreaBorderWidth through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("retains plotAreaBorderWidth independently of a hidden legend", () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("composes independently with plotAreaBorderColor (each lands on its own slot)", () => {
+    const clone = cloneChart(
+      source({
+        plotAreaBorderColor: "1F77B4",
+        plotAreaBorderWidth: 1.5,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.plotAreaBorderColor).toBe("1F77B4");
+    expect(clone.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("survives a writeXlsx round trip — plotAreaBorderWidth lands in the cloned chart XML", async () => {
+    const clone = cloneChart(source({ plotAreaBorderWidth: 0.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderWidth: 1.75,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.plotAreaBorderWidth).toBe(1.75);
+  });
+});
+
 // ── cloneChart — axisTitleLayout (manual placement) ─────────────────
 
 describe("cloneChart — axisTitleLayout", () => {

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -20167,6 +20167,191 @@ describe("writeChart — plotAreaBorderColor", () => {
     expect(reparsed?.plotAreaBorderColor).toBe("1F77B4");
   });
 });
+
+// ── writeChart — plotAreaBorderWidth (line stroke thickness) ─────────
+
+describe("writeChart — plotAreaBorderWidth", () => {
+  function plotAreaOf(xml: string): string {
+    const m = xml.match(/<c:plotArea>[\s\S]*?<\/c:plotArea>/);
+    if (!m) throw new Error("No <c:plotArea> block found in chart XML");
+    return m[0];
+  }
+
+  it("does not emit <c:spPr> when plotAreaBorderWidth is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+    expect(plotArea).not.toContain("<a:ln");
+  });
+
+  it("emits <c:spPr><a:ln w=..> when plotAreaBorderWidth is set without a color", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: 1.5 }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain("<c:spPr>");
+    // 1.5 pt = 19050 EMU.
+    expect(plotArea).toContain('<a:ln w="19050"');
+    // No solid-fill child when only width is pinned.
+    expect(plotArea).not.toContain("<a:solidFill>");
+  });
+
+  it("snaps to the 0.25 pt grid (1.4 → 1.5 pt → 19050 EMU)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: 1.4 }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<a:ln w="19050"');
+  });
+
+  it("clamps below the minimum (0.1 pt → 0.25 pt → 3175 EMU)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: 0.1 }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<a:ln w="3175"');
+  });
+
+  it("clamps above the maximum (50 pt → 13.5 pt → 171450 EMU)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: 50 }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<a:ln w="171450"');
+  });
+
+  it("places <c:spPr> at the tail of <c:plotArea> (CT_PlotArea sequence)", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: 2 }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    const spPrIdx = plotArea.indexOf("<c:spPr>");
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:barChart"));
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:catAx"));
+    expect(spPrIdx).toBeGreaterThan(plotArea.indexOf("<c:valAx"));
+  });
+
+  it("only emits one <c:spPr> inside <c:plotArea>", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: 2 }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    const occurrences = plotArea.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads plotAreaBorderWidth through every chart family that owns a <c:plotArea>", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, plotAreaBorderWidth: 1 }), "Sheet1");
+      const plotArea = plotAreaOf(result.chartXml);
+      expect(plotArea).toContain('<a:ln w="12700"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        plotAreaBorderWidth: 1,
+      }),
+      "Sheet1",
+    );
+    expect(plotAreaOf(scatter.chartXml)).toContain('<a:ln w="12700"');
+  });
+
+  it("drops a NaN value", () => {
+    const result = writeChart(makeChart({ plotAreaBorderWidth: Number.NaN }), "Sheet1");
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops a non-finite value (Infinity)", () => {
+    const result = writeChart(
+      makeChart({ plotAreaBorderWidth: Number.POSITIVE_INFINITY }),
+      "Sheet1",
+    );
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-number escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ plotAreaBorderWidth: "1.5" as any }), "Sheet1");
+    expect(plotAreaOf(a.chartXml)).not.toContain("<c:spPr>");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ plotAreaBorderWidth: null as any }), "Sheet1");
+    expect(plotAreaOf(b.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("composes independently with plotAreaBorderColor — width on <a:ln>, color inside it", () => {
+    const result = writeChart(
+      makeChart({
+        plotAreaBorderColor: "1F77B4",
+        plotAreaBorderWidth: 2,
+      }),
+      "Sheet1",
+    );
+    const plotArea = plotAreaOf(result.chartXml);
+    expect(plotArea).toContain('<a:ln w="25400">');
+    expect(plotArea).toContain('<a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill>');
+    // Width attribute hosts the color child.
+    expect(plotArea).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("composes independently with plotAreaFillColor — fill in <a:solidFill>, width on <a:ln>", () => {
+    const result = writeChart(
+      makeChart({
+        plotAreaFillColor: "F2F2F2",
+        plotAreaBorderWidth: 1,
+      }),
+      "Sheet1",
+    );
+    const plotArea = plotAreaOf(result.chartXml);
+    // Single <c:spPr> hosts both knobs.
+    const spPrCount = plotArea.match(/<c:spPr>/g) ?? [];
+    expect(spPrCount).toHaveLength(1);
+    expect(plotArea).toContain('<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>');
+    expect(plotArea).toContain('<a:ln w="12700"');
+    // CT_ShapeProperties order: <a:solidFill> precedes <a:ln>.
+    expect(plotArea.indexOf("<a:solidFill>")).toBeLessThan(plotArea.indexOf("<a:ln "));
+  });
+
+  it("round-trips plotAreaBorderWidth through parseChart", () => {
+    const written = writeChart(makeChart({ plotAreaBorderWidth: 2.25 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaBorderWidth).toBe(2.25);
+  });
+
+  it("collapses an unset plotAreaBorderWidth round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("round-trips both border color and width together through parseChart", () => {
+    const written = writeChart(
+      makeChart({ plotAreaBorderColor: "1F77B4", plotAreaBorderWidth: 1.5 }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.plotAreaBorderColor).toBe("1F77B4");
+    expect(reparsed?.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("survives a writeXlsx round trip — plotAreaBorderWidth lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            plotAreaBorderWidth: 1.75,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.plotAreaBorderWidth).toBe(1.75);
+  });
+});
+
 // ── writeChart — axisTitleLayout (manual placement) ─────────────────
 
 describe("writeChart — axisTitleLayout", () => {

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -20138,6 +20138,131 @@ describe("parseChart — plotAreaBorderColor", () => {
   });
 });
 
+// ── parseChart — plotAreaBorderWidth (line stroke thickness) ─────────
+
+describe("parseChart — plotAreaBorderWidth", () => {
+  const NS_PBW = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withPlotAreaSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_PBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the stroke width in points (12700 EMU = 1 pt)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="12700"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBe(1);
+  });
+
+  it("surfaces a fractional stroke width (19050 EMU = 1.5 pt)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="19050"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBe(1.5);
+  });
+
+  it("surfaces the minimum width (3175 EMU = 0.25 pt)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="3175"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBe(0.25);
+  });
+
+  it("snaps an exotic EMU value to the nearest 0.25 pt grid", () => {
+    // 14000 EMU ≈ 1.10 pt → snaps to 1.0 pt.
+    const xml = withPlotAreaSpPr(`<a:ln w="14000"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBe(1);
+  });
+
+  it("clamps below the minimum band (1000 EMU → 0.25 pt)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="1000"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBe(0.25);
+  });
+
+  it("clamps above the maximum band (1000000 EMU → 13.5 pt)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="1000000"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBe(13.5);
+  });
+
+  it("surfaces both border color and width when both are pinned on <a:ln>", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.plotAreaBorderWidth).toBe(2);
+    expect(parsed?.plotAreaBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the chart has no <c:plotArea>", () => {
+    const xml = `<c:chartSpace ${NS_PBW}><c:chart></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:plotArea> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_PBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    const xml = withPlotAreaSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no w attribute", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when the w attribute is malformed (non-numeric)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="thick"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when the w attribute is zero (Excel's 'no border' marker)", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="0"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when the w attribute is negative", () => {
+    const xml = withPlotAreaSpPr(`<a:ln w="-12700"/>`);
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln w=..> on a series <c:spPr> (not the plotArea)", () => {
+    const xml = `<c:chartSpace ${NS_PBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:ln w="50800"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderWidth).toBeUndefined();
+  });
+});
+
 // ── parseChart — axisTitleLayout (manual placement) ─────────────────
 
 describe("parseChart — axisTitleLayout", () => {


### PR DESCRIPTION
## Summary

- Add `SheetChart.plotAreaBorderWidth` to the writer/reader/clone surfaces so the plot-area stroke thickness round-trips alongside the existing `plotAreaBorderColor` knob.
- The width lands on the `w` attribute of `<c:plotArea><c:spPr><a:ln w="EMU">` (English Metric Units; 1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1, §20.1.2.3.24).
- Values clamp to the 0.25..13.5 pt band Excel's UI exposes and snap to the 0.25 pt grid so a parsed-then-written width does not drift; non-finite / non-numeric / zero / negative tokens collapse to `undefined` and the writer omits the `w` attribute.
- The `cloneChart` resolver mirrors the existing border-color override grammar (`undefined` inherits, `null` drops, `number` replaces) and shares the clamp/snap.

Refs #309

## Test plan

- [x] `pnpm vitest run --dir=test` — 89 files / 7015 tests passing (47 new).
- [x] `pnpm build` (obuild) — succeeds.
- [x] `pnpm typecheck` (tsgo --noEmit) — clean.
- [x] `pnpm lint` (oxlint + oxfmt --check) — 0 errors, formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)