### PR TITLE
fix(security): harden against malicious file DoS + HTML export XSS

### DIFF
--- a/src/export/html.ts
+++ b/src/export/html.ts
@@ -275,7 +275,10 @@ function buildCellAttrs(
     const cell = sheet.cells?.get(`${row},${col}`)
     if (cell?.style) {
       const css = styleToCss(cell.style)
-      if (css) attrs.push(`style="${css}"`)
+      // Escape for the double-quoted attribute context — style values can
+      // derive from untrusted workbook content (e.g. a number-format
+      // string) and must not be able to break out of the attribute.
+      if (css) attrs.push(`style="${escapeHtml(css)}"`)
     }
   }
 

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -1,0 +1,23 @@
+// ── Resource limits (DoS hardening) ─────────────────────────────────
+// Central place for the bounds used to defend against malicious /
+// malformed input (zip bombs, billion-laughs cell refs, etc.).
+
+/**
+ * Absolute hard cap on the number of bytes any single entry may
+ * decompress to. Defends against zip bombs that claim a small
+ * compressed size but expand to gigabytes. Default ~2 GiB.
+ */
+export const MAX_DECOMPRESSED_BYTES = 2 * 1024 * 1024 * 1024
+
+/** Maximum row index (0-based) — Excel supports 1,048,576 rows. */
+export const MAX_ROW_INDEX = 1_048_575
+
+/** Maximum column index (0-based) — Excel supports 16,384 columns. */
+export const MAX_COL_INDEX = 16_383
+
+/**
+ * Upper bound on the password-derivation spin count accepted from an
+ * encrypted workbook. Office uses 100,000; we allow a generous ceiling
+ * so a hostile file cannot pin a CPU for minutes.
+ */
+export const MAX_SPIN_COUNT = 10_000_000

