### PR TITLE
feat(xlsx): true constant-memory streaming writer — closes #347

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ import { readXml, writeXml } from "hucre/xml" // Tabular XML
 | --------------------- | ------------ | ------------- | --------------- | --------------- | ----------------- |
 | **Read XLSX**         | Yes          | Yes           | No              | No              | Yes               |
 | **Write XLSX**        | Yes          | Yes           | Yes             | Yes             | Yes               |
-| **Streaming**         | Read+Write   | Write-only    | No              | const_memory    | SXSSF (write)     |
+| **Streaming**         | Read+Write   | Write-only    | const_memory    | const_memory    | SXSSF (write)     |
 | **Charts**            | Round-trip   | 15+ types     | 9 types         | 12+ types       | Limited           |
 | **Pivot tables**      | Read + Write | Read-only     | No              | No              | Limited           |
 | **Cond. formatting**  | Yes (all)    | Yes           | Yes             | Yes             | Yes               |
@@ -273,7 +273,7 @@ await writeXlsx({
 Process large files row-by-row without loading everything into memory:
 
 ```ts
-import { streamXlsxRows, XlsxStreamWriter } from "hucre/xlsx"
+import { streamXlsxRows, writeXlsxStream, XlsxStreamWriter } from "hucre/xlsx"
 
 // Stream read — async generator yields rows one at a time
 for await (const row of streamXlsxRows(buffer)) {
@@ -307,7 +307,31 @@ for await (const row of streamXlsxRows(buffer, { range: "B2:D1000" })) {
   // row.values[1..3] carry B/C/D
 }
 
-// Stream write — add rows incrementally
+// Stream write — the workbook is emitted as bytes while rows are pulled
+// from the source, so peak memory doesn't grow with the row count.
+function* rows() {
+  for (let i = 0; i < 5_000_000; i++) yield [i + 1, Math.random()]
+}
+
+return new Response(
+  writeXlsxStream(
+    {
+      name: "BigData",
+      columns: [{ header: "ID" }, { header: "Value" }],
+      freezePane: { rows: 1 },
+    },
+    rows(), // any Iterable or AsyncIterable — a DB cursor, another stream, …
+  ),
+  {
+    headers: {
+      "content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    },
+  },
+)
+
+// Incremental write — serializes each row on arrival, but holds the
+// serialized parts until finish() returns one buffer. Use it when you
+// need a Uint8Array anyway; use writeXlsxStream for constant memory.
 const writer = new XlsxStreamWriter({
   name: "BigData",
   columns: [{ header: "ID" }, { header: "Value" }],
@@ -319,11 +343,47 @@ for (let i = 0; i < 100_000; i++) {
 const buffer = await writer.finish()
 ```
 
+#### Which writer to use
+
+|             | `writeXlsxStream()`             | `XlsxStreamWriter`                |
+| ----------- | ------------------------------- | --------------------------------- |
+| Output      | `ReadableStream<Uint8Array>`    | `Promise<Uint8Array>`             |
+| Rows        | pulled from an (async) iterable | pushed via `addRow` / `addObject` |
+| Peak memory | O(distinct styles) — flat       | O(data)                           |
+| Strings     | inline by default               | shared string table               |
+
+Measured on 5 columns of mixed text/number/date data, writing to a sink
+that discards the bytes (Node 24):
+
+|      Rows | `writeXlsxStream` peak heap | `XlsxStreamWriter` peak heap |
+| --------: | --------------------------: | ---------------------------: |
+|   300,000 |                       41 MB |                       328 MB |
+| 1,000,000 |                       67 MB |                     1,037 MB |
+| 3,000,000 |                       70 MB |                   not viable |
+
+Streaming trade-offs worth knowing:
+
+- Strings are written inline (`t="inlineStr"`) by default. A shared
+  string table has to live in memory until the workbook closes, which
+  would undo the constant-memory guarantee — pass `inlineStrings: false`
+  when the data is repetitive and file size matters more.
+- Part sizes aren't known when their ZIP headers go out, so entries carry
+  trailing ZIP data descriptors and `[Content_Types].xml` is written last.
+  That's the same layout `archiver`/`zip-stream` emit, which is what
+  ExcelJS's own streaming writer produces. Verified against `hucre`'s
+  reader, ExcelJS, and `unzip`.
+- Zip64 is not emitted, so any single part — and the whole archive — caps
+  at 4 GiB. Crossing it throws rather than writing a broken file.
+- Compression uses the platform `CompressionStream`. Without it, parts are
+  stored uncompressed rather than buffered.
+
 #### Auto-split past Excel's row limit
 
 Pass `maxRowsPerSheet` to spill into `{name}_2`, `{name}_3`, … when the
 data crosses Excel's 1,048,576-row hard limit (default). The captured
 header row is repeated on every rolled sheet.
+
+Both writers do this.
 
 ```ts
 import { XlsxStreamWriter, XLSX_MAX_ROWS_PER_SHEET } from "hucre/xlsx"
@@ -1261,13 +1321,13 @@ hucre works everywhere — no Node.js APIs (`fs`, `crypto`, `Buffer`) in core.
 
 ```
 hucre (~37 KB gzipped)
-├── zip/            Zero-dep DEFLATE/inflate + ZIP read/write
+├── zip/            Zero-dep DEFLATE/inflate + ZIP read/write (+ streaming both ways)
 ├── xml/            SAX parser + XML writer (CSP-compliant, no eval)
 ├── xlsx/
 │   ├── reader      Shared strings, styles, worksheets, relationships
 │   ├── writer      Styles, shared strings, drawing, tables, comments
 │   ├── roundtrip   Open → modify → save with preservation
-│   ├── stream-*    Streaming reader (AsyncGenerator) + writer
+│   ├── stream-*    Streaming reader (AsyncGenerator) + incremental/streaming writers
 │   └── auto-width  Font-aware column width calculation
 ├── ods/            OpenDocument Spreadsheet read/write
 ├── csv/            RFC 4180 parser/writer + streaming
@@ -1309,6 +1369,7 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 | `openXlsx(input, options?)`        | Open for round-trip (preserves unknown parts)                               |
 | `saveXlsx(workbook)`               | Save round-trip workbook back to XLSX                                       |
 | `streamXlsxRows(input, options?)`  | AsyncGenerator yielding rows one at a time                                  |
+| `writeXlsxStream(options, rows)`   | Constant-memory XLSX writing — returns a `ReadableStream<Uint8Array>`       |
 | `XlsxStreamWriter`                 | Incremental row-by-row XLSX writing; auto-splits past `maxRowsPerSheet`     |
 | `XLSX_MAX_ROWS_PER_SHEET`          | Excel hard row limit (1,048,576) — exported constant                        |
 | `parseExternalLink(xml, relsXml?)` | Parse `xl/externalLinks/externalLinkN.xml` → `ExternalLink`                 |

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,12 @@ export { calculateColumnWidth, measureValueWidth, calculateRowHeight } from "./x
 export { parseThemeColors, resolveThemeColor } from "./xlsx/theme"
 export { streamXlsxRows } from "./xlsx/stream-reader"
 export type { StreamRow } from "./xlsx/stream-reader"
-export { XlsxStreamWriter } from "./xlsx/stream-writer"
-export type { StreamWriterOptions } from "./xlsx/stream-writer"
+export { XlsxStreamWriter, writeXlsxStream, XLSX_MAX_ROWS_PER_SHEET } from "./xlsx/stream-writer"
+export type {
+  StreamWriterOptions,
+  XlsxWriteStreamOptions,
+  XlsxStreamRow,
+} from "./xlsx/stream-writer"
 export { readXlsxObjects, writeXlsxObjects } from "./xlsx/objects"
 export type {
   XlsxObjectsReadOptions,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -423,6 +423,7 @@ export const WORKER_SAFE_FUNCTIONS: string[] = [
   "hashSheetPassword",
   "streamXlsxRows",
   "XlsxStreamWriter",
+  "writeXlsxStream",
   // ODS
   "readOds",
   "writeOds",

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -7,8 +7,12 @@ export type { RoundtripWorkbook } from "./xlsx/roundtrip"
 export { hashSheetPassword } from "./xlsx/password"
 export { streamXlsxRows } from "./xlsx/stream-reader"
 export type { StreamRow } from "./xlsx/stream-reader"
-export { XlsxStreamWriter } from "./xlsx/stream-writer"
-export type { StreamWriterOptions } from "./xlsx/stream-writer"
+export { XlsxStreamWriter, writeXlsxStream, XLSX_MAX_ROWS_PER_SHEET } from "./xlsx/stream-writer"
+export type {
+  StreamWriterOptions,
+  XlsxWriteStreamOptions,
+  XlsxStreamRow,
+} from "./xlsx/stream-writer"
 
 // ── Cell Utilities ─────────────────────────────────────────────────
 export { parseCellRef } from "./xlsx/worksheet"

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -1,18 +1,28 @@
-// ── Streaming XLSX Writer ────────────────────────────────────────────
-// Incrementally builds an XLSX file row by row.
-// Each addRow() serializes the row to XML immediately.
-// finish() assembles all parts into a valid XLSX ZIP archive.
+// ── Incremental & Streaming XLSX Writers ─────────────────────────────
+//
+// Two writers share the row-serialization core below:
+//
+// • `XlsxStreamWriter` — incremental. Each `addRow()` serializes to XML
+//   right away, so no workbook object model is ever built, but the
+//   serialized parts are held until `finish()` returns the whole file as
+//   one buffer. Peak memory is O(data).
+//
+// • `writeXlsxStream()` — genuinely streaming. Rows are pulled from a
+//   source on demand and the ZIP is emitted chunk by chunk, so peak
+//   memory is O(distinct styles), independent of row count.
 
 import type { CellValue, CellStyle, ColumnDef, FreezePane } from "../_types"
 import { ZipWriter } from "../zip/writer"
+import { zipStream, type ZipStreamEntry } from "../zip/stream-writer"
 import { writeContentTypes } from "./content-types-writer"
 import { writeRootRels, writeWorkbookRels } from "./workbook-writer"
-import { createStylesCollector } from "./styles-writer"
+import { createStylesCollector, type StylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml } from "./worksheet-writer"
 import { cellRef } from "./worksheet-writer"
-import { dateToSerial } from "../_date"
-import { xmlDocument, xmlElement, xmlSelfClose } from "../xml/writer"
+import type { SharedStringsCollector } from "./worksheet-writer"
 import { writeThemeXml } from "./theme-writer"
+import { dateToSerial } from "../_date"
+import { xmlDocument, xmlDeclaration, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
 
@@ -49,6 +59,24 @@ export interface StreamWriterOptions {
   repeatHeaders?: boolean
 }
 
+export interface XlsxWriteStreamOptions extends StreamWriterOptions {
+  /**
+   * Write strings as inline `<is><t>` cells instead of routing them
+   * through `xl/sharedStrings.xml`. Default `true`.
+   *
+   * A shared string table has to be held in memory until the workbook is
+   * finished, so it grows with the number of *distinct* strings and
+   * undoes the constant-memory guarantee. Set to `false` when the data is
+   * highly repetitive and a smaller file matters more than peak memory.
+   */
+  inlineStrings?: boolean
+  /** DEFLATE the parts. Default `true`. */
+  compress?: boolean
+}
+
+/** A streamed row: positional values, or an object read through `columns[].key`. */
+export type XlsxStreamRow = CellValue[] | Record<string, unknown>
+
 /** Excel's hard row limit since Excel 2007 (2^20). */
 export const XLSX_MAX_ROWS_PER_SHEET = 1_048_576
 
@@ -56,80 +84,40 @@ export const XLSX_MAX_ROWS_PER_SHEET = 1_048_576
 
 const DEFAULT_DATE_FORMAT = "yyyy-mm-dd"
 
-// ── Stream Writer Class ─────────────────────────────────────────────
+/** Flush the XML accumulator once it crosses this many characters. */
+const CHUNK_THRESHOLD = 64 * 1024
 
-export class XlsxStreamWriter {
-  private sheetName: string
+// ── Row Serialization Core ──────────────────────────────────────────
+
+interface RowSerializerOptions {
+  columns?: ColumnDef[]
+  dateSystem?: "1900" | "1904"
+  inlineStrings?: boolean
+}
+
+/**
+ * Turns row values into `<row>` XML, collecting styles (and, unless
+ * `inlineStrings`, shared strings) along the way. Both writers share
+ * one of these so their output stays byte-identical.
+ */
+class RowSerializer {
+  readonly styles: StylesCollector = createStylesCollector()
+  readonly sharedStrings: SharedStringsCollector = createSharedStrings()
   private columns: ColumnDef[] | undefined
-  private freezePane: FreezePane | undefined
-  private dateSystem: "1900" | "1904"
-  private maxRowsPerSheet: number
-  private repeatHeaders: boolean
-  private styles = createStylesCollector()
-  private sharedStrings = createSharedStrings()
-  /**
-   * One fragment array per sheet. New sheets are appended when the row
-   * limit is reached.
-   */
-  private sheetFragments: string[][] = [[]]
-  /** Row index within the *current* sheet, NOT the global count. */
-  private currentSheetRowCount = 0
-  /** Global row count across every sheet — preserves the original semantics. */
-  private rowCount = 0
-  private maxCols = 0
-  /** Captured for `repeatHeaders`. Set when the first row is written. */
-  private headerRowValues: CellValue[] | null = null
-  /** Was the captured header injected by the constructor (vs. a user call)? */
-  private headerWasFromColumns = false
+  private is1904: boolean
+  private inlineStrings: boolean
 
-  constructor(options: StreamWriterOptions) {
-    this.sheetName = options.name
+  constructor(options: RowSerializerOptions) {
     this.columns = options.columns
-    this.freezePane = options.freezePane
-    this.dateSystem = options.dateSystem ?? "1900"
-    this.maxRowsPerSheet = options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET
-    this.repeatHeaders = options.repeatHeaders ?? true
-
-    if (this.maxRowsPerSheet < 2) {
-      throw new Error("maxRowsPerSheet must be at least 2 (one header + one data row)")
-    }
-
-    // If columns have headers, write the header row immediately
-    if (this.columns && this.columns.some((col) => col.header)) {
-      const headerValues: CellValue[] = this.columns.map((col) => col.header ?? col.key ?? null)
-      this.headerRowValues = headerValues.slice()
-      this.headerWasFromColumns = true
-      this.addRow(headerValues)
-    }
+    this.is1904 = options.dateSystem === "1904"
+    this.inlineStrings = options.inlineStrings ?? false
   }
 
-  /** Add a row of values */
-  addRow(values: CellValue[]): void {
-    // Capture the very first row as a fallback header for repeatHeaders, in
-    // case the caller didn't supply column definitions but does want their
-    // first row repeated when sheets roll over.
-    if (this.rowCount === 0 && !this.headerRowValues) {
-      this.headerRowValues = values.slice()
-    }
-
-    // Roll over before writing this row when the current sheet is full.
-    if (this.currentSheetRowCount >= this.maxRowsPerSheet) {
-      this.rolloverSheet()
-    }
-
-    const rowIndex = this.currentSheetRowCount
-    this.currentSheetRowCount++
-    this.rowCount++
-
-    if (values.length > this.maxCols) {
-      this.maxCols = values.length
-    }
-
-    const is1904 = this.dateSystem === "1904"
+  /** Serialize one row. Returns `null` when every cell was empty. */
+  serializeRow(rowIndex: number, values: CellValue[]): string | null {
     const cellElements: string[] = []
 
     for (let c = 0; c < values.length; c++) {
-      const value = values[c]
       const colDef = this.columns?.[c]
       let style: CellStyle | undefined = colDef?.style
 
@@ -138,235 +126,19 @@ export class XlsxStreamWriter {
         style = { ...style, numFmt: colDef.numFmt }
       }
 
-      const cellXml = this.serializeCell(rowIndex, c, value, style, is1904)
-      if (cellXml) {
-        cellElements.push(cellXml)
-      }
+      const cellXml = this.serializeCell(rowIndex, c, values[c], style)
+      if (cellXml) cellElements.push(cellXml)
     }
 
-    if (cellElements.length > 0) {
-      this.sheetFragments[this.sheetFragments.length - 1]!.push(
-        xmlElement("row", { r: rowIndex + 1 }, cellElements),
-      )
-    }
+    if (cellElements.length === 0) return null
+    return xmlElement("row", { r: rowIndex + 1 }, cellElements)
   }
-
-  /**
-   * Open a new sheet for the next row. Optionally re-emits the captured
-   * header row at the top of the new sheet.
-   */
-  private rolloverSheet(): void {
-    this.sheetFragments.push([])
-    this.currentSheetRowCount = 0
-
-    if (this.repeatHeaders && this.headerRowValues) {
-      // Re-emit the header row at row 0 of the new sheet. We bypass the
-      // public `addRow` to avoid double-counting in `rowCount` and to dodge
-      // the rollover guard at the top.
-      const headerValues = this.headerRowValues
-      const rowIndex = this.currentSheetRowCount
-      this.currentSheetRowCount++
-      const is1904 = this.dateSystem === "1904"
-      const cellElements: string[] = []
-
-      for (let c = 0; c < headerValues.length; c++) {
-        const value = headerValues[c]
-        const colDef = this.columns?.[c]
-        let style: CellStyle | undefined = colDef?.style
-        if (colDef?.numFmt && (!style || !style.numFmt)) {
-          style = { ...style, numFmt: colDef.numFmt }
-        }
-        const cellXml = this.serializeCell(rowIndex, c, value, style, is1904)
-        if (cellXml) cellElements.push(cellXml)
-      }
-      if (cellElements.length > 0) {
-        this.sheetFragments[this.sheetFragments.length - 1]!.push(
-          xmlElement("row", { r: rowIndex + 1 }, cellElements),
-        )
-      }
-    }
-  }
-
-  /** Add a row from an object, using column definitions for value extraction.
-   *  Requires columns with key accessors. */
-  addObject(item: Record<string, unknown>): void {
-    if (!this.columns) throw new Error("addObject requires columns with key accessors")
-    const values: CellValue[] = this.columns.map((col) => {
-      if (col.key !== undefined) return (item[col.key] ?? null) as CellValue
-      return null
-    })
-    this.addRow(values)
-  }
-
-  /** Finalize and return the XLSX buffer */
-  async finish(): Promise<Uint8Array> {
-    const hasSharedStrings = this.sharedStrings.count() > 0
-    const sheetCount = this.sheetFragments.length
-    const sheetNames = this.generateSheetNames(sheetCount)
-
-    // Build the same view/columns prelude for every emitted sheet.
-    const sheetPrelude = this.buildSheetPrelude()
-
-    // Build ZIP archive
-    const zip = new ZipWriter()
-
-    // [Content_Types].xml
-    zip.add(
-      "[Content_Types].xml",
-      encoder.encode(writeContentTypes({ sheetCount, hasSharedStrings })),
-    )
-
-    // _rels/.rels
-    zip.add("_rels/.rels", encoder.encode(writeRootRels()))
-
-    // xl/_rels/workbook.xml.rels
-    zip.add(
-      "xl/_rels/workbook.xml.rels",
-      encoder.encode(writeWorkbookRels(sheetCount, hasSharedStrings)),
-    )
-
-    // xl/styles.xml
-    zip.add("xl/styles.xml", encoder.encode(this.styles.toXml()))
-
-    // xl/theme/theme1.xml — declared in [Content_Types].xml and referenced
-    // from workbook.xml.rels, so the part must actually be written or Excel
-    // rejects the workbook as corrupt (matches the batch writer).
-    zip.add("xl/theme/theme1.xml", encoder.encode(writeThemeXml()))
-
-    // xl/sharedStrings.xml (if any strings)
-    if (hasSharedStrings) {
-      zip.add("xl/sharedStrings.xml", encoder.encode(writeSharedStringsXml(this.sharedStrings)))
-    }
-
-    // xl/worksheets/sheet{N}.xml — one entry per fragment array
-    for (let s = 0; s < sheetCount; s++) {
-      const fragments = this.sheetFragments[s]!
-      const worksheetParts: string[] = []
-      worksheetParts.push(...sheetPrelude)
-      worksheetParts.push(xmlElement("sheetData", undefined, fragments.length > 0 ? fragments : ""))
-      const worksheetXml = xmlDocument(
-        "worksheet",
-        { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R },
-        worksheetParts,
-      )
-      zip.add(`xl/worksheets/sheet${s + 1}.xml`, encoder.encode(worksheetXml))
-    }
-
-    // Build workbook XML
-    const sheetElements: string[] = []
-    for (let s = 0; s < sheetCount; s++) {
-      sheetElements.push(
-        xmlSelfClose("sheet", {
-          name: sheetNames[s]!,
-          sheetId: s + 1,
-          "r:id": `rId${s + 1}`,
-        }),
-      )
-    }
-    const workbookParts: string[] = []
-    if (this.dateSystem === "1904") {
-      workbookParts.push(xmlSelfClose("workbookPr", { date1904: 1 }))
-    }
-    workbookParts.push(xmlElement("sheets", undefined, sheetElements))
-    const workbookXml = xmlDocument(
-      "workbook",
-      { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R },
-      workbookParts,
-    )
-
-    // xl/workbook.xml
-    zip.add("xl/workbook.xml", encoder.encode(workbookXml))
-
-    return zip.build()
-  }
-
-  /** Build sheetView + sheetFormatPr + cols (same on every emitted sheet). */
-  private buildSheetPrelude(): string[] {
-    const parts: string[] = []
-
-    // SheetViews (freeze panes)
-    const sheetViewParts: string[] = []
-    if (this.freezePane) {
-      const fp = this.freezePane
-      const topLeftCell = cellRef(fp.rows ?? 0, fp.columns ?? 0)
-      const paneAttrs: Record<string, string | number> = {}
-      if (fp.columns && fp.columns > 0) paneAttrs["xSplit"] = fp.columns
-      if (fp.rows && fp.rows > 0) paneAttrs["ySplit"] = fp.rows
-      paneAttrs["topLeftCell"] = topLeftCell
-      paneAttrs["state"] = "frozen"
-      const hasXSplit = fp.columns && fp.columns > 0
-      const hasYSplit = fp.rows && fp.rows > 0
-      if (hasXSplit && hasYSplit) paneAttrs["activePane"] = "bottomRight"
-      else if (hasXSplit) paneAttrs["activePane"] = "topRight"
-      else paneAttrs["activePane"] = "bottomLeft"
-      sheetViewParts.push(xmlSelfClose("pane", paneAttrs))
-    }
-    parts.push(
-      xmlElement("sheetViews", undefined, [
-        sheetViewParts.length > 0
-          ? xmlElement("sheetView", { workbookViewId: 0 }, sheetViewParts)
-          : xmlSelfClose("sheetView", { workbookViewId: 0 }),
-      ]),
-    )
-
-    // SheetFormatPr
-    parts.push(xmlSelfClose("sheetFormatPr", { defaultRowHeight: 15 }))
-
-    // Columns
-    if (this.columns && this.columns.length > 0) {
-      const colElements: string[] = []
-      for (let i = 0; i < this.columns.length; i++) {
-        const col = this.columns[i]
-        if (col.width !== undefined || col.hidden || col.outlineLevel) {
-          const colAttrs: Record<string, string | number | boolean> = {
-            min: i + 1,
-            max: i + 1,
-          }
-          if (col.width !== undefined) {
-            colAttrs["width"] = col.width
-            colAttrs["customWidth"] = true
-          }
-          if (col.hidden) colAttrs["hidden"] = true
-          if (col.outlineLevel) colAttrs["outlineLevel"] = col.outlineLevel
-          colElements.push(xmlSelfClose("col", colAttrs))
-        }
-      }
-      if (colElements.length > 0) {
-        parts.push(xmlElement("cols", undefined, colElements))
-      }
-    }
-
-    return parts
-  }
-
-  /**
-   * Generate `count` unique sheet names: the configured base name first,
-   * then `{name}_2`, `{name}_3`, …. Each name is truncated to fit Excel's
-   * 31-character limit by trimming the base, not the suffix.
-   */
-  private generateSheetNames(count: number): string[] {
-    const names: string[] = []
-    for (let i = 0; i < count; i++) {
-      if (i === 0) {
-        names.push(truncateSheetName(this.sheetName))
-      } else {
-        const suffix = `_${i + 1}`
-        const room = 31 - suffix.length
-        const base = this.sheetName.length > room ? this.sheetName.slice(0, room) : this.sheetName
-        names.push(base + suffix)
-      }
-    }
-    return names
-  }
-
-  // ── Private helpers ───────────────────────────────────────────────
 
   private serializeCell(
     row: number,
     col: number,
     value: CellValue,
     style: CellStyle | undefined,
-    is1904: boolean,
   ): string | null {
     let effectiveStyle = style
 
@@ -392,6 +164,11 @@ export class XlsxStreamWriter {
 
     // String
     if (typeof value === "string") {
+      if (this.inlineStrings) {
+        const attrs: Record<string, string | number> = { r: ref, t: "inlineStr" }
+        if (styleIdx !== 0) attrs["s"] = styleIdx
+        return xmlElement("c", attrs, [xmlElement("is", undefined, [textElement(value)])])
+      }
       const ssIdx = this.sharedStrings.add(value)
       const attrs: Record<string, string | number> = { r: ref, t: "s" }
       if (styleIdx !== 0) attrs["s"] = styleIdx
@@ -421,7 +198,7 @@ export class XlsxStreamWriter {
 
     // Date — convert to serial number
     if (value instanceof Date) {
-      const serial = dateToSerial(value, is1904)
+      const serial = dateToSerial(value, this.is1904)
       const attrs: Record<string, string | number> = { r: ref }
       if (styleIdx !== 0) attrs["s"] = styleIdx
       return xmlElement("c", attrs, [xmlElement("v", undefined, String(serial))])
@@ -431,7 +208,571 @@ export class XlsxStreamWriter {
   }
 }
 
+/** `<t>` element, preserving significant whitespace like the shared-string writer. */
+function textElement(value: string): string {
+  const escaped = xmlEscape(value)
+  const needsPreserve =
+    value.length > 0 &&
+    (value[0] === " " ||
+      value[value.length - 1] === " " ||
+      value.includes("\n") ||
+      value.includes("\t"))
+  return needsPreserve
+    ? `<t xml:space="preserve">${escaped}</t>`
+    : xmlElement("t", undefined, escaped)
+}
+
+// ── Shared Sheet Scaffolding ────────────────────────────────────────
+
+/** Build sheetView + sheetFormatPr + cols (same on every emitted sheet). */
+function buildSheetPrelude(columns: ColumnDef[] | undefined, freezePane: FreezePane | undefined) {
+  const parts: string[] = []
+
+  // SheetViews (freeze panes)
+  const sheetViewParts: string[] = []
+  if (freezePane) {
+    const fp = freezePane
+    const topLeftCell = cellRef(fp.rows ?? 0, fp.columns ?? 0)
+    const paneAttrs: Record<string, string | number> = {}
+    if (fp.columns && fp.columns > 0) paneAttrs["xSplit"] = fp.columns
+    if (fp.rows && fp.rows > 0) paneAttrs["ySplit"] = fp.rows
+    paneAttrs["topLeftCell"] = topLeftCell
+    paneAttrs["state"] = "frozen"
+    const hasXSplit = fp.columns && fp.columns > 0
+    const hasYSplit = fp.rows && fp.rows > 0
+    if (hasXSplit && hasYSplit) paneAttrs["activePane"] = "bottomRight"
+    else if (hasXSplit) paneAttrs["activePane"] = "topRight"
+    else paneAttrs["activePane"] = "bottomLeft"
+    sheetViewParts.push(xmlSelfClose("pane", paneAttrs))
+  }
+  parts.push(
+    xmlElement("sheetViews", undefined, [
+      sheetViewParts.length > 0
+        ? xmlElement("sheetView", { workbookViewId: 0 }, sheetViewParts)
+        : xmlSelfClose("sheetView", { workbookViewId: 0 }),
+    ]),
+  )
+
+  // SheetFormatPr
+  parts.push(xmlSelfClose("sheetFormatPr", { defaultRowHeight: 15 }))
+
+  // Columns
+  if (columns && columns.length > 0) {
+    const colElements: string[] = []
+    for (let i = 0; i < columns.length; i++) {
+      const col = columns[i]
+      if (col.width !== undefined || col.hidden || col.outlineLevel) {
+        const colAttrs: Record<string, string | number | boolean> = {
+          min: i + 1,
+          max: i + 1,
+        }
+        if (col.width !== undefined) {
+          colAttrs["width"] = col.width
+          colAttrs["customWidth"] = true
+        }
+        if (col.hidden) colAttrs["hidden"] = true
+        if (col.outlineLevel) colAttrs["outlineLevel"] = col.outlineLevel
+        colElements.push(xmlSelfClose("col", colAttrs))
+      }
+    }
+    if (colElements.length > 0) {
+      parts.push(xmlElement("cols", undefined, colElements))
+    }
+  }
+
+  return parts
+}
+
+/**
+ * Generate `count` unique sheet names: the configured base name first,
+ * then `{name}_2`, `{name}_3`, …. Each name is truncated to fit Excel's
+ * 31-character limit by trimming the base, not the suffix.
+ */
+function generateSheetNames(baseName: string, count: number): string[] {
+  const names: string[] = []
+  for (let i = 0; i < count; i++) {
+    if (i === 0) {
+      names.push(truncateSheetName(baseName))
+    } else {
+      const suffix = `_${i + 1}`
+      const room = 31 - suffix.length
+      const base = baseName.length > room ? baseName.slice(0, room) : baseName
+      names.push(base + suffix)
+    }
+  }
+  return names
+}
+
+/** Build xl/workbook.xml for `count` sheets carrying the base name. */
+function buildWorkbookXml(baseName: string, count: number, dateSystem: "1900" | "1904"): string {
+  const sheetNames = generateSheetNames(baseName, count)
+  const sheetElements: string[] = []
+  for (let s = 0; s < count; s++) {
+    sheetElements.push(
+      xmlSelfClose("sheet", {
+        name: sheetNames[s]!,
+        sheetId: s + 1,
+        "r:id": `rId${s + 1}`,
+      }),
+    )
+  }
+
+  const workbookParts: string[] = []
+  if (dateSystem === "1904") {
+    workbookParts.push(xmlSelfClose("workbookPr", { date1904: 1 }))
+  }
+  workbookParts.push(xmlElement("sheets", undefined, sheetElements))
+
+  return xmlDocument("workbook", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, workbookParts)
+}
+
+/** Header values implied by `columns[].header`, or `null` when there are none. */
+function headerFromColumns(columns: ColumnDef[] | undefined): CellValue[] | null {
+  if (!columns || !columns.some((col) => col.header)) return null
+  return columns.map((col) => col.header ?? col.key ?? null)
+}
+
+function validateMaxRowsPerSheet(value: number): void {
+  if (value < 2) {
+    throw new Error("maxRowsPerSheet must be at least 2 (one header + one data row)")
+  }
+}
+
+// ── Stream Writer Class (incremental, buffered) ─────────────────────
+
+/**
+ * Incremental XLSX writer.
+ *
+ * Rows are serialized to XML as they arrive — no workbook object model
+ * is built — but every serialized part is retained until {@link finish}
+ * assembles the archive, so peak memory still scales with the data.
+ * For constant-memory output use {@link writeXlsxStream} instead.
+ */
+export class XlsxStreamWriter {
+  private sheetName: string
+  private columns: ColumnDef[] | undefined
+  private freezePane: FreezePane | undefined
+  private dateSystem: "1900" | "1904"
+  private maxRowsPerSheet: number
+  private repeatHeaders: boolean
+  private serializer: RowSerializer
+  /**
+   * One fragment array per sheet. New sheets are appended when the row
+   * limit is reached.
+   */
+  private sheetFragments: string[][] = [[]]
+  /** Row index within the *current* sheet, NOT the global count. */
+  private currentSheetRowCount = 0
+  /** Global row count across every sheet — preserves the original semantics. */
+  private rowCount = 0
+  private maxCols = 0
+  /** Captured for `repeatHeaders`. Set when the first row is written. */
+  private headerRowValues: CellValue[] | null = null
+
+  constructor(options: StreamWriterOptions) {
+    this.sheetName = options.name
+    this.columns = options.columns
+    this.freezePane = options.freezePane
+    this.dateSystem = options.dateSystem ?? "1900"
+    this.maxRowsPerSheet = options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET
+    this.repeatHeaders = options.repeatHeaders ?? true
+    this.serializer = new RowSerializer({
+      columns: options.columns,
+      dateSystem: this.dateSystem,
+    })
+
+    validateMaxRowsPerSheet(this.maxRowsPerSheet)
+
+    // If columns have headers, write the header row immediately
+    const headerValues = headerFromColumns(this.columns)
+    if (headerValues) {
+      this.headerRowValues = headerValues.slice()
+      this.addRow(headerValues)
+    }
+  }
+
+  /** Add a row of values */
+  addRow(values: CellValue[]): void {
+    // Capture the very first row as a fallback header for repeatHeaders, in
+    // case the caller didn't supply column definitions but does want their
+    // first row repeated when sheets roll over.
+    if (this.rowCount === 0 && !this.headerRowValues) {
+      this.headerRowValues = values.slice()
+    }
+
+    // Roll over before writing this row when the current sheet is full.
+    if (this.currentSheetRowCount >= this.maxRowsPerSheet) {
+      this.rolloverSheet()
+    }
+
+    const rowIndex = this.currentSheetRowCount
+    this.currentSheetRowCount++
+    this.rowCount++
+
+    if (values.length > this.maxCols) {
+      this.maxCols = values.length
+    }
+
+    this.emit(rowIndex, values)
+  }
+
+  /**
+   * Open a new sheet for the next row. Optionally re-emits the captured
+   * header row at the top of the new sheet.
+   */
+  private rolloverSheet(): void {
+    this.sheetFragments.push([])
+    this.currentSheetRowCount = 0
+
+    if (this.repeatHeaders && this.headerRowValues) {
+      // Re-emit the header row at row 0 of the new sheet. We bypass the
+      // public `addRow` to avoid double-counting in `rowCount` and to dodge
+      // the rollover guard at the top.
+      const rowIndex = this.currentSheetRowCount
+      this.currentSheetRowCount++
+      this.emit(rowIndex, this.headerRowValues)
+    }
+  }
+
+  private emit(rowIndex: number, values: CellValue[]): void {
+    const xml = this.serializer.serializeRow(rowIndex, values)
+    if (xml) {
+      this.sheetFragments[this.sheetFragments.length - 1]!.push(xml)
+    }
+  }
+
+  /** Add a row from an object, using column definitions for value extraction.
+   *  Requires columns with key accessors. */
+  addObject(item: Record<string, unknown>): void {
+    if (!this.columns) throw new Error("addObject requires columns with key accessors")
+    this.addRow(objectToValues(item, this.columns))
+  }
+
+  /** Finalize and return the XLSX buffer */
+  async finish(): Promise<Uint8Array> {
+    const hasSharedStrings = this.serializer.sharedStrings.count() > 0
+    const sheetCount = this.sheetFragments.length
+
+    // Build the same view/columns prelude for every emitted sheet.
+    const sheetPrelude = buildSheetPrelude(this.columns, this.freezePane)
+
+    // Build ZIP archive
+    const zip = new ZipWriter()
+
+    // [Content_Types].xml
+    zip.add(
+      "[Content_Types].xml",
+      encoder.encode(writeContentTypes({ sheetCount, hasSharedStrings })),
+    )
+
+    // _rels/.rels
+    zip.add("_rels/.rels", encoder.encode(writeRootRels()))
+
+    // xl/_rels/workbook.xml.rels
+    zip.add(
+      "xl/_rels/workbook.xml.rels",
+      encoder.encode(writeWorkbookRels(sheetCount, hasSharedStrings)),
+    )
+
+    // xl/styles.xml
+    zip.add("xl/styles.xml", encoder.encode(this.serializer.styles.toXml()))
+
+    // xl/theme/theme1.xml — declared in [Content_Types].xml and referenced
+    // from workbook.xml.rels, so the part must actually be written or Excel
+    // rejects the workbook as corrupt (matches the batch writer).
+    zip.add("xl/theme/theme1.xml", encoder.encode(writeThemeXml()))
+
+    // xl/sharedStrings.xml (if any strings)
+    if (hasSharedStrings) {
+      zip.add(
+        "xl/sharedStrings.xml",
+        encoder.encode(writeSharedStringsXml(this.serializer.sharedStrings)),
+      )
+    }
+
+    // xl/worksheets/sheet{N}.xml — one entry per fragment array
+    for (let s = 0; s < sheetCount; s++) {
+      const fragments = this.sheetFragments[s]!
+      const worksheetParts: string[] = []
+      worksheetParts.push(...sheetPrelude)
+      worksheetParts.push(xmlElement("sheetData", undefined, fragments.length > 0 ? fragments : ""))
+      const worksheetXml = xmlDocument(
+        "worksheet",
+        { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R },
+        worksheetParts,
+      )
+      zip.add(`xl/worksheets/sheet${s + 1}.xml`, encoder.encode(worksheetXml))
+    }
+
+    // xl/workbook.xml
+    zip.add(
+      "xl/workbook.xml",
+      encoder.encode(buildWorkbookXml(this.sheetName, sheetCount, this.dateSystem)),
+    )
+
+    return zip.build()
+  }
+}
+
+// ── True Streaming Writer ───────────────────────────────────────────
+
+/**
+ * Write an XLSX workbook as a byte stream, pulling rows from `rows` only
+ * as the consumer reads.
+ *
+ * Peak memory is independent of the row count: rows are serialized,
+ * compressed, and flushed as they arrive, and nothing but the style
+ * table (bounded by the number of *distinct* styles) plus one small ZIP
+ * record per part is retained.
+ *
+ * ```ts
+ * return new Response(writeXlsxStream({ name: "Export", columns }, rowSource), {
+ *   headers: {
+ *     "content-type":
+ *       "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+ *   },
+ * })
+ * ```
+ *
+ * Notes:
+ * - Strings are written inline by default; see {@link XlsxWriteStreamOptions.inlineStrings}.
+ * - Part sizes are unknown up front, so entries carry ZIP data
+ *   descriptors. Zip64 is not emitted, which caps any single part — and
+ *   the archive — at 4 GiB.
+ * - Compression needs `CompressionStream`; without it parts are stored
+ *   uncompressed rather than buffered.
+ */
+export function writeXlsxStream(
+  options: XlsxWriteStreamOptions,
+  rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
+): ReadableStream<Uint8Array> {
+  return zipStream(xlsxStreamEntries(options, rows))
+}
+
+/** Lazily produce the ZIP entries for a streamed workbook. */
+async function* xlsxStreamEntries(
+  options: XlsxWriteStreamOptions,
+  rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
+): AsyncGenerator<ZipStreamEntry> {
+  const dateSystem = options.dateSystem ?? "1900"
+  const maxRowsPerSheet = options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET
+  const repeatHeaders = options.repeatHeaders ?? true
+  const inlineStrings = options.inlineStrings ?? true
+  const compress = options.compress ?? true
+  const columns = options.columns
+
+  validateMaxRowsPerSheet(maxRowsPerSheet)
+
+  const serializer = new RowSerializer({ columns, dateSystem, inlineStrings })
+  const prelude = buildSheetPrelude(columns, options.freezePane).join("")
+  const cursor = createRowCursor(rows)
+
+  let headerRow = headerFromColumns(columns)
+  let globalRowCount = 0
+
+  /** Stream one worksheet, stopping at the row cap or when rows run out. */
+  async function* sheetChunks(sheetIndex: number): AsyncGenerator<Uint8Array> {
+    const chunker = new XmlChunker()
+
+    const open =
+      xmlDeclaration() +
+      `<worksheet xmlns="${NS_SPREADSHEET}" xmlns:r="${NS_R}">` +
+      prelude +
+      "<sheetData>"
+    const openChunk = chunker.push(open)
+    if (openChunk) yield openChunk
+
+    let rowIndex = 0
+
+    // Sheet 0 emits the column header as a real row (matching the
+    // incremental writer); later sheets repeat it when asked to.
+    if (headerRow && (sheetIndex === 0 || repeatHeaders)) {
+      const xml = serializer.serializeRow(rowIndex, headerRow)
+      rowIndex++
+      if (sheetIndex === 0) globalRowCount++
+      if (xml) {
+        const chunk = chunker.push(xml)
+        if (chunk) yield chunk
+      }
+    }
+
+    while (rowIndex < maxRowsPerSheet) {
+      const row = await cursor.next()
+      if (row === undefined) break
+
+      const values = Array.isArray(row) ? row : objectToValues(row, requireColumns(columns))
+
+      // Without column headers the first row doubles as the repeated header.
+      if (globalRowCount === 0 && !headerRow) {
+        headerRow = values.slice()
+      }
+
+      const xml = serializer.serializeRow(rowIndex, values)
+      rowIndex++
+      globalRowCount++
+      if (xml) {
+        const chunk = chunker.push(xml)
+        if (chunk) yield chunk
+      }
+    }
+
+    const closeChunk = chunker.push("</sheetData></worksheet>")
+    if (closeChunk) yield closeChunk
+    const tail = chunker.flush()
+    if (tail) yield tail
+  }
+
+  let sheetCount = 0
+  try {
+    for (;;) {
+      const sheetIndex = sheetCount++
+      yield {
+        path: `xl/worksheets/sheet${sheetIndex + 1}.xml`,
+        data: sheetChunks(sheetIndex),
+        compress,
+      }
+      // The ZIP writer drains each entry before pulling the next, so by
+      // now the sheet above is closed and the cursor is positioned on the
+      // first row that didn't fit.
+      if ((await cursor.peek()) === undefined) break
+    }
+  } finally {
+    await cursor.close()
+  }
+
+  const hasSharedStrings = serializer.sharedStrings.count() > 0
+
+  yield { path: "xl/styles.xml", data: encoder.encode(serializer.styles.toXml()), compress }
+
+  if (hasSharedStrings) {
+    yield {
+      path: "xl/sharedStrings.xml",
+      data: encoder.encode(writeSharedStringsXml(serializer.sharedStrings)),
+      compress,
+    }
+  }
+
+  yield { path: "xl/theme/theme1.xml", data: encoder.encode(writeThemeXml()), compress }
+
+  yield {
+    path: "xl/workbook.xml",
+    data: encoder.encode(buildWorkbookXml(options.name, sheetCount, dateSystem)),
+    compress,
+  }
+
+  yield {
+    path: "xl/_rels/workbook.xml.rels",
+    data: encoder.encode(writeWorkbookRels(sheetCount, hasSharedStrings)),
+    compress,
+  }
+
+  yield { path: "_rels/.rels", data: encoder.encode(writeRootRels()), compress }
+
+  // [Content_Types].xml lands last: the sheet count isn't known until the
+  // rows run out. ZIP consumers resolve parts through the central
+  // directory, so package order doesn't matter.
+  yield {
+    path: "[Content_Types].xml",
+    data: encoder.encode(writeContentTypes({ sheetCount, hasSharedStrings })),
+    compress,
+  }
+}
+
+// ── Streaming helpers ───────────────────────────────────────────────
+
+/** Accumulate XML text and hand it back as ~64 KB encoded chunks. */
+class XmlChunker {
+  private pending: string[] = []
+  private size = 0
+
+  /** Buffer `xml`, returning an encoded chunk once the threshold is crossed. */
+  push(xml: string): Uint8Array | undefined {
+    if (xml.length === 0) return undefined
+    this.pending.push(xml)
+    this.size += xml.length
+    if (this.size < CHUNK_THRESHOLD) return undefined
+    return this.flush()
+  }
+
+  /** Encode and release whatever is still buffered. */
+  flush(): Uint8Array | undefined {
+    if (this.size === 0) return undefined
+    const text = this.pending.join("")
+    this.pending = []
+    this.size = 0
+    return encoder.encode(text)
+  }
+}
+
+interface RowCursor {
+  /** Consume the next row, or `undefined` when the source is exhausted. */
+  next(): Promise<XlsxStreamRow | undefined>
+  /** Look at the next row without consuming it. */
+  peek(): Promise<XlsxStreamRow | undefined>
+  /** Release the underlying iterator. */
+  close(): Promise<void>
+}
+
+function createRowCursor(
+  source: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
+): RowCursor {
+  const iterator: AsyncIterator<XlsxStreamRow> | Iterator<XlsxStreamRow> =
+    Symbol.asyncIterator in Object(source)
+      ? (source as AsyncIterable<XlsxStreamRow>)[Symbol.asyncIterator]()
+      : (source as Iterable<XlsxStreamRow>)[Symbol.iterator]()
+
+  let lookahead: XlsxStreamRow | undefined
+  let hasLookahead = false
+  let done = false
+
+  async function pull(): Promise<XlsxStreamRow | undefined> {
+    if (done) return undefined
+    const result = await iterator.next()
+    if (result.done) {
+      done = true
+      return undefined
+    }
+    return result.value
+  }
+
+  return {
+    async peek() {
+      if (!hasLookahead) {
+        lookahead = await pull()
+        hasLookahead = true
+      }
+      return lookahead
+    },
+    async next() {
+      if (hasLookahead) {
+        hasLookahead = false
+        const value = lookahead
+        lookahead = undefined
+        return value
+      }
+      return pull()
+    },
+    async close() {
+      if (done) return
+      done = true
+      await iterator.return?.()
+    },
+  }
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────
+
+function requireColumns(columns: ColumnDef[] | undefined): ColumnDef[] {
+  if (!columns) throw new Error("Object rows require columns with key accessors")
+  return columns
+}
+
+function objectToValues(item: Record<string, unknown>, columns: ColumnDef[]): CellValue[] {
+  return columns.map((col) => {
+    if (col.key !== undefined) return (item[col.key] ?? null) as CellValue
+    return null
+  })
+}
 
 /** Excel sheet names cap at 31 characters. */
 function truncateSheetName(name: string): string {

--- a/src/zip/deflate.ts
+++ b/src/zip/deflate.ts
@@ -18,12 +18,25 @@ const crcTable = /* @__PURE__ */ (() => {
   return table
 })()
 
-export function crc32(data: Uint8Array): number {
-  let crc = 0xffffffff
+/** Seed value for an incremental CRC-32 run. */
+export const CRC32_INIT = 0xffffffff
+
+/** Fold one more chunk into a running CRC-32 state. */
+export function crc32Update(state: number, data: Uint8Array): number {
+  let crc = state
   for (let i = 0; i < data.length; i++) {
     crc = crcTable[(crc ^ data[i]) & 0xff] ^ (crc >>> 8)
   }
-  return (crc ^ 0xffffffff) >>> 0
+  return crc >>> 0
+}
+
+/** Turn a running CRC-32 state into the final checksum. */
+export function crc32Final(state: number): number {
+  return (state ^ 0xffffffff) >>> 0
+}
+
+export function crc32(data: Uint8Array): number {
+  return crc32Final(crc32Update(CRC32_INIT, data))
 }
 
 // ── Bit Reader (for inflate) ────────────────────────────────────────

--- a/src/zip/stream-writer.ts
+++ b/src/zip/stream-writer.ts
@@ -1,0 +1,330 @@
+// ── Streaming ZIP Writer ─────────────────────────────────────────────
+// Emits a ZIP archive as a byte stream: for every entry a local file
+// header goes out first, then the (optionally DEFLATE-compressed) bytes
+// as they arrive, then a trailing data descriptor. The central directory
+// and EOCD close the archive.
+//
+// Because an entry's size and CRC are unknown when its header is
+// written, every entry sets general-purpose bit 3 and carries a data
+// descriptor — the same layout `archiver`/`zip-stream` produce, which
+// Excel, LibreOffice, and the platform unzip tools all accept.
+//
+// Nothing is buffered beyond the current chunk plus one central
+// directory record per entry, so peak memory is O(entries), not
+// O(archive size).
+
+import { CRC32_INIT, crc32Update, crc32Final } from "./deflate"
+import { ZipError } from "../errors"
+
+// ── ZIP Signatures ──────────────────────────────────────────────────
+
+const SIG_LOCAL_FILE = 0x04034b50
+const SIG_DATA_DESCRIPTOR = 0x08074b50
+const SIG_CENTRAL_DIR = 0x02014b50
+const SIG_END_OF_CENTRAL_DIR = 0x06054b50
+
+/** General purpose bit 3 — sizes and CRC live in a trailing descriptor. */
+const FLAG_DATA_DESCRIPTOR = 0x0008
+
+/** Largest value a 32-bit ZIP size/offset field can hold. */
+const MAX_UINT32 = 0xffffffff
+
+const METHOD_STORE = 0
+const METHOD_DEFLATE = 8
+
+const encoder = /* @__PURE__ */ new TextEncoder()
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/** Bytes for one entry — a whole buffer, or chunks pulled on demand. */
+export type ZipStreamData = Uint8Array | AsyncIterable<Uint8Array> | Iterable<Uint8Array>
+
+export interface ZipStreamEntry {
+  /** Path inside the archive, e.g. `xl/worksheets/sheet1.xml` */
+  path: string
+  /** Entry contents */
+  data: ZipStreamData
+  /**
+   * DEFLATE the entry. Default `true`. Falls back to STORE when the
+   * platform has no `CompressionStream` — the pure-TS DEFLATE needs the
+   * whole buffer up front, which would defeat streaming.
+   */
+  compress?: boolean
+}
+
+/** Entries may themselves be produced lazily (that's the point). */
+export type ZipStreamEntries = AsyncIterable<ZipStreamEntry> | Iterable<ZipStreamEntry>
+
+// ── Compression ─────────────────────────────────────────────────────
+
+let hasCompressionStream: boolean | undefined
+
+function checkCompressionStream(): boolean {
+  if (hasCompressionStream === undefined) {
+    try {
+      hasCompressionStream = typeof CompressionStream !== "undefined"
+    } catch {
+      hasCompressionStream = false
+    }
+  }
+  return hasCompressionStream
+}
+
+/** Pipe chunks through `deflate-raw`, preserving backpressure both ways. */
+async function* deflateRawChunks(source: AsyncIterable<Uint8Array>): AsyncGenerator<Uint8Array> {
+  const cs = new CompressionStream("deflate-raw")
+  const writer = cs.writable.getWriter()
+
+  let pumpError: unknown
+  const pump = (async () => {
+    try {
+      for await (const chunk of source) {
+        // `ready` is what makes the producer wait when the consumer
+        // stops pulling — this is the backpressure hinge.
+        await writer.ready
+        await writer.write(chunk as unknown as BufferSource)
+      }
+      await writer.close()
+    } catch (err) {
+      pumpError = err
+      try {
+        await writer.abort(err)
+      } catch {
+        // Already errored — nothing to salvage.
+      }
+    }
+  })()
+
+  const reader = cs.readable.getReader()
+  let drained = false
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) {
+        drained = true
+        break
+      }
+      if (value && value.length > 0) yield value
+    }
+  } finally {
+    if (!drained) {
+      try {
+        await reader.cancel()
+      } catch {
+        // Consumer walked away; the pump rejection is swallowed above.
+      }
+    }
+  }
+
+  await pump
+  if (pumpError) throw pumpError
+}
+
+/** Normalize entry data into an async chunk source. */
+async function* toChunks(data: ZipStreamData): AsyncGenerator<Uint8Array> {
+  if (data instanceof Uint8Array) {
+    if (data.length > 0) yield data
+    return
+  }
+  for await (const chunk of data as AsyncIterable<Uint8Array>) {
+    if (chunk.length > 0) yield chunk
+  }
+}
+
+/** Pass chunks through untouched while feeding them to `onChunk`. */
+async function* tapChunks(
+  source: AsyncIterable<Uint8Array>,
+  onChunk: (chunk: Uint8Array) => void,
+): AsyncGenerator<Uint8Array> {
+  for await (const chunk of source) {
+    onChunk(chunk)
+    yield chunk
+  }
+}
+
+// ── Header / trailer builders ───────────────────────────────────────
+
+interface CentralRecord {
+  pathBytes: Uint8Array
+  method: number
+  crc: number
+  compressedSize: number
+  uncompressedSize: number
+  localOffset: number
+}
+
+function buildLocalHeader(pathBytes: Uint8Array, method: number): Uint8Array {
+  const buf = new Uint8Array(30 + pathBytes.length)
+  const view = new DataView(buf.buffer)
+
+  view.setUint32(0, SIG_LOCAL_FILE, true)
+  view.setUint16(4, 20, true) // Version needed (2.0)
+  view.setUint16(6, FLAG_DATA_DESCRIPTOR, true)
+  view.setUint16(8, method, true)
+  view.setUint16(10, 0, true) // Mod time
+  view.setUint16(12, 0x0021, true) // Mod date (1980-01-01)
+  view.setUint32(14, 0, true) // CRC — in the data descriptor
+  view.setUint32(18, 0, true) // Compressed size — in the data descriptor
+  view.setUint32(22, 0, true) // Uncompressed size — in the data descriptor
+  view.setUint16(26, pathBytes.length, true)
+  view.setUint16(28, 0, true) // Extra field length
+
+  buf.set(pathBytes, 30)
+  return buf
+}
+
+function buildDataDescriptor(crc: number, compressedSize: number, uncompressedSize: number) {
+  const buf = new Uint8Array(16)
+  const view = new DataView(buf.buffer)
+
+  view.setUint32(0, SIG_DATA_DESCRIPTOR, true)
+  view.setUint32(4, crc, true)
+  view.setUint32(8, compressedSize, true)
+  view.setUint32(12, uncompressedSize, true)
+  return buf
+}
+
+function buildCentralDirectory(records: CentralRecord[], centralDirOffset: number): Uint8Array {
+  let size = 22 // EOCD
+  for (const rec of records) size += 46 + rec.pathBytes.length
+
+  const buf = new Uint8Array(size)
+  const view = new DataView(buf.buffer)
+  let offset = 0
+
+  for (const rec of records) {
+    view.setUint32(offset, SIG_CENTRAL_DIR, true)
+    view.setUint16(offset + 4, 20, true) // Version made by (2.0)
+    view.setUint16(offset + 6, 20, true) // Version needed (2.0)
+    view.setUint16(offset + 8, FLAG_DATA_DESCRIPTOR, true)
+    view.setUint16(offset + 10, rec.method, true)
+    view.setUint16(offset + 12, 0, true) // Mod time
+    view.setUint16(offset + 14, 0x0021, true) // Mod date (1980-01-01)
+    view.setUint32(offset + 16, rec.crc, true)
+    view.setUint32(offset + 20, rec.compressedSize, true)
+    view.setUint32(offset + 24, rec.uncompressedSize, true)
+    view.setUint16(offset + 28, rec.pathBytes.length, true)
+    view.setUint16(offset + 30, 0, true) // Extra field length
+    view.setUint16(offset + 32, 0, true) // File comment length
+    view.setUint16(offset + 34, 0, true) // Disk number start
+    view.setUint16(offset + 36, 0, true) // Internal file attributes
+    view.setUint32(offset + 38, 0, true) // External file attributes
+    view.setUint32(offset + 42, rec.localOffset, true)
+    buf.set(rec.pathBytes, offset + 46)
+    offset += 46 + rec.pathBytes.length
+  }
+
+  const centralDirSize = offset
+
+  view.setUint32(offset, SIG_END_OF_CENTRAL_DIR, true)
+  view.setUint16(offset + 4, 0, true) // Disk number
+  view.setUint16(offset + 6, 0, true) // Central dir start disk
+  view.setUint16(offset + 8, records.length, true)
+  view.setUint16(offset + 10, records.length, true)
+  view.setUint32(offset + 12, centralDirSize, true)
+  view.setUint32(offset + 16, centralDirOffset, true)
+  view.setUint16(offset + 20, 0, true) // Comment length
+
+  return buf
+}
+
+// ── Streaming writer ────────────────────────────────────────────────
+
+function assertFits(value: number, what: string, path: string): void {
+  if (value > MAX_UINT32) {
+    throw new ZipError(
+      `ZIP ${what} exceeds the 4 GiB limit at "${path}". ` +
+        `Zip64 is not supported yet — split the data across more parts.`,
+    )
+  }
+}
+
+/**
+ * Emit a ZIP archive chunk by chunk.
+ *
+ * Each entry's data is consumed to completion before the next entry is
+ * pulled from `entries`, so an async generator can safely compute a
+ * later entry (styles, shared strings, the workbook index) from state
+ * accumulated while earlier entries streamed out.
+ */
+export async function* zipStreamChunks(entries: ZipStreamEntries): AsyncGenerator<Uint8Array> {
+  const records: CentralRecord[] = []
+  const seen = new Set<string>()
+  let offset = 0
+  const canDeflate = checkCompressionStream()
+
+  for await (const entry of entries) {
+    if (seen.has(entry.path)) {
+      throw new ZipError(`Duplicate ZIP entry: "${entry.path}"`)
+    }
+    seen.add(entry.path)
+
+    const pathBytes = encoder.encode(entry.path)
+    const method = entry.compress !== false && canDeflate ? METHOD_DEFLATE : METHOD_STORE
+    const localOffset = offset
+
+    const header = buildLocalHeader(pathBytes, method)
+    offset += header.length
+    yield header
+
+    let crcState = CRC32_INIT
+    let uncompressedSize = 0
+    let compressedSize = 0
+
+    const raw = tapChunks(toChunks(entry.data), (chunk) => {
+      crcState = crc32Update(crcState, chunk)
+      uncompressedSize += chunk.length
+    })
+
+    const body = method === METHOD_DEFLATE ? deflateRawChunks(raw) : raw
+
+    for await (const chunk of body) {
+      compressedSize += chunk.length
+      offset += chunk.length
+      yield chunk
+    }
+
+    assertFits(uncompressedSize, "uncompressed size", entry.path)
+    assertFits(compressedSize, "compressed size", entry.path)
+
+    const descriptor = buildDataDescriptor(crc32Final(crcState), compressedSize, uncompressedSize)
+    offset += descriptor.length
+    yield descriptor
+
+    assertFits(offset, "archive size", entry.path)
+
+    records.push({
+      pathBytes,
+      method,
+      crc: crc32Final(crcState),
+      compressedSize,
+      uncompressedSize,
+      localOffset,
+    })
+  }
+
+  yield buildCentralDirectory(records, offset)
+}
+
+/** Wrap {@link zipStreamChunks} in a `ReadableStream` of bytes. */
+export function zipStream(entries: ZipStreamEntries): ReadableStream<Uint8Array> {
+  const chunks = zipStreamChunks(entries)
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await chunks.next()
+        if (done) {
+          controller.close()
+          return
+        }
+        controller.enqueue(value)
+      } catch (err) {
+        controller.error(err)
+      }
+    },
+    async cancel(reason) {
+      await chunks.return?.(reason)
+    },
+  })
+}

--- a/test/xlsx-stream-write.test.ts
+++ b/test/xlsx-stream-write.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsxStream, XlsxStreamWriter } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { zipStreamChunks } from "../src/zip/stream-writer"
+import type { CellValue } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+async function collectChunks(stream: ReadableStream<Uint8Array>): Promise<Uint8Array[]> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return chunks
+}
+
+async function* asyncRows(rows: CellValue[][]): AsyncGenerator<CellValue[]> {
+  for (const row of rows) {
+    await Promise.resolve()
+    yield row
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Streaming ZIP writer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("zipStreamChunks", () => {
+  it("produces an archive our own reader can open", async () => {
+    const encoder = new TextEncoder()
+    const chunks: Uint8Array[] = []
+    for await (const chunk of zipStreamChunks([
+      { path: "a.txt", data: encoder.encode("hello hello hello hello") },
+      { path: "b.txt", data: encoder.encode("world"), compress: false },
+    ])) {
+      chunks.push(chunk)
+    }
+
+    const total = chunks.reduce((n, c) => n + c.length, 0)
+    const bytes = new Uint8Array(total)
+    let offset = 0
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset)
+      offset += chunk.length
+    }
+
+    const zip = new ZipReader(bytes)
+    const decoder = new TextDecoder()
+    expect(decoder.decode(await zip.extract("a.txt"))).toBe("hello hello hello hello")
+    expect(decoder.decode(await zip.extract("b.txt"))).toBe("world")
+  })
+
+  it("sets the data descriptor flag on every local header", async () => {
+    const encoder = new TextEncoder()
+    const chunks: Uint8Array[] = []
+    for await (const chunk of zipStreamChunks([{ path: "a.txt", data: encoder.encode("x") }])) {
+      chunks.push(chunk)
+    }
+    const header = chunks[0]!
+    const view = new DataView(header.buffer, header.byteOffset, header.byteLength)
+    expect(view.getUint32(0, true)).toBe(0x04034b50)
+    expect(view.getUint16(6, true) & 0x0008).toBe(0x0008)
+    // Sizes and CRC are deferred to the descriptor.
+    expect(view.getUint32(14, true)).toBe(0)
+    expect(view.getUint32(18, true)).toBe(0)
+    expect(view.getUint32(22, true)).toBe(0)
+  })
+
+  it("rejects duplicate entry paths", async () => {
+    const run = async () => {
+      for await (const _ of zipStreamChunks([
+        { path: "a.txt", data: new Uint8Array([1]) },
+        { path: "a.txt", data: new Uint8Array([2]) },
+      ])) {
+        // drain
+      }
+    }
+    await expect(run()).rejects.toThrow(/Duplicate ZIP entry/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// writeXlsxStream
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("writeXlsxStream", () => {
+  it("writes a workbook readable by readXlsx", async () => {
+    const stream = writeXlsxStream(
+      { name: "Data", columns: [{ header: "ID" }, { header: "Name" }] },
+      [
+        [1, "Alice"],
+        [2, "Bob"],
+      ],
+    )
+
+    const workbook = await readXlsx(await collect(stream))
+    expect(workbook.sheets).toHaveLength(1)
+    expect(workbook.sheets[0].name).toBe("Data")
+    expect(workbook.sheets[0].rows).toEqual([
+      ["ID", "Name"],
+      [1, "Alice"],
+      [2, "Bob"],
+    ])
+  })
+
+  it("accepts an async row source", async () => {
+    const stream = writeXlsxStream({ name: "S" }, asyncRows([["a"], ["b"], ["c"]]))
+    const workbook = await readXlsx(await collect(stream))
+    expect(workbook.sheets[0].rows).toEqual([["a"], ["b"], ["c"]])
+  })
+
+  it("accepts object rows through column keys", async () => {
+    const stream = writeXlsxStream(
+      {
+        name: "S",
+        columns: [
+          { key: "id", header: "ID" },
+          { key: "name", header: "Name" },
+        ],
+      },
+      [
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ],
+    )
+    const workbook = await readXlsx(await collect(stream))
+    expect(workbook.sheets[0].rows).toEqual([
+      ["ID", "Name"],
+      [1, "Alice"],
+      [2, "Bob"],
+    ])
+  })
+
+  it("round-trips every cell type", async () => {
+    const date = new Date(Date.UTC(2024, 0, 15))
+    const stream = writeXlsxStream({ name: "S" }, [["text", 42, true, false, null, date]])
+    const workbook = await readXlsx(await collect(stream))
+    const row = workbook.sheets[0].rows[0]
+    expect(row[0]).toBe("text")
+    expect(row[1]).toBe(42)
+    expect(row[2]).toBe(true)
+    expect(row[3]).toBe(false)
+    expect(row[5]).toBeInstanceOf(Date)
+    expect((row[5] as Date).toISOString().slice(0, 10)).toBe("2024-01-15")
+  })
+
+  it("writes inline strings by default (no sharedStrings part)", async () => {
+    const bytes = await collect(writeXlsxStream({ name: "S" }, [["hello"]]))
+    const zip = new ZipReader(bytes)
+    expect(zip.has("xl/sharedStrings.xml")).toBe(false)
+    const sheet = new TextDecoder().decode(await zip.extract("xl/worksheets/sheet1.xml"))
+    expect(sheet).toContain('t="inlineStr"')
+    expect(sheet).toContain("<is><t>hello</t></is>")
+  })
+
+  it("uses the shared string table when asked", async () => {
+    const bytes = await collect(
+      writeXlsxStream({ name: "S", inlineStrings: false }, [["hello"], ["hello"]]),
+    )
+    const zip = new ZipReader(bytes)
+    expect(zip.has("xl/sharedStrings.xml")).toBe(true)
+    const shared = new TextDecoder().decode(await zip.extract("xl/sharedStrings.xml"))
+    expect(shared).toContain('uniqueCount="1"')
+    const workbook = await readXlsx(bytes)
+    expect(workbook.sheets[0].rows).toEqual([["hello"], ["hello"]])
+  })
+
+  it("preserves significant whitespace in inline strings", async () => {
+    const bytes = await collect(writeXlsxStream({ name: "S" }, [["  padded  "], ["a\nb"]]))
+    const workbook = await readXlsx(bytes)
+    expect(workbook.sheets[0].rows).toEqual([["  padded  "], ["a\nb"]])
+  })
+
+  it("escapes XML-hostile characters", async () => {
+    const bytes = await collect(writeXlsxStream({ name: "S" }, [["<a> & \"b\" 'c'"]]))
+    const workbook = await readXlsx(bytes)
+    expect(workbook.sheets[0].rows[0][0]).toBe("<a> & \"b\" 'c'")
+  })
+
+  it("declares every part it references", async () => {
+    const bytes = await collect(writeXlsxStream({ name: "S" }, [["x"]]))
+    const zip = new ZipReader(bytes)
+    const contentTypes = new TextDecoder().decode(await zip.extract("[Content_Types].xml"))
+
+    for (const match of contentTypes.matchAll(/PartName="\/([^"]+)"/g)) {
+      expect(zip.has(match[1]!), `missing part ${match[1]}`).toBe(true)
+    }
+  })
+
+  it("splits into extra sheets past maxRowsPerSheet, repeating the header", async () => {
+    const rows: CellValue[][] = []
+    for (let i = 1; i <= 6; i++) rows.push([i])
+
+    const stream = writeXlsxStream(
+      { name: "Big", columns: [{ header: "N" }], maxRowsPerSheet: 3 },
+      rows,
+    )
+    const workbook = await readXlsx(await collect(stream))
+
+    expect(workbook.sheets.map((s) => s.name)).toEqual(["Big", "Big_2", "Big_3"])
+    expect(workbook.sheets[0].rows).toEqual([["N"], [1], [2]])
+    expect(workbook.sheets[1].rows).toEqual([["N"], [3], [4]])
+    expect(workbook.sheets[2].rows).toEqual([["N"], [5], [6]])
+  })
+
+  it("does not repeat headers when told not to", async () => {
+    const rows: CellValue[][] = [[1], [2], [3], [4]]
+    const stream = writeXlsxStream(
+      { name: "Big", columns: [{ header: "N" }], maxRowsPerSheet: 2, repeatHeaders: false },
+      rows,
+    )
+    const workbook = await readXlsx(await collect(stream))
+    expect(workbook.sheets[0].rows).toEqual([["N"], [1]])
+    expect(workbook.sheets[1].rows).toEqual([[2], [3]])
+  })
+
+  it("emits a single sheet when the row count lands exactly on the cap", async () => {
+    const stream = writeXlsxStream({ name: "S", maxRowsPerSheet: 3 }, [[1], [2], [3]])
+    const workbook = await readXlsx(await collect(stream))
+    expect(workbook.sheets).toHaveLength(1)
+    expect(workbook.sheets[0].rows).toEqual([[1], [2], [3]])
+  })
+
+  it("handles an empty row source", async () => {
+    const workbook = await readXlsx(await collect(writeXlsxStream({ name: "Empty" }, [])))
+    expect(workbook.sheets).toHaveLength(1)
+    expect(workbook.sheets[0].name).toBe("Empty")
+    expect(workbook.sheets[0].rows).toEqual([])
+  })
+
+  it("rejects a maxRowsPerSheet below 2", () => {
+    expect(() =>
+      collect(writeXlsxStream({ name: "S", maxRowsPerSheet: 1 }, [[1]])),
+    ).rejects.toThrow(/maxRowsPerSheet must be at least 2/)
+  })
+
+  it("carries freeze panes and column widths onto every sheet", async () => {
+    const bytes = await collect(
+      writeXlsxStream(
+        {
+          name: "S",
+          columns: [{ header: "A", width: 25 }],
+          freezePane: { rows: 1 },
+          maxRowsPerSheet: 2,
+        },
+        [[1], [2]],
+      ),
+    )
+    const zip = new ZipReader(bytes)
+    const decoder = new TextDecoder()
+    for (const path of ["xl/worksheets/sheet1.xml", "xl/worksheets/sheet2.xml"]) {
+      const xml = decoder.decode(await zip.extract(path))
+      expect(xml).toContain('state="frozen"')
+      expect(xml).toContain('width="25"')
+    }
+  })
+
+  it("applies column number formats", async () => {
+    const bytes = await collect(
+      writeXlsxStream({ name: "S", columns: [{ header: "Amount", numFmt: "#,##0.00" }] }, [[12.5]]),
+    )
+    const zip = new ZipReader(bytes)
+    const styles = new TextDecoder().decode(await zip.extract("xl/styles.xml"))
+    expect(styles).toContain("#,##0.00")
+  })
+
+  it("honours the 1904 date system", async () => {
+    const bytes = await collect(
+      writeXlsxStream({ name: "S", dateSystem: "1904" }, [[new Date(Date.UTC(2024, 0, 15))]]),
+    )
+    const zip = new ZipReader(bytes)
+    const workbookXml = new TextDecoder().decode(await zip.extract("xl/workbook.xml"))
+    expect(workbookXml).toContain('date1904="1"')
+    const workbook = await readXlsx(bytes)
+    expect((workbook.sheets[0].rows[0][0] as Date).toISOString().slice(0, 10)).toBe("2024-01-15")
+  })
+
+  it("stores uncompressed parts when asked", async () => {
+    const bytes = await collect(writeXlsxStream({ name: "S", compress: false }, [["x"]]))
+    const workbook = await readXlsx(bytes)
+    expect(workbook.sheets[0].rows).toEqual([["x"]])
+  })
+
+  it("streams incrementally rather than emitting one blob", async () => {
+    const rows: CellValue[][] = []
+    for (let i = 0; i < 20_000; i++) rows.push([i, `value-${i}`, i * 1.5])
+
+    const chunks = await collectChunks(writeXlsxStream({ name: "S", compress: false }, rows))
+    // The worksheet alone spans many 64 KB flushes, so the archive must
+    // arrive as many chunks — a buffered writer would produce a handful.
+    expect(chunks.length).toBeGreaterThan(20)
+  })
+
+  it("pulls rows lazily and stops when the consumer cancels", async () => {
+    let produced = 0
+    async function* infinite(): AsyncGenerator<CellValue[]> {
+      for (;;) {
+        produced++
+        yield [produced]
+      }
+    }
+
+    const stream = writeXlsxStream({ name: "S", compress: false }, infinite())
+    const reader = stream.getReader()
+    await reader.read()
+    await reader.cancel()
+
+    const afterCancel = produced
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    // Nothing keeps running in the background once the reader is gone.
+    expect(produced).toBe(afterCancel)
+    // And the source was never drained eagerly.
+    expect(produced).toBeLessThan(1_000_000)
+  })
+
+  it("matches the buffered writer's cell output", async () => {
+    const rows: CellValue[][] = [
+      [1, "Alice", true],
+      [2, "Bob", false],
+    ]
+
+    const buffered = new XlsxStreamWriter({ name: "S", columns: [{ header: "ID" }] })
+    for (const row of rows) buffered.addRow(row)
+    const bufferedBook = await readXlsx(await buffered.finish())
+
+    const streamedBook = await readXlsx(
+      await collect(writeXlsxStream({ name: "S", columns: [{ header: "ID" }] }, rows)),
+    )
+
+    expect(streamedBook.sheets[0].rows).toEqual(bufferedBook.sheets[0].rows)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Buffered writer regression
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("XlsxStreamWriter", () => {
+  it("ships the theme part it declares", async () => {
+    const writer = new XlsxStreamWriter({ name: "S" })
+    writer.addRow(["x"])
+    const zip = new ZipReader(await writer.finish())
+
+    const contentTypes = new TextDecoder().decode(await zip.extract("[Content_Types].xml"))
+    for (const match of contentTypes.matchAll(/PartName="\/([^"]+)"/g)) {
+      expect(zip.has(match[1]!), `missing part ${match[1]}`).toBe(true)
+    }
+    expect(zip.has("xl/theme/theme1.xml")).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #347.

## The report was right

`XlsxStreamWriter` serialized each row to XML on arrival — no workbook object model was ever built — but it kept every serialized fragment in `sheetFragments` until `finish()` joined them, encoded them, deflated them, and concatenated the archive into one `Uint8Array`. Peak memory scaled with the data, at roughly 2–3× the output. Calling that "streaming" was wrong, and the README's "without loading everything into memory" claim didn't hold for the write path.

## What this adds

`writeXlsxStream(options, rows)` → `ReadableStream<Uint8Array>`. Rows are pulled from any `Iterable` or `AsyncIterable` as the consumer reads.

```ts
import { writeXlsxStream } from "hucre/xlsx"

return new Response(
  writeXlsxStream({ name: "Export", columns }, rowCursor),
  {
    headers: {
      "content-type":
        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
    },
  },
)
```

- **`src/zip/stream-writer.ts` (new)** — streaming ZIP writer. Per entry: local file header → deflated chunks → trailing data descriptor; central directory + EOCD at the end. Compression runs through `CompressionStream("deflate-raw")` and awaits `writer.ready`, so backpressure is preserved end to end. Only one central directory record per part is retained.
- **`src/zip/deflate.ts`** — incremental CRC-32 (`crc32Update` / `crc32Final`), needed to checksum chunk by chunk. `crc32()` now builds on them.
- **`src/xlsx/stream-writer.ts`** — cell serialization extracted into a shared `RowSerializer`, so the incremental and streaming writers emit identical cells. Sheet auto-split, `repeatHeaders`, freeze panes, column widths/`numFmt`, and the 1904 date system all work while streaming.
- Strings are written inline (`t="inlineStr"`) by default. A shared string table has to live in memory until the workbook closes, which would undo the guarantee — `inlineStrings: false` restores the table. Inline text carries `xml:space="preserve"` when needed, so leading/trailing whitespace survives a round-trip.
- `[Content_Types].xml` is written last, since the sheet count is only known once the rows run out. ZIP consumers resolve parts through the central directory, so package order doesn't matter.

## Measured

5 columns of mixed text/number/date, writing to a sink that discards the bytes (Node 24):

| Rows | `writeXlsxStream` peak heap | `XlsxStreamWriter` peak heap |
| ---: | ---: | ---: |
| 300,000 | 41 MB | 328 MB |
| 1,000,000 | 67 MB | 1,037 MB |
| 3,000,000 | 70 MB | not viable |

67 MB → 70 MB across 1M → 3M rows: flat, as intended.

## Verification

- 25 new tests in `test/xlsx-stream-write.test.ts`; full suite is 7,648 tests / 107 files green on top of `v0.6.2`, lint + typecheck + build clean.
- Output validated against an independent implementation: **ExcelJS** reads all variants correctly (auto-split + freeze pane, shared strings, stored/uncompressed, inline strings, dates), and `unzip -t` reports no errors on each. Excel itself wasn't available in this environment — the data-descriptor + trailing-content-types layout is the same one `archiver`/`zip-stream` produce, which is what ExcelJS's own streaming writer emits.

## Known limit

Zip64 is not emitted, so any single part — and the whole archive — caps at 4 GiB. Crossing it throws a `ZipError` rather than writing a broken file, matching how the random-access reader now fails loudly on Zip64 (#338). Lifting this needs Zip64 on both sides; happy to open a follow-up issue.

`XlsxStreamWriter` is unchanged behaviourally and stays exported — no breaking change. Its docs now say plainly that it buffers, and point at `writeXlsxStream` for constant memory.

Rebased onto `v0.6.2`. Two overlaps with work that landed meanwhile were folded in rather than reverted: the non-finite number guard from #334 now lives in the shared `RowSerializer` (so it covers both writers), and the `xl/theme/theme1.xml` dangling-part fix that landed independently is kept as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
