### PR TITLE
fix(html-import): colspan fill after rowspan-reserved column

### DIFF
--- a/src/export/html-import.ts
+++ b/src/export/html-import.ts
@@ -80,11 +80,12 @@ export function fromHtml(html: string, options?: { sheetName?: string }): Sheet 
         // Place the value
         currentRowCells.push(value)
 
-        // Fill extra colspan cells with null
+        // Fill the remaining colspan slots with null. Track the actual grid
+        // column via currentRowCells.length so any cells reserved by an
+        // earlier row's rowspan (occupied) are skipped correctly — the old
+        // arithmetic drifted as nulls were pushed.
         for (let c = 1; c < currentCellColspan; c++) {
-          const nextCol = col + c
-          // Skip occupied cells between colspan fills
-          while (occupied.has(`${currentRow},${nextCol + currentRowCells.length - col - 1}`)) {
+          while (occupied.has(`${currentRow},${currentRowCells.length}`)) {
             currentRowCells.push(null)
           }
           currentRowCells.push(null)

--- a/test/extras.test.ts
+++ b/test/extras.test.ts
@@ -142,6 +142,21 @@ describe("fromHtml", () => {
     })
   })
 
+  it("handles a colspan cell after a rowspan-reserved column", () => {
+    // Row 0: A spans 2 rows in col 0; B spans 2 cols (col 1-2).
+    // Row 1: col 0 is reserved by A's rowspan, then C spans cols 1-2.
+    const html = `
+      <table>
+        <tr><td rowspan="2">A</td><td colspan="2">B</td></tr>
+        <tr><td colspan="2">C</td></tr>
+      </table>
+    `
+    const sheet = fromHtml(html)
+    expect(sheet.rows[0]).toEqual(["A", "B", null])
+    // C must land at col 1 (col 0 occupied by rowspan), not col 0.
+    expect(sheet.rows[1]).toEqual([null, "C", null])
+  })
+
   it("returns empty rows for an empty table", () => {
     const html = "<table></table>"
     const sheet = fromHtml(html)


### PR DESCRIPTION
## Problem

In `fromHtml`, the colspan filler computed each fill position as `nextCol + currentRowCells.length - col - 1`. Because `currentRowCells.length` changes as nulls are pushed inside the loop, the offset drifted — a `colspan` cell following a column reserved by an earlier row's `rowspan` was misplaced.

## Fix

Track the actual grid column directly via `currentRowCells.length` and skip `occupied` cells, so colspan slots and rowspan reservations interleave correctly.

## Tests

`test/extras.test.ts`: new case — `A rowspan=2` in col 0 plus `colspan=2` cells; the second row's colspan cell now correctly lands at col 1. Existing colspan/rowspan tests still pass.

Full chain (`pnpm test`): lint 0/0, format clean, typecheck clean, 7623 tests pass. `pnpm build` emits all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)