### PR TITLE
feat(zip): ZIP64 read support, opt-in ZIP64 write

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,30 @@ Streaming trade-offs worth knowing:
   That's the same layout `archiver`/`zip-stream` emit, which is what
   ExcelJS's own streaming writer produces. Verified against `hucre`'s
   reader, ExcelJS, and `unzip`.
-- Zip64 is not emitted, so any single part — and the whole archive — caps
-  at 4 GiB. Crossing it throws rather than writing a broken file.
+- ZIP64 records are off by default, which caps any single part — and the
+  whole archive — at 4 GiB. Crossing that throws rather than writing a
+  broken file. Pass `zip64: true` to lift it (see below).
 - Compression uses the platform `CompressionStream`. Without it, parts are
   stored uncompressed rather than buffered.
+
+#### ZIP64 — past 4 GiB
+
+Reading ZIP64 archives needs no configuration: `readXlsx`, `openXlsx`, and
+`streamXlsxRows` resolve ZIP64 EOCD records and per-entry extra fields
+transparently, whether the producer escaped every field or only the ones
+that actually overflowed.
+
+Writing is opt-in, because part sizes aren't known when their headers go
+out — it can't be decided per entry mid-stream:
+
+```ts
+const stream = writeXlsxStream({ name: "Huge", columns, zip64: true }, rows)
+```
+
+Turn it on when one worksheet's XML may cross 4 GiB — very wide sheets
+near the per-sheet row cap can. ZIP64 archives need a ZIP64-aware
+consumer; the output here is verified against Info-ZIP's `unzip`,
+ExcelJS, and `hucre`'s own reader.
 
 #### Auto-split past Excel's row limit
 

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -72,6 +72,16 @@ export interface XlsxWriteStreamOptions extends StreamWriterOptions {
   inlineStrings?: boolean
   /** DEFLATE the parts. Default `true`. */
   compress?: boolean
+  /**
+   * Emit ZIP64 records, lifting the 4 GiB ceiling on any single part and
+   * on the archive. Default `false`.
+   *
+   * Turn this on when one worksheet's XML may exceed 4 GiB — very wide
+   * sheets near the per-sheet row cap can. With it off, an overflow
+   * throws rather than writing a corrupt file. ZIP64 archives need a
+   * ZIP64-aware consumer; Excel 2007+ and hucre's own reader qualify.
+   */
+  zip64?: boolean
 }
 
 /** A streamed row: positional values, or an object read through `columns[].key`. */
