### PR TITLE
fix: XML parser strictness, XLS typed errors, and #338 typecheck regression

### DIFF
--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -45,6 +45,20 @@ export async function readXls(
   const stream = streams.get("Workbook") ?? streams.get("Book")
   if (!stream) throw new ParseError("Invalid XLS: missing Workbook stream")
 
+  // Record parsing reads many length-prefixed binary fields; a truncated or
+  // hostile file can make DataView accessors throw a raw RangeError. Wrap the
+  // whole pass so malformed input surfaces as the library's ParseError.
+  try {
+    return parseWorkbookRecords(stream, options)
+  } catch (err) {
+    if (err instanceof ParseError) throw err
+    throw new ParseError("Failed to parse XLS workbook (malformed or truncated)", undefined, {
+      cause: err,
+    })
+  }
+}
+
+function parseWorkbookRecords(stream: Uint8Array, options?: ReadOptions): Workbook {
   const records = parseRecords(stream)
   const offsetToIndex = new Map<number, number>()
   for (let i = 0; i < records.length; i++) offsetToIndex.set(records[i].offset, i)

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -46,6 +46,10 @@ function decodeEntities(text: string): string {
           ? parseInt(ref.slice(2), 16)
           : parseInt(ref.slice(1), 10)
       if (Number.isNaN(code)) return match
+      // A numeric reference outside the Unicode range (> 0x10FFFF) would make
+      // String.fromCodePoint throw a raw RangeError, escaping the library's
+      // error contract on hostile input. Leave such references unexpanded.
+      if (code < 0 || code > 0x10ffff) return match
       return String.fromCodePoint(code)
     }
     return ENTITY_MAP[ref] ?? match
@@ -442,11 +446,17 @@ export function parseXml(xml: string): XmlElement {
       stack[stack.length - 1].children.push(el)
       stack.push(el)
     },
-    onCloseTag(_tag) {
+    onCloseTag(tag) {
       if (stack.length <= 1) {
         throw new XmlError("Unexpected closing tag: no matching open tag")
       }
-      const el = stack.pop()!
+      const el = stack[stack.length - 1]
+      // A mismatched close tag (</b> closing <a>) means the document is
+      // malformed; mis-nesting silently would corrupt the parsed tree.
+      if (el.tag !== tag) {
+        throw new XmlError(`Mismatched closing tag: expected </${el.tag}> but found </${tag}>`)
+      }
+      stack.pop()
       // Collect direct text from text-only children
       if (el.children.length > 0) {
         const texts: string[] = []
@@ -463,6 +473,14 @@ export function parseXml(xml: string): XmlElement {
       stack[stack.length - 1].children.push(text)
     },
   })
+
+  // Any unclosed elements left on the stack mean the document was truncated
+  // mid-element; parsing "successfully" with silently missing data is worse
+  // than a clear error.
+  if (stack.length > 1) {
+    const unclosed = stack[stack.length - 1].tag
+    throw new XmlError(`Unexpected end of document: unclosed element <${unclosed}>`)
+  }
 
   // The root wrapper should have exactly one real child (the document element)
   if (root.children.length === 0) {

--- a/test/xml-parser.test.ts
+++ b/test/xml-parser.test.ts
@@ -545,6 +545,21 @@ describe("parseXml — errors", () => {
     expect(() => parseXml("<root></root")).toThrow(/unterminated/i)
   })
 
+  it("throws on a mismatched closing tag", () => {
+    expect(() => parseXml("<a><b></a></b>")).toThrow(/mismatched/i)
+  })
+
+  it("throws on a truncated document with an unclosed element", () => {
+    expect(() => parseXml("<a><b>text</b>")).toThrow(/unclosed/i)
+  })
+
+  it("leaves an out-of-range numeric character reference unexpanded instead of crashing", () => {
+    // &#x110000; (> U+10FFFF) would make String.fromCodePoint throw a raw
+    // RangeError; the parser must not crash on it.
+    const el = parseXml("<a>x&#x110000;y</a>")
+    expect(el.text).toBe("x&#x110000;y")
+  })
+
   it("includes position info in errors", () => {
     try {
       parseXml("<root>\n  <!-- unclosed")

--- a/test/zip64-detection.test.ts
+++ b/test/zip64-detection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { ZipWriter } from "../src/zip/writer"
-import { ZipReader, ZipError } from "../src/zip/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipError } from "../src/errors"
 
 const enc = new TextEncoder()
 


### PR DESCRIPTION
## Changes

**XML parser robustness** (`src/xml/parser.ts`)
- Reject mismatched closing tags (`</b>` closing `<a>`) — previously silently mis-nested the tree.
- Reject truncated documents that leave unclosed elements on the stack — previously parsed "successfully" with missing data.
- Out-of-range numeric character references (`&#x110000;`, > U+10FFFF) are left unexpanded instead of throwing a raw `RangeError`.

**XLS typed errors** (`src/xls/reader.ts`)
- Wrap BIFF record parsing so a truncated/malformed binary surfaces as `ParseError` instead of a raw `DataView` `RangeError`, matching the library's documented error contract.

**Hotfix: #338 typecheck regression**
- The zip64 test imported `ZipError` from `../src/zip/reader` (which only re-imports, doesn't re-export it), turning `main`'s CI red. Now imported from `../src/errors`.

## Tests
- New XML parser cases: mismatched tag, truncated doc, out-of-range numeric ref.
- Existing XLS suite still green (wrapper is error-type-only, no behavior change).
- Full suite: 7614 pass. lint 0/0, typecheck clean, `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)