### PR TITLE
fix: CSV yes/no not boolean-coerced; replaceCells/sortRows keep cells Map in sync

### DIFF
--- a/src/csv/reader.ts
+++ b/src/csv/reader.ts
@@ -342,10 +342,12 @@ function inferType(value: CellValue, preserveLeadingZeros: boolean): CellValue {
   const trimmed = value.trim()
   if (trimmed === "") return value
 
-  // Boolean detection
+  // Boolean detection — only the literal true/false. "yes"/"no" are NOT
+  // coerced: they collide with real data (the ISO country code "NO", a
+  // yes/no/maybe survey column) and most CSV libraries don't coerce them.
   const lower = trimmed.toLowerCase()
-  if (lower === "true" || lower === "yes") return true
-  if (lower === "false" || lower === "no") return false
+  if (lower === "true") return true
+  if (lower === "false") return false
 
   // ISO 8601 date detection (must come before number to avoid matching partial numbers)
   if (ISO_DATE_RE.test(trimmed)) {

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -13,9 +13,11 @@ function inferType(value: string, preserveLeadingZeros: boolean): CellValue {
   const trimmed = value.trim()
   if (trimmed === "") return value
 
+  // Only literal true/false — "yes"/"no" collide with real data (ISO code
+  // "NO", survey columns) and are left as strings. Mirrors parseCsv.
   const lower = trimmed.toLowerCase()
-  if (lower === "true" || lower === "yes") return true
-  if (lower === "false" || lower === "no") return false
+  if (lower === "true") return true
+  if (lower === "false") return false
 
   if (ISO_DATE_RE.test(trimmed)) {
     const d = new Date(trimmed)

--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -1227,12 +1227,14 @@ export function replaceCells(sheet: Sheet, find: CellValue | RegExp, replace: Ce
           }
           // Reset lastIndex after test() for global regexes
           find.lastIndex = 0
+          syncCellOverride(sheet, r, c, row[c]!)
           count++
         }
       } else {
         // Exact value matching
         if (value === find) {
           row[c] = replace
+          syncCellOverride(sheet, r, c, replace)
           count++
         }
       }
@@ -1255,12 +1257,56 @@ export function replaceCells(sheet: Sheet, find: CellValue | RegExp, replace: Ce
 export function sortRows(sheet: Sheet, colIndex: number, order?: "asc" | "desc"): void {
   const desc = order === "desc"
 
+  // When the sheet carries a per-cell override Map (styles/formulas/
+  // hyperlinks keyed by "row,col"), the row reordering has to be mirrored
+  // there or every override lands on the wrong row. Tag each row with its
+  // original index, sort, then rebuild the Map from old→new index.
+  if (sheet.cells && sheet.cells.size > 0) {
+    const tagged = sheet.rows.map((row, i) => ({ row, i }))
+    tagged.sort((a, b) => {
+      const va = colIndex < a.row.length ? (a.row[colIndex] ?? null) : null
+      const vb = colIndex < b.row.length ? (b.row[colIndex] ?? null) : null
+      const cmp = compareCellValues(va, vb)
+      return desc ? -cmp : cmp
+    })
+
+    const oldToNew = new Map<number, number>()
+    for (let newIdx = 0; newIdx < tagged.length; newIdx++) {
+      oldToNew.set(tagged[newIdx]!.i, newIdx)
+    }
+
+    const remapped = new Map<string, Cell>()
+    for (const [key, cell] of sheet.cells) {
+      const comma = key.indexOf(",")
+      const oldRow = Number(key.slice(0, comma))
+      const col = key.slice(comma + 1)
+      const newRow = oldToNew.get(oldRow)
+      // Keep non-positional keys untouched if any slipped in.
+      remapped.set(newRow === undefined ? key : `${newRow},${col}`, cell)
+    }
+
+    sheet.rows = tagged.map((t) => t.row)
+    sheet.cells = remapped
+    return
+  }
+
   sheet.rows.sort((a, b) => {
     const va = colIndex < a.length ? (a[colIndex] ?? null) : null
     const vb = colIndex < b.length ? (b[colIndex] ?? null) : null
     const cmp = compareCellValues(va, vb)
     return desc ? -cmp : cmp
   })
+}
+
+/**
+ * Keep a sheet's per-cell override Map in sync when a row value changes via
+ * {@link replaceCells}: if an override exists at (row,col), update its
+ * `value` so the writer (which prefers the override) doesn't emit the stale
+ * pre-replace value.
+ */
+function syncCellOverride(sheet: Sheet, row: number, col: number, value: CellValue): void {
+  const existing = sheet.cells?.get(`${row},${col}`)
+  if (existing) existing.value = value
 }
 
 /** Compare two cell values for sorting: nulls last, numbers < strings < booleans. */

--- a/test/csv-reader.test.ts
+++ b/test/csv-reader.test.ts
@@ -295,9 +295,9 @@ describe("parseCsv", () => {
     expect(result).toEqual([[true, false]])
   })
 
-  it("should infer booleans: yes/no", () => {
+  it("should NOT coerce yes/no to booleans (collides with ISO code 'NO', surveys)", () => {
     const result = parseCsv("yes,no", { typeInference: true })
-    expect(result).toEqual([[true, false]])
+    expect(result).toEqual([["yes", "no"]])
   })
 
   it("should infer 1/0 as numbers (not booleans)", () => {

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -524,7 +524,7 @@ describe("CSV Edge Cases", () => {
     expect(rows[3][0]).toBe(1e5)
   })
 
-  it("type inference: true/TRUE/True/yes/YES", () => {
+  it("type inference: true/TRUE/True coerce; yes/YES stay strings", () => {
     const csv = "true\nTRUE\nTrue\nyes\nYES\nYes"
     const rows = parseCsv(csv, { typeInference: true })
 
@@ -532,9 +532,10 @@ describe("CSV Edge Cases", () => {
     expect(rows[0][0]).toBe(true)
     expect(rows[1][0]).toBe(true)
     expect(rows[2][0]).toBe(true)
-    expect(rows[3][0]).toBe(true)
-    expect(rows[4][0]).toBe(true)
-    expect(rows[5][0]).toBe(true)
+    // "yes"/"YES" are NOT coerced — they collide with real data.
+    expect(rows[3][0]).toBe("yes")
+    expect(rows[4][0]).toBe("YES")
+    expect(rows[5][0]).toBe("Yes")
   })
 
   it("type inference: null, undefined, NaN, Infinity should stay strings", () => {

--- a/test/sheet-ops-cells-sync.test.ts
+++ b/test/sheet-ops-cells-sync.test.ts
@@ -5,7 +5,7 @@ import { replaceCells, sortRows } from "../src/sheet-ops"
 describe("replaceCells — keeps cells override Map in sync", () => {
   it("updates the override value when the row value is replaced", () => {
     const cells = new Map<string, Cell>()
-    cells.set("0,0", { value: "old", style: { bold: true } })
+    cells.set("0,0", { type: "string", value: "old", style: { font: { bold: true } } })
     const sheet: Sheet = { name: "S", rows: [["old"]], cells }
 
     const n = replaceCells(sheet, "old", "new")
@@ -13,7 +13,7 @@ describe("replaceCells — keeps cells override Map in sync", () => {
     expect(sheet.rows[0][0]).toBe("new")
     // The styled override must not keep the stale value.
     expect(sheet.cells!.get("0,0")!.value).toBe("new")
-    expect(sheet.cells!.get("0,0")!.style?.bold).toBe(true)
+    expect(sheet.cells!.get("0,0")!.style?.font?.bold).toBe(true)
   })
 })
 
@@ -21,14 +21,14 @@ describe("sortRows — remaps cells override Map to new row positions", () => {
   it("moves a styled cell with its row", () => {
     const cells = new Map<string, Cell>()
     // Style attached to the row that currently holds value 3 (row 0).
-    cells.set("0,0", { value: 3, style: { bold: true } })
+    cells.set("0,0", { type: "number", value: 3, style: { font: { bold: true } } })
     const sheet: Sheet = { name: "S", rows: [[3], [1], [2]], cells }
 
     sortRows(sheet, 0, "asc")
 
     // Rows are now 1,2,3 — the styled cell (value 3) is at row index 2.
     expect(sheet.rows.map((r) => r[0])).toEqual([1, 2, 3])
-    expect(sheet.cells!.get("2,0")?.style?.bold).toBe(true)
-    expect(sheet.cells!.get("0,0")?.style?.bold).toBeUndefined()
+    expect(sheet.cells!.get("2,0")?.style?.font?.bold).toBe(true)
+    expect(sheet.cells!.get("0,0")?.style?.font?.bold).toBeUndefined()
   })
 })

--- a/test/sheet-ops-cells-sync.test.ts
+++ b/test/sheet-ops-cells-sync.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import type { Cell, Sheet } from "../src/_types"
+import { replaceCells, sortRows } from "../src/sheet-ops"
+
+describe("replaceCells — keeps cells override Map in sync", () => {
+  it("updates the override value when the row value is replaced", () => {
+    const cells = new Map<string, Cell>()
+    cells.set("0,0", { value: "old", style: { bold: true } })
+    const sheet: Sheet = { name: "S", rows: [["old"]], cells }
+
+    const n = replaceCells(sheet, "old", "new")
+    expect(n).toBe(1)
+    expect(sheet.rows[0][0]).toBe("new")
+    // The styled override must not keep the stale value.
+    expect(sheet.cells!.get("0,0")!.value).toBe("new")
+    expect(sheet.cells!.get("0,0")!.style?.bold).toBe(true)
+  })
+})
+
+describe("sortRows — remaps cells override Map to new row positions", () => {
+  it("moves a styled cell with its row", () => {
+    const cells = new Map<string, Cell>()
+    // Style attached to the row that currently holds value 3 (row 0).
+    cells.set("0,0", { value: 3, style: { bold: true } })
+    const sheet: Sheet = { name: "S", rows: [[3], [1], [2]], cells }
+
+    sortRows(sheet, 0, "asc")
+
+    // Rows are now 1,2,3 — the styled cell (value 3) is at row index 2.
+    expect(sheet.rows.map((r) => r[0])).toEqual([1, 2, 3])
+    expect(sheet.cells!.get("2,0")?.style?.bold).toBe(true)
+    expect(sheet.cells!.get("0,0")?.style?.bold).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Changes (behavior-affecting — explicitly requested)

**CSV type inference** (`src/csv/reader.ts`, `src/csv/stream.ts`)
- `typeInference` now coerces only the literal `true`/`false`. `"yes"`/`"no"` are left as strings — they collide with real data (the ISO country code `NO`, a yes/no/maybe survey column) and most CSV libraries don't coerce them.
- ⚠️ Minor breaking change: `yes`/`no` with `typeInference: true` now stay strings.

**Sheet ops cells-Map sync** (`src/sheet-ops.ts`)
- `replaceCells` updates the matching `cells` override entry's `value` so the writer (which prefers the override) doesn't emit the stale value.
- `sortRows` remaps the `cells` override Map to the new row positions, so styles/formulas/hyperlinks move with their row instead of sticking to the old index.

## Tests
- Updated 3 existing CSV tests that asserted yes/no→boolean.
- New `test/sheet-ops-cells-sync.test.ts`: replace updates override value; sort moves styled cell with its row.
- Full suite: 7616 pass. lint 0/0, typecheck clean, `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)