### PR TITLE
feat(xlsx): password-protected workbooks (ECMA-376 Agile) — closes #156, #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,41 @@ for (let i = 0; i < 3_000_000; i++) writer.addRow([i + 1, Math.random()])
 const buf = await writer.finish()
 ```
 
+### Password Protection
+
+Read and write password-protected XLSX workbooks (ECMA-376 **Agile**
+encryption — the Excel 2010+ scheme). Encryption is built on the
+platform's WebCrypto, so it stays zero-dependency and runs in Node, Deno,
+Bun, Cloudflare Workers, and browsers.
+
+```ts
+import { writeXlsx, readXlsx, readObjects, EncryptedFileError, DecryptionError } from "hucre"
+
+// Write an encrypted workbook
+const encrypted = await writeXlsx({
+  sheets: [{ name: "Secret", rows: [["pin", 1234]] }],
+  encryption: { password: "hunter2" },
+})
+
+// Read it back with the password
+const wb = await readXlsx(encrypted, { password: "hunter2" })
+
+// Works through every read entry point: read(), readObjects(), streamXlsxRows()
+const rows = await readObjects(encrypted, { password: "hunter2" })
+
+// Without a password an encrypted file throws EncryptedFileError;
+// with the wrong password it throws DecryptionError.
+try {
+  await readXlsx(encrypted)
+} catch (e) {
+  if (e instanceof EncryptedFileError) console.log("needs a password")
+}
+```
+
+The roundtrip path takes the same option: `await saveXlsx(wb, { encryption: { password } })`.
+The key-derivation iteration count defaults to Excel's 100000; lower it via
+`encryption: { password, spinCount }` when the speed/security trade-off calls for it.
+
 ### ODS (OpenDocument)
 
 ```ts

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1344,6 +1344,17 @@ export interface WriteOptions {
   stringMode?: "shared" | "inline"
   /** VBA project binary (vbaProject.bin) to embed. Output becomes macro-enabled (.xlsm). */
   vbaProject?: Uint8Array
+  /**
+   * Encrypt the output as a password-protected workbook (ECMA-376 Agile,
+   * the Excel 2010+ scheme). The result is an OLE2/CFB container that Excel
+   * opens after prompting for the password.
+   *
+   * `spinCount` is the password key-derivation iteration count (default
+   * 100000, matching Excel). Lower it only when the speed/security trade-off
+   * genuinely calls for it — the value is stored in the file, so any reader
+   * (including Excel) honors it.
+   */
+  encryption?: { password: string; spinCount?: number }
 }
 
 export interface WriteSheet {

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -15,6 +15,7 @@ import type {
   TableColumn,
 } from "./_types"
 import { readXlsx } from "./xlsx/reader"
+import { decryptAgile } from "./xlsx/crypto/agile"
 import { writeXlsx } from "./xlsx/writer"
 import { readOds } from "./ods/reader"
 import { writeOds } from "./ods/writer"
@@ -82,15 +83,21 @@ function detectFormat(data: Uint8Array): "xlsx" | "ods" {
  * ReadableStream input is buffered fully before format detection runs.
  */
 export async function read(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  const data = await readInputToUint8Array(input)
+  let data = await readInputToUint8Array(input)
 
-  // Surface password-protected workbooks (OLE2/CFB envelope) before
-  // `detectFormat` rejects them as "not a ZIP archive". The container
-  // alone doesn't tell us whether the encrypted package inside is XLSX
-  // or ODS, so we leave `format` unset on the error. Decryption is
-  // tracked in #156.
+  // Password-protected workbooks arrive as an OLE2/CFB envelope. With a
+  // password we decrypt the inner package (then `detectFormat` works on
+  // the plaintext ZIP); without one we surface a typed error. The
+  // container alone doesn't reveal XLSX vs ODS, so the no-password error
+  // leaves `format` unset. (ODS uses a different in-ZIP scheme, so only
+  // XLSX decryption is wired up — an ODS password yields a ZIP that
+  // detectFormat routes to readOds, which handles its own encryption.)
   if (isOle2Container(data)) {
-    throw new EncryptedFileError()
+    if (options?.password) {
+      data = await decryptAgile(data, options.password)
+    } else {
+      throw new EncryptedFileError()
+    }
   }
 
   const format = detectFormat(data)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -71,9 +71,26 @@ export class EncryptedFileError extends DefterError {
     super(
       message ??
         (format
-          ? `File is password-protected (${format.toUpperCase()} encrypted with the OLE2/CFB container). Reading password-protected files is not yet supported.`
+          ? `File is password-protected (${format.toUpperCase()} encrypted with the OLE2/CFB container). Provide a password in options to decrypt it.`
           : "File is password-protected. Provide a password in options."),
     )
     this.format = format
+  }
+}
+
+/**
+ * Thrown when a password WAS supplied for an encrypted workbook but
+ * decryption failed — almost always a wrong password, occasionally a
+ * corrupt or unsupported encryption blob. Distinct from
+ * {@link EncryptedFileError} ("encrypted, and no password was given").
+ */
+export class DecryptionError extends DefterError {
+  override name = "DecryptionError"
+
+  constructor(
+    message = "Failed to decrypt: incorrect password or corrupt encryption data.",
+    options?: ErrorOptions,
+  ) {
+    super(message, options)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,7 @@ export {
   ValidationError,
   UnsupportedFormatError,
   EncryptedFileError,
+  DecryptionError,
 } from "./errors"
 
 // ── Types ──────────────────────────────────────────────────────────

--- a/src/xlsx/crypto/agile.ts
+++ b/src/xlsx/crypto/agile.ts
@@ -1,0 +1,538 @@
+// ── ECMA-376 Agile Encryption ────────────────────────────────────────
+// Decrypt and encrypt password-protected OOXML workbooks using the Agile
+// encryption scheme (Excel 2010+ default), per [MS-OFFCRYPTO].
+//
+// The cipher is AES-CBC. WebCrypto's AES-CBC always applies PKCS#7
+// padding, but OOXML segments are raw (unpadded, block-aligned), so we use
+// two well-known tricks:
+//   • decrypt: append one ciphertext block crafted so its plaintext is a
+//     full 0x10×16 PKCS#7 pad block, which WebCrypto strips — leaving the
+//     true plaintext.
+//   • encrypt: encrypt normally, then drop the trailing padding block;
+//     the leading blocks are the raw CBC ciphertext.
+// SHA hashing uses WebCrypto's `subtle.digest` directly.
+
+import { readCfb, writeCfb } from "./cfb"
+import { DecryptionError } from "../../errors"
+
+// Block keys (MS-OFFCRYPTO §2.3.4.x).
+const BLOCK_VERIFIER_INPUT = new Uint8Array([0xfe, 0xa7, 0xd2, 0x76, 0x3b, 0x4b, 0x9e, 0x79])
+const BLOCK_VERIFIER_VALUE = new Uint8Array([0xd7, 0xaa, 0x0f, 0x6d, 0x30, 0x61, 0x34, 0x4e])
+const BLOCK_KEY_VALUE = new Uint8Array([0x14, 0x6e, 0x0b, 0xe7, 0xab, 0xac, 0xd0, 0xd6])
+const BLOCK_HMAC_KEY = new Uint8Array([0x5f, 0xb2, 0xad, 0x01, 0x0c, 0xb9, 0xe1, 0xf6])
+const BLOCK_HMAC_VALUE = new Uint8Array([0xa0, 0x67, 0x7f, 0x02, 0xb2, 0x2c, 0x84, 0x33])
+
+const SEGMENT = 4096
+const ZERO_IV = new Uint8Array(16)
+
+interface AgileKeyInfo {
+  saltValue: Uint8Array
+  hashAlgorithm: string // WebCrypto name, e.g. "SHA-512"
+  keyBytes: number
+  blockSize: number
+  spinCount: number
+  encryptedVerifierHashInput: Uint8Array
+  encryptedVerifierHashValue: Uint8Array
+  encryptedKeyValue: Uint8Array
+}
+
+interface AgileKeyData {
+  saltValue: Uint8Array
+  hashAlgorithm: string
+  keyBytes: number
+  blockSize: number
+}
+
+// ── Public: decrypt ──────────────────────────────────────────────────
+
+/**
+ * Decrypt an Agile-encrypted OOXML container into the inner ZIP package.
+ * Throws {@link DecryptionError} for a wrong password or unsupported
+ * encryption variant.
+ */
+export async function decryptAgile(data: Uint8Array, password: string): Promise<Uint8Array> {
+  let streams: Map<string, Uint8Array>
+  try {
+    streams = readCfb(data)
+  } catch (err) {
+    throw new DecryptionError("Not a valid encrypted workbook container.", { cause: err })
+  }
+  const info = streams.get("EncryptionInfo")
+  const pkg = streams.get("EncryptedPackage")
+  if (!info || !pkg)
+    throw new DecryptionError("Encrypted workbook missing EncryptionInfo/EncryptedPackage.")
+
+  const major = info[0] | (info[1] << 8)
+  const minor = info[2] | (info[3] << 8)
+  if (major !== 4 || minor !== 4) {
+    throw new DecryptionError(
+      `Unsupported encryption (version ${major}.${minor}); only ECMA-376 Agile is supported.`,
+    )
+  }
+  const xml = new TextDecoder("utf-8").decode(info.subarray(8))
+  const key = parseKeyEncryptor(xml)
+  const keyData = parseKeyData(xml)
+
+  const secretKey = await deriveSecretKey(password, key)
+  if (!secretKey) throw new DecryptionError("Incorrect password.")
+
+  return decryptPackage(pkg, secretKey, keyData)
+}
+
+// ── Public: encrypt ──────────────────────────────────────────────────
+
+/**
+ * Encrypt an OOXML ZIP package into an Agile-encrypted OLE2/CFB container.
+ * `spinCount` defaults to Excel's 100000; tests may lower it for speed.
+ */
+export async function encryptAgile(
+  zip: Uint8Array,
+  password: string,
+  opts?: { spinCount?: number },
+): Promise<Uint8Array> {
+  const spinCount = opts?.spinCount ?? 100000
+  const hashAlgorithm = "SHA-512"
+  const keyBytes = 32
+  const blockSize = 16
+  const hashSize = 64
+
+  const keyDataSalt = randomBytes(16)
+  const pwSalt = randomBytes(16)
+  const secretKey = randomBytes(keyBytes)
+
+  // Password-derived key chain.
+  const chain = await passwordChain(password, pwSalt, spinCount, hashAlgorithm)
+
+  // Verifier: random input, its hash, both encrypted under password keys.
+  const verifierInput = randomBytes(blockSize)
+  const verifierHash = await digest(hashAlgorithm, verifierInput)
+  const kVin = await deriveBlockKey(chain, BLOCK_VERIFIER_INPUT, keyBytes, hashAlgorithm)
+  const kVval = await deriveBlockKey(chain, BLOCK_VERIFIER_VALUE, keyBytes, hashAlgorithm)
+  const kVkey = await deriveBlockKey(chain, BLOCK_KEY_VALUE, keyBytes, hashAlgorithm)
+  const encryptedVerifierHashInput = await aesEncrypt(kVin, pwSalt, verifierInput)
+  const encryptedVerifierHashValue = await aesEncrypt(
+    kVval,
+    pwSalt,
+    padBlock(verifierHash, blockSize),
+  )
+  const encryptedKeyValue = await aesEncrypt(kVkey, pwSalt, secretKey)
+
+  // Encrypted package (8-byte size prefix + segmented AES-CBC).
+  const encryptedPackage = await encryptPackage(zip, secretKey, {
+    saltValue: keyDataSalt,
+    hashAlgorithm,
+    keyBytes,
+    blockSize,
+  })
+
+  // Data integrity: HMAC-SHA512 over the encrypted package.
+  const hmacKey = randomBytes(hashSize)
+  const ivHmacKey = await iv(keyDataSalt, BLOCK_HMAC_KEY, hashAlgorithm, blockSize)
+  const encryptedHmacKey = await aesEncrypt(secretKey, ivHmacKey, padBlock(hmacKey, blockSize))
+  const hmacValue = await hmacSha512(hmacKey, encryptedPackage)
+  const ivHmacValue = await iv(keyDataSalt, BLOCK_HMAC_VALUE, hashAlgorithm, blockSize)
+  const encryptedHmacValue = await aesEncrypt(
+    secretKey,
+    ivHmacValue,
+    padBlock(hmacValue, blockSize),
+  )
+
+  const xml = buildEncryptionInfoXml({
+    keyDataSalt,
+    pwSalt,
+    spinCount,
+    keyBits: keyBytes * 8,
+    hashSize,
+    blockSize,
+    encryptedVerifierHashInput,
+    encryptedVerifierHashValue,
+    encryptedKeyValue,
+    encryptedHmacKey,
+    encryptedHmacValue,
+  })
+  const header = new Uint8Array(8)
+  const dv = new DataView(header.buffer)
+  dv.setUint16(0, 4, true)
+  dv.setUint16(2, 4, true)
+  dv.setUint32(4, 0x40, true)
+  const encryptionInfo = concat([header, new TextEncoder().encode(xml)])
+
+  return writeCfb([
+    { name: "EncryptionInfo", data: encryptionInfo },
+    { name: "EncryptedPackage", data: encryptedPackage },
+  ])
+}
+
+// ── Key derivation ───────────────────────────────────────────────────
+
+function utf16le(s: string): Uint8Array {
+  const out = new Uint8Array(s.length * 2)
+  const dv = new DataView(out.buffer)
+  for (let i = 0; i < s.length; i++) dv.setUint16(i * 2, s.charCodeAt(i), true)
+  return out
+}
+
+async function passwordChain(
+  password: string,
+  salt: Uint8Array,
+  spinCount: number,
+  algo: string,
+): Promise<Uint8Array> {
+  let h = await digest(algo, concat([salt, utf16le(password)]))
+  const counter = new Uint8Array(4)
+  const cv = new DataView(counter.buffer)
+  for (let i = 0; i < spinCount; i++) {
+    cv.setUint32(0, i, true)
+    h = await digest(algo, concat([counter, h]))
+  }
+  return h
+}
+
+async function deriveBlockKey(
+  chain: Uint8Array,
+  blockKey: Uint8Array,
+  keyBytes: number,
+  algo: string,
+): Promise<Uint8Array> {
+  const h = await digest(algo, concat([chain, blockKey]))
+  return fitKey(h, keyBytes)
+}
+
+/** Truncate or 0x36-pad a hash to the required key length (MS-OFFCRYPTO §2.3.4.11). */
+function fitKey(hashBytes: Uint8Array, keyBytes: number): Uint8Array {
+  if (hashBytes.length >= keyBytes) return hashBytes.subarray(0, keyBytes)
+  const out = new Uint8Array(keyBytes).fill(0x36)
+  out.set(hashBytes, 0)
+  return out
+}
+
+/** Derive the package secret key, verifying the password. Returns null on mismatch. */
+async function deriveSecretKey(password: string, key: AgileKeyInfo): Promise<Uint8Array | null> {
+  const chain = await passwordChain(password, key.saltValue, key.spinCount, key.hashAlgorithm)
+  const kVin = await deriveBlockKey(chain, BLOCK_VERIFIER_INPUT, key.keyBytes, key.hashAlgorithm)
+  const kVval = await deriveBlockKey(chain, BLOCK_VERIFIER_VALUE, key.keyBytes, key.hashAlgorithm)
+  const kVkey = await deriveBlockKey(chain, BLOCK_KEY_VALUE, key.keyBytes, key.hashAlgorithm)
+
+  const verifierInput = await aesDecrypt(kVin, key.saltValue, key.encryptedVerifierHashInput)
+  const expectedHash = await aesDecrypt(kVval, key.saltValue, key.encryptedVerifierHashValue)
+  const actualHash = await digest(key.hashAlgorithm, verifierInput)
+  const hashLen = Math.min(actualHash.length, expectedHash.length)
+  if (!bytesEqual(actualHash.subarray(0, hashLen), expectedHash.subarray(0, hashLen))) {
+    return null
+  }
+  const secret = await aesDecrypt(kVkey, key.saltValue, key.encryptedKeyValue)
+  return secret.subarray(0, key.keyBytes)
+}
+
+// ── Package (de/en)cryption ──────────────────────────────────────────
+
+async function iv(
+  salt: Uint8Array,
+  blockKey: Uint8Array,
+  algo: string,
+  blockSize: number,
+): Promise<Uint8Array> {
+  const h = await digest(algo, concat([salt, blockKey]))
+  return fitIv(h, blockSize)
+}
+
+function fitIv(h: Uint8Array, blockSize: number): Uint8Array {
+  if (h.length >= blockSize) return h.subarray(0, blockSize)
+  const out = new Uint8Array(blockSize).fill(0x36)
+  out.set(h, 0)
+  return out
+}
+
+async function decryptPackage(
+  pkg: Uint8Array,
+  secretKey: Uint8Array,
+  keyData: AgileKeyData,
+): Promise<Uint8Array> {
+  const totalSize = Number(new DataView(pkg.buffer, pkg.byteOffset, 8).getBigUint64(0, true))
+  const cipher = pkg.subarray(8)
+  const out = new Uint8Array(Math.ceil(cipher.length / SEGMENT) * SEGMENT)
+  const counter = new Uint8Array(4)
+  const cv = new DataView(counter.buffer)
+  let off = 0
+  let segIndex = 0
+  while (off < cipher.length) {
+    const chunk = cipher.subarray(off, Math.min(off + SEGMENT, cipher.length))
+    cv.setUint32(0, segIndex, true)
+    const segIv = fitIv(
+      await digest(keyData.hashAlgorithm, concat([keyData.saltValue, counter])),
+      keyData.blockSize,
+    )
+    const plain = await aesDecrypt(secretKey, segIv, chunk)
+    out.set(plain, off)
+    off += SEGMENT
+    segIndex++
+  }
+  return out.subarray(0, totalSize)
+}
+
+async function encryptPackage(
+  zip: Uint8Array,
+  secretKey: Uint8Array,
+  keyData: AgileKeyData,
+): Promise<Uint8Array> {
+  const header = new Uint8Array(8)
+  new DataView(header.buffer).setBigUint64(0, BigInt(zip.length), true)
+  const padded = padBlock(zip, SEGMENT) // segment-align (also block-aligned)
+  const out = new Uint8Array(padded.length)
+  const counter = new Uint8Array(4)
+  const cv = new DataView(counter.buffer)
+  let off = 0
+  let segIndex = 0
+  while (off < padded.length) {
+    const chunk = padded.subarray(off, off + SEGMENT)
+    cv.setUint32(0, segIndex, true)
+    const segIv = fitIv(
+      await digest(keyData.hashAlgorithm, concat([keyData.saltValue, counter])),
+      keyData.blockSize,
+    )
+    const enc = await aesEncrypt(secretKey, segIv, chunk)
+    out.set(enc, off)
+    off += SEGMENT
+    segIndex++
+  }
+  return concat([header, out])
+}
+
+// ── WebCrypto primitives ─────────────────────────────────────────────
+
+// WebCrypto's lib types want `BufferSource` backed by a plain ArrayBuffer;
+// our byte views are `Uint8Array<ArrayBufferLike>`. They're always
+// ArrayBuffer-backed at runtime, so cast at the boundary.
+const bs = (u: Uint8Array): BufferSource => u as unknown as BufferSource
+
+async function digest(algo: string, data: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest(algo, bs(data)))
+}
+
+async function importAesKey(raw: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey("raw", bs(raw), { name: "AES-CBC" }, false, ["encrypt", "decrypt"])
+}
+
+/** AES-CBC encrypt of one block via zero IV → raw ECB block. */
+async function ecbBlock(key: CryptoKey, block: Uint8Array): Promise<Uint8Array> {
+  const out = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-CBC", iv: bs(ZERO_IV) }, key, bs(block)),
+  )
+  return out.subarray(0, 16)
+}
+
+/** Raw (unpadded) AES-CBC decrypt of block-aligned data. */
+async function aesDecryptRaw(
+  key: CryptoKey,
+  ivBytes: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  if (data.length === 0) return new Uint8Array(0)
+  const last = data.subarray(data.length - 16)
+  const x = new Uint8Array(16)
+  for (let i = 0; i < 16; i++) x[i] = last[i] ^ 0x10
+  const pad = await ecbBlock(key, x)
+  const ext = concat([data, pad])
+  const dec = new Uint8Array(
+    await crypto.subtle.decrypt({ name: "AES-CBC", iv: bs(ivBytes) }, key, bs(ext)),
+  )
+  return dec.subarray(0, data.length)
+}
+
+/** Raw (unpadded) AES-CBC encrypt of block-aligned data. */
+async function aesEncryptRawKey(
+  key: CryptoKey,
+  ivBytes: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  if (data.length === 0) return new Uint8Array(0)
+  const enc = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-CBC", iv: bs(ivBytes) }, key, bs(data)),
+  )
+  return enc.subarray(0, data.length)
+}
+
+async function aesDecrypt(
+  rawKey: Uint8Array,
+  ivBytes: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  return aesDecryptRaw(await importAesKey(rawKey), ivBytes, data)
+}
+
+async function aesEncrypt(
+  rawKey: Uint8Array,
+  ivBytes: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  return aesEncryptRawKey(await importAesKey(rawKey), ivBytes, data)
+}
+
+async function hmacSha512(rawKey: Uint8Array, data: Uint8Array): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    bs(rawKey),
+    { name: "HMAC", hash: "SHA-512" },
+    false,
+    ["sign"],
+  )
+  return new Uint8Array(await crypto.subtle.sign("HMAC", key, bs(data)))
+}
+
+// ── EncryptionInfo XML ───────────────────────────────────────────────
+
+function getElementTag(xml: string, local: string): string | null {
+  const re = new RegExp(`<(?:\\w+:)?${local}\\b[^>]*?/?>`)
+  const m = re.exec(xml)
+  return m ? m[0] : null
+}
+
+function getAttr(tag: string, name: string): string {
+  const m = new RegExp(`\\b${name}="([^"]*)"`).exec(tag)
+  return m ? m[1] : ""
+}
+
+const HASH_NAME_MAP: Record<string, string> = {
+  SHA512: "SHA-512",
+  SHA384: "SHA-384",
+  SHA256: "SHA-256",
+  SHA1: "SHA-1",
+}
+
+function mapHash(name: string): string {
+  return HASH_NAME_MAP[name] ?? "SHA-512"
+}
+
+function parseKeyData(xml: string): AgileKeyData {
+  const tag = getElementTag(xml, "keyData")
+  if (!tag) throw new DecryptionError("EncryptionInfo missing keyData.")
+  return {
+    saltValue: base64Decode(getAttr(tag, "saltValue")),
+    hashAlgorithm: mapHash(getAttr(tag, "hashAlgorithm")),
+    keyBytes: parseInt(getAttr(tag, "keyBits"), 10) / 8,
+    blockSize: parseInt(getAttr(tag, "blockSize"), 10),
+  }
+}
+
+function parseKeyEncryptor(xml: string): AgileKeyInfo {
+  const tag = getElementTag(xml, "encryptedKey")
+  if (!tag) throw new DecryptionError("EncryptionInfo missing encryptedKey.")
+  return {
+    saltValue: base64Decode(getAttr(tag, "saltValue")),
+    hashAlgorithm: mapHash(getAttr(tag, "hashAlgorithm")),
+    keyBytes: parseInt(getAttr(tag, "keyBits"), 10) / 8,
+    blockSize: parseInt(getAttr(tag, "blockSize"), 10),
+    spinCount: parseInt(getAttr(tag, "spinCount"), 10),
+    encryptedVerifierHashInput: base64Decode(getAttr(tag, "encryptedVerifierHashInput")),
+    encryptedVerifierHashValue: base64Decode(getAttr(tag, "encryptedVerifierHashValue")),
+    encryptedKeyValue: base64Decode(getAttr(tag, "encryptedKeyValue")),
+  }
+}
+
+function buildEncryptionInfoXml(p: {
+  keyDataSalt: Uint8Array
+  pwSalt: Uint8Array
+  spinCount: number
+  keyBits: number
+  hashSize: number
+  blockSize: number
+  encryptedVerifierHashInput: Uint8Array
+  encryptedVerifierHashValue: Uint8Array
+  encryptedKeyValue: Uint8Array
+  encryptedHmacKey: Uint8Array
+  encryptedHmacValue: Uint8Array
+}): string {
+  const b = base64Encode
+  return (
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+    `<encryption xmlns="http://schemas.microsoft.com/office/2006/encryption" ` +
+    `xmlns:p="http://schemas.microsoft.com/office/2006/keyEncryptor/password">` +
+    `<keyData saltSize="${p.keyDataSalt.length}" blockSize="${p.blockSize}" keyBits="${p.keyBits}" ` +
+    `hashSize="${p.hashSize}" cipherAlgorithm="AES" cipherChaining="ChainingModeCBC" ` +
+    `hashAlgorithm="SHA512" saltValue="${b(p.keyDataSalt)}"/>` +
+    `<dataIntegrity encryptedHmacKey="${b(p.encryptedHmacKey)}" ` +
+    `encryptedHmacValue="${b(p.encryptedHmacValue)}"/>` +
+    `<keyEncryptors><keyEncryptor uri="http://schemas.microsoft.com/office/2006/keyEncryptor/password">` +
+    `<p:encryptedKey spinCount="${p.spinCount}" saltSize="${p.pwSalt.length}" blockSize="${p.blockSize}" ` +
+    `keyBits="${p.keyBits}" hashSize="${p.hashSize}" cipherAlgorithm="AES" cipherChaining="ChainingModeCBC" ` +
+    `hashAlgorithm="SHA512" saltValue="${b(p.pwSalt)}" ` +
+    `encryptedVerifierHashInput="${b(p.encryptedVerifierHashInput)}" ` +
+    `encryptedVerifierHashValue="${b(p.encryptedVerifierHashValue)}" ` +
+    `encryptedKeyValue="${b(p.encryptedKeyValue)}"/>` +
+    `</keyEncryptor></keyEncryptors></encryption>`
+  )
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function randomBytes(n: number): Uint8Array {
+  const b = new Uint8Array(n)
+  crypto.getRandomValues(b)
+  return b
+}
+
+function padBlock(data: Uint8Array, multiple: number): Uint8Array {
+  if (data.length % multiple === 0) return data
+  const out = new Uint8Array(Math.ceil(data.length / multiple) * multiple)
+  out.set(data, 0)
+  return out
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i]
+  return diff === 0
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  let total = 0
+  for (const c of chunks) total += c.length
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const c of chunks) {
+    out.set(c, off)
+    off += c.length
+  }
+  return out
+}
+
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+function base64Encode(bytes: Uint8Array): string {
+  let out = ""
+  let i = 0
+  for (; i + 2 < bytes.length; i += 3) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2]
+    out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + B64[(n >> 6) & 63] + B64[n & 63]
+  }
+  if (i < bytes.length) {
+    const rem = bytes.length - i
+    if (rem === 1) {
+      const n = bytes[i] << 16
+      out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + "=="
+    } else {
+      const n = (bytes[i] << 16) | (bytes[i + 1] << 8)
+      out += B64[(n >> 18) & 63] + B64[(n >> 12) & 63] + B64[(n >> 6) & 63] + "="
+    }
+  }
+  return out
+}
+
+function base64Decode(s: string): Uint8Array {
+  const clean = s.replace(/[^A-Za-z0-9+/]/g, "")
+  const len = Math.floor((clean.length * 3) / 4)
+  const out = new Uint8Array(len)
+  let bits = 0
+  let acc = 0
+  let oi = 0
+  for (let i = 0; i < clean.length; i++) {
+    acc = (acc << 6) | B64.indexOf(clean[i])
+    bits += 6
+    if (bits >= 8) {
+      bits -= 8
+      out[oi++] = (acc >> bits) & 0xff
+    }
+  }
+  return out.subarray(0, oi)
+}

