### PR TITLE
fix(xlsb): surface malformed .bin as ParseError

### DIFF
--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -119,6 +119,27 @@ export async function readXlsb(
   }
   const workbookDir = dirname(workbookPath)
 
+  // Binary record parsing reads many length-prefixed fields; a truncated or
+  // hostile .bin can make the Cursor/DataView throw a raw RangeError. Wrap the
+  // parse so malformed input surfaces as the library's ParseError.
+  try {
+    return await parseXlsbParts(zip, workbookPath, workbookDir, date1904)
+  } catch (err) {
+    if (err instanceof ParseError || err instanceof EncryptedFileError || err instanceof ZipError) {
+      throw err
+    }
+    throw new ParseError("Failed to parse XLSB workbook (malformed or truncated)", undefined, {
+      cause: err,
+    })
+  }
+}
+
+async function parseXlsbParts(
+  zip: ZipReader,
+  workbookPath: string,
+  workbookDir: string,
+  date1904: boolean,
+): Promise<Workbook> {
   // Sheets (name + relId) from the workbook .bin.
   const sheetEntries = parseWorkbookBin(await zip.extract(workbookPath))
 

--- a/test/xlsb.test.ts
+++ b/test/xlsb.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { ZipWriter } from "../src/zip/writer"
 import { readXlsb } from "../src/xlsx/xlsb/reader"
 import { read } from "../src/defter"
+import { ParseError } from "../src/errors"
 
 // ── Minimal XLSB builder (test-only) ─────────────────────────────────
 // Emits valid MS-XLSB binary records so the reader can be round-tripped
@@ -166,5 +167,19 @@ describe("XLSB reader", () => {
     zw.add("xl/worksheets/sheet1.bin", ws)
     const out = await readXlsb(await zw.build())
     expect(out.sheets[0].rows[0][0]).toBeCloseTo(12.34, 5)
+  })
+
+  it("surfaces a malformed workbook.bin as ParseError, not a raw RangeError", async () => {
+    // A BrtBundleSh record whose body is truncated (only the 4-byte hsState,
+    // missing iTabID/relId/name) makes the Cursor read past the end.
+    const wb = rec(BrtBundleSh, u32(0))
+    const rels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/></Relationships>`
+    const ct = `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>`
+    const zw = new ZipWriter()
+    zw.add("[Content_Types].xml", enc.encode(ct))
+    zw.add("_rels/.rels", enc.encode(rels))
+    zw.add("xl/workbook.bin", wb)
+
+    await expect(readXlsb(await zw.build())).rejects.toBeInstanceOf(ParseError)
   })
 })


### PR DESCRIPTION
## Change

XLSB binary record parsing could throw a raw `DataView`/`Cursor` `RangeError` on a truncated or hostile `.bin`. Wrapped the parse (`parseXlsbParts`) so malformed input surfaces as the library's `ParseError`, matching the XLS reader's contract from #339/#341.

## Not done (deliberately)

XLSB 1904 date-system auto-detection (`BrtWbProp`/`f1904`) was reviewed but **not** added: there is no XLSB *writer* in the repo to verify the flag bit against, and no 1904 fixture, so hard-coding a bit position risks silent ±1462-day corruption. The `dateSystem` read option still controls it. Tracking separately if a verified fixture appears.

## Tests

`test/xlsb.test.ts`: a truncated `BrtBundleSh` body now rejects with `ParseError` instead of a raw RangeError; existing round-trip tests still pass.

Full chain (`pnpm test`): lint 0/0, format clean, typecheck clean, 7622 tests pass. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)