### PR TITLE
feat(xlsx): XLSB (binary workbook) read support — closes #154, #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,24 @@ The roundtrip path takes the same option: `await saveXlsx(wb, { encryption: { pa
 The key-derivation iteration count defaults to Excel's 100000; lower it via
 `encryption: { password, spinCount }` when the speed/security trade-off calls for it.
 
+### XLSB (Binary Excel) — read
+
+Read `.xlsb` (Excel Binary Workbook) files — the binary package format
+that's smaller and faster to open than `.xlsx`. `read()` auto-detects it,
+or call `readXlsb` directly:
+
+```ts
+import { read, readXlsb } from "hucre"
+
+const wb = await readXlsb(bytes) // sheet names + typed cell values
+const same = await read(bytes) // auto-detected (XLSX vs XLSB vs ODS)
+```
+
+Decodes shared strings, RK / floating-point numbers, inline strings,
+booleans, error codes, cached formula values, and dates (via the binary
+style table). Read-only; password-protected `.xlsb` also decrypts with
+`{ password }`.
+
 ### ODS (OpenDocument)
 
 ```ts

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -15,6 +15,8 @@ import type {
   TableColumn,
 } from "./_types"
 import { readXlsx } from "./xlsx/reader"
+import { readXlsb, looksLikeXlsb } from "./xlsx/xlsb/reader"
+import { ZipReader } from "./zip/reader"
 import { decryptAgile } from "./xlsx/crypto/agile"
 import { writeXlsx } from "./xlsx/writer"
 import { readOds } from "./ods/reader"
@@ -104,6 +106,13 @@ export async function read(input: ReadInput, options?: ReadOptions): Promise<Wor
 
   if (format === "ods") {
     return readOds(data, options)
+  }
+  // XLSX and XLSB share the ZIP shape; tell them apart by the binary
+  // workbook part before dispatching.
+  try {
+    if (looksLikeXlsb(new ZipReader(data))) return readXlsb(data, options)
+  } catch {
+    // Not a readable ZIP here — fall through to readXlsx for a typed error.
   }
   return readXlsx(data, options)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type { WriteObjectsTableOption } from "./defter"
 
 // ── XLSX ────────────────────────────────────────────────────────────
 export { readXlsx } from "./xlsx/reader"
+export { readXlsb } from "./xlsx/xlsb/reader"
 export { writeXlsx } from "./xlsx/writer"
 export { link } from "./xlsx/hyperlink"
 export { openXlsx, saveXlsx } from "./xlsx/roundtrip"

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -1,0 +1,308 @@
+// ── XLSB Reader ──────────────────────────────────────────────────────
+// Read Excel Binary Workbook (.xlsb) files. XLSB shares XLSX's ZIP package
+// and XML relationships/[Content_Types], but stores the workbook, shared
+// strings, styles, and worksheets as binary `.bin` record streams instead
+// of XML. We reuse the ZIP layer + the XML rels parser, and decode the
+// `.bin` parts with the record reader. Read-only (MS-XLSB).
+
+import type { CellValue, ReadOptions, Sheet, Workbook } from "../../_types"
+import { EncryptedFileError, ParseError, ZipError } from "../../errors"
+import { isOle2Container, readInputToUint8Array } from "../../_input"
+import { decryptAgile } from "../crypto/agile"
+import { ZipReader } from "../../zip/reader"
+import { parseRelationships } from "../relationships"
+import { isDateFormat, serialToDate } from "../../_date"
+import { Cursor, decodeRk, iterateRecords } from "./record"
+
+// Record ids we care about (MS-XLSB §2.4).
+const BrtRowHdr = 0
+const BrtCellBlank = 1
+const BrtCellRk = 2
+const BrtCellError = 3
+const BrtCellBool = 4
+const BrtCellReal = 5
+const BrtCellSt = 6
+const BrtCellIsst = 7
+const BrtFmlaString = 8
+const BrtFmlaNum = 9
+const BrtFmlaBool = 10
+const BrtFmlaError = 11
+const BrtSSTItem = 19
+const BrtFmt = 44
+const BrtXF = 47
+const BrtBundleSh = 156
+const BrtBeginCellXFs = 617
+const BrtEndCellXFs = 618
+
+const REL_WORKBOOK =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+const REL_WORKSHEET =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet"
+const REL_SHARED_STRINGS =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings"
+const REL_STYLES = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles"
+
+const BUILTIN_DATE_IDS = new Set([14, 15, 16, 17, 18, 19, 20, 21, 22, 45, 46, 47])
+
+const ERROR_TEXT: Record<number, string> = {
+  0x00: "#NULL!",
+  0x07: "#DIV/0!",
+  0x0f: "#VALUE!",
+  0x17: "#REF!",
+  0x1d: "#NAME?",
+  0x24: "#NUM!",
+  0x2a: "#N/A",
+  0x2b: "#GETTING_DATA",
+}
+
+const decoder = new TextDecoder("utf-8")
+
+function decodeUtf8(d: Uint8Array): string {
+  return decoder.decode(d)
+}
+
+function dirname(path: string): string {
+  const i = path.lastIndexOf("/")
+  return i === -1 ? "" : path.slice(0, i)
+}
+
+function resolvePath(base: string, target: string): string {
+  if (target.startsWith("/")) return target.slice(1)
+  const parts = base.split("/").filter(Boolean)
+  for (const seg of target.split("/").filter(Boolean)) {
+    if (seg === "..") parts.pop()
+    else if (seg !== ".") parts.push(seg)
+  }
+  return parts.join("/")
+}
+
+/** Whether an .xlsb-shaped ZIP is present (used for format auto-detection). */
+export function looksLikeXlsb(zip: ZipReader): boolean {
+  return zip.has("xl/workbook.bin")
+}
+
+/**
+ * Read an XLSB workbook into the same {@link Workbook} model `readXlsx`
+ * produces (sheet names + typed cell values in `rows`).
+ */
+export async function readXlsb(
+  input: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
+  options?: ReadOptions,
+): Promise<Workbook> {
+  let data = await readInputToUint8Array(input)
+  if (isOle2Container(data)) {
+    if (options?.password) data = await decryptAgile(data, options.password)
+    else throw new EncryptedFileError("xlsx")
+  }
+
+  let zip: ZipReader
+  try {
+    zip = new ZipReader(data)
+  } catch (err) {
+    if (err instanceof ZipError) throw err
+    throw new ParseError("Failed to open XLSB: not a valid ZIP archive", undefined, { cause: err })
+  }
+
+  const date1904 = options?.dateSystem === "1904"
+
+  // Locate the workbook part via the root relationships (fallback to the
+  // conventional path).
+  let workbookPath = "xl/workbook.bin"
+  if (zip.has("_rels/.rels")) {
+    const rootRels = parseRelationships(decodeUtf8(await zip.extract("_rels/.rels")))
+    const wbRel = rootRels.find((r) => r.type === REL_WORKBOOK)
+    if (wbRel) workbookPath = wbRel.target.startsWith("/") ? wbRel.target.slice(1) : wbRel.target
+  }
+  if (!zip.has(workbookPath)) {
+    throw new ParseError(`Invalid XLSB: missing workbook at ${workbookPath}`)
+  }
+  const workbookDir = dirname(workbookPath)
+
+  // Sheets (name + relId) from the workbook .bin.
+  const sheetEntries = parseWorkbookBin(await zip.extract(workbookPath))
+
+  // Workbook relationships (XML) → relId → part path.
+  const wbRelsPath = workbookDir
+    ? `${workbookDir}/_rels/${workbookPath.slice(workbookDir.length + 1)}.rels`
+    : `_rels/${workbookPath}.rels`
+  const relMap = new Map<string, string>()
+  let sharedStringsPath: string | undefined
+  let stylesPath: string | undefined
+  if (zip.has(wbRelsPath)) {
+    for (const rel of parseRelationships(decodeUtf8(await zip.extract(wbRelsPath)))) {
+      const target = resolvePath(workbookDir, rel.target)
+      if (rel.type === REL_WORKSHEET) relMap.set(rel.id, target)
+      else if (rel.type === REL_SHARED_STRINGS) sharedStringsPath = target
+      else if (rel.type === REL_STYLES) stylesPath = target
+    }
+  }
+
+  const sharedStrings =
+    sharedStringsPath && zip.has(sharedStringsPath)
+      ? parseSharedStringsBin(await zip.extract(sharedStringsPath))
+      : []
+  const dateXf =
+    stylesPath && zip.has(stylesPath) ? parseStylesBin(await zip.extract(stylesPath)) : []
+
+  const sheets: Sheet[] = []
+  for (const entry of sheetEntries) {
+    const path = entry.relId ? relMap.get(entry.relId) : undefined
+    if (!path || !zip.has(path)) {
+      sheets.push({ name: entry.name, rows: [] })
+      continue
+    }
+    const rows = parseWorksheetBin(await zip.extract(path), sharedStrings, dateXf, date1904)
+    sheets.push({ name: entry.name, rows })
+  }
+
+  return { sheets }
+}
+
+// ── workbook.bin ─────────────────────────────────────────────────────
+
+interface SheetEntry {
+  name: string
+  relId: string
+}
+
+function parseWorkbookBin(bin: Uint8Array): SheetEntry[] {
+  const out: SheetEntry[] = []
+  for (const rec of iterateRecords(bin)) {
+    if (rec.id !== BrtBundleSh) continue
+    const c = new Cursor(rec.data)
+    c.u32() // hsState
+    c.u32() // iTabID
+    const relId = c.nullableWideString()
+    const name = c.wideString()
+    out.push({ name, relId })
+  }
+  return out
+}
+
+// ── sharedStrings.bin ────────────────────────────────────────────────
+
+function parseSharedStringsBin(bin: Uint8Array): string[] {
+  const out: string[] = []
+  for (const rec of iterateRecords(bin)) {
+    if (rec.id !== BrtSSTItem) continue
+    const c = new Cursor(rec.data)
+    c.u8() // flags (rich/phonetic) — we only need the plain text
+    out.push(c.wideString())
+  }
+  return out
+}
+
+// ── styles.bin (cell xf → is-date) ───────────────────────────────────
+
+function parseStylesBin(bin: Uint8Array): boolean[] {
+  const numFmtCodes = new Map<number, string>()
+  const cellXfFmtIds: number[] = []
+  let inCellXfs = false
+  for (const rec of iterateRecords(bin)) {
+    if (rec.id === BrtFmt) {
+      const c = new Cursor(rec.data)
+      const ifmt = c.u16()
+      numFmtCodes.set(ifmt, c.wideString())
+    } else if (rec.id === BrtBeginCellXFs) {
+      inCellXfs = true
+    } else if (rec.id === BrtEndCellXFs) {
+      inCellXfs = false
+    } else if (rec.id === BrtXF && inCellXfs) {
+      const c = new Cursor(rec.data)
+      c.u16() // ixfeParent
+      cellXfFmtIds.push(c.u16()) // iFmt
+    }
+  }
+  return cellXfFmtIds.map((id) => {
+    if (BUILTIN_DATE_IDS.has(id)) return true
+    const code = numFmtCodes.get(id)
+    return code ? isDateFormat(code) : false
+  })
+}
+
+// ── worksheet.bin ────────────────────────────────────────────────────
+
+function parseWorksheetBin(
+  bin: Uint8Array,
+  sst: string[],
+  dateXf: boolean[],
+  date1904: boolean,
+): CellValue[][] {
+  const rows: CellValue[][] = []
+  let row = 0
+
+  const setCell = (col: number, value: CellValue): void => {
+    let r = rows[row]
+    if (!r) r = rows[row] = []
+    while (r.length < col) r.push(null)
+    r[col] = value
+  }
+  const numericCell = (col: number, styleRef: number, num: number): void => {
+    setCell(col, dateXf[styleRef] ? serialToDate(num, date1904) : num)
+  }
+
+  for (const rec of iterateRecords(bin)) {
+    switch (rec.id) {
+      case BrtRowHdr: {
+        row = new Cursor(rec.data).u32()
+        break
+      }
+      case BrtCellBlank: {
+        const c = new Cursor(rec.data)
+        c.u32() // col — record present but no value
+        break
+      }
+      case BrtCellRk: {
+        const c = new Cursor(rec.data)
+        const col = c.u32()
+        const styleRef = c.u32() & 0xffffff
+        numericCell(col, styleRef, decodeRk(c.u32()))
+        break
+      }
+      case BrtCellReal:
+      case BrtFmlaNum: {
+        const c = new Cursor(rec.data)
+        const col = c.u32()
+        const styleRef = c.u32() & 0xffffff
+        numericCell(col, styleRef, c.f64())
+        break
+      }
+      case BrtCellBool:
+      case BrtFmlaBool: {
+        const c = new Cursor(rec.data)
+        const col = c.u32()
+        c.u32() // styleRef
+        setCell(col, c.u8() !== 0)
+        break
+      }
+      case BrtCellError:
+      case BrtFmlaError: {
+        const c = new Cursor(rec.data)
+        const col = c.u32()
+        c.u32() // styleRef
+        setCell(col, ERROR_TEXT[c.u8()] ?? "#ERR!")
+        break
+      }
+      case BrtCellSt:
+      case BrtFmlaString: {
+        const c = new Cursor(rec.data)
+        const col = c.u32()
+        c.u32() // styleRef
+        setCell(col, c.wideString())
+        break
+      }
+      case BrtCellIsst: {
+        const c = new Cursor(rec.data)
+        const col = c.u32()
+        c.u32() // styleRef
+        const idx = c.u32()
+        setCell(col, sst[idx] ?? "")
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  return rows
+}

--- a/src/xlsx/xlsb/record.ts
+++ b/src/xlsx/xlsb/record.ts
@@ -1,0 +1,112 @@
+// ── XLSB Binary Record Stream ────────────────────────────────────────
+// XLSB `.bin` parts are a flat sequence of records:
+//   record id (1–2 bytes, 7-bit varint) + size (1–4 bytes, 7-bit varint)
+//   + `size` bytes of payload.
+// See [MS-XLSB] §2.1.4.
+
+export interface XlsbRecord {
+  id: number
+  data: Uint8Array
+}
+
+/** Iterate every record in a `.bin` part, yielding its id and raw payload. */
+export function* iterateRecords(bin: Uint8Array): Generator<XlsbRecord> {
+  let pos = 0
+  const len = bin.length
+  while (pos < len) {
+    let id = bin[pos++]
+    if (id & 0x80) {
+      id = (id & 0x7f) | ((bin[pos++] & 0x7f) << 7)
+    }
+    let size = 0
+    for (let k = 0; k < 4; k++) {
+      const b = bin[pos++]
+      size |= (b & 0x7f) << (7 * k)
+      if ((b & 0x80) === 0) break
+    }
+    yield { id, data: bin.subarray(pos, pos + size) }
+    pos += size
+  }
+}
+
+/** Little-endian cursor over a record payload. */
+export class Cursor {
+  pos = 0
+  private view: DataView
+
+  constructor(public buf: Uint8Array) {
+    this.view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+  }
+
+  u8(): number {
+    return this.buf[this.pos++]
+  }
+
+  u16(): number {
+    const v = this.view.getUint16(this.pos, true)
+    this.pos += 2
+    return v
+  }
+
+  u32(): number {
+    const v = this.view.getUint32(this.pos, true)
+    this.pos += 4
+    return v
+  }
+
+  i32(): number {
+    const v = this.view.getInt32(this.pos, true)
+    this.pos += 4
+    return v
+  }
+
+  f64(): number {
+    const v = this.view.getFloat64(this.pos, true)
+    this.pos += 8
+    return v
+  }
+
+  skip(n: number): void {
+    this.pos += n
+  }
+
+  /** XLWideString: UInt32 char count + UTF-16LE units. */
+  wideString(): string {
+    const cch = this.u32()
+    return this.readUtf16(cch)
+  }
+
+  /** XLNullableWideString: like {@link wideString} but 0xFFFFFFFF means absent. */
+  nullableWideString(): string {
+    const cch = this.u32()
+    if (cch === 0xffffffff) return ""
+    return this.readUtf16(cch)
+  }
+
+  private readUtf16(cch: number): string {
+    let s = ""
+    for (let i = 0; i < cch; i++) {
+      s += String.fromCharCode(this.view.getUint16(this.pos, true))
+      this.pos += 2
+    }
+    return s
+  }
+}
+
+/** Decode an RK number (MS-XLSB §2.5.122 RkNumber). */
+export function decodeRk(rk: number): number {
+  const fX100 = (rk & 1) !== 0
+  const fInt = (rk & 2) !== 0
+  let value: number
+  if (fInt) {
+    value = (rk | 0) >> 2 // arithmetic shift — signed 30-bit integer
+  } else {
+    // The 30 high bits are the most-significant bits of an IEEE-754 double;
+    // the low 34 bits are zero. Place them in the high word.
+    const buf = new ArrayBuffer(8)
+    const dv = new DataView(buf)
+    dv.setUint32(4, rk & 0xfffffffc, true)
+    value = dv.getFloat64(0, true)
+  }
+  return fX100 ? value / 100 : value
+}

--- a/test/xlsb.test.ts
+++ b/test/xlsb.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { readXlsb } from "../src/xlsx/xlsb/reader"
+import { read } from "../src/defter"
+
+// ── Minimal XLSB builder (test-only) ─────────────────────────────────
+// Emits valid MS-XLSB binary records so the reader can be round-tripped
+// without an external fixture.
+
+const enc = new TextEncoder()
+
+function concat(parts: Array<number[] | Uint8Array>): Uint8Array {
+  let len = 0
+  for (const p of parts) len += p.length
+  const out = new Uint8Array(len)
+  let off = 0
+  for (const p of parts) {
+    out.set(p instanceof Uint8Array ? p : new Uint8Array(p), off)
+    off += p.length
+  }
+  return out
+}
+
+const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff]
+const u32 = (n: number): number[] => [
+  n & 0xff,
+  (n >> 8) & 0xff,
+  (n >> 16) & 0xff,
+  (n >>> 24) & 0xff,
+]
+function f64(n: number): Uint8Array {
+  const b = new Uint8Array(8)
+  new DataView(b.buffer).setFloat64(0, n, true)
+  return b
+}
+function wstr(s: string): Uint8Array {
+  const out = new Uint8Array(4 + s.length * 2)
+  const dv = new DataView(out.buffer)
+  dv.setUint32(0, s.length, true)
+  for (let i = 0; i < s.length; i++) dv.setUint16(4 + i * 2, s.charCodeAt(i), true)
+  return out
+}
+const nwstr = (s: string | null): Uint8Array =>
+  s === null ? new Uint8Array(u32(0xffffffff)) : wstr(s)
+function varint(n: number): number[] {
+  const out: number[] = []
+  let s = n
+  do {
+    let b = s & 0x7f
+    s >>>= 7
+    if (s) b |= 0x80
+    out.push(b)
+  } while (s)
+  return out
+}
+function rec(id: number, payload: Uint8Array | number[]): Uint8Array {
+  const body = payload instanceof Uint8Array ? payload : new Uint8Array(payload)
+  const idBytes = id < 0x80 ? [id] : [(id & 0x7f) | 0x80, (id >> 7) & 0x7f]
+  return concat([idBytes, varint(body.length), body])
+}
+const rkInt = (v: number): number[] => u32(((v << 2) | 2) >>> 0) // fInt set
+const cellPrefix = (col: number, style: number): number[] => [...u32(col), ...u32(style & 0xffffff)]
+
+// record ids (MS-XLSB §2.4)
+const BrtRowHdr = 0,
+  BrtCellRk = 2,
+  BrtCellError = 3,
+  BrtCellBool = 4,
+  BrtCellReal = 5,
+  BrtCellSt = 6,
+  BrtCellIsst = 7,
+  BrtSSTItem = 19,
+  BrtXF = 47,
+  BrtBundleSh = 156,
+  BrtBeginCellXFs = 617,
+  BrtEndCellXFs = 618
+
+const REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+const NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+async function buildXlsb(): Promise<Uint8Array> {
+  // Shared strings: 0:"Name" 1:"Score" 2:"Ada"
+  const sst = concat([
+    rec(BrtSSTItem, concat([[0], wstr("Name")])),
+    rec(BrtSSTItem, concat([[0], wstr("Score")])),
+    rec(BrtSSTItem, concat([[0], wstr("Ada")])),
+  ])
+  // Styles: xf0 general (iFmt 0), xf1 date (iFmt 14 builtin)
+  const styles = concat([
+    rec(BrtBeginCellXFs, u32(2)),
+    rec(BrtXF, concat([u16(0), u16(0), u16(0), u16(0), u16(0), [0, 0]])),
+    rec(BrtXF, concat([u16(0), u16(14), u16(0), u16(0), u16(0), [0, 0]])),
+    rec(BrtEndCellXFs, []),
+  ])
+  // Worksheet rows.
+  const ws = concat([
+    rec(BrtRowHdr, u32(0)),
+    rec(BrtCellIsst, concat([cellPrefix(0, 0), u32(0)])),
+    rec(BrtCellIsst, concat([cellPrefix(1, 0), u32(1)])),
+    rec(BrtRowHdr, u32(1)),
+    rec(BrtCellIsst, concat([cellPrefix(0, 0), u32(2)])),
+    rec(BrtCellRk, concat([cellPrefix(1, 0), rkInt(95)])),
+    rec(BrtCellReal, concat([cellPrefix(2, 0), f64(3.14)])),
+    rec(BrtCellReal, concat([cellPrefix(3, 1), f64(45000)])), // date serial via date xf
+    rec(BrtRowHdr, u32(2)),
+    rec(BrtCellSt, concat([cellPrefix(0, 0), wstr("Hi")])),
+    rec(BrtCellBool, concat([cellPrefix(1, 0), [1]])),
+    rec(BrtCellError, concat([cellPrefix(2, 0), [0x07]])),
+  ])
+  const wb = rec(BrtBundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")]))
+  const rels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="rIdWb" Type="${REL}/officeDocument" Target="xl/workbook.bin"/></Relationships>`
+  const wbRels =
+    `<?xml version="1.0"?><Relationships xmlns="${NS}">` +
+    `<Relationship Id="rId1" Type="${REL}/worksheet" Target="worksheets/sheet1.bin"/>` +
+    `<Relationship Id="rId2" Type="${REL}/sharedStrings" Target="sharedStrings.bin"/>` +
+    `<Relationship Id="rId3" Type="${REL}/styles" Target="styles.bin"/></Relationships>`
+  const ct = `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>`
+
+  const zw = new ZipWriter()
+  zw.add("[Content_Types].xml", enc.encode(ct))
+  zw.add("_rels/.rels", enc.encode(rels))
+  zw.add("xl/workbook.bin", wb)
+  zw.add("xl/_rels/workbook.bin.rels", enc.encode(wbRels))
+  zw.add("xl/sharedStrings.bin", sst)
+  zw.add("xl/styles.bin", styles)
+  zw.add("xl/worksheets/sheet1.bin", ws)
+  return zw.build()
+}
+
+describe("XLSB reader", () => {
+  it("decodes shared strings, RK ints, reals, inline strings, bools, errors, and dates", async () => {
+    const wb = await readXlsb(await buildXlsb())
+    expect(wb.sheets.length).toBe(1)
+    expect(wb.sheets[0].name).toBe("Sheet1")
+    const rows = wb.sheets[0].rows
+    expect(rows[0]).toEqual(["Name", "Score"])
+    expect(rows[1][0]).toBe("Ada")
+    expect(rows[1][1]).toBe(95)
+    expect(rows[1][2]).toBeCloseTo(3.14, 5)
+    expect(rows[1][3]).toBeInstanceOf(Date)
+    expect(rows[2][0]).toBe("Hi")
+    expect(rows[2][1]).toBe(true)
+    expect(rows[2][2]).toBe("#DIV/0!")
+  })
+
+  it("is auto-detected by read()", async () => {
+    const wb = await read(await buildXlsb())
+    expect(wb.sheets[0].rows[1][1]).toBe(95)
+    expect(wb.sheets[0].rows[1][0]).toBe("Ada")
+  })
+
+  it("decodes RK fractional (x100) numbers", async () => {
+    // rkInt with x100: value 1234 with fX100 → 12.34
+    const rkX100 = (cents: number): number[] => u32(((cents << 2) | 2 | 1) >>> 0)
+    const ws = concat([
+      rec(BrtRowHdr, u32(0)),
+      rec(BrtCellRk, concat([cellPrefix(0, 0), rkX100(1234)])),
+    ])
+    const wb = rec(BrtBundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("S")]))
+    const rels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/></Relationships>`
+    const wbRels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="rId1" Type="${REL}/worksheet" Target="worksheets/sheet1.bin"/></Relationships>`
+    const zw = new ZipWriter()
+    zw.add("_rels/.rels", enc.encode(rels))
+    zw.add("xl/workbook.bin", wb)
+    zw.add("xl/_rels/workbook.bin.rels", enc.encode(wbRels))
+    zw.add("xl/worksheets/sheet1.bin", ws)
+    const out = await readXlsb(await zw.build())
+    expect(out.sheets[0].rows[0][0]).toBeCloseTo(12.34, 5)
+  })
+})