--- a/src/xlsx/crypto/cfb.ts
+++ b/src/xlsx/crypto/cfb.ts
@@ -1,0 +1,412 @@
+// ── Compound File Binary (CFB / OLE2) ────────────────────────────────
+// Minimal reader + writer for the OLE2 container Office uses to wrap a
+// password-protected workbook. We only need two named streams:
+// `EncryptionInfo` (small) and `EncryptedPackage` (the encrypted OOXML
+// ZIP). The writer lays out a compliant container generically, routing
+// each stream to the mini-stream or the regular FAT by size, so it works
+// for tiny and large packages alike.
+//
+// Reference: [MS-CFB] Compound File Binary File Format.
+
+import { ParseError } from "../../errors"
+
+const SIG = [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]
+const ENDOFCHAIN = 0xfffffffe
+const FREESECT = 0xffffffff
+const FATSECT = 0xfffffffd
+const MINI_CUTOFF = 4096
+const MINI_SECTOR = 64
+
+// ── Reader ───────────────────────────────────────────────────────────
+
+interface DirEntry {
+  name: string
+  type: number // 0 unknown, 1 storage, 2 stream, 5 root
+  startSector: number
+  size: number
+}
+
+/**
+ * Parse a CFB container and return its named streams. Storage hierarchy
+ * is flattened — we only deal with top-level streams, which is all an
+ * encrypted workbook has.
+ */
+export function readCfb(data: Uint8Array): Map<string, Uint8Array> {
+  if (data.length < 512) throw new ParseError("CFB: file too small")
+  for (let i = 0; i < SIG.length; i++) {
+    if (data[i] !== SIG[i]) throw new ParseError("CFB: bad signature")
+  }
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength)
+  const sectorShift = view.getUint16(30, true)
+  const sectorSize = 1 << sectorShift
+  const miniSectorShift = view.getUint16(32, true)
+  const miniSectorSize = 1 << miniSectorShift
+  const numFatSectors = view.getUint32(44, true)
+  const firstDirSector = view.getUint32(48, true)
+  const miniCutoff = view.getUint32(56, true)
+  const firstMiniFatSector = view.getUint32(60, true)
+  const numMiniFatSectors = view.getUint32(64, true)
+  const firstDifatSector = view.getUint32(68, true)
+  const numDifatSectors = view.getUint32(72, true)
+
+  const sectorOffset = (sector: number): number => (sector + 1) * sectorSize
+
+  const readSector = (sector: number): Uint8Array => {
+    const off = sectorOffset(sector)
+    if (off + sectorSize > data.length) throw new ParseError("CFB: sector out of range")
+    return data.subarray(off, off + sectorSize)
+  }
+
+  // Collect FAT sector locations: first 109 from the header DIFAT, then
+  // any chained DIFAT sectors.
+  const fatSectorList: number[] = []
+  for (let i = 0; i < 109 && fatSectorList.length < numFatSectors; i++) {
+    const s = view.getUint32(76 + i * 4, true)
+    if (s === FREESECT || s === ENDOFCHAIN) break
+    fatSectorList.push(s)
+  }
+  let difatSector = firstDifatSector
+  let difatGuard = 0
+  while (
+    difatSector !== ENDOFCHAIN &&
+    difatSector !== FREESECT &&
+    numDifatSectors > 0 &&
+    difatGuard++ < numDifatSectors + 1
+  ) {
+    const sec = readSector(difatSector)
+    const dv = new DataView(sec.buffer, sec.byteOffset, sec.byteLength)
+    const entries = sectorSize / 4 - 1
+    for (let i = 0; i < entries && fatSectorList.length < numFatSectors; i++) {
+      const s = dv.getUint32(i * 4, true)
+      if (s !== FREESECT && s !== ENDOFCHAIN) fatSectorList.push(s)
+    }
+    difatSector = dv.getUint32(sectorSize - 4, true)
+  }
+
+  // Build the FAT.
+  const fat: number[] = []
+  for (const fs of fatSectorList) {
+    const sec = readSector(fs)
+    const dv = new DataView(sec.buffer, sec.byteOffset, sec.byteLength)
+    for (let i = 0; i < sectorSize / 4; i++) fat.push(dv.getUint32(i * 4, true))
+  }
+
+  const chain = (start: number): number[] => {
+    const out: number[] = []
+    let s = start
+    let guard = 0
+    while (s !== ENDOFCHAIN && s !== FREESECT && guard++ < fat.length + 1) {
+      out.push(s)
+      s = fat[s] ?? ENDOFCHAIN
+    }
+    return out
+  }
+
+  const readChain = (start: number, size: number): Uint8Array => {
+    const sectors = chain(start)
+    const buf = new Uint8Array(sectors.length * sectorSize)
+    let off = 0
+    for (const s of sectors) {
+      buf.set(readSector(s), off)
+      off += sectorSize
+    }
+    return size >= 0 ? buf.subarray(0, size) : buf
+  }
+
+  // Directory entries (each 128 bytes).
+  const dirBytes = readChain(firstDirSector, -1)
+  const dirView = new DataView(dirBytes.buffer, dirBytes.byteOffset, dirBytes.byteLength)
+  const entries: DirEntry[] = []
+  for (let off = 0; off + 128 <= dirBytes.length; off += 128) {
+    const type = dirBytes[off + 66]
+    if (type === 0) continue // unused entry
+    const nameLen = dirView.getUint16(off + 64, true)
+    let name = ""
+    for (let i = 0; i + 1 < nameLen; i += 2) {
+      const code = dirView.getUint16(off + i, true)
+      if (code === 0) break
+      name += String.fromCharCode(code)
+    }
+    const startSector = dirView.getUint32(off + 116, true)
+    const size = dirView.getUint32(off + 120, true) // low 32 bits (streams here are < 4 GB)
+    entries.push({ name, type, startSector, size })
+  }
+
+  const root = entries.find((e) => e.type === 5)
+  if (!root) throw new ParseError("CFB: missing root entry")
+
+  // Mini-stream container lives in the regular FAT, anchored on the root.
+  const miniStream = readChain(root.startSector, root.size)
+
+  // Mini-FAT.
+  const miniFat: number[] = []
+  if (numMiniFatSectors > 0 && firstMiniFatSector !== ENDOFCHAIN) {
+    const mfBytes = readChain(firstMiniFatSector, numMiniFatSectors * sectorSize)
+    const mfView = new DataView(mfBytes.buffer, mfBytes.byteOffset, mfBytes.byteLength)
+    for (let i = 0; i < mfBytes.length / 4; i++) miniFat.push(mfView.getUint32(i * 4, true))
+  }
+
+  const readMini = (start: number, size: number): Uint8Array => {
+    const out = new Uint8Array(size)
+    let s = start
+    let off = 0
+    let guard = 0
+    while (s !== ENDOFCHAIN && s !== FREESECT && off < size && guard++ < miniFat.length + 1) {
+      const from = s * miniSectorSize
+      const take = Math.min(miniSectorSize, size - off)
+      out.set(miniStream.subarray(from, from + take), off)
+      off += take
+      s = miniFat[s] ?? ENDOFCHAIN
+    }
+    return out
+  }
+
+  const streams = new Map<string, Uint8Array>()
+  for (const e of entries) {
+    if (e.type !== 2) continue
+    const cutoff = miniCutoff || MINI_CUTOFF
+    streams.set(
+      e.name,
+      e.size < cutoff ? readMini(e.startSector, e.size) : readChain(e.startSector, e.size),
+    )
+  }
+  return streams
+}
+
+// ── Writer ───────────────────────────────────────────────────────────
+
+interface StreamInput {
+  name: string
+  data: Uint8Array
+}
+
+/**
+ * Assemble a CFB container holding the given top-level streams (plus the
+ * implicit Root Entry). Uses 512-byte sectors and 64-byte mini sectors;
+ * streams smaller than 4096 bytes go in the mini-stream, the rest in the
+ * regular FAT.
+ */
+export function writeCfb(inputs: StreamInput[]): Uint8Array {
+  const sectorSize = 512
+  const perSector = sectorSize / 4 // FAT entries per sector
+
+  // 1. Partition streams into mini vs regular and build the mini-stream.
+  const miniChunks: Uint8Array[] = []
+  const miniStartMini: number[] = [] // mini-sector index where each mini stream starts
+  const regular: Array<{ name: string; data: Uint8Array }> = []
+  const placement = new Map<string, { mini: boolean }>()
+
+  let miniSectorCount = 0
+  for (const s of inputs) {
+    if (s.data.length < MINI_CUTOFF) {
+      placement.set(s.name, { mini: true })
+      miniStartMini.push(miniSectorCount)
+      const padded = padTo(s.data, MINI_SECTOR)
+      miniChunks.push(padded)
+      miniSectorCount += padded.length / MINI_SECTOR
+    } else {
+      placement.set(s.name, { mini: false })
+      regular.push({ name: s.name, data: s.data })
+    }
+  }
+  const miniStream = concat(miniChunks)
+
+  // 2. Lay out regular-FAT payload sectors: each regular stream, then the
+  // mini-stream container, then the mini-FAT, then the directory. The FAT
+  // sectors themselves come last (their count depends on the total).
+  interface Region {
+    startSector: number
+    sectorCount: number
+  }
+  let cursor = 0
+  const alloc = (byteLen: number): Region => {
+    const sectorCount = Math.max(1, Math.ceil(byteLen / sectorSize))
+    const startSector = cursor
+    cursor += sectorCount
+    return { startSector, sectorCount }
+  }
+
+  const regularRegions = regular.map((r) => ({
+    name: r.name,
+    data: r.data,
+    region: alloc(r.data.length),
+  }))
+  const miniStreamRegion = miniStream.length > 0 ? alloc(miniStream.length) : null
+
+  // Mini-FAT: one entry per mini sector.
+  const miniFat = new Uint8Array(Math.ceil(Math.max(miniSectorCount, 0) / perSector) * sectorSize)
+  {
+    const dv = new DataView(miniFat.buffer)
+    for (let i = 0; i < miniFat.length / 4; i++) dv.setUint32(i * 4, FREESECT, true)
+    // Chain each mini stream's mini sectors.
+    let idx = 0
+    let mi = 0
+    for (const s of inputs) {
+      if (s.data.length >= MINI_CUTOFF) continue
+      const sectors = padTo(s.data, MINI_SECTOR).length / MINI_SECTOR
+      for (let k = 0; k < sectors; k++) {
+        const cur = miniStartMini[mi] + k
+        dv.setUint32(cur * 4, k === sectors - 1 ? ENDOFCHAIN : cur + 1, true)
+      }
+      mi++
+      idx += sectors
+    }
+    void idx
+  }
+  const miniFatRegion = miniSectorCount > 0 ? alloc(miniFat.length) : null
+
+  // Directory: Root + one entry per stream. 4 entries per 512 sector.
+  const dirEntryCount = 1 + inputs.length
+  const dirBytesLen = Math.ceil(dirEntryCount / (sectorSize / 128)) * sectorSize
+  const dirRegion = alloc(dirBytesLen)
+
+  // 3. FAT sizing: total payload sectors so far + the FAT sectors we are
+  // about to add. Solve for FAT sector count (self-referential).
+  const payloadSectors = cursor
+  let numFatSectors = 1
+  for (;;) {
+    const totalSectors = payloadSectors + numFatSectors
+    const need = Math.ceil(totalSectors / perSector)
+    if (need <= numFatSectors) break
+    numFatSectors = need
+  }
+  const fatRegion = { startSector: cursor, sectorCount: numFatSectors }
+  cursor += numFatSectors
+  const totalSectors = cursor
+
+  // 4. Build the FAT.
+  const fat = new Uint32Array(numFatSectors * perSector)
+  fat.fill(FREESECT)
+  const chainRegion = (r: Region): void => {
+    for (let i = 0; i < r.sectorCount; i++) {
+      fat[r.startSector + i] = i === r.sectorCount - 1 ? ENDOFCHAIN : r.startSector + i + 1
+    }
+  }
+  for (const r of regularRegions) chainRegion(r.region)
+  if (miniStreamRegion) chainRegion(miniStreamRegion)
+  if (miniFatRegion) chainRegion(miniFatRegion)
+  chainRegion(dirRegion)
+  for (let i = 0; i < numFatSectors; i++) fat[fatRegion.startSector + i] = FATSECT
+
+  // 5. Directory bytes.
+  const dir = new Uint8Array(dirBytesLen)
+  const dirView = new DataView(dir.buffer)
+  const writeDirEntry = (
+    idx: number,
+    name: string,
+    type: number,
+    color: number,
+    left: number,
+    right: number,
+    child: number,
+    start: number,
+    size: number,
+  ): void => {
+    const o = idx * 128
+    for (let i = 0; i < name.length; i++) dirView.setUint16(o + i * 2, name.charCodeAt(i), true)
+    dirView.setUint16(o + 64, (name.length + 1) * 2, true)
+    dir[o + 66] = type
+    dir[o + 67] = color
+    dirView.setUint32(o + 68, left, true)
+    dirView.setUint32(o + 72, right, true)
+    dirView.setUint32(o + 76, child, true)
+    dirView.setUint32(o + 116, start, true)
+    dirView.setUint32(o + 120, size, true)
+  }
+  // Mark all slots free first.
+  for (let i = 0; i < dirBytesLen / 128; i++) {
+    dirView.setUint32(i * 128 + 68, FREESECT, true)
+    dirView.setUint32(i * 128 + 72, FREESECT, true)
+    dirView.setUint32(i * 128 + 76, FREESECT, true)
+  }
+  // Root entry (index 0): its child is the first stream; start = mini-stream container.
+  writeDirEntry(
+    0,
+    "Root Entry",
+    5,
+    1,
+    FREESECT,
+    FREESECT,
+    inputs.length > 0 ? 1 : FREESECT,
+    miniStreamRegion ? miniStreamRegion.startSector : ENDOFCHAIN,
+    miniStream.length,
+  )
+  // Stream entries 1..n laid out as a degenerate right-leaning tree:
+  // entry i's right sibling is i+1. (Excel's reader accepts this.)
+  for (let i = 0; i < inputs.length; i++) {
+    const s = inputs[i]
+    const place = placement.get(s.name)!
+    const entryIdx = i + 1
+    const right = i + 1 < inputs.length ? entryIdx + 1 : FREESECT
+    let start: number
+    if (place.mini) {
+      // mini sector index where this stream starts
+      let miOff = 0
+      for (let j = 0; j < i; j++) {
+        const sj = inputs[j]
+        if (sj.data.length < MINI_CUTOFF) miOff += padTo(sj.data, MINI_SECTOR).length / MINI_SECTOR
+      }
+      start = miOff
+    } else {
+      const reg = regularRegions.find((r) => r.name === s.name)!
+      start = reg.region.startSector
+    }
+    writeDirEntry(entryIdx, s.name, 2, 1, FREESECT, right, FREESECT, start, s.data.length)
+  }
+
+  // 6. Assemble the file: header sector + payload sectors.
+  const file = new Uint8Array((totalSectors + 1) * sectorSize)
+  const fileView = new DataView(file.buffer)
+  // Header.
+  for (let i = 0; i < SIG.length; i++) file[i] = SIG[i]
+  fileView.setUint16(24, 0x003e, true) // minor version
+  fileView.setUint16(26, 0x0003, true) // major version (3 → 512-byte sectors)
+  fileView.setUint16(28, 0xfffe, true) // byte order
+  fileView.setUint16(30, 9, true) // sector shift (512)
+  fileView.setUint16(32, 6, true) // mini sector shift (64)
+  fileView.setUint32(44, numFatSectors, true)
+  fileView.setUint32(48, dirRegion.startSector, true)
+  fileView.setUint32(56, MINI_CUTOFF, true)
+  fileView.setUint32(60, miniFatRegion ? miniFatRegion.startSector : ENDOFCHAIN, true)
+  fileView.setUint32(64, miniFatRegion ? miniFatRegion.sectorCount : 0, true)
+  fileView.setUint32(68, ENDOFCHAIN, true) // first DIFAT sector
+  fileView.setUint32(72, 0, true) // num DIFAT sectors
+  for (let i = 0; i < 109; i++) {
+    fileView.setUint32(76 + i * 4, i < numFatSectors ? fatRegion.startSector + i : FREESECT, true)
+  }
+
+  const sectorAt = (sector: number): number => (sector + 1) * sectorSize
+  const putBytes = (region: Region, bytes: Uint8Array): void => {
+    file.set(bytes, sectorAt(region.startSector))
+  }
+  for (const r of regularRegions) putBytes(r.region, r.data)
+  if (miniStreamRegion) putBytes(miniStreamRegion, miniStream)
+  if (miniFatRegion) putBytes(miniFatRegion, miniFat)
+  putBytes(dirRegion, dir)
+  // FAT.
+  {
+    const off = sectorAt(fatRegion.startSector)
+    const dv = new DataView(file.buffer, off, numFatSectors * sectorSize)
+    for (let i = 0; i < fat.length; i++) dv.setUint32(i * 4, fat[i], true)
+  }
+  return file
+}
+
+function padTo(data: Uint8Array, multiple: number): Uint8Array {
+  if (data.length % multiple === 0) return data
+  const out = new Uint8Array(Math.ceil(data.length / multiple) * multiple)
+  out.set(data, 0)
+  return out
+}
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  let total = 0
+  for (const c of chunks) total += c.length
+  const out = new Uint8Array(total)
+  let off = 0
+  for (const c of chunks) {
+    out.set(c, off)
+    off += c.length
+  }
+  return out
+}

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -25,8 +25,9 @@ import { assembleCellImages, parseCellImages, REL_CELL_IMAGES } from "./cell-ima
 import { attachPivotCacheFields, parsePivotCacheDefinition, parsePivotTable } from "./pivot-reader"
 import { parseSlicers, parseSlicerCache, parseTimelines, parseTimelineCache } from "./slicer-reader"
 import { parseChart } from "./chart-reader"
