### PR TITLE
fix: explicit types for isolatedDeclarations — missing dist files

### DIFF
--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -114,7 +114,7 @@ function detectCurrencySymbol(code: string): string | undefined {
   const quoted = code.match(/"([^"]+)"/);
   if (quoted && /[$€£¥₺₽₹]/.test(quoted[1])) return quoted[1];
   // Bare $ at the start
-  if (/^\$/.test(code) || /[$€£¥₺₽₹]/.test(code)) {
+  if (code.startsWith("$") || /[$€£¥₺₽₹]/.test(code)) {
     const m = code.match(/[$€£¥₺₽₹]/);
     if (m) return m[0];
   }

--- a/src/xlsx/chart/text.ts
+++ b/src/xlsx/chart/text.ts
@@ -127,7 +127,7 @@ export function makeFontSizeNormalizer(
 }
 
 /** Normalize a font-size value against the standard `1..400` pt band. */
-export const normalizeFontSizePt = makeFontSizeNormalizer(FONT_SIZE_MIN_PT, FONT_SIZE_MAX_PT);
+export const normalizeFontSizePt: (value: number | undefined) => number | undefined = makeFontSizeNormalizer(FONT_SIZE_MIN_PT, FONT_SIZE_MAX_PT);
 
 // ── Font family ───────────────────────────────────────────────────
 

--- a/src/xlsx/chart/text.ts
+++ b/src/xlsx/chart/text.ts
@@ -127,7 +127,8 @@ export function makeFontSizeNormalizer(
 }
 
 /** Normalize a font-size value against the standard `1..400` pt band. */
-export const normalizeFontSizePt: (value: number | undefined) => number | undefined = makeFontSizeNormalizer(FONT_SIZE_MIN_PT, FONT_SIZE_MAX_PT);
+export const normalizeFontSizePt: (value: number | undefined) => number | undefined =
+  makeFontSizeNormalizer(FONT_SIZE_MIN_PT, FONT_SIZE_MAX_PT);
 
 // ── Font family ───────────────────────────────────────────────────
 

--- a/src/xlsx/external-link-reader.ts
+++ b/src/xlsx/external-link-reader.ts
@@ -165,7 +165,7 @@ function parseIntSafe(s: string | undefined, fallback: number): number {
 
 // Deliberately exported but not used internally — exposed for callers
 // that already extracted the relationship list and just want the body.
-export const REL_EXTERNAL_LINK_PATH_TYPES = [
+export const REL_EXTERNAL_LINK_PATH_TYPES: readonly [string, string] = [
   REL_EXTERNAL_LINK_PATH,
   REL_EXTERNAL_LINK_PATH_STRICT,
-] as const;
+];


### PR DESCRIPTION
## Problem

With `--isolatedDeclarations` mode active, two exports were missing explicit type annotations. This caused `obuild` to skip `.d.mts` generation, and in older versions to skip `.mjs` emission entirely — leaving `external-link-reader.mjs` absent from the published `dist` folder. Users would hit:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/hucre/dist/xlsx/external-link-reader.mjs'
```

## Changes

- `src/xlsx/external-link-reader.ts` — added explicit `readonly [string, string]` type to `REL_EXTERNAL_LINK_PATH_TYPES`
- `src/xlsx/chart/text.ts` — added explicit `(value: number | undefined) => number | undefined` type to `normalizeFontSizePt`

## Verification

`pnpm build` now completes without any WARN and all files (`external-link-reader.mjs`, `external-link-reader.d.mts`) are present in dist.

Closes #323