### PR TITLE
feat(xlsx): chart border-width / border-dash siblings + README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,72 +508,74 @@ or any sibling sheet, and accept either `rows` (raw 2-D arrays) or
 ### Charts
 
 Charts (`xl/charts/chartN.xml` plus the optional `styleN.xml` /
-`colorsN.xml` companions) are read into a per-sheet `sheet.charts`
-array surfacing the chart kind(s), series count, plain-text title,
-and per-series metadata (name, value/category ranges, fill color).
-On `saveXlsx` the chart parts are re-declared in
-`[Content_Types].xml`, the chart-bearing drawing and its rels are
-force-preserved, and the regenerated worksheet body gets a
-`<drawing r:id="..."/>` re-anchor — without these wirings Excel
-previously saw the chart parts as orphans and dropped them on next
-open.
+`colorsN.xml` companions) round-trip through three layers:
+
+- `parseChart(xml)` / `readXlsx().sheets[].charts[]` — surfaces a
+  read-side `Chart` record (kinds, title, series, axes, legend, data
+  labels, fills / borders, manual layout, view3D, etc.).
+- `writeXlsx({ sheets: [{ charts: [SheetChart] }] })` — emits the
+  chart parts and re-anchors the drawing in the regenerated worksheet
+  body so Excel never sees the chart as an orphan.
+- `cloneChart(source, options)` — bridges the two: it converts a
+  parsed `Chart` into a writable `SheetChart`, applies a typed override
+  bag (`undefined` = inherit, `null` = drop, value = replace), and
+  returns the result ready for `writeXlsx`.
+
+`getCharts(workbook)` flattens every chart anchored on the workbook's
+sheets into a single array; `addChart(sheet, chart)` is the symmetric
+writer-side helper that appends a `SheetChart` to a `WriteSheet`.
+
+#### Capability matrix
+
+The table summarises which knobs flow through each layer. "Read"
+means `parseChart` surfaces the field on `Chart` (or
+`ChartAxisInfo` / `ChartDataLabelsInfo` / `ChartDataTable` for nested
+slots); "Write" means `writeXlsx` emits it from the matching
+`SheetChart` field; "Clone" means `cloneChart` carries it through
+with the standard `undefined` / `null` / value override grammar.
+
+| Family                                                                                                                       | Read | Write | Clone |
+| ---------------------------------------------------------------------------------------------------------------------------- | :--: | :---: | :---: |
+| Chart kinds (bar / column / line / pie / doughnut / area / scatter / bubble / combo)                                         |  x   |   x   |   x   |
+| Title text + visibility (`title`, `showTitle`, `autoTitleDeleted`)                                                           |  x   |   x   |   x   |
+| Title typography (size / bold / italic / strike / underline / color / family)                                                |  x   |   x   |   x   |
+| Title rotation, manual layout                                                                                                |  x   |   x   |   x   |
+| Title fill / border color / border width / border dash                                                                       |  x   |   x   |   x   |
+| Legend position, overlay, font knobs, manual layout                                                                          |  x   |   x   |   x   |
+| Legend fill / border color / border width / border dash, per-entry hide                                                      |  x   |   x   |   x   |
+| Plot-area manual layout, fill / border color / border width / border dash                                                    |  x   |   x   |   x   |
+| Chart-space fill / border color / border width / border dash, rounded corners, style preset                                  |  x   |   x   |   x   |
+| Axis title text + typography (per-axis), rotation, manual layout, fill / border knobs                                        |  x   |   x   |   x   |
+| Axis label rotation, font size, bold / italic / underline / strike, color, font family                                       |  x   |   x   |   x   |
+| Axis scale (min / max / logBase / majorUnit / minorUnit), reverse, hidden, crosses, dispUnits                                |  x   |   x   |   x   |
+| Axis number format, tick marks, tick-label position / skip, label offset / alignment                                         |  x   |   x   |   x   |
+| Axis gridlines (major / minor)                                                                                               |  x   |   x   |   x   |
+| Series name, value/category refs, fill color, line stroke (width / dash)                                                     |  x   |   x   |   x   |
+| Series markers (symbol / size / fill / outline)                                                                              |  x   |   x   |   x   |
+| Data labels — chart-level + per-series (show\*, position, separator, number format, leader lines, typography, fill / border) |  x   |   x   |   x   |
+| Data table (showHorzBorder / showVertBorder / showOutline / showKeys, typography, fill / border)                             |  x   |   x   |   x   |
+| Bar / column gap-width and overlap                                                                                           |  x   |   x   |   x   |
+| Pie / doughnut hole size, vary-colors, first-slice angle                                                                     |  x   |   x   |   x   |
+| Display blanks-as, plot-vis-only, show-data-labels-over-max, lang, date1904                                                  |  x   |   x   |   x   |
+| 3D walls / floor / view3D                                                                                                    |  x   |   x   |   x   |
+| Chart-space protection block                                                                                                 |  x   |   x   |   x   |
+| Anchor (twoCellAnchor / oneCellAnchor) + relative offsets                                                                    |  x   |   x   |   x   |
+
+#### Read side — `parseChart` / `getCharts`
 
 ```ts
-import { readXlsx, parseChart } from "hucre";
+import { getCharts, openXlsx, parseChart } from "hucre";
 
-const wb = await readXlsx(buf);
+const wb = await openXlsx(buf);
 
-for (const sheet of wb.sheets) {
-  for (const chart of sheet.charts ?? []) {
-    console.log(chart.kinds, chart.seriesCount, chart.title);
-    // e.g. ["bar"], 2, "Quarterly Sales"
+for (const { sheetName, chart } of getCharts(wb)) {
+  console.log(sheetName, chart.kinds, chart.title);
+  // e.g. "Sales" ["bar"] "Quarterly Sales"
+  console.log(chart.anchor); // { from: { row: 1, col: 3 }, to: { row: 16, col: 10 } }
+  console.log(chart.axes?.x?.title, chart.axes?.y?.scale);
 
-    // chart.anchor surfaces the drawing-layer cell anchor that pins
-    // the chart to the host sheet (twoCellAnchor / oneCellAnchor).
-    console.log(chart.anchor);
-    // e.g. { from: { row: 1, col: 3 }, to: { row: 16, col: 10 } }
-
-    // chart.legend / chart.barGrouping / chart.lineGrouping /
-    // chart.areaGrouping mirror the writer-side fields so a parsed chart
-    // slots straight back into cloneChart without remapping. `legend: false`
-    // means the source chart explicitly hid the legend; `barGrouping` only
-    // surfaces on bar/column charts, `lineGrouping` only on line charts,
-    // and `areaGrouping` only on area charts.
-    console.log(chart.legend, chart.barGrouping, chart.lineGrouping, chart.areaGrouping);
-    // e.g. "bottom" "stacked" undefined undefined
-
-    // chart.axes carries per-axis labels, gridline visibility, numeric
-    // scaling, tick-label number format and tick rendering (major /
-    // minor tick mark style and tick-label position) pulled from
-    // <c:catAx>/<c:valAx>. Only populated axes show up — pie/doughnut
-    // never do, and OOXML defaults collapse to undefined so absence
-    // and the default round-trip identically.
-    console.log(chart.axes);
-    // e.g. {
-    //   x: { title: "Quarter" },
-    //   y: {
-    //     title: "Revenue (USD)",
-    //     gridlines: { major: true },
-    //     scale: { min: 0, max: 100, majorUnit: 25 },
-    //     numberFormat: { formatCode: "$#,##0" },
-    //     majorTickMark: "cross",
-    //     tickLblPos: "low",
-    //   },
-    // }
-
-    // chart.dataLabels surfaces the chart-type-level <c:dLbls> block.
-    // showValue / showCategoryName / showSeriesName / showPercent /
-    // showLegendKey and position / separator round-trip through
-    // cloneChart unchanged.
-    console.log(chart.dataLabels);
-    // e.g. { showValue: true, showLegendKey: true, position: "outEnd" }
-
-    for (const s of chart.series ?? []) {
-      console.log(s.kind, s.index, s.name, s.valuesRef, s.categoriesRef, s.color);
-      // e.g. "bar" 0 "Revenue" "Sheet1!$B$2:$B$10" "Sheet1!$A$2:$A$10" "1F77B4"
-      // s.dataLabels (when present) overrides the chart-level default
-      // for that single series.
-    }
+  for (const s of chart.series ?? []) {
+    console.log(s.kind, s.name, s.valuesRef, s.color, s.dataLabels);
   }
 }
 
@@ -581,1424 +583,124 @@ for (const sheet of wb.sheets) {
 const chart = parseChart(xml);
 ```
 
-`Chart.kinds` lists every chart-type element present under
-`<c:plotArea>` in declaration order, so combo charts surface as e.g.
-`["bar", "line"]`. `Chart.series` mirrors the field shape that
-`ChartSeries` accepts on the write side — a parsed series can be
-fed back into `WriteSheet.charts` to clone or re-bind a chart.
-Bubble/scatter `<c:numLit>` series (literal embedded data, no
-formula) intentionally surface no `valuesRef`/`categoriesRef`.
-`Chart.anchor` mirrors `SheetChart.anchor` on the writer side —
-`twoCellAnchor` charts surface both `from` and `to`,
-`oneCellAnchor` charts surface `from` only (intrinsic size lives in
-`<xdr:ext>`), and `absoluteAnchor` charts (EMU-positioned, no cell
-anchor) report `anchor` as `undefined`. `Chart.legend` and
-`Chart.barGrouping` mirror the writer-side fields of the same name:
-`legend` reports `false` when the chart explicitly suppresses the
-legend (`<c:delete val="1"/>`), `right` when `<c:legend>` is present
-without a `legendPos`, and the matching writer label otherwise;
-`barGrouping` is pulled from the first `<c:barChart>` and only
-surfaces the stacked variants (the OOXML `standard` value collapses
-to `undefined` since the writer treats it as the unspecified default,
-and non-bar charts never report a grouping). `lineGrouping` and
-`areaGrouping` apply the same convention to `<c:lineChart>` and
-`<c:areaChart>` respectively, surfacing only `stacked` /
-`percentStacked` so combo workbooks can declare both alongside a bar
-grouping without colliding. `Chart.axes` mirrors
-the writer-side `SheetChart.axes` and surfaces per-axis labels,
-gridline visibility, numeric scaling, tick-label number format and
-tick rendering: `x` is the category axis (or, for scatter, the first
-value axis) and `y` is the value axis. Empty / whitespace-only
-`<c:title>` text is dropped, `gridlines: { major, minor }` flips on
-when the matching `<c:majorGridlines>` / `<c:minorGridlines>`
-element is present (any nested styling is tolerated),
-`scale: { min, max, majorUnit, minorUnit, logBase }` captures the
-explicit `<c:min>` / `<c:max>` / `<c:logBase>` (under `<c:scaling>`)
-and `<c:majorUnit>` / `<c:minorUnit>` (direct axis children) —
-fields Excel auto-computes are left off so the round trip never
-accidentally pins a value, and zero or negative tick spacings are
-filtered out — and `numberFormat: { formatCode, sourceLinked }`
-mirrors `<c:numFmt>` (an empty `formatCode` collapses the record).
-`majorTickMark` / `minorTickMark` / `tickLblPos` mirror the
-matching axis children, surfacing only non-default values: the
-OOXML defaults `"out"` (major) / `"none"` (minor) / `"nextTo"` (tick
-labels) collapse to `undefined` so absence and the default
-round-trip identically through `cloneChart`. Unknown enum tokens
-are dropped rather than fabricated. Charts without any axis label,
-gridline, scale, number format, or tick override leave `axes`
-undefined, and pie/doughnut charts (which have no axes in OOXML)
-never report one.
-`Chart.dataLabels` mirrors the writer-side `SheetChart.dataLabels`
-and surfaces the toggles Excel carries inside `<c:dLbls>`
-(`showValue`, `showCategoryName`, `showSeriesName`, `showPercent`,
-`showLegendKey`, plus `position` and `separator`). Series-level
-overrides land on `ChartSeriesInfo.dataLabels`; a `<c:dLbls>` block
-that only contains `<c:delete val="1"/>` (Excel's "labels off" idiom)
-collapses to `undefined` rather than a record so callers see the
-absence cleanly. `showLegendKey` mirrors Excel's "Format Data Labels
--> Legend Key" checkbox: pin it `true` to paint the legend's color
-swatch beside every label. The OOXML default `false` collapses to
-`undefined` on the read side so absence and `<c:showLegendKey val="0"/>`
-round-trip identically through `cloneChart`.
-`Chart.holeSize` surfaces `<c:doughnutChart><c:holeSize val=".."/>`
-on doughnut charts so a parsed template can round-trip its hole back
-through `cloneChart`; non-doughnut charts (and doughnut charts that
-omit the element) never report it.
-`Chart.gapWidth` and `Chart.overlap` surface the bar / column
-spacing knobs (`<c:barChart><c:gapWidth val=".."/>` and
-`<c:overlap val=".."/>`). `gapWidth` (0 – 500 % of the bar width)
-controls the gap between category groups and `overlap` (-100..100 %)
-controls how much series within a group separate or stack. The OOXML
-defaults (`gapWidth=150`, `overlap=0`) collapse to `undefined`;
-non-bar / non-column charts never report either.
-`Chart.firstSliceAng` surfaces the
-`<c:pieChart><c:firstSliceAng val=".."/>` /
-`<c:doughnutChart><c:firstSliceAng val=".."/>` rotation (degrees
-clockwise from 12 o'clock) on pie and doughnut charts. The OOXML
-default `0` (and the schema-equivalent `360`) collapses to
-`undefined` so absence and the default round-trip identically;
-non-pie / non-doughnut charts never report it.
-`Chart.dispBlanksAs` surfaces the chart-level
-`<c:chart><c:dispBlanksAs val=".."/>` element — Excel's "Select Data
-Source → Hidden and Empty Cells" knob — and reports the literal
-`"zero"` or `"span"` token. The OOXML default `"gap"` collapses to
-`undefined` so absence and the default round-trip identically;
-unknown / malformed values (and a missing `val` attribute) drop to
-`undefined` rather than fabricate a token Excel rejects.
-`Chart.varyColors` surfaces the chart-type element's
-`<c:varyColors val=".."/>` flag — Excel's "Format Data Series → Fill →
-Vary colors by point" toggle — and reports the literal `true` or
-`false` value when it differs from the per-family OOXML default. Pie /
-doughnut / pie3D / ofPie default to `true` (every slice paints in a
-unique color), so absence and `<c:varyColors val="1"/>` both collapse
-to `undefined`; only an explicit `val="0"` surfaces `false` (the
-single-color override). Every other chart family defaults to `false`,
-so absence and `<c:varyColors val="0"/>` both collapse to `undefined`
-and only an explicit `val="1"` surfaces `true`. Unknown / malformed
-values and a missing `val` attribute drop to `undefined`.
-`Chart.scatterStyle` surfaces `<c:scatterChart><c:scatterStyle
-val=".."/></c:scatterChart>` — the chart-level XY-scatter preset
-Excel selects in the chart-type picker (`"none"`, `"line"`,
-`"lineMarker"`, `"marker"`, `"smooth"`, or `"smoothMarker"`). Every
-recognized token surfaces literally so a clone preserves the exact
-preset; missing elements, missing `val` attributes, and tokens
-outside the OOXML enum drop to `undefined`. Only `scatter` charts
-report the field — the schema places the element exclusively on
-`<c:scatterChart>`.
-`Chart.plotVisOnly` surfaces the chart-level
-`<c:chart><c:plotVisOnly val=".."/>` flag — the inverse of Excel's
-"Hidden and Empty Cells → Show data in hidden rows and columns"
-checkbox. The OOXML default `true` (hidden cells drop out) collapses
-to `undefined` so absence and `<c:plotVisOnly val="1"/>` round-trip
-identically; only an explicit `val="0"` surfaces `false` (the
-non-default that keeps hidden cells in the chart). The reader accepts
-the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
-`"false"`); unknown values and missing `val` attributes drop to
-`undefined`.
-`Chart.showDLblsOverMax` surfaces the chart-level
-`<c:chart><c:showDLblsOverMax val=".."/>` flag — Excel's "Format Axis
-→ Labels → Show data labels for values over maximum scale" checkbox.
-The OOXML default `true` (labels render for every point) collapses to
-`undefined` so absence and `<c:showDLblsOverMax val="1"/>` round-trip
-identically; only an explicit `val="0"` surfaces `false` (the
-non-default that strips labels off any point whose value exceeds the
-pinned `<c:max>`). The reader accepts the OOXML truthy / falsy
-spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and
-missing `val` attributes drop to `undefined`.
-`Chart.dataTable` surfaces the chart-level
-`<c:plotArea><c:dTable>...</c:dTable></c:plotArea>` block — Excel's
-"Add Chart Element → Data Table" toggle (the small grid of underlying
-series values painted beneath the plot area). The reader returns a
-`ChartDataTable` object with up to four boolean children
-(`showHorzBorder`, `showVertBorder`, `showOutline`, `showKeys`); each
-flag round-trips literally because all four are required on
-`CT_DTable` and Excel always emits every one. Children with missing or
-unknown `val` attributes drop to `undefined` rather than fabricate a
-flag the file did not pin, and absence of the `<c:dTable>` element
-collapses the whole field to `undefined`. Only chart families with
-axes (`bar`, `column`, `line`, `area`, `scatter`) carry a slot for the
-element — the OOXML schema places `<c:dTable>` inside `<c:plotArea>`
-alongside the axes, so pie / doughnut surface `undefined`.
-`Chart.protection` surfaces the chart-space-level
-`<c:chartSpace><c:protection>...</c:protection>` block — Excel's
-chart-level lock that pairs with the host worksheet's
-`<sheetProtection>` to decide which interactions remain allowed when
-the parent sheet is protected. The reader returns a `ChartProtection`
-object with up to five independently optional boolean children
-(`chartObject`, `data`, `formatting`, `selection`, `userInterface`);
-each flag is independently optional on `CT_Protection`, so the reader
-only surfaces the flags the file actually pinned. Children with
-missing or unknown `val` attributes drop to `undefined` rather than
-fabricate a flag the file did not pin. The element itself is the
-gating signal — a `<c:protection>` block with no resolvable children
-surfaces as an empty `{}`, and absence of the element collapses the
-field to `undefined`. Every chart family carries a slot — the element
-lives on `<c:chartSpace>` (a sibling of `<c:chart>`), not inside
-`<c:plotArea>`, so pie / doughnut still surface the block.
-`Chart.view3D` surfaces the chart-level `<c:chart><c:view3D>` block
-(CT_View3D, ECMA-376 Part 1, §21.2.2.228) — Excel's "3-D Rotation"
-pane on 3D chart families. The reader returns a `ChartView3D` object
-with up to six independently optional fields (`rotX`, `hPercent`,
-`rotY`, `depthPercent`, `rAngAx`, `perspective`); each child is
-independently optional on `CT_View3D`, so the reader only surfaces
-the fields the file actually pinned. Numeric fields are validated
-against the matching OOXML simple-type range
-(`ST_RotX` / `ST_HPercent` / `ST_RotY` / `ST_DepthPercent` /
-`ST_Perspective`) — out-of-range, fractional, and non-numeric `val`
-attributes drop rather than fabricate a clamped value. The boolean
-`<c:rAngAx>` accepts the OOXML truthy / falsy spellings (`"1"` /
-`"true"` / `"0"` / `"false"`); unknown tokens drop to `undefined`.
-The element itself is the gating signal — a `<c:view3D>` block with
-no resolvable children surfaces as an empty `{}`, and absence of the
-element collapses the field to `undefined`. The element lives on
-`<c:chart>` (between `<c:autoTitleDeleted>` and `<c:plotArea>`), so
-the OOXML schema accepts it on every chart family — though it is
-only meaningful on 3D families (`bar3D`, `line3D`, `pie3D`, `area3D`,
-`surface3D`); a stray element on a 2D chart still surfaces here so
-the round-trip through `cloneChart` stays lossless.
-`ChartAxisInfo.tickLblSkip` and `ChartAxisInfo.tickMarkSkip` surface
-the category-axis tick-thinning knobs (`<c:catAx><c:tickLblSkip val=".."/>`
-and `<c:catAx><c:tickMarkSkip val=".."/>`). Both elements live on
-`CT_CatAx` / `CT_DateAx` only — the reader skips the parse on
-`<c:valAx>` so a corrupt template carrying a stray skip on a value
-axis does not surface a field the writer would never emit anyway. The
-OOXML default `1` (show every label / mark) collapses to `undefined`;
-out-of-range values (non-positive or > 32767) drop rather than clamp
-so a malformed input cannot leak into the writer.
-`ChartAxisInfo.lblOffset` surfaces the category-axis label-offset
-percentage (`<c:catAx><c:lblOffset val=".."/>`). Same scope as the
-tick skips above — `CT_CatAx` / `CT_DateAx` only — and the same
-default-collapse semantics: the OOXML default `100` (Excel's
-reference label spacing) collapses to `undefined` so absence and the
-default round-trip identically; out-of-range values (negative or
-greater than 1000) drop rather than clamp.
-`ChartAxisInfo.lblAlgn` surfaces the category-axis tick-label
-horizontal alignment (`<c:catAx><c:lblAlgn val=".."/>`) — Excel's
-"Format Axis → Alignment → Text alignment" preset. Same scope as
-`lblOffset` (`CT_CatAx` / `CT_DateAx` only — `<c:valAx>` /
-`<c:serAx>` reject the element) and the same default-collapse
-semantics: the OOXML default `"ctr"` (centered) collapses to
-`undefined` so absence and the default round-trip identically.
-Unknown tokens (anything outside the `ST_LblAlgn` enumeration of
-`"ctr"` / `"l"` / `"r"`) drop rather than fabricate a value the
-writer would never emit.
-`ChartAxisInfo.hidden` surfaces the per-axis `<c:delete val=".."/>`
-flag — Excel's "Format Axis -> Show axis" toggle. Only an explicit
-`val="1"` (axis hidden) surfaces `true`; the OOXML default `val="0"`,
-absence, missing `val`, and unknown tokens all collapse to `undefined`
-so absence and the default round-trip identically. The reader accepts
-the OOXML truthy / falsy spellings (`"1"` / `"true"` / `"0"` /
-`"false"`).
-`ChartAxisInfo.noMultiLvlLbl` surfaces the per-axis
-`<c:noMultiLvlLbl val=".."/>` flag — Excel's "Format Axis ->
-Multi-level Category Labels" checkbox (the checkbox is the inverse:
-checked means tiered labels, i.e. `noMultiLvlLbl: false`). The OOXML
-schema places the element on `CT_CatAx` exclusively (even
-`<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject it), so the parser
-ignores the element on every other axis flavour. Only an explicit
-`val="1"` (multi-tier labels collapsed onto a single line) surfaces
-`true`; the OOXML default `val="0"`, absence, missing `val`, and
-unknown tokens all collapse to `undefined` so absence and the default
-round-trip identically. The reader accepts the OOXML truthy / falsy
-spellings (`"1"` / `"true"` / `"0"` / `"false"`).
-`ChartAxisInfo.auto` surfaces the per-axis `<c:auto val=".."/>` flag
-— Excel's "Format Axis -> Axis Options -> Axis Type" radio (the
-"Text axis" choice flips the value to `0`). The OOXML default `true`
-lets Excel inspect the axis labels and decide at render time whether
-to treat the axis as a discrete category axis or a chronological
-date axis; `false` pins the axis as a literal category axis so a
-date-shaped category range still renders as a flat category axis
-without any chronological grouping. The OOXML schema places the
-element on `CT_CatAx` exclusively, so the parser ignores it on every
-other axis flavour. Only an explicit `val="0"` surfaces `false`; the
-OOXML default `val="1"`, absence, missing `val`, and unknown tokens
-all collapse to `undefined` so absence and the default round-trip
-identically. The reader accepts the OOXML truthy / falsy spellings
-(`"1"` / `"true"` / `"0"` / `"false"`).
-`ChartAxisInfo.reverse` surfaces the per-axis
-`<c:scaling><c:orientation val="maxMin"/></c:scaling>` flag — Excel's
-"Categories / Values in reverse order" toggle. Only `"maxMin"` surfaces
-`true`; the OOXML default `"minMax"` (and unknown tokens, missing `val`
-attributes, missing `<c:orientation>` / `<c:scaling>` elements) all
-collapse to `undefined` so absence and the default round-trip
-identically through `cloneChart`. Reverse can fire on either or both
-axes independently — bar / column / line / area / scatter all support
-it; pie / doughnut never report it because they have no axes.
-`ChartAxisInfo.crosses` and `ChartAxisInfo.crossesAt` surface the
-per-axis crossing pin — where the perpendicular axis crosses this axis
-along its own range. `crosses` mirrors the OOXML `ST_Crosses`
-enumeration (`"autoZero"` / `"min"` / `"max"`) on `<c:crosses>`;
-`crossesAt` carries the literal numeric pin from `<c:crossesAt>`. The
-two elements live in an XSD choice (only one may legally appear at a
-time), and the reader honours that schema by preferring `crossesAt`
-when both surface on a malformed template — mirroring the writer's
-emit order. The OOXML default `crosses: "autoZero"` collapses to
-`undefined`, but `crossesAt: 0` is preserved (a numeric pin at zero is
-distinct from the `"autoZero"` default which defers to Excel's
-auto-placement). Unknown semantic tokens and non-numeric `val`
-attributes drop rather than fabricate values the writer would reject.
-`ChartAxisInfo.dispUnits` surfaces the per-value-axis display-unit
-configuration pulled from `<c:valAx><c:dispUnits>...</c:dispUnits></c:valAx>`
-— Excel's "Format Axis -> Display units" dropdown. The element rescales
-the numeric tick labels by the chosen divisor (e.g. `"millions"` divides
-every label by 1e6) so a chart whose source range stores raw amounts
-can show compact tick labels without modifying the underlying cells.
-The OOXML schema places the element exclusively on `CT_ValAx`, so
-`dispUnits` only surfaces on the value-axis side of bar / column / line
-/ area charts (the Y axis) and on both axes of scatter charts (both are
-value axes); category axes (`<c:catAx>`) and pie / doughnut never
-surface the field. The reader keeps both choices the OOXML schema
-allows: the named `unit` token from `<c:builtInUnit val=".."/>` and the
-arbitrary numeric divisor from `<c:custUnit val=".."/>` (Excel's
-"Display units → Other" path — e.g. `86400` to convert seconds to
-days). The OOXML schema places the two children in an `xsd:choice`
-(exactly one may appear); on emit hucre prefers `custUnit` when both
-fields are pinned so a clone can layer a custom divisor on top of an
-inherited preset without manually pruning the original. The
-`showLabel: true` flag tracks the presence of `<c:dispUnitsLbl>`
-(Excel paints its automatic annotation alongside the axis); the rich-
-text `<c:dispUnitsLbl>` body is intentionally not surfaced. The OOXML
-schema accepts the nine `ST_BuiltInUnit` tokens (`"hundreds"`,
-`"thousands"`, `"tenThousands"`, `"hundredThousands"`, `"millions"`,
-`"tenMillions"`, `"hundredMillions"`, `"billions"`, `"trillions"`);
-unknown tokens drop to `undefined` rather than fabricate a value the
-writer would never emit. Non-positive / non-finite `custUnit` values
-drop at the same boundary.
-`ChartAxisInfo.crossBetween` surfaces the per-value-axis cross-between
-mode pulled from `<c:valAx><c:crossBetween val=".."/></c:valAx>` — the
-OOXML `ST_CrossBetween` enum (`"between"` / `"midCat"`) that controls
-whether the perpendicular axis crosses BETWEEN data points (a half-
-category gap on each end of the plot area) or AT the midpoint of each
-category (data points sit ON the perpendicular-axis ticks). The element
-is required on every `<c:valAx>` and Excel emits a per-family default
-on every freshly-drawn chart — `"between"` on bar / column / line /
-area Y axes; `"midCat"` on both scatter axes — so the reader collapses
-the family-default value to `undefined` and only surfaces a non-default
-override (e.g. a template that pinned `"midCat"` on a line chart's Y
-axis to land the first / last data point flush with the value-axis
-line). The OOXML schema places the element exclusively on `CT_ValAx`,
-so `crossBetween` only surfaces on value-axis sides; category axes
-(`<c:catAx>`) and pie / doughnut never carry one. Unknown tokens drop
-to `undefined`.
-`Chart.roundedCorners` surfaces the chart-frame
-`<c:chartSpace><c:roundedCorners val=".."/>` flag — Excel's "Format
-Chart Area → Border → Rounded corners" toggle. The element sits on
-`<c:chartSpace>` (a sibling of `<c:chart>`) because it styles the
-outer frame rather than the plot area. The OOXML default `false`
-collapses to `undefined` so absence and `<c:roundedCorners val="0"/>`
-round-trip identically; only an explicit `val="1"` surfaces `true`.
-The reader accepts the OOXML truthy / falsy spellings (`"1"` / `"true"`
-/ `"0"` / `"false"`); unknown values and missing `val` attributes drop
-to `undefined`.
-`Chart.legendOverlay` surfaces the legend-overlay flag pulled from
-`<c:legend><c:overlay val=".."/></c:legend>` — Excel's "Format Legend →
-Show the legend without overlapping the chart" toggle (the checkbox is
-the inverse of this flag — checked means `false`, unchecked means
-`true`). The OOXML default `false` collapses to `undefined` so absence
-and `<c:overlay val="0"/>` round-trip identically; only an explicit
-`val="1"` surfaces `true`. The reader accepts the OOXML truthy / falsy
-spellings (`"1"` / `"true"` / `"0"` / `"false"`); unknown values and
-missing `val` attributes drop to `undefined`. The flag is dropped
-whenever `Chart.legend` is `false` or the chart omits the legend
-element entirely — there is no overlay slot on a hidden legend, so the
-parsed shape stays minimal.
-`Chart.legendEntries` surfaces the per-series legend-entry overrides
-pulled from `<c:legend><c:legendEntry>` children — Excel's "Format
-Legend Entries → Hide" action surfaces the same elements. Each entry
-exposes the 0-based series `idx` selector and the `delete` flag (the
-hide-bit pulled from `<c:delete val=".."/>`); per-entry text styling
-(`<c:txPr>`) is intentionally not modelled at this layer. Entries
-without a valid `<c:idx>` selector drop on parse rather than surface a
-fabricated index, and duplicate `<c:idx>` values keep only the first
-occurrence so a re-emit stays canonical. Absence collapses to
-`undefined` so a chart with no overrides round-trips minimally — the
-field is dropped whenever `Chart.legend` is `false` or the chart omits
-the legend element entirely.
-`Chart.titleOverlay` surfaces the title-overlay flag pulled from
-`<c:title><c:overlay val=".."/></c:title>` — Excel's "Format Chart
-Title → Show the title without overlapping the chart" toggle (the
-checkbox is the inverse of this flag — checked means `false`, unchecked
-means `true`). The OOXML default `false` collapses to `undefined` so
-absence and `<c:overlay val="0"/>` round-trip identically; only an
-explicit `val="1"` surfaces `true`. The reader accepts the OOXML
-truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
-unknown values and missing `val` attributes drop to `undefined`. The
-flag is dropped whenever the chart omits the `<c:title>` element
-entirely — there is no overlay slot to surface in that case.
-`Chart.titleRotation` surfaces the chart-title rotation pulled from
-`<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
-— Excel's "Format Chart Title → Size & Properties → Alignment → Custom
-angle" knob. The OOXML attribute is in 60000ths of a degree; the reader
-divides by 60000 (rounding) to surface a whole-degree value in the
-`-90..90` band Excel's UI exposes. The OOXML default `0` (and absence
-of the `<a:bodyPr>` element / `rot` attribute) collapses to `undefined`
-so absence and the default round-trip identically through `cloneChart`.
-Out-of-range values clamp to the nearest endpoint of the `-90..90` band;
-non-numeric tokens drop back to `undefined`. The field is dropped
-whenever the chart omits the `<c:title>` element entirely — there is no
-rotation to surface in that case. Mirrors the axis-side
-`ChartAxisInfo.labelRotation` field — same range, same conversion
-factor — so a parsed value threads straight back into the writer-side
-`SheetChart.titleRotation`.
-`Chart.autoTitleDeleted` surfaces the chart-level
-`<c:chart><c:autoTitleDeleted val=".."/>` flag — Excel's record of
-whether the user explicitly deleted the auto-generated title that
-single-series charts synthesise from the series name. The element sits
-on `<c:chart>` directly (between `<c:title>` and `<c:plotArea>` per
-CT_Chart, ECMA-376 Part 1, §21.2.2.4), not nested inside `<c:title>`,
-so a chart with no `<c:title>` may still pin the flag. The OOXML
-default `false` collapses to `undefined` so absence and
-`<c:autoTitleDeleted val="0"/>` round-trip identically; only an
-explicit `val="1"` surfaces `true`. The reader accepts the OOXML
-truthy / falsy spellings (`"1"` / `"true"` / `"0"` / `"false"`);
-unknown values and missing `val` attributes drop to `undefined`.
-`Chart.dropLines` surfaces the chart-type-level `<c:dropLines/>` flag
-on the first `<c:lineChart>` / `<c:line3DChart>` / `<c:areaChart>` /
-`<c:area3DChart>` element — Excel's "Add Chart Element → Lines → Drop
-Lines" toggle (vertical reference lines connecting each data point to
-the category axis). The element is bare (no `val` attribute), so its
-mere presence surfaces `true` and absence collapses to `undefined`.
-The reader does not surface `dropLines` for chart families whose OOXML
-schema rejects the element (bar / column / pie / doughnut / scatter /
-stock / radar / surface / bubble) — a stray element on those parents
-is ignored.
-`Chart.hiLowLines` surfaces the chart-type-level `<c:hiLowLines/>`
-flag on the first `<c:lineChart>` / `<c:line3DChart>` / `<c:stockChart>`
-element — Excel's "Add Chart Element → Lines → High-Low Lines" toggle
-(vertical connectors between the highest and lowest series values at
-each category position). Same bare-element shape as `dropLines`:
-presence surfaces `true`, absence collapses to `undefined`. The
-element has no slot on `<c:areaChart>` / `<c:area3DChart>` per the
-OOXML schema, so the reader ignores it on those parents and on every
-non-line / non-stock family.
-`Chart.serLines` surfaces the chart-type-level `<c:serLines/>` flag on
-the first `<c:barChart>` / `<c:ofPieChart>` element — Excel's "Add
-Chart Element → Lines → Series Lines" toggle (connector lines drawn
-between paired data points across consecutive series in a stacked bar
-/ column chart). Same bare-element shape as `dropLines` / `hiLowLines`:
-presence surfaces `true`, absence collapses to `undefined`. The reader
-does not surface `serLines` for chart families whose OOXML schema
-rejects the element (line / pie / doughnut / area / scatter / stock /
-radar / surface / bubble) — a stray element on those parents is
-ignored.
-`ChartSeriesInfo.smooth` surfaces the per-series
-`<c:ser><c:smooth val=".."/>` flag — Excel's "Format Data Series →
-Line → Smoothed line" toggle — only on `line` / `line3D` / `scatter`
-series (the OOXML schema places `<c:smooth>` exclusively on
-`CT_LineSer` and `CT_ScatterSer`). Absence and the OOXML default
-`val="0"` both collapse to `undefined`, so only an explicit
-`<c:smooth val="1"/>` round-trips as `smooth: true`.
-`ChartSeriesInfo.marker` surfaces the per-series `<c:ser><c:marker>`
-glyph configuration on `line` / `line3D` / `scatter` series (the
-schema places `<c:marker>` only on `CT_LineSer` and `CT_ScatterSer`).
-The reader pulls `symbol` (`circle` / `square` / `diamond` /
-`triangle` / `x` / `star` / `dot` / `dash` / `plus` / `auto` /
-`none`), `size` (clamped to the OOXML 2..72 band), and the marker's
-fill / outline colors out of `<c:spPr><a:solidFill>` and
-`<c:spPr><a:ln><a:solidFill>` — empty `<c:marker/>` elements collapse
-to `undefined` so absence and a bare element round-trip identically.
-`ChartSeriesInfo.stroke` surfaces the per-series
-`<c:ser><c:spPr><a:ln>` line styling on the same `line` / `line3D` /
-`scatter` series — `dash` mirrors the OOXML `ST_PresetLineDashVal`
-enum (`solid`, `dot`, `dash`, `lgDash`, `dashDot`, `lgDashDot`,
-`lgDashDotDot`, `sysDash`, `sysDot`, `sysDashDot`, `sysDashDotDot`)
-and `width` is reported in points after converting from EMU and
-clamping to Excel's 0.25 – 13.5 pt UI band. Empty `<a:ln/>` blocks,
-unknown dash tokens, and out-of-band widths collapse to `undefined`
-so the parsed shape stays minimal.
-`ChartSeriesInfo.invertIfNegative` surfaces the per-series
-`<c:ser><c:invertIfNegative val=".."/>` flag — Excel's "Format Data
-Series → Fill → Invert if negative" toggle — only on `bar` / `bar3D`
-series (the OOXML schema places `<c:invertIfNegative>` exclusively on
-`CT_BarSer` / `CT_Bar3DSer`). Absence and the OOXML default
-`val="0"` both collapse to `undefined`, so only an explicit
-`<c:invertIfNegative val="1"/>` round-trips as `invertIfNegative: true`.
-`Chart.upDownBars` surfaces the line-chart up / down bars flag pulled
-from `<c:lineChart><c:upDownBars>...</c:upDownBars></c:lineChart>` —
-Excel's "Add Chart Element -> Up/Down Bars" toggle. The element
-paints a vertical bar at each category whose top tracks the higher
-series value and bottom tracks the lower one (typically used to
-visualize open / close differences on a line-style stock chart).
-Surfaces `true` whenever the element is present (with or without the
-optional `<c:gapWidth>` / `<c:upBars>` / `<c:downBars>` children — the
-model is a plain presence flag at this layer); absence collapses to
-`undefined`. Only line-flavored chart-type bodies surface the field —
-`CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` per the OOXML
-schema; a stray `<c:upDownBars>` on a bar / column / pie / doughnut /
-area / scatter chart is ignored.
-`Chart.showLineMarkers` surfaces the chart-level marker visibility
-flag pulled from `<c:lineChart><c:marker val=".."/></c:lineChart>` —
-Excel's "Line vs. Line with Markers" chart-type distinction. The flag
-gates whether per-series markers paint at all on a line chart;
-per-series `<c:marker>` blocks (CT_Marker, with `<c:symbol>` /
-`<c:size>`) still pick the symbol / size / fill that paints when the
-gate is open. The Excel-default `val="1"` and absence both collapse to
-`undefined` so absence and the default round-trip identically through
-{@link cloneChart} — only an explicit `val="0"` surfaces `false`. The
-chart-level slot lives exclusively on `CT_LineChart` per the OOXML
-schema; `CT_Line3DChart` / `CT_StockChart` and every non-line family
-have no slot for the chart-level CT_Boolean variant, so a stray
-`<c:marker val=".."/>` on those bodies is ignored.
-Sheets that hucre actively regenerates because they
-also carry hucre-managed images currently keep the chart bodies but
-lose the in-drawing chart anchor — merging hucre's drawing output
-with the original chart graphicFrames is a follow-up.
+`Chart.kinds` lists every chart-type element under `<c:plotArea>` in
+declaration order, so combo charts surface as e.g. `["bar", "line"]`.
+`Chart.series` mirrors the field shape that `ChartSeries` accepts on
+the write side — a parsed series can be fed straight back into
+`SheetChart.series`. Bubble/scatter `<c:numLit>` series (literal
+embedded data, no formula) intentionally surface no
+`valuesRef` / `categoriesRef`. `Chart.anchor` mirrors
+`SheetChart.anchor`: `twoCellAnchor` charts surface both `from` and
+`to`, `oneCellAnchor` charts surface `from` only,
+`absoluteAnchor` charts (EMU-positioned, no cell anchor) report
+`anchor` as `undefined`.
 