--- a/src/xls/biff.ts
+++ b/src/xls/biff.ts
@@ -133,6 +133,12 @@ class BlockStream {
   atEnd(): boolean {
     return this.bi >= this.blocks.length
   }
+  /** Total bytes across all blocks — an upper bound on decodable records. */
+  totalBytes(): number {
+    let n = 0
+    for (const b of this.blocks) n += b.length
+    return n
+  }
   /** Move to the next block (used when a string's chars continue). */
   nextBlock(): void {
     this.bi++
@@ -177,8 +183,17 @@ export function parseSst(blocks: Uint8Array[]): string[] {
   const s = new BlockStream(blocks)
   s.skip(4) // cstTotal
   const cstUnique = s.u32()
+  // cstUnique is an untrusted u32. Each string costs at least 3 bytes
+  // (2-byte cch + 1-byte grbit), so a string count larger than the total
+  // available bytes is a corrupt / hostile header — cap the loop by the
+  // bytes actually present so we don't spin allocating empty strings.
+  const maxStrings = Math.min(cstUnique, s.totalBytes())
   const out: string[] = []
-  for (let i = 0; i < cstUnique; i++) out.push(readSstString(s))
+  for (let i = 0; i < maxStrings; i++) {
+    s.ensure()
+    if (s.atEnd()) break
+    out.push(readSstString(s))
+  }
   return out
 }
 

--- a/src/xlsx/crypto/agile.ts
+++ b/src/xlsx/crypto/agile.ts
@@ -14,6 +14,7 @@
 
 import { readCfb, writeCfb } from "./cfb"
 import { DecryptionError } from "../../errors"
+import { MAX_SPIN_COUNT } from "../../limits"
 
 // Block keys (MS-OFFCRYPTO §2.3.4.x).
 const BLOCK_VERIFIER_INPUT = new Uint8Array([0xfe, 0xa7, 0xd2, 0x76, 0x3b, 0x4b, 0x9e, 0x79])
@@ -76,7 +77,61 @@ export async function decryptAgile(data: Uint8Array, password: string): Promise<
   const secretKey = await deriveSecretKey(password, key)
   if (!secretKey) throw new DecryptionError("Incorrect password.")
 
+  // Data integrity (MS-OFFCRYPTO §2.3.4.14): verify the HMAC over the
+  // EncryptedPackage stream before trusting the decrypted bytes. Tamper or
+  // truncation of the ciphertext is rejected here rather than surfacing as
+  // silently-corrupt output.
+  await verifyDataIntegrity(xml, pkg, secretKey, keyData)
+
   return decryptPackage(pkg, secretKey, keyData)
+}
+
+/**
+ * Verify the `<dataIntegrity>` HMAC (MS-OFFCRYPTO §2.3.4.14). The HMAC key
+ * and value are AES-CBC encrypted with the package secret key; once
+ * recovered, the HMAC is computed over the entire EncryptedPackage stream
+ * (8-byte size prefix included). A mismatch means the ciphertext was
+ * tampered with or corrupted. No-op when the element is absent (older
+ * writers) or the hash isn't SHA-512.
+ */
+async function verifyDataIntegrity(
+  xml: string,
+  pkg: Uint8Array,
+  secretKey: Uint8Array,
+  keyData: AgileKeyData,
+): Promise<void> {
+  const tag = getElementTag(xml, "dataIntegrity")
+  if (!tag) return // not present — nothing to verify
+  if (keyData.hashAlgorithm !== "SHA-512") return // only SHA-512 HMAC supported
+
+  const encHmacKey = base64Decode(getAttr(tag, "encryptedHmacKey"))
+  const encHmacValue = base64Decode(getAttr(tag, "encryptedHmacValue"))
+  if (encHmacKey.length === 0 || encHmacValue.length === 0) return
+
+  const ivKey = await iv(
+    keyData.saltValue,
+    BLOCK_HMAC_KEY,
+    keyData.hashAlgorithm,
+    keyData.blockSize,
+  )
+  const ivVal = await iv(
+    keyData.saltValue,
+    BLOCK_HMAC_VALUE,
+    keyData.hashAlgorithm,
+    keyData.blockSize,
+  )
+  const hmacKey = await aesDecrypt(secretKey, ivKey, encHmacKey)
+  const expected = await aesDecrypt(secretKey, ivVal, encHmacValue)
+
+  const actual = await hmacSha512(hmacKey, pkg)
+  // Compare the leading hashSize (64) bytes — the decrypted value is
+  // block-padded to 16-byte alignment.
+  const n = Math.min(actual.length, expected.length)
+  let diff = actual.length === 0 ? 1 : 0
+  for (let i = 0; i < n; i++) diff |= actual[i] ^ expected[i]
+  if (diff !== 0) {
+    throw new DecryptionError("Encrypted package failed integrity check (HMAC mismatch).")
+  }
 }
 
 // ── Public: encrypt ──────────────────────────────────────────────────
@@ -417,12 +472,24 @@ function parseKeyData(xml: string): AgileKeyData {
 function parseKeyEncryptor(xml: string): AgileKeyInfo {
   const tag = getElementTag(xml, "encryptedKey")
   if (!tag) throw new DecryptionError("EncryptionInfo missing encryptedKey.")
+  const rawSpinCount = parseInt(getAttr(tag, "spinCount"), 10)
+  if (!Number.isFinite(rawSpinCount) || rawSpinCount < 0) {
+    throw new DecryptionError("EncryptionInfo has an invalid spinCount.")
+  }
+  // The spinCount drives the password-derivation loop. Cap the untrusted
+  // value so a hostile file can't pin a CPU for minutes (Office uses
+  // 100,000; the ceiling is deliberately generous).
+  if (rawSpinCount > MAX_SPIN_COUNT) {
+    throw new DecryptionError(
+      `EncryptionInfo spinCount ${rawSpinCount} exceeds the maximum of ${MAX_SPIN_COUNT}.`,
+    )
+  }
   return {
     saltValue: base64Decode(getAttr(tag, "saltValue")),
     hashAlgorithm: mapHash(getAttr(tag, "hashAlgorithm")),
     keyBytes: parseInt(getAttr(tag, "keyBits"), 10) / 8,
     blockSize: parseInt(getAttr(tag, "blockSize"), 10),
-    spinCount: parseInt(getAttr(tag, "spinCount"), 10),
+    spinCount: rawSpinCount,
     encryptedVerifierHashInput: base64Decode(getAttr(tag, "encryptedVerifierHashInput")),
     encryptedVerifierHashValue: base64Decode(getAttr(tag, "encryptedVerifierHashValue")),
     encryptedKeyValue: base64Decode(getAttr(tag, "encryptedKeyValue")),

--- a/src/xlsx/crypto/cfb.ts
+++ b/src/xlsx/crypto/cfb.ts
@@ -65,13 +65,18 @@ export function readCfb(data: Uint8Array): Map<string, Uint8Array> {
     if (s === FREESECT || s === ENDOFCHAIN) break
     fatSectorList.push(s)
   }
+  // Bound the DIFAT walk by the number of sectors that can physically fit
+  // in the file rather than the header-claimed `numDifatSectors`, which is
+  // untrusted and could be inflated to spin this loop.
+  const maxSectors = Math.floor(data.length / sectorSize) + 1
+  const difatLimit = Math.min(numDifatSectors, maxSectors)
   let difatSector = firstDifatSector
   let difatGuard = 0
   while (
     difatSector !== ENDOFCHAIN &&
     difatSector !== FREESECT &&
-    numDifatSectors > 0 &&
-    difatGuard++ < numDifatSectors + 1
+    difatLimit > 0 &&
+    difatGuard++ < difatLimit + 1
   ) {
     const sec = readSector(difatSector)
     const dv = new DataView(sec.buffer, sec.byteOffset, sec.byteLength)
@@ -147,6 +152,12 @@ export function readCfb(data: Uint8Array): Map<string, Uint8Array> {
   }
 
   const readMini = (start: number, size: number): Uint8Array => {
+    // `size` is an untrusted u32 from the directory entry. A mini stream
+    // cannot exceed the mini-stream container, so reject anything larger
+    // before allocating — otherwise a hostile size would OOM here.
+    if (size < 0 || size > miniStream.length) {
+      throw new ParseError("CFB: mini stream size out of range")
+    }
     const out = new Uint8Array(size)
     let s = start
     let off = 0

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -32,6 +32,8 @@ import type { Relationship } from "./relationships"
 import { resolveStyle, isDateStyle } from "./styles"
 import { serialToDate } from "../_date"
 import { parseSax, decodeOoxmlEscapes } from "../xml/parser"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../limits"
+import { ParseError } from "../errors"
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -1401,6 +1403,23 @@ function processCell(
 
   const pos = parseCellRef(ref)
   const { row, col } = pos
+
+  // Guard against malicious / corrupt cell references that would
+  // otherwise allocate billions of null slots and OOM the process.
+  if (
+    !Number.isInteger(row) ||
+    !Number.isInteger(col) ||
+    row < 0 ||
+    col < 0 ||
+    row > MAX_ROW_INDEX ||
+    col > MAX_COL_INDEX
+  ) {
+    throw new ParseError(
+      `Cell reference "${ref}" is outside the supported sheet bounds (max row ${
+        MAX_ROW_INDEX + 1
+      }, max col ${MAX_COL_INDEX + 1})`,
+    )
+  }
 
   // Ensure row array exists
   while (rows.length <= row) {

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -13,6 +13,7 @@ import { ZipReader } from "../../zip/reader"
 import { parseRelationships } from "../relationships"
 import { isDateFormat, serialToDate } from "../../_date"
 import { Cursor, decodeRk, iterateRecords } from "./record"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../../limits"
 
 // Record ids we care about (MS-XLSB §2.4).
 const BrtRowHdr = 0
@@ -232,6 +233,13 @@ function parseWorksheetBin(
   let row = 0
 
   const setCell = (col: number, value: CellValue): void => {
+    // Reject out-of-range column indices from untrusted u32 fields, which
+    // would otherwise grow a row to billions of null slots and OOM.
+    if (col < 0 || col > MAX_COL_INDEX) {
+      throw new ParseError(
+        `Cell column ${col} is outside the supported sheet bounds (max ${MAX_COL_INDEX + 1})`,
+      )
+    }
     let r = rows[row]
     if (!r) r = rows[row] = []
     while (r.length < col) r.push(null)
@@ -245,6 +253,11 @@ function parseWorksheetBin(
     switch (rec.id) {
       case BrtRowHdr: {
         row = new Cursor(rec.data).u32()
+        if (row < 0 || row > MAX_ROW_INDEX) {
+          throw new ParseError(
+            `Cell row ${row} is outside the supported sheet bounds (max ${MAX_ROW_INDEX + 1})`,
+          )
+        }
         break
       }
       case BrtCellBlank: {

--- a/src/zip/deflate.ts
+++ b/src/zip/deflate.ts
@@ -1,6 +1,9 @@
 // ── Pure TypeScript DEFLATE (RFC 1951) ─────────────────────────────
 // Fallback for environments without CompressionStream/DecompressionStream.
 
+import { ZipError } from "../errors"
+import { MAX_DECOMPRESSED_BYTES } from "../limits"
+
 // ── CRC-32 ──────────────────────────────────────────────────────────
 
 const crcTable = /* @__PURE__ */ (() => {
@@ -183,18 +186,22 @@ const codeLengthOrder = [16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 
  * Decompress raw DEFLATE data (no zlib/gzip header).
  * Pure TypeScript implementation of RFC 1951.
  */
-export function inflate(data: Uint8Array): Uint8Array {
+export function inflate(data: Uint8Array, maxBytes = MAX_DECOMPRESSED_BYTES): Uint8Array {
   const reader = new BitReader(data)
   // Dynamic output buffer
   let output = new Uint8Array(data.length * 3 || 1024)
   let outPos = 0
 
   function ensureCapacity(needed: number): void {
+    if (outPos + needed > maxBytes) {
+      throw new ZipError(`Decompressed size exceeds limit of ${maxBytes} bytes (possible zip bomb)`)
+    }
     if (outPos + needed > output.length) {
       let newSize = output.length * 2
       while (outPos + needed > newSize) {
         newSize *= 2
       }
+      if (newSize > maxBytes) newSize = maxBytes
       const newBuf = new Uint8Array(newSize)
       newBuf.set(output)
       output = newBuf

--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -3,6 +3,7 @@
 // Supports STORE (method 0) and DEFLATE (method 8).
 
 import { ZipError } from "../errors"
+import { MAX_DECOMPRESSED_BYTES } from "../limits"
 import { crc32, inflate } from "./deflate"
 
 // ── ZIP Signatures ──────────────────────────────────────────────────
@@ -43,7 +44,10 @@ function checkDecompressionStream(): boolean {
   return hasDecompressionStream
 }
 
-async function decompressDeflateRaw(data: Uint8Array): Promise<Uint8Array> {
+async function decompressDeflateRaw(
+  data: Uint8Array,
+  maxBytes = MAX_DECOMPRESSED_BYTES,
+): Promise<Uint8Array> {
   if (checkDecompressionStream()) {
     try {
       const ds = new DecompressionStream("deflate-raw")
@@ -61,8 +65,18 @@ async function decompressDeflateRaw(data: Uint8Array): Promise<Uint8Array> {
       for (;;) {
         const { done, value } = await reader.read()
         if (done) break
-        chunks.push(value)
         totalLen += value.length
+        if (totalLen > maxBytes) {
+          try {
+            await reader.cancel()
+          } catch {
+            // ignore
+          }
+          throw new ZipError(
+            `Decompressed size exceeds limit of ${maxBytes} bytes (possible zip bomb)`,
+          )
+        }
+        chunks.push(value)
       }
 
       // Combine chunks
@@ -73,13 +87,16 @@ async function decompressDeflateRaw(data: Uint8Array): Promise<Uint8Array> {
         offset += chunk.length
       }
       return result
-    } catch {
-      // Fall through to pure TS implementation
+    } catch (err) {
+      // A size-limit breach is a hard failure — don't retry with the
+      // pure-TS path (which would just OOM the same way).
+      if (err instanceof ZipError) throw err
+      // Otherwise fall through to pure TS implementation
     }
   }
 
   // Pure TypeScript fallback
-  return inflate(data)
+  return inflate(data, maxBytes)
 }
 
 // ── ZipReader ───────────────────────────────────────────────────────
@@ -272,7 +289,13 @@ export class ZipReader {
       if (compressedSize === 0 && uncompressedSize === 0) {
         result = new Uint8Array(0)
       } else {
-        result = await decompressDeflateRaw(compressedData)
+        // Bound output by the central-directory uncompressedSize (when
+        // declared and trustworthy) as well as the absolute hard cap.
+        const declaredCap =
+          uncompressedSize > 0
+            ? Math.min(uncompressedSize, MAX_DECOMPRESSED_BYTES)
+            : MAX_DECOMPRESSED_BYTES
+        result = await decompressDeflateRaw(compressedData, declaredCap)
       }
     } else {
       throw new ZipError(
@@ -363,7 +386,11 @@ export class ZipReader {
       }
 
       // Fallback: inflate synchronously and emit as stream
-      const inflated = inflate(compressedData)
+      const declaredCap =
+        entry.uncompressedSize > 0
+          ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
+          : MAX_DECOMPRESSED_BYTES
+      const inflated = inflate(compressedData, declaredCap)
       return new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(inflated)

--- a/src/zip/stream-reader.ts
+++ b/src/zip/stream-reader.ts
@@ -18,6 +18,7 @@
 
 import { inflate } from "./deflate"
 import { ZipError } from "../errors"
+import { MAX_DECOMPRESSED_BYTES } from "../limits"
 
 const SIG_LOCAL_FILE = 0x04034b50
 const SIG_CENTRAL_DIR = 0x02014b50
@@ -182,7 +183,11 @@ export class ZipStreamReader {
     // Copy out of the leftover-backed view so later reads can't alias it.
     const owned = compressed.slice()
     if (entry.compressionMethod === 0) return owned
-    return inflate(owned)
+    const cap =
+      entry.uncompressedSize > 0
+        ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
+        : MAX_DECOMPRESSED_BYTES
+    return inflate(owned, cap)
   }
 
   /**
@@ -235,7 +240,11 @@ export class ZipStreamReader {
           if (done) break
           if (value) chunks.push(value)
         }
-        controller.enqueue(inflate(concat(chunks)))
+        const cap =
+          entry.uncompressedSize > 0
+            ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
+            : MAX_DECOMPRESSED_BYTES
+        controller.enqueue(inflate(concat(chunks), cap))
         controller.close()
       },
     })

--- a/test/security-dos.test.ts
+++ b/test/security-dos.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+import { deflate, inflate } from "../src/zip/deflate"
+import { parseWorksheet } from "../src/xlsx/worksheet"
+import type { WorksheetContext } from "../src/xlsx/worksheet"
+import { parseSst } from "../src/xls/biff"
+import { readCfb } from "../src/xlsx/crypto/cfb"
+import { decryptAgile } from "../src/xlsx/crypto/agile"
+import { toHtml } from "../src/export/html"
+import { ParseError, ZipError, DecryptionError } from "../src/errors"
+import type { CellValue, Sheet } from "../src/_types"
+
+const ctx: WorksheetContext = {
+  sharedStrings: [],
+  styles: null,
+  readStyles: false,
+  dateSystem: "1900",
+}
+
+describe("DoS hardening — zip bomb (inflate cap)", () => {
+  it("throws ZipError when decompressed output exceeds the cap", () => {
+    // Highly compressible input that inflates to ~10 KiB; cap at 256 bytes.
+    const raw = new Uint8Array(10_000) // all zeros — compresses tiny
+    const compressed = deflate(raw)
+    expect(() => inflate(compressed, 256)).toThrow(ZipError)
+  })
+
+  it("still inflates normally under the cap", () => {
+    const raw = new Uint8Array(1000).fill(7)
+    const compressed = deflate(raw)
+    const out = inflate(compressed, 1_000_000)
+    expect(out.length).toBe(1000)
+    expect(out[0]).toBe(7)
+  })
+})
+
+describe("DoS hardening — cell-ref OOM (worksheet bounds)", () => {
+  it("rejects a cell reference beyond Excel's row limit", () => {
+    const xml = `<worksheet><sheetData><row r="2000000"><c r="A2000000"><v>1</v></c></row></sheetData></worksheet>`
+    expect(() => parseWorksheet(xml, "S", ctx)).toThrow(ParseError)
+  })
+
+  it("rejects a cell reference beyond Excel's column limit", () => {
+    // Column XFE = 16385 (> 16384 max).
+    const xml = `<worksheet><sheetData><row r="1"><c r="XFE1"><v>1</v></c></row></sheetData></worksheet>`
+    expect(() => parseWorksheet(xml, "S", ctx)).toThrow(ParseError)
+  })
+
+  it("accepts an in-bounds reference", () => {
+    const xml = `<worksheet><sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData></worksheet>`
+    const sheet = parseWorksheet(xml, "S", ctx)
+    expect(sheet.rows[0][0]).toBe(1)
+  })
+})
+
+describe("DoS hardening — XLS SST loop bound", () => {
+  it("does not spin on an inflated cstUnique", () => {
+    // cstTotal (4) + cstUnique (4 = 0xFFFFFFFF) with no string data.
+    const block = new Uint8Array(8)
+    const dv = new DataView(block.buffer)
+    dv.setUint32(0, 0xffffffff, true) // cstTotal
+    dv.setUint32(4, 0xffffffff, true) // cstUnique — hostile
+    const out = parseSst([block])
+    // Bounded by available bytes; returns quickly without OOM/hang.
+    expect(Array.isArray(out)).toBe(true)
+    expect(out.length).toBe(0)
+  })
+})
+
+describe("DoS hardening — CFB DIFAT / mini-stream bounds", () => {
+  it("does not allocate from a hostile mini-stream size", () => {
+    // A minimal-but-corrupt CFB: valid signature, but the DIFAT/mini walks
+    // must terminate by file size rather than header-claimed counts.
+    const data = new Uint8Array(512)
+    // CFB signature
+    const sig = [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]
+    data.set(sig, 0)
+    const dv = new DataView(data.buffer)
+    dv.setUint16(30, 9, true) // sectorShift -> 512
+    dv.setUint16(32, 6, true) // miniSectorShift -> 64
+    dv.setUint32(44, 1, true) // numFatSectors
+    dv.setUint32(72, 0xffffffff, true) // numDifatSectors — hostile, must be bounded
+    // readCfb should fail with a typed ParseError rather than hanging/OOMing.
+    expect(() => readCfb(data)).toThrow(ParseError)
+  })
+})
+
+describe("DoS hardening — Agile crypto spinCount cap", () => {
+  it("rejects an absurd spinCount before deriving the key", async () => {
+    // Build a CFB with EncryptionInfo whose spinCount is enormous. Decrypt
+    // must reject via DecryptionError instead of spinning for minutes.
+    const xml =
+      `<?xml version="1.0"?><encryption><keyData saltSize="16" blockSize="16" keyBits="256" hashSize="64" cipherAlgorithm="AES" cipherChaining="ChainingModeCBC" hashAlgorithm="SHA512" saltValue="AAAAAAAAAAAAAAAAAAAAAA=="/>` +
+      `<keyEncryptors><keyEncryptor><p:encryptedKey spinCount="999999999" saltSize="16" blockSize="16" keyBits="256" hashSize="64" cipherAlgorithm="AES" cipherChaining="ChainingModeCBC" hashAlgorithm="SHA512" saltValue="AAAAAAAAAAAAAAAAAAAAAA==" encryptedVerifierHashInput="AAAAAAAAAAAAAAAAAAAAAA==" encryptedVerifierHashValue="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" encryptedKeyValue="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/></keyEncryptor></keyEncryptors></encryption>`
+    const { writeCfb } = await import("../src/xlsx/crypto/cfb")
+    const infoHeader = new Uint8Array(8)
+    const dv = new DataView(infoHeader.buffer)
+    dv.setUint16(0, 4, true) // major
+    dv.setUint16(2, 4, true) // minor
+    const info = new Uint8Array([...infoHeader, ...new TextEncoder().encode(xml)])
+    const pkg = new Uint8Array(8 + 16) // dummy
+    const cfb = writeCfb([
+      { name: "EncryptionInfo", data: info },
+      { name: "EncryptedPackage", data: pkg },
+    ])
+    await expect(decryptAgile(cfb, "x")).rejects.toThrow(DecryptionError)
+  })
+})
+
+describe("HTML export XSS — style attribute escaping", () => {
+  it("escapes quotes/brackets injected via font name", () => {
+    const sheet: Sheet = {
+      name: "S",
+      rows: [["x"]] as CellValue[][],
+      cells: new Map([
+        [
+          "0,0",
+          {
+            value: "x",
+            type: "string",
+            style: { font: { name: `Arial";}</style><script>alert(1)</script>` } },
+          },
+        ],
+      ]),
+    } as unknown as Sheet
+    const html = toHtml(sheet, { styles: true })
+    expect(html).not.toContain("<script>alert(1)</script>")
+    expect(html).toContain("&quot;")
+  })
+})


### PR DESCRIPTION
Hardens the parsers and HTML exporter against crafted / malformed files that could OOM, hang the process, or inject markup.

## Fixes

1. **Zip-bomb (decompression cap)** — `src/zip/deflate.ts`, `src/zip/reader.ts`, `src/zip/stream-reader.ts`
   - `inflate()` now takes a `maxBytes` cap (default `MAX_DECOMPRESSED_BYTES` ~2 GiB) and throws `ZipError` when the doubling output buffer would exceed it.
   - `decompressDeflateRaw()` enforces the same cap on the `DecompressionStream` path (cancels the stream and throws `ZipError`; does **not** fall through to the pure-TS path on a size breach).
   - Per-entry cap derived from the central-directory `uncompressedSize` (when declared) intersected with the hard cap; threaded through the stream reader too.
   - *Test:* a tiny deflate stream that inflates to 10 KiB throws `ZipError` under a 256-byte cap.

2. **Cell-ref OOM** — `src/xlsx/worksheet.ts`, `src/xlsx/xlsb/reader.ts`
   - `processCell` and the XLSB `setCell` / `BrtRowHdr` paths reject row/col indices beyond Excel limits (1,048,576 rows / 16,384 cols) with `ParseError` instead of growing arrays to billions of null slots.
   - *Tests:* refs past the row and column limits throw `ParseError`; in-bounds refs still parse.

3. **XLS / CFB infinite loops** — `src/xls/biff.ts`, `src/xlsx/crypto/cfb.ts`
   - SST loop bounded by total available bytes (untrusted `cstUnique` u32 can no longer spin).
   - CFB DIFAT walk bounded by `data.length / sectorSize` rather than the header-claimed `numDifatSectors`.
   - `readMini` rejects an out-of-range stream size (untrusted u32) before allocating.
   - *Tests:* hostile `cstUnique=0xFFFFFFFF` returns quickly; a CFB with `numDifatSectors=0xFFFFFFFF` throws `ParseError`.

4. **Agile crypto** — `src/xlsx/crypto/agile.ts`
   - Untrusted `spinCount` capped at `MAX_SPIN_COUNT` (10,000,000); invalid/negative rejected with `DecryptionError`.
   - Implemented `dataIntegrity` HMAC verification per MS-OFFCRYPTO §2.3.4.14 — decrypts the HMAC key/value under the package secret key and verifies HMAC-SHA512 over the EncryptedPackage stream; mismatch throws `DecryptionError`. No-op when the element is absent or the hash isn't SHA-512.
   - *Test:* an `EncryptionInfo` with `spinCount=999999999` is rejected before key derivation. The existing encrypt→decrypt roundtrip tests confirm the HMAC check passes for valid files.

5. **HTML export XSS** — `src/export/html.ts`
   - The inline `style` attribute (built from untrusted workbook content such as font names / format strings) is now attribute-escaped via the existing `escapeHtml` helper.
   - *Test:* a font name containing `";}</style><script>...` is escaped (no live `<script>`, quotes encoded as `&quot;`).

New `src/limits.ts` centralizes the bounds. Regression tests in `test/security-dos.test.ts`.

## Validation
- `pnpm typecheck` — clean
- `pnpm lint` (oxlint + oxfmt) — clean
- `vitest run` — 7568 tests pass, no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)