### PR TITLE
fix(zip): detect ZIP64 in random-access reader, fail with clear error

### DIFF
--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -13,6 +13,9 @@ const SIG_CENTRAL_DIR = 0x02014b50
 const SIG_END_OF_CENTRAL_DIR = 0x06054b50
 const SIG_DATA_DESCRIPTOR = 0x08074b50
 
+/** 0xFFFFFFFF marker that signals a 32-bit ZIP field overflowed into ZIP64. */
+const ZIP64_SENTINEL = 0xffffffff
+
 // ── Types ───────────────────────────────────────────────────────────
 
 interface CentralDirEntry {
@@ -176,6 +179,20 @@ export class ZipReader {
     const centralDirSize = this.view.getUint32(eocdOffset + 12, true)
     const centralDirOffset = this.view.getUint32(eocdOffset + 16, true)
     const entryCount = this.view.getUint16(eocdOffset + 10, true)
+
+    // ZIP64: when the entry count or central-directory size/offset overflows
+    // the 16-/32-bit EOCD fields they hold a 0xFFFF / 0xFFFFFFFF sentinel and
+    // the real values live in a ZIP64 EOCD record we don't parse. Fail loudly
+    // instead of silently reading a truncated entry list or a garbage offset.
+    if (
+      entryCount === 0xffff ||
+      centralDirSize === ZIP64_SENTINEL ||
+      centralDirOffset === ZIP64_SENTINEL
+    ) {
+      throw new ZipError(
+        "ZIP64 archives are not supported (entry count or size exceeds the classic ZIP limits)",
+      )
+    }
 
     this.readCentralDirectory(centralDirOffset, centralDirSize, entryCount)
   }

--- a/test/zip64-detection.test.ts
+++ b/test/zip64-detection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { ZipReader, ZipError } from "../src/zip/reader"
+
+const enc = new TextEncoder()
+
+/** Locate the End-Of-Central-Directory record (signature 0x06054b50). */
+function findEocd(buf: Uint8Array): number {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (view.getUint32(i, true) === 0x06054b50) return i
+  }
+  throw new Error("EOCD not found")
+}
+
+describe("ZipReader — ZIP64 sentinel detection", () => {
+  it("throws a clear error instead of mis-parsing a ZIP64-escaped entry count", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"))
+    const buf = await zip.build()
+
+    // Forge a ZIP64 escape: set the EOCD entry-count fields to 0xFFFF.
+    const eocd = findEocd(buf)
+    const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+    view.setUint16(eocd + 8, 0xffff, true) // total entries on this disk
+    view.setUint16(eocd + 10, 0xffff, true) // total entries
+
+    expect(() => new ZipReader(buf)).toThrow(ZipError)
+    expect(() => new ZipReader(buf)).toThrow(/ZIP64/)
+  })
+
+  it("still reads a normal (non-ZIP64) archive", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"))
+    const buf = await zip.build()
+    const reader = new ZipReader(buf)
+    expect(new TextDecoder().decode(await reader.extract("a.txt"))).toBe("hello")
+  })
+})


### PR DESCRIPTION
## Problem

The random-access `ZipReader` read the EOCD entry count as u16 and central-directory size/offset as u32 with no check for the ZIP64 escape sentinels (`0xFFFF` / `0xFFFFFFFF`). A ZIP64 archive (>65,535 entries, or ≥4 GiB) was silently mis-parsed — truncated entry list or garbage offset — instead of failing clearly. The streaming reader already detects this; the random-access path did not.

## Fix

After reading the EOCD, throw a `ZipError` when the entry count is `0xFFFF` or the central-directory size/offset is `0xFFFFFFFF`.

## Tests

`test/zip64-detection.test.ts`: forging a `0xFFFF` entry-count escape now throws `ZipError` matching `/ZIP64/`; a normal archive still reads back correctly.

Full suite: 7611 pass. lint + typecheck clean. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)