-import { ParseError, ZipError } from "../errors"
-import { assertNotEncrypted, readInputToUint8Array } from "../_input"
+import { EncryptedFileError, ParseError, ZipError } from "../errors"
+import { isOle2Container, readInputToUint8Array } from "../_input"
+import { decryptAgile } from "./crypto/agile"
 import { ZipReader } from "../zip/reader"
 import { parseXml } from "../xml/parser"
 import { parseContentTypes } from "./content-types"
@@ -110,13 +111,18 @@ function dirname(path: string): string {
  * you need row-level streaming with low per-row memory.
  */
 export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  const data = await readInputToUint8Array(input)
+  let data = await readInputToUint8Array(input)
 
-  // Detect password-protected workbooks (OLE2/CFB envelope) and surface
-  // a typed `EncryptedFileError` instead of letting the ZIP reader fail
-  // with a generic "not a valid ZIP archive" ParseError. Decryption
-  // itself is tracked in #156.
-  assertNotEncrypted(data, "xlsx")
+  // Password-protected workbooks arrive as an OLE2/CFB envelope. With a
+  // password we decrypt the inner OOXML ZIP and continue; without one we
+  // surface a typed `EncryptedFileError` instead of a generic ZIP failure.
+  if (isOle2Container(data)) {
+    if (options?.password) {
+      data = await decryptAgile(data, options.password)
+    } else {
+      throw new EncryptedFileError("xlsx")
+    }
+  }
 
   // 1. Open ZIP archive
   let zip: ZipReader

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -32,6 +32,9 @@ import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
 import { writeChart } from "./chart-writer"
 import { cloneChart } from "./chart-clone"
+import { isOle2Container } from "../_input"
+import { EncryptedFileError } from "../errors"
+import { decryptAgile, encryptAgile } from "./crypto/agile"
 import { writeComments } from "./comments-writer"
 import type { CommentsResult } from "./comments-writer"
 import { writeTable } from "./table-writer"
@@ -118,7 +121,17 @@ export async function openXlsx(
   input: Uint8Array | ArrayBuffer,
   options?: ReadOptions,
 ): Promise<RoundtripWorkbook> {
-  const data = input instanceof Uint8Array ? input : new Uint8Array(input)
+  let data = input instanceof Uint8Array ? input : new Uint8Array(input)
+
+  // Decrypt password-protected workbooks up front so both the parse and
+  // the raw-entry capture below see the plaintext OOXML ZIP.
+  if (isOle2Container(data)) {
+    if (options?.password) {
+      data = await decryptAgile(data, options.password)
+    } else {
+      throw new EncryptedFileError("xlsx")
+    }
+  }
 
   // 1. Parse the workbook normally
   const workbook = await readXlsx(data, options)
@@ -154,8 +167,13 @@ export async function openXlsx(
 
 /**
  * Write a RoundtripWorkbook back to XLSX, preserving unmodified parts.
+ * Pass `{ encryption: { password } }` to emit a password-protected
+ * (ECMA-376 Agile) workbook.
  */
-export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array> {
+export async function saveXlsx(
+  workbook: RoundtripWorkbook,
+  saveOptions?: { encryption?: { password: string; spinCount?: number } },
+): Promise<Uint8Array> {
   const { sheets, properties, namedRanges, dateSystem, defaultFont, activeSheet } = workbook
 
   // Convert Sheet[] to WriteSheet[] for the writer infrastructure
@@ -1027,7 +1045,9 @@ export async function saveXlsx(workbook: RoundtripWorkbook): Promise<Uint8Array>
     }
   }
 
-  return zip.build()
+  const out = await zip.build()
+  const enc = saveOptions?.encryption
+  return enc?.password ? encryptAgile(out, enc.password, { spinCount: enc.spinCount }) : out
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -7,8 +7,9 @@ import type { CellValue, ReadOptions } from "../_types"
 import type { SharedString } from "./shared-strings"
 import type { ParsedStyles } from "./styles"
 import type { Relationship } from "./relationships"
-import { ParseError, ZipError } from "../errors"
-import { assertNotEncrypted } from "../_input"
+import { EncryptedFileError, ParseError, ZipError } from "../errors"
+import { isOle2Container } from "../_input"
+import { decryptAgile } from "./crypto/agile"
 import { ZipReader } from "../zip/reader"
 import { ZipStreamReader } from "../zip/stream-reader"
 import { parseXml, parseSaxStream, decodeOoxmlEscapes } from "../xml/parser"
@@ -768,10 +769,19 @@ export async function* streamXlsxRows(
     data = prep.data
   }
 
-  // Detect password-protected workbooks (OLE2/CFB envelope) up front so
-  // streamers fail fast with a typed `EncryptedFileError` instead of a
-  // generic ZIP ParseError. Decryption is tracked in #156.
-  assertNotEncrypted(data, "xlsx")
+  // Password-protected workbooks arrive as an OLE2/CFB envelope (a stream
+  // input falls back to a buffer in prepareStreaming, so we always have
+  // the full bytes here). Decrypt with a password, else fail fast with a
+  // typed `EncryptedFileError`. The decrypted package is a plain ZIP read
+  // via the buffered path below (one-pass streaming of encrypted input
+  // isn't possible — the whole package must be decrypted first).
+  if (isOle2Container(data)) {
+    if (options?.password) {
+      data = await decryptAgile(data, options.password)
+    } else {
+      throw new EncryptedFileError("xlsx")
+    }
+  }
 
   // 1. Open ZIP archive
   let zip: ZipReader

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -22,6 +22,7 @@ import { unwrapCellValue } from "./hyperlink"
 import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
 import { writeChart } from "./chart-writer"
+import { encryptAgile } from "./crypto/agile"
 import { writeComments } from "./comments-writer"
 import type { CommentsResult } from "./comments-writer"
 import { writeTable } from "./table-writer"
@@ -548,7 +549,9 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     )
   }
 
-  return zip.build()
+  const out = await zip.build()
+  const enc = options.encryption
+  return enc?.password ? encryptAgile(out, enc.password, { spinCount: enc.spinCount }) : out
 }
 
 // ── Pivot Source Resolution ────────────────────────────────────────────