@@ -537,8 +547,9 @@ export class XlsxStreamWriter {
  * Notes:
  * - Strings are written inline by default; see {@link XlsxWriteStreamOptions.inlineStrings}.
  * - Part sizes are unknown up front, so entries carry ZIP data
- *   descriptors. Zip64 is not emitted, which caps any single part — and
- *   the archive — at 4 GiB.
+ *   descriptors. By default no ZIP64 records are emitted, which caps any
+ *   single part — and the archive — at 4 GiB; see
+ *   {@link XlsxWriteStreamOptions.zip64}.
  * - Compression needs `CompressionStream`; without it parts are stored
  *   uncompressed rather than buffered.
  */
@@ -546,7 +557,7 @@ export function writeXlsxStream(
   options: XlsxWriteStreamOptions,
   rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
 ): ReadableStream<Uint8Array> {
-  return zipStream(xlsxStreamEntries(options, rows))
+  return zipStream(xlsxStreamEntries(options, rows), { zip64: options.zip64 })
 }
 
 /** Lazily produce the ZIP entries for a streamed workbook. */

--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -12,9 +12,15 @@ const SIG_LOCAL_FILE = 0x04034b50
 const SIG_CENTRAL_DIR = 0x02014b50
 const SIG_END_OF_CENTRAL_DIR = 0x06054b50
 const SIG_DATA_DESCRIPTOR = 0x08074b50
+const SIG_ZIP64_EOCD = 0x06064b50
+const SIG_ZIP64_EOCD_LOCATOR = 0x07064b50
 
 /** 0xFFFFFFFF marker that signals a 32-bit ZIP field overflowed into ZIP64. */
 const ZIP64_SENTINEL = 0xffffffff
+/** 0xFFFF marker for the 16-bit entry-count fields. */
+const ZIP64_SENTINEL_16 = 0xffff
+/** Header id of the ZIP64 extended information extra field. */
+const ZIP64_EXTRA_ID = 0x0001
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -176,25 +182,71 @@ export class ZipReader {
       throw new ZipError("End of Central Directory not found — not a valid ZIP file")
     }
 
-    const centralDirSize = this.view.getUint32(eocdOffset + 12, true)
-    const centralDirOffset = this.view.getUint32(eocdOffset + 16, true)
-    const entryCount = this.view.getUint16(eocdOffset + 10, true)
+    let centralDirSize = this.view.getUint32(eocdOffset + 12, true)
+    let centralDirOffset = this.view.getUint32(eocdOffset + 16, true)
+    let entryCount = this.view.getUint16(eocdOffset + 10, true)
 
     // ZIP64: when the entry count or central-directory size/offset overflows
     // the 16-/32-bit EOCD fields they hold a 0xFFFF / 0xFFFFFFFF sentinel and
-    // the real values live in a ZIP64 EOCD record we don't parse. Fail loudly
-    // instead of silently reading a truncated entry list or a garbage offset.
+    // the real values live in a ZIP64 EOCD record. Producers also emit these
+    // records defensively on small archives, so a sentinel is not by itself
+    // evidence that the archive is huge.
     if (
-      entryCount === 0xffff ||
+      entryCount === ZIP64_SENTINEL_16 ||
       centralDirSize === ZIP64_SENTINEL ||
       centralDirOffset === ZIP64_SENTINEL
     ) {
-      throw new ZipError(
-        "ZIP64 archives are not supported (entry count or size exceeds the classic ZIP limits)",
-      )
+      const zip64 = this.readZip64EndOfCentralDir(eocdOffset)
+      entryCount = zip64.entryCount
+      centralDirSize = zip64.centralDirSize
+      centralDirOffset = zip64.centralDirOffset
     }
 
     this.readCentralDirectory(centralDirOffset, centralDirSize, entryCount)
+  }
+
+  /**
+   * Resolve the real directory bounds from the ZIP64 EOCD record.
+   *
+   * The 20-byte ZIP64 locator sits immediately before the classic EOCD and
+   * points at the ZIP64 EOCD record, which repeats the same fields at 64-bit
+   * width.
+   */
+  private readZip64EndOfCentralDir(eocdOffset: number): {
+    entryCount: number
+    centralDirSize: number
+    centralDirOffset: number
+  } {
+    const locatorOffset = eocdOffset - 20
+    if (locatorOffset < 0 || this.view.getUint32(locatorOffset, true) !== SIG_ZIP64_EOCD_LOCATOR) {
+      throw new ZipError("ZIP64 End of Central Directory locator not found")
+    }
+
+    const recordOffset = this.readUint64(locatorOffset + 8, "ZIP64 EOCD offset")
+    if (recordOffset + 56 > this.data.length) {
+      throw new ZipError("ZIP64 End of Central Directory record extends beyond file")
+    }
+    if (this.view.getUint32(recordOffset, true) !== SIG_ZIP64_EOCD) {
+      throw new ZipError("Invalid ZIP64 End of Central Directory signature")
+    }
+
+    return {
+      entryCount: this.readUint64(recordOffset + 32, "ZIP64 entry count"),
+      centralDirSize: this.readUint64(recordOffset + 40, "ZIP64 central directory size"),
+      centralDirOffset: this.readUint64(recordOffset + 48, "ZIP64 central directory offset"),
+    }
+  }
+
+  /** Read a 64-bit little-endian field, refusing values JS can't index with. */
+  private readUint64(offset: number, what: string): number {
+    if (offset + 8 > this.data.length) {
+      throw new ZipError(`${what} extends beyond file`)
+    }
+    const value = this.view.getBigUint64(offset, true)
+    if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+      throw new ZipError(`${what} (${value}) exceeds the addressable range`)
+    }
+    return Number(value)
   }
 
   private readCentralDirectory(offset: number, _size: number, expectedCount: number): void {
@@ -215,15 +267,35 @@ export class ZipReader {
       const generalFlag = this.view.getUint16(pos + 8, true)
       const compressionMethod = this.view.getUint16(pos + 10, true)
       const entryCrc32 = this.view.getUint32(pos + 16, true)
-      const compressedSize = this.view.getUint32(pos + 20, true)
-      const uncompressedSize = this.view.getUint32(pos + 24, true)
+      let compressedSize = this.view.getUint32(pos + 20, true)
+      let uncompressedSize = this.view.getUint32(pos + 24, true)
       const fileNameLength = this.view.getUint16(pos + 28, true)
       const extraFieldLength = this.view.getUint16(pos + 30, true)
       const commentLength = this.view.getUint16(pos + 32, true)
-      const localHeaderOffset = this.view.getUint32(pos + 42, true)
+      let localHeaderOffset = this.view.getUint32(pos + 42, true)
 
       const fileNameBytes = this.data.subarray(pos + 46, pos + 46 + fileNameLength)
       const fileName = new TextDecoder().decode(fileNameBytes)
+
+      // Any field left at the sentinel is carried at 64-bit width in the
+      // ZIP64 extra field instead.
+      if (
+        compressedSize === ZIP64_SENTINEL ||
+        uncompressedSize === ZIP64_SENTINEL ||
+        localHeaderOffset === ZIP64_SENTINEL
+      ) {
+        const zip64 = this.readZip64Extra(
+          pos + 46 + fileNameLength,
+          extraFieldLength,
+          uncompressedSize === ZIP64_SENTINEL,
+          compressedSize === ZIP64_SENTINEL,
+          localHeaderOffset === ZIP64_SENTINEL,
+          fileName,
+        )
+        if (zip64.uncompressedSize !== undefined) uncompressedSize = zip64.uncompressedSize
+        if (zip64.compressedSize !== undefined) compressedSize = zip64.compressedSize
+        if (zip64.localHeaderOffset !== undefined) localHeaderOffset = zip64.localHeaderOffset
+      }
 
       const hasDataDescriptor = (generalFlag & 0x08) !== 0
 
@@ -242,6 +314,61 @@ export class ZipReader {
 
       pos += 46 + fileNameLength + extraFieldLength + commentLength
     }
+  }
+
+  /**
+   * Pull the overflowed fields out of a central-directory ZIP64 extra field.
+   *
+   * The record is positional: only the fields whose 32-bit counterpart held
+   * the sentinel are present, always in the order size → compressed size →
+   * local header offset → disk number.
+   */
+  private readZip64Extra(
+    offset: number,
+    length: number,
+    wantUncompressed: boolean,
+    wantCompressed: boolean,
+    wantOffset: boolean,
+    fileName: string,
+  ): { uncompressedSize?: number; compressedSize?: number; localHeaderOffset?: number } {
+    const end = Math.min(offset + length, this.data.length)
+    let pos = offset
+
+    while (pos + 4 <= end) {
+      const headerId = this.view.getUint16(pos, true)
+      const dataSize = this.view.getUint16(pos + 2, true)
+      const dataStart = pos + 4
+
+      if (headerId !== ZIP64_EXTRA_ID) {
+        pos = dataStart + dataSize
+        continue
+      }
+
+      const dataEnd = dataStart + dataSize
+      let cursor = dataStart
+      const result: {
+        uncompressedSize?: number
+        compressedSize?: number
+        localHeaderOffset?: number
+      } = {}
+
+      const take = (what: string): number => {
+        if (cursor + 8 > dataEnd) {
+          throw new ZipError(`Truncated ZIP64 extra field for entry: ${fileName}`)
+        }
+        const value = this.readUint64(cursor, what)
+        cursor += 8
+        return value
+      }
+
+      if (wantUncompressed) result.uncompressedSize = take("ZIP64 uncompressed size")
+      if (wantCompressed) result.compressedSize = take("ZIP64 compressed size")
+      if (wantOffset) result.localHeaderOffset = take("ZIP64 local header offset")
+
+      return result
+    }
+
+    throw new ZipError(`Missing ZIP64 extra field for entry: ${fileName}`)
   }
 
   private async extractEntry(entry: CentralDirEntry): Promise<Uint8Array> {
@@ -270,12 +397,14 @@ export class ZipReader {
       // Try to read from data descriptor after compressed data.
       // This is a tricky case; we rely on central dir being authoritative.
       // If central dir also has zeros, we need to find the data descriptor.
+      // A sentinel here means the real value lives in the local ZIP64 extra
+      // field; taking it literally would read 4 GiB past the entry.
       const localCompressedSize = this.view.getUint32(pos + 18, true)
-      if (localCompressedSize > 0) {
+      if (localCompressedSize > 0 && localCompressedSize !== ZIP64_SENTINEL) {
         compressedSize = localCompressedSize
       }
       const localUncompressedSize = this.view.getUint32(pos + 22, true)
-      if (localUncompressedSize > 0) {
+      if (localUncompressedSize > 0 && localUncompressedSize !== ZIP64_SENTINEL) {
         uncompressedSize = localUncompressedSize
       }
 

--- a/src/zip/stream-writer.ts
+++ b/src/zip/stream-writer.ts
@@ -22,12 +22,21 @@ const SIG_LOCAL_FILE = 0x04034b50
 const SIG_DATA_DESCRIPTOR = 0x08074b50
 const SIG_CENTRAL_DIR = 0x02014b50
 const SIG_END_OF_CENTRAL_DIR = 0x06054b50
+const SIG_ZIP64_EOCD = 0x06064b50
+const SIG_ZIP64_EOCD_LOCATOR = 0x07064b50
 
 /** General purpose bit 3 — sizes and CRC live in a trailing descriptor. */
 const FLAG_DATA_DESCRIPTOR = 0x0008
 
 /** Largest value a 32-bit ZIP size/offset field can hold. */
 const MAX_UINT32 = 0xffffffff
+
+/** Header id of the ZIP64 extended information extra field. */
+const ZIP64_EXTRA_ID = 0x0001
+
+/** ZIP spec version encoded in headers: 2.0 classic, 4.5 once ZIP64 is in play. */
+const VERSION_CLASSIC = 20
+const VERSION_ZIP64 = 45
 
 const METHOD_STORE = 0
 const METHOD_DEFLATE = 8
@@ -54,6 +63,20 @@ export interface ZipStreamEntry {
 
 /** Entries may themselves be produced lazily (that's the point). */
 export type ZipStreamEntries = AsyncIterable<ZipStreamEntry> | Iterable<ZipStreamEntry>
+
+export interface ZipStreamOptions {
+  /**
+   * Emit ZIP64 records, lifting the 4 GiB ceiling on both individual
+   * entries and the archive as a whole. Default `false`.
+   *
+   * Sizes aren't known when an entry's header goes out, so this can't be
+   * decided per entry mid-stream — it's an up-front choice. Leave it off
+   * unless a part may actually exceed 4 GiB: ZIP64 archives need a
+   * ZIP64-aware consumer, and with it off an overflow throws rather than
+   * writing a corrupt archive.
+   */
+  zip64?: boolean
+}
 
 // ── Compression ─────────────────────────────────────────────────────
 
@@ -153,12 +176,28 @@ interface CentralRecord {
   localOffset: number
 }
 
-function buildLocalHeader(pathBytes: Uint8Array, method: number): Uint8Array {
-  const buf = new Uint8Array(30 + pathBytes.length)
+/**
+ * ZIP64 extra field carried in a local header. Sizes are placeholders —
+ * bit 3 is set, so the real values arrive in the data descriptor — but the
+ * field has to be there, because its presence is what tells a reader the
+ * descriptor holds 64-bit sizes.
+ */
+const ZIP64_LOCAL_EXTRA_SIZE = 20
+
+function writeZip64LocalExtra(view: DataView, offset: number): void {
+  view.setUint16(offset, ZIP64_EXTRA_ID, true)
+  view.setUint16(offset + 2, 16, true) // Data size
+  view.setBigUint64(offset + 4, 0n, true) // Uncompressed size
+  view.setBigUint64(offset + 12, 0n, true) // Compressed size
+}
+
+function buildLocalHeader(pathBytes: Uint8Array, method: number, zip64: boolean): Uint8Array {
+  const extraSize = zip64 ? ZIP64_LOCAL_EXTRA_SIZE : 0
+  const buf = new Uint8Array(30 + pathBytes.length + extraSize)
   const view = new DataView(buf.buffer)
 
   view.setUint32(0, SIG_LOCAL_FILE, true)
-  view.setUint16(4, 20, true) // Version needed (2.0)
+  view.setUint16(4, zip64 ? VERSION_ZIP64 : VERSION_CLASSIC, true)
   view.setUint16(6, FLAG_DATA_DESCRIPTOR, true)
   view.setUint16(8, method, true)
   view.setUint16(10, 0, true) // Mod time
@@ -167,62 +206,124 @@ function buildLocalHeader(pathBytes: Uint8Array, method: number): Uint8Array {
   view.setUint32(18, 0, true) // Compressed size — in the data descriptor
   view.setUint32(22, 0, true) // Uncompressed size — in the data descriptor
   view.setUint16(26, pathBytes.length, true)
-  view.setUint16(28, 0, true) // Extra field length
+  view.setUint16(28, extraSize, true)
 
   buf.set(pathBytes, 30)
+  if (zip64) writeZip64LocalExtra(view, 30 + pathBytes.length)
   return buf
 }
 
-function buildDataDescriptor(crc: number, compressedSize: number, uncompressedSize: number) {
-  const buf = new Uint8Array(16)
+function buildDataDescriptor(
+  crc: number,
+  compressedSize: number,
+  uncompressedSize: number,
+  zip64: boolean,
+): Uint8Array {
+  const buf = new Uint8Array(zip64 ? 24 : 16)
   const view = new DataView(buf.buffer)
 
   view.setUint32(0, SIG_DATA_DESCRIPTOR, true)
   view.setUint32(4, crc, true)
-  view.setUint32(8, compressedSize, true)
-  view.setUint32(12, uncompressedSize, true)
+  if (zip64) {
+    view.setBigUint64(8, BigInt(compressedSize), true)
+    view.setBigUint64(16, BigInt(uncompressedSize), true)
+  } else {
+    view.setUint32(8, compressedSize, true)
+    view.setUint32(12, uncompressedSize, true)
+  }
   return buf
 }
 
-function buildCentralDirectory(records: CentralRecord[], centralDirOffset: number): Uint8Array {
-  let size = 22 // EOCD
-  for (const rec of records) size += 46 + rec.pathBytes.length
+/**
+ * Central directory + EOCD. With `zip64`, every overflowable field in the
+ * fixed records is left at its sentinel and the real value is carried at
+ * 64-bit width — in a per-entry extra field, and in a ZIP64 EOCD record
+ * that the classic EOCD points at through a locator.
+ */
+function buildCentralDirectory(
+  records: CentralRecord[],
+  centralDirOffset: number,
+  zip64: boolean,
+): Uint8Array {
+  // Uncompressed size, compressed size, and local header offset, each 8
+  // bytes, behind a 4-byte extra-field header.
+  const entryExtraSize = zip64 ? 4 + 24 : 0
+  const trailerSize = zip64 ? 56 + 20 + 22 : 22
+
+  let size = trailerSize
+  for (const rec of records) size += 46 + rec.pathBytes.length + entryExtraSize
 
   const buf = new Uint8Array(size)
   const view = new DataView(buf.buffer)
+  const version = zip64 ? VERSION_ZIP64 : VERSION_CLASSIC
   let offset = 0
 
   for (const rec of records) {
     view.setUint32(offset, SIG_CENTRAL_DIR, true)
-    view.setUint16(offset + 4, 20, true) // Version made by (2.0)
-    view.setUint16(offset + 6, 20, true) // Version needed (2.0)
+    view.setUint16(offset + 4, version, true) // Version made by
+    view.setUint16(offset + 6, version, true) // Version needed
     view.setUint16(offset + 8, FLAG_DATA_DESCRIPTOR, true)
     view.setUint16(offset + 10, rec.method, true)
     view.setUint16(offset + 12, 0, true) // Mod time
     view.setUint16(offset + 14, 0x0021, true) // Mod date (1980-01-01)
     view.setUint32(offset + 16, rec.crc, true)
-    view.setUint32(offset + 20, rec.compressedSize, true)
-    view.setUint32(offset + 24, rec.uncompressedSize, true)
+    view.setUint32(offset + 20, zip64 ? MAX_UINT32 : rec.compressedSize, true)
+    view.setUint32(offset + 24, zip64 ? MAX_UINT32 : rec.uncompressedSize, true)
     view.setUint16(offset + 28, rec.pathBytes.length, true)
-    view.setUint16(offset + 30, 0, true) // Extra field length
+    view.setUint16(offset + 30, entryExtraSize, true)
     view.setUint16(offset + 32, 0, true) // File comment length
     view.setUint16(offset + 34, 0, true) // Disk number start
     view.setUint16(offset + 36, 0, true) // Internal file attributes
     view.setUint32(offset + 38, 0, true) // External file attributes
-    view.setUint32(offset + 42, rec.localOffset, true)
+    view.setUint32(offset + 42, zip64 ? MAX_UINT32 : rec.localOffset, true)
     buf.set(rec.pathBytes, offset + 46)
-    offset += 46 + rec.pathBytes.length
+
+    if (zip64) {
+      // Positional: only the sentinel-escaped fields appear, in this order.
+      const extra = offset + 46 + rec.pathBytes.length
+      view.setUint16(extra, ZIP64_EXTRA_ID, true)
+      view.setUint16(extra + 2, 24, true) // Data size
+      view.setBigUint64(extra + 4, BigInt(rec.uncompressedSize), true)
+      view.setBigUint64(extra + 12, BigInt(rec.compressedSize), true)
+      view.setBigUint64(extra + 20, BigInt(rec.localOffset), true)
+    }
+
+    offset += 46 + rec.pathBytes.length + entryExtraSize
   }
 
   const centralDirSize = offset
 
+  if (zip64) {
+    const recordOffset = centralDirOffset + centralDirSize
+
+    view.setUint32(offset, SIG_ZIP64_EOCD, true)
+    view.setBigUint64(offset + 4, 44n, true) // Size of the rest of this record
+    view.setUint16(offset + 12, VERSION_ZIP64, true) // Version made by
+    view.setUint16(offset + 14, VERSION_ZIP64, true) // Version needed
+    view.setUint32(offset + 16, 0, true) // Disk number
+    view.setUint32(offset + 20, 0, true) // Central dir start disk
+    view.setBigUint64(offset + 24, BigInt(records.length), true)
+    view.setBigUint64(offset + 32, BigInt(records.length), true)
+    view.setBigUint64(offset + 40, BigInt(centralDirSize), true)
+    view.setBigUint64(offset + 48, BigInt(centralDirOffset), true)
+    offset += 56
+
+    view.setUint32(offset, SIG_ZIP64_EOCD_LOCATOR, true)
+    view.setUint32(offset + 4, 0, true) // Disk holding the ZIP64 EOCD
+    view.setBigUint64(offset + 8, BigInt(recordOffset), true)
+    view.setUint32(offset + 16, 1, true) // Total disks
+    offset += 20
+  }
+
+  const sentinel16 = zip64 ? 0xffff : records.length
+
   view.setUint32(offset, SIG_END_OF_CENTRAL_DIR, true)
   view.setUint16(offset + 4, 0, true) // Disk number
   view.setUint16(offset + 6, 0, true) // Central dir start disk
-  view.setUint16(offset + 8, records.length, true)
-  view.setUint16(offset + 10, records.length, true)
-  view.setUint32(offset + 12, centralDirSize, true)
-  view.setUint32(offset + 16, centralDirOffset, true)
+  view.setUint16(offset + 8, sentinel16, true)
+  view.setUint16(offset + 10, sentinel16, true)
+  view.setUint32(offset + 12, zip64 ? MAX_UINT32 : centralDirSize, true)
+  view.setUint32(offset + 16, zip64 ? MAX_UINT32 : centralDirOffset, true)
   view.setUint16(offset + 20, 0, true) // Comment length
 
   return buf
@@ -234,7 +335,8 @@ function assertFits(value: number, what: string, path: string): void {
   if (value > MAX_UINT32) {
     throw new ZipError(
       `ZIP ${what} exceeds the 4 GiB limit at "${path}". ` +
-        `Zip64 is not supported yet — split the data across more parts.`,
+        `Pass { zip64: true } to lift it — note that ZIP64 archives need a ` +
+        `ZIP64-aware consumer.`,
     )
   }
 }
@@ -247,7 +349,11 @@ function assertFits(value: number, what: string, path: string): void {
  * later entry (styles, shared strings, the workbook index) from state
  * accumulated while earlier entries streamed out.
  */
-export async function* zipStreamChunks(entries: ZipStreamEntries): AsyncGenerator<Uint8Array> {
+export async function* zipStreamChunks(
+  entries: ZipStreamEntries,
+  options?: ZipStreamOptions,
+): AsyncGenerator<Uint8Array> {
+  const zip64 = options?.zip64 ?? false
   const records: CentralRecord[] = []
   const seen = new Set<string>()
   let offset = 0
@@ -263,7 +369,7 @@ export async function* zipStreamChunks(entries: ZipStreamEntries): AsyncGenerato
     const method = entry.compress !== false && canDeflate ? METHOD_DEFLATE : METHOD_STORE
     const localOffset = offset
 
-    const header = buildLocalHeader(pathBytes, method)
+    const header = buildLocalHeader(pathBytes, method, zip64)
     offset += header.length
     yield header
 
@@ -284,14 +390,21 @@ export async function* zipStreamChunks(entries: ZipStreamEntries): AsyncGenerato
       yield chunk
     }
 
-    assertFits(uncompressedSize, "uncompressed size", entry.path)
-    assertFits(compressedSize, "compressed size", entry.path)
+    if (!zip64) {
+      assertFits(uncompressedSize, "uncompressed size", entry.path)
+      assertFits(compressedSize, "compressed size", entry.path)
+    }
 
-    const descriptor = buildDataDescriptor(crc32Final(crcState), compressedSize, uncompressedSize)
+    const descriptor = buildDataDescriptor(
+      crc32Final(crcState),
+      compressedSize,
+      uncompressedSize,
+      zip64,
+    )
     offset += descriptor.length
     yield descriptor
 
-    assertFits(offset, "archive size", entry.path)
+    if (!zip64) assertFits(offset, "archive size", entry.path)
 
     records.push({
       pathBytes,
@@ -303,12 +416,15 @@ export async function* zipStreamChunks(entries: ZipStreamEntries): AsyncGenerato
     })
   }
 
-  yield buildCentralDirectory(records, offset)
+  yield buildCentralDirectory(records, offset, zip64)
 }
 
 /** Wrap {@link zipStreamChunks} in a `ReadableStream` of bytes. */
-export function zipStream(entries: ZipStreamEntries): ReadableStream<Uint8Array> {
-  const chunks = zipStreamChunks(entries)
+export function zipStream(
+  entries: ZipStreamEntries,
+  options?: ZipStreamOptions,
+): ReadableStream<Uint8Array> {
+  const chunks = zipStreamChunks(entries, options)
 
   return new ReadableStream<Uint8Array>({
     async pull(controller) {

--- a/test/zip64-detection.test.ts
+++ b/test/zip64-detection.test.ts
@@ -14,13 +14,14 @@ function findEocd(buf: Uint8Array): number {
   throw new Error("EOCD not found")
 }
 
-describe("ZipReader — ZIP64 sentinel detection", () => {
-  it("throws a clear error instead of mis-parsing a ZIP64-escaped entry count", async () => {
+describe("ZipReader — malformed ZIP64 escapes", () => {
+  it("throws instead of mis-parsing an escape with no ZIP64 records behind it", async () => {
     const zip = new ZipWriter()
     zip.add("a.txt", enc.encode("hello"))
     const buf = await zip.build()
 
-    // Forge a ZIP64 escape: set the EOCD entry-count fields to 0xFFFF.
+    // Forge a ZIP64 escape on an archive that has no ZIP64 EOCD record.
+    // Well-formed ZIP64 archives are covered in zip64.test.ts.
     const eocd = findEocd(buf)
     const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
     view.setUint16(eocd + 8, 0xffff, true) // total entries on this disk

--- a/test/zip64.test.ts
+++ b/test/zip64.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { ZipReader } from "../src/zip/reader"
+import { zipStreamChunks } from "../src/zip/stream-writer"
+import { writeXlsxStream } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipError } from "../src/errors"
+import { crc32 } from "../src/zip/deflate"
+import type { CellValue } from "../src/_types"
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+  const total = chunks.reduce((n, c) => n + c.length, 0)
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+async function buildStreamZip(
+  entries: Array<{ path: string; data: Uint8Array; compress?: boolean }>,
+  options?: { zip64?: boolean },
+): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  for await (const chunk of zipStreamChunks(entries, options)) chunks.push(chunk)
+  return concat(chunks)
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return concat(chunks)
+}
+
+/** Locate the End-Of-Central-Directory record (signature 0x06054b50). */
+function findEocd(buf: Uint8Array): number {
+  const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (view.getUint32(i, true) === 0x06054b50) return i
+  }
+  throw new Error("EOCD not found")
+}
+
+function viewOf(buf: Uint8Array): DataView {
+  return new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+}
+
+/**
+ * Hand-build a single-entry STORE archive, escaping exactly the chosen
+ * fields into the ZIP64 extra field.
+ *
+ * Real producers escape only what actually overflows — an archive past
+ * 4 GiB made of small entries escapes the offset but not the sizes. The
+ * extra field is positional, so each combination exercises a different
+ * read path than the writer's always-escape-everything output.
+ */
+function buildPartialZip64(
+  name: string,
+  payload: Uint8Array,
+  escape: { size?: boolean; offset?: boolean },
+): Uint8Array {
+  const SENTINEL = 0xffffffff
+  const nameBytes = enc.encode(name)
+  const crc = crc32(payload)
+
+  const escapeSize = escape.size ?? false
+  const escapeOffset = escape.offset ?? false
+  // Order is fixed: uncompressed, compressed, then local header offset.
+  const extraFields = (escapeSize ? 2 : 0) + (escapeOffset ? 1 : 0)
+  const extraSize = extraFields > 0 ? 4 + extraFields * 8 : 0
+
+  const localSize = 30 + nameBytes.length
+  const centralSize = 46 + nameBytes.length + extraSize
+  const buf = new Uint8Array(localSize + payload.length + centralSize + 56 + 20 + 22)
+  const view = viewOf(buf)
+
+  // Local file header — sizes always real here; only the directory is escaped.
+  view.setUint32(0, 0x04034b50, true)
+  view.setUint16(4, 45, true)
+  view.setUint16(6, 0, true)
+  view.setUint16(8, 0, true) // STORE
+  view.setUint16(12, 0x0021, true)
+  view.setUint32(14, crc, true)
+  view.setUint32(18, payload.length, true)
+  view.setUint32(22, payload.length, true)
+  view.setUint16(26, nameBytes.length, true)
+  buf.set(nameBytes, 30)
+  buf.set(payload, localSize)
+
+  // Central directory
+  let pos = localSize + payload.length
+  const centralDirOffset = pos
+  view.setUint32(pos, 0x02014b50, true)
+  view.setUint16(pos + 4, 45, true)
+  view.setUint16(pos + 6, 45, true)
+  view.setUint16(pos + 10, 0, true) // STORE
+  view.setUint16(pos + 14, 0x0021, true)
+  view.setUint32(pos + 16, crc, true)
+  view.setUint32(pos + 20, escapeSize ? SENTINEL : payload.length, true)
+  view.setUint32(pos + 24, escapeSize ? SENTINEL : payload.length, true)
+  view.setUint16(pos + 28, nameBytes.length, true)
+  view.setUint16(pos + 30, extraSize, true)
+  view.setUint32(pos + 42, escapeOffset ? SENTINEL : 0, true)
+  buf.set(nameBytes, pos + 46)
+
+  if (extraSize > 0) {
+    let extra = pos + 46 + nameBytes.length
+    view.setUint16(extra, 0x0001, true)
+    view.setUint16(extra + 2, extraFields * 8, true)
+    extra += 4
+    if (escapeSize) {
+      view.setBigUint64(extra, BigInt(payload.length), true)
+      view.setBigUint64(extra + 8, BigInt(payload.length), true)
+      extra += 16
+    }
+    if (escapeOffset) view.setBigUint64(extra, 0n, true)
+  }
+
+  pos += centralSize
+  const centralDirSize = pos - centralDirOffset
+  const zip64EocdOffset = pos
+
+  view.setUint32(pos, 0x06064b50, true)
+  view.setBigUint64(pos + 4, 44n, true)
+  view.setUint16(pos + 12, 45, true)
+  view.setUint16(pos + 14, 45, true)
+  view.setBigUint64(pos + 24, 1n, true)
+  view.setBigUint64(pos + 32, 1n, true)
+  view.setBigUint64(pos + 40, BigInt(centralDirSize), true)
+  view.setBigUint64(pos + 48, BigInt(centralDirOffset), true)
+  pos += 56
+
+  view.setUint32(pos, 0x07064b50, true)
+  view.setBigUint64(pos + 8, BigInt(zip64EocdOffset), true)
+  view.setUint32(pos + 16, 1, true)
+  pos += 20
+
+  view.setUint32(pos, 0x06054b50, true)
+  view.setUint16(pos + 8, 0xffff, true)
+  view.setUint16(pos + 10, 0xffff, true)
+  view.setUint32(pos + 12, SENTINEL, true)
+  view.setUint32(pos + 16, SENTINEL, true)
+
+  return buf
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Writing ZIP64
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("zipStreamChunks — ZIP64 output", () => {
+  it("emits a ZIP64 EOCD record and locator", async () => {
+    const buf = await buildStreamZip([{ path: "a.txt", data: enc.encode("hello") }], {
+      zip64: true,
+    })
+    const view = viewOf(buf)
+    const eocd = findEocd(buf)
+
+    // Locator sits immediately before the classic EOCD...
+    expect(view.getUint32(eocd - 20, true)).toBe(0x07064b50)
+    // ...and points at the ZIP64 EOCD record.
+    const recordOffset = Number(view.getBigUint64(eocd - 20 + 8, true))
+    expect(view.getUint32(recordOffset, true)).toBe(0x06064b50)
+    expect(Number(view.getBigUint64(recordOffset + 32, true))).toBe(1) // total entries
+  })
+
+  it("escapes the classic EOCD fields to sentinels", async () => {
+    const buf = await buildStreamZip([{ path: "a.txt", data: enc.encode("hello") }], {
+      zip64: true,
+    })
+    const view = viewOf(buf)
+    const eocd = findEocd(buf)
+
+    expect(view.getUint16(eocd + 8, true)).toBe(0xffff)
+    expect(view.getUint16(eocd + 10, true)).toBe(0xffff)
+    expect(view.getUint32(eocd + 12, true)).toBe(0xffffffff)
+    expect(view.getUint32(eocd + 16, true)).toBe(0xffffffff)
+  })
+
+  it("writes a 24-byte data descriptor and a local ZIP64 extra field", async () => {
+    const chunks: Uint8Array[] = []
+    for await (const chunk of zipStreamChunks([{ path: "a.txt", data: enc.encode("x") }], {
+      zip64: true,
+    })) {
+      chunks.push(chunk)
+    }
+
+    const header = chunks[0]!
+    const hv = viewOf(header)
+    expect(hv.getUint16(4, true)).toBe(45) // Version needed — 4.5
+    const nameLen = hv.getUint16(26, true)
+    expect(hv.getUint16(28, true)).toBe(20) // Extra field length
+    expect(hv.getUint16(30 + nameLen, true)).toBe(0x0001) // ZIP64 extra id
+
+    // Descriptor is the chunk right before the central directory.
+    const descriptor = chunks[chunks.length - 2]!
+    expect(descriptor.length).toBe(24)
+    expect(viewOf(descriptor).getUint32(0, true)).toBe(0x08074b50)
+  })
+
+  it("stays classic (16-byte descriptor, no locator) by default", async () => {
+    const buf = await buildStreamZip([{ path: "a.txt", data: enc.encode("hello") }])
+    const view = viewOf(buf)
+    const eocd = findEocd(buf)
+
+    expect(view.getUint16(eocd + 8, true)).toBe(1)
+    expect(view.getUint32(eocd + 12, true)).not.toBe(0xffffffff)
+    expect(view.getUint16(4, true)).toBe(20) // Local header version needed — 2.0
+    expect(view.getUint16(28, true)).toBe(0) // No extra field
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Reading ZIP64
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipReader — ZIP64 input", () => {
+  it("round-trips a ZIP64 archive written by the stream writer", async () => {
+    const buf = await buildStreamZip(
+      [
+        { path: "a.txt", data: enc.encode("hello hello hello") },
+        { path: "nested/b.bin", data: new Uint8Array([1, 2, 3, 4, 5]), compress: false },
+        { path: "c.txt", data: enc.encode("") },
+      ],
+      { zip64: true },
+    )
+
+    const zip = new ZipReader(buf)
+    expect(zip.entries().sort()).toEqual(["a.txt", "c.txt", "nested/b.bin"])
+    expect(dec.decode(await zip.extract("a.txt"))).toBe("hello hello hello")
+    expect(Array.from(await zip.extract("nested/b.bin"))).toEqual([1, 2, 3, 4, 5])
+    expect(await zip.extract("c.txt")).toHaveLength(0)
+  })
+
+  it("resolves per-entry sizes and offsets from the ZIP64 extra field", async () => {
+    // Every entry in a ZIP64 archive we write carries sentinels in the
+    // fixed record, so a correct read has to come from the extra field.
+    const payload = enc.encode("x".repeat(5000))
+    const buf = await buildStreamZip(
+      [
+        { path: "first.txt", data: payload },
+        { path: "second.txt", data: enc.encode("tail") },
+      ],
+      { zip64: true },
+    )
+
+    const view = viewOf(buf)
+    // Second entry's fixed central-directory offset field must be escaped —
+    // otherwise this test would pass without any extra-field parsing.
+    let pos = -1
+    for (let i = 0; i < buf.length - 4; i++) {
+      if (view.getUint32(i, true) === 0x02014b50) {
+        pos = i
+        break
+      }
+    }
+    expect(pos).toBeGreaterThan(-1)
+    expect(view.getUint32(pos + 42, true)).toBe(0xffffffff)
+
+    const zip = new ZipReader(buf)
+    expect(dec.decode(await zip.extract("first.txt"))).toHaveLength(5000)
+    expect(dec.decode(await zip.extract("second.txt"))).toBe("tail")
+  })
+
+  it("reads a ZIP64 XLSX end to end", async () => {
+    const rows: CellValue[][] = [
+      [1, "Alice", true],
+      [2, "Bob", false],
+    ]
+    const bytes = await collect(
+      writeXlsxStream(
+        {
+          name: "Data",
+          columns: [{ header: "ID" }, { header: "Name" }, { header: "Flag" }],
+          zip64: true,
+        },
+        rows,
+      ),
+    )
+
+    const workbook = await readXlsx(bytes)
+    expect(workbook.sheets[0].name).toBe("Data")
+    expect(workbook.sheets[0].rows).toEqual([["ID", "Name", "Flag"], ...rows])
+  })
+
+  it.each([
+    ["only the local header offset escaped", { offset: true }],
+    ["only the sizes escaped", { size: true }],
+    ["sizes and offset escaped", { size: true, offset: true }],
+    ["nothing escaped but ZIP64 records present", {}],
+  ])("reads an archive with %s", async (_label, escape) => {
+    const payload = enc.encode("partial zip64 payload")
+    const zip = new ZipReader(buildPartialZip64("a.txt", payload, escape))
+    expect(dec.decode(await zip.extract("a.txt"))).toBe("partial zip64 payload")
+  })
+
+  it("still reads a classic archive", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"))
+    const reader = new ZipReader(await zip.build())
+    expect(dec.decode(await reader.extract("a.txt"))).toBe("hello")
+  })
+
+  it("rejects a ZIP64 escape with no locator behind it", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"))
+    const buf = await zip.build()
+
+    // Forge a ZIP64 escape on an archive that has no ZIP64 records.
+    const eocd = findEocd(buf)
+    const view = viewOf(buf)
+    view.setUint16(eocd + 8, 0xffff, true)
+    view.setUint16(eocd + 10, 0xffff, true)
+
+    expect(() => new ZipReader(buf)).toThrow(ZipError)
+    expect(() => new ZipReader(buf)).toThrow(/ZIP64 End of Central Directory locator/)
+  })
+
+  it("rejects an entry whose ZIP64 extra field is missing", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"))
+    const buf = await zip.build()
+
+    // Escape the compressed size without supplying an extra field.
+    const view = viewOf(buf)
+    let pos = -1
+    for (let i = 0; i < buf.length - 4; i++) {
+      if (view.getUint32(i, true) === 0x02014b50) {
+        pos = i
+        break
+      }
+    }
+    view.setUint32(pos + 20, 0xffffffff, true)
+
+    expect(() => new ZipReader(buf)).toThrow(/Missing ZIP64 extra field/)
+  })
+})


### PR DESCRIPTION
Follow-up to #348, which shipped the streaming writer with a documented 4 GiB ceiling. This lifts it, and fixes the other half of the problem: the reader rejected ZIP64 archives outright.

## Reading — no configuration

`#338` taught the random-access reader to detect ZIP64 sentinels and fail loudly instead of mis-parsing them. That was the right stopgap, but it also meant any ZIP64-formatted archive was unreadable — including small ones, since some producers emit ZIP64 records defensively regardless of size.

- Resolve the real entry count and directory bounds from the ZIP64 EOCD record, reached through the 20-byte locator that precedes the classic EOCD.
- Resolve per-entry sizes and local header offsets from the ZIP64 extra field. That record is **positional** — only the fields whose 32-bit counterpart held the sentinel are present, in a fixed order — so a producer that escaped only the offset (a >4 GiB archive of small entries) parses correctly, not just the escape-everything shape our own writer emits.
- Refuse 64-bit values past `Number.MAX_SAFE_INTEGER` with a clear error rather than truncating them into a garbage offset.
- Stop treating a `0xFFFFFFFF` in a **local** header as a real size in the data-descriptor fallback path — that read 4 GiB past the entry.

`readXlsx`, `openXlsx`, and `streamXlsxRows` all inherit this; nothing to opt into.

## Writing — opt-in

```ts
const stream = writeXlsxStream({ name: "Huge", columns, zip64: true }, rows)
```

Also available as `zipStream(entries, { zip64: true })`. When on: ZIP64 extra field in local headers (version 4.5), 24-byte data descriptors, central directory records escaped to sentinels with 64-bit extras, and a ZIP64 EOCD record plus locator.

It's opt-in rather than automatic because part sizes aren't known when their headers go out — there's no point mid-stream where "this entry needs ZIP64" can still change the header that already shipped. Default output is byte-identical to before, and an overflow with it off still throws rather than writing a corrupt archive; the error now names the option.

## Verified

- **Our ZIP64 output, read by others**: `unzip -t` reports no errors; ExcelJS reads a ZIP64 XLSX correctly, including the auto-split + freeze-pane variant across 4 sheets.
- **Others' ZIP64 output, read by us**: an archive built with Info-ZIP `zip -fz` extracts through `ZipReader` with SHA-256 matching `unzip`'s extraction, per entry — including an empty file and a 200 KB binary.
- **Round-trip**: a ZIP64 XLSX reads back through both `readXlsx` and `streamXlsxRows` with identical rows.
- 14 new tests in `test/zip64.test.ts`, covering writer record layout, reader round-trip, all four escape combinations via a hand-built fixture, and the malformed cases. Full suite 7,662 tests / 108 files green; lint, typecheck, and build clean.

`test/zip64-detection.test.ts` from #338 is kept as a malformed-archive regression (an escape with no ZIP64 records behind it must still throw), retitled since "ZIP64 is not supported" is no longer what it's asserting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
