### PR TITLE
feat(xls): reject BIFF5/7 with a clear error instead of decoding garbage

### DIFF
--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -60,6 +60,26 @@ export async function readXls(
 
 function parseWorkbookRecords(stream: Uint8Array, options?: ReadOptions): Workbook {
   const records = parseRecords(stream)
+
+  // ── BIFF version gate ──
+  // The first record is the workbook globals BOF; its first u16 is the BIFF
+  // version (0x0600 = BIFF8). BIFF5/7 store strings as codepage byte strings
+  // with a different SST/record layout — parsing them as BIFF8 yields garbage
+  // names and cell text, so reject them with a clear error instead.
+  const bof = records[0]
+  if (!bof || bof.id !== SID.BOF) {
+    throw new ParseError("Invalid XLS: missing BOF record at start of Workbook stream")
+  }
+  if (bof.data.length >= 2) {
+    const biffVersion = new Reader(bof.data).u16()
+    if (biffVersion !== 0x0600) {
+      throw new ParseError(
+        `Unsupported XLS version (BIFF 0x${biffVersion.toString(16)}). ` +
+          "Only BIFF8 (Excel 97-2003) is supported; re-save the file as .xlsx or BIFF8 .xls.",
+      )
+    }
+  }
+
   const offsetToIndex = new Map<number, number>()
   for (let i = 0; i < records.length; i++) offsetToIndex.set(records[i].offset, i)
 

--- a/test/xls.test.ts
+++ b/test/xls.test.ts
@@ -133,4 +133,19 @@ describe("XLS (BIFF8) reader", () => {
     expect(wb.sheets[0].rows[1][0]).toBe("Ada")
     expect(wb.sheets[0].rows[1][1]).toBe(95)
   })
+
+  it("rejects BIFF5/7 (0x0500) workbooks with a clear error", async () => {
+    // A globals BOF declaring BIFF version 0x0500 (Excel 5/95), then EOF.
+    const biff5Bof = record(SID.BOF, [
+      ...u16(0x0500),
+      ...u16(0x0005),
+      ...u16(0),
+      ...u16(0),
+      ...u32(0),
+      ...u32(0),
+    ])
+    const stream = concat([biff5Bof, eof()])
+    const data = writeCfb([{ name: "Workbook", data: stream }])
+    await expect(readXls(data)).rejects.toThrow(/BIFF/)
+  })
 })


### PR DESCRIPTION
## Problem

The XLS reader parsed any `Workbook`/`Book` stream with BIFF8 logic. BIFF5/7 (Excel 5/95) use codepage byte strings and a different SST/record layout, so such files decoded to garbage sheet names and cell text rather than failing.

## Fix

Check the globals BOF version (first u16 of the first record) up front. Anything other than BIFF8 (`0x0600`) — and a missing/invalid BOF — is rejected with a clear `ParseError` telling the user to re-save as `.xlsx` or BIFF8 `.xls`.

(Full BIFF5 *support* would need codepage decoding and a separate SST path; this PR makes the failure honest. Tracking the rest separately.)

## Tests

`test/xls.test.ts`: a BIFF5 (`0x0500`) BOF now rejects with `/BIFF/`; existing BIFF8 round-trip and auto-detect tests still pass.

Full chain (`pnpm test`): lint 0/0, format clean, typecheck clean, 7617 tests pass. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)