### PR TITLE
fix: ODS reader text loss + JSON flatten __proto__ data loss

### DIFF
--- a/src/json/flatten.ts
+++ b/src/json/flatten.ts
@@ -30,7 +30,14 @@ export function flattenValue(
   const arrayJoin = options.arrayJoin ?? ", "
   const maxDepth = options.maxDepth ?? 32
 
-  const out: Record<string, CellValue> = {}
+  // Null-prototype so keys like "__proto__" / "constructor" (which
+  // JSON.parse produces as ordinary own properties) are stored as plain
+  // entries instead of hitting the prototype setter — which would silently
+  // drop the value (primitives) or corrupt the object (objects). Returned
+  // as-is: spread, JSON.stringify, Object.keys, and for-in all work on a
+  // null-prototype object; only inherited methods like .hasOwnProperty are
+  // absent (use Object.hasOwn / the `in` operator instead).
+  const out: Record<string, CellValue> = Object.create(null)
   walk(value, "", out, flatten, arrayJoin, maxDepth, 0)
   return out
 }

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -243,29 +243,41 @@ function odsStyleToCellStyle(def: OdsStyleDef): CellStyle {
 
 // ── Hyperlink Parsing ───────────────────────────────────────────────
 
-/** Extract text and hyperlink from a cell's children */
-function extractTextAndHyperlink(cell: XmlElement): { text: string; hyperlink?: Hyperlink } {
-  const textP = findChild(cell, "p")
-  if (!textP) return { text: "" }
-
-  // Look for <text:a> elements inside <text:p>
-  for (const child of textP.children) {
+/** Find the first <text:a> hyperlink anywhere under an element. */
+function findHyperlink(el: XmlElement): { href: string; display: string } | undefined {
+  for (const child of el.children) {
     if (typeof child === "string") continue
     const local = child.local || child.tag
     if (local === "a") {
       const href = child.attrs["xlink:href"]
-      const text = child.children.filter((c: unknown) => typeof c === "string").join("")
-      if (href) {
-        return {
-          text,
-          hyperlink: { target: href, display: text },
-        }
-      }
+      if (href) return { href, display: collectText(child) }
+    }
+    const nested = findHyperlink(child)
+    if (nested) return nested
+  }
+  return undefined
+}
+
+/** Extract text and hyperlink from a cell's children */
+function extractTextAndHyperlink(cell: XmlElement): { text: string; hyperlink?: Hyperlink } {
+  // A cell may hold multiple <text:p> paragraphs (ODF joins them with a
+  // newline). Collect the full text of every paragraph — including any text
+  // surrounding a hyperlink — rather than only the first paragraph or only
+  // the anchor text.
+  const paragraphs = findChildren(cell, "p")
+  if (paragraphs.length === 0) return { text: "" }
+
+  const text = paragraphs.map((p) => collectText(p)).join("\n")
+
+  // Surface the first hyperlink found in the cell, if any, without dropping
+  // the surrounding text.
+  for (const p of paragraphs) {
+    const link = findHyperlink(p)
+    if (link) {
+      return { text, hyperlink: { target: link.href, display: link.display } }
     }
   }
 
-  // No hyperlink — collect all text content (including from nested elements)
-  const text = collectText(textP)
   return { text }
 }
 

--- a/test/flatten-proto.test.ts
+++ b/test/flatten-proto.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { flattenValue } from "../src/json"
+
+describe("flattenValue — __proto__ / constructor keys are preserved", () => {
+  it("keeps a primitive value under a __proto__ key instead of dropping it", () => {
+    // JSON.parse produces "__proto__" as an ordinary own property.
+    const parsed = JSON.parse('{"__proto__": "x", "a": 1}')
+    const flat = flattenValue(parsed)
+    expect(flat["__proto__"]).toBe("x")
+    expect(flat["a"]).toBe(1)
+    expect(Object.keys(flat).sort()).toEqual(["__proto__", "a"])
+  })
+
+  it("does not pollute Object.prototype", () => {
+    const parsed = JSON.parse('{"__proto__": {"polluted": true}}')
+    flattenValue(parsed)
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  it("keeps a constructor key", () => {
+    const parsed = JSON.parse('{"constructor": "boom"}')
+    const flat = flattenValue(parsed)
+    expect(flat["constructor"]).toBe("boom")
+  })
+})

--- a/test/ods-text-extract.test.ts
+++ b/test/ods-text-extract.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { readOds } from "../src/ods/reader"
+
+const enc = new TextEncoder()
+
+/** Build a minimal ODS containing one sheet whose single cell holds the
+ *  given raw <table:table-cell> inner XML. */
+async function odsWithCell(cellInnerXml: string): Promise<Uint8Array> {
+  const content = `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <office:body><office:spreadsheet>
+    <table:table table:name="S">
+      <table:table-row>
+        <table:table-cell office:value-type="string">${cellInnerXml}</table:table-cell>
+      </table:table-row>
+    </table:table>
+  </office:spreadsheet></office:body>
+</office:document-content>`
+  const zip = new ZipWriter()
+  zip.add("mimetype", enc.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+    compress: false,
+  })
+  zip.add("content.xml", enc.encode(content))
+  return zip.build()
+}
+
+describe("ODS reader — multi-paragraph and surrounded hyperlinks", () => {
+  it("joins multiple <text:p> paragraphs with a newline", async () => {
+    const data = await odsWithCell("<text:p>line1</text:p><text:p>line2</text:p>")
+    const wb = await readOds(data)
+    expect(wb.sheets[0].rows[0][0]).toBe("line1\nline2")
+  })
+
+  it("keeps text surrounding a hyperlink", async () => {
+    const data = await odsWithCell(
+      '<text:p>before <text:a xlink:href="https://example.com">link</text:a> after</text:p>',
+    )
+    const wb = await readOds(data)
+    const cell = wb.sheets[0].cells?.get("0,0")
+    expect(wb.sheets[0].rows[0][0]).toBe("before link after")
+    expect(cell?.hyperlink?.target).toBe("https://example.com")
+    expect(cell?.hyperlink?.display).toBe("link")
+  })
+})


### PR DESCRIPTION
## Problems (from full-repo review)

1. **ODS reader drops cell text.** `extractTextAndHyperlink` read only the first `<text:p>` paragraph (multi-paragraph cells lost everything after the first), and when a `<text:a>` hyperlink was present it returned *only* the anchor text — so `before <link> after` came back as just `link`.

2. **JSON flatten silently loses `__proto__` / `constructor` keys.** `flattenValue` assigned results into a plain `{}`. Since `JSON.parse` produces `"__proto__"` as an ordinary own property, `out["__proto__"] = v` went through the prototype setter — dropping the value (primitive) or corrupting the object — instead of storing the key.

## Fixes

- `extractTextAndHyperlink` now joins all `<text:p>` paragraphs with `\n` and locates the first hyperlink (recursively) without discarding the surrounding text. Added `findHyperlink` helper.
- `flattenValue` builds its result on a null-prototype object (`Object.create(null)`), preserving `__proto__`/`constructor` keys and removing any prototype-pollution surface. `Object.keys`/spread/`JSON.stringify` on the result are unaffected.

## Tests

- `test/ods-text-extract.test.ts`: multi-paragraph join and surrounded-hyperlink text preservation (builds a minimal ODS in-memory).
- `test/flatten-proto.test.ts`: `__proto__`/`constructor` keys preserved; no Object.prototype pollution.
- Full suite: 7609 pass. lint + typecheck clean. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)