-#### Authoring charts with `writeXlsx`
-
-The writer covers seven chart families — bar, column, line, pie,
-doughnut, scatter, and area — through the `WriteSheet.charts` field.
-Each chart is anchored to cells like an image and serialized as
-`xl/charts/chartN.xml`:
+#### Write side — `writeXlsx` + `addChart`
 
 ```ts
-import { writeXlsx } from "hucre";
+import { addChart, writeXlsx } from "hucre";
 
-const xlsx = await writeXlsx({
-  sheets: [
-    {
-      name: "Sales",
-      rows: [
-        ["Quarter", "Revenue", "Cost"],
-        ["Q1", 12000, 7000],
-        ["Q2", 15500, 8500],
-        ["Q3", 14000, 7800],
-      ],
-      charts: [
-        {
-          type: "column",
-          title: "Quarterly Performance",
-          series: [
-            { name: "Revenue", values: "B2:B4", categories: "A2:A4", color: "1F77B4" },
-            { name: "Cost", values: "C2:C4", categories: "A2:A4", color: "FF7F0E" },
-          ],
-          anchor: { from: { row: 6, col: 0 }, to: { row: 22, col: 8 } },
-          legend: "bottom",
-        },
-      ],
-    },
+const dashboard = {
+  name: "Dashboard",
+  rows: [
+    ["Quarter", "Revenue", "Forecast"],
+    ["Q1", 12000, 11500],
+    ["Q2", 15500, 15000],
+    ["Q3", 14000, 14500],
+    ["Q4", 17800, 17200],
+  ],
+};
+
+addChart(dashboard, {
+  type: "column",
+  title: "Quarterly Revenue",
+  titleFontSize: 14,
+  titleBold: true,
+  titleColor: "1F77B4",
+  titleBorderColor: "1F77B4",
+  titleBorderWidth: 1.5,
+  titleBorderDash: "dash",
+  series: [
+    { name: "Revenue", values: "B2:B5", categories: "A2:A5", color: "1F77B4" },
+    { name: "Forecast", values: "C2:C5", categories: "A2:A5", color: "FF7F0E" },
+  ],
+  axes: {
+    x: { title: "Quarter" },
+    y: { title: "Revenue (USD)", numberFormat: { formatCode: "$#,##0" } },
+  },
+  legend: "bottom",
+  legendFillColor: "F2F2F2",
+  legendBorderDash: "dot",
+  plotAreaBorderColor: "DDDDDD",
+  plotAreaBorderWidth: 0.75,
+  dataLabels: { showValue: true, position: "outEnd", fontSize: 9 },
+  anchor: { from: { row: 6, col: 0 }, to: { row: 22, col: 7 } },
+});
+
+const xlsx = await writeXlsx({ sheets: [dashboard] });
+```
+
+Every knob the writer accepts lives on the `SheetChart` type — see
+[`SheetChart` in `src/_types.ts`](./src/_types.ts) for the full
+field list with per-field semantics, OOXML mapping, and clamp /
+default behavior. The capability table above lists the families
+covered.
+
+#### Clone — `cloneChart(source, options)`
+
+`cloneChart` takes a parsed `Chart` and a `CloneChartOptions` override
+bag and returns a `SheetChart` ready for `writeXlsx`. Every override
+field uses the same grammar:
+
+- `undefined` (or omitted) — inherit the source value.
+- `null` — drop the source value (writer falls back to the OOXML
+  default for that slot).
+- a typed value — replace the source value (after running through the
+  same clamp / normalize as the writer).
+
+Per-series overrides are supplied as a positional `series` array;
+each entry merges with the source series at the matching index.
+
+```ts
+import { cloneChart, openXlsx, parseChart, writeXlsx } from "hucre";
+
+const wb = await openXlsx(templateBytes);
+const sourceChart = wb.sheets[0].charts?.[0];
+if (!sourceChart) throw new Error("template missing chart");
+
+// Re-bind the template chart to a new data range and recolour series.
+const cloned = cloneChart(sourceChart, {
+  anchor: { from: { row: 0, col: 0 }, to: { row: 18, col: 8 } },
+  title: "FY 2026 Revenue by Region",
+  titleColor: "1F77B4",
+  legend: "right",
+  series: [
+    { values: "B2:B13", categories: "A2:A13", color: "1F77B4" },
+    { values: "C2:C13", categories: "A2:A13", color: null /* drop template tint */ },
   ],
 });
-```
 
