### PR TITLE
fix(ods): streaming reader text/sheet parity + repeat-count DoS caps

### DIFF
--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -17,6 +17,7 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseXml } from "../xml/parser"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../limits"
 import type { XmlElement } from "../xml/parser"
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -510,7 +511,11 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
       let col = 0
 
       for (const entry of cellEntries) {
-        for (let r = 0; r < entry.repeat; r++) {
+        // Clamp column repeats too: a non-trailing cell with a huge
+        // number-columns-repeated would otherwise allocate past Excel's
+        // column limit. (Trailing empty repeats are already trimmed above.)
+        const repeat = Math.min(entry.repeat, MAX_COL_INDEX + 1)
+        for (let r = 0; r < repeat; r++) {
           rowData.push(entry.value)
 
           // Collect merge ranges
@@ -568,8 +573,11 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
       }
 
       // Cap row repeats for empty rows to avoid memory issues
-      // (LibreOffice may emit large row repeats for trailing empty rows)
-      const effectiveRowRepeat = rowData.length > 0 ? rowRepeat : 0
+      // (LibreOffice may emit large row repeats for trailing empty rows).
+      // For non-empty rows, a hostile file can set a huge number-rows-repeated
+      // on a one-cell row to force millions of allocations — clamp to Excel's
+      // row limit.
+      const effectiveRowRepeat = rowData.length > 0 ? Math.min(rowRepeat, MAX_ROW_INDEX + 1) : 0
 
       for (let r = 0; r < effectiveRowRepeat; r++) {
         rows.push(effectiveRowRepeat === 1 && r === 0 ? rowData : [...rowData])

--- a/src/ods/stream.ts
+++ b/src/ods/stream.ts
@@ -6,6 +6,7 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseSax } from "../xml/parser"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../limits"
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -21,8 +22,10 @@ function toUint8Array(input: Uint8Array | ArrayBuffer): Uint8Array {
 // ── Row parser via SAX ──────────────────────────────────────────────
 
 interface OdsStreamRow {
-  /** 0-based row index */
+  /** 0-based row index within its sheet */
   index: number
+  /** 0-based index of the sheet (table) this row belongs to */
+  sheetIndex: number
   /** Cell values for this row */
   values: CellValue[]
 }
@@ -37,6 +40,7 @@ function* parseContentRows(xml: string): Generator<OdsStreamRow, void, undefined
   let inCell = false
   let inP = false
 
+  let sheetIndex = -1
   let currentRowIndex = -1
   let cellRepeat = 1
   let rowRepeat = 1
@@ -61,20 +65,28 @@ function* parseContentRows(xml: string): Generator<OdsStreamRow, void, undefined
         case "table":
           if (inSpreadsheet) {
             inTable = true
+            sheetIndex++
             currentRowIndex = -1
           }
           break
         case "table-row":
           if (inTable) {
             inRow = true
-            rowRepeat = Number(attrs["table:number-rows-repeated"] ?? "1")
+            // Clamp against a hostile huge number-rows-repeated on a row.
+            rowRepeat = Math.min(
+              Number(attrs["table:number-rows-repeated"] ?? "1"),
+              MAX_ROW_INDEX + 1,
+            )
             currentCells = []
           }
           break
         case "table-cell":
           if (inRow) {
             inCell = true
-            cellRepeat = Number(attrs["table:number-columns-repeated"] ?? "1")
+            cellRepeat = Math.min(
+              Number(attrs["table:number-columns-repeated"] ?? "1"),
+              MAX_COL_INDEX + 1,
+            )
             cellText = ""
             cellValueType = attrs["office:value-type"] ?? attrs["calcext:value-type"] ?? ""
             cellValue = attrs["office:value"] ?? ""
@@ -84,7 +96,10 @@ function* parseContentRows(xml: string): Generator<OdsStreamRow, void, undefined
           break
         case "covered-table-cell":
           if (inRow) {
-            const repeat = Number(attrs["table:number-columns-repeated"] ?? "1")
+            const repeat = Math.min(
+              Number(attrs["table:number-columns-repeated"] ?? "1"),
+              MAX_COL_INDEX + 1,
+            )
             for (let i = 0; i < repeat; i++) {
               currentCells.push(null)
             }
@@ -92,6 +107,20 @@ function* parseContentRows(xml: string): Generator<OdsStreamRow, void, undefined
           break
         case "p":
           if (inCell) inP = true
+          break
+        // Text content special elements — mirror collectText() in reader.ts so
+        // the streaming and batch readers return the same string for a cell.
+        case "s":
+          if (inP && inCell) {
+            const count = Number(attrs["text:c"] ?? "1")
+            cellText += " ".repeat(count > 0 ? count : 1)
+          }
+          break
+        case "line-break":
+          if (inP && inCell) cellText += "\n"
+          break
+        case "tab":
+          if (inP && inCell) cellText += "\t"
           break
       }
     },
@@ -138,6 +167,7 @@ function* parseContentRows(xml: string): Generator<OdsStreamRow, void, undefined
                 currentRowIndex++
                 completedRows.push({
                   index: currentRowIndex,
+                  sheetIndex,
                   values: r === 0 ? currentCells : [...currentCells],
                 })
               }

--- a/test/ods-stream-parity.test.ts
+++ b/test/ods-stream-parity.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { writeOds } from "../src/ods/writer"
+import { streamOdsRows } from "../src/ods/stream"
+import { readOds } from "../src/ods/reader"
+
+const enc = new TextEncoder()
+
+async function odsFromContent(bodyXml: string): Promise<Uint8Array> {
+  const content = `<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">
+  <office:body><office:spreadsheet>${bodyXml}</office:spreadsheet></office:body>
+</office:document-content>`
+  const zip = new ZipWriter()
+  zip.add("mimetype", enc.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+    compress: false,
+  })
+  zip.add("content.xml", enc.encode(content))
+  return zip.build()
+}
+
+describe("streamOdsRows — text element parity with batch reader", () => {
+  it("expands text:s / line-break / tab like collectText", async () => {
+    const buf = await odsFromContent(
+      `<table:table table:name="S"><table:table-row><table:table-cell office:value-type="string">` +
+        `<text:p>a<text:s text:c="2"/>b<text:tab/>c<text:line-break/>d</text:p>` +
+        `</table:table-cell></table:table-row></table:table>`,
+    )
+    const rows = []
+    for await (const row of streamOdsRows(buf)) rows.push(row)
+    expect(rows[0].values[0]).toBe("a  b\tc\nd")
+  })
+})
+
+describe("streamOdsRows — sheet index", () => {
+  it("tags rows with their sheet index", async () => {
+    const buf = await writeOds({
+      sheets: [
+        { name: "One", rows: [["a"]] },
+        { name: "Two", rows: [["b"], ["c"]] },
+      ],
+    })
+    const rows = []
+    for await (const row of streamOdsRows(buf)) rows.push(row)
+    expect(rows.map((r) => [r.sheetIndex, r.index, r.values[0]])).toEqual([
+      [0, 0, "a"],
+      [1, 0, "b"],
+      [1, 1, "c"],
+    ])
+  })
+})
+
+describe("streamOdsRows — number-rows-repeated DoS cap", () => {
+  it("does not allocate millions of rows for a non-empty repeated row", async () => {
+    const buf = await odsFromContent(
+      `<table:table table:name="S"><table:table-row table:number-rows-repeated="5000000">` +
+        `<table:table-cell office:value-type="float" office:value="1"/></table:table-row></table:table>`,
+    )
+    let count = 0
+    for await (const _row of streamOdsRows(buf)) {
+      count++
+      if (count > 1_048_576) break // safety
+    }
+    expect(count).toBeLessThanOrEqual(1_048_576)
+    expect(count).toBeGreaterThan(0)
+  })
+
+  it("batch readOds also caps a non-empty repeated row", async () => {
+    const buf = await odsFromContent(
+      `<table:table table:name="S"><table:table-row table:number-rows-repeated="5000000">` +
+        `<table:table-cell office:value-type="float" office:value="1"/></table:table-row></table:table>`,
+    )
+    const wb = await readOds(buf)
+    expect(wb.sheets[0].rows.length).toBeLessThanOrEqual(1_048_576)
+    expect(wb.sheets[0].rows.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Changes

**streamOdsRows** (`src/ods/stream.ts`)
- Expand `text:s` / `text:line-break` / `text:tab` like the batch reader's `collectText`, so streaming and batch return identical cell strings (previously these were ignored in the stream path).
- Tag each yielded row with `sheetIndex` so multi-sheet documents are disambiguable — the per-table `index` restarts at 0 per sheet, so callers couldn't tell sheets apart before.
- Clamp `number-rows-repeated` / `number-columns-repeated` to Excel limits — a crafted huge repeat on a non-empty row/cell could otherwise force millions of allocations (memory DoS).

**readOds** (`src/ods/reader.ts`)
- Also clamp non-empty `number-rows-repeated` and non-trailing `number-columns-repeated` to Excel limits (only trailing-empty repeats were capped before).

## Tests
`test/ods-stream-parity.test.ts`: text-element parity, sheet-index tagging, and DoS caps for both stream and batch readers.

Full chain (`pnpm test`): lint 0/0, format clean, typecheck clean, 7621 tests pass. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)