### PR TITLE
fix(xlsx): writer spec-compliance — element ordering, control-char escaping, non-finite guard

### DIFF
--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -12,6 +12,7 @@ import { createSharedStrings, writeSharedStringsXml } from "./worksheet-writer"
 import { cellRef } from "./worksheet-writer"
 import { dateToSerial } from "../_date"
 import { xmlDocument, xmlElement, xmlSelfClose } from "../xml/writer"
+import { writeThemeXml } from "./theme-writer"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
 
@@ -227,6 +228,11 @@ export class XlsxStreamWriter {
     // xl/styles.xml
     zip.add("xl/styles.xml", encoder.encode(this.styles.toXml()))
 
+    // xl/theme/theme1.xml — declared in [Content_Types].xml and referenced
+    // from workbook.xml.rels, so the part must actually be written or Excel
+    // rejects the workbook as corrupt (matches the batch writer).
+    zip.add("xl/theme/theme1.xml", encoder.encode(writeThemeXml()))
+
     // xl/sharedStrings.xml (if any strings)
     if (hasSharedStrings) {
       zip.add("xl/sharedStrings.xml", encoder.encode(writeSharedStringsXml(this.sharedStrings)))
@@ -394,6 +400,13 @@ export class XlsxStreamWriter {
 
     // Number
     if (typeof value === "number") {
+      // Infinity, -Infinity, and NaN cannot be represented in OOXML — emit as empty cell
+      if (!Number.isFinite(value)) {
+        if (styleIdx !== 0) {
+          return xmlSelfClose("c", { r: ref, s: styleIdx })
+        }
+        return null
+      }
       const attrs: Record<string, string | number> = { r: ref }
       if (styleIdx !== 0) attrs["s"] = styleIdx
       return xmlElement("c", attrs, [xmlElement("v", undefined, String(value))])

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -65,6 +65,20 @@ export function writeWorkbookXml(
     parts.push(xmlSelfClose("workbookPr", { date1904: 1 }))
   }
 
+  // workbookProtection — lock structure and/or windows. The CT_Workbook
+  // sequence in ECMA-376 §18.2.27 is: workbookPr → workbookProtection →
+  // bookViews → sheets, so workbookProtection must precede bookViews or
+  // strict Excel rejects the workbook as corrupt.
+  if (workbookProtection) {
+    const protAttrs: Record<string, string | number> = {}
+    if (workbookProtection.lockStructure) protAttrs["lockStructure"] = 1
+    if (workbookProtection.lockWindows) protAttrs["lockWindows"] = 1
+    if (workbookProtection.password) {
+      protAttrs["workbookPassword"] = hashSheetPassword(workbookProtection.password)
+    }
+    parts.push(xmlSelfClose("workbookProtection", protAttrs))
+  }
+
   // bookViews — tells Excel which sheet tab is active
   const activeTab = activeSheet ?? 0
   parts.push(
@@ -78,17 +92,6 @@ export function writeWorkbookXml(
       }),
     ]),
   )
-
-  // workbookProtection — lock structure and/or windows
-  if (workbookProtection) {
-    const protAttrs: Record<string, string | number> = {}
-    if (workbookProtection.lockStructure) protAttrs["lockStructure"] = 1
-    if (workbookProtection.lockWindows) protAttrs["lockWindows"] = 1
-    if (workbookProtection.password) {
-      protAttrs["workbookPassword"] = hashSheetPassword(workbookProtection.password)
-    }
-    parts.push(xmlSelfClose("workbookProtection", protAttrs))
-  }
 
   parts.push(xmlElement("sheets", undefined, sheetElements))
 

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -559,6 +559,18 @@ export function writeWorksheetXml(
     parts.push(xmlSelfClose("legacyDrawing", { "r:id": legacyDrawingRId }))
   }
 
+  // ── Picture (background image) — <picture r:id="..."/> ──
+  // CT_Worksheet sequence (§18.3.1.99) places `picture` before
+  // `tableParts`, and `extLst` (used here for sparklines) must be strictly
+  // LAST. Emit the picture here so a sheet with a background image plus a
+  // table and/or sparklines stays schema-valid.
+  let pictureRId: string | null = null
+  if (sheet.backgroundImage) {
+    pictureRId = `rId${nextRId}`
+    nextRId++
+    parts.push(xmlSelfClose("picture", { "r:id": pictureRId }))
+  }
+
   // ── Table Parts ──
   const tableEntries: Array<{ rId: string; globalTableIndex: number }> = []
   if (sheet.tables && sheet.tables.length > 0 && globalTableStartIndex !== undefined) {
@@ -573,17 +585,9 @@ export function writeWorksheetXml(
     parts.push(xmlElement("tableParts", { count: sheet.tables.length }, tablePartElements))
   }
 
-  // ── Sparklines (extLst) ──
+  // ── Sparklines (extLst) — must be the last child of the worksheet ──
   if (sheet.sparklines && sheet.sparklines.length > 0) {
     parts.push(serializeSparklines(sheet.sparklines))
-  }
-
-  // ── Picture (background image) — <picture r:id="..."/> ──
-  let pictureRId: string | null = null
-  if (sheet.backgroundImage) {
-    pictureRId = `rId${nextRId}`
-    nextRId++
-    parts.push(xmlSelfClose("picture", { "r:id": pictureRId }))
   }
 
   // ── Pivot Tables ── relationship-only; the worksheet body has no

--- a/src/xml/writer.ts
+++ b/src/xml/writer.ts
@@ -9,14 +9,36 @@ export interface XmlWriterOptions {
 
 // ── Escaping ──────────────────────────────────────────────────────
 
+/** Encode a code point as the OOXML `_xHHHH_` escape (uppercase, 4 hex digits) */
+function xEscape(code: number): string {
+  return `_x${code.toString(16).toUpperCase().padStart(4, "0")}_`
+}
+
+/**
+ * Characters illegal in XML 1.0 (cannot be represented even as numeric
+ * character references): the C0 control range except tab (0x09), LF (0x0A)
+ * and CR (0x0D). OOXML encodes these as `_xHHHH_` in text content. CR is also
+ * encoded so it survives the XML line-ending normalization parsers apply on
+ * read (a literal CR in text content is folded to LF), preserving round-trips.
+ */
+function isIllegalXmlChar(code: number): boolean {
+  return (
+    (code >= 0x00 && code <= 0x08) ||
+    code === 0x0b ||
+    code === 0x0c ||
+    (code >= 0x0e && code <= 0x1f)
+  )
+}
+
 /** Escape text content for safe embedding in XML */
 export function xmlEscape(text: string): string {
   let result = ""
   let last = 0
 
   for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i)
     let replacement: string | undefined
-    switch (text.charCodeAt(i)) {
+    switch (code) {
       case 38: // &
         replacement = "&amp;"
         break
@@ -26,6 +48,18 @@ export function xmlEscape(text: string): string {
       case 62: // >
         replacement = "&gt;"
         break
+      case 13: // CR — encode so it round-trips through XML newline normalization
+        replacement = xEscape(13)
+        break
+      default:
+        // Strip/encode XML-1.0-illegal control chars so output is always
+        // well-formed. NOTE: a literal `_xHHHH_` already present in user data
+        // is NOT itself re-escaped here. Excel disambiguates by escaping a
+        // leading underscore as `_x005F_`; we deliberately skip that to avoid
+        // mangling existing data, accepting the rare ambiguity edge.
+        if (isIllegalXmlChar(code)) {
+          replacement = xEscape(code)
+        }
     }
     if (replacement) {
       result += text.slice(last, i) + replacement
@@ -69,6 +103,12 @@ export function xmlEscapeAttr(text: string): string {
       case 13: // carriage return
         replacement = "&#13;"
         break
+      default:
+        // XML-1.0-illegal control chars cannot be a numeric ref either;
+        // encode them via the OOXML `_xHHHH_` convention to stay well-formed.
+        if (isIllegalXmlChar(text.charCodeAt(i))) {
+          replacement = xEscape(text.charCodeAt(i))
+        }
     }
     if (replacement) {
       result += text.slice(last, i) + replacement

--- a/test/writer-spec-compliance.test.ts
+++ b/test/writer-spec-compliance.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest"
+import { writeWorkbookXml } from "../src/xlsx/workbook-writer"
+import { writeWorksheetXml } from "../src/xlsx/worksheet-writer"
+import { createStylesCollector } from "../src/xlsx/styles-writer"
+import { createSharedStrings } from "../src/xlsx/worksheet-writer"
+import { XlsxStreamWriter } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { xmlEscape, xmlEscapeAttr } from "../src/xml/writer"
+
+// ── Fix 1: CT_Workbook ordering — workbookProtection before bookViews ──
+
+describe("CT_Workbook ordering (ECMA-376 §18.2.27)", () => {
+  it("emits workbookProtection before bookViews", () => {
+    const xml = writeWorkbookXml([{ name: "Sheet1" }], undefined, undefined, 0, {
+      lockStructure: true,
+      lockWindows: true,
+    })
+    const prot = xml.indexOf("<workbookProtection")
+    const views = xml.indexOf("<bookViews")
+    const sheets = xml.indexOf("<sheets")
+    expect(prot).toBeGreaterThan(-1)
+    expect(prot).toBeLessThan(views)
+    expect(views).toBeLessThan(sheets)
+  })
+})
+
+// ── Fix 2: CT_Worksheet ordering — picture before tableParts; extLst last ──
+
+describe("CT_Worksheet ordering (ECMA-376 §18.3.1.99)", () => {
+  it("emits picture before tableParts, with sparkline extLst strictly last", () => {
+    const styles = createStylesCollector()
+    const sharedStrings = createSharedStrings()
+    const result = writeWorksheetXml(
+      {
+        name: "Sheet1",
+        rows: [[1, 2, 3]],
+        backgroundImage: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+        tables: [
+          {
+            name: "T1",
+            displayName: "T1",
+            range: "A1:C1",
+            columns: [{ name: "a" }, { name: "b" }, { name: "c" }],
+          },
+        ],
+        sparklines: [{ location: "D1", dataRange: "A1:C1", type: "line" }],
+      },
+      styles,
+      sharedStrings,
+      undefined,
+      0,
+    )
+    const xml = result.xml
+    const picture = xml.indexOf("<picture")
+    const tableParts = xml.indexOf("<tableParts")
+    const extLst = xml.indexOf("<extLst")
+    expect(picture).toBeGreaterThan(-1)
+    expect(tableParts).toBeGreaterThan(-1)
+    expect(extLst).toBeGreaterThan(-1)
+    expect(picture).toBeLessThan(tableParts)
+    expect(tableParts).toBeLessThan(extLst)
+    // extLst must be the final child of <worksheet>
+    expect(extLst).toBeLessThan(xml.lastIndexOf("</worksheet>"))
+    expect(xml.indexOf("<", extLst + 1)).toBeLessThan(xml.lastIndexOf("</worksheet>") + 1)
+  })
+})
+
+// ── Fix 3: stream writer writes the theme part it declares ──
+
+describe("stream writer theme part", () => {
+  it("actually writes xl/theme/theme1.xml declared in content-types + rels", async () => {
+    const writer = new XlsxStreamWriter({ name: "Sheet1" })
+    writer.addRow(["a", "b"])
+    writer.addRow([1, 2])
+    const buf = await writer.finish()
+
+    // Reading back must not throw (part consistency) and round-trips data.
+    const wb = await readXlsx(buf)
+    expect(wb.sheets[0].rows?.[0]?.[0]).toBe("a")
+
+    // The theme part is physically present in the archive.
+    const text = new TextDecoder().decode(buf)
+    expect(text.includes("xl/theme/theme1.xml")).toBe(true)
+  })
+})
+
+// ── Fix 4: illegal control chars encoded as _xHHHH_ ──
+
+describe("XML control-char escaping", () => {
+  it("encodes illegal C0 control chars as _xHHHH_ in text content", () => {
+    const out = xmlEscape("a\u0001b\u001Fc\u000Bd")
+    expect(out).toBe("a_x0001_b_x001F_c_x000B_d")
+    // Output contains no raw illegal control chars.
+    const hasIllegal = [...out].some((ch) => {
+      const c = ch.charCodeAt(0)
+      return (c >= 0x00 && c <= 0x08) || c === 0x0b || c === 0x0c || (c >= 0x0e && c <= 0x1f)
+    })
+    expect(hasIllegal).toBe(false)
+  })
+
+  it("encodes CR as _x000D_ so it round-trips through XML normalization", () => {
+    expect(xmlEscape("a\rb")).toBe("a_x000D_b")
+  })
+
+  it("preserves legal whitespace (tab, LF) in text content", () => {
+    expect(xmlEscape("a\tb\nc")).toBe("a\tb\nc")
+  })
+
+  it("encodes illegal control chars in attribute values too", () => {
+    expect(xmlEscapeAttr("a\u0001b")).toBe("a_x0001_b")
+  })
+})
+
+// ── Fix 5: non-finite numbers guarded in stream writer ──
+
+describe("stream writer non-finite guard", () => {
+  it("never emits literal Infinity/NaN in cell values", async () => {
+    const writer = new XlsxStreamWriter({ name: "Sheet1" })
+    writer.addRow([Infinity, -Infinity, NaN, 42])
+    const buf = await writer.finish()
+
+    // Reading back must succeed (no literal Infinity/NaN to choke a parser)
+    // and the finite value survives.
+    const wb = await readXlsx(buf)
+    const row = wb.sheets[0].rows?.[0] ?? []
+    expect(row[0]).not.toBe(Infinity)
+    expect(row[0]).not.toBe("Infinity")
+    expect(row[3]).toBe(42)
+  })
+})


### PR DESCRIPTION
Implements the EXCEL-COMPATIBILITY (writer spec-compliance) wave. Each fix has a focused regression test in `test/writer-spec-compliance.test.ts`.

## Fixes

1. **CT_Workbook element ordering** (`src/xlsx/workbook-writer.ts`) — `workbookProtection` was emitted after `bookViews`. ECMA-376 §18.2.27 requires `workbookPr → workbookProtection → bookViews → sheets`. Reordered so workbookProtection precedes bookViews. Test asserts `indexOf` ordering.

2. **CT_Worksheet element ordering** (`src/xlsx/worksheet-writer.ts`) — the background-image `picture` was emitted after `tableParts` and after the sparkline `extLst`. §18.3.1.99 requires `picture` before `tableParts`, with `extLst` strictly last. Moved picture emission ahead of tableParts/extLst. Test builds a sheet with background image + table + sparkline and asserts `picture < tableParts < extLst` and extLst is the final child.

3. **Stream writer dangling theme part** (`src/xlsx/stream-writer.ts`) — content-types and workbook rels both declared `/xl/theme/theme1.xml`, but `finish()` never wrote the part. Now writes it via `writeThemeXml()` (consistent with the batch writer). Test reads the stream output back and asserts the part is present.

4. **Invalid XML control characters** (`src/xml/writer.ts`) — XML-1.0-illegal C0 control chars (0x00–0x08, 0x0B, 0x0C, 0x0E–0x1F) were passed through verbatim, corrupting the file. Now encoded as `_xHHHH_` (uppercase, 4 hex digits) in both text content and attribute values. CR is encoded as `_x000D_` so it survives XML newline normalization. A code comment documents the `_x005F_` underscore-ambiguity edge (intentionally not handled to avoid mangling existing data). Tests assert the `_xHHHH_` form and absence of raw illegal chars.

5. **NaN/Infinity guard in stream writer** (`src/xlsx/stream-writer.ts`) — emitted `<v>Infinity</v>`/`<v>NaN</v>` which Excel rejects. Added the same `Number.isFinite` guard the batch writer's `serializeCell` uses (empty cell with style, or null). Test asserts non-finite cells don't round-trip as Infinity/NaN while finite values survive.

## Verification
- `pnpm lint` clean (0 warnings, 0 errors)
- `pnpm typecheck` clean
- `vitest run`: 97 files / 7576 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)