### PR TITLE
feat(xlsx): chart legend border width — read, write, clone-through

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -2468,6 +2468,47 @@ export interface SheetChart {
    */
   legendBorderColor?: string;
   /**
+   * Legend border (stroke) thickness in points (e.g. `1.5`). Maps to
+   * the `w` attribute on `<c:legend><c:spPr><a:ln w="EMU">` — Excel's
+   * "Format Legend -> Border -> Width" spinner. The OOXML `w`
+   * attribute carries the stroke width in English Metric Units
+   * (`1 pt = 12 700 EMU`) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24). The writer multiplies the input by 12 700 and rounds
+   * to the nearest integer because the schema types `w` as `xsd:int`.
+   *
+   * Accepts any finite number; values are clamped to the `0.25..13.5`
+   * pt band Excel's UI exposes (the same band used by the series
+   * stroke knob `series[i].stroke.width` and the plot-area border
+   * width knob {@link plotAreaBorderWidth}) and snapped to the
+   * 0.25 pt grid so a parsed-then-written width does not drift across
+   * round-trips. Non-finite / non-numeric / `NaN` values collapse to
+   * `undefined` and the writer omits the `w` attribute (the line keeps
+   * Excel's auto-thickness — typically 0.75 pt).
+   *
+   * Default: omitted — the legend border inherits Excel's
+   * auto-thickness. Pin a value to thicken the border around the legend
+   * block (a hairline at 0.25 pt, a heavy frame at several points) or
+   * to match the stroke width of neighboring chart tiles.
+   *
+   * Composes independently with {@link legendBorderColor} — the width
+   * attribute lands on the same `<a:ln>` element as the color's
+   * `<a:solidFill>` child, but the writer authors `<a:ln>` whenever
+   * either knob is set. A caller can pin a width without a color (the
+   * border picks Excel's auto-color), pin a color without a width (the
+   * border picks Excel's auto-thickness), or pin both. Setting only the
+   * width is valid Excel UI — the user can drag the "Width" spinner
+   * without picking a custom color.
+   *
+   * Silently ignored when `legend === false` (no `<c:legend>` element
+   * is emitted) — there is no slot to host the stroke in that case.
+   * Mirrors {@link plotAreaBorderWidth} — same accept-finite-number
+   * grammar, same `<a:ln w="EMU">` host attribute on a different parent
+   * (`<c:legend>` rather than `<c:plotArea>`), and shares the same
+   * 0.25..13.5 pt clamp + 0.25 pt snap so width values compose the same
+   * way at the call site.
+   */
+  legendBorderWidth?: number;
+  /**
    * Custom plot-area placement inside the chart frame. Maps to
    * `<c:plotArea><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
    * </c:plotArea>` — Excel's "Format Plot Area -> Position -> Custom"
@@ -7615,6 +7656,33 @@ export interface Chart {
    * (`<a:solidFill>` for fill, `<a:ln><a:solidFill>` for stroke).
    */
   legendBorderColor?: string;
+  /**
+   * Legend border (stroke) thickness in points pulled from the `w`
+   * attribute on `<c:legend><c:spPr><a:ln w="EMU">`. Reflects Excel's
+   * "Format Legend -> Border -> Width" spinner. The OOXML `w`
+   * attribute stores the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24); the reader divides by 12 700 and snaps the result
+   * to the 0.25 pt grid Excel's UI exposes so a parsed-then-cloned
+   * width does not drift across round-trips.
+   *
+   * Reports the point value clamped to the `0.25..13.5` pt band Excel
+   * accepts in the UI when the source chart pinned a finite, positive
+   * `w` attribute. Absence (no `<a:ln>` or `<a:ln>` without a `w`
+   * attribute), zero, negative, and non-numeric `w` values all collapse
+   * to `undefined` so absence and an unrenderable width round-trip
+   * identically through {@link cloneChart}. Mirrors the writer-side
+   * {@link SheetChart.legendBorderWidth} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever {@link legend} is `false` or the
+   * source chart has no `<c:legend>` element at all — there is no
+   * `<c:spPr>` slot to surface the stroke from in either case. Composes
+   * independently with {@link legendBorderColor} — both fields surface
+   * from the same `<a:ln>` element but on a different slot (the color
+   * child versus the width attribute).
+   */
+  legendBorderWidth?: number;
   /**
    * Custom plot-area placement pulled from `<c:plotArea><c:layout>
    * <c:manualLayout>...</c:manualLayout></c:layout></c:plotArea>`.

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -419,6 +419,34 @@ export interface CloneChartOptions {
    */
   legendBorderColor?: string | null;
   /**
+   * Override `SheetChart.legendBorderWidth`. `undefined` (or omitted)
+   * inherits the source's parsed `legendBorderWidth`; `null` drops the
+   * inherited width (the writer emits `<a:ln>` without a `w` attribute,
+   * the line keeps Excel's auto-thickness — typically 0.75 pt); a
+   * finite point value (e.g. `1.5`) replaces it.
+   *
+   * The override runs through the same clamp / snap as the writer —
+   * values are clamped to the `0.25..13.5` pt band Excel's UI exposes
+   * and snapped to the 0.25 pt grid so a parsed-then-written width does
+   * not drift across round-trips. Non-finite / non-numeric tokens
+   * (`NaN`, `Infinity`, strings, `null` from an untyped caller) collapse
+   * to `undefined` so the cloned `SheetChart` drops the field rather
+   * than carry a value the writer would silently elide back to absence.
+   *
+   * Composes independently with `legendBorderColor` — both knobs land
+   * on the same `<a:ln>` element but on a different slot (the color's
+   * `<a:solidFill>` child versus the line's `w` attribute). A caller
+   * can pin a width without a color (the border picks Excel's
+   * auto-color), pin a color without a width (the border picks Excel's
+   * auto-thickness), or pin both. The override is silently dropped from
+   * the cloned `SheetChart` when the resolved legend is `false` (no
+   * `<c:legend>` element will be emitted) — there is no slot to host
+   * the stroke on a hidden legend. Mirrors `plotAreaBorderWidth` —
+   * same accept-finite-number / clamp / snap grammar — but on the
+   * legend's own `<c:spPr>` block.
+   */
+  legendBorderWidth?: number | null;
+  /**
    * Override `SheetChart.plotAreaLayout`. `undefined` (or omitted)
    * inherits the source's parsed `plotAreaLayout`; `null` drops the
    * inherited layout (the writer emits the bare `<c:layout/>`
@@ -2168,6 +2196,27 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     );
     if (resolvedLegendBorderColor !== undefined) {
       out.legendBorderColor = resolvedLegendBorderColor;
+    }
+
+    // Same hidden-legend scoping for the border (line) stroke width —
+    // `<a:ln w=..>` lives inside `<c:legend><c:spPr>` per
+    // CT_ShapeProperties, so a clone whose legend is hidden has no slot
+    // for the width. `undefined` inherits the source's parsed
+    // `legendBorderWidth` (after the writer-side clamp collapses any
+    // malformed token), `null` drops the inherited width (the writer
+    // emits `<a:ln>` without the `w` attribute, the line keeps Excel's
+    // auto-thickness), a finite point value replaces it. Malformed
+    // overrides collapse to `undefined` via the normalizer. Composes
+    // independently with `legendBorderColor` — both knobs land on the
+    // same `<a:ln>` element but on a different attribute (color is
+    // `<a:solidFill><a:srgbClr>`, width is the `w` attribute on
+    // `<a:ln>`).
+    const resolvedLegendBorderWidth = resolveLegendBorderWidth(
+      source.legendBorderWidth,
+      options.legendBorderWidth,
+    );
+    if (resolvedLegendBorderWidth !== undefined) {
+      out.legendBorderWidth = resolvedLegendBorderWidth;
     }
   }
 
@@ -3926,6 +3975,63 @@ function resolveLegendBorderColor(
   if (override === undefined) return normalizeTitleColor(sourceValue);
   if (override === null) return undefined;
   return normalizeTitleColor(override);
+}
+
+const LEGEND_BORDER_WIDTH_MIN_PT = 0.25;
+const LEGEND_BORDER_WIDTH_MAX_PT = 13.5;
+
+/**
+ * Normalize a `legendBorderWidth` value for the cloned `SheetChart`.
+ * Mirrors the writer's `clampStrokeWidthPt` — values are clamped to the
+ * `0.25..13.5` pt band Excel's UI exposes and snapped to the 0.25 pt
+ * grid so a parsed-then-cloned-then-written width does not drift across
+ * round-trips (Excel rounds in the UI anyway). Non-finite / non-numeric
+ * tokens (`NaN`, `Infinity`, strings, `null` from an untyped caller)
+ * collapse to `undefined` so the cloned chart drops the field rather
+ * than carry a value the writer would silently elide back to absence.
+ */
+function normalizeLegendBorderWidth(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const snapped = Math.round(value * 4) / 4;
+  if (snapped < LEGEND_BORDER_WIDTH_MIN_PT) return LEGEND_BORDER_WIDTH_MIN_PT;
+  if (snapped > LEGEND_BORDER_WIDTH_MAX_PT) return LEGEND_BORDER_WIDTH_MAX_PT;
+  return snapped;
+}
+
+/**
+ * Resolve a `legendBorderWidth` override.
+ *
+ * `undefined` → inherit the source's parsed `legendBorderWidth` (after
+ *               running it through {@link normalizeLegendBorderWidth}
+ *               so a malformed source value drops cleanly).
+ * `null`      → drop the inherited width (the writer emits `<a:ln>`
+ *               without a `w` attribute, the line keeps Excel's
+ *               auto-thickness).
+ * `number`    → replace with the clamped / snapped point value.
+ *               Non-finite / non-numeric overrides collapse to
+ *               `undefined` via the normalizer so the cloned
+ *               `SheetChart` always carries a value the writer will
+ *               accept.
+ *
+ * The grammar mirrors `plotAreaBorderWidth` / the series-line stroke
+ * width so the chart `<a:ln w=..>` knobs compose the same way at the
+ * call site. Callers should gate the result on the resolved legend
+ * visibility — when no legend is emitted, the width has no slot in the
+ * rendered chart.
+ *
+ * Independent of `legendBorderColor`: both knobs land on the same
+ * `<a:ln>` element but on a different slot (color is
+ * `<a:solidFill><a:srgbClr>`, width is the `w` attribute on `<a:ln>`),
+ * so a caller can pin both without conflict.
+ */
+function resolveLegendBorderWidth(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeLegendBorderWidth(sourceValue);
+  if (override === null) return undefined;
+  return normalizeLegendBorderWidth(override);
 }
 
 /**

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -593,6 +593,20 @@ export function parseChart(xml: string): Chart | undefined {
     // knobs.
     const legendBorderColor = parseLegendBorderColor(chartEl);
     if (legendBorderColor !== undefined) out.legendBorderColor = legendBorderColor;
+
+    // `<c:legend><c:spPr><a:ln w="EMU">` carries Excel's "Format Legend
+    // -> Border -> Width" pin. The OOXML `w` attribute stores the
+    // stroke width in English Metric Units (1 pt = 12 700 EMU) per
+    // CT_LineProperties (ECMA-376 Part 1, §20.1.2.3.24); the reader
+    // converts back to points and clamps to the same 0.25..13.5 pt band
+    // Excel's UI exposes so a template carrying an exotic width still
+    // round-trips through the writer's clamp. Scoped to the legend's
+    // `<c:spPr>` so a stray `<a:ln w=..>` elsewhere (series stroke,
+    // axis line, plot-area border) cannot leak into this field. Same
+    // hidden-legend scoping as the fill / border-color / typography
+    // knobs.
+    const legendBorderWidth = parseLegendBorderWidth(chartEl);
+    if (legendBorderWidth !== undefined) out.legendBorderWidth = legendBorderWidth;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -4178,6 +4192,48 @@ function parseLegendBorderColor(chartEl: XmlElement): string | undefined {
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;
   return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull the `w` attribute off `<c:legend><c:spPr><a:ln w="EMU"/>` and
+ * return the stroke width in points after clamping to the
+ * `0.25..13.5` pt band Excel's UI exposes. The OOXML `w` attribute
+ * carries the stroke width in English Metric Units (1 pt = 12 700 EMU)
+ * per `CT_LineProperties` (ECMA-376 Part 1, §20.1.2.3.24); the reader
+ * snaps the result to the 0.25 pt grid so a parsed-then-written width
+ * does not drift across round-trips (Excel rounds in the UI anyway).
+ *
+ * Returns `undefined` when the chart omits `<c:legend>`, when the
+ * legend has no `<c:spPr><a:ln w=..>` slot, when the attribute is
+ * missing, when the value cannot be parsed as a finite positive
+ * number, or when it parses to zero (Excel's "no border" marker — the
+ * writer-side knob does not model that state). Mirrors the writer-side
+ * {@link SheetChart.legendBorderWidth} so a parsed value slots
+ * straight into {@link cloneChart} without conversion.
+ *
+ * The lookup is scoped to direct children of `<c:legend>` so a stray
+ * `<a:ln w=..>` elsewhere (on a series stroke, on an axis line, on the
+ * plot-area border) cannot leak in. Mirrors {@link parseLegendBorderColor} —
+ * same `<c:spPr>` host on the same `<c:legend>` parent — but lands on
+ * the `w` attribute rather than the `<a:solidFill><a:srgbClr>` color
+ * child.
+ */
+function parseLegendBorderWidth(chartEl: XmlElement): number | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  const spPr = findChild(legend, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const wAttr = ln.attrs.w;
+  if (typeof wAttr !== "string") return undefined;
+  const emu = Number.parseFloat(wAttr);
+  if (!Number.isFinite(emu) || emu <= 0) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const pt = Math.round((emu / EMU_PER_PT) * 4) / 4;
+  if (pt < STROKE_WIDTH_MIN_PT) return STROKE_WIDTH_MIN_PT;
+  if (pt > STROKE_WIDTH_MAX_PT) return STROKE_WIDTH_MAX_PT;
+  return pt;
 }
 
 /**

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -193,6 +193,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendLayout(chart),
         resolveLegendFillColor(chart),
         resolveLegendBorderColor(chart),
+        resolveLegendBorderWidth(chart),
       ),
     );
   }
@@ -5574,6 +5575,7 @@ function buildLegend(
   layout: ResolvedManualLayout | undefined,
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
+  borderWidthPt: number | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -5621,7 +5623,7 @@ function buildLegend(
   // children (`<a:effectLst>` effects, gradient / pattern / picture
   // fills, line dash / width / compound styles) are not modelled at
   // this layer.
-  const legendSpPrXml = buildLegendSpPr(fillRgbHex, borderRgbHex);
+  const legendSpPrXml = buildLegendSpPr(fillRgbHex, borderRgbHex, borderWidthPt);
   if (legendSpPrXml !== undefined) {
     children.push(legendSpPrXml);
   }
@@ -5654,21 +5656,24 @@ function buildLegend(
 
 /**
  * Build the `<c:spPr>` element on `<c:legend>` that carries the
- * legend's background fill and / or border (line stroke) colors.
- * Returns `undefined` when no knob is pinned so the caller can elide
- * the entire block — Excel's reference serialization omits `<c:spPr>`
- * from `<c:legend>` whenever the legend renders at the theme default
- * fill / stroke (typically a transparent legend background with no
- * `<c:spPr>` block).
+ * legend's background fill, border (line stroke) color, and border
+ * width. Returns `undefined` when no knob is pinned so the caller can
+ * elide the entire block — Excel's reference serialization omits
+ * `<c:spPr>` from `<c:legend>` whenever the legend renders at the
+ * theme default fill / stroke (typically a transparent legend
+ * background with no `<c:spPr>` block).
  *
  * The emitted block mirrors the minimal `<c:spPr>` shape Excel writes
  * when the user pins "Format Legend -> Fill -> Solid fill -> Color"
- * and / or "Format Legend -> Border -> Solid line -> Color":
+ * and / or "Format Legend -> Border -> Solid line -> Color" / "Width":
  * `<c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
- * <a:ln><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></a:ln>
- * </c:spPr>`. The `val` attribute holds the canonical 6-character
- * uppercase hex form (the writer normalizes the input ahead of this
- * call so a malformed source value never reaches emit). When at least
+ * <a:ln w="EMU"><a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill>
+ * </a:ln></c:spPr>`. The `val` attribute holds the canonical
+ * 6-character uppercase hex form (the writer normalizes the input
+ * ahead of this call so a malformed source value never reaches emit).
+ * The width attribute lands on `<a:ln>` (EMU; 1 pt = 12 700 EMU)
+ * authored together with the border-color child so a stroke-only or
+ * color-only legend still emits a single `<a:ln>` block. When at least
  * one knob lands on the wire, the children are emitted in
  * `CT_ShapeProperties` schema order: `<a:solidFill>` (fill) then
  * `<a:ln>` (line / stroke).
@@ -5680,19 +5685,34 @@ function buildLegend(
 function buildLegendSpPr(
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
+  borderWidthPt: number | undefined,
 ): string | undefined {
-  if (fillRgbHex === undefined && borderRgbHex === undefined) return undefined;
+  if (fillRgbHex === undefined && borderRgbHex === undefined && borderWidthPt === undefined) {
+    return undefined;
+  }
   const children: string[] = [];
   if (fillRgbHex !== undefined) {
     children.push(
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
     );
   }
-  if (borderRgbHex !== undefined) {
-    children.push(
-      xmlElement("a:ln", undefined, [
+  if (borderRgbHex !== undefined || borderWidthPt !== undefined) {
+    const lnAttrs: Record<string, string | number> = {};
+    if (borderWidthPt !== undefined) {
+      // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
+      // the nearest integer because the schema types `w` as `xsd:int`.
+      lnAttrs.w = Math.round(borderWidthPt * EMU_PER_PT);
+    }
+    const lnChildren: string[] = [];
+    if (borderRgbHex !== undefined) {
+      lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
-      ]),
+      );
+    }
+    children.push(
+      lnChildren.length === 0
+        ? xmlSelfClose("a:ln", lnAttrs)
+        : xmlElement("a:ln", Object.keys(lnAttrs).length > 0 ? lnAttrs : undefined, lnChildren),
     );
   }
   return xmlElement("c:spPr", undefined, children);
@@ -6124,6 +6144,34 @@ function resolveLegendFillColor(chart: SheetChart): string | undefined {
  */
 function resolveLegendBorderColor(chart: SheetChart): string | undefined {
   return normalizeTitleColor(chart.legendBorderColor);
+}
+
+/**
+ * Resolve `<c:legend><c:spPr><a:ln w="EMU"/></c:spPr></c:legend>` from
+ * {@link SheetChart.legendBorderWidth}.
+ *
+ * Returns the point value clamped to the `0.25..13.5` pt band Excel's
+ * UI exposes and snapped to the 0.25 pt grid, or `undefined` when the
+ * chart leaves the field unset / passed a malformed token (`NaN`,
+ * `Infinity`, non-finite). Delegates to {@link clampStrokeWidthPt} so
+ * the snap / clamp grammar matches every other `<a:ln w=..>` slot the
+ * writer authors (the series stroke knob `series[i].stroke.width`,
+ * the plot-area border width knob {@link SheetChart.plotAreaBorderWidth}).
+ * The width is only meaningful when the chart actually emits a
+ * legend — the caller is expected to gate the call on the resolved
+ * legend visibility (`resolveLegendPosition` returning a non-null
+ * value). A chart whose legend is suppressed has no `<c:legend>`
+ * block to host the `<c:spPr>` slot in either case.
+ *
+ * Independent of {@link resolveLegendBorderColor}: both knobs land on
+ * the same `<a:ln>` element but on a different slot (the color child
+ * `<a:solidFill>` versus the line's `w` attribute). Mirrors the
+ * chart-title / axis-title / chart-space / plot-area `<c:spPr>` slots —
+ * same EMU encoding, same `<a:ln>` host — but lands on `<c:legend>`'s
+ * own `<c:spPr>` block.
+ */
+function resolveLegendBorderWidth(chart: SheetChart): number | undefined {
+  return clampStrokeWidthPt(chart.legendBorderWidth);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -23711,3 +23711,177 @@ describe("cloneChart — legendBorderColor", () => {
     expect(parseChart(written)?.legendBorderColor).toBe("1F77B4");
   });
 });