--- a/test/coverage-gaps.test.ts
+++ b/test/coverage-gaps.test.ts
@@ -90,6 +90,7 @@ import {
   ValidationError,
   UnsupportedFormatError,
   EncryptedFileError,
+  DecryptionError,
 } from "../src/index"
 import type { CellValue } from "../src/_types"
 
@@ -204,6 +205,7 @@ describe("Coverage gaps: every exported function is callable (#135)", () => {
     expect(typeof ValidationError).toBe("function")
     expect(typeof UnsupportedFormatError).toBe("function")
     expect(typeof EncryptedFileError).toBe("function")
+    expect(typeof DecryptionError).toBe("function")
   })
 })
 

--- a/test/encryption.test.ts
+++ b/test/encryption.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { streamXlsxRows } from "../src/xlsx/stream-reader"
+import { read, readObjects } from "../src/defter"
+import { isOle2Container } from "../src/_input"
+import { DecryptionError, EncryptedFileError } from "../src/errors"
+import { readCfb, writeCfb } from "../src/xlsx/crypto/cfb"
+import { decryptAgile, encryptAgile } from "../src/xlsx/crypto/agile"
+import type { CellValue } from "../src/_types"
+
+const FAST = { spinCount: 64 }
+
+function book() {
+  return {
+    sheets: [
+      {
+        name: "Sheet1",
+        rows: [
+          ["Name", "Score"],
+          ["Ada", 95],
+          ["Linus", 88],
+        ] as CellValue[][],
+      },
+    ],
+  }
+}
+
+describe("CFB container", () => {
+  it("round-trips mini (small) and regular (large) streams", () => {
+    const small = new Uint8Array(1300).map((_, i) => i & 0xff)
+    const big = new Uint8Array(20000).map((_, i) => (i * 31) & 0xff)
+    const streams = readCfb(
+      writeCfb([
+        { name: "EncryptionInfo", data: small },
+        { name: "EncryptedPackage", data: big },
+      ]),
+    )
+    expect([...streams.get("EncryptionInfo")!]).toEqual([...small])
+    expect([...streams.get("EncryptedPackage")!]).toEqual([...big])
+  })
+})
+
+describe("agile crypto primitive", () => {
+  it("encrypt → decrypt recovers arbitrary bytes", async () => {
+    const payload = new TextEncoder().encode("PK" + "payload ".repeat(900))
+    const enc = await encryptAgile(payload, "hunter2", FAST)
+    expect(isOle2Container(enc)).toBe(true)
+    expect([...(await decryptAgile(enc, "hunter2"))]).toEqual([...payload])
+  })
+
+  it("wrong password rejects with DecryptionError", async () => {
+    const enc = await encryptAgile(new TextEncoder().encode("data ".repeat(2000)), "right", FAST)
+    await expect(decryptAgile(enc, "wrong")).rejects.toBeInstanceOf(DecryptionError)
+  })
+
+  it("interoperates at Excel's default spin count", { timeout: 30000 }, async () => {
+    const payload = new TextEncoder().encode("z".repeat(9000))
+    const enc = await encryptAgile(payload, "pw") // default 100000
+    expect([...(await decryptAgile(enc, "pw"))]).toEqual([...payload])
+  })
+})
+
+describe("writeXlsx encryption ↔ readXlsx decryption", () => {
+  it("encrypts on write and decrypts on read with the password", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    expect(isOle2Container(enc)).toBe(true) // output is an encrypted OLE2 container, not a ZIP
+
+    const wb = await readXlsx(enc, { password: "pw" })
+    expect(wb.sheets[0].name).toBe("Sheet1")
+    expect(wb.sheets[0].rows[1]).toEqual(["Ada", 95])
+  })
+
+  it("reading without a password throws EncryptedFileError", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    await expect(readXlsx(enc)).rejects.toBeInstanceOf(EncryptedFileError)
+  })
+
+  it("reading with the wrong password throws DecryptionError", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    await expect(readXlsx(enc, { password: "nope" })).rejects.toBeInstanceOf(DecryptionError)
+  })
+})
+
+describe("decryption across the read entry points", () => {
+  it("read() auto-detects and decrypts", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    const wb = await read(enc, { password: "pw" })
+    expect(wb.sheets[0].rows[2]).toEqual(["Linus", 88])
+  })
+
+  it("readObjects() decrypts", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    const objs = await readObjects<{ Name: string; Score: number }>(enc, { password: "pw" })
+    expect(objs).toEqual([
+      { Name: "Ada", Score: 95 },
+      { Name: "Linus", Score: 88 },
+    ])
+  })
+
+  it("streamXlsxRows() decrypts", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    const rows: CellValue[][] = []
+    for await (const row of streamXlsxRows(enc, { password: "pw" })) rows.push(row.values)
+    expect(rows[0]).toEqual(["Name", "Score"])
+    expect(rows[1]).toEqual(["Ada", 95])
+  })
+
+  it("streamXlsxRows() without a password throws EncryptedFileError", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    await expect(async () => {
+      for await (const _ of streamXlsxRows(enc)) void _
+    }).rejects.toBeInstanceOf(EncryptedFileError)
+  })
+})
+
+describe("roundtrip open → save with encryption", () => {
+  it("opens an encrypted workbook and re-saves it encrypted", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "first", spinCount: 64 } })
+    const wb = await openXlsx(enc, { password: "first" })
+    expect(wb.sheets[0].rows[1]).toEqual(["Ada", 95])
+
+    const resaved = await saveXlsx(wb, { encryption: { password: "second", spinCount: 64 } })
+    expect(isOle2Container(resaved)).toBe(true)
+
+    const reopened = await readXlsx(resaved, { password: "second" })
+    expect(reopened.sheets[0].rows[2]).toEqual(["Linus", 88])
+    // old password no longer works on the re-encrypted file
+    await expect(readXlsx(resaved, { password: "first" })).rejects.toBeInstanceOf(DecryptionError)
+  })
+
+  it("saveXlsx without an encryption option produces a plain ZIP", async () => {
+    const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
+    const wb = await openXlsx(enc, { password: "pw" })
+    const plain = await saveXlsx(wb)
+    expect(isOle2Container(plain)).toBe(false)
+    expect((await readXlsx(plain)).sheets[0].rows[1]).toEqual(["Ada", 95])
+  })
+})