-Bare `B2:B4` series ranges are auto-qualified with the owning sheet
-name (sheet names containing whitespace or punctuation are quoted and
-embedded apostrophes are doubled per the OOXML spec). `barGrouping`
-toggles `clustered` / `stacked` / `percentStacked` on bar/column
-charts; `lineGrouping` and `areaGrouping` accept
-`standard` / `stacked` / `percentStacked` for line and area charts
-(`standard` is the writer default and matches Excel's plain layout).
-`legend` accepts
-`top` / `bottom` / `left` / `right` / `topRight` / `false`, and
-`altText` / `frameTitle` flow through to the drawing's `xdr:cNvPr`
-attributes for screen readers.
-`axes: { x: { title, axisTitleRotation, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween }, y: { title, axisTitleRotation, gridlines, scale, numberFormat, majorTickMark, minorTickMark, tickLblPos, labelRotation, reverse, crosses, crossesAt, dispUnits, crossBetween } }`
-attaches per-axis labels, gridlines, numeric scaling, the tick-label
-number format and the tick-rendering trio — `x` lands inside
-`<c:catAx>` (or the X value axis for scatter), `y` inside the value
-axis. Empty or whitespace-only titles are silently dropped,
-`gridlines: { major, minor }` emits
-`<c:majorGridlines>` / `<c:minorGridlines>` in the spec-required
-position (after `<c:axPos>`, before any `<c:title>`, major before
-minor), `scale: { min, max, majorUnit, minorUnit, logBase }` pins
-explicit axis bounds (`<c:min>` / `<c:max>` / `<c:logBase>` go inside
-`<c:scaling>`; `<c:majorUnit>` / `<c:minorUnit>` are emitted after
-`<c:crossBetween>` per CT_ValAx) — non-finite numbers, zero/negative
-tick spacings, log bases outside `2..1000`, and `min >= max` ranges
-are filtered out so Excel never sees a value it would reject — and
-`numberFormat: { formatCode, sourceLinked }` emits
-`<c:numFmt formatCode=".." sourceLinked="0|1"/>` between the axis
-title and `<c:crossAx>` (an empty `formatCode` skips emission).
-`majorTickMark` / `minorTickMark` accept `"none"` / `"in"` / `"out"`
-/ `"cross"` (the OOXML `ST_TickMark` enum) and emit
-`<c:majorTickMark val=".."/>` / `<c:minorTickMark val=".."/>` right
-after `<c:numFmt>`; absent fields fall back to Excel's reference
-defaults (`"out"` for major, `"none"` for minor) so a chart that
-omits both renders identically to one a freshly-drawn Excel chart
-would emit. `tickLblPos` accepts `"nextTo"` / `"low"` / `"high"` /
-`"none"` and lands in `<c:tickLblPos val=".."/>` immediately after
-the tick-mark elements — useful for pinning numeric axis labels to
-the chart edge when the value axis crosses elsewhere
-(`tickLblPos: "low"`) or hiding labels entirely
-(`tickLblPos: "none"`). Unknown enum values on either field are
-dropped silently so the writer never emits a token Excel rejects.
-Pie / doughnut charts ignore the entire `axes` field because OOXML
-defines no axes for them.
-`dataLabels: { showValue, showCategoryName, showSeriesName, showPercent, showLegendKey, position, separator }`
-attaches Excel's small in-chart annotations: set at the chart level
-to label every series, or set on a single `series[i].dataLabels` to
-override (passing `false` suppresses labels for that series alone
-even when the chart-level default has them on). `showLegendKey` repeats
-the legend's color swatch inside each label slot (Excel's "Format
-Data Labels -> Legend Key" checkbox); the OOXML default is `false`
-so omit the field for the standard label shape. For doughnut charts,
-`holeSize` (10 – 90, Excel's UI band; default 50) controls the
-diameter of the inner hole — values outside the band are clamped to
-the closest end and non-doughnut kinds silently ignore the field.
-For bar and column charts, `gapWidth` (0 – 500 % of the bar width;
-default `150` for unstacked, omitted for stacked) controls the empty
-space between adjacent category groups and `overlap` (-100..100 %;
-default `0` for clustered, `100` for stacked) controls how series
-within a group separate or stack. Out-of-band values clamp to the
-schema bounds, and non-bar / non-column kinds silently ignore both.
-For pie and doughnut charts, `firstSliceAng` (0 – 360 degrees, default
-0 = 12 o'clock) rotates the first wedge clockwise — useful for
-aligning paired charts in a dashboard. Out-of-band values wrap modulo
-360 (380 → 20, -90 → 270) the same way Excel's chart-formatting pane
-does, and non-pie / non-doughnut kinds silently ignore the field.
-The chart-level `dispBlanksAs` field maps to
-`<c:chart><c:dispBlanksAs val=".."/>` — Excel's "Select Data Source →
-Hidden and Empty Cells" toggle — and accepts `"gap"` (leave a break),
-`"zero"` (drop missing points to the X axis) or `"span"` (connect
-across the gap; line / scatter only). The writer always emits the
-element, defaulting to `"gap"` (the OOXML default Excel itself emits)
-and clamping unknown tokens back to `"gap"` so a malformed input
-cannot produce invalid OOXML.
-The chart-level `varyColors` field maps to `<c:varyColors val=".."/>`
-on the chart-type element — Excel's "Format Data Series → Fill → Vary
-colors by point" toggle. Absent it, the writer falls back to Excel's
-per-family defaults (`true` on pie / doughnut, `false` on bar / column
-/ line / area / scatter), so a fresh chart matches Excel's reference
-serialization. Pin `varyColors: true` on a single-series column or
-bar chart to paint each bar a different color, or pin `false` on a
-doughnut to collapse every wedge to one color (Excel's "single color"
-preset).
-The chart-level `scatterStyle` field maps to `<c:scatterStyle val=".."/>`
-on `<c:scatterChart>` and picks one of Excel's six XY-scatter presets:
-`"none"` / `"marker"` (markers only), `"line"` (straight lines, no
-markers), `"lineMarker"` (Excel's chart-picker default — straight
-lines with markers; the writer's fallback when the field is absent),
-`"smooth"` (smoothed curves, no markers), or `"smoothMarker"`
-(smoothed curves with markers). The element is required by the OOXML
-schema on `<c:scatterChart>` and the writer always emits it; values
-outside the enum fall back to `"lineMarker"` so a malformed input
-cannot produce invalid OOXML. Other chart kinds silently ignore the
-field — the schema places `<c:scatterStyle>` exclusively on
-`<c:scatterChart>`.
-The chart-level `plotVisOnly` field maps to `<c:plotVisOnly val=".."/>`
-on `<c:chart>` — the inverse of Excel's "Hidden and Empty Cells →
-Show data in hidden rows and columns" checkbox. Absent it, the writer
-emits the OOXML default `val="1"` (hidden rows / columns drop out of
-the chart), matching Excel's reference serialization. Pin
-`plotVisOnly: false` to keep hidden helper cells in the rendered
-chart (`val="0"`). The writer always emits the element so the
-rendered intent is explicit on roundtrip — no chart family is special-
-cased.
-The chart-level `showDLblsOverMax` field maps to
-`<c:showDLblsOverMax val=".."/>` on `<c:chart>` — Excel's "Format
-Axis → Labels → Show data labels for values over maximum scale"
-checkbox. Absent it, the writer emits the OOXML default `val="1"`
-(labels render for every point regardless of the axis ceiling),
-matching Excel's reference serialization. Pin `showDLblsOverMax: false`
-to strip labels off any point whose value exceeds the pinned `<c:max>`
-(`val="0"`). The writer always emits the element so the rendered
-intent is explicit on roundtrip — no chart family is special-cased,
-since the toggle lives on `<c:chart>` and is valid on every chart
-family.
-The chart-level `dataTable` field maps to
-`<c:plotArea><c:dTable>...</c:dTable></c:plotArea>` — Excel's "Add
-Chart Element → Data Table" toggle. The field accepts a
-`boolean | ChartDataTable` discriminated union: pass `true` for
-Excel's reference defaults (every border drawn, the outline frame on,
-and the legend keys shown next to each series row), pass an object to
-opt individual children in or out (each field maps to the matching
-`<c:dTable>` boolean child — `showHorzBorder`, `showVertBorder`,
-`showOutline`, `showKeys`), or omit it (or pass `false`) to suppress
-the element entirely. When emitted, the writer always serializes all
-four children in `CT_DTable` schema order, falling back to the OOXML
-reference default `true` for any flag the caller leaves unset. The
-field is silently dropped on `pie` / `doughnut` charts because those
-families have no axes and the OOXML schema places no slot for
-`<c:dTable>` on their plot areas.
-The chart-level `protection` field maps to
-`<c:chartSpace><c:protection>...</c:protection>` — Excel's chart-level
-lock that pairs with the host worksheet's `<sheetProtection>` to
-decide which interactions remain allowed when the parent sheet is
-protected. The field accepts a `boolean | ChartProtection`
-discriminated union: pass `true` for the bare `<c:protection>` shell
-with every flag at the OOXML default `false` (action permitted), pass
-an object to opt individual children in (each field maps to the
-matching `<c:protection>` boolean child — `chartObject`, `data`,
-`formatting`, `selection`, `userInterface`), or omit it (or pass
-`false`) to suppress the element entirely. When emitted, the writer
-always serializes all five children in `CT_Protection` schema order,
-falling back to the OOXML default `false` (action permitted) for any
-flag the caller leaves unset. The element sits on `<c:chartSpace>`
-(not inside `<c:plotArea>`), so every chart family — including pie /
-doughnut — carries a slot for it. Excel only enforces these flags
-when the host worksheet is itself protected; on an unprotected sheet
-the element round-trips literally but has no observable runtime
-effect.
-The chart-level `view3D` field maps to `<c:chart><c:view3D>` (CT_View3D,
-ECMA-376 Part 1, §21.2.2.228) — Excel's "3-D Rotation" pane on 3D
-chart families. The field accepts a `ChartView3D` object with up to
-six independently optional fields (`rotX`, `hPercent`, `rotY`,
-`depthPercent`, `rAngAx`, `perspective`); pass an object to pin any
-subset of the children, pass `{}` to declare a bare `<c:view3D/>`
-shell (useful for round-trip parity with templates that author the
-empty element), or omit the field to suppress the element entirely so
-the writer skips emission and Excel falls back to the per-family
-default. Each numeric field is clamped against the matching OOXML
-simple-type range (`rotX` -90..90, `hPercent` 5..500, `rotY` 0..360,
-`depthPercent` 20..2000, `perspective` 0..240); out-of-range,
-fractional, and non-finite inputs drop silently rather than emit a
-token Excel's strict validator would reject. The writer emits the
-six children in `CT_View3D` schema order, slots the block between
-`<c:autoTitleDeleted>` and `<c:plotArea>` per `CT_Chart`, and accepts
-the element on every chart family — though it is only meaningful on
-3D families (`bar3D`, `line3D`, `pie3D`, `area3D`, `surface3D`); on
-2D families the element round-trips literally but Excel ignores it.
-Useful primarily for round-tripping a 3D template chart through
-`cloneChart`.
-The chart-level `roundedCorners` field maps to
-`<c:roundedCorners val=".."/>` on `<c:chartSpace>` (a sibling of
-`<c:chart>`, not a child) — Excel's "Format Chart Area → Border →
-Rounded corners" toggle. Absent it, the writer emits the OOXML default
-`val="0"` (square chart frame), matching Excel's reference
-serialization. Pin `roundedCorners: true` to soften the chart frame's
-outer edge (`val="1"`). The writer always emits the element so the
-rendered intent is explicit on roundtrip — no chart family is
-special-cased, since the toggle styles the outer wrapper rather than
-any chart-family-specific markup.
-The chart-level `legendOverlay` field maps to `<c:overlay val=".."/>`
-inside `<c:legend>` — Excel's "Format Legend → Show the legend without
-overlapping the chart" toggle (the checkbox is the inverse of this
-flag — checked means `false`, unchecked means `true`). Absent it, the
-writer emits the OOXML default `val="0"` (the legend reserves its own
-slot and the plot area shrinks to make room), matching Excel's
-reference serialization. Pin `legendOverlay: true` to draw the legend
-on top of the plot area so the chart series get the full frame
-(`val="1"`). The flag is silently ignored when `legend: false`
-suppresses the entire legend element — there is no overlay slot on a
-hidden legend, so the writer skips emitting any orphaned `<c:overlay>`.
-The chart-level `legendEntries` field maps to `<c:legendEntry>` children
-inside `<c:legend>` — Excel's "Format Legend Entries → Hide" action
-surfaces the same elements. Each entry pins a 0-based series `idx` and
-a `delete` flag (defaults to `false` — the entry renders); the writer
-emits both `<c:idx>` and `<c:delete>` children explicitly so a re-parse
-sees the canonical CT_LegendEntry shape. Entries whose `idx` is
-non-finite, negative, or non-integer drop at write time rather than emit
-a token Excel rejects, and duplicate `idx` values are deduplicated with
-last-wins semantics so a clone-through that appends an override naturally
-beats the source's parsed value. The writer slots `<c:legendEntry>`
-between `<c:legendPos>` and `<c:overlay>` (CT_Legend sequence) and
-emits entries in ascending `idx` order so the file matches Excel's
-reference serialization. The list is silently ignored when `legend:
-false` suppresses the entire legend element — there is no slot for
-entries on a hidden legend, so the writer skips emission entirely.
-The chart-level `titleOverlay` field maps to `<c:overlay val=".."/>`
-inside `<c:title>` — Excel's "Format Chart Title → Show the title
-without overlapping the chart" toggle (the checkbox is the inverse of
-this flag — checked means `false`, unchecked means `true`). Absent it,
-the writer emits the OOXML default `val="0"` (the title reserves its
-own slot above the plot area and the plot area shrinks to make room),
-matching Excel's reference serialization. Pin `titleOverlay: true` to
-draw the title on top of the plot area so the chart series get the
-full frame (`val="1"`). The flag is silently ignored when no title is
-emitted (no `title` set or `showTitle: false`) — there is no `<c:title>`
-block to host the overlay child in either case. Independent of
-`legendOverlay`: the legend and title `<c:overlay>` elements live on
-different parents, so the two flags compose freely.
-The chart-level `titleRotation` field maps to `<a:bodyPr rot="N"/>`
-inside `<c:title><c:tx><c:rich>` — Excel's "Format Chart Title → Size &
-Properties → Alignment → Custom angle" knob. The OOXML attribute is in
-60000ths of a degree, so `titleRotation: 45` serializes as
-`rot="2700000"` and `titleRotation: -90` as `rot="-5400000"`; the writer
-performs the conversion at emit time. Accepted range: `-90..90` (Excel's
-UI band) — out-of-range inputs clamp to the nearest endpoint, non-integer
-inputs round to the nearest whole degree, and `0` / `NaN` / `Infinity` /
-non-numeric inputs collapse to absence so the writer falls back to the
-OOXML default `rot="0"` (horizontal). The flag is silently ignored when
-no title is emitted (no `title` set or `showTitle: false`) — there is no
-`<c:title>` block to host the rotation in either case. Mirrors the axis-
-side `axes.x.labelRotation` / `axes.y.labelRotation` fields — same
-range, same conversion factor — so a caller can thread a single rotation
-value through both the chart title and an axis label set without
-bookkeeping the units.
-The chart-level `autoTitleDeleted` field maps to
-`<c:autoTitleDeleted val=".."/>` inside `<c:chart>` — Excel's record of
-whether the user explicitly deleted the auto-generated title that
-single-series charts synthesise from the series name. The element sits
-on `<c:chart>` directly (between `<c:title>` and `<c:plotArea>` per
-CT_Chart, ECMA-376 Part 1, §21.2.2.4), not nested inside `<c:title>`,
-and is independent of whether a literal `<c:title>` is emitted. Absent
-it, the writer derives the value from the title presence: a chart with
-a literal title (and `showTitle !== false`) emits `val="0"` so Excel
-keeps the literal visible; a chart with no literal title emits
-`val="1"` so Excel does not silently grow an auto-title from the
-series name. Pin `autoTitleDeleted: true` to suppress Excel's
-auto-title even on a charted dashboard tile that should stay anonymous,
-or `autoTitleDeleted: false` on a titleless single-series column chart
-to let Excel synthesise the series-name title. The writer always emits
-the element so the rendered intent is explicit on roundtrip — Excel
-itself includes it on every reference serialization.
-The chart-level `dropLines` field maps to a bare `<c:dropLines/>`
-inside `<c:lineChart>` / `<c:areaChart>` — Excel's "Add Chart Element
-→ Lines → Drop Lines" toggle (vertical reference lines from each data
-point down to the category axis). Default: `false` — the writer emits
-no element so untouched line / area charts match Excel's reference
-serialization byte-for-byte. Set `true` to paint the connector lines.
-Only literal `true` emits the element; `false`, absence, and
-non-boolean inputs all drop to the default. The flag is silently
-ignored on chart families whose schema rejects `<c:dropLines>` (bar /
-column / pie / doughnut / scatter) — the writer never leaks the element
-into a host that cannot accept it.
-The chart-level `hiLowLines` field maps to a bare `<c:hiLowLines/>`
-inside `<c:lineChart>` only — Excel's "Add Chart Element → Lines →
-High-Low Lines" toggle (vertical connectors between the highest and
-lowest series values at each category position; the same connector
-painted on stock charts). Same default and emit grammar as
-`dropLines`. The element has no slot on `<c:areaChart>` per the OOXML
-schema, so the area writer ignores `hiLowLines` entirely; same for
-bar / column / pie / doughnut / scatter. The two flags compose freely
-on a line chart and the writer pins `<c:dropLines>` before
-`<c:hiLowLines>` to honour the CT_LineChart sequence.
-The chart-level `serLines` field maps to a bare `<c:serLines/>` inside
-`<c:barChart>` — Excel's "Add Chart Element → Lines → Series Lines"
-toggle (connector lines between paired data points across consecutive
-series in a stacked bar / column chart). Same default and emit grammar
-as `dropLines` / `hiLowLines`: only literal `true` emits the element;
-`false`, absence, and non-boolean inputs all drop to the default. The
-flag is silently ignored on chart families whose schema rejects
-`<c:serLines>` (line / pie / doughnut / area / scatter). Excel only
-renders the connectors on the `stacked` / `percentStacked` groupings,
-but the writer honours the toggle on a clustered chart too — the
-element pins, the renderer paints nothing (matches Excel's own
-behavior when the toggle is flipped on a clustered chart). The writer
-slots `<c:serLines>` after `<c:overlap>` (when emitted on a stacked
-chart) and before the first `<c:axId>` to honour the CT_BarChart
-sequence.
-The chart-level `upDownBars` field maps to `<c:upDownBars>` inside
-`<c:lineChart>` — Excel's "Add Chart Element -> Up/Down Bars" toggle
-on a line chart. The element paints a vertical bar at each category
-whose top tracks the higher series value and bottom tracks the lower
-one (typically used to visualize open / close differences on a
-line-style stock chart). The OOXML default is absence, so the writer
-omits the element on a fresh chart. Pin `upDownBars: true` on a
-`type: "line"` chart to emit the element with Excel's reference
-`<c:gapWidth val="150"/>` child. The flag is silently ignored on
-every other chart family — `<c:upDownBars>` lives exclusively on
-`CT_LineChart` / `CT_Line3DChart` / `CT_StockChart` per the OOXML
-schema, and the writer never authors the 3D / stock variants.
-The chart-level `showLineMarkers` field maps to `<c:marker val=".."/>`
-inside `<c:lineChart>` — the chart-level CT_Boolean variant that gates
-whether per-series markers paint at all on a line chart (Excel's
-"Line vs. Line with Markers" chart-type distinction). The writer
-always emits the element (Excel's reference behavior — every authored
-line chart includes one), defaulting to `val="1"` when the field is
-unset or `true`. Pin `showLineMarkers: false` to suppress markers
-chart-wide so the line renders as a clean stroke without the
-per-point dots. The flag is silently ignored on every other chart
-family — the OOXML schema places the chart-level `<c:marker>`
-exclusively on `CT_LineChart`, and `CT_Line3DChart` / `CT_StockChart`
-and every non-line family have no slot for it. Independent of any
-per-series marker styling: this gate sits at the chart level and
-decides whether markers paint, while the per-series block picks the
-symbol / size / fill that paints when the gate is open.
-The `axes.{x,y}.dispUnits` field controls the per-value-axis
-display-unit configuration (`<c:valAx><c:dispUnits>...</c:dispUnits></c:valAx>`)
-— Excel's "Format Axis -> Display units" dropdown. Each numeric tick
-label is divided by the chosen divisor before rendering, so a chart
-whose source range stores raw amounts (e.g. `1_500_000`) can show
-compact tick labels (`1.5` with an optional "Millions" annotation)
-without modifying the underlying cells. Pass a `ChartAxisDispUnit`
-shorthand (e.g. `"millions"`) or a `{ unit?, custUnit?, showLabel? }`
-object: pin `unit` for one of the named OOXML presets, or pin
-`custUnit` for an arbitrary positive divisor (Excel's "Display units →
-Other" path — e.g. `86400` to convert seconds to days). The two
-fields are mutually exclusive in the OOXML schema's `xsd:choice`; when
-both are set, `custUnit` wins on emit so a clone can layer a custom
-divisor on top of an inherited preset without manually pruning the
-original. Set `showLabel: true` to opt into the automatic unit
-annotation (the writer emits a bare `<c:dispUnitsLbl/>` so Excel
-paints its default label alongside the axis). Accepted unit tokens:
-`"hundreds"`, `"thousands"`, `"tenThousands"`, `"hundredThousands"`,
-`"millions"`, `"tenMillions"`, `"hundredMillions"`, `"billions"`,
-`"trillions"`. The OOXML schema places `<c:dispUnits>` exclusively on
-`CT_ValAx`, so the field only takes effect on the value-axis side of
-bar / column / line / area charts (the Y axis) and on both axes of
-scatter charts (both are value axes); category axes (`<c:catAx>`)
-silently drop the field and pie / doughnut have no axes at all.
-Unknown tokens drop silently rather than fabricate a value the OOXML
-`ST_BuiltInUnit` enum would reject; non-positive / non-finite
-`custUnit` values drop at the same boundary. The rich-text
-`<c:dispUnitsLbl>` body is intentionally not surfaced.
-The `axes.{x,y}.crossBetween` field controls the per-value-axis
-cross-between mode (`<c:valAx><c:crossBetween val=".."/></c:valAx>`) —
-the OOXML `ST_CrossBetween` enum that picks between `"between"` (the
-perpendicular axis crosses BETWEEN data points, leaving a half-category
-gap on each end of the plot area; Excel's default on bar / column /
-line / area Y axes) and `"midCat"` (the perpendicular axis crosses AT
-the midpoint of each category, so data points sit ON the
-perpendicular-axis ticks; Excel's default on both scatter axes). The
-writer pins the per-family default when no override is set so untouched
-charts match Excel's reference serialization byte-for-byte; pass
-`crossBetween: "midCat"` on a line / area Y axis to land the first /
-last data point flush with the value-axis line, or `crossBetween:
-"between"` on a scatter axis to leave a margin around the outermost
-points. The OOXML schema places `<c:crossBetween>` exclusively on
-`CT_ValAx`, so category axes (`<c:catAx>`) silently drop the field and
-pie / doughnut have no axes at all. Unknown tokens drop silently rather
-than fabricate a value the enum would reject — the writer falls back to
-the family default in that case.
-The `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` fields thin out a
-crowded category axis (`<c:catAx><c:tickLblSkip val=".."/>` and
-`<c:catAx><c:tickMarkSkip val=".."/>`). Pass a positive integer to
-show every Nth label or mark; the OOXML default `1` (show every tick)
-is omitted from the rendered XML so untouched charts match Excel's
-reference serialization byte-for-byte. Out-of-range values
-(non-positive or > 32767) drop silently rather than clamp. Both
-fields live on category axes only — bar / column / line / area
-honour them; scatter (whose two axes are value axes) and pie /
-doughnut (no axes at all) silently ignore them. Non-integer inputs
-round to the nearest integer.
-The `axes.x.lblOffset` field controls the distance between the tick
-labels and the axis line on a category axis (`<c:catAx><c:lblOffset
-val=".."/>`), expressed as a percentage of Excel's default spacing.
-Pass a value in the `0..1000` band to pull labels in towards the axis
-or push them out. The writer always emits `<c:lblOffset>` because
-Excel's reference serialization includes it on every category axis;
-absence (and the OOXML default `100`) emit `val="100"` so untouched
-charts match the reference output byte-for-byte. Out-of-range values
-(negative or greater than 1000) drop silently rather than clamp — the
-writer falls back to the default `100`. Same scope as the tick skips
-above: bar / column / line / area honour the override; scatter and
-pie / doughnut silently ignore it. Non-integer inputs round to the
-nearest integer.
-The `axes.x.lblAlgn` field pins the horizontal alignment of the tick
-labels along a category axis (`<c:catAx><c:lblAlgn val=".."/>`) —
-Excel's "Format Axis → Alignment → Text alignment" preset. Pass
-`"l"` (flush left), `"r"` (flush right), or `"ctr"` (centered, the
-OOXML default) to override the default; useful when wrapped multi-line
-labels look ragged against a column chart's left-aligned bars. The
-writer always emits `<c:lblAlgn>` because Excel's reference
-serialization includes it on every category axis; absence (and the
-default `"ctr"`) emit `val="ctr"` so untouched charts match the
-reference output byte-for-byte. Unknown tokens (anything outside the
-`ST_LblAlgn` enumeration) drop silently — the writer falls back to
-the default. Same scope as `lblOffset`: bar / column / line / area
-honour the override; scatter and pie / doughnut silently ignore it.
-The per-axis `axes.x.hidden` and `axes.y.hidden` flags toggle
-`<c:catAx><c:delete val=".."/>` / `<c:valAx><c:delete val=".."/>` —
-Excel's "Format Axis -> Show axis" toggle. Set `true` to collapse the
-axis line, tick marks, and tick labels off the rendered chart (handy
-for sparkline-style dashboard tiles). The writer always emits the
-element because Excel's reference serialization includes
-`<c:delete val="0"/>` on every axis; `false` and absence both produce
-that default, while only an explicit `true` emits `val="1"`. The flag
-threads through bar / column / line / area / scatter; pie / doughnut
-silently ignore it because OOXML defines no axes for those families.
-The `axes.x.noMultiLvlLbl` flag maps to
-`<c:catAx><c:noMultiLvlLbl val=".."/>` — Excel's "Format Axis ->
-Multi-level Category Labels" checkbox (the checkbox is the inverse:
-checked means tiered labels, i.e. `noMultiLvlLbl: false`). When a
-category range spans multiple columns / rows Excel groups the labels
-into tiers; setting `true` flattens every category onto a single line
-regardless of the source range's shape. The writer always emits the
-element because Excel's reference serialization includes
-`<c:noMultiLvlLbl val="0"/>` on every category axis; `false`, absence,
-and non-boolean inputs all collapse to the default `val="0"`, while
-only an explicit `true` emits `val="1"`. The element lives on
-`CT_CatAx` exclusively (even `<c:dateAx>`, `<c:valAx>`, and
-`<c:serAx>` reject it), so the flag threads through bar / column /
-line / area but is silently dropped on scatter (both axes are value
-axes) and pie / doughnut (no axes at all).
-The `axes.x.auto` flag maps to `<c:catAx><c:auto val=".."/>` — Excel's
-"Format Axis -> Axis Options -> Axis Type" radio (the "Text axis"
-choice flips the value to `0`). Excel's default `true` lets the
-renderer inspect the axis labels and decide at render time whether to
-treat the axis as a discrete category axis or a chronological date
-axis; `false` pins the axis as a literal category axis so a
-date-shaped category range still renders as a flat category axis
-without any chronological grouping. The writer always emits the
-element because Excel's reference serialization includes
-`<c:auto val="1"/>` on every category axis; `true`, absence, and
-non-boolean inputs all collapse to the default `val="1"`, while only
-an explicit `false` emits `val="0"`. The element lives on `CT_CatAx`
-exclusively (even `<c:dateAx>`, `<c:valAx>`, and `<c:serAx>` reject
-it), so the flag threads through bar / column / line / area but is
-silently dropped on scatter (both axes are value axes) and pie /
-doughnut (no axes at all).
-The `axes.x.labelRotation` and `axes.y.labelRotation` fields pin the
-tick-label rotation in whole degrees, mapping to
-`<c:txPr><a:bodyPr rot="N"/></c:txPr>` on the matching axis — Excel's
-"Format Axis -> Alignment -> Custom angle" knob. The OOXML `rot`
-attribute is in 60000ths of a degree; the writer converts at emit
-time so callers pin the value in degrees. Useful for rotating long
-category labels diagonally so they fit underneath a column chart's
-bars without overlapping their neighbours, or for tilting a value
-axis's number labels when a tight chart frame would otherwise crowd
-them. Range: `-90..90` (Excel's UI band — out-of-range values clamp
-to the nearest endpoint, fractional inputs round to the nearest whole
-degree, non-finite / non-numeric inputs drop). The writer omits the
-entire `<c:txPr>` block on the OOXML default `0` (and on absence) so a
-fresh chart matches Excel's minimal serialization. The element sits on
-every axis flavour per the OOXML schema (`<c:catAx>` / `<c:valAx>` /
-`<c:dateAx>` / `<c:serAx>` all carry an optional `<c:txPr>`), so the
-field threads through every chart family that has axes (bar / column /
-line / area / scatter); pie / doughnut have no axes at all and the
-field is silently dropped there.
-The `axes.x.axisTitleRotation` and `axes.y.axisTitleRotation` fields
-pin the rotation of the axis title in whole degrees, mapping to
-`<c:title><c:tx><c:rich><a:bodyPr rot="N"/></c:rich></c:tx></c:title>`
-on the matching axis — Excel's "Format Axis Title -> Size & Properties
--> Alignment -> Custom angle" knob. Mirrors the chart-level
-`titleRotation` field for axis titles: same `-90..90` band, same
-60000ths-of-a-degree on-the-wire conversion, same `0` / absence /
-non-finite collapse to the OOXML default `rot="0"`. Useful for
-standing the Y-axis title vertically next to the value labels (the
-typical "rotated axis label" dashboard look) or pinning a custom angle
-on a long X-axis title that would otherwise crowd the plot area. The
-field is silently dropped when the matching axis has no title (no
-`<c:title>` block to host the rotation in either case) and on
-`pie` / `doughnut` charts (no axes at all). Out-of-range inputs clamp
-to the nearest endpoint, fractional inputs round to the nearest whole
-degree, and non-finite / non-numeric inputs collapse to absence so a
-corrupt input never leaks through to a token Excel's strict validator
-would reject.
-The `axes.x.reverse` and `axes.y.reverse` flags map to
-`<c:scaling><c:orientation val="maxMin"/></c:scaling>` — Excel's
-"Categories / Values in reverse order" toggle. On a category axis,
-reversing flips the order in which categories are drawn (right-to-left
-on a column chart, top-to-bottom on a bar chart); on a value axis it
-flips the numeric direction so the maximum sits at the origin and the
-minimum at the far end. The writer always emits `<c:orientation>`
-because Excel requires it inside `<c:scaling>`, pinning `"maxMin"` only
-when `reverse === true` — `false`, absent, or non-boolean inputs all
-collapse to the forward `"minMax"` default. Each axis carries its own
-flag so reversing X never propagates to Y. Bar / column / line / area /
-scatter all honour both axes; pie / doughnut silently ignore the entire
-`axes` block since OOXML defines no axes for them.
-The `axes.x.crosses` / `axes.x.crossesAt` (and the matching `axes.y.*`)
-fields control where the perpendicular axis crosses this axis along its
-own range. `crosses` accepts the OOXML `ST_Crosses` tokens
-(`"autoZero"` / `"min"` / `"max"`) — Excel's "Format Axis -> Vertical
-axis crosses" toggle — and `crossesAt` accepts a literal numeric pin
-(useful when the perpendicular axis should cross at a specific value
-like `crossesAt: 100`). The two fields share an XSD choice in the
-schema (only `<c:crosses>` or `<c:crossesAt>` may legally appear at a
-time), so the writer favours `crossesAt` whenever it is set to a
-finite number — including `crossesAt: 0`, which pins the crossing
-point to the numeric value zero, distinct from the `"autoZero"`
-default. Non-finite numeric inputs and unknown semantic tokens drop
-silently to the `"autoZero"` default. The pin threads through bar /
-column / line / area / scatter; pie / doughnut silently ignore it
-because OOXML defines no axes for those families.
-For line and scatter charts, each `series[i].smooth` flag toggles
-Excel's curved-line variant (`<c:smooth val="..">` inside `<c:ser>`).
-Line series always emit the element — `smooth: true` writes `val="1"`,
-absence or `false` writes the OOXML default `val="0"`; scatter series
-only emit `<c:smooth val="1"/>` when `smooth` is explicitly `true` so
-untouched scatter charts stay byte-clean. Bar / column / pie /
-doughnut / area kinds silently ignore the flag.
-For line and scatter charts, each `series[i].marker` block also
-controls the per-point glyph: `symbol`
-(`circle` / `square` / `diamond` / `triangle` / `x` / `star` / `dot` /
-`dash` / `plus` / `auto` / `none`) picks the shape, `size` (2 – 72)
-sets the diameter, and `fill` / `line` (6-digit RGB hex) tint the
-glyph fill and outline. Out-of-range sizes clamp to the schema band,
-unknown symbols and malformed hex values are dropped so Excel never
-receives an attribute it would reject, and an empty marker (`{}`)
-collapses to no `<c:marker>` at all. Bar / column / pie / doughnut /
-area kinds silently ignore the field.
-The same line / scatter series accept a `stroke` block that maps to
-`<c:ser><c:spPr><a:ln>`: `dash` selects a preset pattern (mirroring
-`ST_PresetLineDashVal`: `solid`, `dot`, `dash`, `lgDash`, `dashDot`,
-`lgDashDot`, `lgDashDotDot`, `sysDash`, `sysDot`, `sysDashDot`,
-`sysDashDotDot`) and `width` sets the stroke thickness in points
-(clamped to Excel's 0.25 – 13.5 pt UI band, snapped to the 0.25 pt
-grid, and converted to integer EMU on the wire). The writer layers
-the stroke onto the existing `<c:spPr>` that carries `series.color`
-so a `color + stroke` combo behaves like Excel's UI: the line picks
-up the fill color, and dash / width override visibility-only
-attributes. Bar / column / pie / doughnut / area kinds silently
-ignore the field.
-For bar and column charts, each `series[i].invertIfNegative` flag
-mirrors Excel's "Format Data Series → Fill → Invert if negative"
-toggle (`<c:invertIfNegative val=".."/>` inside `<c:ser>`). The
-writer only emits the element when `invertIfNegative` is explicitly
-`true` — `false` and absence both round-trip as the OOXML default
-(omission), so untouched bar charts stay byte-clean. Line / pie /
-doughnut / area / scatter kinds silently ignore the flag.
-Radar, stock, 3D variants, trendlines, and combo charts are out of
-scope today.
-
-#### Cloning a parsed chart with `cloneChart`
-
-`cloneChart(source, options)` bridges the read-side `Chart` produced by
-`parseChart` to the write-side `SheetChart` consumed by `writeXlsx`, so
-a template workbook can supply the visual styling for a new export and
-the caller only needs to swap the data ranges:
-
-```ts
-import { parseChart, cloneChart, writeXlsx } from "hucre";
-
-const template = parseChart(templateChartXml)!;
-
-const chart = cloneChart(template, {
-  anchor: { from: { row: 14, col: 0 }, to: { row: 28, col: 8 } },
-  title: "Q1 Revenue",
-  seriesOverrides: [{ values: "Dashboard!$B$2:$B$13", color: "1070CA" }],
-});
-
-await writeXlsx({
-  sheets: [{ name: "Dashboard", rows: dashboardRows, charts: [chart] }],
+const out = await writeXlsx({
+  sheets: [{ name: "Sheet1", rows: dashboardRows, charts: [cloned] }],
 });
 ```
 
-`anchor` is required (the read side has no placement metadata).
-Per-series overrides accept `null` to drop an inherited value (e.g.
-`color: null` strips the template tint), can append new series past
-the source length, and fall back to the source's `valuesRef` /
-`categoriesRef` / `name` / `color` when omitted. Source kinds the
-writer can author collapse onto their write counterparts (`bar` /
-`bar3D` → `column`, `pie3D` → `pie`, `doughnut` → `doughnut` (kept as
-its own kind so the hole survives), `line3D` → `line`, `area3D` →
-`area`); kinds with no analog (`bubble`, `radar`, `surface`, `stock`,
-`ofPie`) require an explicit `options.type` override. Axis titles,
-gridlines, scaling, tick-label number format and the tick-rendering
-trio (`majorTickMark` / `minorTickMark` / `tickLblPos`) inherit
-from the source by default; pass `axes: { y: { title: "Revenue" } }`
-to replace one side, `null` to drop an inherited label,
-`axes: { y: { gridlines: { major: true, minor: true } } }` to
-replace inherited gridlines, `axes: { y: { scale: { min: 0, max: 50 } } }`
-to replace the inherited scale wholesale (overrides do **not** merge
-field-by-field — `{ min: 0 }` plus `{ max: 50 }` yields `{ max: 50 }`,
-not `{ min: 0, max: 50 }`), `axes: { y: { numberFormat: { formatCode: "0.00%" } } }`
-to replace the format,
-`axes: { y: { majorTickMark: "cross", tickLblPos: "low" } }` to
-pin the tick-mark style or anchor labels to the chart edge, or
-`null` on any of the seven to drop the inherited value (the writer
-falls back to the OOXML default — `"out"` for major, `"none"` for
-minor, `"nextTo"` for tick labels). The writer drops the entire
-`axes` block automatically when the resolved type is `pie` or
-`doughnut`, so a template that happened to carry stray scale,
-numberFormat or tick values does not poison a pie/doughnut clone. Per-family stacking
-(`barGrouping`, `lineGrouping`, `areaGrouping`) is carried over only
-when the resolved clone target matches that family — flattening a
-stacked line template into a column drops the inherited grouping
-rather than silently emitting a value the writer would ignore.
-Doughnut clones also inherit the parsed `holeSize` from the template;
-pass `holeSize: 60` to override or `type: "pie"` to flatten into a
-plain pie (the hole hint is dropped silently in that case). Pie and
-doughnut clones inherit the parsed `firstSliceAng` from the template;
-the rotation also survives a `type: "pie"` flattening of a doughnut
-source (the element lives on both pie and doughnut), but is dropped
-when the resolved clone target is anything else. Data labels inherit
-too: omit `dataLabels`
-to carry the source's chart-level labels through, pass an object to
-replace, or `null` to drop them; per-series overrides accept the same
-`undefined`/`null`/object grammar plus `false` to suppress labels on
-a single series. Per-series smooth-line state inherits from the
-template by default; `seriesOverrides[i].smooth` accepts the same
-`undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar,
-and the inherited flag is dropped automatically when the resolved
-clone target is anything other than `line` or `scatter`. Per-series
-markers carry over the same way: `seriesOverrides[i].marker` accepts
-`undefined` (inherit), `null` (drop the inherited block), or a
-`ChartMarker` object (replace wholesale — there is no per-field
-merge, so pass every field you want preserved). The inherited block
-is also dropped automatically when the resolved clone target is
-anything other than `line` or `scatter`.
-Per-series line strokes follow the same grammar:
-`seriesOverrides[i].stroke` accepts `undefined` (inherit), `null`
-(drop the inherited `<a:ln>` block), or a `ChartLineStroke` object
-(replace wholesale — `dash` and `width` together, no per-field
-merge). The inherited stroke is also dropped automatically when the
-resolved clone target is anything other than `line` or `scatter`.
-Per-series `invertIfNegative` follows the same grammar:
-`seriesOverrides[i].invertIfNegative` accepts `undefined` (inherit),
-`null` (drop the inherited flag), or a `boolean` (replace). `false`
-collapses to `undefined` for symmetry with the OOXML default — the
-writer omits `<c:invertIfNegative>` either way. The inherited flag
-is also dropped automatically when the resolved clone target is
-anything other than `bar` or `column`, since the schema rejects the
-element on every other chart family.
-The chart-level `dispBlanksAs` follows the standard
-`undefined` (inherit) / `null` (drop the inherited value, falling
-back to the writer's `"gap"` default) / value (`"gap"` / `"zero"` /
-`"span"`) override grammar. Unlike smooth and marker, this field
-lives on `<c:chart>` and is valid on every chart family, so a
-coercion (line → column, doughnut → pie, etc.) preserves the
-inherited value rather than dropping it.
-The chart-level `varyColors` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's per-family default (`true` for pie / doughnut,
-`false` everywhere else), or a `boolean` to replace it. The OOXML
-schema places `<c:varyColors>` on every chart-type element hucre
-authors, so the inherited value carries through every coercion
-(column → pie, doughnut → line, etc.) without being silently dropped.
-The chart-level `scatterStyle` follows the same grammar: pass
-`undefined` to inherit the source's parsed preset, `null` to drop it
-back to the writer's `"lineMarker"` default, or a {@link
-ChartScatterStyle} value to replace it. The inherited value is also
-dropped automatically when the resolved clone target is anything
-other than `scatter`, since the schema rejects `<c:scatterStyle>` on
-every other chart family.
-The chart-level `plotVisOnly` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's OOXML `true` default (hidden cells drop out), or
-a `boolean` to replace it. Like `dispBlanksAs` and `varyColors`, the
-field lives on `<c:chart>` and is valid on every chart family, so a
-coercion (line → column, doughnut → pie, etc.) preserves the
-inherited value rather than dropping it.
-The chart-level `showDLblsOverMax` flag follows the same grammar:
-pass `undefined` to inherit the source's parsed value, `null` to drop
-it back to the writer's OOXML `true` default (labels render for every
-point regardless of axis ceiling), or a `boolean` to replace it. Like
-`plotVisOnly` / `dispBlanksAs`, the field lives on `<c:chart>` and is
-valid on every chart family, so a coercion (line → column, doughnut →
-pie, etc.) preserves the inherited value rather than dropping it.
-The chart-level `dataTable` field follows the standard
-`object | boolean | null` override grammar: pass `undefined` (or omit
-it) to inherit the source's parsed `ChartDataTable`, `null` (or
-`false`) to drop the inherited block so the writer skips `<c:dTable>`
-entirely, `true` to pin every flag to its OOXML default `true`, or a
-`ChartDataTable` object to replace the block wholesale (no per-field
-merge with the source — pass every flag the cloned table should
-render). Unlike the chart-level toggles that live on `<c:chart>`, the
-data-table block lives inside `<c:plotArea>` alongside the axes, so
-the field is silently dropped from the cloned `SheetChart` whenever
-the resolved chart type is `pie` or `doughnut` — those families have
-no axes and the OOXML schema places no slot for the element on their
-plot areas. Coercions between axis-bearing families (line → column,
-scatter → area, etc.) preserve the inherited block.
-The chart-level `protection` field follows the standard
-`object | boolean | null` override grammar: pass `undefined` (or omit
-it) to inherit the source's parsed `ChartProtection`, `null` (or
-`false`) to drop the inherited block so the writer skips
-`<c:protection>` entirely, `true` to pin every flag to its OOXML
-default `false` (the bare `<c:protection>` shell), or a
-`ChartProtection` object to replace the block wholesale (no per-field
-merge with the source — pass every flag the cloned protection should
-pin). Unlike `dataTable`, the field lives on `<c:chartSpace>` (not
-inside `<c:plotArea>`), so every chart family — pie / doughnut
-included — carries a slot for it. Coercions between any chart
-families preserve the inherited block.
-The chart-level `view3D` field follows the standard `object | null`
-override grammar: pass `undefined` (or omit it) to inherit the
-source's parsed `ChartView3D` (defensively shallow-copied so a clone
-mutation never leaks back into the parsed `Chart`), `null` to drop
-the inherited block so the writer skips `<c:view3D>` entirely, or a
-`ChartView3D` object to replace the block wholesale (no per-field
-merge with the source — pass every field the cloned 3D view should
-pin). An empty object (`{}`) collapses to a bare `<c:view3D/>` shell
-on emit. Unlike `dataTable`, the field lives on `<c:chart>` (not
-inside `<c:plotArea>`), so every chart family — pie / doughnut
-included — carries a slot for it. Coercions between any chart
-families (line → column, doughnut → pie, etc.) preserve the inherited
-block, mirroring how `protection` composes across the type-coercion
-flow.
-The chart-level `roundedCorners` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's OOXML `false` default (square chart frame), or a
-`boolean` to replace it. Like `plotVisOnly` / `varyColors`, the field
-lives on `<c:chartSpace>` and is valid on every chart family, so a
-coercion (line → column, doughnut → pie, etc.) preserves the
-inherited value rather than dropping it.
-The chart-level `legendOverlay` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's OOXML `false` default (no overlap with the plot
-area), or a `boolean` to replace it. The flag lives on `<c:legend>` so
-the field is valid on every chart family, but it is silently dropped
-from the cloned `SheetChart` whenever the resolved `legend` is `false`
-— a hidden legend has no overlay slot in the rendered chart, so an
-inherited `true` would carry no on-screen effect. Re-enabling a hidden
-source legend through `legend: "top"` (or any visible position) on the
-override re-opens the slot, and an explicit `legendOverlay: true`
-override threads through.
-The chart-level `legendEntries` list follows the same `undefined`
-(inherit) / `null` (drop) / `array` (replace) grammar as the other
-list-shaped overrides. An empty-array override collapses to `undefined`
-just like `null` because the writer skips emission for empty lists,
-matching Excel's omit-default serialization. The list lives on
-`<c:legend>` so the field is valid on every chart family, but it is
-silently dropped from the cloned `SheetChart` whenever the resolved
-`legend` is `false` — a hidden legend has no slot for entries in the
-rendered chart, so inherited overrides would carry no on-screen effect.
-Each inherited entry is defensively copied so a downstream mutation to
-the cloned `SheetChart` never leaks back into the parsed `Chart` the
-caller passed in. Re-enabling a hidden source legend through `legend:
-"top"` (or any visible position) on the override re-opens the slot, and
-an explicit `legendEntries: [...]` override threads through.
-The chart-level `titleOverlay` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's OOXML `false` default (no overlap with the plot
-area), or a `boolean` to replace it. The flag lives on `<c:title>` so
-the field is valid on every chart family, but it is silently dropped
-from the cloned `SheetChart` whenever the resolved chart renders no
-title (`title` resolved to `undefined` or `showTitle: false`) — there
-is no `<c:title>` block to host the overlay flag in either case.
-Re-introducing a missing source title through an explicit `title:
-"..."` override re-opens the slot, and an explicit `titleOverlay: true`
-override threads through.
-The chart-level `titleRotation` field follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's OOXML `0` default (horizontal title), or a
-`number` to replace it. Out-of-range overrides clamp to the `-90..90`
-band Excel's UI exposes; non-integer overrides round to the nearest
-whole degree; `0` / `NaN` / `Infinity` / non-numeric overrides collapse
-to a drop so the cloned `SheetChart` always carries a value the writer
-will accept. Same scope rule as `titleOverlay`: the rotation lives on
-`<c:title>` so the field is valid on every chart family, but it is
-silently dropped from the cloned `SheetChart` whenever the resolved
-chart renders no title — there is no `<a:bodyPr rot="N"/>` slot to host
-the rotation in either case.
-The per-axis `axes.x.axisTitleRotation` and `axes.y.axisTitleRotation`
-fields follow the same grammar: pass `undefined` to inherit the source
-axis's parsed rotation, `null` to drop it back to the writer's OOXML
-`0` default (horizontal axis title), or a `number` to replace it.
-Range, clamp, rounding, and non-finite-collapse semantics mirror the
-chart-level `titleRotation` knob exactly, so a single rotation value
-threads cleanly through both the chart title and either axis title.
-The override is silently dropped from the cloned `SheetChart` whenever
-the resolved axis title is unset (no `<c:title>` block to host the
-rotation) and on `pie` / `doughnut` charts (no axes at all). Re-
-introducing a missing axis title through an explicit
-`axes.x.title: "..."` override re-opens the slot for the matching
-`axisTitleRotation` to take effect.
-The chart-level `autoTitleDeleted` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's title-presence-derived default, or a `boolean` to
-replace it. Unlike `titleOverlay`, this flag is independent of the
-resolved title presence — `<c:autoTitleDeleted>` sits on `<c:chart>`
-directly (not nested inside `<c:title>`), so a clone with no literal
-title can still pin `false` to let Excel synthesise the series-name
-auto-title and a clone with a literal title can pin `true` to suppress
-the synthesis even though the literal renders. The override carries
-through every chart family because the element has no per-family
-restriction in the OOXML schema.
-The chart-level `dropLines` and `hiLowLines` flags follow the same
-`undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar
-as the other chart-level toggles. An override of `false` is equivalent
-to `null` — the writer treats both as the OOXML default of no element,
-so the cloned `SheetChart` collapses both shapes to `undefined`.
-Non-boolean overrides drop rather than fall through to the inherited
-value. Both flags are silently dropped from the cloned `SheetChart`
-when the resolved clone target's chart-type element has no slot for
-the corresponding OOXML element: `dropLines` carries through line ↔
-area coercions but flattens on bar / column / pie / doughnut /
-scatter clones, while `hiLowLines` carries through line resolutions
-only and flattens on every other family (including area, where
-`<c:hiLowLines>` has no schema slot). Flattening a line template into
-a column clone therefore never leaks the connector lines into a host
-that cannot host them.
-The chart-level `upDownBars` flag follows the same grammar: pass
-`undefined` to inherit the source's parsed value, `null` to drop it
-back to the writer's OOXML default (no `<c:upDownBars>` element), or a
-`boolean` to replace it. The element renders inside `<c:lineChart>`
-so the field is silently dropped from the cloned `SheetChart`
-whenever the resolved chart type is anything but `line` — flattening
-a stock or line template into a column / pie / doughnut / area /
-scatter clone therefore never leaks a stale up / down bars block into
-a chart-type element whose schema rejects the element.
-The chart-level `serLines` flag follows the same `undefined` (inherit)
-/ `null` (drop) / `boolean` (replace) grammar as the other connector-
-line toggles. An override of `false` is equivalent to `null` — the
-writer treats both as the OOXML default of no element. The element
-renders inside `<c:barChart>` so the field is silently dropped from
-the cloned `SheetChart` whenever the resolved chart type is anything
-other than `bar` / `column` — flattening a stacked-bar template into a
-line / area / pie / doughnut / scatter clone therefore never leaks the
-series-line connectors into a chart-type element whose schema rejects
-the element. The flag does carry through the bar ↔ column coercion
-unchanged (both write to `<c:barChart>` with a different `barDir`).
-The chart-level `showLineMarkers` flag follows the same grammar:
-`undefined` inherits, `null` drops the inherited value (the writer
-falls back to Excel's default `<c:marker val="1"/>`), and a `boolean`
-replaces it. Like `upDownBars`, the element renders exclusively
-inside `<c:lineChart>` per the OOXML schema, so the field is silently
-dropped from the cloned `SheetChart` whenever the resolved chart
-type is anything but `line` — flattening a line template into a
-column / pie / doughnut / area / scatter clone never leaks the
-chart-level marker gate into a host that cannot carry it.
-The per-axis `axes.x.tickLblSkip` and `axes.x.tickMarkSkip` overrides
-follow the same `undefined` (inherit) / `null` (drop) / number
-(replace) grammar as `gridlines` / `scale` / `numberFormat`. The
-inherited values are dropped silently when the resolved clone target
-is `scatter` (its X axis is a value axis, so the skip would have no
-slot in the rendered chart) and when the target is `pie` or
-`doughnut` (no axes at all) — flattening a column template into a
-scatter clone therefore never leaks a stale catAx skip into the
-output.
-The per-axis `axes.x.lblOffset` override follows the same `undefined`
-(inherit) / `null` (drop) / number (replace) grammar. An explicit
-override of `100` (the OOXML default) collapses to `undefined` so it
-behaves identically to `null` — both leave the cloned chart with
-Excel's default label spacing. Same scope-restriction as the tick
-skips: the inherited offset is dropped silently when the resolved
-clone target is `scatter` or `pie` / `doughnut`, so flattening a
-column template into a scatter clone never leaks a stale catAx offset
-into the output.
-The per-axis `axes.x.lblAlgn` override follows the same `undefined`
-(inherit) / `null` (drop) / token (replace) grammar. An explicit
-override of `"ctr"` (the OOXML default) collapses to `undefined` so
-it behaves identically to `null` — both leave the cloned chart with
-Excel's default centered alignment. Unknown tokens drop rather than
-fall through, so a malformed override surfaces as "no alignment
-emitted" instead of silently snapping to the default. Same scope-
-restriction as `lblOffset`: the inherited alignment is dropped
-silently when the resolved clone target is `scatter` or `pie` /
-`doughnut`, so flattening a column template into a scatter clone
-never leaks a stale catAx alignment into the output.
-The per-axis `axes.x.hidden` and `axes.y.hidden` overrides follow the
-same `undefined` (inherit) / `null` (drop) / `boolean` (replace)
-grammar. Because `<c:delete>` lives on every axis flavour, the flag
-threads through every coercion that has axes (bar / column / line /
-area / scatter); pie / doughnut clones drop the entire `axes` block
-because OOXML defines no axes for them. An override of `false` is
-equivalent to `null` — the writer treats both as the OOXML default
-`val="0"`, so the cloned `SheetChart` collapses both shapes to
-`undefined`.
-The per-axis `axes.x.noMultiLvlLbl` override follows the same
-`undefined` (inherit) / `null` (drop) / `boolean` (replace) grammar.
-Because `<c:noMultiLvlLbl>` lives exclusively on `CT_CatAx`, the flag
-threads through bar / column / line / area coercions but is dropped
-silently when the resolved clone target is `scatter` (its X axis is a
-value axis, so the element has no slot) or `pie` / `doughnut` (no
-axes at all) — flattening a column template into a scatter clone
-therefore never leaks a stale catAx flag into the output. An override
-of `false` is equivalent to `null` — the writer treats both as the
-OOXML default `val="0"`, so the cloned `SheetChart` collapses both
-shapes to `undefined`. Non-boolean overrides drop rather than fall
-through to the inherited value.
-The per-axis `axes.x.reverse` / `axes.y.reverse` overrides follow the
-same `undefined` (inherit) / `null` (drop) / boolean (replace) grammar
-as the other axis fields. A literal `false` override behaves
-identically to `null` because the OOXML default and an explicit
-`false` produce the same forward `"minMax"` orientation on the wire.
-The inherited flag is dropped silently when the resolved clone target
-is `pie` or `doughnut` so flattening a bar template into a pie clone
-never leaks a stale orientation into the output.
-The per-axis `axes.x.crosses` / `axes.x.crossesAt` (and the matching
-`axes.y.*`) overrides follow the same `undefined` (inherit) / `null`
-(drop) / value (replace) grammar as the other axis fields, applied
-independently to each side of the XSD choice between `<c:crosses>` and
-`<c:crossesAt>`. The writer enforces the schema's mutual exclusion
-downstream by preferring the numeric pin when both fields are set —
-inheriting `crosses: "max"` and overriding only `crossesAt: 50`
-therefore leaves the numeric pin in the cloned shape and surfaces the
-inherited semantic value alongside it; the writer picks `crossesAt`,
-matching how the parser handles the same pair on a malformed input.
-Drop only one side by passing `null`; the other side then inherits
-normally. The inherited pin is dropped silently when the resolved
-clone target is `pie` or `doughnut` because OOXML defines no axes for
-those families.
+A common pattern is "template -> override -> write" — keep one
+chart-of-each-flavour template and use `cloneChart` to spawn many
+variants without re-encoding the whole `<c:chartSpace>` tree by
+hand. See [`CloneChartOptions` in
+`src/xlsx/chart-clone.ts`](./src/xlsx/chart-clone.ts) for the full
+override surface (every knob on `SheetChart` has a matching
+`undefined | null | value` override field).
 
-#### Walking and adding charts with `getCharts` / `addChart`
-
-`getCharts(workbook)` flattens every chart anchored on the workbook's
-sheets into a single array, attaching the sheet name and indexes so
-callers don't have to walk `workbook.sheets[].charts` themselves.
-`addChart(sheet, chart)` is the symmetric writer-side helper that
-appends a `SheetChart` to a `WriteSheet`, lazily allocating the
-`charts` array on the first call:
+#### Walking and adding charts
 
 ```ts
 import { addChart, getCharts, openXlsx, writeXlsx } from "hucre";
 
-// Read side — find every chart in a template workbook.
 const wb = await openXlsx(templateBytes);
+
+// Read side — find every chart in a template workbook.
 for (const { sheetName, chart } of getCharts(wb)) {
   console.log(sheetName, chart.kinds, chart.title);
 }

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -995,6 +995,46 @@ export interface ChartDataLabels {
    * {@link fontColor} / {@link fontFamily} / {@link fillColor}.
    */
   borderColor?: string;
+  /**
+   * Data-labels border (stroke) thickness in points (e.g. `1.5`). Maps
+   * to the `w` attribute on `<c:dLbls><c:spPr><a:ln w="EMU">` — Excel's
+   * "Format Data Labels -> Border -> Width" spinner. The OOXML `w`
+   * attribute carries the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24). The writer multiplies by 12 700 and rounds to the
+   * nearest integer because the schema types `w` as `xsd:int`.
+   *
+   * Accepts any finite number; values are clamped to the `0.25..13.5`
+   * pt band Excel's UI exposes (the same band used by every other
+   * chart-frame border-width knob) and snapped to the 0.25 pt grid so
+   * a parsed-then-written width does not drift across round-trips.
+   * Non-finite / non-numeric / `NaN` values collapse to `undefined`
+   * and the writer omits the `w` attribute (the line keeps Excel's
+   * auto-thickness — typically 0.75 pt).
+   *
+   * Default: omitted — the data-label border inherits Excel's
+   * auto-thickness.
+   *
+   * Composes independently with {@link borderColor} — the width
+   * attribute lands on the same `<a:ln>` element as the color's
+   * `<a:solidFill>` child, but the writer authors `<a:ln>` whenever
+   * either knob is set.
+   */
+  borderWidth?: number;
+  /**
+   * Data-labels border (stroke) preset dash pattern. Maps to the `val`
+   * attribute on `<c:dLbls><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Mirrors Excel's "Format Data Labels -> Border -> Dash type"
+   * picker. Same {@link ChartBorderDash} accept-or-drop grammar as the
+   * chart-level {@link SheetChart.plotAreaBorderDash} — `"solid"`
+   * collapses to `undefined` so absence and the OOXML default
+   * round-trip identically.
+   *
+   * Composes independently with {@link borderColor} and
+   * {@link borderWidth} — all three knobs share the same `<a:ln>`
+   * element.
+   */
+  borderDash?: ChartBorderDash;
 }
 
 /**
@@ -1017,6 +1057,32 @@ export type ChartLineDashStyle =
   | "sysDot"
   | "sysDashDot"
   | "sysDashDotDot";
+
+/**
+ * Preset dash pattern for a chart-frame border stroke (plot-area /
+ * legend / title / chart-space / axis-title / data-table / data-label
+ * borders). Mirrors the OOXML `ST_PresetLineDashVal` enum exactly —
+ * the same set of preset patterns the per-series
+ * {@link ChartLineDashStyle} carries — but lands on `<c:spPr><a:ln>
+ * <a:prstDash val="..">` for chart-frame borders.
+ *
+ * The OOXML default is `"solid"` (no `<a:prstDash>` child); the writer
+ * omits the element when `"solid"` (or `undefined`) is passed so a
+ * fresh chart matches Excel's reference shape byte-for-byte. Excel
+ * ignores any unrecognized value.
+ */
+export type ChartBorderDash =
+  | "solid"
+  | "dash"
+  | "dashDot"
+  | "dot"
+  | "lgDash"
+  | "lgDashDot"
+  | "lgDashDotDot"
+  | "sysDash"
+  | "sysDashDot"
+  | "sysDashDotDot"
+  | "sysDot";
 
 /**
  * Per-series line stroke styling for line / scatter charts.
@@ -1542,6 +1608,51 @@ export interface ChartDataTable {
    * pie / doughnut along with the rest of the data-table configuration.
    */
   borderColor?: string;
+  /**
+   * Data-table border (stroke) thickness in points (e.g. `1.5`). Maps
+   * to the `w` attribute on `<c:dTable><c:spPr><a:ln w="EMU">` — Excel's
+   * "Format Data Table -> Border -> Width" spinner. The OOXML `w`
+   * attribute carries the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24). The writer multiplies by 12 700 and rounds to the
+   * nearest integer because the schema types `w` as `xsd:int`.
+   *
+   * Accepts any finite number; values are clamped to the `0.25..13.5`
+   * pt band Excel's UI exposes (the same band used by every other
+   * chart-frame border-width knob) and snapped to the 0.25 pt grid so
+   * a parsed-then-written width does not drift across round-trips.
+   * Non-finite / non-numeric / `NaN` values collapse to `undefined`
+   * and the writer omits the `w` attribute (the line keeps Excel's
+   * auto-thickness — typically 0.75 pt).
+   *
+   * Default: omitted — the data-table border inherits Excel's
+   * auto-thickness.
+   *
+   * Composes independently with {@link borderColor} — the width
+   * attribute lands on the same `<a:ln>` element as the color's
+   * `<a:solidFill>` child, but the writer authors `<a:ln>` whenever
+   * either knob is set.
+   *
+   * Only meaningful for chart families with axes; silently dropped on
+   * pie / doughnut along with the rest of the data-table configuration.
+   */
+  borderWidth?: number;
+  /**
+   * Data-table border (stroke) preset dash pattern. Maps to the `val`
+   * attribute on `<c:dTable><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Mirrors Excel's "Format Data Table -> Border -> Dash type" picker.
+   * Same {@link ChartBorderDash} accept-or-drop grammar as the
+   * chart-level {@link SheetChart.plotAreaBorderDash} — `"solid"`
+   * collapses to `undefined` so absence and the OOXML default
+   * round-trip identically.
+   *
+   * Composes independently with {@link borderColor} and
+   * {@link borderWidth} — all three knobs share the same `<a:ln>`
+   * element. Only meaningful for chart families with axes; silently
+   * dropped on pie / doughnut along with the rest of the data-table
+   * configuration.
+   */
+  borderDash?: ChartBorderDash;
 }
 
 /**
@@ -2509,6 +2620,20 @@ export interface SheetChart {
    */
   legendBorderWidth?: number;
   /**
+   * Chart legend border (stroke) preset dash pattern. Maps to the
+   * `val` attribute on `<c:legend><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Mirrors Excel's "Format Legend -> Border -> Dash type" picker. Same
+   * {@link ChartBorderDash} accept-or-drop grammar as
+   * {@link plotAreaBorderDash} — `"solid"` collapses to `undefined`
+   * so absence and the OOXML default round-trip identically.
+   *
+   * Composes independently with {@link legendBorderColor} and
+   * {@link legendBorderWidth} — all three knobs share the same `<a:ln>`
+   * element. Silently ignored when `legend === false` (no `<c:legend>`
+   * element is emitted).
+   */
+  legendBorderDash?: ChartBorderDash;
+  /**
    * Custom plot-area placement inside the chart frame. Maps to
    * `<c:plotArea><c:layout><c:manualLayout>...</c:manualLayout></c:layout>
    * </c:plotArea>` — Excel's "Format Plot Area -> Position -> Custom"
@@ -2670,6 +2795,34 @@ export interface SheetChart {
    */
   plotAreaBorderWidth?: number;
   /**
+   * Plot-area border (stroke) preset dash pattern. Maps to the `val`
+   * attribute on `<c:plotArea><c:spPr><a:ln><a:prstDash val=".."/>` —
+   * Excel's "Format Plot Area -> Border -> Dash type" picker. The OOXML
+   * `<a:prstDash>` element carries the `ST_PresetLineDashVal` enum on
+   * `CT_PresetLineDashProperties` (ECMA-376 Part 1, §20.1.8.48). Per
+   * `CT_LineProperties` schema sequence (§20.1.2.3.24), `<a:prstDash>`
+   * follows `<a:solidFill>` and precedes `<a:headEnd>` / `<a:tailEnd>`.
+   *
+   * Accepts any {@link ChartBorderDash} value; `"solid"` (the OOXML
+   * default) collapses to `undefined` for round-trip symmetry — the
+   * writer skips the `<a:prstDash>` element entirely so a fresh plot
+   * area matches Excel's reference shape byte-for-byte. Unrecognized
+   * tokens drop to `undefined` rather than fabricate a value Excel
+   * would reject.
+   *
+   * Default: omitted — the border renders solid. Pin a value to dash /
+   * dot the plot-area border, useful for distinguishing the inner band
+   * from the outer chart frame.
+   *
+   * Composes independently with {@link plotAreaBorderColor} and
+   * {@link plotAreaBorderWidth} — all three knobs land on the same
+   * `<a:ln>` element but on different children / attributes (the color
+   * `<a:solidFill>` child, the `w` attribute, and the dash
+   * `<a:prstDash>` child); the writer authors `<a:ln>` whenever any
+   * of them is set.
+   */
+  plotAreaBorderDash?: ChartBorderDash;
+  /**
    * Chart-space (entire chart background) solid fill color as a 6-digit
    * RGB hex string (e.g. `"F2F2F2"`). Maps to `<c:chartSpace><c:spPr>
    * <a:solidFill><a:srgbClr val="RRGGBB"/></a:solidFill></c:spPr>
@@ -2764,6 +2917,60 @@ export interface SheetChart {
    * hex string through every `<a:ln>`-based stroke slot.
    */
   chartSpaceBorderColor?: string;
