### PR TITLE
feat(xlsx): inline hyperlinks in data rows (#325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,31 @@ const buffer = await writeXlsx({
 })
 ```
 
+For tabular reports, put links **inline in `data` rows** instead of a parallel
+`cells` map — keyed by the column's `key`. Use the `link()` helper (or a plain
+`{ text, hyperlink, tooltip? }` object). A `#`-prefixed target is treated as an
+internal reference (`#Sheet2!A1`).
+
+```ts
+import { writeXlsx, link } from "hucre/xlsx"
+
+await writeXlsx({
+  sheets: [
+    {
+      name: "Summary",
+      columns: [
+        { header: "Link", key: "link" },
+        { header: "ID", key: "id" },
+      ],
+      data: [
+        { link: link("Open", "https://example.com/items/abc-123"), id: "abc-123" },
+        { link: { text: "Open", hyperlink: "https://example.com/items/def-456" }, id: "def-456" },
+      ],
+    },
+  ],
+})
+```
+
 ### Streaming
 
 Process large files row-by-row without loading everything into memory:

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -164,6 +164,25 @@ export interface Hyperlink {
   location?: string
 }
 
+/**
+ * A rich hyperlink value that can be placed inline in a {@link WriteSheet.data}
+ * row object, keyed by a column's `key`. The display text and link target live
+ * together, so a "Link" column needs no parallel `cells` coordinate map.
+ *
+ * @example
+ * ```ts
+ * data: [{ id: "abc", link: { text: "Open", hyperlink: "https://example.com/abc" } }]
+ * ```
+ */
+export interface HyperlinkValue {
+  /** Display text shown in the cell. */
+  text: string
+  /** Link destination — an external URL, or an internal ref prefixed with `#` (e.g. `"#Sheet2!A1"`). */
+  hyperlink: string
+  /** Optional hover tooltip. */
+  tooltip?: string
+}
+
 // ── Comment ────────────────────────────────────────────────────────
 
 export interface CellComment {
@@ -1329,8 +1348,11 @@ export interface WriteSheet {
   columns?: ColumnDef[]
   /** Raw row data (array of arrays) */
   rows?: CellValue[][]
-  /** Object data (array of objects — uses column keys) */
-  data?: Array<Record<string, CellValue>>
+  /**
+   * Object data (array of objects — uses column keys). A value may be a scalar
+   * {@link CellValue} or a rich {@link HyperlinkValue} for inline clickable links.
+   */
+  data?: Array<Record<string, CellValue | HyperlinkValue>>
   /** Detailed cell overrides (keyed by "row,col") */
   cells?: Map<string, Partial<Cell>>
   merges?: MergeRange[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export type { WriteObjectsTableOption } from "./defter"
 // ── XLSX ────────────────────────────────────────────────────────────
 export { readXlsx } from "./xlsx/reader"
 export { writeXlsx } from "./xlsx/writer"
+export { link } from "./xlsx/hyperlink"
 export { openXlsx, saveXlsx } from "./xlsx/roundtrip"
 export type { RoundtripWorkbook } from "./xlsx/roundtrip"
 export { hashSheetPassword } from "./xlsx/password"
@@ -252,6 +253,7 @@ export type {
   Cell,
   RichTextRun,
   Hyperlink,
+  HyperlinkValue,
   CellComment,
   // Style
   CellStyle,

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -12,6 +12,7 @@ import type {
   MergeRange,
 } from "../_types"
 import { ZipWriter } from "../zip/writer"
+import { unwrapCellValue } from "../xlsx/hyperlink"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
@@ -741,7 +742,7 @@ function writeContentXml(options: WriteOptions): string {
       }
 
       for (const item of sheet.data) {
-        const row = keys.map((k) => (k in item ? item[k] : null))
+        const row = keys.map((k) => (k in item ? unwrapCellValue(item[k]) : null))
         rows.push(row)
       }
     }

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -1,5 +1,7 @@
 export { readXlsx } from "./xlsx/reader"
 export { writeXlsx } from "./xlsx/writer"
+export { link } from "./xlsx/hyperlink"
+export type { HyperlinkValue } from "./_types"
 export { openXlsx, saveXlsx } from "./xlsx/roundtrip"
 export type { RoundtripWorkbook } from "./xlsx/roundtrip"
 export { hashSheetPassword } from "./xlsx/password"

--- a/src/xlsx/hyperlink.ts
+++ b/src/xlsx/hyperlink.ts
@@ -1,0 +1,49 @@
+// ── Hyperlink helpers ────────────────────────────────────────────────
+
+import type { CellValue, HyperlinkValue } from "../_types"
+
+/**
+ * Narrow a row-data value to a {@link HyperlinkValue}. Plain scalars are the
+ * common case; a hyperlink is always an object carrying `text` and `hyperlink`
+ * strings.
+ */
+export function isHyperlinkValue(v: unknown): v is HyperlinkValue {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as HyperlinkValue).hyperlink === "string" &&
+    typeof (v as HyperlinkValue).text === "string"
+  )
+}
+
+/** Reduce a rich data-row value to its scalar display value (for non-XLSX consumers). */
+export function unwrapCellValue(v: CellValue | HyperlinkValue): CellValue {
+  return isHyperlinkValue(v) ? v.text : v
+}
+
+/**
+ * Build a rich {@link HyperlinkValue} for inline use in a {@link WriteSheet.data}
+ * row object. The returned object can also be written by hand — this helper is
+ * purely ergonomic sugar.
+ *
+ * @param text Display text shown in the cell.
+ * @param hyperlink Link destination — an external URL, or an internal ref
+ *   prefixed with `#` (e.g. `"#Sheet2!A1"`).
+ * @param tooltip Optional hover tooltip.
+ *
+ * @example
+ * ```ts
+ * import { writeXlsx, link } from "hucre/xlsx"
+ *
+ * await writeXlsx({
+ *   sheets: [{
+ *     name: "Summary",
+ *     columns: [{ header: "Link", key: "link" }, { header: "ID", key: "id" }],
+ *     data: [{ link: link("Open", "https://example.com/items/abc"), id: "abc" }],
+ *   }],
+ * })
+ * ```
+ */
+export function link(text: string, hyperlink: string, tooltip?: string): HyperlinkValue {
+  return tooltip === undefined ? { text, hyperlink } : { text, hyperlink, tooltip }
+}

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -16,9 +16,12 @@ import type {
   FontStyle,
   Color,
   Sparkline,
+  Hyperlink,
+  HyperlinkValue,
 } from "../_types"
 import type { StylesCollector } from "./styles-writer"
 import { dateToSerial } from "../_date"
+import { isHyperlinkValue } from "./hyperlink"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 import { calculateColumnWidth } from "./auto-width"
 import { hashSheetPassword } from "./password"
@@ -157,6 +160,19 @@ interface ResolvedCell {
   formulaRef?: string
   formulaDynamic?: boolean
   richText?: RichTextRun[]
+  hyperlink?: Hyperlink
+}
+
+// ── Rich data-row values ───────────────────────────────────────────
+
+/** Convert a {@link HyperlinkValue} to the internal {@link Hyperlink} shape. */
+function toHyperlink(hv: HyperlinkValue): Hyperlink {
+  const internal = hv.hyperlink.startsWith("#")
+  const h: Hyperlink = internal
+    ? { target: "", location: hv.hyperlink.slice(1), display: hv.text }
+    : { target: hv.hyperlink, display: hv.text }
+  if (hv.tooltip !== undefined) h.tooltip = hv.tooltip
+  return h
 }
 
 // ── Default date format ────────────────────────────────────────────
@@ -622,15 +638,17 @@ function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
       const row: Array<ResolvedCell | null> = []
       for (let c = 0; c < keys.length; c++) {
         const key = keys[c]
-        const value = key !== undefined ? (obj[key] ?? null) : null
+        const raw = key !== undefined ? (obj[key] ?? null) : null
         const col = sheet.columns[c]
-        row.push({
-          value,
+        const cell: ResolvedCell = {
+          value: isHyperlinkValue(raw) ? raw.text : raw,
           style: col.style,
           ...(col.numFmt && !col.style?.numFmt
             ? { style: { ...col.style, numFmt: col.numFmt } }
             : {}),
-        })
+        }
+        if (isHyperlinkValue(raw)) cell.hyperlink = toHyperlink(raw)
+        row.push(cell)
       }
       resolved.push(row)
     }