+
+// ── cloneChart — legendBorderWidth (line stroke thickness) ───────────
+
+describe("cloneChart — legendBorderWidth", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [
+        {
+          kind: "line",
+          index: 0,
+          name: "Revenue",
+          valuesRef: "Sheet1!$B$2:$B$5",
+          categoriesRef: "Sheet1!$A$2:$A$5",
+        },
+      ],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits the source's legendBorderWidth by default", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendBorderWidth).toBe(1.5);
+  });
+
+  it("lets options.legendBorderWidth override the source's value", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: 2.5,
+    });
+    expect(clone.legendBorderWidth).toBe(2.5);
+  });
+
+  it("drops the inherited legendBorderWidth when the override is null", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: null,
+    });
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined legendBorderWidth when neither source nor override sets it", () => {
+    const clone = cloneChart(source(), { anchor: { from: { row: 0, col: 0 } } });
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("snaps the override to the 0.25 pt grid (1.4 → 1.5)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: 1.4,
+    });
+    expect(clone.legendBorderWidth).toBe(1.5);
+  });
+
+  it("clamps the override below the minimum (0.1 → 0.25)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: 0.1,
+    });
+    expect(clone.legendBorderWidth).toBe(0.25);
+  });
+
+  it("clamps the override above the maximum (50 → 13.5)", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: 50,
+    });
+    expect(clone.legendBorderWidth).toBe(13.5);
+  });
+
+  it("drops a NaN override", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: Number.NaN,
+    });
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("drops an Infinity override", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: Number.POSITIVE_INFINITY,
+    });
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("drops a non-number override (typed escape from an untyped caller)", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      legendBorderWidth: "1.5" as any,
+    });
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("normalizes a malformed source value through the resolver", () => {
+    const clone = cloneChart(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      source({ legendBorderWidth: Number.NaN as any }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("carries legendBorderWidth through a flatten (line → column)", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      type: "column",
+    });
+    expect(clone.type).toBe("column");
+    expect(clone.legendBorderWidth).toBe(1.5);
+  });
+
+  it("drops legendBorderWidth when the legend is hidden (legend=false)", () => {
+    const clone = cloneChart(source({ legendBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendBorderWidth).toBeUndefined();
+  });
+
+  it("composes independently with legendBorderColor (each lands on its own slot)", () => {
+    const clone = cloneChart(
+      source({
+        legendBorderColor: "1F77B4",
+        legendBorderWidth: 1.5,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendBorderColor).toBe("1F77B4");
+    expect(clone.legendBorderWidth).toBe(1.5);
+  });
+
+  it("composes independently with legendFillColor", () => {
+    const clone = cloneChart(
+      source({
+        legendFillColor: "F2F2F2",
+        legendBorderWidth: 1.5,
+      }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.legendFillColor).toBe("F2F2F2");
+    expect(clone.legendBorderWidth).toBe(1.5);
+  });
+
+  it("survives a writeXlsx round trip — legendBorderWidth lands in the cloned chart XML", async () => {
+    const clone = cloneChart(source({ legendBorderWidth: 0.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderWidth: 1.75,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+            [3, 4],
+            [5, 6],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.legendBorderWidth).toBe(1.75);
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -22879,3 +22879,191 @@ describe("writeChart — legendBorderColor", () => {
     expect(reparsed?.legendBorderColor).toBe("1F77B4");
   });
 });
+
+// ── writeChart — legendBorderWidth (line stroke thickness) ───────────
+
+describe("writeChart — legendBorderWidth", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend> block found in chart XML");
+    return m[0];
+  }
+
+  it("does not emit <c:spPr> when legendBorderWidth is unset (matches Excel reference)", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:spPr>");
+    expect(legend).not.toContain("<a:ln");
+  });
+
+  it("emits <c:spPr><a:ln w=..> when legendBorderWidth is set without a color", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: 1.5 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain("<c:spPr>");
+    // 1.5 pt = 19050 EMU.
+    expect(legend).toContain('<a:ln w="19050"');
+    // No solid-fill child when only width is pinned.
+    expect(legend).not.toContain("<a:solidFill><a:srgbClr");
+  });
+
+  it("snaps to the 0.25 pt grid (1.4 → 1.5 pt → 19050 EMU)", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: 1.4 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:ln w="19050"');
+  });
+
+  it("clamps below the minimum (0.1 pt → 0.25 pt → 3175 EMU)", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: 0.1 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:ln w="3175"');
+  });
+
+  it("clamps above the maximum (50 pt → 13.5 pt → 171450 EMU)", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: 50 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:ln w="171450"');
+  });
+
+  it("places <c:spPr> after <c:overlay> and before <c:txPr> inside <c:legend>", () => {
+    const result = writeChart(
+      makeChart({ legendBorderWidth: 2, legendFontColor: "445566" }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend.indexOf("c:overlay")).toBeLessThan(legend.indexOf("c:spPr"));
+    expect(legend.indexOf("c:spPr")).toBeLessThan(legend.indexOf("c:txPr"));
+  });
+
+  it("only emits one <c:spPr> inside <c:legend>", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: 2 }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    const occurrences = legend.match(/<c:spPr>/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("threads legendBorderWidth through every chart family that emits a legend", () => {
+    for (const type of ["bar", "column", "line", "pie", "doughnut", "area"] as const) {
+      const result = writeChart(makeChart({ type, legendBorderWidth: 1 }), "Sheet1");
+      const legend = legendOf(result.chartXml);
+      expect(legend).toContain('<a:ln w="12700"');
+    }
+    const scatter = writeChart(
+      makeChart({
+        type: "scatter",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        legendBorderWidth: 1,
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(scatter.chartXml)).toContain('<a:ln w="12700"');
+  });
+
+  it("does not emit any <c:legend> when legend=false, even with legendBorderWidth set", () => {
+    const result = writeChart(makeChart({ legend: false, legendBorderWidth: 1.5 }), "Sheet1");
+    expect(result.chartXml).not.toContain("<c:legend>");
+  });
+
+  it("drops a NaN value", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: Number.NaN }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:spPr>");
+  });
+
+  it("drops a non-finite value (Infinity)", () => {
+    const result = writeChart(makeChart({ legendBorderWidth: Number.POSITIVE_INFINITY }), "Sheet1");
+    const legend = legendOf(result.chartXml);
+    expect(legend).not.toContain("<c:spPr>");
+  });
+
+  it("drops non-number escapes (typed escape from an untyped caller)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = writeChart(makeChart({ legendBorderWidth: "1.5" as any }), "Sheet1");
+    expect(legendOf(a.chartXml)).not.toContain("<c:spPr>");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const b = writeChart(makeChart({ legendBorderWidth: null as any }), "Sheet1");
+    expect(legendOf(b.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("composes independently with legendBorderColor — width on <a:ln>, color inside it", () => {
+    const result = writeChart(
+      makeChart({
+        legendBorderColor: "1F77B4",
+        legendBorderWidth: 2,
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    expect(legend).toContain('<a:ln w="25400">');
+    expect(legend).toContain('<a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill>');
+    // Width attribute hosts the color child.
+    expect(legend).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("composes independently with legendFillColor — fill in <a:solidFill>, width on <a:ln>", () => {
+    const result = writeChart(
+      makeChart({
+        legendFillColor: "F2F2F2",
+        legendBorderWidth: 1,
+      }),
+      "Sheet1",
+    );
+    const legend = legendOf(result.chartXml);
+    // Single <c:spPr> hosts both knobs.
+    const spPrCount = legend.match(/<c:spPr>/g) ?? [];
+    expect(spPrCount).toHaveLength(1);
+    expect(legend).toContain('<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>');
+    expect(legend).toContain('<a:ln w="12700"');
+    // CT_ShapeProperties order: <a:solidFill> precedes <a:ln>.
+    const spPrBlock = legend.match(/<c:spPr>[\s\S]*?<\/c:spPr>/)?.[0] ?? "";
+    expect(spPrBlock.indexOf("<a:solidFill>")).toBeLessThan(spPrBlock.indexOf("<a:ln "));
+  });
+
+  it("round-trips legendBorderWidth through parseChart", () => {
+    const written = writeChart(makeChart({ legendBorderWidth: 2.25 }), "Sheet1").chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendBorderWidth).toBe(2.25);
+  });
+
+  it("collapses an unset legendBorderWidth round-trip back to undefined", () => {
+    const written = writeChart(makeChart(), "Sheet1").chartXml;
+    expect(parseChart(written)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("round-trips both border color and width together through parseChart", () => {
+    const written = writeChart(
+      makeChart({ legendBorderColor: "1F77B4", legendBorderWidth: 1.5 }),
+      "Sheet1",
+    ).chartXml;
+    const reparsed = parseChart(written);
+    expect(reparsed?.legendBorderColor).toBe("1F77B4");
+    expect(reparsed?.legendBorderWidth).toBe(1.5);
+  });
+
+  it("survives a writeXlsx round trip — legendBorderWidth lands in the packaged chart XML", async () => {
+    const sheets: WriteSheet[] = [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Region", "Sales"],
+          ["North", 100],
+          ["South", 200],
+        ],
+        charts: [
+          {
+            type: "column",
+            title: "Sales",
+            series: [{ name: "Sales", values: "B2:B3", categories: "A2:A3" }],
+            anchor: { from: { row: 5, col: 0 }, to: { row: 20, col: 6 } },
+            legendBorderWidth: 1.75,
+          },
+        ],
+      },
+    ];
+    const out = await writeXlsx({ sheets });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.legendBorderWidth).toBe(1.75);
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -22415,3 +22415,182 @@ describe("parseChart — legendBorderColor", () => {
     expect(parseChart(xml)?.legendBorderColor).toBeUndefined();
   });
 });
+
+// ── parseChart — legendBorderWidth (line stroke thickness) ───────────
+
+describe("parseChart — legendBorderWidth", () => {
+  const NS_LBW = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS_LBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the stroke width in points (12700 EMU = 1 pt)", () => {
+    const xml = withLegendSpPr(`<a:ln w="12700"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBe(1);
+  });
+
+  it("surfaces a fractional stroke width (19050 EMU = 1.5 pt)", () => {
+    const xml = withLegendSpPr(`<a:ln w="19050"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBe(1.5);
+  });
+
+  it("surfaces the minimum width (3175 EMU = 0.25 pt)", () => {
+    const xml = withLegendSpPr(`<a:ln w="3175"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBe(0.25);
+  });
+
+  it("snaps an exotic EMU value to the nearest 0.25 pt grid", () => {
+    // 14000 EMU ≈ 1.10 pt → snaps to 1.0 pt.
+    const xml = withLegendSpPr(`<a:ln w="14000"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBe(1);
+  });
+
+  it("clamps below the minimum band (1000 EMU → 0.25 pt)", () => {
+    const xml = withLegendSpPr(`<a:ln w="1000"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBe(0.25);
+  });
+
+  it("clamps above the maximum band (1000000 EMU → 13.5 pt)", () => {
+    const xml = withLegendSpPr(`<a:ln w="1000000"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBe(13.5);
+  });
+
+  it("surfaces both border color and width when both are pinned on <a:ln>", () => {
+    const xml = withLegendSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.legendBorderWidth).toBe(2);
+    expect(parsed?.legendBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when the chart has no <c:legend>", () => {
+    const xml = `<c:chartSpace ${NS_LBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:legend> has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS_LBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    const xml = withLegendSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no w attribute", () => {
+    const xml = withLegendSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when the w attribute is malformed (non-numeric)", () => {
+    const xml = withLegendSpPr(`<a:ln w="thick"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when the w attribute is zero (Excel's 'no border' marker)", () => {
+    const xml = withLegendSpPr(`<a:ln w="0"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when the w attribute is negative", () => {
+    const xml = withLegendSpPr(`<a:ln w="-12700"/>`);
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it('drops the width when the legend is hidden via <c:delete val="1"/>', () => {
+    const xml = `<c:chartSpace ${NS_LBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:delete val="1"/>
+      <c:overlay val="1"/>
+      <c:spPr><a:ln w="19050"/></c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    const chart = parseChart(xml);
+    expect(chart?.legend).toBe(false);
+    expect(chart?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln w=..> on a series <c:spPr> (not the legend)", () => {
+    const xml = `<c:chartSpace ${NS_LBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:ln w="50800"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln w=..> on a plot-area <c:spPr> (not the legend)", () => {
+    const xml = `<c:chartSpace ${NS_LBW}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:ln w="50800"/></c:spPr>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderWidth).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `SheetChart.legendBorderWidth` to the writer/reader/clone surfaces so the legend stroke thickness round-trips alongside the existing `legendBorderColor` knob.
- Mirrors the new `plotAreaBorderWidth` knob (#316) — same EMU encoding, same clamp/snap grammar — but on the legend's own `<c:spPr>` block.
- The width lands on the `w` attribute of `<c:legend><c:spPr><a:ln w="EMU">` (English Metric Units; 1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1, §20.1.2.3.24).
- Values clamp to the 0.25..13.5 pt band Excel's UI exposes and snap to the 0.25 pt grid so a parsed-then-written width does not drift; non-finite / non-numeric / zero / negative tokens collapse to `undefined` and the writer omits the `w` attribute (the line keeps Excel's auto-thickness).
- The `cloneChart` resolver mirrors the border-color override grammar (`undefined` inherits, `null` drops, `number` replaces) and shares the clamp/snap.
- Composes independently with `legendBorderColor` — both knobs land on the same `<a:ln>` element but on a different slot (the color's `<a:solidFill>` child vs the line's `w` attribute). Silently ignored when `legend === false` (no `<c:legend>` element to host the `<c:spPr>` slot).

Refs #316

## Test plan

- [x] `pnpm vitest run --dir=test` — 89 files / 7070 tests passing (51 new tests across `parseChart`, `writeChart`, and `cloneChart`).
- [x] `pnpm build` (obuild) — succeeds.
- [x] `pnpm typecheck` (tsgo --noEmit) — clean.
- [x] `pnpm lint` (oxlint + oxfmt --check) — 0 errors, formatting clean.
- [x] Round-trips covered: writer → reader, writer → `writeXlsx` → packaged `chart1.xml` → reader, plus clone-through with override / null / inheritance / malformed-token / cross-family flatten / hidden-legend scoping.
- [x] Composition with `legendBorderColor` and `legendFillColor` — single `<c:spPr>`, correct child order per `CT_ShapeProperties`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)