### PR DESCRIPTION
## Summary

Read **and** write password-protected XLSX files using ECMA-376 **Agile** encryption (the Excel 2010+ default). Until now an encrypted workbook only produced a typed `EncryptedFileError`; now a password decrypts it on read, and `writeXlsx`/`saveXlsx` can produce one. Zero-dependency — built entirely on WebCrypto.

## Implementation

- **`src/xlsx/crypto/cfb.ts`** — minimal Compound File Binary (OLE2) reader + writer for the envelope Office uses (`EncryptionInfo` + `EncryptedPackage` streams), routing streams to the mini-stream or regular FAT by size.
- **`src/xlsx/crypto/agile.ts`** — Agile decrypt + encrypt per [MS-OFFCRYPTO]: SHA-512 password key derivation (`spinCount`), verifier-hash password check, secret-key unwrap, 4096-byte segmented AES-CBC of the package, and HMAC-SHA512 `dataIntegrity`. AES uses WebCrypto AES-CBC with the standard no-padding tricks (append one crafted ciphertext block on decrypt so WebCrypto strips a full pad block; drop the trailing pad block on encrypt) — so there's **no hand-rolled cipher**, just WebCrypto.
- **`DecryptionError`** (wrong password / corrupt blob) added, distinct from `EncryptedFileError` (encrypted, but no password supplied).

