### PR TITLE
fix(xlsx): emit externalReferences before definedNames in workbook.xml

### DIFF
--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -92,6 +92,20 @@ export function writeWorkbookXml(
 
   parts.push(xmlElement("sheets", undefined, sheetElements))
 
+  // ── externalReferences — must precede definedNames. The CT_Workbook
+  // sequence in ECMA-376 §18.2.27 is: sheets → functionGroups →
+  // externalReferences → definedNames → calcPr. Defined names that
+  // dereference an external book (e.g. "[1]Sheet!$A$1") need that book's
+  // <externalReference> declared first, or Excel rejects the workbook as
+  // corrupt — even though lenient readers (Numbers, QuickLook, openpyxl)
+  // ignore element order and open it fine.
+  if (externalLinkRels && externalLinkRels.length > 0) {
+    const refChildren = externalLinkRels.map((r) =>
+      xmlSelfClose("externalReference", { "r:id": r.rId }),
+    )
+    parts.push(xmlElement("externalReferences", undefined, refChildren))
+  }
+
   // ── Defined Names (named ranges + print area/titles) ──
   if (namedRanges && namedRanges.length > 0) {
     // Build sheet name → index map for resolving scoped named ranges
@@ -123,16 +137,6 @@ export function writeWorkbookXml(
     }
 
     parts.push(xmlElement("definedNames", undefined, dnElements))
-  }
-
-  // ── externalReferences — ECMA-376 §18.2.2 places the block after
-  // definedNames and before calcPr. Excel tolerates other orders, but
-  // the spec order is what we emit so generated files validate clean.
-  if (externalLinkRels && externalLinkRels.length > 0) {
-    const refChildren = externalLinkRels.map((r) =>
-      xmlSelfClose("externalReference", { "r:id": r.rId }),
-    )
-    parts.push(xmlElement("externalReferences", undefined, refChildren))
   }
 
   // ── calcPr — tells Excel to recalculate all formulas on open ──

--- a/test/ooxml-spec-compliance.test.ts
+++ b/test/ooxml-spec-compliance.test.ts
@@ -3,6 +3,7 @@ import { ZipWriter } from "../src/zip/writer"
 import { readXlsx } from "../src/xlsx/reader"
 import { isDateStyle, parseStyles, resolveStyle } from "../src/xlsx/styles"
 import { createStylesCollector } from "../src/xlsx/styles-writer"
+import { writeWorkbookXml } from "../src/xlsx/workbook-writer"
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -364,5 +365,52 @@ describe("Bug #106: Missing cellStyles element in styles.xml", () => {
     expect(cellXfsIdx).toBeLessThan(cellStylesIdx)
     expect(cellStylesIdx).toBeLessThan(dxfsIdx)
     expect(dxfsIdx).toBeLessThan(tableStylesIdx)
+  })
+
+  // ── CT_Workbook element ordering ──────────────────────────────────
+  // ECMA-376 §18.2.27 fixes the sequence: sheets → externalReferences →
+  // definedNames → calcPr. Emitting definedNames before externalReferences
+  // produces a file that Numbers/QuickLook/openpyxl open fine but Excel
+  // flags as corrupt — especially when a defined name dereferences the
+  // external book (e.g. "[1]Daten!$C$1"), since the [1] reference resolves
+  // against an <externalReference> that has not been declared yet.
+
+  it("workbook.xml emits externalReferences before definedNames", () => {
+    const sheets = [{ name: "Sheet1" }]
+    const namedRanges = [{ name: "Lst_Faktoren", range: "[1]Daten!$C$183:$C$192" }]
+    const externalLinkRels = [{ rId: "rId13" }]
+
+    const xml = writeWorkbookXml(
+      sheets,
+      namedRanges,
+      undefined,
+      undefined,
+      undefined,
+      externalLinkRels,
+    )
+
+    const sheetsIdx = xml.indexOf("<sheets")
+    const externalRefsIdx = xml.indexOf("<externalReferences")
+    const definedNamesIdx = xml.indexOf("<definedNames")
+    const calcPrIdx = xml.indexOf("<calcPr")
+
+    // All four blocks present
+    expect(externalRefsIdx).toBeGreaterThan(-1)
+    expect(definedNamesIdx).toBeGreaterThan(-1)
+
+    // Required CT_Workbook sequence
+    expect(sheetsIdx).toBeLessThan(externalRefsIdx)
+    expect(externalRefsIdx).toBeLessThan(definedNamesIdx)
+    expect(definedNamesIdx).toBeLessThan(calcPrIdx)
+  })
+
+  it("workbook.xml keeps definedNames before calcPr when there is no external link", () => {
+    const sheets = [{ name: "Sheet1" }]
+    const namedRanges = [{ name: "MyRange", range: "Sheet1!$A$1:$B$2" }]
+
+    const xml = writeWorkbookXml(sheets, namedRanges)
+
+    expect(xml).not.toContain("<externalReferences")
+    expect(xml.indexOf("<definedNames")).toBeLessThan(xml.indexOf("<calcPr"))
   })
 })


### PR DESCRIPTION
## Problem

`writeWorkbookXml` emits the `<definedNames>` block **before** `<externalReferences>` in `xl/workbook.xml`. The OOXML **CT_Workbook** sequence (ECMA-376 §18.2.27) is fixed:

```
sheets → functionGroups → externalReferences → definedNames → calcPr
```

`externalReferences` must come **before** `definedNames`.

Lenient readers (Apple Numbers, macOS QuickLook, Slack preview, openpyxl) ignore element order and open such files fine — but **Excel validates the sequence strictly and reports the workbook as corrupt** ("We found a problem with some content… do you want us to recover"). This is especially fatal when a defined name dereferences the external book, e.g.

```xml
<definedName name="Lst_FaktorenHeizung">[1]Daten!$C$183:$C$192</definedName>
```

since the `[1]` reference resolves against an `<externalReference>` that has not been declared yet at that point in the document.

This was found in the wild: a hucre-generated workbook (`<Application>hucre</Application>`) combining named ranges + an external link opened everywhere except Excel. Reordering these two elements (only) makes Excel open it without the repair dialog.

## Fix

- Move the `externalReferences` emission above the `definedNames` block in `writeWorkbookXml`.
- Correct the inline comment, which previously claimed (backwards) that the spec places `externalReferences` *after* `definedNames`.

The resulting order is now:

```
workbookPr → bookViews → workbookProtection → sheets → externalReferences → definedNames → calcPr → pivotCaches → extLst
```

## Tests

Adds two regression tests in `test/ooxml-spec-compliance.test.ts`, mirroring the existing `styles.xml` ordering test:

- asserts `sheets < externalReferences < definedNames < calcPr` when both blocks are present (fails on the old ordering)
- asserts `definedNames < calcPr` and no `externalReferences` when there is no external link

Full suite green: lint + typecheck + **7559 tests pass**. Verified the new ordering test fails on the pre-fix source and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)