### PR TITLE
feat: XLS (BIFF8, Excel 97-2003) read support — closes #153, #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,22 @@ booleans, error codes, cached formula values, and dates (via the binary
 style table). Read-only; password-protected `.xlsb` also decrypts with
 `{ password }`.
 
+### XLS (Legacy Excel 97-2003) — read
+
+Read legacy `.xls` (BIFF8) files — the OLE2/CFB binary format from Excel
+97-2003. `read()` auto-detects it, or call `readXls`:
+
+```ts
+import { read, readXls } from "hucre"
+
+const wb = await readXls(bytes)
+const same = await read(bytes) // auto-detected
+```
+
+Decodes the shared-string table (with CONTINUE spanning), RK / MULRK /
+number / boolean / error cells, labels, cached formula values, dates, and
+merged cells. Read-only.
+
 ### ODS (OpenDocument)
 
 ```ts

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -16,6 +16,8 @@ import type {
 } from "./_types"
 import { readXlsx } from "./xlsx/reader"
 import { readXlsb, looksLikeXlsb } from "./xlsx/xlsb/reader"
+import { readXls, looksLikeXls } from "./xls/reader"
+import { readCfb } from "./xlsx/crypto/cfb"
 import { ZipReader } from "./zip/reader"
 import { decryptAgile } from "./xlsx/crypto/agile"
 import { writeXlsx } from "./xlsx/writer"
@@ -95,6 +97,17 @@ export async function read(input: ReadInput, options?: ReadOptions): Promise<Wor
   // XLSX decryption is wired up — an ODS password yields a ZIP that
   // detectFormat routes to readOds, which handles its own encryption.)
   if (isOle2Container(data)) {
+    // An OLE2 container is either a legacy .xls (BIFF "Workbook" stream)
+    // or an encrypted OOXML/ODS package (an "EncryptionInfo" stream).
+    let cfbStreams: Map<string, Uint8Array> | null = null
+    try {
+      cfbStreams = readCfb(data)
+    } catch {
+      cfbStreams = null // not a parseable CFB — treat as encrypted/unknown
+    }
+    if (cfbStreams && looksLikeXls(cfbStreams)) {
+      return readXls(data, options)
+    }
     if (options?.password) {
       data = await decryptAgile(data, options.password)
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export type { WriteObjectsTableOption } from "./defter"
 // ── XLSX ────────────────────────────────────────────────────────────
 export { readXlsx } from "./xlsx/reader"
 export { readXlsb } from "./xlsx/xlsb/reader"
+export { readXls } from "./xls/reader"
 export { writeXlsx } from "./xlsx/writer"
 export { link } from "./xlsx/hyperlink"
 export { openXlsx, saveXlsx } from "./xlsx/roundtrip"

--- a/src/xls/biff.ts
+++ b/src/xls/biff.ts
@@ -1,0 +1,210 @@
+// ── BIFF8 Record Stream ──────────────────────────────────────────────
+// The "Workbook" stream inside an .xls OLE2 container is a flat sequence
+// of BIFF records: 2-byte record id + 2-byte length + `length` bytes of
+// data (each record body is ≤ 8224 bytes; longer data overflows into
+// CONTINUE records). See [MS-XLS].
+
+export interface BiffRecord {
+  /** Record id (sid). */
+  id: number
+  data: Uint8Array
+  /** Byte offset of this record's header within the stream. */
+  offset: number
+}
+
+export const SID = {
+  FORMULA: 0x0006,
+  EOF: 0x000a,
+  CONTINUE: 0x003c,
+  DATEMODE: 0x0022,
+  BLANK: 0x0201,
+  NUMBER: 0x0203,
+  LABEL: 0x0204,
+  BOOLERR: 0x0205,
+  STRING: 0x0207,
+  ROW: 0x0208,
+  INDEX: 0x020b,
+  RK: 0x027e,
+  MULRK: 0x00bd,
+  MULBLANK: 0x00be,
+  LABELSST: 0x00fd,
+  RSTRING: 0x00d6,
+  SST: 0x00fc,
+  XF: 0x00e0,
+  FORMAT: 0x041e,
+  BOUNDSHEET: 0x0085,
+  MERGECELLS: 0x00e5,
+  BOF: 0x0809,
+} as const
+
+/** Parse a stream into records, recording each one's byte offset. */
+export function parseRecords(stream: Uint8Array): BiffRecord[] {
+  const out: BiffRecord[] = []
+  const view = new DataView(stream.buffer, stream.byteOffset, stream.byteLength)
+  let pos = 0
+  while (pos + 4 <= stream.length) {
+    const id = view.getUint16(pos, true)
+    const len = view.getUint16(pos + 2, true)
+    const start = pos
+    pos += 4
+    out.push({ id, data: stream.subarray(pos, pos + len), offset: start })
+    pos += len
+    // A zero id past real data means padding — stop.
+    if (id === 0 && len === 0) break
+  }
+  return out
+}
+
+/** Little-endian cursor over a record body. */
+export class Reader {
+  pos = 0
+  private view: DataView
+
+  constructor(public buf: Uint8Array) {
+    this.view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+  }
+
+  u8(): number {
+    return this.buf[this.pos++]
+  }
+  u16(): number {
+    const v = this.view.getUint16(this.pos, true)
+    this.pos += 2
+    return v
+  }
+  i16(): number {
+    const v = this.view.getInt16(this.pos, true)
+    this.pos += 2
+    return v
+  }
+  u32(): number {
+    const v = this.view.getUint32(this.pos, true)
+    this.pos += 4
+    return v
+  }
+  f64(): number {
+    const v = this.view.getFloat64(this.pos, true)
+    this.pos += 8
+    return v
+  }
+  skip(n: number): void {
+    this.pos += n
+  }
+  remaining(): number {
+    return this.buf.length - this.pos
+  }
+}
+
+/** Decode an RK number (MS-XLS §2.5.166). */
+export function decodeRk(rk: number): number {
+  const fX100 = (rk & 1) !== 0
+  const fInt = (rk & 2) !== 0
+  let value: number
+  if (fInt) {
+    value = (rk | 0) >> 2
+  } else {
+    const buf = new ArrayBuffer(8)
+    const dv = new DataView(buf)
+    dv.setUint32(4, rk & 0xfffffffc, true)
+    value = dv.getFloat64(0, true)
+  }
+  return fX100 ? value / 100 : value
+}
+
+// ── SST (shared string table) with CONTINUE handling ─────────────────
+// Strings split across CONTINUE records on character boundaries; each
+// CONTINUE that resumes a string's character array restarts with a 1-byte
+// option flag (fHighByte). Header fields and rich/phonetic trailers are
+// assumed not to straddle a boundary (how Excel writes them).
+
+/** Reads across the SST record + its trailing CONTINUE blocks. */
+class BlockStream {
+  private bi = 0
+  private pos = 0
+  constructor(private blocks: Uint8Array[]) {}
+
+  private cur(): Uint8Array {
+    return this.blocks[this.bi]
+  }
+  remainingInBlock(): number {
+    const b = this.cur()
+    return b ? b.length - this.pos : 0
+  }
+  atEnd(): boolean {
+    return this.bi >= this.blocks.length
+  }
+  /** Move to the next block (used when a string's chars continue). */
+  nextBlock(): void {
+    this.bi++
+    this.pos = 0
+  }
+  ensure(): void {
+    while (!this.atEnd() && this.remainingInBlock() === 0) this.nextBlock()
+  }
+  u8(): number {
+    return this.cur()[this.pos++]
+  }
+  u16(): number {
+    const v = this.cur()[this.pos] | (this.cur()[this.pos + 1] << 8)
+    this.pos += 2
+    return v
+  }
+  u32(): number {
+    const b = this.cur()
+    const v =
+      (b[this.pos] | (b[this.pos + 1] << 8) | (b[this.pos + 2] << 16) | (b[this.pos + 3] << 24)) >>>
+      0
+    this.pos += 4
+    return v
+  }
+  skip(n: number): void {
+    // skip may cross blocks (rich/phonetic trailers), no grbit byte
+    let left = n
+    while (left > 0) {
+      this.ensure()
+      const take = Math.min(left, this.remainingInBlock())
+      this.pos += take
+      left -= take
+    }
+  }
+}
+
+/**
+ * Parse an SST record (plus its following CONTINUE records) into the
+ * shared-string array. `blocks` is `[sstData, ...continueDatas]`.
+ */
+export function parseSst(blocks: Uint8Array[]): string[] {
+  const s = new BlockStream(blocks)
+  s.skip(4) // cstTotal
+  const cstUnique = s.u32()
+  const out: string[] = []
+  for (let i = 0; i < cstUnique; i++) out.push(readSstString(s))
+  return out
+}
+
+function readSstString(s: BlockStream): string {
+  const cch = s.u16()
+  let grbit = s.u8()
+  let compressed = (grbit & 0x01) === 0
+  const rich = (grbit & 0x08) !== 0
+  const phonetic = (grbit & 0x04) !== 0
+  const cRun = rich ? s.u16() : 0
+  const cbExt = phonetic ? s.u32() : 0
+
+  let str = ""
+  let read = 0
+  while (read < cch) {
+    if (s.remainingInBlock() === 0) {
+      // Continue into the next block: it restarts with an option flag for
+      // the remaining characters.
+      s.nextBlock()
+      grbit = s.u8()
+      compressed = (grbit & 0x01) === 0
+    }
+    str += String.fromCharCode(compressed ? s.u8() : s.u16())
+    read++
+  }
+  if (rich) s.skip(cRun * 4)
+  if (phonetic) s.skip(cbExt)
+  return str
+}

--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -1,0 +1,268 @@
+// ── XLS (BIFF8) Reader ───────────────────────────────────────────────
+// Read legacy Excel 97-2003 .xls files: an OLE2/CFB container whose
+// "Workbook" stream is a BIFF8 record sequence. Reuses the CFB reader
+// (shared with encryption) and decodes the records into the standard
+// Workbook model. Read-only (MS-XLS).
+
+import type { CellValue, MergeRange, ReadOptions, Sheet, Workbook } from "../_types"
+import { ParseError } from "../errors"
+import { readInputToUint8Array } from "../_input"
+import { readCfb } from "../xlsx/crypto/cfb"
+import { isDateFormat, serialToDate } from "../_date"
+import { decodeRk, parseRecords, parseSst, Reader, SID, type BiffRecord } from "./biff"
+
+const BUILTIN_DATE_IDS = new Set([14, 15, 16, 17, 18, 19, 20, 21, 22, 45, 46, 47])
+
+const ERROR_TEXT: Record<number, string> = {
+  0x00: "#NULL!",
+  0x07: "#DIV/0!",
+  0x0f: "#VALUE!",
+  0x17: "#REF!",
+  0x1d: "#NAME?",
+  0x24: "#NUM!",
+  0x2a: "#N/A",
+}
+
+/** Whether a CFB container holds a BIFF Workbook stream (.xls). */
+export function looksLikeXls(streams: Map<string, Uint8Array>): boolean {
+  return streams.has("Workbook") || streams.has("Book")
+}
+
+/** Read a BIFF8 .xls workbook into the standard {@link Workbook} model. */
+export async function readXls(
+  input: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
+  options?: ReadOptions,
+): Promise<Workbook> {
+  const data = await readInputToUint8Array(input)
+  let streams: Map<string, Uint8Array>
+  try {
+    streams = readCfb(data)
+  } catch (err) {
+    throw new ParseError("Failed to open XLS: not a valid OLE2 container", undefined, {
+      cause: err,
+    })
+  }
+  const stream = streams.get("Workbook") ?? streams.get("Book")
+  if (!stream) throw new ParseError("Invalid XLS: missing Workbook stream")
+
+  const records = parseRecords(stream)
+  const offsetToIndex = new Map<number, number>()
+  for (let i = 0; i < records.length; i++) offsetToIndex.set(records[i].offset, i)
+
+  // ── Globals substream (records[0] = BOF … first EOF) ──
+  let date1904 = options?.dateSystem === "1904"
+  const xfFmtIds: number[] = []
+  const fmtCodes = new Map<number, string>()
+  const boundSheets: Array<{ name: string; pos: number }> = []
+  const sst: string[] = []
+
+  let gi = 0
+  for (; gi < records.length; gi++) {
+    const rec = records[gi]
+    if (rec.id === SID.EOF) {
+      gi++
+      break
+    }
+    switch (rec.id) {
+      case SID.DATEMODE: {
+        if (!options?.dateSystem || options.dateSystem === "auto") {
+          date1904 = new Reader(rec.data).u16() === 1
+        }
+        break
+      }
+      case SID.FORMAT: {
+        const r = new Reader(rec.data)
+        const ifmt = r.u16()
+        fmtCodes.set(ifmt, readXLString(r))
+        break
+      }
+      case SID.XF: {
+        const r = new Reader(rec.data)
+        r.u16() // ifnt
+        xfFmtIds.push(r.u16()) // ifmt
+        break
+      }
+      case SID.BOUNDSHEET: {
+        const r = new Reader(rec.data)
+        const pos = r.u32()
+        r.u8() // hsState (visibility)
+        r.u8() // dt (sheet type)
+        boundSheets.push({ name: readShortString(r), pos })
+        break
+      }
+      case SID.SST: {
+        const blocks: Uint8Array[] = [rec.data]
+        // Gather trailing CONTINUE records belonging to the SST.
+        for (let j = gi + 1; j < records.length; j++) {
+          if (records[j].id !== SID.CONTINUE) break
+          blocks.push(records[j].data)
+        }
+        sst.push(...parseSst(blocks))
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  const dateXf = xfFmtIds.map((id) => {
+    if (BUILTIN_DATE_IDS.has(id)) return true
+    const code = fmtCodes.get(id)
+    return code ? isDateFormat(code) : false
+  })
+
+  const isDate = (ixfe: number): boolean => dateXf[ixfe] === true
+
+  // ── Sheet substreams ──
+  const sheets: Sheet[] = []
+  for (const bs of boundSheets) {
+    const startIdx = offsetToIndex.get(bs.pos)
+    if (startIdx === undefined) {
+      sheets.push({ name: bs.name, rows: [] })
+      continue
+    }
+    sheets.push(parseSheet(records, startIdx, bs.name, sst, isDate, date1904))
+  }
+
+  return { sheets }
+}
+
+function parseSheet(
+  records: BiffRecord[],
+  startIdx: number,
+  name: string,
+  sst: string[],
+  isDate: (ixfe: number) => boolean,
+  date1904: boolean,
+): Sheet {
+  const rows: CellValue[][] = []
+  const merges: MergeRange[] = []
+
+  const setCell = (row: number, col: number, value: CellValue): void => {
+    let r = rows[row]
+    if (!r) r = rows[row] = []
+    while (r.length < col) r.push(null)
+    r[col] = value
+  }
+  const numeric = (row: number, col: number, ixfe: number, n: number): void => {
+    setCell(row, col, isDate(ixfe) ? serialToDate(n, date1904) : n)
+  }
+
+  for (let i = startIdx + 1; i < records.length; i++) {
+    const rec = records[i]
+    if (rec.id === SID.EOF) break
+    const r = new Reader(rec.data)
+    switch (rec.id) {
+      case SID.LABELSST: {
+        const row = r.u16(),
+          col = r.u16()
+        r.u16() // ixfe
+        setCell(row, col, sst[r.u32()] ?? "")
+        break
+      }
+      case SID.RK: {
+        const row = r.u16(),
+          col = r.u16(),
+          ixfe = r.u16()
+        numeric(row, col, ixfe, decodeRk(r.u32()))
+        break
+      }
+      case SID.NUMBER: {
+        const row = r.u16(),
+          col = r.u16(),
+          ixfe = r.u16()
+        numeric(row, col, ixfe, r.f64())
+        break
+      }
+      case SID.MULRK: {
+        const row = r.u16()
+        const colFirst = r.u16()
+        const count = (rec.data.length - 6) / 6
+        for (let k = 0; k < count; k++) {
+          const ixfe = r.u16()
+          numeric(row, colFirst + k, ixfe, decodeRk(r.u32()))
+        }
+        break
+      }
+      case SID.BOOLERR: {
+        const row = r.u16(),
+          col = r.u16()
+        r.u16() // ixfe
+        const val = r.u8()
+        const isError = r.u8() === 1
+        setCell(row, col, isError ? (ERROR_TEXT[val] ?? "#ERR!") : val !== 0)
+        break
+      }
+      case SID.LABEL: {
+        const row = r.u16(),
+          col = r.u16()
+        r.u16() // ixfe
+        setCell(row, col, readXLString(r))
+        break
+      }
+      case SID.FORMULA: {
+        const row = r.u16(),
+          col = r.u16(),
+          ixfe = r.u16()
+        const b = rec.data.subarray(r.pos, r.pos + 8)
+        if (b[6] === 0xff && b[7] === 0xff) {
+          const kind = b[0]
+          if (kind === 1)
+            setCell(row, col, b[2] !== 0) // boolean
+          else if (kind === 2)
+            setCell(row, col, ERROR_TEXT[b[2]] ?? "#ERR!") // error
+          else if (kind === 0) {
+            // string: value is in the following STRING record
+            const next = records[i + 1]
+            if (next && next.id === SID.STRING)
+              setCell(row, col, readXLString(new Reader(next.data)))
+          }
+          // kind === 3 → blank/empty
+        } else {
+          const num = new DataView(b.buffer, b.byteOffset, 8).getFloat64(0, true)
+          numeric(row, col, ixfe, num)
+        }
+        break
+      }
+      case SID.MERGECELLS: {
+        const cmcs = r.u16()
+        for (let k = 0; k < cmcs; k++) {
+          const rwFirst = r.u16(),
+            rwLast = r.u16(),
+            colFirst = r.u16(),
+            colLast = r.u16()
+          merges.push({ startRow: rwFirst, endRow: rwLast, startCol: colFirst, endCol: colLast })
+        }
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  const sheet: Sheet = { name, rows }
+  if (merges.length > 0) sheet.merges = merges
+  return sheet
+}
+
+// ── String helpers ───────────────────────────────────────────────────
+
+/** XLUnicodeString: u16 char count + 1 grbit byte + chars. */
+function readXLString(r: Reader): string {
+  const cch = r.u16()
+  return readChars(r, cch)
+}
+
+/** ShortXLUnicodeString: u8 char count + 1 grbit byte + chars. */
+function readShortString(r: Reader): string {
+  const cch = r.u8()
+  return readChars(r, cch)
+}
+
+function readChars(r: Reader, cch: number): string {
+  const grbit = r.u8()
+  const compressed = (grbit & 0x01) === 0
+  let s = ""
+  for (let i = 0; i < cch; i++) s += String.fromCharCode(compressed ? r.u8() : r.u16())
+  return s
+}

--- a/test/xls.test.ts
+++ b/test/xls.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { writeCfb } from "../src/xlsx/crypto/cfb"
+import { readXls } from "../src/xls/reader"
+import { read } from "../src/defter"
+
+// ── Minimal BIFF8 .xls builder (test-only) ───────────────────────────
+
+function concat(parts: Array<number[] | Uint8Array>): Uint8Array {
+  let len = 0
+  for (const p of parts) len += p.length
+  const out = new Uint8Array(len)
+  let off = 0
+  for (const p of parts) {
+    out.set(p instanceof Uint8Array ? p : new Uint8Array(p), off)
+    off += p.length
+  }
+  return out
+}
+const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff]
+const u32 = (n: number): number[] => [
+  n & 0xff,
+  (n >> 8) & 0xff,
+  (n >> 16) & 0xff,
+  (n >>> 24) & 0xff,
+]
+function f64(n: number): number[] {
+  const b = new Uint8Array(8)
+  new DataView(b.buffer).setFloat64(0, n, true)
+  return [...b]
+}
+// XLUnicodeString (u16 cch) / ShortXLUnicodeString (u8 cch), compressed
+const xlStr = (s: string): number[] => [...u16(s.length), 0, ...[...s].map((c) => c.charCodeAt(0))]
+const shortStr = (s: string): number[] => [s.length, 0, ...[...s].map((c) => c.charCodeAt(0))]
+function record(sid: number, data: number[]): number[] {
+  return [...u16(sid), ...u16(data.length), ...data]
+}
+const rkInt = (v: number): number[] => u32(((v << 2) | 2) >>> 0)
+
+const SID = {
+  FORMULA: 0x0006,
+  EOF: 0x000a,
+  DATEMODE: 0x0022,
+  NUMBER: 0x0203,
+  LABEL: 0x0204,
+  BOOLERR: 0x0205,
+  RK: 0x027e,
+  MULRK: 0x00bd,
+  LABELSST: 0x00fd,
+  SST: 0x00fc,
+  XF: 0x00e0,
+  BOUNDSHEET: 0x0085,
+  MERGECELLS: 0x00e5,
+  BOF: 0x0809,
+}
+
+const bof = (dt: number): number[] =>
+  record(SID.BOF, [...u16(0x0600), ...u16(dt), ...u16(0), ...u16(0), ...u32(0), ...u32(0)])
+const eof = (): number[] => record(SID.EOF, [])
+
+function sstRecord(strings: string[]): number[] {
+  const body: number[] = [...u32(strings.length), ...u32(strings.length)]
+  for (const s of strings) body.push(...u16(s.length), 0, ...[...s].map((c) => c.charCodeAt(0)))
+  return record(SID.SST, body)
+}
+
+function buildXls(): Uint8Array {
+  const strings = ["Name", "Score", "Ada"]
+
+  const sheet = concat([
+    bof(0x0010),
+    record(SID.LABELSST, [...u16(0), ...u16(0), ...u16(0), ...u32(0)]),
+    record(SID.LABELSST, [...u16(0), ...u16(1), ...u16(0), ...u32(1)]),
+    record(SID.LABELSST, [...u16(1), ...u16(0), ...u16(0), ...u32(2)]),
+    record(SID.RK, [...u16(1), ...u16(1), ...u16(0), ...rkInt(95)]),
+    record(SID.NUMBER, [...u16(1), ...u16(2), ...u16(0), ...f64(3.14)]),
+    record(SID.NUMBER, [...u16(1), ...u16(3), ...u16(1), ...f64(45000)]), // date xf
+    record(SID.LABEL, [...u16(2), ...u16(0), ...u16(0), ...xlStr("Hi")]),
+    record(SID.BOOLERR, [...u16(2), ...u16(1), ...u16(0), 1, 0]), // true
+    record(SID.BOOLERR, [...u16(2), ...u16(2), ...u16(0), 0x07, 1]), // #DIV/0!
+    record(SID.MULRK, [
+      ...u16(3),
+      ...u16(0),
+      ...u16(0),
+      ...rkInt(10),
+      ...u16(0),
+      ...rkInt(20),
+      ...u16(1),
+    ]),
+    record(SID.MERGECELLS, [...u16(1), ...u16(0), ...u16(0), ...u16(0), ...u16(1)]),
+    eof(),
+  ])
+
+  // Globals — BOUNDSHEET position is filled in once the globals size is known.
+  const makeGlobals = (sheetPos: number): Uint8Array =>
+    concat([
+      bof(0x0005),
+      record(SID.DATEMODE, u16(0)),
+      record(SID.XF, [...u16(0), ...u16(0), ...new Array(16).fill(0)]), // general
+      record(SID.XF, [...u16(0), ...u16(14), ...new Array(16).fill(0)]), // date (builtin 14)
+      sstRecord(strings),
+      record(SID.BOUNDSHEET, [...u32(sheetPos), 0, 0, ...shortStr("Sheet1")]),
+      eof(),
+    ])
+
+  const globalsLen = makeGlobals(0).length
+  const globals = makeGlobals(globalsLen)
+  const workbookStream = concat([globals, sheet])
+
+  return writeCfb([{ name: "Workbook", data: workbookStream }])
+}
+
+describe("XLS (BIFF8) reader", () => {
+  it("decodes SST labels, RK, MULRK, numbers, bools, errors, dates, and merges", async () => {
+    const wb = await readXls(buildXls())
+    expect(wb.sheets.length).toBe(1)
+    expect(wb.sheets[0].name).toBe("Sheet1")
+    const rows = wb.sheets[0].rows
+    expect(rows[0]).toEqual(["Name", "Score"])
+    expect(rows[1][0]).toBe("Ada")
+    expect(rows[1][1]).toBe(95)
+    expect(rows[1][2]).toBeCloseTo(3.14, 5)
+    expect(rows[1][3]).toBeInstanceOf(Date)
+    expect(rows[2][0]).toBe("Hi")
+    expect(rows[2][1]).toBe(true)
+    expect(rows[2][2]).toBe("#DIV/0!")
+    expect(rows[3][0]).toBe(10)
+    expect(rows[3][1]).toBe(20)
+    expect(wb.sheets[0].merges).toEqual([{ startRow: 0, endRow: 0, startCol: 0, endCol: 1 }])
+  })
+
+  it("is auto-detected by read()", async () => {
+    const wb = await read(buildXls())
+    expect(wb.sheets[0].rows[1][0]).toBe("Ada")
+    expect(wb.sheets[0].rows[1][1]).toBe(95)
+  })
+})

--- a/test/xls.test.ts
+++ b/test/xls.test.ts
@@ -95,8 +95,8 @@ function buildXls(): Uint8Array {
     concat([
       bof(0x0005),
       record(SID.DATEMODE, u16(0)),
-      record(SID.XF, [...u16(0), ...u16(0), ...new Array(16).fill(0)]), // general
-      record(SID.XF, [...u16(0), ...u16(14), ...new Array(16).fill(0)]), // date (builtin 14)
+      record(SID.XF, [...u16(0), ...u16(0), ...Array.from({ length: 16 }, () => 0)]), // general
+      record(SID.XF, [...u16(0), ...u16(14), ...Array.from({ length: 16 }, () => 0)]), // date (builtin 14)
       sstRecord(strings),
       record(SID.BOUNDSHEET, [...u32(sheetPos), 0, 0, ...shortStr("Sheet1")]),
       eof(),


### PR DESCRIPTION
## Summary

Read legacy `.xls` files (BIFF8, Excel 97-2003): an OLE2/CFB container whose `Workbook` stream is a BIFF8 record sequence. Reuses the CFB reader built for password-protected XLSX — completing the format coverage (XLSX, XLSB, XLS, CSV, ODS, JSON).

## Implementation

- **`src/xls/biff.ts`** — BIFF record parser (2-byte sid + 2-byte length, tracking each record's byte offset so `BOUNDSHEET` stream positions resolve), a little-endian `Reader`, `decodeRk`, and an **SST parser that handles strings split across `CONTINUE` records** on character boundaries — the classic BIFF8 gotcha where each `CONTINUE` restates the compression flag for the remaining characters.
- **`src/xls/reader.ts`** — `readXls()`: `readCfb` → `Workbook`/`Book` stream → records. The globals substream collects `DATEMODE` (1900/1904), `FORMAT` + `XF` (→ date detection), `BOUNDSHEET` (sheet name + stream offset), and the `SST`. Each sheet substream (located via its `BOUNDSHEET` offset) decodes `LABELSST`, `RK`, `MULRK`, `NUMBER`, `BOOLERR`, `LABEL`, `FORMULA` cached values (number / string-via-`STRING` / bool / error), and `MERGECELLS` into the standard `Workbook` model. Date-formatted numerics become `Date` via `serialToDate`.

## API

```ts
import { read, readXls } from "hucre"
const wb = await readXls(bytes)
const same = await read(bytes) // auto-detected
```

`read()` now tells apart an OLE2 container that's a legacy `.xls` (a `Workbook`/`Book` stream) from an **encrypted** OOXML package (an `EncryptionInfo` stream) and routes accordingly. The CFB parse is wrapped so the existing encrypted-file detection (and its synthetic non-CFB fixture) still throws `EncryptedFileError` exactly as before.

## Tests

`test/xls.test.ts` (+2): a small test-only BIFF8 *builder* (records wrapped in a CFB via `writeCfb`) round-trips SST labels, `RK`, `MULRK`, numbers, booleans, error codes, dates, and merged cells, plus `read()` auto-detection. Full suite **7557 / 7557**; `pnpm lint` / `typecheck` / `build` clean.

## Scope & honesty

- **Read-only** (per the issue), covering the common value records that hold the data + merged cells.
- Validated against a spec-shaped builder; **not** verified against an Excel-produced `.xls` fixture in this offline environment. The SST/CONTINUE handler assumes Excel's character-boundary splits (documented in the code).
- Follow-ups: BIFF5/`Book` quirks, `XF`→`CellStyle` formatting, and rarer records.

Closes #153
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)