### PR TITLE
feat(xlsx): chart composition through the roundtrip (saveXlsx) — closes #136

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,31 @@ addChart(dashboard, {
 await writeXlsx({ sheets: [dashboard] })
 ```
 
+Charts also survive the **roundtrip** (`openXlsx` → modify → `saveXlsx`),
+not just the fresh `writeXlsx` path. A chart attached to a newly added
+sheet — or carried across workbooks by `copySheetToWorkbook` — is
+serialized into proper `xl/charts/chartN.xml` parts with their drawing
+relationships on save:
+
+```ts
+import { copySheetToWorkbook, getCharts, openXlsx, saveXlsx } from "hucre"
+
+const template = await openXlsx(templateBytes)
+const report = await openXlsx(reportBytes)
+
+// Copy a chart-bearing sheet from the template into the report workbook…
+copySheetToWorkbook(template.sheets[0], report, "Dashboard")
+
+// …and saveXlsx re-emits the chart parts (not just the cell data).
+const out = await saveXlsx(report)
+console.log(getCharts(await openXlsx(out)).length) // includes the copied chart
+```
+
+The roundtrip path serializes model charts for sheets that don't already
+own a drawing (new or copied sheets); to add a chart to a sheet that
+already carries one, compose it through the fresh `writeXlsx` path
+instead.
+
 ### Unified API
 
 Auto-detect format and work with simple helpers:

--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -1004,6 +1004,15 @@ export function cloneSheet(sheet: Sheet, newName: string): Sheet {
     }))
   }
 
+  // Deep copy charts. Charts are plain JSON-serializable records (no
+  // Map / Uint8Array / function members), so a structuredClone gives a
+  // faithful independent copy without hand-walking the deep axis / series
+  // / dataLabels trees. Carrying them here is what lets
+  // copySheetToWorkbook bring charts across workbooks (issue #136).
+  if (sheet.charts && sheet.charts.length > 0) {
+    cloned.charts = structuredClone(sheet.charts)
+  }
+
   return cloned
 }
 

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -3,7 +3,15 @@
 // images, macros, shapes, or other features that defter doesn't natively
 // understand.
 
-import type { Sheet, Workbook, ReadOptions, WriteSheet, NamedRange } from "../_types"
+import type {
+  Sheet,
+  Workbook,
+  ReadOptions,
+  WriteSheet,
+  NamedRange,
+  Chart,
+  SheetChart,
+} from "../_types"
 import { readXlsx } from "./reader"
 import { ZipReader } from "../zip/reader"
 import { ZipWriter } from "../zip/writer"
@@ -22,6 +30,8 @@ import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from ".
 import type { WorksheetResult } from "./worksheet-writer"
 import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
+import { writeChart } from "./chart-writer"
+import { cloneChart } from "./chart-clone"
 import { writeComments } from "./comments-writer"
 import type { CommentsResult } from "./comments-writer"
 import { writeTable } from "./table-writer"
@@ -548,6 +558,86 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     }
   }
 
+  // ── Model chart serialization (issue #136) ────────────────────────
+  // Charts carried on a sheet's `charts` array as data (not preserved
+  // raw parts) — e.g. a sheet brought in by copySheetToWorkbook, or
+  // charts appended to a workbook after openXlsx — are serialized here
+  // through the same drawing + chart pipeline the fresh writer uses.
+  //
+  // SAFETY: we only emit model charts for a sheet that has NO drawing of
+  // its own already in play — no hucre-regenerated image drawing
+  // (`drawingResults[i]`), no preserved original chart drawing
+  // (`sheetPreservedDrawingTargets[i]`), and no other original drawing
+  // relationship. That keeps this purely additive: it never rewrites or
+  // collides with a drawing the roundtrip is already preserving. Adding
+  // a chart to a sheet that already owns a drawing is out of scope for
+  // the roundtrip path — use the fresh writeXlsx path for that.
+  type ChartFileEntry = { globalIndex: number; xml: string; rels: string }
+  interface ModelChartDrawing {
+    drawing: DrawingResult
+    drawingNumber: number
+    charts: ChartFileEntry[]
+  }
+  const modelChartDrawings: Array<ModelChartDrawing | null> = sheets.map(() => null)
+  const newModelChartIndices: number[] = []
+  {
+    const sheetHasOriginalDrawingRel = (i: number): boolean => {
+      const expected = `xl/worksheets/_rels/sheet${i + 1}.xml.rels`
+      for (const [p, d] of workbook._rawEntries) {
+        if (p.toLowerCase() !== expected) continue
+        return parseRelationships(new TextDecoder("utf-8").decode(d)).some((r) =>
+          r.type.endsWith("/relationships/drawing"),
+        )
+      }
+      return false
+    }
+
+    // Allocate drawing / chart numbers past anything already used so the
+    // new parts never collide with a preserved or regenerated drawing.
+    const usedDrawingNumbers = new Set<number>(preservedDrawingNumbers)
+    for (const path of workbook._rawEntries.keys()) {
+      const m = path.match(/^xl\/drawings\/drawing(\d+)\.xml$/i)
+      if (m) usedDrawingNumbers.add(parseInt(m[1], 10))
+    }
+    for (let i = 0; i < drawingResults.length; i++) {
+      if (drawingResults[i]) usedDrawingNumbers.add(i + 1)
+    }
+    let nextDrawingNumber = (usedDrawingNumbers.size ? Math.max(...usedDrawingNumbers) : 0) + 1
+    let nextChartNumber = (chartIndices.length ? chartIndices[chartIndices.length - 1] : 0) + 1
+
+    for (let i = 0; i < sheets.length; i++) {
+      const srcCharts = sheets[i].charts
+      if (!srcCharts || srcCharts.length === 0) continue
+      // Skip sheets that already own a drawing — see SAFETY note above.
+      if (drawingResults[i]) continue
+      if (sheetPreservedDrawingTargets[i] !== undefined) continue
+      if (sheetHasOriginalDrawingRel(i)) continue
+
+      const writeCharts = toWriteCharts(srcCharts as Array<Chart | SheetChart>)
+      if (writeCharts.length === 0) continue
+
+      const drawingNumber = nextDrawingNumber++
+      const drawing = writeDrawing([], globalImageIndex, undefined, writeCharts, nextChartNumber)
+      const charts: ChartFileEntry[] = []
+      for (let c = 0; c < writeCharts.length; c++) {
+        const written = writeChart(writeCharts[c], sheets[i].name)
+        const g = nextChartNumber + c
+        charts.push({ globalIndex: g, xml: written.chartXml, rels: written.chartRels })
+        newModelChartIndices.push(g)
+      }
+      nextChartNumber += writeCharts.length
+
+      modelChartDrawings[i] = { drawing, drawingNumber, charts }
+      drawingIndices.push(drawingNumber)
+      regeneratedPaths.add(`xl/drawings/drawing${drawingNumber}.xml`)
+      regeneratedPaths.add(`xl/drawings/_rels/drawing${drawingNumber}.xml.rels`)
+      for (const cf of charts) {
+        regeneratedPaths.add(`xl/charts/chart${cf.globalIndex}.xml`)
+        regeneratedPaths.add(`xl/charts/_rels/chart${cf.globalIndex}.xml.rels`)
+      }
+    }
+  }
+
   // Build ZIP archive
   const zip = new ZipWriter()
 
@@ -601,6 +691,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
   // need to declare any drawings we force-preserved (chart-only) so
   // Excel doesn't see the preserved bytes as orphan.
   const allDrawingIndices = mergeSortedUnique(drawingIndices, preservedDrawingNumbers)
+  const allChartIndices = mergeSortedUnique(chartIndices, newModelChartIndices)
   const ctOpts: ContentTypesOptions = {
     sheetCount: writeSheets.length,
     hasSharedStrings,
@@ -622,7 +713,7 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     slicerCacheIndices: slicerCacheIndices.length > 0 ? slicerCacheIndices : undefined,
     timelineIndices: timelineIndices.length > 0 ? timelineIndices : undefined,
     timelineCacheIndices: timelineCacheIndices.length > 0 ? timelineCacheIndices : undefined,
-    chartIndices: chartIndices.length > 0 ? chartIndices : undefined,
+    chartIndices: allChartIndices.length > 0 ? allChartIndices : undefined,
     chartStyleIndices: chartStyleIndices.length > 0 ? chartStyleIndices : undefined,
     chartColorsIndices: chartColorsIndices.length > 0 ? chartColorsIndices : undefined,
     hasCoreProps: true,
@@ -709,6 +800,12 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     const preservedDrawingTarget = sheetPreservedDrawingTargets[i]
     const hasPreservedDrawing = preservedDrawingTarget !== undefined && !hasDrawing
     let preservedDrawingRId: string | undefined
+    // Model charts serialized for this sheet (issue #136). Like the
+    // preserved-drawing case, the regenerated worksheet body has no
+    // `<drawing>` element, so we emit a drawing relationship and inject
+    // the reference below.
+    const modelDrawing = modelChartDrawings[i]
+    const hasModelChartDrawing = modelDrawing !== null
     let worksheetXml = result.xml
 
     if (
@@ -720,7 +817,8 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
       hasTimelines ||
       hasThreadedComments ||
       hasSheetPivotTables ||
-      hasPreservedDrawing
+      hasPreservedDrawing ||
+      hasModelChartDrawing
     ) {
       const relElements: string[] = []
       // Track the highest existing rId so newly added slicer/timeline
@@ -829,6 +927,20 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
         worksheetXml = injectWorksheetDrawing(worksheetXml, preservedDrawingRId)
       }
 
+      // Wire up the model-chart drawing (issue #136): emit the drawing
+      // relationship and splice `<drawing r:id="..."/>` into the body.
+      if (hasModelChartDrawing && modelDrawing) {
+        const modelDrawingRId = `rId${nextSheetRid++}`
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: modelDrawingRId,
+            Type: REL_DRAWING,
+            Target: `../drawings/drawing${modelDrawing.drawingNumber}.xml`,
+          }),
+        )
+        worksheetXml = injectWorksheetDrawing(worksheetXml, modelDrawingRId)
+      }
+
       // Threaded comments (Excel 365). The rId only needs to be unique
       // within this rels file — `nextSheetRid` already tracks the next
       // free rId past every relationship emitted above (including the
@@ -870,6 +982,22 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
       zip.add(`xl/drawings/_rels/drawing${i + 1}.xml.rels`, encoder.encode(drawing.drawingRels))
       for (const img of drawing.images) {
         zip.add(img.path, img.data, { compress: false })
+      }
+    }
+
+    // Add model-chart drawing + chart bodies (issue #136)
+    if (modelDrawing) {
+      zip.add(
+        `xl/drawings/drawing${modelDrawing.drawingNumber}.xml`,
+        encoder.encode(modelDrawing.drawing.drawingXml),
+      )
+      zip.add(
+        `xl/drawings/_rels/drawing${modelDrawing.drawingNumber}.xml.rels`,
+        encoder.encode(modelDrawing.drawing.drawingRels),
+      )
+      for (const cf of modelDrawing.charts) {
+        zip.add(`xl/charts/chart${cf.globalIndex}.xml`, encoder.encode(cf.xml))
+        zip.add(`xl/charts/_rels/chart${cf.globalIndex}.xml.rels`, encoder.encode(cf.rels))
       }
     }
 
@@ -1016,6 +1144,43 @@ function mergeSortedUnique(a: number[], b: number[]): number[] {
   const out = new Set<number>(a)
   for (const n of b) out.add(n)
   return Array.from(out).sort((x, y) => x - y)
+}
+
+/**
+ * Normalize a sheet's `charts` entries to writer-ready {@link SheetChart}
+ * objects (issue #136).
+ *
+ * Entries are accepted in either model: a write-model {@link SheetChart}
+ * (it carries a `type` discriminator) passes through, gaining a default
+ * top-left anchor only if it has none; a parsed read-model {@link Chart}
+ * (it carries `kinds`) is bridged via {@link cloneChart}, forwarding its
+ * own `anchor` when present and falling back to the top-left cell for
+ * absolute-anchored charts.
+ *
+ * Charts that cannot be expressed in the write model — non-writable kinds
+ * (radar / surface / stock / …) or series with no formula reference — are
+ * dropped rather than throwing, so a save never fails on a chart the
+ * writer can't represent.
+ */
+function toWriteCharts(charts: Array<Chart | SheetChart>): SheetChart[] {
+  const out: SheetChart[] = []
+  for (const c of charts) {
+    if (!c || typeof c !== "object") continue
+    if ("type" in c && c.type) {
+      // Already a write-model SheetChart.
+      out.push(c.anchor ? c : { ...c, anchor: { from: { row: 0, col: 0 } } })
+      continue
+    }
+    // Parsed read-model Chart → bridge to the write model.
+    try {
+      out.push(
+        cloneChart(c as Chart, { anchor: (c as Chart).anchor ?? { from: { row: 0, col: 0 } } }),
+      )
+    } catch {
+      // Non-writable kind or series without a formula ref — skip it.
+    }
+  }
+  return out
 }
 
 /**

--- a/test/chart-roundtrip.test.ts
+++ b/test/chart-roundtrip.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { addChart, getCharts } from "../src/xlsx/chart-helpers"
+import { cloneChart } from "../src/xlsx/chart-clone"
+import { copySheetToWorkbook } from "../src/sheet-ops"
+import { ZipReader } from "../src/zip/reader"
+import type { SheetChart, WriteSheet } from "../src/_types"
+
+const decoder = new TextDecoder("utf-8")
+
+function entries(data: Uint8Array): string[] {
+  return new ZipReader(data).entries()
+}
+
+async function readPart(data: Uint8Array, path: string): Promise<string> {
+  const zip = new ZipReader(data)
+  const bytes = await zip.extract(path)
+  return decoder.decode(bytes)
+}
+
+function dataRows(): WriteSheet {
+  return {
+    name: "Data",
+    rows: [
+      ["Quarter", "Revenue", "Forecast"],
+      ["Q1", 12000, 11500],
+      ["Q2", 15500, 15000],
+      ["Q3", 14000, 14500],
+      ["Q4", 17800, 17200],
+    ],
+  }
+}
+
+function chart(type: SheetChart["type"], title: string, row = 6): SheetChart {
+  return {
+    type,
+    title,
+    series: [{ name: "Revenue", values: "B2:B5", categories: "A2:A5", color: "1F77B4" }],
+    anchor: { from: { row, col: 0 }, to: { row: row + 14, col: 7 } },
+  }
+}
+
+describe("issue #136 — model charts survive the roundtrip (saveXlsx)", () => {
+  it("a chart written fresh survives openXlsx -> saveXlsx -> reread", async () => {
+    const sheet = dataRows()
+    sheet.charts = [chart("column", "Quarterly Revenue")]
+    const fresh = await writeXlsx({ sheets: [sheet] })
+
+    // Open it (roundtrip model) and save it back unchanged.
+    const wb = await openXlsx(fresh)
+    const saved = await saveXlsx(wb)
+
+    const re = await openXlsx(saved)
+    const charts = getCharts(re)
+    expect(charts.length).toBe(1)
+    expect(charts[0].chart.title).toBe("Quarterly Revenue")
+    expect(charts[0].chart.kinds).toContain("bar") // column maps to bar/<c:barChart> with col dir
+  })
+
+  it("a chart added to an opened workbook on a NEW sheet is emitted by saveXlsx", async () => {
+    const base = await writeXlsx({ sheets: [dataRows()] })
+    const wb = await openXlsx(base)
+
+    // Append a brand-new sheet carrying a model chart.
+    const newSheet = {
+      name: "Dashboard",
+      rows: [
+        ["Region", "Sales"],
+        ["North", 100],
+        ["South", 200],
+        ["East", 150],
+        ["West", 175],
+      ],
+      charts: [chart("line", "Sales by Region")],
+    }
+    // @ts-expect-error roundtrip Sheet.charts is the read model; the writer
+    // accepts write-model SheetChart entries here (issue #136 bridge).
+    wb.sheets.push(newSheet)
+
+    const saved = await saveXlsx(wb)
+    const names = entries(saved)
+    // A chart + drawing part pair was emitted.
+    expect(names.some((n) => /^xl\/charts\/chart\d+\.xml$/.test(n))).toBe(true)
+    expect(names.some((n) => /^xl\/drawings\/drawing\d+\.xml$/.test(n))).toBe(true)
+    // Content types declares the chart Override.
+    const ct = await readPart(saved, "[Content_Types].xml")
+    expect(ct).toContain("drawingml.chart+xml")
+
+    const re = await openXlsx(saved)
+    const titles = getCharts(re).map((c) => c.chart.title)
+    expect(titles).toContain("Sales by Region")
+  })
+
+  it("preserved original charts and newly added model charts coexist without index collisions", async () => {
+    // Workbook A: sheet 1 has an original chart (preserved as raw parts).
+    const a = dataRows()
+    a.charts = [chart("bar", "Original")]
+    const baseBytes = await writeXlsx({ sheets: [a] })
+    const wb = await openXlsx(baseBytes)
+
+    // Append a new sheet with its own model chart.
+    const extra = {
+      name: "Extra",
+      rows: [
+        ["X", "Y"],
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ],
+      charts: [chart("pie", "Added")],
+    }
+    // @ts-expect-error see note above
+    wb.sheets.push(extra)
+
+    const saved = await saveXlsx(wb)
+
+    // Two distinct chart parts, no overwrite.
+    const chartParts = entries(saved).filter((n) => /^xl\/charts\/chart\d+\.xml$/.test(n))
+    expect(new Set(chartParts).size).toBe(chartParts.length) // unique
+    expect(chartParts.length).toBeGreaterThanOrEqual(2)
+
+    const re = await openXlsx(saved)
+    const titles = getCharts(re)
+      .map((c) => c.chart.title)
+      .sort()
+    expect(titles).toEqual(["Added", "Original"])
+  })
+
+  it("copySheetToWorkbook carries charts across workbooks and saveXlsx emits them", async () => {
+    const src = dataRows()
+    src.charts = [chart("column", "Carried")]
+    const srcWb = await openXlsx(await writeXlsx({ sheets: [src] }))
+    expect(getCharts(srcWb).length).toBe(1)
+
+    const target = await openXlsx(await writeXlsx({ sheets: [{ name: "Blank", rows: [["x"]] }] }))
+    copySheetToWorkbook(srcWb.sheets[0], target, "CopiedData")
+
+    // In-memory: the copied sheet carries the chart model.
+    expect(getCharts(target).length).toBe(1)
+
+    // And it survives the save round-trip.
+    const saved = await saveXlsx(target)
+    const re = await openXlsx(saved)
+    const charts = getCharts(re)
+    expect(charts.length).toBe(1)
+    expect(charts[0].chart.title).toBe("Carried")
+  })
+
+  it("the dashboard composition flow from the issue works end-to-end", async () => {
+    // Template workbook with one of several chart kinds.
+    const kinds: SheetChart["type"][] = ["line", "bar", "pie", "area"]
+    const template = await openXlsx(
+      await writeXlsx({
+        sheets: [
+          {
+            ...dataRows(),
+            name: "Template",
+            charts: kinds.map((k, i) => chart(k, `T-${k}`, 6 + i * 16)),
+          },
+        ],
+      }),
+    )
+    const parsed = getCharts(template)
+    expect(parsed.length).toBe(kinds.length)
+
+    // Compose a dashboard: clone each template chart onto a fresh sheet.
+    const dashboard: WriteSheet = {
+      name: "Dashboard",
+      rows: [
+        ["Region", "Sales"],
+        ["N", 1],
+        ["S", 2],
+        ["E", 3],
+        ["W", 4],
+      ],
+    }
+    parsed.forEach(({ chart: c }, i) => {
+      const cloned = cloneChart(c, {
+        title: `Panel ${i}`,
+        series: [{ name: "Sales", values: "B2:B5", categories: "A2:A5", color: "00C586" }],
+        anchor: { from: { row: 6 + i * 16, col: 0 }, to: { row: 20 + i * 16, col: 7 } },
+      })
+      addChart(dashboard, cloned)
+    })
+
+    const out = await openXlsx(await writeXlsx({ sheets: [dashboard] }))
+    const outCharts = getCharts(out)
+    expect(outCharts.length).toBe(kinds.length)
+    expect(outCharts.every((c) => /^Panel /.test(c.chart.title ?? ""))).toBe(true)
+  })
+
+  it("a non-writable chart kind is skipped, not fatal, on save", async () => {
+    const base = await writeXlsx({ sheets: [dataRows()] })
+    const wb = await openXlsx(base)
+    const newSheet = {
+      name: "Mixed",
+      rows: [
+        ["A", "B"],
+        ["x", 1],
+        ["y", 2],
+      ],
+      // A bogus/non-writable kind alongside a valid one — only the valid
+      // chart should land; the save must not throw.
+      charts: [
+        { kinds: ["radar"], seriesCount: 0 }, // read-model shape, non-writable
+        chart("column", "Valid"),
+      ],
+    }
+    // @ts-expect-error mixed read/write model entries to exercise the guard
+    wb.sheets.push(newSheet)
+
+    const saved = await saveXlsx(wb) // must not throw
+    const re = await openXlsx(saved)
+    const titles = getCharts(re).map((c) => c.chart.title)
+    expect(titles).toContain("Valid")
+  })
+})

--- a/test/chart-roundtrip.test.ts
+++ b/test/chart-roundtrip.test.ts
@@ -187,7 +187,7 @@ describe("issue #136 — model charts survive the roundtrip (saveXlsx)", () => {
     const out = await openXlsx(await writeXlsx({ sheets: [dashboard] }))
     const outCharts = getCharts(out)
     expect(outCharts.length).toBe(kinds.length)
-    expect(outCharts.every((c) => /^Panel /.test(c.chart.title ?? ""))).toBe(true)
+    expect(outCharts.every((c) => (c.chart.title ?? "").startsWith("Panel "))).toBe(true)
   })
 
   it("a non-writable chart kind is skipped, not fatal, on save", async () => {

--- a/test/sheet-copy.test.ts
+++ b/test/sheet-copy.test.ts
@@ -387,6 +387,38 @@ describe("cloneSheet", () => {
     cloned.tables![0].columns[0].name = "Modified"
     expect(sheet.tables![0].columns[0].name).toBe("Name")
   })
+
+  it("should clone charts as an independent deep copy (issue #136)", () => {
+    const sheet = makeSheet({
+      rows: [
+        ["Q", "Rev"],
+        ["Q1", 1],
+      ],
+      charts: [
+        {
+          kinds: ["bar"],
+          seriesCount: 1,
+          title: "Original",
+          series: [{ kind: "bar", index: 0, name: "Rev", valuesRef: "Sheet1!$B$2:$B$2" }],
+          anchor: { from: { row: 5, col: 0 }, to: { row: 19, col: 7 } },
+        },
+      ],
+    })
+
+    const cloned = cloneSheet(sheet, "Cloned")
+
+    expect(cloned.charts!.length).toBe(1)
+    expect(cloned.charts![0].title).toBe("Original")
+    expect(cloned.charts![0].kinds).toEqual(["bar"])
+
+    // Mutating the clone must not leak into the original (deep copy).
+    cloned.charts![0].title = "Mutated"
+    cloned.charts![0].series![0].name = "Changed"
+    cloned.charts![0].anchor!.from.row = 99
+    expect(sheet.charts![0].title).toBe("Original")
+    expect(sheet.charts![0].series![0].name).toBe("Rev")
+    expect(sheet.charts![0].anchor!.from.row).toBe(5)
+  })
 })
 
 // ── copySheetToWorkbook ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Finishes issue #136 (chart cloning & composition from template workbooks). The dashboard-composition API the issue asked for — `getCharts` / `cloneChart` / `addChart` — already worked on the **fresh** `writeXlsx` path. The remaining gap was the **roundtrip** path: `openXlsx → modify → saveXlsx` silently dropped any chart that wasn't backed by a preserved raw part. So the two scenarios the issue explicitly calls out failed:

1. `copySheetToWorkbook(sheetWithCharts, target)` then `saveXlsx` → charts lost.
2. Add a chart to an opened workbook → `saveXlsx` → chart lost.

This PR makes model charts survive the roundtrip.

## What changed

- **`saveXlsx` serializes model charts** for sheets that don't already own a drawing (new / appended / copied sheets). It reuses the exact `writeDrawing` + `writeChart` pipeline the fresh writer uses, emitting:
  - `xl/charts/chart{n}.xml` + `xl/charts/_rels/chart{n}.xml.rels`
  - the drawing part + rels, and the worksheet `<drawing>` reference (via the same `injectWorksheetDrawing` mechanism the preserved-chart path uses)
  - `[Content_Types].xml` Overrides for the new chart + drawing parts
  - New part numbers are allocated **past every preserved/used index**, so they never collide with charts the roundtrip preserves verbatim.
- **Safety guard — purely additive.** Sheets that already carry a hucre-regenerated image drawing, a preserved original chart drawing, or any other original drawing relationship are left exactly as before. Adding a chart to a sheet that already owns a drawing stays out of scope for the roundtrip path (use the fresh `writeXlsx` path).
- **`toWriteCharts` bridges both models.** Write-model `SheetChart` entries pass through; parsed read-model `Chart` entries go through `cloneChart`; charts the writer can't represent (non-writable kinds, series without a formula ref) are skipped rather than throwing — a save never fails on an un-serializable chart.
- **`cloneSheet` deep-copies `sheet.charts`**, which is what lets `copySheetToWorkbook` carry charts across workbooks.

## Tests

- New `test/chart-roundtrip.test.ts` (6 tests): fresh→roundtrip survival; add-chart-to-new-sheet; preserved + newly-added charts coexisting with unique, non-colliding part indices; `copySheetToWorkbook` + `saveXlsx`; the issue's end-to-end dashboard composition flow; graceful skip of a non-writable kind.
- `test/sheet-copy.test.ts`: `cloneSheet` chart deep-copy independence.
- Full suite **7533 / 7533** passing (+7). `pnpm lint`, `pnpm typecheck`, `pnpm build` all clean.

## Known limitation (documented)

The roundtrip path serializes model charts only for sheets without an existing drawing. To add a chart to a sheet that already carries one, compose through the fresh `writeXlsx` path. README updated accordingly.

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)