+  /**
+   * Chart-space (entire chart frame) border (stroke) thickness in
+   * points (e.g. `1.5`). Maps to the `w` attribute on
+   * `<c:chartSpace><c:spPr><a:ln w="EMU">` — Excel's "Format Chart
+   * Area -> Border -> Width" spinner (the same dialog the user reaches
+   * by right-clicking the chart's outer frame). The OOXML `w`
+   * attribute carries the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24). The writer multiplies the input by 12 700 and rounds
+   * to the nearest integer because the schema types `w` as `xsd:int`.
+   *
+   * Accepts any finite number; values are clamped to the `0.25..13.5`
+   * pt band Excel's UI exposes (the same band used by
+   * {@link plotAreaBorderWidth} / {@link legendBorderWidth} /
+   * {@link titleBorderWidth} / the series stroke knob) and snapped to
+   * the 0.25 pt grid so a parsed-then-written width does not drift
+   * across round-trips. Non-finite / non-numeric / `NaN` values
+   * collapse to `undefined` and the writer omits the `w` attribute
+   * (the line keeps Excel's auto-thickness — typically 0.75 pt).
+   *
+   * Default: omitted — the chart-frame border inherits Excel's
+   * auto-thickness.
+   *
+   * Composes independently with {@link chartSpaceBorderColor} — the
+   * width attribute lands on the same `<a:ln>` element as the color's
+   * `<a:solidFill>` child, but the writer authors `<a:ln>` whenever
+   * either knob is set. A caller can pin a width without a color (the
+   * border picks Excel's auto-color), pin a color without a width (the
+   * border picks Excel's auto-thickness), or pin both. Setting only
+   * the width is valid Excel UI — the user can drag the "Width"
+   * spinner without picking a custom color.
+   *
+   * Mirrors {@link plotAreaBorderWidth} / {@link legendBorderWidth} /
+   * {@link titleBorderWidth} — same accept-finite-number / clamp /
+   * snap grammar, same `<a:ln w="EMU">` host attribute on a different
+   * parent (`<c:chartSpace>` rather than `<c:plotArea>` / `<c:legend>`
+   * / `<c:title>`).
+   */
+  chartSpaceBorderWidth?: number;
+  /**
+   * Chart-space (entire chart frame) border (stroke) preset dash
+   * pattern. Maps to the `val` attribute on `<c:chartSpace><c:spPr>
+   * <a:ln><a:prstDash val=".."/>`. Mirrors Excel's "Format Chart Area
+   * -> Border -> Dash type" picker. Same {@link ChartBorderDash}
+   * accept-or-drop grammar as {@link plotAreaBorderDash} — `"solid"`
+   * collapses to `undefined` so absence and the OOXML default round-
+   * trip identically.
+   *
+   * Composes independently with {@link chartSpaceBorderColor} and
+   * {@link chartSpaceBorderWidth} — all three knobs share the same
+   * `<a:ln>` element. Mirrors {@link plotAreaBorderDash} and lands on
+   * `<c:chartSpace>`'s own `<c:spPr>` block.
+   */
+  chartSpaceBorderDash?: ChartBorderDash;
   /** Show the chart-level title element. Default: `true` when `title` is set. */
   showTitle?: boolean;
   /**
@@ -3268,6 +3475,20 @@ export interface SheetChart {
    * compose the same way at the call site.
    */
   titleBorderWidth?: number;
+  /**
+   * Chart title border (stroke) preset dash pattern. Maps to the `val`
+   * attribute on `<c:title><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Mirrors Excel's "Format Chart Title -> Border -> Dash type" picker.
+   * Same {@link ChartBorderDash} accept-or-drop grammar as
+   * {@link plotAreaBorderDash} — `"solid"` collapses to `undefined`
+   * so absence and the OOXML default round-trip identically.
+   *
+   * Composes independently with {@link titleBorderColor} and
+   * {@link titleBorderWidth} — all three knobs share the same `<a:ln>`
+   * element. Silently ignored when no title is rendered
+   * (`showTitle === false` or `title` is absent).
+   */
+  titleBorderDash?: ChartBorderDash;
   /**
    * Auto-title-deleted flag. Maps to `<c:chart><c:autoTitleDeleted
    * val=".."/>` — Excel's record of whether the user explicitly deleted
@@ -4355,6 +4576,56 @@ export interface SheetChart {
        * area / scatter).
        */
       axisTitleBorderColor?: string;
