### PR TITLE
fix: formula-ref conversion corruption + markdown newline escaping

### DIFF
--- a/src/cell-utils.ts
+++ b/src/cell-utils.ts
@@ -11,6 +11,61 @@ export { colToLetter, cellRef, rangeRef } from "./xlsx/worksheet-writer"
 // ── New Utilities ──────────────────────────────────────────────────
 
 /**
+ * Matches an A1-style cell reference that is NOT part of a larger
+ * identifier and NOT a function name. The negative lookbehind rejects a
+ * preceding letter/digit/underscore (so the "G10" inside "LOG10" or the
+ * tail of a defined name is left alone); the negative lookahead rejects a
+ * following "(" (so "SUM(" / "ATAN2(" are not treated as the column "SUM"
+ * etc.) and a following letter/digit (so "A1B" isn't split).
+ */
+const A1_REF_TOKEN = /(?<![A-Za-z0-9_$])(\$?[A-Z]{1,3}\$?\d+)(?![A-Za-z0-9_(])/g
+
+/** Like {@link A1_REF_TOKEN} but also captures an optional `:ref2` range tail. */
+const A1_RANGE_TOKEN =
+  /(?<![A-Za-z0-9_$])(\$?[A-Z]{1,3}\$?\d+)(?::(\$?[A-Z]{1,3}\$?\d+))?(?![A-Za-z0-9_(])/g
+
+/**
+ * Run a replacer over the A1 cell references / ranges in an Excel formula,
+ * skipping quoted string literals, function names, and embedded
+ * identifiers (same safety rules as {@link replaceA1Refs}). `replacer`
+ * receives the first ref and, for a range, the second; it returns the
+ * full replacement for the matched span.
+ */
+export function replaceA1Ranges(
+  formula: string,
+  replacer: (ref1: string, ref2?: string) => string,
+): string {
+  const parts = formula.split(/("(?:[^"]|"")*")/)
+  for (let i = 0; i < parts.length; i++) {
+    if (i % 2 === 1) continue
+    parts[i] = parts[i].replace(A1_RANGE_TOKEN, (_m, r1: string, r2?: string) => replacer(r1, r2))
+  }
+  return parts.join("")
+}
+
+/**
+ * Run a replacer over the A1 cell references in an Excel formula while
+ * leaving quoted string literals (`"..."`), function names, and embedded
+ * identifiers untouched. The naive `/[A-Z]+\d+/g` approach corrupts
+ * `LOG10(...)`, `ATAN2`, and `"AB1"` — this splits the formula on string
+ * literals first and only rewrites refs in the code spans.
+ *
+ * `replacer` receives the matched reference text (e.g. `"$A$1"`) and
+ * returns its replacement.
+ */
+export function replaceA1Refs(formula: string, replacer: (ref: string) => string): string {
+  // Split on double-quoted string literals (Excel doubles "" to escape a
+  // quote, which this regex keeps inside one literal token).
+  const parts = formula.split(/("(?:[^"]|"")*")/)
+  for (let i = 0; i < parts.length; i++) {
+    // Odd indices are the captured string literals — leave them verbatim.
+    if (i % 2 === 1) continue
+    parts[i] = parts[i].replace(A1_REF_TOKEN, (m) => replacer(m))
+  }
+  return parts.join("")
+}
+
+/**
  * Convert a column letter (e.g. "A", "Z", "AA") to a 0-based column index.
  * This is the inverse of `colToLetter`.
  *
@@ -125,10 +180,15 @@ export function r1c1ToA1(formula: string, currentRow: number, currentCol: number
  * Replaces all A1 references in the formula string.
  */
 export function a1ToR1C1(formula: string, currentRow?: number, currentCol?: number): string {
-  // Match A1 patterns: $A$1, A1, $A1, A$1, AA100
-  return formula.replace(
-    /(\$?)([A-Z]{1,3})(\$?)(\d+)/g,
-    (_match, colDollar: string, colLetters: string, rowDollar: string, rowDigits: string) => {
+  // Match A1 patterns: $A$1, A1, $A1, A$1, AA100 — but skip refs inside
+  // function names ("LOG10") and string literals ("AB1").
+  return replaceA1Refs(formula, (ref) => {
+    const m = /(\$?)([A-Z]{1,3})(\$?)(\d+)/.exec(ref)!
+    const colDollar = m[1]
+    const colLetters = m[2]
+    const rowDollar = m[3]
+    const rowDigits = m[4]
+    {
       const col = letterToCol(colLetters) // 0-based
       const row = parseInt(rowDigits, 10) - 1 // 0-based
       const colAbs = colDollar === "$"
@@ -151,6 +211,6 @@ export function a1ToR1C1(formula: string, currentRow?: number, currentCol?: numb
       }
 
       return `R${rowPart}C${colPart}`
-    },
-  )
+    }
+  })
 }

--- a/src/export/markdown.ts
+++ b/src/export/markdown.ts
@@ -9,9 +9,13 @@ export interface MarkdownExportOptions {
   maxWidth?: number
 }
 
-/** Escape pipe characters in cell values */
+/**
+ * Escape characters that would break a Markdown table cell: pipes (column
+ * separators) and newlines (row separators). A literal newline inside a
+ * cell is rendered as `<br>` (GFM) so the table structure survives.
+ */
 function escapePipe(str: string): string {
-  return str.replace(/\|/g, "\\|")
+  return str.replace(/\|/g, "\\|").replace(/\r\n|\r|\n/g, "<br>")
 }
 
 /** Format a cell value as a string for Markdown output */

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -14,6 +14,7 @@ import type {
 import { ZipWriter } from "../zip/writer"
 import { unwrapCellValue } from "../xlsx/hyperlink"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
+import { replaceA1Ranges } from "../cell-utils"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
 
@@ -472,16 +473,11 @@ function getOrCreateStyleName(collector: StyleCollector, style: CellStyle): stri
  * ODS formulas use `of:=` prefix and `[.A1]` cell references.
  */
 function excelFormulaToOds(formula: string): string {
-  // Convert cell references like A1, $A$1, A1:B2 to ODS [.A1] notation
-  // Handle range references like A1:B2 → [.A1:.B2]
-  const converted = formula.replace(
-    /(\$?[A-Z]{1,3}\$?\d+)(?::(\$?[A-Z]{1,3}\$?\d+))?/g,
-    (_match, ref1: string, ref2?: string) => {
-      if (ref2) {
-        return `[.${ref1}:.${ref2}]`
-      }
-      return `[.${ref1}]`
-    },
+  // Convert cell references like A1, $A$1, A1:B2 to ODS [.A1] notation,
+  // handling ranges (A1:B2 → [.A1:.B2]) while leaving function names
+  // (LOG10), string literals ("AB1"), and embedded identifiers untouched.
+  const converted = replaceA1Ranges(formula, (ref1, ref2) =>
+    ref2 ? `[.${ref1}:.${ref2}]` : `[.${ref1}]`,
   )
   return `of:=${converted}`
 }

--- a/test/export-markdown.test.ts
+++ b/test/export-markdown.test.ts
@@ -222,4 +222,15 @@ describe("toMarkdown", () => {
     const pipeCounts = lines.map((l) => (l.match(/\|/g) || []).length)
     expect(new Set(pipeCounts).size).toBe(1)
   })
+
+  it("newlines inside a cell don't break the table structure", () => {
+    const sheet = makeSheet([["Col"], ["line1\nline2"], ["a\r\nb"]])
+    const md = toMarkdown(sheet)
+    const lines = md.split("\n")
+    // header + separator + 2 data rows = 4 lines; an embedded newline must
+    // not spill into extra table rows.
+    expect(lines).toHaveLength(4)
+    expect(md).toContain("line1<br>line2")
+    expect(md).toContain("a<br>b")
+  })
 })

--- a/test/formula-ref-safety.test.ts
+++ b/test/formula-ref-safety.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { a1ToR1C1 } from "../src/index"
+import { writeOds } from "../src/ods/writer"
+import { ZipReader } from "../src/zip/reader"
+
+describe("a1ToR1C1 — does not corrupt function names or string literals", () => {
+  it("rewrites a bare cell reference", () => {
+    expect(a1ToR1C1("A1")).toBe("R1C1")
+    expect(a1ToR1C1("$C$2")).toBe("R2C3")
+  })
+
+  it("leaves a function name like LOG10 untouched", () => {
+    // "G10" inside "LOG10" must not be treated as a cell ref, and the
+    // argument A1 must still be converted.
+    expect(a1ToR1C1("LOG10(A1)")).toBe("LOG10(R1C1)")
+  })
+
+  it("leaves a quoted string literal untouched", () => {
+    expect(a1ToR1C1('IF(A1>1,"AB1",0)')).toBe('IF(R1C1>1,"AB1",0)')
+  })
+
+  it("does not treat ATAN2( as the column AT", () => {
+    expect(a1ToR1C1("ATAN2(B2,C3)")).toBe("ATAN2(R2C2,R3C3)")
+  })
+})
+
+describe("ODS formula conversion — function names and literals preserved", () => {
+  async function odsContent(formula: string): Promise<string> {
+    const cells = new Map<string, { value: number; formula: string }>()
+    cells.set("0,0", { value: 0, formula })
+    const data = await writeOds({
+      sheets: [{ name: "S", rows: [[0]], cells: cells as never }],
+    })
+    const raw = await new ZipReader(data).extract("content.xml")
+    return new TextDecoder().decode(raw)
+  }
+
+  it("converts cell refs but not LOG10 or quoted literals", async () => {
+    const xml = await odsContent('LOG10(A1)+IF(A1>1,"AB1",0)')
+    // Refs A1 become [.A1]; LOG10 and the "AB1" literal stay intact.
+    expect(xml).toContain("[.A1]")
+    expect(xml).toContain("LOG10(")
+    expect(xml).toContain("&quot;AB1&quot;")
+    // The bug produced [.LOG10] and [.AB1] — assert those never appear.
+    expect(xml).not.toContain("[.LOG10]")
+    expect(xml).not.toContain("[.AB1]")
+  })
+
+  it("handles ranges", async () => {
+    const xml = await odsContent("SUM(A1:B2)")
+    expect(xml).toContain("[.A1:.B2]")
+    expect(xml).not.toContain("[.SUM]")
+  })
+})


### PR DESCRIPTION
## Problem

Two correctness bugs surfaced in the full-repo review:

1. **Formula reference conversion corrupts function names & string literals.** Both `a1ToR1C1` (cell-utils) and `excelFormulaToOds` (ODS writer) used a naive `/[A-Z]{1,3}\d+/` regex that matched *inside* function names and quoted literals:
   - `LOG10(A1)` → `[.LOG10](...)` (the `G10` in `LOG10` treated as a ref)
   - `IF(A1>1,"AB1",0)` → the `"AB1"` literal rewritten to `[.AB1]`
   - `ATAN2(...)`, `SUM(...)` etc. likewise mangled
   This produced broken formulas in generated ODS files and wrong R1C1 output.

2. **Markdown export breaks on multi-line cells.** `toMarkdown` escaped pipes but not newlines, so a cell containing `\n` spilled into extra table rows, corrupting the GFM table.

## Fix

- Added shared `replaceA1Refs` / `replaceA1Ranges` helpers in `src/cell-utils.ts` that:
  - split the formula on double-quoted string literals (Excel `""` escaping aware) and only rewrite refs in the code spans;
  - use lookbehind/lookahead to reject refs that are part of a larger identifier or immediately followed by `(` (function calls).
- `a1ToR1C1` and ODS `excelFormulaToOds` now use these helpers.
- `toMarkdown` renders embedded newlines as `<br>`.

## Tests

- New `test/formula-ref-safety.test.ts`: `a1ToR1C1` and ODS round-trip assert `LOG10`/`ATAN2`/`SUM` and quoted literals are preserved, refs and ranges still convert.
- `test/export-markdown.test.ts`: embedded newline no longer adds table rows.
- Full suite: 7604 pass. lint + typecheck clean. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)