### PR DESCRIPTION
## Summary

Read `.xlsb` (Excel Binary Workbook) files. XLSB uses the same ZIP package + XML relationships/`[Content_Types]` as XLSX, but stores the workbook, shared strings, styles, and worksheets as **binary record streams** (`.bin`) instead of XML. This reuses the existing ZIP layer and rels parser and adds a binary record decoder.

## Implementation

- **`src/xlsx/xlsb/record.ts`** — MS-XLSB record stream iterator (7-bit varint record id + size), a little-endian `Cursor` (`u8`/`u16`/`u32`/`i32`/`f64`, `XL[Nullable]WideString`), and `decodeRk` for RK numbers.
- **`src/xlsx/xlsb/reader.ts`** — `readXlsb()`: resolves the workbook part via `_rels/.rels`, enumerates sheets from `BrtBundleSh`, parses `sharedStrings.bin` (SST), `styles.bin` (cell-xf number formats → date detection via `isDateFormat` + builtin date ids), and each worksheet's rows/cells into the **same `Workbook` model** `readXlsx` produces. Handles `BrtCell{Rk,Real,Bool,Error,St,Isst,Blank}` and the cached values of `BrtFmla{Num,String,Bool,Error}`; numeric cells carrying a date number format become `Date` via `serialToDate`. Password-protected `.xlsb` decrypts through the existing agile path when `{ password }` is supplied.

## API

```ts
import { read, readXlsb } from "hucre"
const wb = await readXlsb(bytes)   // typed cell values
const same = await read(bytes)     // auto-detected: XLSX vs XLSB vs ODS
```

`read()` opens the ZIP, checks for `xl/workbook.bin` (`looksLikeXlsb`), and routes to `readXlsb` vs `readXlsx`.

## Tests

`test/xlsb.test.ts` (+3): a small test-only XLSB *builder* emits valid records, and the reader round-trips shared strings, RK integers, RK ×100 fractions, IEEE reals, inline strings, booleans, error codes, and dates — plus `read()` auto-detection. Full suite **7555 / 7555**; `pnpm lint` / `typecheck` / `build` clean.

## Scope & honesty

- **Read-only** (per the issue), covering the common cell/value records that hold the data.
- Validated by round-tripping a spec-shaped builder; **not** verified against an Excel-produced `.xlsb` fixture in this offline environment.
- Follow-ups: write support, and rarer records (rich-text runs, array/shared formula structures).

Closes #154
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)