@@ -674,6 +692,7 @@ function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
         formulaRef: cellOverride.formulaRef ?? existing?.formulaRef,
         formulaDynamic: cellOverride.formulaDynamic ?? existing?.formulaDynamic,
         richText: cellOverride.richText ?? existing?.richText,
+        hyperlink: cellOverride.hyperlink ?? existing?.hyperlink,
       }
     }
   }
@@ -983,43 +1002,42 @@ export function collectHyperlinks(sheet: WriteSheet): {
   xml: string
   relationships: HyperlinkRelationship[]
 } {
-  if (!sheet.cells) {
-    return { xml: "", relationships: [] }
-  }
+  // Resolve the full grid so links from both inline `data` values and the
+  // `cells` override map are collected from a single source, in row-major order.
+  const resolved = resolveRows(sheet)
 
   const hyperlinkElements: string[] = []
   const relationships: HyperlinkRelationship[] = []
   let rIdCounter = 1
 
-  for (const [key, cellOverride] of sheet.cells) {
-    if (!cellOverride.hyperlink) continue
+  for (let r = 0; r < resolved.length; r++) {
+    const row = resolved[r]
+    for (let c = 0; c < row.length; c++) {
+      const hl = row[c]?.hyperlink
+      if (!hl) continue
 
-    const [rowStr, colStr] = key.split(",")
-    const r = parseInt(rowStr, 10)
-    const c = parseInt(colStr, 10)
-    const ref = cellRef(r, c)
-    const hl = cellOverride.hyperlink
+      const ref = cellRef(r, c)
+      const attrs: Record<string, string> = { ref }
 
-    const attrs: Record<string, string> = { ref }
+      if (hl.location) {
+        // Internal hyperlink — uses location attribute directly, no relationship needed
+        attrs["location"] = hl.location
+      } else if (hl.target) {
+        // External hyperlink — needs a relationship entry
+        const rId = `rId${rIdCounter++}`
+        attrs["r:id"] = rId
+        relationships.push({ id: rId, target: hl.target })
+      }
 
-    if (hl.location) {
-      // Internal hyperlink — uses location attribute directly, no relationship needed
-      attrs["location"] = hl.location
-    } else if (hl.target) {
-      // External hyperlink — needs a relationship entry
-      const rId = `rId${rIdCounter++}`
-      attrs["r:id"] = rId
-      relationships.push({ id: rId, target: hl.target })
+      if (hl.tooltip) {
+        attrs["tooltip"] = hl.tooltip
+      }
+      if (hl.display) {
+        attrs["display"] = hl.display
+      }
+
+      hyperlinkElements.push(xmlSelfClose("hyperlink", attrs))
     }
-
-    if (hl.tooltip) {
-      attrs["tooltip"] = hl.tooltip
-    }
-    if (hl.display) {
-      attrs["display"] = hl.display
-    }
-
-    hyperlinkElements.push(xmlSelfClose("hyperlink", attrs))
   }
 
   if (hyperlinkElements.length === 0) {

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -18,6 +18,7 @@ import type { PivotCacheRef, PivotCacheRel } from "./workbook-writer"
 import { createStylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer"
 import type { WorksheetResult } from "./worksheet-writer"
+import { unwrapCellValue } from "./hyperlink"
 import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
 import { writeChart } from "./chart-writer"
@@ -572,7 +573,7 @@ function collectSourceRows(sheet: WriteSheet): CellValue[][] {
       const row: CellValue[] = sheet.columns.map((c) => {
         if (!c.key) return null
         const v = obj[c.key]
-        return v === undefined ? null : (v as CellValue)
+        return v === undefined ? null : unwrapCellValue(v)
       })
       out.push(row)
     }

--- a/test/hyperlinks.test.ts
+++ b/test/hyperlinks.test.ts
@@ -5,6 +5,7 @@ import { parseXml } from "../src/xml/parser"
 import { writeXlsx } from "../src/xlsx/writer"
 import { readXlsx } from "../src/xlsx/reader"
 import { collectHyperlinks } from "../src/xlsx/worksheet-writer"
+import { link } from "../src/xlsx/hyperlink"
 import type { WriteSheet, Cell } from "../src/_types"
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -759,5 +760,131 @@ describe("XLSX hyperlink round-trip", () => {
     const cell = sheet.cells!.get("0,0")
     expect(cell!.hyperlink!.target).toBe("https://example.com")
     expect(cell!.value).toBe("Visit us")
+  })
+})
+
+// ── Inline hyperlinks in data rows (issue #325) ──────────────────────
+
+describe("inline hyperlinks in data rows", () => {
+  const columns = [
+    { header: "Link", key: "link" },
+    { header: "ID", key: "id" },
+  ]
+
+  it("writes a rich hyperlink value from a data row", async () => {
+    const written = await writeXlsx({
+      sheets: [
+        {
+          name: "Summary",
+          columns,
+          data: [{ link: { text: "Open", hyperlink: "https://example.com/items/abc" }, id: "abc" }],
+        },
+      ],
+    })
+
+    const workbook = await readXlsx(written)
+    const sheet = workbook.sheets[0]
+
+    // Header is row 0, data starts at row 1; link column is col 0
+    const cell = sheet.cells!.get("1,0")
+    expect(cell!.value).toBe("Open")
+    expect(cell!.hyperlink!.target).toBe("https://example.com/items/abc")
+  })
+
+  it("the link() helper produces the same result as the raw object", async () => {
+    const written = await writeXlsx({
+      sheets: [
+        {
+          name: "Summary",
+          columns,
+          data: [{ link: link("Open", "https://example.com/items/abc"), id: "abc" }],
+        },
+      ],
+    })
+
+    const workbook = await readXlsx(written)
+    const cell = workbook.sheets[0].cells!.get("1,0")
+    expect(cell!.value).toBe("Open")
+    expect(cell!.hyperlink!.target).toBe("https://example.com/items/abc")
+  })
+
+  it("round-trips a tooltip", async () => {
+    const written = await writeXlsx({
+      sheets: [
+        {
+          name: "Summary",
+          columns,
+          data: [{ link: link("Open", "https://example.com", "Click to open"), id: "abc" }],
+        },
+      ],
+    })
+
+    const wsDoc = findChild(
+      await parseXmlFromZip(written, "xl/worksheets/sheet1.xml"),
+      "hyperlinks",
+    )
+    const hl = findChildren(wsDoc, "hyperlink")[0]
+    expect(hl.attrs["tooltip"]).toBe("Click to open")
+    expect(hl.attrs["display"]).toBe("Open")
+  })
+
+  it("treats a #-prefixed hyperlink as an internal location (no relationship)", async () => {
+    const written = await writeXlsx({
+      sheets: [
+        {
+          name: "Summary",
+          columns,
+          data: [{ link: link("Go to Sheet2", "#Sheet2!A1"), id: "abc" }],
+        },
+      ],
+    })
+
+    const hyperlinks = findChild(
+      await parseXmlFromZip(written, "xl/worksheets/sheet1.xml"),
+      "hyperlinks",
+    )
+    const hl = findChildren(hyperlinks, "hyperlink")[0]
+    expect(hl.attrs["location"]).toBe("Sheet2!A1")
+    expect(hl.attrs["r:id"]).toBeUndefined()
+    // No external relationship part should be created for an internal link
+    expect(zipHas(written, "xl/worksheets/_rels/sheet1.xml.rels")).toBe(false)
+  })
+
+  it("leaves scalar values in data untouched", async () => {
+    const written = await writeXlsx({
+      sheets: [
+        {
+          name: "Summary",
+          columns,
+          data: [{ link: "plain text", id: "abc" }],
+        },
+      ],
+    })
+
+    const sheet = (await readXlsx(written)).sheets[0]
+    // Header row 0, data row 1; no hyperlinks means no <hyperlinks> section
+    expect(sheet.rows[1][0]).toBe("plain text")
+    expect(zipHas(written, "xl/worksheets/_rels/sheet1.xml.rels")).toBe(false)
+  })
+
+  it("collects hyperlinks from both data rows and the cells map", async () => {
+    const cells = new Map<string, Partial<Cell>>()
+    // Override the ID column (col 1) of the data row with its own hyperlink
+    cells.set("1,1", { value: "abc", hyperlink: { target: "https://example.com/by-id" } })
+
+    const written = await writeXlsx({
+      sheets: [
+        {
+          name: "Summary",
+          columns,
+          data: [{ link: link("Open", "https://example.com/items/abc"), id: "abc" }],
+          cells,
+        },
+      ],
+    })
+
+    const sheet = (await readXlsx(written)).sheets[0]
+    expect(sheet.cells!.get("1,0")!.hyperlink!.target).toBe("https://example.com/items/abc")
+    expect(sheet.cells!.get("1,1")!.hyperlink!.target).toBe("https://example.com/by-id")
   })
 })


### PR DESCRIPTION
Closes #325.

## Problem

`writeXlsx`'s `columns` + `data` API only accepted scalar `CellValue` for row values. Hyperlinks with separate display text could only be expressed via the parallel `cells: Map<"row,col", …>` API — meaning **three sources of truth** for one logical "Link" column (schema in `columns`, value in `cells`, coordinate in a hand-computed `"row,col"` string). Reordering or inserting columns broke the index math.

## Solution

Allow **rich values inline in `data` rows** — an ExcelJS-compatible `{ text, hyperlink, tooltip? }` shape, keyed by the column's `key`. The `cells` map path is fully preserved for backward compatibility.

```ts
import { writeXlsx, link } from "hucre/xlsx"

await writeXlsx({
  sheets: [{
    name: "Summary",
    columns: [{ header: "Link", key: "link" }, { header: "ID", key: "id" }],
    data: [
      { link: link("Open", "https://example.com/items/abc-123"), id: "abc-123" },
      { link: { text: "Open", hyperlink: "https://example.com/items/def-456" }, id: "def-456" },
    ],
  }],
})
```

## Changes

- **`HyperlinkValue`** type + widened `data` type. `CellValue` union is left untouched, so CSV/ODS/formula serialization paths are unaffected.
- **`link(text, hyperlink, tooltip?)`** helper exported from both `hucre` and `hucre/xlsx`. A plain object is also accepted (stays JSON-serializable).
- `#`-prefixed targets become internal references (`location`), e.g. `"#Sheet2!A1"`.
- `collectHyperlinks` now reads the resolved grid, so links from both inline `data` rows and the `cells` map are collected from a single source (this also closes the existing gap where a `cells`-map hyperlink was never carried onto the `ResolvedCell`).
- Non-XLSX consumers (ODS writer, pivot source rows) unwrap rich values to scalar text.

## Design note

Surveyed competing libraries (ExcelJS, SheetJS, write-excel-file). `{ text, hyperlink, tooltip }` is the most familiar shape in the ecosystem (ExcelJS) and maps almost 1:1 to hucre's internal `Hyperlink` type. Issue Option A (inline) was chosen as the core solution; Option B (column-level getter) was left out of scope.

## Testing

- `pnpm test`: 7472 tests pass (including lint + typecheck).
- 6 new tests: raw object, `link()` helper, tooltip round-trip, `#`-internal ref, scalar values left untouched, mixed data + cells on the same sheet.
- README updated with an inline `data` + `link()` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)