+      /**
+       * Axis-title border (stroke) thickness in points (e.g. `1.5`).
+       * Maps to the `w` attribute on `<c:catAx><c:title><c:spPr>
+       * <a:ln w="EMU">` (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`).
+       * Mirrors Excel's "Format Axis Title -> Border -> Width"
+       * spinner. The OOXML `w` attribute carries the stroke width in
+       * English Metric Units (1 pt = 12 700 EMU) per
+       * `CT_LineProperties` (ECMA-376 Part 1, §20.1.2.3.24); the
+       * writer multiplies by 12 700 and rounds to the nearest integer
+       * because the schema types `w` as `xsd:int`.
+       *
+       * Accepts any finite number; values are clamped to the
+       * `0.25..13.5` pt band Excel's UI exposes (the same band used by
+       * {@link SheetChart.plotAreaBorderWidth} / {@link SheetChart.legendBorderWidth} /
+       * {@link SheetChart.titleBorderWidth} / the series stroke knob)
+       * and snapped to the 0.25 pt grid so a parsed-then-written width
+       * does not drift across round-trips. Non-finite / non-numeric /
+       * `NaN` values collapse to `undefined` and the writer omits the
+       * `w` attribute (the line keeps Excel's auto-thickness —
+       * typically 0.75 pt).
+       *
+       * Default: omitted — the border inherits Excel's auto-thickness.
+       *
+       * Composes independently with {@link axisTitleBorderColor} —
+       * the width attribute lands on the same `<a:ln>` element as the
+       * color's `<a:solidFill>` child, but the writer authors `<a:ln>`
+       * whenever either knob is set.
+       *
+       * Silently dropped when the axis renders no title (no `<c:title>`
+       * to host `<c:spPr>`) and on `pie` / `doughnut` charts (no axes
+       * at all).
+       */
+      axisTitleBorderWidth?: number;
+      /**
+       * Axis-title border (stroke) preset dash pattern. Maps to the
+       * `val` attribute on `<c:catAx><c:title><c:spPr><a:ln>
+       * <a:prstDash val=".."/>` (or `<c:valAx>` / `<c:dateAx>` /
+       * `<c:serAx>`). Mirrors Excel's "Format Axis Title -> Border ->
+       * Dash type" picker. Same {@link ChartBorderDash}
+       * accept-or-drop grammar as the chart-level
+       * {@link SheetChart.titleBorderDash} — `"solid"` collapses to
+       * `undefined` so absence and the OOXML default round-trip
+       * identically.
+       *
+       * Composes independently with {@link axisTitleBorderColor} and
+       * {@link axisTitleBorderWidth} — all three knobs share the same
+       * `<a:ln>` element. Silently dropped when the axis renders no
+       * title and on `pie` / `doughnut` charts.
+       */
+      axisTitleBorderDash?: ChartBorderDash;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -5140,6 +5411,22 @@ export interface SheetChart {
        * `<c:catAx>`. See the X-axis variant for the full semantics.
        */
       axisTitleBorderColor?: string;
+      /**
+       * Value-axis-title border (stroke) thickness in points. Same
+       * canonical `<c:title><c:spPr><a:ln w="EMU">` slot and grammar
+       * as {@link SheetChart.axes.x.axisTitleBorderWidth} — the field
+       * round-trips on `<c:valAx>` exactly as it does on `<c:catAx>`.
+       * See the X-axis variant for the full semantics.
+       */
+      axisTitleBorderWidth?: number;
+      /**
+       * Value-axis-title border (stroke) preset dash pattern. Same
+       * canonical `<c:title><c:spPr><a:ln><a:prstDash val=".."/>` slot
+       * and grammar as {@link SheetChart.axes.x.axisTitleBorderDash} —
+       * the field round-trips on `<c:valAx>` exactly as it does on
+       * `<c:catAx>`. See the X-axis variant for the full semantics.
+       */
+      axisTitleBorderDash?: ChartBorderDash;
       gridlines?: ChartAxisGridlines;
       scale?: ChartAxisScale;
       numberFormat?: ChartAxisNumberFormat;
@@ -6269,6 +6556,36 @@ export interface ChartDataLabelsInfo {
    * conflict.
    */
   borderColor?: string;
+  /**
+   * Data-labels border (stroke) thickness in points pulled from the
+   * `w` attribute on `<c:dLbls><c:spPr><a:ln w="EMU">`. Reflects
+   * Excel's "Format Data Labels -> Border -> Width" spinner. The OOXML
+   * `w` attribute carries the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24); the reader divides by 12 700 and snaps to the
+   * 0.25 pt grid Excel's UI exposes so a parsed-then-cloned width
+   * does not drift across round-trips.
+   *
+   * Reports the point value clamped to the `0.25..13.5` pt band Excel
+   * accepts in the UI when the source labels pinned a finite, positive
+   * `w` attribute. Absence (no `<a:ln>` or no `w` attribute), zero,
+   * negative, and non-numeric `w` values all collapse to `undefined`
+   * so absence and an unrenderable width round-trip identically through
+   * {@link cloneChart}. Mirrors the writer-side
+   * {@link ChartDataLabels.borderWidth} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   */
+  borderWidth?: number;
+  /**
+   * Data-labels border (stroke) preset dash pattern pulled from the
+   * `val` attribute on `<c:dLbls><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Reflects Excel's "Format Data Labels -> Border -> Dash type"
+   * picker. Reports the {@link ChartBorderDash} value pinned by the
+   * source, or `undefined` when the element is absent / the OOXML
+   * default `"solid"` was authored / the value is unrecognized. Mirrors
+   * the writer-side {@link ChartDataLabels.borderDash}.
+   */
+  borderDash?: ChartBorderDash;
 }
 
 /**
@@ -6996,6 +7313,49 @@ export interface ChartAxisInfo {
    * of whether the source axis was a category or value axis.
    */
   axisTitleBorderColor?: string;
+  /**
+   * Axis-title border (stroke) thickness in points pulled from the
+   * `w` attribute on `<c:catAx><c:title><c:spPr><a:ln w="EMU">` (or
+   * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`). Reflects Excel's
+   * "Format Axis Title -> Border -> Width" spinner. The OOXML `w`
+   * attribute stores the stroke width in English Metric Units
+   * (1 pt = 12 700 EMU) per `CT_LineProperties` (ECMA-376 Part 1,
+   * §20.1.2.3.24); the reader divides by 12 700 and snaps the result
+   * to the 0.25 pt grid Excel's UI exposes so a parsed-then-cloned
+   * width does not drift across round-trips.
+   *
+   * Reports the point value clamped to the `0.25..13.5` pt band
+   * Excel accepts in the UI when the source axis pinned a finite,
+   * positive `w` attribute. Absence (no `<a:ln>` or no `w`
+   * attribute), zero, negative, and non-numeric `w` values all
+   * collapse to `undefined` so absence and an unrenderable width
+   * round-trip identically through {@link cloneChart}. Mirrors the
+   * writer-side {@link SheetChart.axes.x.axisTitleBorderWidth} so a
+   * parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   *
+   * Reported as `undefined` whenever the axis omits `<c:title>`
+   * entirely. Composes independently with {@link axisTitleBorderColor} —
+   * both fields surface from the same `<a:ln>` element but on a
+   * different slot (color child vs the width attribute). Mirrors the
+   * chart-level {@link Chart.titleBorderWidth} on a different host
+   * element.
+   */
+  axisTitleBorderWidth?: number;
+  /**
+   * Axis-title border (stroke) preset dash pattern pulled from the
+   * `val` attribute on `<c:catAx><c:title><c:spPr><a:ln><a:prstDash
+   * val=".."/>` (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`). Reflects
+   * Excel's "Format Axis Title -> Border -> Dash type" picker. Reports
+   * the {@link ChartBorderDash} value pinned by the source, or
+   * `undefined` when the element is absent / the OOXML default
+   * `"solid"` was authored / the value is unrecognized.
+   *
+   * Mirrors the writer-side {@link SheetChart.axes.x.axisTitleBorderDash}
+   * so a parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   */
+  axisTitleBorderDash?: ChartBorderDash;
   /**
    * Major / minor gridline visibility. Omitted when neither
    * `<c:majorGridlines>` nor `<c:minorGridlines>` is declared on the
@@ -7765,6 +8125,19 @@ export interface Chart {
    */
   legendBorderWidth?: number;
   /**
+   * Chart legend border (stroke) preset dash pattern pulled from the
+   * `val` attribute on `<c:legend><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Reflects Excel's "Format Legend -> Border -> Dash type" picker.
+   * Reports the {@link ChartBorderDash} value pinned by the source, or
+   * `undefined` when the element is absent / the OOXML default
+   * `"solid"` was authored / the value is unrecognized.
+   *
+   * Mirrors the writer-side {@link SheetChart.legendBorderDash} so a
+   * parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   */
+  legendBorderDash?: ChartBorderDash;
+  /**
    * Custom plot-area placement pulled from `<c:plotArea><c:layout>
    * <c:manualLayout>...</c:manualLayout></c:layout></c:plotArea>`.
    * Reflects Excel's "Format Plot Area -> Position -> Custom" placement —
@@ -7880,6 +8253,20 @@ export interface Chart {
    */
   plotAreaBorderWidth?: number;
   /**
+   * Plot-area border (stroke) preset dash pattern pulled from the
+   * `val` attribute on `<c:plotArea><c:spPr><a:ln><a:prstDash
+   * val=".."/>`. Reflects Excel's "Format Plot Area -> Border -> Dash
+   * type" picker. Reports the {@link ChartBorderDash} value that the
+   * source chart pinned, or `undefined` when the element is absent /
+   * the source chart authored the OOXML default `"solid"` / the value
+   * is unrecognized.
+   *
+   * Mirrors the writer-side {@link SheetChart.plotAreaBorderDash} so a
+   * parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   */
+  plotAreaBorderDash?: ChartBorderDash;
+  /**
    * Chart-space (entire chart background) solid fill color pulled
    * from `<c:chartSpace><c:spPr><a:solidFill><a:srgbClr val=".."/>
    * </a:solidFill></c:spPr></c:chartSpace>`. Reflects Excel's
@@ -7948,6 +8335,51 @@ export interface Chart {
    * a series) cannot leak into this field.
    */
   chartSpaceBorderColor?: string;
+  /**
+   * Chart-space (entire chart frame) border (stroke) thickness in
+   * points pulled from the `w` attribute on `<c:chartSpace><c:spPr>
+   * <a:ln w="EMU">`. Reflects Excel's "Format Chart Area -> Border ->
+   * Width" spinner. The OOXML `w` attribute stores the stroke width
+   * in English Metric Units (1 pt = 12 700 EMU) per
+   * `CT_LineProperties` (ECMA-376 Part 1, §20.1.2.3.24); the reader
+   * divides by 12 700 and snaps the result to the 0.25 pt grid Excel's
+   * UI exposes so a parsed-then-cloned width does not drift across
+   * round-trips.
+   *
+   * Reports the point value clamped to the `0.25..13.5` pt band Excel
+   * accepts in the UI when the source chart pinned a finite, positive
+   * `w` attribute. Absence (no `<a:ln>` or no `w` attribute), zero,
+   * negative, and non-numeric `w` values all collapse to `undefined`
+   * so absence and an unrenderable width round-trip identically
+   * through {@link cloneChart}. Mirrors the writer-side
+   * {@link SheetChart.chartSpaceBorderWidth} so a parsed value slots
+   * straight into {@link cloneChart} without conversion.
+   *
+   * Reported as `undefined` whenever the source chart has no
+   * `<c:chartSpace><c:spPr>` block at all — there is no `<a:ln>` slot
+   * to surface the width from in that case. Composes independently
+   * with {@link chartSpaceBorderColor} — both fields surface from the
+   * same `<a:ln>` element but on a different slot (the color child
+   * versus the width attribute). Mirrors {@link plotAreaBorderWidth} /
+   * {@link legendBorderWidth} / {@link titleBorderWidth} — same EMU
+   * encoding, same `<a:ln>` host — but lands on `<c:chartSpace>`'s own
+   * `<c:spPr>` block.
+   */
+  chartSpaceBorderWidth?: number;
+  /**
+   * Chart-space (entire chart frame) border (stroke) preset dash
+   * pattern pulled from the `val` attribute on `<c:chartSpace><c:spPr>
+   * <a:ln><a:prstDash val=".."/>`. Reflects Excel's "Format Chart Area
+   * -> Border -> Dash type" picker. Reports the {@link ChartBorderDash}
+   * value that the source chart pinned, or `undefined` when the element
+   * is absent / the source chart authored the OOXML default `"solid"` /
+   * the value is unrecognized.
+   *
+   * Mirrors the writer-side {@link SheetChart.chartSpaceBorderDash} so
+   * a parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   */
+  chartSpaceBorderDash?: ChartBorderDash;
   /**
    * Title-overlay flag pulled from `<c:title><c:overlay val=".."/>`.
    * Reflects Excel's "Format Chart Title -> Show the title without
@@ -8292,6 +8724,19 @@ export interface Chart {
    * but lands on `<c:title>`'s own `<c:spPr>` block.
    */
   titleBorderWidth?: number;
+  /**
+   * Chart title border (stroke) preset dash pattern pulled from the
+   * `val` attribute on `<c:title><c:spPr><a:ln><a:prstDash val=".."/>`.
+   * Reflects Excel's "Format Chart Title -> Border -> Dash type"
+   * picker. Reports the {@link ChartBorderDash} value pinned by the
+   * source, or `undefined` when the element is absent / the OOXML
+   * default `"solid"` was authored / the value is unrecognized.
+   *
+   * Mirrors the writer-side {@link SheetChart.titleBorderDash} so a
+   * parsed value slots straight into {@link cloneChart} without
+   * conversion.
+   */
+  titleBorderDash?: ChartBorderDash;
   /**
    * Auto-title-deleted flag pulled from `<c:chart><c:autoTitleDeleted
    * val=".."/>`. Reflects Excel's "the user explicitly deleted the

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -22,6 +22,7 @@ import type {
   ChartAxisScale,
   ChartAxisTickLabelPosition,
   ChartAxisTickMark,
+  ChartBorderDash,
   ChartDataLabels,
   ChartDataLabelsInfo,
   ChartDataTable,
@@ -447,6 +448,17 @@ export interface CloneChartOptions {
    */
   legendBorderWidth?: number | null;
   /**
+   * Override `SheetChart.legendBorderDash`. `undefined` (or omitted)
+   * inherits the source's parsed dash; `null` drops the inherited
+   * dash (the writer renders solid); a {@link ChartBorderDash} value
+   * replaces it.
+   *
+   * Composes independently with `legendBorderColor` and
+   * `legendBorderWidth`. Silently dropped from the cloned `SheetChart`
+   * when the resolved legend is `false`.
+   */
+  legendBorderDash?: ChartBorderDash | null;
+  /**
    * Override `SheetChart.plotAreaLayout`. `undefined` (or omitted)
    * inherits the source's parsed `plotAreaLayout`; `null` drops the
    * inherited layout (the writer emits the bare `<c:layout/>`
@@ -542,6 +554,19 @@ export interface CloneChartOptions {
    */
   plotAreaBorderWidth?: number | null;
   /**
+   * Override `SheetChart.plotAreaBorderDash`. `undefined` (or omitted)
+   * inherits the source's parsed dash; `null` drops the inherited
+   * dash (the writer renders solid); a {@link ChartBorderDash} value
+   * replaces it. Unrecognized tokens (and the OOXML default `"solid"`)
+   * collapse to `undefined` so the cloned `SheetChart` drops the field.
+   *
+   * Composes independently with `plotAreaBorderColor` and
+   * `plotAreaBorderWidth` — all three knobs share the same `<a:ln>`
+   * element. Like the color / width knobs, the dash is never gated on
+   * a visibility flag — every chart has a `<c:plotArea>` element.
+   */
+  plotAreaBorderDash?: ChartBorderDash | null;
+  /**
    * Override `SheetChart.chartSpaceFillColor`. `undefined` (or omitted)
    * inherits the source's parsed `chartSpaceFillColor`; `null` drops
    * the inherited fill (the writer emits no `<c:spPr>` block on
@@ -593,6 +618,27 @@ export interface CloneChartOptions {
    * a `<c:chartSpace>` document root to host the stroke.
    */
   chartSpaceBorderColor?: string | null;
+  /**
+   * Override `SheetChart.chartSpaceBorderWidth`. `undefined` (or
+   * omitted) inherits the source's parsed width; `null` drops the
+   * inherited width (the writer emits `<a:ln>` without a `w` attribute,
+   * the line keeps Excel's auto-thickness — typically 0.75 pt); a
+   * finite point value (e.g. `1.5`) replaces it. Values are clamped
+   * to the `0.25..13.5` pt band Excel's UI exposes and snapped to the
+   * 0.25 pt grid; non-finite / non-numeric overrides collapse to
+   * `undefined`. Composes independently with `chartSpaceBorderColor`
+   * and `chartSpaceBorderDash` — all three knobs share the same
+   * `<a:ln>` element.
+   */
+  chartSpaceBorderWidth?: number | null;
+  /**
+   * Override `SheetChart.chartSpaceBorderDash`. `undefined` (or
+   * omitted) inherits the source's parsed dash style; `null` drops
+   * the inherited dash (the writer renders solid); a
+   * {@link ChartBorderDash} value replaces it. Unrecognized tokens
+   * (and the OOXML default `"solid"`) collapse to `undefined`.
+   */
+  chartSpaceBorderDash?: ChartBorderDash | null;
   /** Override `SheetChart.barGrouping`. */
   barGrouping?: SheetChart["barGrouping"];
   /**
@@ -949,6 +995,19 @@ export interface CloneChartOptions {
    * title's own `<c:spPr>` block.
    */
   titleBorderWidth?: number | null;
+  /**
+   * Override `SheetChart.titleBorderDash`. `undefined` (or omitted)
+   * inherits the source's parsed dash; `null` drops the inherited
+   * dash (the writer renders solid); a {@link ChartBorderDash} value
+   * replaces it. Unrecognized tokens (and the OOXML default `"solid"`)
+   * collapse to `undefined`.
+   *
+   * Composes independently with `titleBorderColor` and
+   * `titleBorderWidth` — all three knobs share the same `<a:ln>`
+   * element. Silently dropped from the cloned `SheetChart` when the
+   * resolved chart renders no title.
+   */
+  titleBorderDash?: ChartBorderDash | null;
   /**
    * Override `<c:autoTitleDeleted>` (the "user explicitly deleted the
    * auto-generated title" flag).
@@ -1619,6 +1678,24 @@ export interface CloneChartOptions {
        * canonical OOXML slots.
        */
       axisTitleBorderColor?: string | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleBorderWidth`. Same
+       * `undefined` / `null` / number grammar as the chart-level
+       * `titleBorderWidth` knob — values are clamped to the
+       * `0.25..13.5` pt band Excel's UI exposes and snapped to the
+       * 0.25 pt grid; non-finite / non-numeric overrides collapse to
+       * `undefined`. Silently dropped on `pie` / `doughnut` charts
+       * (no axes) and on any axis whose `title` is unset.
+       */
+      axisTitleBorderWidth?: number | null;
+      /**
+       * Override `SheetChart.axes.x.axisTitleBorderDash`. Same
+       * `undefined` / `null` / value grammar as the chart-level
+       * `titleBorderDash` knob — `"solid"` and unrecognized tokens
+       * collapse to `undefined`. Silently dropped on `pie` /
+       * `doughnut` charts and on any axis whose `title` is unset.
+       */
+      axisTitleBorderDash?: ChartBorderDash | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -1965,6 +2042,10 @@ export interface CloneChartOptions {
       axisTitleFillColor?: string | null;
       /** See {@link CloneChartOptions.axes.x.axisTitleBorderColor}. */
       axisTitleBorderColor?: string | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleBorderWidth}. */
+      axisTitleBorderWidth?: number | null;
+      /** See {@link CloneChartOptions.axes.x.axisTitleBorderDash}. */
+      axisTitleBorderDash?: ChartBorderDash | null;
       gridlines?: ChartAxisGridlines | null;
       scale?: ChartAxisScale | null;
       numberFormat?: ChartAxisNumberFormat | null;
@@ -2272,6 +2353,16 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     if (resolvedLegendBorderWidth !== undefined) {
       out.legendBorderWidth = resolvedLegendBorderWidth;
     }
+
+    // Legend border preset dash pattern — same hidden-legend scoping
+    // as the color / width knobs above.
+    const resolvedLegendBorderDash = resolveBorderDash(
+      source.legendBorderDash,
+      options.legendBorderDash,
+    );
+    if (resolvedLegendBorderDash !== undefined) {
+      out.legendBorderDash = resolvedLegendBorderDash;
+    }
   }
 
   // Plot-area manual layout is independent of the legend visibility —
@@ -2340,6 +2431,18 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
     out.plotAreaBorderWidth = resolvedPlotAreaBorderWidth;
   }
 
+  // Plot-area border preset dash pattern. Same `<a:ln>` host as the
+  // color and width knobs above, but lands on the `<a:prstDash>` child.
+  // `"solid"` collapses to `undefined` so absence and the OOXML default
+  // round-trip identically.
+  const resolvedPlotAreaBorderDash = resolveBorderDash(
+    source.plotAreaBorderDash,
+    options.plotAreaBorderDash,
+  );
+  if (resolvedPlotAreaBorderDash !== undefined) {
+    out.plotAreaBorderDash = resolvedPlotAreaBorderDash;
+  }
+
   // Chart-space solid fill color is independent of every visibility
   // flag — every chart has a `<c:chartSpace>` document root to host the
   // `<c:spPr>` slot. `undefined` inherits the source's parsed
@@ -2378,6 +2481,35 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   );
   if (resolvedChartSpaceBorderColor !== undefined) {
     out.chartSpaceBorderColor = resolvedChartSpaceBorderColor;
+  }
+
+  // Chart-space border (stroke) thickness shares the same `<a:ln>`
+  // host as the color knob above, but lands on the `w` attribute
+  // rather than the `<a:solidFill>` child. Independent of every
+  // visibility flag — every chart has a `<c:chartSpace>` document root
+  // to host the slot. `undefined` inherits the source's parsed width
+  // (after clamp / snap), `null` drops the inherited width (the writer
+  // omits the `w` attribute, the line keeps Excel's auto-thickness),
+  // a finite number replaces it. Composes independently with
+  // `chartSpaceBorderColor` and `chartSpaceBorderDash`.
+  const resolvedChartSpaceBorderWidth = resolveBorderWidthPt(
+    source.chartSpaceBorderWidth,
+    options.chartSpaceBorderWidth,
+  );
+  if (resolvedChartSpaceBorderWidth !== undefined) {
+    out.chartSpaceBorderWidth = resolvedChartSpaceBorderWidth;
+  }
+
+  // Chart-space border preset dash pattern. Same `<a:ln>` host as the
+  // color and width knobs above, but lands on the `<a:prstDash>` child.
+  // `"solid"` collapses to `undefined` so absence and the OOXML default
+  // round-trip identically.
+  const resolvedChartSpaceBorderDash = resolveBorderDash(
+    source.chartSpaceBorderDash,
+    options.chartSpaceBorderDash,
+  );
+  if (resolvedChartSpaceBorderDash !== undefined) {
+    out.chartSpaceBorderDash = resolvedChartSpaceBorderDash;
   }
 
   const barGrouping = options.barGrouping !== undefined ? options.barGrouping : source.barGrouping;
@@ -2646,6 +2778,19 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
       options.titleBorderWidth,
     );
     if (resolvedTitleBorderWidth !== undefined) out.titleBorderWidth = resolvedTitleBorderWidth;
+
+    // Title border preset dash pattern. Same hidden-title scoping as
+    // the border color / width knobs above — the writer drops the
+    // dash when no title is rendered. `undefined` inherits the
+    // source's parsed dash, `null` drops the inherited dash (the
+    // writer renders solid), a {@link ChartBorderDash} value replaces
+    // it. Unrecognized tokens (and the OOXML default `"solid"`)
+    // collapse to `undefined` via the shared normalizer.
+    const resolvedTitleBorderDash = resolveBorderDash(
+      source.titleBorderDash,
+      options.titleBorderDash,
+    );
+    if (resolvedTitleBorderDash !== undefined) out.titleBorderDash = resolvedTitleBorderDash;
   }
 
   // `<c:autoTitleDeleted>` sits on `<c:chart>` directly, not inside
@@ -4449,6 +4594,109 @@ function resolveChartSpaceBorderColor(
   return normalizeChartSpaceBorderColor(override);
 }
 
+const BORDER_WIDTH_MIN_PT = 0.25;
+const BORDER_WIDTH_MAX_PT = 13.5;
+
+/**
+ * Normalize a chart-frame border-width value (points) for the cloned
+ * `SheetChart`. Mirrors the writer's `clampStrokeWidthPt` — values are
+ * clamped to the `0.25..13.5` pt band Excel's UI exposes and snapped
+ * to the 0.25 pt grid so a parsed-then-cloned-then-written width does
+ * not drift across round-trips. Non-finite / non-numeric tokens
+ * (`NaN`, `Infinity`, strings, escapes from an untyped caller) collapse
+ * to `undefined` so the cloned chart drops the field rather than carry
+ * a value the writer would silently elide back to absence. Used by
+ * every chart-frame border-width slot — chart-space, axis-title, data
+ * table, data labels — alongside the host-specific normalizers
+ * inherited from the earlier plot-area / legend / title surface.
+ */
+function normalizeBorderWidthPt(value: number | undefined): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const snapped = Math.round(value * 4) / 4;
+  if (snapped < BORDER_WIDTH_MIN_PT) return BORDER_WIDTH_MIN_PT;
+  if (snapped > BORDER_WIDTH_MAX_PT) return BORDER_WIDTH_MAX_PT;
+  return snapped;
+}
+
+/**
+ * Resolve a chart-frame border-width override.
+ *
+ * `undefined` → inherit the source value (after running it through
+ *               {@link normalizeBorderWidthPt} so a malformed source
+ *               value drops cleanly).
+ * `null`      → drop the inherited width (the writer emits `<a:ln>`
+ *               without a `w` attribute, the line keeps Excel's
+ *               auto-thickness).
+ * `number`    → replace with the clamped / snapped point value.
+ *               Non-finite / non-numeric overrides collapse to
+ *               `undefined` via the normalizer.
+ *
+ * Used by every chart-frame border-width slot the clone surface
+ * exposes — chart-space, axis-title, data table, data labels — and
+ * mirrors the existing host-specific resolvers for plot-area / legend /
+ * title border widths.
+ */
+function resolveBorderWidthPt(
+  sourceValue: number | undefined,
+  override: number | null | undefined,
+): number | undefined {
+  if (override === undefined) return normalizeBorderWidthPt(sourceValue);
+  if (override === null) return undefined;
+  return normalizeBorderWidthPt(override);
+}
+
+const VALID_BORDER_DASHES_CLONE: ReadonlySet<ChartBorderDash> = new Set([
+  "solid",
+  "dash",
+  "dashDot",
+  "dot",
+  "lgDash",
+  "lgDashDot",
+  "lgDashDotDot",
+  "sysDash",
+  "sysDashDot",
+  "sysDashDotDot",
+  "sysDot",
+]);
+
+/**
+ * Normalize a chart-frame border-dash value for the cloned
+ * `SheetChart`. Mirrors the writer's `normalizeBorderDash` — drops the
+ * OOXML default `"solid"` to `undefined` so absence and the default
+ * round-trip identically, and drops every unrecognized
+ * `ST_PresetLineDashVal` token so a malformed source / override does
+ * not surface a value Excel would reject. Used by every chart-frame
+ * border-dash slot — plot-area, legend, title, chart-space, axis-title,
+ * data table, data labels.
+ */
+function normalizeBorderDash(value: ChartBorderDash | undefined): ChartBorderDash | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") return undefined;
+  if (!VALID_BORDER_DASHES_CLONE.has(value)) return undefined;
+  if (value === "solid") return undefined;
+  return value;
+}
+
+/**
+ * Resolve a chart-frame border-dash override.
+ *
+ * `undefined` → inherit the source value (after running it through
+ *               {@link normalizeBorderDash}).
+ * `null`      → drop the inherited dash (the writer renders solid).
+ * value       → replace with the normalized dash. Unrecognized tokens
+ *               and the OOXML default `"solid"` collapse to
+ *               `undefined`.
+ */
+function resolveBorderDash(
+  sourceValue: ChartBorderDash | undefined,
+  override: ChartBorderDash | null | undefined,
+): ChartBorderDash | undefined {
+  if (override === undefined) return normalizeBorderDash(sourceValue);
+  if (override === null) return undefined;
+  return normalizeBorderDash(override);
+}
+
 /**
  * Resolve a `titleOverlay` override.
  *
@@ -5363,6 +5611,32 @@ function resolveAxes(
     sourceAxes?.y?.axisTitleBorderColor,
     overrides?.y?.axisTitleBorderColor,
   );
+  // `<c:title><c:spPr><a:ln w="EMU"/></c:spPr></c:title>` —
+  // axis-title border (line stroke) thickness. Reuse the shared
+  // {@link resolveBorderWidthPt} helper so the snap / clamp grammar
+  // matches every other chart-frame border-width slot. Like every
+  // other axis-title knob, the writer drops the width when the
+  // matching axis title is unset, so a stray pin on an axis with no
+  // title silently disappears at emit time.
+  const xAxisTitleBorderWidth = resolveBorderWidthPt(
+    sourceAxes?.x?.axisTitleBorderWidth,
+    overrides?.x?.axisTitleBorderWidth,
+  );
+  const yAxisTitleBorderWidth = resolveBorderWidthPt(
+    sourceAxes?.y?.axisTitleBorderWidth,
+    overrides?.y?.axisTitleBorderWidth,
+  );
+  // `<c:title><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+  // </c:title>` — axis-title border preset dash pattern. Same accept-
+  // or-drop grammar as every other chart-frame border-dash slot.
+  const xAxisTitleBorderDash = resolveBorderDash(
+    sourceAxes?.x?.axisTitleBorderDash,
+    overrides?.x?.axisTitleBorderDash,
+  );
+  const yAxisTitleBorderDash = resolveBorderDash(
+    sourceAxes?.y?.axisTitleBorderDash,
+    overrides?.y?.axisTitleBorderDash,
+  );
   const xGridlines = applyGridlinesOverride(sourceAxes?.x?.gridlines, overrides?.x?.gridlines);
   const yGridlines = applyGridlinesOverride(sourceAxes?.y?.gridlines, overrides?.y?.gridlines);
   const xScale = applyScaleOverride(sourceAxes?.x?.scale, overrides?.x?.scale);
@@ -5678,6 +5952,13 @@ function resolveAxes(
   // both the fill and border are absent).
   const xAxisTitleBorderColorResolved = xTitle === undefined ? undefined : xAxisTitleBorderColor;
   const yAxisTitleBorderColorResolved = yTitle === undefined ? undefined : yAxisTitleBorderColor;
+  // Same hidden-axis-title scoping as the color knob — drop the
+  // inherited width / dash on an axis whose title is unset so the
+  // cloned `SheetChart` accurately reflects what the chart will paint.
+  const xAxisTitleBorderWidthResolved = xTitle === undefined ? undefined : xAxisTitleBorderWidth;
+  const yAxisTitleBorderWidthResolved = yTitle === undefined ? undefined : yAxisTitleBorderWidth;
+  const xAxisTitleBorderDashResolved = xTitle === undefined ? undefined : xAxisTitleBorderDash;
+  const yAxisTitleBorderDashResolved = yTitle === undefined ? undefined : yAxisTitleBorderDash;
 
   const out: NonNullable<SheetChart["axes"]> = {};
   if (
@@ -5694,6 +5975,8 @@ function resolveAxes(
     xAxisTitleLayoutResolved !== undefined ||
     xAxisTitleFillColorResolved !== undefined ||
     xAxisTitleBorderColorResolved !== undefined ||
+    xAxisTitleBorderWidthResolved !== undefined ||
+    xAxisTitleBorderDashResolved !== undefined ||
     xGridlines !== undefined ||
     xScale !== undefined ||
     xNumFmt !== undefined ||
@@ -5741,6 +6024,10 @@ function resolveAxes(
       out.x.axisTitleFillColor = xAxisTitleFillColorResolved;
     if (xAxisTitleBorderColorResolved !== undefined)
       out.x.axisTitleBorderColor = xAxisTitleBorderColorResolved;
+    if (xAxisTitleBorderWidthResolved !== undefined)
+      out.x.axisTitleBorderWidth = xAxisTitleBorderWidthResolved;
+    if (xAxisTitleBorderDashResolved !== undefined)
+      out.x.axisTitleBorderDash = xAxisTitleBorderDashResolved;
     if (xGridlines !== undefined) out.x.gridlines = xGridlines;
     if (xScale !== undefined) out.x.scale = xScale;
     if (xNumFmt !== undefined) out.x.numberFormat = xNumFmt;
@@ -5782,6 +6069,8 @@ function resolveAxes(
     yAxisTitleLayoutResolved !== undefined ||
     yAxisTitleFillColorResolved !== undefined ||
     yAxisTitleBorderColorResolved !== undefined ||
+    yAxisTitleBorderWidthResolved !== undefined ||
+    yAxisTitleBorderDashResolved !== undefined ||
     yGridlines !== undefined ||
     yScale !== undefined ||
     yNumFmt !== undefined ||
@@ -5823,6 +6112,10 @@ function resolveAxes(
       out.y.axisTitleFillColor = yAxisTitleFillColorResolved;
     if (yAxisTitleBorderColorResolved !== undefined)
       out.y.axisTitleBorderColor = yAxisTitleBorderColorResolved;
+    if (yAxisTitleBorderWidthResolved !== undefined)
+      out.y.axisTitleBorderWidth = yAxisTitleBorderWidthResolved;
+    if (yAxisTitleBorderDashResolved !== undefined)
+      out.y.axisTitleBorderDash = yAxisTitleBorderDashResolved;
     if (yGridlines !== undefined) out.y.gridlines = yGridlines;
     if (yScale !== undefined) out.y.scale = yScale;
     if (yNumFmt !== undefined) out.y.numberFormat = yNumFmt;

--- a/src/xlsx/chart-reader.ts
+++ b/src/xlsx/chart-reader.ts
@@ -26,6 +26,7 @@ import type {
   ChartAxisTickLabelPosition,
   ChartAxisTickMark,
   ChartBarGrouping,
+  ChartBorderDash,
   ChartDataLabelPosition,
   ChartDataLabelsInfo,
   ChartDataTable,
@@ -257,6 +258,16 @@ export function parseChart(xml: string): Chart | undefined {
   // line, plot-area / legend border) cannot leak into this field.
   const titleBorderWidth = parseTitleBorderWidth(chartEl);
   if (titleBorderWidth !== undefined) out.titleBorderWidth = titleBorderWidth;
+
+  // `<c:title><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+  // </c:title>` carries Excel's "Format Chart Title -> Border -> Dash
+  // type" pin. Same accept-or-drop grammar as every other chart-frame
+  // border-dash slot — `"solid"` collapses to `undefined` so absence
+  // and the OOXML default round-trip identically. Scoped to the
+  // title's `<c:spPr>` so a stray `<a:prstDash>` elsewhere cannot leak
+  // in.
+  const titleBorderDash = parseTitleBorderDash(chartEl);
+  if (titleBorderDash !== undefined) out.titleBorderDash = titleBorderDash;
 
   // `<c:autoTitleDeleted>` records whether the user explicitly deleted
   // the auto-generated title — independent of whether a literal
@@ -509,6 +520,13 @@ export function parseChart(xml: string): Chart | undefined {
     // axis line) cannot leak into this field.
     const plotAreaBorderWidth = parsePlotAreaBorderWidth(plotArea);
     if (plotAreaBorderWidth !== undefined) out.plotAreaBorderWidth = plotAreaBorderWidth;
+
+    // `<c:plotArea><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+    // </c:plotArea>` carries Excel's "Format Plot Area -> Border ->
+    // Dash type" pin. Same accept-or-drop grammar as every other
+    // chart-frame border-dash slot.
+    const plotAreaBorderDash = parseBorderDashFromSpPr(plotArea);
+    if (plotAreaBorderDash !== undefined) out.plotAreaBorderDash = plotAreaBorderDash;
   }
 
   const legend = parseLegend(chartEl);
@@ -631,6 +649,13 @@ export function parseChart(xml: string): Chart | undefined {
     // knobs.
     const legendBorderWidth = parseLegendBorderWidth(chartEl);
     if (legendBorderWidth !== undefined) out.legendBorderWidth = legendBorderWidth;
+
+    // `<c:legend><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+    // </c:legend>` carries Excel's "Format Legend -> Border -> Dash
+    // type" pin. Same accept-or-drop grammar as every other chart-
+    // frame border-dash slot.
+    const legendBorderDash = parseLegendBorderDash(chartEl);
+    if (legendBorderDash !== undefined) out.legendBorderDash = legendBorderDash;
   }
 
   const dispBlanksAs = parseDispBlanksAs(chartEl);
@@ -759,6 +784,22 @@ export function parseChart(xml: string): Chart | undefined {
   // round-trip never fabricates a stroke Excel cannot render.
   const chartSpaceBorderColor = parseChartSpaceBorderColor(chartSpace);
   if (chartSpaceBorderColor !== undefined) out.chartSpaceBorderColor = chartSpaceBorderColor;
+
+  // `<c:chartSpace><c:spPr><a:ln w="EMU">` carries Excel's "Format
+  // Chart Area -> Border -> Width" pin. Same EMU encoding and clamp /
+  // snap grammar as every other chart-frame border-width slot. Scoped
+  // to direct children of `<c:chartSpace>` so a stray `<a:ln w=..>`
+  // elsewhere cannot leak in.
+  const chartSpaceBorderWidth = parseBorderWidthFromSpPr(chartSpace);
+  if (chartSpaceBorderWidth !== undefined) out.chartSpaceBorderWidth = chartSpaceBorderWidth;
+
+  // `<c:chartSpace><c:spPr><a:ln><a:prstDash val=".."/>` carries
+  // Excel's "Format Chart Area -> Border -> Dash type" pin. Same
+  // accept-or-drop grammar as every other chart-frame border-dash
+  // slot — `"solid"` collapses to `undefined` so absence and the OOXML
+  // default round-trip identically.
+  const chartSpaceBorderDash = parseBorderDashFromSpPr(chartSpace);
+  if (chartSpaceBorderDash !== undefined) out.chartSpaceBorderDash = chartSpaceBorderDash;
 
   return out;
 }
@@ -982,6 +1023,19 @@ function parseAxisInfo(
   // three readers walk disjoint paths so a caller can pin all three
   // knobs without conflict.
   const axisTitleBorderColor = parseAxisTitleBorderColor(axis);
+  // `<c:catAx><c:title><c:spPr><a:ln w="EMU"/>` (or `<c:valAx>` /
+  // `<c:dateAx>` / `<c:serAx>`) carries Excel's "Format Axis Title ->
+  // Border -> Width" pin. Same EMU encoding and clamp / snap grammar
+  // as every other chart-frame border-width slot. Independent of
+  // `axisTitleBorderColor` (color child) and `axisTitleBorderDash`
+  // (`<a:prstDash>` child) — the three readers walk disjoint slots of
+  // the shared `<a:ln>` element so a caller can pin all three knobs
+  // without conflict.
+  const axisTitleBorderWidth = parseAxisTitleBorderWidth(axis);
+  // `<c:catAx><c:title><c:spPr><a:ln><a:prstDash val=".."/>` (or
+  // `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) carries Excel's "Format
+  // Axis Title -> Border -> Dash type" pin.
+  const axisTitleBorderDash = parseAxisTitleBorderDash(axis);
   const gridlines = parseAxisGridlines(axis);
   const scale = parseAxisScale(axis);
   const numberFormat = parseAxisNumberFormat(axis);
@@ -1144,6 +1198,8 @@ function parseAxisInfo(
     axisTitleLayout === undefined &&
     axisTitleFillColor === undefined &&
     axisTitleBorderColor === undefined &&
+    axisTitleBorderWidth === undefined &&
+    axisTitleBorderDash === undefined &&
     gridlines === undefined &&
     scale === undefined &&
     numberFormat === undefined &&
@@ -1187,6 +1243,8 @@ function parseAxisInfo(
   if (axisTitleLayout !== undefined) out.axisTitleLayout = axisTitleLayout;
   if (axisTitleFillColor !== undefined) out.axisTitleFillColor = axisTitleFillColor;
   if (axisTitleBorderColor !== undefined) out.axisTitleBorderColor = axisTitleBorderColor;
+  if (axisTitleBorderWidth !== undefined) out.axisTitleBorderWidth = axisTitleBorderWidth;
+  if (axisTitleBorderDash !== undefined) out.axisTitleBorderDash = axisTitleBorderDash;
   if (gridlines !== undefined) out.gridlines = gridlines;
   if (scale !== undefined) out.scale = scale;
   if (numberFormat !== undefined) out.numberFormat = numberFormat;
@@ -3133,6 +3191,19 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
   const borderColor = parseDataLabelsBorderColor(el);
   if (borderColor !== undefined) out.borderColor = borderColor;
 
+  // `<c:dLbls><c:spPr><a:ln w="EMU">` carries Excel's "Format Data
+  // Labels -> Border -> Width" pin. Delegates to the shared
+  // {@link parseBorderWidthFromSpPr} so the EMU encoding and snap /
+  // clamp grammar match every other chart-frame border-width slot.
+  const borderWidth = parseBorderWidthFromSpPr(el);
+  if (borderWidth !== undefined) out.borderWidth = borderWidth;
+
+  // `<c:dLbls><c:spPr><a:ln><a:prstDash val=".."/>` carries Excel's
+  // "Format Data Labels -> Border -> Dash type" pin. Delegates to the
+  // shared {@link parseBorderDashFromSpPr} helper.
+  const borderDash = parseBorderDashFromSpPr(el);
+  if (borderDash !== undefined) out.borderDash = borderDash;
+
   // Empty record is meaningless to a consumer — collapse to undefined.
   if (
     out.position === undefined &&
@@ -3152,7 +3223,9 @@ function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined {
     out.strikethrough === undefined &&
     out.fontFamily === undefined &&
     out.fillColor === undefined &&
-    out.borderColor === undefined
+    out.borderColor === undefined &&
+    out.borderWidth === undefined &&
+    out.borderDash === undefined
   ) {
     return undefined;
   }
@@ -3603,6 +3676,91 @@ const VALID_DASH_STYLES: ReadonlySet<ChartLineDashStyle> = new Set([
 const STROKE_WIDTH_MIN_PT = 0.25;
 const STROKE_WIDTH_MAX_PT = 13.5;
 const EMU_PER_PT = 12700;
+
+/**
+ * Recognized values of {@link ChartBorderDash} — the chart-frame
+ * preset dash enum. Mirrors the OOXML `ST_PresetLineDashVal` set
+ * exactly (see {@link VALID_DASH_STYLES} on the per-series side); the
+ * reader collapses `"solid"` (the OOXML default) to `undefined` for
+ * round-trip symmetry with the writer.
+ */
+const VALID_BORDER_DASHES: ReadonlySet<ChartBorderDash> = new Set([
+  "solid",
+  "dash",
+  "dashDot",
+  "dot",
+  "lgDash",
+  "lgDashDot",
+  "lgDashDotDot",
+  "sysDash",
+  "sysDashDot",
+  "sysDashDotDot",
+  "sysDot",
+]);
+
+/**
+ * Pull the `w` attribute off a `<c:spPr><a:ln w="EMU"/>` block scoped
+ * to the supplied parent (`<c:plotArea>` / `<c:legend>` / `<c:title>` /
+ * `<c:chartSpace>` / `<c:dTable>` / `<c:dLbls>`). Returns the stroke
+ * width in points after clamping to the `0.25..13.5` pt band Excel's
+ * UI exposes; the OOXML `w` attribute carries the value in EMU
+ * (1 pt = 12 700 EMU) per CT_LineProperties (ECMA-376 Part 1,
+ * §20.1.2.3.24). Snaps to the 0.25 pt grid Excel's UI exposes so a
+ * parsed-then-written width does not drift across round-trips.
+ *
+ * Returns `undefined` when there is no `<c:spPr><a:ln>` block, when
+ * the attribute is missing, when the value cannot be parsed as a
+ * finite positive number, or when it parses to zero (Excel's "no
+ * border" marker — the writer-side knob does not model that state).
+ * Mirrors the {@link parsePlotAreaBorderWidth} /
+ * {@link parseLegendBorderWidth} / {@link parseTitleBorderWidth}
+ * helpers — used by every chart-frame border-width slot the reader
+ * surfaces.
+ */
+function parseBorderWidthFromSpPr(parent: XmlElement): number | undefined {
+  const spPr = findChild(parent, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const wAttr = ln.attrs.w;
+  if (typeof wAttr !== "string") return undefined;
+  const emu = Number.parseFloat(wAttr);
+  if (!Number.isFinite(emu) || emu <= 0) return undefined;
+  // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
+  const pt = Math.round((emu / EMU_PER_PT) * 4) / 4;
+  if (pt < STROKE_WIDTH_MIN_PT) return STROKE_WIDTH_MIN_PT;
+  if (pt > STROKE_WIDTH_MAX_PT) return STROKE_WIDTH_MAX_PT;
+  return pt;
+}
+
+/**
+ * Pull the `val` attribute off a `<c:spPr><a:ln><a:prstDash val=".."/>`
+ * chain scoped to the supplied parent. Returns the {@link ChartBorderDash}
+ * value when the chain is present and the value is a recognized
+ * `ST_PresetLineDashVal` token other than the OOXML default `"solid"`.
+ *
+ * Returns `undefined` when the chain is missing at any link, when the
+ * attribute is absent, when the value is unrecognized, or when it
+ * matches the OOXML default `"solid"` (so absence and the default
+ * round-trip identically through {@link cloneChart}). Mirrors the
+ * writer-side {@link normalizeBorderDash} so the accept-or-drop
+ * grammar matches every chart-frame border-dash slot the writer
+ * authors.
+ */
+function parseBorderDashFromSpPr(parent: XmlElement): ChartBorderDash | undefined {
+  const spPr = findChild(parent, "spPr");
+  if (!spPr) return undefined;
+  const ln = findChild(spPr, "ln");
+  if (!ln) return undefined;
+  const prstDash = findChild(ln, "prstDash");
+  if (!prstDash) return undefined;
+  const raw = prstDash.attrs.val;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim() as ChartBorderDash;
+  if (!VALID_BORDER_DASHES.has(trimmed)) return undefined;
+  if (trimmed === "solid") return undefined;
+  return trimmed;
+}
 
 /**
  * Pull `<c:spPr><a:ln>` off a series and surface its dash + width as
@@ -4258,6 +4416,22 @@ function parseLegendBorderWidth(chartEl: XmlElement): number | undefined {
   if (pt < STROKE_WIDTH_MIN_PT) return STROKE_WIDTH_MIN_PT;
   if (pt > STROKE_WIDTH_MAX_PT) return STROKE_WIDTH_MAX_PT;
   return pt;
+}
+
+/**
+ * Pull `<c:legend><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+ * </c:legend>` off a chart. Returns the recognized
+ * {@link ChartBorderDash} value when the chain is present and the
+ * value is a valid `ST_PresetLineDashVal` token other than the OOXML
+ * default `"solid"`. Returns `undefined` when the chart omits
+ * `<c:legend>`, when the chain is broken, or when the value matches
+ * the default. Mirrors {@link parseTitleBorderDash} on a different
+ * host element.
+ */
+function parseLegendBorderDash(chartEl: XmlElement): ChartBorderDash | undefined {
+  const legend = findChild(chartEl, "legend");
+  if (!legend) return undefined;
+  return parseBorderDashFromSpPr(legend);
 }
 
 /**
@@ -5045,6 +5219,24 @@ function parseTitleBorderWidth(chartEl: XmlElement): number | undefined {
 }
 
 /**
+ * Pull the `val` attribute off `<c:title><c:spPr><a:ln><a:prstDash
+ * val=".."/></a:ln></c:spPr></c:title>` and return the recognized
+ * {@link ChartBorderDash} value. Returns `undefined` when the chain
+ * is missing at any link, when the attribute is absent / unrecognized,
+ * or when it matches the OOXML default `"solid"` (so absence and the
+ * default round-trip identically through {@link cloneChart}).
+ *
+ * Delegates to {@link parseBorderDashFromSpPr} so the accept-or-drop
+ * grammar matches every chart-frame border-dash slot the reader
+ * surfaces.
+ */
+function parseTitleBorderDash(chartEl: XmlElement): ChartBorderDash | undefined {
+  const title = findChild(chartEl, "title");
+  if (!title) return undefined;
+  return parseBorderDashFromSpPr(title);
+}
+
+/**
  * Pull `<c:title><c:spPr><a:solidFill><a:srgbClr val="RRGGBB"/>
  * </a:solidFill></c:spPr></c:title>` off an axis element. Returns the
  * axis title's solid fill color as a 6-character uppercase hex string
@@ -5159,6 +5351,42 @@ function parseAxisTitleBorderColor(axis: XmlElement): string | undefined {
   const srgbClr = findChild(solidFill, "srgbClr");
   if (!srgbClr) return undefined;
   return normalizeRgbHex(srgbClr.attrs.val);
+}
+
+/**
+ * Pull the `w` attribute off `<c:catAx><c:title><c:spPr><a:ln w="EMU">`
+ * (or `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) and return the stroke
+ * width in points after clamping to the `0.25..13.5` pt band Excel's
+ * UI exposes. Same EMU encoding (1 pt = 12 700 EMU) and snap / clamp
+ * grammar as every other chart-frame border-width slot. Delegates to
+ * {@link parseBorderWidthFromSpPr} so the implementation stays
+ * uniform across all hosts.
+ *
+ * Returns `undefined` when the axis omits `<c:title>`, when the title
+ * has no `<c:spPr><a:ln w=..>` slot, when the attribute is absent,
+ * when the value cannot be parsed as a finite positive number, or
+ * when it parses to zero. Independent of {@link parseAxisTitleBorderColor}
+ * and {@link parseAxisTitleBorderDash}: all three readers walk
+ * disjoint slots of the shared `<a:ln>` element.
+ */
+function parseAxisTitleBorderWidth(axis: XmlElement): number | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  return parseBorderWidthFromSpPr(title);
+}
+
+/**
+ * Pull the `val` attribute off `<c:catAx><c:title><c:spPr><a:ln>
+ * <a:prstDash val=".."/></a:ln></c:spPr></c:title></c:catAx>` (or
+ * `<c:valAx>` / `<c:dateAx>` / `<c:serAx>`) and return the recognized
+ * {@link ChartBorderDash} value. Returns `undefined` when the chain
+ * is missing at any link, when the attribute is absent / unrecognized,
+ * or when it matches the OOXML default `"solid"`.
+ */
+function parseAxisTitleBorderDash(axis: XmlElement): ChartBorderDash | undefined {
+  const title = findChild(axis, "title");
+  if (!title) return undefined;
+  return parseBorderDashFromSpPr(title);
 }
 
 /**
@@ -5687,6 +5915,18 @@ function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined {
   if (fillColor !== undefined) out.fillColor = fillColor;
   const borderColor = parseDataTableBorderColor(el);
   if (borderColor !== undefined) out.borderColor = borderColor;
+  // `<c:dTable><c:spPr><a:ln w="EMU">` carries Excel's "Format Data
+  // Table -> Border -> Width" pin. Delegates to the shared
+  // {@link parseBorderWidthFromSpPr} so the EMU encoding and snap /
+  // clamp grammar match every other chart-frame border-width slot.
+  const borderWidth = parseBorderWidthFromSpPr(el);
+  if (borderWidth !== undefined) out.borderWidth = borderWidth;
+  // `<c:dTable><c:spPr><a:ln><a:prstDash val=".."/>` carries Excel's
+  // "Format Data Table -> Border -> Dash type" pin. Delegates to the
+  // shared {@link parseBorderDashFromSpPr} so the accept-or-drop
+  // grammar matches every chart-frame border-dash slot.
+  const borderDash = parseBorderDashFromSpPr(el);
+  if (borderDash !== undefined) out.borderDash = borderDash;
   return out;
 }
 

--- a/src/xlsx/chart-writer.ts
+++ b/src/xlsx/chart-writer.ts
@@ -17,6 +17,7 @@ import type {
   ChartAxisScale,
   ChartAxisTickLabelPosition,
   ChartAxisTickMark,
+  ChartBorderDash,
   ChartDataLabels,
   ChartDisplayBlanksAs,
   ChartLineDashStyle,
@@ -84,6 +85,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveTitleFillColor(chart),
         resolveTitleBorderColor(chart),
         resolveTitleBorderWidth(chart),
+        resolveTitleBorderDash(chart),
       ),
     );
   }
@@ -195,6 +197,7 @@ export function writeChart(chart: SheetChart, sheetName: string): ChartWriteResu
         resolveLegendFillColor(chart),
         resolveLegendBorderColor(chart),
         resolveLegendBorderWidth(chart),
+        resolveLegendBorderDash(chart),
       ),
     );
   }
@@ -310,6 +313,7 @@ function buildTitle(
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
   borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string {
   // OOXML's `<a:bodyPr rot="N"/>` attribute is in 60000ths of a degree.
   // The writer holds `titleRotation` in whole degrees and converts at
@@ -482,7 +486,7 @@ function buildTitle(
   // {@link SheetChart.titleColor} pins — the typography knobs target
   // different children of `<c:title>` so a caller can pin both
   // without conflict.
-  const titleSpPrXml = buildTitleSpPr(fillRgbHex, borderRgbHex, borderWidthPt);
+  const titleSpPrXml = buildTitleSpPr(fillRgbHex, borderRgbHex, borderWidthPt, borderDash);
   if (titleSpPrXml !== undefined) {
     titleChildren.push(titleSpPrXml);
   }
@@ -521,8 +525,14 @@ function buildTitleSpPr(
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
   borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string | undefined {
-  if (fillRgbHex === undefined && borderRgbHex === undefined && borderWidthPt === undefined) {
+  if (
+    fillRgbHex === undefined &&
+    borderRgbHex === undefined &&
+    borderWidthPt === undefined &&
+    borderDash === undefined
+  ) {
     return undefined;
   }
   const children: string[] = [];
@@ -531,7 +541,7 @@ function buildTitleSpPr(
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
     );
   }
-  if (borderRgbHex !== undefined || borderWidthPt !== undefined) {
+  if (borderRgbHex !== undefined || borderWidthPt !== undefined || borderDash !== undefined) {
     const lnAttrs: Record<string, string | number> = {};
     if (borderWidthPt !== undefined) {
       // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
@@ -543,6 +553,11 @@ function buildTitleSpPr(
       lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
       );
+    }
+    // `<a:prstDash>` follows `<a:solidFill>` per CT_LineProperties
+    // schema sequence (ECMA-376 Part 1, §20.1.2.3.24).
+    if (borderDash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: borderDash }));
     }
     children.push(
       lnChildren.length === 0
@@ -848,6 +863,27 @@ function resolveTitleBorderColor(chart: SheetChart): string | undefined {
  */
 function resolveTitleBorderWidth(chart: SheetChart): number | undefined {
   return clampStrokeWidthPt(chart.titleBorderWidth);
+}
+
+/**
+ * Resolve `<c:title><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+ * </c:title>` from {@link SheetChart.titleBorderDash}.
+ *
+ * Returns the recognized {@link ChartBorderDash} value, or `undefined`
+ * for the OOXML default `"solid"` and every unrecognized token —
+ * delegates to {@link normalizeBorderDash} so the accept / drop grammar
+ * matches every other `<a:prstDash>` slot the writer authors. The
+ * caller is expected to gate the call on `showTitle && chart.title`
+ * since a chart whose title is suppressed has no `<c:title>` block to
+ * host the `<c:spPr>` slot.
+ *
+ * Independent of {@link resolveTitleBorderColor} and
+ * {@link resolveTitleBorderWidth}: all three knobs land on the same
+ * `<a:ln>` element but on different children / attributes — color is
+ * `<a:solidFill>`, width is the `w` attribute, dash is `<a:prstDash>`.
+ */
+function resolveTitleBorderDash(chart: SheetChart): ChartBorderDash | undefined {
+  return normalizeBorderDash(chart.titleBorderDash);
 }
 
 /**
@@ -1188,6 +1224,22 @@ function buildPlotArea(chart: SheetChart, sheetName: string): string {
     // border).
     xAxisTitleBorderColor: normalizeTitleColor(chart.axes?.x?.axisTitleBorderColor),
     yAxisTitleBorderColor: normalizeTitleColor(chart.axes?.y?.axisTitleBorderColor),
+    // `<c:title><c:spPr><a:ln w="EMU"/></c:spPr></c:title>` —
+    // axis-title border (line stroke) thickness. Reuse the chart-level
+    // {@link clampStrokeWidthPt} so the snap / clamp grammar matches
+    // every other `<a:ln w=..>` slot the writer authors. Only
+    // meaningful when the axis actually emits a title; the per-family
+    // axis builder gates the value on the `xAxisTitle` / `yAxisTitle`
+    // field.
+    xAxisTitleBorderWidth: clampStrokeWidthPt(chart.axes?.x?.axisTitleBorderWidth),
+    yAxisTitleBorderWidth: clampStrokeWidthPt(chart.axes?.y?.axisTitleBorderWidth),
+    // `<c:title><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+    // </c:title>` — axis-title border preset dash pattern. The
+    // {@link normalizeBorderDash} helper drops `"solid"` and any
+    // unrecognized value to `undefined` so a fresh axis title matches
+    // Excel's reference shape byte-for-byte.
+    xAxisTitleBorderDash: normalizeBorderDash(chart.axes?.x?.axisTitleBorderDash),
+    yAxisTitleBorderDash: normalizeBorderDash(chart.axes?.y?.axisTitleBorderDash),
     xGridlines: normalizeAxisGridlines(chart.axes?.x?.gridlines),
     yGridlines: normalizeAxisGridlines(chart.axes?.y?.gridlines),
     xScale: normalizeAxisScale(chart.axes?.x?.scale),
@@ -1435,7 +1487,13 @@ function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
   const fillHex = normalizePlotAreaFillColor(chart.plotAreaFillColor);
   const borderHex = normalizePlotAreaBorderColor(chart.plotAreaBorderColor);
   const borderWidthPt = clampStrokeWidthPt(chart.plotAreaBorderWidth);
-  if (fillHex === undefined && borderHex === undefined && borderWidthPt === undefined) {
+  const borderDash = normalizeBorderDash(chart.plotAreaBorderDash);
+  if (
+    fillHex === undefined &&
+    borderHex === undefined &&
+    borderWidthPt === undefined &&
+    borderDash === undefined
+  ) {
     return undefined;
   }
 
@@ -1445,7 +1503,7 @@ function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
     );
   }
-  if (borderHex !== undefined || borderWidthPt !== undefined) {
+  if (borderHex !== undefined || borderWidthPt !== undefined || borderDash !== undefined) {
     const lnAttrs: Record<string, string | number> = {};
     if (borderWidthPt !== undefined) {
       // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
@@ -1457,6 +1515,13 @@ function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
       lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderHex })]),
       );
+    }
+    // `<a:prstDash>` follows `<a:solidFill>` per CT_LineProperties
+    // (ECMA-376 Part 1, §20.1.2.3.24) — fill before dash before
+    // headEnd / tailEnd. Skip emission for `"solid"` and unset values
+    // so a fresh chart matches Excel's reference shape byte-for-byte.
+    if (borderDash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: borderDash }));
     }
     children.push(
       lnChildren.length === 0
@@ -1534,7 +1599,16 @@ function normalizePlotAreaBorderColor(value: string | undefined): string | undef
 function buildChartSpaceSpPr(chart: SheetChart): string | undefined {
   const fillHex = normalizeChartSpaceFillColor(chart.chartSpaceFillColor);
   const borderHex = normalizeChartSpaceBorderColor(chart.chartSpaceBorderColor);
-  if (fillHex === undefined && borderHex === undefined) return undefined;
+  const borderWidthPt = clampStrokeWidthPt(chart.chartSpaceBorderWidth);
+  const borderDash = normalizeBorderDash(chart.chartSpaceBorderDash);
+  if (
+    fillHex === undefined &&
+    borderHex === undefined &&
+    borderWidthPt === undefined &&
+    borderDash === undefined
+  ) {
+    return undefined;
+  }
 
   const children: string[] = [];
   if (fillHex !== undefined) {
@@ -1542,11 +1616,28 @@ function buildChartSpaceSpPr(chart: SheetChart): string | undefined {
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillHex })]),
     );
   }
-  if (borderHex !== undefined) {
-    children.push(
-      xmlElement("a:ln", undefined, [
+  if (borderHex !== undefined || borderWidthPt !== undefined || borderDash !== undefined) {
+    const lnAttrs: Record<string, string | number> = {};
+    if (borderWidthPt !== undefined) {
+      // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
+      // the nearest integer because the schema types `w` as `xsd:int`.
+      lnAttrs.w = Math.round(borderWidthPt * EMU_PER_PT);
+    }
+    const lnChildren: string[] = [];
+    if (borderHex !== undefined) {
+      lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderHex })]),
-      ]),
+      );
+    }
+    // `<a:prstDash>` follows `<a:solidFill>` per CT_LineProperties
+    // schema sequence (ECMA-376 Part 1, §20.1.2.3.24).
+    if (borderDash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: borderDash }));
+    }
+    children.push(
+      lnChildren.length === 0
+        ? xmlSelfClose("a:ln", lnAttrs)
+        : xmlElement("a:ln", Object.keys(lnAttrs).length > 0 ? lnAttrs : undefined, lnChildren),
     );
   }
   return xmlElement("c:spPr", undefined, children);
@@ -1628,6 +1719,8 @@ function resolveDataTable(chart: SheetChart):
       fontFamily: string | undefined;
       fillColor: string | undefined;
       borderColor: string | undefined;
+      borderWidth: number | undefined;
+      borderDash: ChartBorderDash | undefined;
     }
   | undefined {
   // Pie / doughnut have no axes — the OOXML schema places `<c:dTable>`
@@ -1654,6 +1747,8 @@ function resolveDataTable(chart: SheetChart):
       fontFamily: undefined,
       fillColor: undefined,
       borderColor: undefined,
+      borderWidth: undefined,
+      borderDash: undefined,
     };
   }
 
@@ -1675,6 +1770,8 @@ function resolveDataTable(chart: SheetChart):
     fontFamily: resolveDataTableFontFamily(raw.fontFamily),
     fillColor: resolveDataTableFillColor(raw.fillColor),
     borderColor: resolveDataTableBorderColor(raw.borderColor),
+    borderWidth: clampStrokeWidthPt(raw.borderWidth),
+    borderDash: normalizeBorderDash(raw.borderDash),
   };
 }
 
@@ -1873,6 +1970,8 @@ function buildDataTable(table: {
   fontFamily: string | undefined;
   fillColor: string | undefined;
   borderColor: string | undefined;
+  borderWidth: number | undefined;
+  borderDash: ChartBorderDash | undefined;
 }): string {
   const children: string[] = [
     xmlSelfClose("c:showHorzBorder", { val: table.showHorzBorder ? 1 : 0 }),
@@ -1885,7 +1984,12 @@ function buildDataTable(table: {
   // (ECMA-376 Part 1, §21.2.2.54). The writer skips emission entirely
   // when no fill / border knob is pinned so a fresh chart matches
   // Excel's reference serialization byte-for-byte.
-  const spPrXml = buildDataTableSpPr(table.fillColor, table.borderColor);
+  const spPrXml = buildDataTableSpPr(
+    table.fillColor,
+    table.borderColor,
+    table.borderWidth,
+    table.borderDash,
+  );
   if (spPrXml !== undefined) children.push(spPrXml);
   // CT_DTable schema places `<c:txPr>` after `<c:spPr>` and before
   // the optional `<c:extLst>` (ECMA-376 Part 1, §21.2.2.54). The writer
@@ -1929,19 +2033,45 @@ function buildDataTable(table: {
 function buildDataTableSpPr(
   fillColor: string | undefined,
   borderColor: string | undefined,
+  borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string | undefined {
-  if (fillColor === undefined && borderColor === undefined) return undefined;
+  if (
+    fillColor === undefined &&
+    borderColor === undefined &&
+    borderWidthPt === undefined &&
+    borderDash === undefined
+  ) {
+    return undefined;
+  }
   const children: string[] = [];
   if (fillColor !== undefined) {
     children.push(
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillColor })]),
     );
   }
-  if (borderColor !== undefined) {
-    children.push(
-      xmlElement("a:ln", undefined, [
+  if (borderColor !== undefined || borderWidthPt !== undefined || borderDash !== undefined) {
+    const lnAttrs: Record<string, string | number> = {};
+    if (borderWidthPt !== undefined) {
+      // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
+      // the nearest integer because the schema types `w` as `xsd:int`.
+      lnAttrs.w = Math.round(borderWidthPt * EMU_PER_PT);
+    }
+    const lnChildren: string[] = [];
+    if (borderColor !== undefined) {
+      lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderColor })]),
-      ]),
+      );
+    }
+    // `<a:prstDash>` follows `<a:solidFill>` per CT_LineProperties
+    // schema sequence (ECMA-376 Part 1, §20.1.2.3.24).
+    if (borderDash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: borderDash }));
+    }
+    children.push(
+      lnChildren.length === 0
+        ? xmlSelfClose("a:ln", lnAttrs)
+        : xmlElement("a:ln", Object.keys(lnAttrs).length > 0 ? lnAttrs : undefined, lnChildren),
     );
   }
   return xmlElement("c:spPr", undefined, children);
@@ -2542,6 +2672,38 @@ interface AxisRenderOptions {
    * semantics as {@link xAxisTitleBorderColor}.
    */
   yAxisTitleBorderColor: string | undefined;
+  /**
+   * Axis-title border (line stroke) thickness emitted on the X axis
+   * via `<c:title><c:spPr><a:ln w="EMU"/></c:spPr></c:title>`. The
+   * OOXML `w` attribute is in EMU (1 pt = 12 700 EMU); the writer
+   * converts at emit time. `undefined` collapses to omitting the
+   * attribute (Excel's reference auto-thickness, typically 0.75 pt).
+   * Composes independently with {@link xAxisTitleBorderColor} and
+   * {@link xAxisTitleBorderDash} on the same `<a:ln>` element.
+   * Only meaningful when the axis renders a title.
+   */
+  xAxisTitleBorderWidth: number | undefined;
+  /**
+   * Axis-title border thickness emitted on the Y axis. Same shape and
+   * emit semantics as {@link xAxisTitleBorderWidth}.
+   */
+  yAxisTitleBorderWidth: number | undefined;
+  /**
+   * Axis-title border (line stroke) preset dash pattern emitted on the
+   * X axis via `<c:title><c:spPr><a:ln><a:prstDash val=".."/></a:ln>
+   * </c:spPr></c:title>`. The OOXML `<a:prstDash>` element follows
+   * `<a:solidFill>` per CT_LineProperties schema sequence (ECMA-376
+   * Part 1, §20.1.2.3.24). `undefined` (and the OOXML default
+   * `"solid"`) collapses to omitting the element so a fresh axis
+   * title renders solid. Composes independently with
+   * {@link xAxisTitleBorderColor} and {@link xAxisTitleBorderWidth}.
+   */
+  xAxisTitleBorderDash: ChartBorderDash | undefined;
+  /**
+   * Axis-title border dash emitted on the Y axis. Same shape and emit
+   * semantics as {@link xAxisTitleBorderDash}.
+   */
+  yAxisTitleBorderDash: ChartBorderDash | undefined;
   xGridlines: { major: boolean; minor: boolean } | undefined;
   yGridlines: { major: boolean; minor: boolean } | undefined;
   xScale: ChartAxisScale | undefined;
@@ -3775,6 +3937,8 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.xAxisTitleLayout,
         opts.xAxisTitleFillColor,
         opts.xAxisTitleBorderColor,
+        opts.xAxisTitleBorderWidth,
+        opts.xAxisTitleBorderDash,
       ),
     );
   catAxChildren.push(
@@ -3854,6 +4018,8 @@ function buildBarAxes(orientation: "bar" | "column", opts: AxisRenderOptions): s
         opts.yAxisTitleLayout,
         opts.yAxisTitleFillColor,
         opts.yAxisTitleBorderColor,
+        opts.yAxisTitleBorderWidth,
+        opts.yAxisTitleBorderDash,
       ),
     );
   valAxChildren.push(
@@ -4234,6 +4400,8 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.xAxisTitleLayout,
         opts.xAxisTitleFillColor,
         opts.xAxisTitleBorderColor,
+        opts.xAxisTitleBorderWidth,
+        opts.xAxisTitleBorderDash,
       ),
     );
   xAxChildren.push(
@@ -4292,6 +4460,8 @@ function buildScatterAxes(opts: AxisRenderOptions): string[] {
         opts.yAxisTitleLayout,
         opts.yAxisTitleFillColor,
         opts.yAxisTitleBorderColor,
+        opts.yAxisTitleBorderWidth,
+        opts.yAxisTitleBorderDash,
       ),
     );
   yAxChildren.push(
@@ -4397,6 +4567,8 @@ function buildAxisTitle(
   layout: ResolvedManualLayout | undefined,
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
+  borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string {
   const rot = rotationDeg === undefined ? 0 : rotationDeg * TITLE_ROT_PER_DEGREE;
   // OOXML's `<a:defRPr sz="N"/>` / `<a:rPr sz="N"/>` attribute is in
@@ -4566,7 +4738,7 @@ function buildAxisTitle(
   // {@link SheetChart.axes.x.axisTitleColor} pins — the typography
   // knobs target different children of `<c:title>` so a caller can
   // pin all three without conflict.
-  const titleSpPrXml = buildTitleSpPr(fillRgbHex, borderRgbHex, undefined);
+  const titleSpPrXml = buildTitleSpPr(fillRgbHex, borderRgbHex, borderWidthPt, borderDash);
   if (titleSpPrXml !== undefined) titleChildren.push(titleSpPrXml);
   return xmlElement("c:title", undefined, titleChildren);
 }
@@ -4910,6 +5082,50 @@ function normalizeDashStyle(value: ChartLineDashStyle | undefined): ChartLineDas
 }
 
 /**
+ * Recognized values of {@link ChartBorderDash} — the chart-frame
+ * border-dash enum that lands on `<c:spPr><a:ln><a:prstDash val=".."/>`.
+ * Mirrors {@link VALID_DASH_STYLES} since the enum mirrors
+ * `ST_PresetLineDashVal` exactly. Listed independently so the writer
+ * stays explicit about which slot the value targets (the chart-frame
+ * `<c:spPr>` rather than the per-series `<c:ser>` block).
+ */
+const VALID_BORDER_DASHES: ReadonlySet<ChartBorderDash> = new Set([
+  "solid",
+  "dash",
+  "dashDot",
+  "dot",
+  "lgDash",
+  "lgDashDot",
+  "lgDashDotDot",
+  "sysDash",
+  "sysDashDot",
+  "sysDashDotDot",
+  "sysDot",
+]);
+
+/**
+ * Validate a chart-frame border dash style against
+ * {@link ChartBorderDash}. Returns `undefined` for unrecognized values
+ * and for the OOXML default `"solid"` so the writer can elide the
+ * `<a:prstDash>` element entirely — Excel paints solid by default and
+ * absence / `"solid"` round-trip identically through {@link cloneChart}.
+ *
+ * Mirrors {@link normalizeDashStyle} for the per-series stroke variant
+ * but collapses `"solid"` to `undefined` for symmetry with the reader
+ * side: the reader drops `"solid"` to surface absence, so the writer
+ * must skip it on emit too. Used by every chart-frame `<c:spPr>` /
+ * `<a:ln>` slot — plot-area, legend, title, chart-space, axis-title,
+ * data-table, and data-labels borders.
+ */
+function normalizeBorderDash(value: ChartBorderDash | undefined): ChartBorderDash | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") return undefined;
+  if (!VALID_BORDER_DASHES.has(value)) return undefined;
+  if (value === "solid") return undefined;
+  return value;
+}
+
+/**
  * Convert a stroke width in points to the integer EMU value the OOXML
  * `w` attribute requires. Excel's UI exposes 0.25..13.5 pt — values
  * outside that band are clamped to keep round-trips inside the range
@@ -5191,6 +5407,8 @@ function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKind): st
   const spPrXml = buildDataLabelsSpPr(
     resolveDataLabelsFillColor(dl.fillColor),
     resolveDataLabelsBorderColor(dl.borderColor),
+    clampStrokeWidthPt(dl.borderWidth),
+    normalizeBorderDash(dl.borderDash),
   );
   if (spPrXml !== undefined) {
     children.push(spPrXml);
@@ -5478,19 +5696,45 @@ function resolveDataLabelsBorderColor(value: string | undefined): string | undef
 function buildDataLabelsSpPr(
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
+  borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string | undefined {
-  if (fillRgbHex === undefined && borderRgbHex === undefined) return undefined;
+  if (
+    fillRgbHex === undefined &&
+    borderRgbHex === undefined &&
+    borderWidthPt === undefined &&
+    borderDash === undefined
+  ) {
+    return undefined;
+  }
   const children: string[] = [];
   if (fillRgbHex !== undefined) {
     children.push(
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
     );
   }
-  if (borderRgbHex !== undefined) {
-    children.push(
-      xmlElement("a:ln", undefined, [
+  if (borderRgbHex !== undefined || borderWidthPt !== undefined || borderDash !== undefined) {
+    const lnAttrs: Record<string, string | number> = {};
+    if (borderWidthPt !== undefined) {
+      // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
+      // the nearest integer because the schema types `w` as `xsd:int`.
+      lnAttrs.w = Math.round(borderWidthPt * EMU_PER_PT);
+    }
+    const lnChildren: string[] = [];
+    if (borderRgbHex !== undefined) {
+      lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
-      ]),
+      );
+    }
+    // `<a:prstDash>` follows `<a:solidFill>` per CT_LineProperties
+    // schema sequence (ECMA-376 Part 1, §20.1.2.3.24).
+    if (borderDash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: borderDash }));
+    }
+    children.push(
+      lnChildren.length === 0
+        ? xmlSelfClose("a:ln", lnAttrs)
+        : xmlElement("a:ln", Object.keys(lnAttrs).length > 0 ? lnAttrs : undefined, lnChildren),
     );
   }
   return xmlElement("c:spPr", undefined, children);
@@ -5643,6 +5887,7 @@ function buildLegend(
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
   borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string {
   const children: string[] = [xmlSelfClose("c:legendPos", { val: pos })];
 
@@ -5690,7 +5935,7 @@ function buildLegend(
   // children (`<a:effectLst>` effects, gradient / pattern / picture
   // fills, line dash / width / compound styles) are not modelled at
   // this layer.
-  const legendSpPrXml = buildLegendSpPr(fillRgbHex, borderRgbHex, borderWidthPt);
+  const legendSpPrXml = buildLegendSpPr(fillRgbHex, borderRgbHex, borderWidthPt, borderDash);
   if (legendSpPrXml !== undefined) {
     children.push(legendSpPrXml);
   }
@@ -5753,8 +5998,14 @@ function buildLegendSpPr(
   fillRgbHex: string | undefined,
   borderRgbHex: string | undefined,
   borderWidthPt: number | undefined,
+  borderDash: ChartBorderDash | undefined,
 ): string | undefined {
-  if (fillRgbHex === undefined && borderRgbHex === undefined && borderWidthPt === undefined) {
+  if (
+    fillRgbHex === undefined &&
+    borderRgbHex === undefined &&
+    borderWidthPt === undefined &&
+    borderDash === undefined
+  ) {
     return undefined;
   }
   const children: string[] = [];
@@ -5763,7 +6014,7 @@ function buildLegendSpPr(
       xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: fillRgbHex })]),
     );
   }
-  if (borderRgbHex !== undefined || borderWidthPt !== undefined) {
+  if (borderRgbHex !== undefined || borderWidthPt !== undefined || borderDash !== undefined) {
     const lnAttrs: Record<string, string | number> = {};
     if (borderWidthPt !== undefined) {
       // OOXML stores stroke width in EMU (1 pt = 12 700 EMU). Round to
@@ -5775,6 +6026,11 @@ function buildLegendSpPr(
       lnChildren.push(
         xmlElement("a:solidFill", undefined, [xmlSelfClose("a:srgbClr", { val: borderRgbHex })]),
       );
+    }
+    // `<a:prstDash>` follows `<a:solidFill>` per CT_LineProperties
+    // schema sequence (ECMA-376 Part 1, §20.1.2.3.24).
+    if (borderDash !== undefined) {
+      lnChildren.push(xmlSelfClose("a:prstDash", { val: borderDash }));
     }
     children.push(
       lnChildren.length === 0
@@ -6239,6 +6495,25 @@ function resolveLegendBorderColor(chart: SheetChart): string | undefined {
  */
 function resolveLegendBorderWidth(chart: SheetChart): number | undefined {
   return clampStrokeWidthPt(chart.legendBorderWidth);
+}
+
+/**
+ * Resolve `<c:legend><c:spPr><a:ln><a:prstDash val=".."/></a:ln></c:spPr>
+ * </c:legend>` from {@link SheetChart.legendBorderDash}.
+ *
+ * Returns the recognized {@link ChartBorderDash} value, or `undefined`
+ * for the OOXML default `"solid"` and every unrecognized token —
+ * delegates to {@link normalizeBorderDash} so absence and the OOXML
+ * default round-trip identically. The dash is only meaningful when the
+ * chart actually emits a legend; the caller gates this on the resolved
+ * legend visibility.
+ *
+ * Independent of {@link resolveLegendBorderColor} and
+ * {@link resolveLegendBorderWidth}: all three knobs land on the same
+ * `<a:ln>` element but on different children / attributes.
+ */
+function resolveLegendBorderDash(chart: SheetChart): ChartBorderDash | undefined {
+  return normalizeBorderDash(chart.legendBorderDash);
 }
 
 /**

--- a/test/chart-clone.test.ts
+++ b/test/chart-clone.test.ts
@@ -24250,3 +24250,745 @@ describe("cloneChart — titleBorderWidth", () => {
     expect(parseChart(written)?.titleBorderWidth).toBe(1.75);
   });
 });
+
+// ── cloneChart — chartSpaceBorderWidth ───────────────────────────────
+
+describe("cloneChart — chartSpaceBorderWidth", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      ...extra,
+    };
+  }
+
+  it("inherits the source value by default", () => {
+    const clone = cloneChart(source({ chartSpaceBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceBorderWidth).toBe(1.5);
+  });
+
+  it("override replaces the source", () => {
+    const clone = cloneChart(source({ chartSpaceBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: 2,
+    });
+    expect(clone.chartSpaceBorderWidth).toBe(2);
+  });
+
+  it("null override drops the inherited width", () => {
+    const clone = cloneChart(source({ chartSpaceBorderWidth: 1.5 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: null,
+    });
+    expect(clone.chartSpaceBorderWidth).toBeUndefined();
+  });
+
+  it("clamps and snaps the override", () => {
+    const clone1 = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: 0.1,
+    });
+    expect(clone1.chartSpaceBorderWidth).toBe(0.25);
+    const clone2 = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: 50,
+    });
+    expect(clone2.chartSpaceBorderWidth).toBe(13.5);
+    const clone3 = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: 1.4,
+    });
+    expect(clone3.chartSpaceBorderWidth).toBe(1.5);
+  });
+
+  it("drops NaN / Infinity overrides", () => {
+    const clone1 = cloneChart(source({ chartSpaceBorderWidth: 1 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: Number.NaN,
+    });
+    expect(clone1.chartSpaceBorderWidth).toBeUndefined();
+    const clone2 = cloneChart(source({ chartSpaceBorderWidth: 1 }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: Number.POSITIVE_INFINITY,
+    });
+    expect(clone2.chartSpaceBorderWidth).toBeUndefined();
+  });
+
+  it("composes with chartSpaceBorderColor", () => {
+    const clone = cloneChart(
+      source({ chartSpaceBorderColor: "FF0000", chartSpaceBorderWidth: 1.5 }),
+      { anchor: { from: { row: 0, col: 0 } } },
+    );
+    expect(clone.chartSpaceBorderColor).toBe("FF0000");
+    expect(clone.chartSpaceBorderWidth).toBe(1.5);
+  });
+
+  it("survives a writeXlsx round trip", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderWidth: 1.75,
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.chartSpaceBorderWidth).toBe(1.75);
+  });
+});
+
+// ── cloneChart — axisTitleBorderWidth ────────────────────────────────
+
+describe("cloneChart — axisTitleBorderWidth", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      axes: { x: { title: "X" }, y: { title: "Y" } },
+      ...extra,
+    };
+  }
+
+  it("inherits source axisTitleBorderWidth on x and y", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "X", axisTitleBorderWidth: 1.5 },
+          y: { title: "Y", axisTitleBorderWidth: 0.5 },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBe(1.5);
+    expect(clone.axes?.y?.axisTitleBorderWidth).toBe(0.5);
+  });
+
+  it("override replaces source on x", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "X", axisTitleBorderWidth: 1 }, y: { title: "Y" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderWidth: 2 } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBe(2);
+  });
+
+  it("null override drops inherited width", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "X", axisTitleBorderWidth: 1 }, y: { title: "Y" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderWidth: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBeUndefined();
+  });
+
+  it("drops the inherited width when the axis title is dropped", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "X", axisTitleBorderWidth: 1.5 }, y: { title: "Y" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBeUndefined();
+  });
+
+  it("clamps / snaps the override", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderWidth: 100 } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBe(13.5);
+  });
+
+  it("drops NaN", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderWidth: Number.NaN } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBeUndefined();
+  });
+
+  it("composes with axisTitleBorderColor", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "X", axisTitleBorderColor: "FF0000", axisTitleBorderWidth: 2 },
+          y: { title: "Y" },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderColor).toBe("FF0000");
+    expect(clone.axes?.x?.axisTitleBorderWidth).toBe(2);
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderWidth: 1.75 }, y: { axisTitleBorderWidth: 0.75 } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const re = parseChart(written);
+    expect(re?.axes?.x?.axisTitleBorderWidth).toBe(1.75);
+    expect(re?.axes?.y?.axisTitleBorderWidth).toBe(0.75);
+  });
+});
+
+// ── cloneChart — *BorderDash family ─────────────────────────────────
+
+describe("cloneChart — plotAreaBorderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      ...extra,
+    };
+  }
+
+  it("inherits source plotAreaBorderDash", () => {
+    const clone = cloneChart(source({ plotAreaBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.plotAreaBorderDash).toBe("dash");
+  });
+
+  it("override replaces source", () => {
+    const clone = cloneChart(source({ plotAreaBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderDash: "dot",
+    });
+    expect(clone.plotAreaBorderDash).toBe("dot");
+  });
+
+  it("null override drops the inherited dash", () => {
+    const clone = cloneChart(source({ plotAreaBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderDash: null,
+    });
+    expect(clone.plotAreaBorderDash).toBeUndefined();
+  });
+
+  it("collapses 'solid' override to undefined", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderDash: "solid",
+    });
+    expect(clone.plotAreaBorderDash).toBeUndefined();
+  });
+
+  it("drops unrecognized override tokens", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderDash: "weirdo" as any,
+    });
+    expect(clone.plotAreaBorderDash).toBeUndefined();
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      plotAreaBorderDash: "lgDashDot",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.plotAreaBorderDash).toBe("lgDashDot");
+  });
+});
+
+describe("cloneChart — legendBorderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      legend: "right",
+      ...extra,
+    };
+  }
+
+  it("inherits source legendBorderDash", () => {
+    const clone = cloneChart(source({ legendBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.legendBorderDash).toBe("dash");
+  });
+
+  it("override replaces", () => {
+    const clone = cloneChart(source({ legendBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderDash: "dot",
+    });
+    expect(clone.legendBorderDash).toBe("dot");
+  });
+
+  it("null override drops dash", () => {
+    const clone = cloneChart(source({ legendBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderDash: null,
+    });
+    expect(clone.legendBorderDash).toBeUndefined();
+  });
+
+  it("dropped when legend hidden", () => {
+    const clone = cloneChart(source({ legendBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      legend: false,
+    });
+    expect(clone.legend).toBe(false);
+    expect(clone.legendBorderDash).toBeUndefined();
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      legendBorderDash: "sysDot",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.legendBorderDash).toBe("sysDot");
+  });
+});
+
+describe("cloneChart — titleBorderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      title: "Sales",
+      ...extra,
+    };
+  }
+
+  it("inherits source titleBorderDash", () => {
+    const clone = cloneChart(source({ titleBorderDash: "dashDot" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.titleBorderDash).toBe("dashDot");
+  });
+
+  it("override replaces", () => {
+    const clone = cloneChart(source({ titleBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderDash: "dot",
+    });
+    expect(clone.titleBorderDash).toBe("dot");
+  });
+
+  it("null override drops dash", () => {
+    const clone = cloneChart(source({ titleBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderDash: null,
+    });
+    expect(clone.titleBorderDash).toBeUndefined();
+  });
+
+  it("collapses 'solid' override to undefined", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderDash: "solid",
+    });
+    expect(clone.titleBorderDash).toBeUndefined();
+  });
+
+  it("drops dash when title is dropped", () => {
+    const clone = cloneChart(source({ titleBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      title: null,
+    });
+    expect(clone.titleBorderDash).toBeUndefined();
+  });
+
+  it("dropped when showTitle is false", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      showTitle: false,
+      titleBorderDash: "dash",
+    });
+    expect(clone.titleBorderDash).toBeUndefined();
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      titleBorderDash: "sysDashDotDot",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.titleBorderDash).toBe("sysDashDotDot");
+  });
+});
+
+describe("cloneChart — chartSpaceBorderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      ...extra,
+    };
+  }
+
+  it("inherits source value", () => {
+    const clone = cloneChart(source({ chartSpaceBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+    });
+    expect(clone.chartSpaceBorderDash).toBe("dash");
+  });
+
+  it("override replaces", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderDash: "lgDash",
+    });
+    expect(clone.chartSpaceBorderDash).toBe("lgDash");
+  });
+
+  it("null override drops dash", () => {
+    const clone = cloneChart(source({ chartSpaceBorderDash: "dash" }), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderDash: null,
+    });
+    expect(clone.chartSpaceBorderDash).toBeUndefined();
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      chartSpaceBorderDash: "sysDash",
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    expect(parseChart(written)?.chartSpaceBorderDash).toBe("sysDash");
+  });
+});
+
+describe("cloneChart — axisTitleBorderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["line"],
+      seriesCount: 1,
+      series: [{ kind: "line", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      axes: { x: { title: "X" }, y: { title: "Y" } },
+      ...extra,
+    };
+  }
+
+  it("inherits source value on x and y", () => {
+    const clone = cloneChart(
+      source({
+        axes: {
+          x: { title: "X", axisTitleBorderDash: "dash" },
+          y: { title: "Y", axisTitleBorderDash: "dot" },
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderDash).toBe("dash");
+    expect(clone.axes?.y?.axisTitleBorderDash).toBe("dot");
+  });
+
+  it("override replaces on x", () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderDash: "lgDash" } },
+    });
+    expect(clone.axes?.x?.axisTitleBorderDash).toBe("lgDash");
+  });
+
+  it("null override drops dash on x", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "X", axisTitleBorderDash: "dash" }, y: { title: "Y" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { axisTitleBorderDash: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderDash).toBeUndefined();
+  });
+
+  it("drops when axis title is dropped", () => {
+    const clone = cloneChart(
+      source({ axes: { x: { title: "X", axisTitleBorderDash: "dash" }, y: { title: "Y" } } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        axes: { x: { title: null } },
+      },
+    );
+    expect(clone.axes?.x?.axisTitleBorderDash).toBeUndefined();
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(source(), {
+      anchor: { from: { row: 0, col: 0 } },
+      axes: { x: { axisTitleBorderDash: "dashDot" }, y: { axisTitleBorderDash: "dot" } },
+    });
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const re = parseChart(written);
+    expect(re?.axes?.x?.axisTitleBorderDash).toBe("dashDot");
+    expect(re?.axes?.y?.axisTitleBorderDash).toBe("dot");
+  });
+});
+
+// dataTable.borderWidth/Dash and dataLabels.borderWidth/Dash are
+// handled via the wholesale-replace `dataTable` / `dataLabels` clone
+// override semantics (the resolver passes the entire object through),
+// so the round-trip lives implicitly under those override flows.
+
+describe("cloneChart — dataTable.borderWidth / borderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      ...extra,
+    };
+  }
+
+  it("inherits dataTable.borderWidth from source", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 1.25,
+          borderDash: "dash",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } }, type: "column" },
+    );
+    expect(typeof clone.dataTable === "object" ? clone.dataTable.borderWidth : undefined).toBe(
+      1.25,
+    );
+    expect(typeof clone.dataTable === "object" ? clone.dataTable.borderDash : undefined).toBe(
+      "dash",
+    );
+  });
+
+  it("override object replaces dataTable wholesale", () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 1,
+          borderDash: "dash",
+        },
+      }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "column",
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 2.5,
+          borderDash: "sysDash",
+        },
+      },
+    );
+    expect(typeof clone.dataTable === "object" ? clone.dataTable.borderWidth : undefined).toBe(2.5);
+    expect(typeof clone.dataTable === "object" ? clone.dataTable.borderDash : undefined).toBe(
+      "sysDash",
+    );
+  });
+
+  it("round-trips through writeXlsx", async () => {
+    const clone = cloneChart(
+      source({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 1.5,
+          borderDash: "lgDashDot",
+        },
+      }),
+      { anchor: { from: { row: 0, col: 0 } }, type: "column" },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const re = parseChart(written);
+    expect(typeof re?.dataTable === "object" ? re.dataTable.borderWidth : undefined).toBe(1.5);
+    expect(typeof re?.dataTable === "object" ? re.dataTable.borderDash : undefined).toBe(
+      "lgDashDot",
+    );
+  });
+});
+
+describe("cloneChart — dataLabels.borderWidth / borderDash", () => {
+  function source(extra?: Partial<Chart>): Chart {
+    return {
+      kinds: ["bar"],
+      seriesCount: 1,
+      series: [{ kind: "bar", index: 0, name: "Revenue", valuesRef: "Sheet1!$B$2:$B$5" }],
+      ...extra,
+    };
+  }
+
+  it("inherits dataLabels.borderWidth/Dash from source (chart-level)", () => {
+    const clone = cloneChart(
+      source({ dataLabels: { showValue: true, borderWidth: 1, borderDash: "dot" } }),
+      { anchor: { from: { row: 0, col: 0 } }, type: "column" },
+    );
+    expect(clone.dataLabels?.borderWidth).toBe(1);
+    expect(clone.dataLabels?.borderDash).toBe("dot");
+  });
+
+  it("override replaces dataLabels wholesale", () => {
+    const clone = cloneChart(
+      source({ dataLabels: { showValue: true, borderWidth: 1, borderDash: "dot" } }),
+      {
+        anchor: { from: { row: 0, col: 0 } },
+        type: "column",
+        dataLabels: { showValue: true, borderWidth: 2, borderDash: "lgDashDotDot" },
+      },
+    );
+    expect(clone.dataLabels?.borderWidth).toBe(2);
+    expect(clone.dataLabels?.borderDash).toBe("lgDashDotDot");
+  });
+
+  it("round-trips dataLabels.borderWidth/Dash through writeXlsx", async () => {
+    const clone = cloneChart(
+      source({ dataLabels: { showValue: true, borderWidth: 0.75, borderDash: "sysDashDot" } }),
+      { anchor: { from: { row: 0, col: 0 } }, type: "column" },
+    );
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          charts: [clone],
+        },
+      ],
+    });
+    const zip = new ZipReader(xlsx);
+    const written = decoder.decode(await zip.extract("xl/charts/chart1.xml"));
+    const re = parseChart(written);
+    // Chart-level <c:dLbls> may be surfaced as `re.dataLabels` (chart
+    // level) or on the first series — accept either since the writer's
+    // emit shape and the OOXML schema let both happen.
+    const labels = re?.dataLabels ?? re?.series?.[0]?.dataLabels;
+    expect(labels?.borderWidth).toBe(0.75);
+    expect(labels?.borderDash).toBe("sysDashDot");
+  });
+});

--- a/test/charts-write.test.ts
+++ b/test/charts-write.test.ts
@@ -23463,3 +23463,847 @@ describe("writeChart — titleBorderWidth", () => {
     expect(reparsed?.titleBorderWidth).toBe(1.75);
   });
 });
+
+// ── writeChart — chartSpaceBorderWidth ──────────────────────────────
+
+describe("writeChart — chartSpaceBorderWidth", () => {
+  function chartSpaceSpPrOf(xml: string): string | undefined {
+    // Find <c:spPr> direct child of <c:chartSpace> (not inside <c:chart>).
+    // The chart-space spPr sits at the tail after </c:chart>.
+    const m = xml.match(/<\/c:chart>\s*<c:spPr>([\s\S]*?)<\/c:spPr>/);
+    return m ? m[0] : undefined;
+  }
+
+  it("does not emit chart-space <c:spPr> when chartSpaceBorderWidth is unset", () => {
+    const result = writeChart(makeChart(), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("emits <c:spPr><a:ln w=..> when chartSpaceBorderWidth is set", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderWidth: 1.5 }), "Sheet1");
+    const sp = chartSpaceSpPrOf(result.chartXml);
+    expect(sp).toContain('<a:ln w="19050"');
+  });
+
+  it("snaps to 0.25 grid", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderWidth: 0.4 }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:ln w="6350"');
+  });
+
+  it("clamps below minimum (0.1 → 0.25 → 3175 EMU)", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderWidth: 0.1 }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:ln w="3175"');
+  });
+
+  it("clamps above maximum (50 → 13.5 → 171450 EMU)", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderWidth: 50 }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:ln w="171450"');
+  });
+
+  it("composes with chartSpaceBorderColor on the same <a:ln>", () => {
+    const result = writeChart(
+      makeChart({ chartSpaceBorderColor: "FF0000", chartSpaceBorderWidth: 2 }),
+      "Sheet1",
+    );
+    const sp = chartSpaceSpPrOf(result.chartXml);
+    expect(sp).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("composes with chartSpaceFillColor + chartSpaceBorderColor + chartSpaceBorderWidth in CT_ShapeProperties order", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceFillColor: "F2F2F2",
+        chartSpaceBorderColor: "1F77B4",
+        chartSpaceBorderWidth: 1,
+      }),
+      "Sheet1",
+    );
+    const sp = chartSpaceSpPrOf(result.chartXml);
+    const fillIdx = sp?.indexOf("<a:solidFill>") ?? -1;
+    const lnIdx = sp?.indexOf("<a:ln") ?? -1;
+    expect(fillIdx).toBeGreaterThanOrEqual(0);
+    expect(lnIdx).toBeGreaterThan(fillIdx);
+  });
+
+  it("drops NaN", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderWidth: Number.NaN }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("drops Infinity", () => {
+    const result = writeChart(
+      makeChart({ chartSpaceBorderWidth: Number.POSITIVE_INFINITY }),
+      "Sheet1",
+    );
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("round-trips through writeXlsx -> parseChart", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [makeChart({ chartSpaceBorderWidth: 1.75 })],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.chartSpaceBorderWidth).toBe(1.75);
+  });
+});
+
+// ── writeChart — axisTitleBorderWidth ───────────────────────────────
+
+describe("writeChart — axisTitleBorderWidth", () => {
+  function xAxisTitleOf(xml: string): string {
+    const m = xml.match(/<c:catAx>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No catAx title found");
+    return m[0];
+  }
+  function yAxisTitleOf(xml: string): string {
+    const m = xml.match(/<c:valAx>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No valAx title found");
+    return m[0];
+  }
+
+  function makeWithAxisTitles(overrides: Partial<SheetChart["axes"]> = {}) {
+    return makeChart({
+      axes: {
+        x: { title: "X" },
+        y: { title: "Y" },
+        ...overrides,
+      },
+    });
+  }
+
+  it("does not emit <c:spPr> when axisTitleBorderWidth is unset", () => {
+    const result = writeChart(makeWithAxisTitles(), "Sheet1");
+    const xTitle = xAxisTitleOf(result.chartXml);
+    expect(xTitle).not.toContain("<c:spPr>");
+  });
+
+  it("emits <a:ln w=..> on the X axis", () => {
+    const result = writeChart(
+      makeWithAxisTitles({ x: { title: "X", axisTitleBorderWidth: 1.5 } }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).toContain('<a:ln w="19050"');
+  });
+
+  it("emits <a:ln w=..> on the Y axis", () => {
+    const result = writeChart(
+      makeWithAxisTitles({ y: { title: "Y", axisTitleBorderWidth: 2 } }),
+      "Sheet1",
+    );
+    expect(yAxisTitleOf(result.chartXml)).toContain('<a:ln w="25400"');
+  });
+
+  it("clamps below the minimum on the X axis", () => {
+    const result = writeChart(
+      makeWithAxisTitles({ x: { title: "X", axisTitleBorderWidth: 0.1 } }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).toContain('<a:ln w="3175"');
+  });
+
+  it("clamps above the maximum on the X axis", () => {
+    const result = writeChart(
+      makeWithAxisTitles({ x: { title: "X", axisTitleBorderWidth: 50 } }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).toContain('<a:ln w="171450"');
+  });
+
+  it("composes axisTitleBorderColor + axisTitleBorderWidth on a single <a:ln>", () => {
+    const result = writeChart(
+      makeWithAxisTitles({
+        x: { title: "X", axisTitleBorderColor: "1F77B4", axisTitleBorderWidth: 2 },
+      }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("does not emit when the axis has no title", () => {
+    const result = writeChart(makeChart({ axes: { x: { axisTitleBorderWidth: 2 } } }), "Sheet1");
+    expect(result.chartXml).not.toContain("<a:ln w=");
+  });
+
+  it("drops NaN", () => {
+    const result = writeChart(
+      makeWithAxisTitles({ x: { title: "X", axisTitleBorderWidth: Number.NaN } }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("round-trips through writeXlsx -> parseChart", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [
+        makeWithAxisTitles({
+          x: { title: "X", axisTitleBorderWidth: 1.75 },
+          y: { title: "Y", axisTitleBorderWidth: 0.5 },
+        }),
+      ],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleBorderWidth).toBe(1.75);
+    expect(reparsed?.axes?.y?.axisTitleBorderWidth).toBe(0.5);
+  });
+});
+
+// ── writeChart — dataTableBorderWidth ───────────────────────────────
+
+describe("writeChart — dataTableBorderWidth", () => {
+  function dTableOf(xml: string): string {
+    const m = xml.match(/<c:dTable>[\s\S]*?<\/c:dTable>/);
+    if (!m) throw new Error("No <c:dTable> found");
+    return m[0];
+  }
+
+  it("emits <a:ln w=..> when dataTable.borderWidth is set", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 1.5,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dTableOf(result.chartXml)).toContain('<a:ln w="19050"');
+  });
+
+  it("does not emit <c:spPr> when only the four boolean toggles are pinned", () => {
+    const result = writeChart(makeChart({ dataTable: true }), "Sheet1");
+    expect(dTableOf(result.chartXml)).not.toContain("<c:spPr>");
+  });
+
+  it("composes borderColor + borderWidth", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderColor: "FF0000",
+          borderWidth: 2,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dTableOf(result.chartXml)).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("clamps borderWidth", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 99,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dTableOf(result.chartXml)).toContain('<a:ln w="171450"');
+  });
+
+  it("drops borderWidth on pie / doughnut (no <c:dTable>)", () => {
+    const result = writeChart(
+      makeChart({
+        type: "pie",
+        series: [{ values: "B2:B4", categories: "A2:A4" }],
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderWidth: 2,
+        },
+      }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<c:dTable>");
+  });
+
+  it("round-trips dataTable.borderWidth", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [
+        makeChart({
+          dataTable: {
+            showHorzBorder: true,
+            showVertBorder: true,
+            showOutline: true,
+            showKeys: true,
+            borderWidth: 1.25,
+          },
+        }),
+      ],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(
+      typeof reparsed?.dataTable === "object" ? reparsed.dataTable.borderWidth : undefined,
+    ).toBe(1.25);
+  });
+});
+
+// ── writeChart — dataLabelsBorderWidth ──────────────────────────────
+
+describe("writeChart — dataLabelsBorderWidth", () => {
+  function dLblsOf(xml: string): string | undefined {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    return m ? m[0] : undefined;
+  }
+
+  it("emits <a:ln w=..> on chart-level dataLabels when borderWidth is set", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderWidth: 1.5 } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:ln w="19050"');
+  });
+
+  it("composes borderColor + borderWidth on data labels", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderColor: "ABCDEF", borderWidth: 2 } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill></a:ln>',
+    );
+  });
+
+  it("clamps borderWidth on data labels", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderWidth: 50 } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:ln w="171450"');
+  });
+
+  it("drops NaN", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderWidth: Number.NaN } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<a:ln");
+  });
+
+  it("round-trips dataLabels.borderWidth", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [
+        makeChart({
+          series: [
+            {
+              name: "Revenue",
+              values: "B2:B4",
+              categories: "A2:A4",
+              dataLabels: { showValue: true, borderWidth: 1.25 },
+            },
+          ],
+        }),
+      ],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.series?.[0]?.dataLabels?.borderWidth).toBe(1.25);
+  });
+});
+
+// ── writeChart — *BorderDash family ─────────────────────────────────
+
+describe("writeChart — plotAreaBorderDash", () => {
+  function plotAreaOf(xml: string): string {
+    const m = xml.match(/<c:plotArea>[\s\S]*?<\/c:plotArea>/);
+    if (!m) throw new Error("No <c:plotArea>");
+    return m[0];
+  }
+
+  it("emits <a:prstDash> for 'dash'", () => {
+    const result = writeChart(makeChart({ plotAreaBorderDash: "dash" }), "Sheet1");
+    expect(plotAreaOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("emits <a:prstDash> for 'dashDot'", () => {
+    const result = writeChart(makeChart({ plotAreaBorderDash: "dashDot" }), "Sheet1");
+    expect(plotAreaOf(result.chartXml)).toContain('<a:prstDash val="dashDot"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(makeChart({ plotAreaBorderDash: "solid" }), "Sheet1");
+    expect(plotAreaOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("drops unrecognized tokens", () => {
+    const result = writeChart(makeChart({ plotAreaBorderDash: "weirdo" as any }), "Sheet1");
+    expect(plotAreaOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("emits <a:prstDash> after <a:solidFill> per CT_LineProperties", () => {
+    const result = writeChart(
+      makeChart({ plotAreaBorderColor: "FF0000", plotAreaBorderDash: "dash" }),
+      "Sheet1",
+    );
+    const pa = plotAreaOf(result.chartXml);
+    const fillIdx = pa.indexOf("<a:solidFill>");
+    const dashIdx = pa.indexOf("<a:prstDash");
+    expect(fillIdx).toBeGreaterThan(0);
+    expect(dashIdx).toBeGreaterThan(fillIdx);
+  });
+
+  it("composes color + width + dash on the same <a:ln>", () => {
+    const result = writeChart(
+      makeChart({
+        plotAreaBorderColor: "1F77B4",
+        plotAreaBorderWidth: 2,
+        plotAreaBorderDash: "dot",
+      }),
+      "Sheet1",
+    );
+    const pa = plotAreaOf(result.chartXml);
+    expect(pa).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill><a:prstDash val="dot"/></a:ln>',
+    );
+  });
+
+  it("round-trips plotAreaBorderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [makeChart({ plotAreaBorderDash: "dash" })],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.plotAreaBorderDash).toBe("dash");
+  });
+});
+
+describe("writeChart — legendBorderDash", () => {
+  function legendOf(xml: string): string {
+    const m = xml.match(/<c:legend>[\s\S]*?<\/c:legend>/);
+    if (!m) throw new Error("No <c:legend>");
+    return m[0];
+  }
+
+  it("emits <a:prstDash> on legend", () => {
+    const result = writeChart(makeChart({ legend: "right", legendBorderDash: "dash" }), "Sheet1");
+    expect(legendOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(makeChart({ legend: "right", legendBorderDash: "solid" }), "Sheet1");
+    expect(legendOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("composes color + width + dash on the legend", () => {
+    const result = writeChart(
+      makeChart({
+        legend: "right",
+        legendBorderColor: "FF0000",
+        legendBorderWidth: 1.5,
+        legendBorderDash: "dot",
+      }),
+      "Sheet1",
+    );
+    expect(legendOf(result.chartXml)).toContain(
+      '<a:ln w="19050"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="dot"/></a:ln>',
+    );
+  });
+
+  it("does not emit when legend is hidden", () => {
+    const result = writeChart(makeChart({ legend: false, legendBorderDash: "dash" }), "Sheet1");
+    expect(result.chartXml).not.toContain("<a:prstDash");
+  });
+
+  it("round-trips legendBorderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [makeChart({ legend: "right", legendBorderDash: "lgDash" })],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.legendBorderDash).toBe("lgDash");
+  });
+});
+
+describe("writeChart — titleBorderDash", () => {
+  function titleOf(xml: string): string {
+    const m = xml.match(/<c:chart>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No chart-level <c:title>");
+    const titleMatch = m[0].match(/<c:title>[\s\S]*?<\/c:title>/);
+    if (!titleMatch) throw new Error("No <c:title>");
+    return titleMatch[0];
+  }
+
+  it("emits <a:prstDash> on title", () => {
+    const result = writeChart(makeChart({ titleBorderDash: "dash" }), "Sheet1");
+    expect(titleOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(makeChart({ titleBorderDash: "solid" }), "Sheet1");
+    expect(titleOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("composes color + width + dash on title", () => {
+    const result = writeChart(
+      makeChart({ titleBorderColor: "1F77B4", titleBorderWidth: 1, titleBorderDash: "sysDash" }),
+      "Sheet1",
+    );
+    expect(titleOf(result.chartXml)).toContain(
+      '<a:ln w="12700"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill><a:prstDash val="sysDash"/></a:ln>',
+    );
+  });
+
+  it("does not emit when title is hidden", () => {
+    const result = writeChart(makeChart({ showTitle: false, titleBorderDash: "dash" }), "Sheet1");
+    const m = result.chartXml.match(/<c:chart>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    expect(m).toBeNull();
+  });
+
+  it("round-trips titleBorderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [makeChart({ titleBorderDash: "dashDot" })],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.titleBorderDash).toBe("dashDot");
+  });
+});
+
+describe("writeChart — chartSpaceBorderDash", () => {
+  function chartSpaceSpPrOf(xml: string): string | undefined {
+    const m = xml.match(/<\/c:chart>\s*<c:spPr>([\s\S]*?)<\/c:spPr>/);
+    return m ? m[0] : undefined;
+  }
+
+  it("emits <a:prstDash> on chartSpace", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderDash: "dash" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(makeChart({ chartSpaceBorderDash: "solid" }), "Sheet1");
+    expect(chartSpaceSpPrOf(result.chartXml)).toBeUndefined();
+  });
+
+  it("composes color + width + dash on chartSpace", () => {
+    const result = writeChart(
+      makeChart({
+        chartSpaceBorderColor: "F2F2F2",
+        chartSpaceBorderWidth: 0.5,
+        chartSpaceBorderDash: "lgDashDot",
+      }),
+      "Sheet1",
+    );
+    expect(chartSpaceSpPrOf(result.chartXml)).toContain(
+      '<a:ln w="6350"><a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill><a:prstDash val="lgDashDot"/></a:ln>',
+    );
+  });
+
+  it("round-trips chartSpaceBorderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [makeChart({ chartSpaceBorderDash: "sysDashDot" })],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.chartSpaceBorderDash).toBe("sysDashDot");
+  });
+});
+
+describe("writeChart — axisTitleBorderDash", () => {
+  function xAxisTitleOf(xml: string): string {
+    const m = xml.match(/<c:catAx>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No catAx title");
+    return m[0];
+  }
+  function yAxisTitleOf(xml: string): string {
+    const m = xml.match(/<c:valAx>[\s\S]*?<c:title>[\s\S]*?<\/c:title>/);
+    if (!m) throw new Error("No valAx title");
+    return m[0];
+  }
+
+  it("emits <a:prstDash> on X axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "X", axisTitleBorderDash: "dash" }, y: { title: "Y" } } }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("emits <a:prstDash> on Y axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "X" }, y: { title: "Y", axisTitleBorderDash: "dot" } } }),
+      "Sheet1",
+    );
+    expect(yAxisTitleOf(result.chartXml)).toContain('<a:prstDash val="dot"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { title: "X", axisTitleBorderDash: "solid" }, y: { title: "Y" } } }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("composes axis title color + width + dash", () => {
+    const result = writeChart(
+      makeChart({
+        axes: {
+          x: {
+            title: "X",
+            axisTitleBorderColor: "ABCDEF",
+            axisTitleBorderWidth: 2,
+            axisTitleBorderDash: "dashDot",
+          },
+          y: { title: "Y" },
+        },
+      }),
+      "Sheet1",
+    );
+    expect(xAxisTitleOf(result.chartXml)).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill><a:prstDash val="dashDot"/></a:ln>',
+    );
+  });
+
+  it("drops axis title dash when no axis title", () => {
+    const result = writeChart(
+      makeChart({ axes: { x: { axisTitleBorderDash: "dash" } } }),
+      "Sheet1",
+    );
+    expect(result.chartXml).not.toContain("<a:prstDash");
+  });
+
+  it("round-trips axisTitleBorderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [
+        makeChart({
+          axes: {
+            x: { title: "X", axisTitleBorderDash: "lgDash" },
+            y: { title: "Y", axisTitleBorderDash: "sysDot" },
+          },
+        }),
+      ],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.axes?.x?.axisTitleBorderDash).toBe("lgDash");
+    expect(reparsed?.axes?.y?.axisTitleBorderDash).toBe("sysDot");
+  });
+});
+
+describe("writeChart — dataTableBorderDash", () => {
+  function dTableOf(xml: string): string {
+    const m = xml.match(/<c:dTable>[\s\S]*?<\/c:dTable>/);
+    if (!m) throw new Error("No <c:dTable>");
+    return m[0];
+  }
+
+  it("emits <a:prstDash> on data table", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderDash: "dash",
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dTableOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderDash: "solid",
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dTableOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("composes data-table color + width + dash", () => {
+    const result = writeChart(
+      makeChart({
+        dataTable: {
+          showHorzBorder: true,
+          showVertBorder: true,
+          showOutline: true,
+          showKeys: true,
+          borderColor: "FF0000",
+          borderWidth: 1.5,
+          borderDash: "lgDashDotDot",
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dTableOf(result.chartXml)).toContain(
+      '<a:ln w="19050"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:prstDash val="lgDashDotDot"/></a:ln>',
+    );
+  });
+
+  it("round-trips dataTable.borderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [
+        makeChart({
+          dataTable: {
+            showHorzBorder: true,
+            showVertBorder: true,
+            showOutline: true,
+            showKeys: true,
+            borderDash: "sysDashDotDot",
+          },
+        }),
+      ],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(
+      typeof reparsed?.dataTable === "object" ? reparsed.dataTable.borderDash : undefined,
+    ).toBe("sysDashDotDot");
+  });
+});
+
+describe("writeChart — dataLabelsBorderDash", () => {
+  function dLblsOf(xml: string): string | undefined {
+    const m = xml.match(/<c:dLbls>[\s\S]*?<\/c:dLbls>/);
+    return m ? m[0] : undefined;
+  }
+
+  it("emits <a:prstDash> on data labels", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderDash: "dash" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain('<a:prstDash val="dash"/>');
+  });
+
+  it("collapses 'solid' to no <a:prstDash>", () => {
+    const result = writeChart(
+      makeChart({ dataLabels: { showValue: true, borderDash: "solid" } }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).not.toContain("<a:prstDash");
+  });
+
+  it("composes data-labels color + width + dash", () => {
+    const result = writeChart(
+      makeChart({
+        dataLabels: {
+          showValue: true,
+          borderColor: "ABCDEF",
+          borderWidth: 2,
+          borderDash: "dashDot",
+        },
+      }),
+      "Sheet1",
+    );
+    expect(dLblsOf(result.chartXml)).toContain(
+      '<a:ln w="25400"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill><a:prstDash val="dashDot"/></a:ln>',
+    );
+  });
+
+  it("round-trips per-series dataLabels.borderDash", async () => {
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [
+        ["A", "B"],
+        ["Q1", 100],
+      ],
+      charts: [
+        makeChart({
+          series: [
+            {
+              name: "Revenue",
+              values: "B2:B4",
+              categories: "A2:A4",
+              dataLabels: { showValue: true, borderDash: "lgDash" },
+            },
+          ],
+        }),
+      ],
+    };
+    const out = await writeXlsx({ sheets: [sheet] });
+    const chartXml = await extractXml(out, "xl/charts/chart1.xml");
+    const reparsed = parseChart(chartXml);
+    expect(reparsed?.series?.[0]?.dataLabels?.borderDash).toBe("lgDash");
+  });
+});

--- a/test/charts.test.ts
+++ b/test/charts.test.ts
@@ -22900,3 +22900,831 @@ describe("parseChart — titleBorderWidth", () => {
     expect(parseChart(xml)?.titleBorderWidth).toBe(1.5);
   });
 });
+
+// ── parseChart — chartSpaceBorderWidth ───────────────────────────────
+
+describe("parseChart — chartSpaceBorderWidth", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withChartSpaceSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+  <c:spPr>${spPrBody}</c:spPr>
+</c:chartSpace>`;
+  }
+
+  it("surfaces the stroke width in points (12700 EMU = 1 pt)", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="12700"/>`))?.chartSpaceBorderWidth).toBe(1);
+  });
+
+  it("surfaces a fractional stroke width (19050 EMU = 1.5 pt)", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="19050"/>`))?.chartSpaceBorderWidth).toBe(1.5);
+  });
+
+  it("surfaces the minimum width (3175 EMU = 0.25 pt)", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="3175"/>`))?.chartSpaceBorderWidth).toBe(0.25);
+  });
+
+  it("snaps an exotic EMU value to the nearest 0.25 pt grid", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="14000"/>`))?.chartSpaceBorderWidth).toBe(1);
+  });
+
+  it("clamps below the minimum band (1000 EMU → 0.25 pt)", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="1000"/>`))?.chartSpaceBorderWidth).toBe(0.25);
+  });
+
+  it("clamps above the maximum band (1000000 EMU → 13.5 pt)", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="1000000"/>`))?.chartSpaceBorderWidth).toBe(13.5);
+  });
+
+  it("surfaces both border color and width when both are pinned on <a:ln>", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.chartSpaceBorderWidth).toBe(2);
+    expect(parsed?.chartSpaceBorderColor).toBe("1F77B4");
+  });
+
+  it("returns undefined when chartSpace has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS}><c:chart><c:plotArea><c:layout/><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart><c:catAx><c:axId val="1"/></c:catAx><c:valAx><c:axId val="2"/></c:valAx></c:plotArea></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.chartSpaceBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when <c:spPr> has no <a:ln>", () => {
+    expect(
+      parseChart(withChartSpaceSpPr(`<a:solidFill><a:srgbClr val="F2F2F2"/></a:solidFill>`))
+        ?.chartSpaceBorderWidth,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no w attribute", () => {
+    expect(
+      parseChart(
+        withChartSpaceSpPr(`<a:ln><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`),
+      )?.chartSpaceBorderWidth,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when w is malformed", () => {
+    expect(
+      parseChart(withChartSpaceSpPr(`<a:ln w="thick"/>`))?.chartSpaceBorderWidth,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when w is zero", () => {
+    expect(parseChart(withChartSpaceSpPr(`<a:ln w="0"/>`))?.chartSpaceBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when w is negative", () => {
+    expect(
+      parseChart(withChartSpaceSpPr(`<a:ln w="-12700"/>`))?.chartSpaceBorderWidth,
+    ).toBeUndefined();
+  });
+
+  it("ignores a stray <a:ln w=..> on a series <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:spPr><a:ln w="50800"/></c:spPr>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.chartSpaceBorderWidth).toBeUndefined();
+  });
+});
+
+// ── parseChart — axisTitleBorderWidth ────────────────────────────────
+
+describe("parseChart — axisTitleBorderWidth", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withAxisTitleSpPr(spPrBody: string, axis: "catAx" | "valAx" = "catAx"): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:${axis}>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Axis</a:t></a:r></a:p></c:rich></c:tx>
+          <c:overlay val="0"/>
+          <c:spPr>${spPrBody}</c:spPr>
+        </c:title>
+      </c:${axis}>
+      <c:${axis === "catAx" ? "valAx" : "catAx"}><c:axId val="2"/></c:${axis === "catAx" ? "valAx" : "catAx"}>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces width on the X axis (catAx)", () => {
+    const parsed = parseChart(withAxisTitleSpPr(`<a:ln w="12700"/>`, "catAx"));
+    expect(parsed?.axes?.x?.axisTitleBorderWidth).toBe(1);
+  });
+
+  it("surfaces width on the Y axis (valAx)", () => {
+    const parsed = parseChart(withAxisTitleSpPr(`<a:ln w="19050"/>`, "valAx"));
+    expect(parsed?.axes?.y?.axisTitleBorderWidth).toBe(1.5);
+  });
+
+  it("surfaces both color and width on the same <a:ln>", () => {
+    const xml = withAxisTitleSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.axes?.x?.axisTitleBorderWidth).toBe(2);
+    expect(parsed?.axes?.x?.axisTitleBorderColor).toBe("1F77B4");
+  });
+
+  it("clamps to the minimum (0.25 pt)", () => {
+    expect(parseChart(withAxisTitleSpPr(`<a:ln w="100"/>`))?.axes?.x?.axisTitleBorderWidth).toBe(
+      0.25,
+    );
+  });
+
+  it("clamps to the maximum (13.5 pt)", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln w="1000000"/>`))?.axes?.x?.axisTitleBorderWidth,
+    ).toBe(13.5);
+  });
+
+  it("returns undefined when axis has no <c:title>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when title has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>X</a:t></a:r></a:p></c:rich></c:tx>
+          <c:overlay val="0"/>
+        </c:title>
+      </c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.axes?.x?.axisTitleBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when w is missing", () => {
+    expect(parseChart(withAxisTitleSpPr(`<a:ln/>`))?.axes?.x?.axisTitleBorderWidth).toBeUndefined();
+  });
+
+  it("returns undefined when w is zero", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln w="0"/>`))?.axes?.x?.axisTitleBorderWidth,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when w is malformed", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln w="bold"/>`))?.axes?.x?.axisTitleBorderWidth,
+    ).toBeUndefined();
+  });
+});
+
+// ── parseChart — dataTableBorderWidth ────────────────────────────────
+
+describe("parseChart — dataTableBorderWidth", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDTableSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:dTable>
+        <c:showHorzBorder val="1"/>
+        <c:showVertBorder val="1"/>
+        <c:showOutline val="1"/>
+        <c:showKeys val="1"/>
+        <c:spPr>${spPrBody}</c:spPr>
+      </c:dTable>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces width (12700 EMU = 1 pt)", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln w="12700"/>`));
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined).toBe(
+      1,
+    );
+  });
+
+  it("surfaces fractional width (19050 EMU = 1.5 pt)", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln w="19050"/>`));
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined).toBe(
+      1.5,
+    );
+  });
+
+  it("clamps to minimum 0.25", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln w="100"/>`));
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined).toBe(
+      0.25,
+    );
+  });
+
+  it("clamps to maximum 13.5", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln w="9999999"/>`));
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined).toBe(
+      13.5,
+    );
+  });
+
+  it("returns undefined when w is zero", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln w="0"/>`));
+    expect(
+      typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when w is missing", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln/>`));
+    expect(
+      typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined,
+    ).toBeUndefined();
+  });
+
+  it("surfaces both color and width together", () => {
+    const parsed = parseChart(
+      withDTableSpPr(`<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`),
+    );
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined).toBe(
+      2,
+    );
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderColor : undefined).toBe(
+      "1F77B4",
+    );
+  });
+});
+
+// ── parseChart — dataLabelsBorderWidth ───────────────────────────────
+
+describe("parseChart — dataLabelsBorderWidth", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:dLbls>
+            <c:spPr>${spPrBody}</c:spPr>
+            <c:showLegendKey val="0"/>
+            <c:showVal val="1"/>
+            <c:showCatName val="0"/>
+            <c:showSerName val="0"/>
+            <c:showPercent val="0"/>
+            <c:showBubbleSize val="0"/>
+          </c:dLbls>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces width on series-level data labels", () => {
+    const parsed = parseChart(withDLblsSpPr(`<a:ln w="12700"/>`));
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBe(1);
+  });
+
+  it("surfaces fractional width on series-level data labels", () => {
+    const parsed = parseChart(withDLblsSpPr(`<a:ln w="19050"/>`));
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBe(1.5);
+  });
+
+  it("clamps to minimum 0.25", () => {
+    const parsed = parseChart(withDLblsSpPr(`<a:ln w="100"/>`));
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBe(0.25);
+  });
+
+  it("clamps to maximum 13.5", () => {
+    const parsed = parseChart(withDLblsSpPr(`<a:ln w="9999999"/>`));
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBe(13.5);
+  });
+
+  it("returns undefined when w is zero", () => {
+    const parsed = parseChart(withDLblsSpPr(`<a:ln w="0"/>`));
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBeUndefined();
+  });
+
+  it("surfaces both color and width on the same <a:ln>", () => {
+    const parsed = parseChart(
+      withDLblsSpPr(`<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill></a:ln>`),
+    );
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBe(2);
+    expect(parsed?.series?.[0]?.dataLabels?.borderColor).toBe("1F77B4");
+  });
+});
+
+// ── parseChart — *BorderDash family ──────────────────────────────────
+
+describe("parseChart — plotAreaBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withPlotAreaSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces a 'dash' preset", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBe("dash");
+  });
+
+  it("surfaces a 'dashDot' preset", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="dashDot"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBe("dashDot");
+  });
+
+  it("surfaces a 'dot' preset", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="dot"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBe("dot");
+  });
+
+  it("surfaces a 'lgDash' preset", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="lgDash"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBe("lgDash");
+  });
+
+  it("surfaces 'lgDashDot' / 'lgDashDotDot'", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="lgDashDot"/></a:ln>`))
+        ?.plotAreaBorderDash,
+    ).toBe("lgDashDot");
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="lgDashDotDot"/></a:ln>`))
+        ?.plotAreaBorderDash,
+    ).toBe("lgDashDotDot");
+  });
+
+  it("surfaces 'sysDash' / 'sysDashDot' / 'sysDashDotDot' / 'sysDot'", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="sysDash"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBe("sysDash");
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="sysDashDot"/></a:ln>`))
+        ?.plotAreaBorderDash,
+    ).toBe("sysDashDot");
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="sysDashDotDot"/></a:ln>`))
+        ?.plotAreaBorderDash,
+    ).toBe("sysDashDotDot");
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="sysDot"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBe("sysDot");
+  });
+
+  it("collapses 'solid' (the OOXML default) to undefined", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`))?.plotAreaBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no <c:spPr> is present", () => {
+    const xml = `<c:chartSpace ${NS}><c:chart><c:plotArea><c:layout/><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart><c:catAx><c:axId val="1"/></c:catAx><c:valAx><c:axId val="2"/></c:valAx></c:plotArea></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.plotAreaBorderDash).toBeUndefined();
+  });
+
+  it("returns undefined when <a:ln> has no <a:prstDash>", () => {
+    expect(parseChart(withPlotAreaSpPr(`<a:ln/>`))?.plotAreaBorderDash).toBeUndefined();
+  });
+
+  it("returns undefined when val is missing", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash/></a:ln>`))?.plotAreaBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when val is unrecognized", () => {
+    expect(
+      parseChart(withPlotAreaSpPr(`<a:ln><a:prstDash val="weirdToken"/></a:ln>`))
+        ?.plotAreaBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("composes with border color and width", () => {
+    const xml = withPlotAreaSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill><a:prstDash val="dash"/></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.plotAreaBorderDash).toBe("dash");
+    expect(parsed?.plotAreaBorderColor).toBe("1F77B4");
+    expect(parsed?.plotAreaBorderWidth).toBe(2);
+  });
+});
+
+describe("parseChart — legendBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withLegendSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces 'dash' on legend", () => {
+    expect(
+      parseChart(withLegendSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`))?.legendBorderDash,
+    ).toBe("dash");
+  });
+
+  it("surfaces 'dot' on legend", () => {
+    expect(
+      parseChart(withLegendSpPr(`<a:ln><a:prstDash val="dot"/></a:ln>`))?.legendBorderDash,
+    ).toBe("dot");
+  });
+
+  it("collapses 'solid' to undefined", () => {
+    expect(
+      parseChart(withLegendSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`))?.legendBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when chart has no legend", () => {
+    const xml = `<c:chartSpace ${NS}><c:chart><c:plotArea><c:layout/><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart><c:catAx><c:axId val="1"/></c:catAx><c:valAx><c:axId val="2"/></c:valAx></c:plotArea></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderDash).toBeUndefined();
+  });
+
+  it("ignores stray prstDash on the plot area when reading legendBorderDash", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:ln><a:prstDash val="dot"/></a:ln></c:spPr>
+    </c:plotArea>
+    <c:legend>
+      <c:legendPos val="r"/>
+      <c:overlay val="0"/>
+    </c:legend>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.legendBorderDash).toBeUndefined();
+  });
+});
+
+describe("parseChart — titleBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withTitleSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:title>
+      <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Hero</a:t></a:r></a:p></c:rich></c:tx>
+      <c:overlay val="0"/>
+      <c:spPr>${spPrBody}</c:spPr>
+    </c:title>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces 'dash' on title", () => {
+    expect(
+      parseChart(withTitleSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`))?.titleBorderDash,
+    ).toBe("dash");
+  });
+
+  it("surfaces 'sysDash' on title", () => {
+    expect(
+      parseChart(withTitleSpPr(`<a:ln><a:prstDash val="sysDash"/></a:ln>`))?.titleBorderDash,
+    ).toBe("sysDash");
+  });
+
+  it("collapses 'solid' to undefined", () => {
+    expect(
+      parseChart(withTitleSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`))?.titleBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when chart has no title", () => {
+    const xml = `<c:chartSpace ${NS}><c:chart><c:plotArea><c:layout/><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart><c:catAx><c:axId val="1"/></c:catAx><c:valAx><c:axId val="2"/></c:valAx></c:plotArea></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.titleBorderDash).toBeUndefined();
+  });
+
+  it("composes with border color, width, and dash on the same <a:ln>", () => {
+    const xml = withTitleSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill><a:prstDash val="dashDot"/></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.titleBorderDash).toBe("dashDot");
+    expect(parsed?.titleBorderColor).toBe("ABCDEF");
+    expect(parsed?.titleBorderWidth).toBe(2);
+  });
+});
+
+describe("parseChart — chartSpaceBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withChartSpaceSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+  <c:spPr>${spPrBody}</c:spPr>
+</c:chartSpace>`;
+  }
+
+  it("surfaces 'dash' on chartSpace", () => {
+    expect(
+      parseChart(withChartSpaceSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`))?.chartSpaceBorderDash,
+    ).toBe("dash");
+  });
+
+  it("collapses 'solid' to undefined", () => {
+    expect(
+      parseChart(withChartSpaceSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`))
+        ?.chartSpaceBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when chartSpace has no <c:spPr>", () => {
+    const xml = `<c:chartSpace ${NS}><c:chart><c:plotArea><c:layout/><c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart><c:catAx><c:axId val="1"/></c:catAx><c:valAx><c:axId val="2"/></c:valAx></c:plotArea></c:chart></c:chartSpace>`;
+    expect(parseChart(xml)?.chartSpaceBorderDash).toBeUndefined();
+  });
+
+  it("composes with chartSpaceBorderColor and chartSpaceBorderWidth", () => {
+    const xml = withChartSpaceSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill><a:prstDash val="dot"/></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.chartSpaceBorderDash).toBe("dot");
+    expect(parsed?.chartSpaceBorderColor).toBe("1F77B4");
+    expect(parsed?.chartSpaceBorderWidth).toBe(2);
+  });
+
+  it("ignores a stray prstDash on the plot area", () => {
+    const xml = `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+      <c:spPr><a:ln><a:prstDash val="dash"/></a:ln></c:spPr>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+    expect(parseChart(xml)?.chartSpaceBorderDash).toBeUndefined();
+  });
+});
+
+describe("parseChart — axisTitleBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withAxisTitleSpPr(spPrBody: string, axis: "catAx" | "valAx" = "catAx"): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:${axis}>
+        <c:axId val="1"/>
+        <c:title>
+          <c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr><a:defRPr/></a:pPr><a:r><a:t>Axis</a:t></a:r></a:p></c:rich></c:tx>
+          <c:overlay val="0"/>
+          <c:spPr>${spPrBody}</c:spPr>
+        </c:title>
+      </c:${axis}>
+      <c:${axis === "catAx" ? "valAx" : "catAx"}><c:axId val="2"/></c:${axis === "catAx" ? "valAx" : "catAx"}>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces 'dash' on the X axis (catAx)", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`, "catAx"))?.axes?.x
+        ?.axisTitleBorderDash,
+    ).toBe("dash");
+  });
+
+  it("surfaces 'dot' on the Y axis (valAx)", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln><a:prstDash val="dot"/></a:ln>`, "valAx"))?.axes?.y
+        ?.axisTitleBorderDash,
+    ).toBe("dot");
+  });
+
+  it("collapses 'solid' to undefined", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`))?.axes?.x
+        ?.axisTitleBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for unrecognized values", () => {
+    expect(
+      parseChart(withAxisTitleSpPr(`<a:ln><a:prstDash val="bogus"/></a:ln>`))?.axes?.x
+        ?.axisTitleBorderDash,
+    ).toBeUndefined();
+  });
+
+  it("composes with axisTitleBorderColor and axisTitleBorderWidth", () => {
+    const xml = withAxisTitleSpPr(
+      `<a:ln w="25400"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill><a:prstDash val="dashDot"/></a:ln>`,
+    );
+    const parsed = parseChart(xml);
+    expect(parsed?.axes?.x?.axisTitleBorderDash).toBe("dashDot");
+    expect(parsed?.axes?.x?.axisTitleBorderColor).toBe("ABCDEF");
+    expect(parsed?.axes?.x?.axisTitleBorderWidth).toBe(2);
+  });
+});
+
+describe("parseChart — dataTableBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDTableSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart><c:ser><c:idx val="0"/></c:ser></c:barChart>
+      <c:dTable>
+        <c:showHorzBorder val="1"/>
+        <c:showVertBorder val="1"/>
+        <c:showOutline val="1"/>
+        <c:showKeys val="1"/>
+        <c:spPr>${spPrBody}</c:spPr>
+      </c:dTable>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces 'dash' on data table", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`));
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderDash : undefined).toBe(
+      "dash",
+    );
+  });
+
+  it("collapses 'solid' to undefined", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`));
+    expect(
+      typeof parsed?.dataTable === "object" ? parsed.dataTable.borderDash : undefined,
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for unrecognized value", () => {
+    const parsed = parseChart(withDTableSpPr(`<a:ln><a:prstDash val="weirdo"/></a:ln>`));
+    expect(
+      typeof parsed?.dataTable === "object" ? parsed.dataTable.borderDash : undefined,
+    ).toBeUndefined();
+  });
+
+  it("composes with dTable border color and width", () => {
+    const parsed = parseChart(
+      withDTableSpPr(
+        `<a:ln w="25400"><a:solidFill><a:srgbClr val="1F77B4"/></a:solidFill><a:prstDash val="dot"/></a:ln>`,
+      ),
+    );
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderDash : undefined).toBe(
+      "dot",
+    );
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderColor : undefined).toBe(
+      "1F77B4",
+    );
+    expect(typeof parsed?.dataTable === "object" ? parsed.dataTable.borderWidth : undefined).toBe(
+      2,
+    );
+  });
+});
+
+describe("parseChart — dataLabelsBorderDash", () => {
+  const NS = `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"`;
+
+  function withDLblsSpPr(spPrBody: string): string {
+    return `<c:chartSpace ${NS}>
+  <c:chart>
+    <c:plotArea>
+      <c:layout/>
+      <c:barChart>
+        <c:ser>
+          <c:idx val="0"/>
+          <c:dLbls>
+            <c:spPr>${spPrBody}</c:spPr>
+            <c:showLegendKey val="0"/>
+            <c:showVal val="1"/>
+            <c:showCatName val="0"/>
+            <c:showSerName val="0"/>
+            <c:showPercent val="0"/>
+            <c:showBubbleSize val="0"/>
+          </c:dLbls>
+        </c:ser>
+      </c:barChart>
+      <c:catAx><c:axId val="1"/></c:catAx>
+      <c:valAx><c:axId val="2"/></c:valAx>
+    </c:plotArea>
+  </c:chart>
+</c:chartSpace>`;
+  }
+
+  it("surfaces 'dash' on data labels", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:ln><a:prstDash val="dash"/></a:ln>`))?.series?.[0]?.dataLabels
+        ?.borderDash,
+    ).toBe("dash");
+  });
+
+  it("collapses 'solid' to undefined", () => {
+    expect(
+      parseChart(withDLblsSpPr(`<a:ln><a:prstDash val="solid"/></a:ln>`))?.series?.[0]?.dataLabels
+        ?.borderDash,
+    ).toBeUndefined();
+  });
+
+  it("composes with data-labels border color and width", () => {
+    const parsed = parseChart(
+      withDLblsSpPr(
+        `<a:ln w="25400"><a:solidFill><a:srgbClr val="ABCDEF"/></a:solidFill><a:prstDash val="dashDot"/></a:ln>`,
+      ),
+    );
+    expect(parsed?.series?.[0]?.dataLabels?.borderDash).toBe("dashDot");
+    expect(parsed?.series?.[0]?.dataLabels?.borderColor).toBe("ABCDEF");
+    expect(parsed?.series?.[0]?.dataLabels?.borderWidth).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining chart-frame styling gaps in three batches:

### 1. Border-width fields on the four hosts that previously only carried color
- `axisTitleBorderWidth` (X / Y axes)
- `chartSpaceBorderWidth`
- `dataTableBorderWidth`
- `dataLabelsBorderWidth`

Mirrors the existing `plotAreaBorderWidth` / `legendBorderWidth` /
`titleBorderWidth` grammar exactly — values are clamped to the
`0.25..13.5` pt band Excel's UI exposes and snapped to the 0.25 pt
grid; non-finite / non-numeric tokens collapse to `undefined`; the
writer omits the `w` attribute when no width is pinned. Each lands
on the canonical `w` attribute of `<c:spPr><a:ln w="EMU">` per
`CT_LineProperties` (1 pt = 12 700 EMU).

### 2. Border-dash family on all seven chart-frame hosts
- `plotAreaBorderDash`
- `legendBorderDash`
- `titleBorderDash`
- `chartSpaceBorderDash`
- `axisTitleBorderDash` (X / Y)
- `dataTableBorderDash`
- `dataLabelsBorderDash`

New `ChartBorderDash` enum (`"solid" | "dash" | "dashDot" | "dot" |
"lgDash" | "lgDashDot" | "lgDashDotDot" | "sysDash" | "sysDashDot" |
"sysDashDotDot" | "sysDot"`) mirrors `ST_PresetLineDashVal` exactly.
Reader collapses `"solid"` (the OOXML default) to `undefined` for
round-trip symmetry; writer skips emission for absence and `"solid"`.
Emitted `<a:prstDash val=".."/>` follows `<a:solidFill>` per the
`CT_LineProperties` schema sequence (fill -> dash -> headEnd /
tailEnd).

All three border-color / border-width / border-dash knobs compose
freely on a single `<a:ln>` element. Pinning all three on the same
chart-frame host emits a single `<a:ln>` block with children in
`CT_LineProperties` schema order.

`cloneChart` resolvers follow the standard `undefined` / `null` /
value override grammar; per-host scoping (hidden title -> drop the
title border knobs, pie / doughnut -> drop the axis-title and data-
table knobs) carries through unchanged.

### 3. README chart section trimmed from ~1500 lines to ~210
Replaces the per-knob exhaustive prose with a capability matrix and
four short examples (`writeXlsx` authoring, `cloneChart` override,
`getCharts` / `addChart` composition, plus a pointer to `SheetChart` /
`CloneChartOptions` in the source for the full knob list).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm vitest run --dir=test` — 7362 / 7362 passing (was 7173 baseline; +189 new tests)
- [x] No existing tests broken
- [x] All emitted XML conforms to OOXML schema sequences (`CT_ShapeProperties` fill -> stroke; `CT_LineProperties` fill -> dash -> head/tail; `CT_Title`, `CT_Legend`, `CT_PlotArea`, `CT_DTable`, `CT_DLbls`, `CT_ChartSpace` host element ordering)
- [x] Round-trip tests through `writeXlsx -> parseChart` cover every new field
- [x] Composition tests verify color + width + dash land on the same `<a:ln>` block in schema order

🤖 Generated with [Claude Code](https://claude.com/claude-code)