## API

```ts
// write encrypted
const enc = await writeXlsx({ sheets, encryption: { password: "pw" } })
// read it back
const wb = await readXlsx(enc, { password: "pw" })
```

- Decryption is wired into **every read entry point**: `readXlsx`, `openXlsx`, `streamXlsxRows`, `read()`, `readObjects()`. With a password they decrypt; without one they still throw `EncryptedFileError`; wrong password throws `DecryptionError`.
- Encryption: `writeXlsx({ ..., encryption: { password, spinCount? } })` and `saveXlsx(wb, { encryption: { password, spinCount? } })`. `spinCount` defaults to Excel's 100000 (lowerable for the speed/security trade-off; it's stored in the file so any reader honors it).

## Tests

`test/encryption.test.ts` (+13): CFB mini/regular round-trip; agile primitive round-trip including the default 100000 spin count; wrong-password → `DecryptionError`; write↔read through `readXlsx`/`read`/`readObjects`/`streamXlsxRows`; no-password → `EncryptedFileError`; and `openXlsx`→`saveXlsx` re-encryption with a new password. Existing encrypted-file-detection tests stay green (the no-password path is unchanged). Full suite **7552 / 7552**; `pnpm lint` / `typecheck` / `build` clean.

## Scope & honesty

- Covers **ECMA-376 Agile** (Excel 2010+, the modern default) for both directions — virtually all password-protected XLSX in the wild.
- **Out of scope** (follow-ups): legacy ECMA-376 **Standard** decryption (older files), and ODS encryption (a different in-ZIP scheme).
- The implementation follows MS-OFFCRYPTO precisely and is validated by encrypt→decrypt round-trips, but I couldn't verify interop against an Excel-produced fixture in this offline environment. Real-Excel interop testing is worth a manual pass before relying on it in production.

Closes #156
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)