### PR TITLE
feat(csv): constant-memory streaming writer; fix NDJSON stream retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -1250,7 +1250,7 @@ For new code prefer `writeJson` / `workbookToJson` from `hucre/json` — same re
 ### CSV
 
 ```ts
-import { parseCsv, parseCsvObjects, writeCsv, detectDelimiter } from "hucre/csv"
+import { parseCsv, parseCsvObjects, writeCsv, writeCsvStream, detectDelimiter } from "hucre/csv"
 
 // Parse — auto-detects delimiter, handles RFC 4180 edge cases
 const rows = parseCsv(csvString, { typeInference: true })
@@ -1261,9 +1261,22 @@ const { data, headers } = parseCsvObjects(csvString, { header: true })
 // Write
 const csv = writeCsv(rows, { delimiter: ";", bom: true })
 
+// Stream write — rows are pulled as the consumer reads, so peak memory
+// doesn't grow with the row count. Takes any Iterable or AsyncIterable
+// of value arrays or objects.
+return new Response(writeCsvStream(dbCursor, { headers: ["id", "name"] }), {
+  headers: { "content-type": "text/csv; charset=utf-8" },
+})
+
 // Detect delimiter
 detectDelimiter(csvString) // "," or ";" or "\t" or "|"
 ```
+
+`writeCsvStream` is to `CsvStreamWriter` what `writeXlsxStream` is to
+`XlsxStreamWriter`: the class formats each row on arrival but retains
+every line until `finish()` returns one string, while the function
+flushes as it goes. Writing 3,000,000 rows (254 MB of CSV) under a
+128 MB heap cap, the stream completes; the class runs out of memory.
 
 ### Schema Validation
 
@@ -1420,30 +1433,31 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 
 ### CSV
 
-| Function                           | Description                                  |
-| ---------------------------------- | -------------------------------------------- |
-| `parseCsv(input, options?)`        | Parse CSV string → `CellValue[][]`           |
-| `parseCsvObjects(input, options?)` | Parse CSV with headers → `{ data, headers }` |
-| `writeCsv(rows, options?)`         | Write `CellValue[][]` → CSV string           |
-| `writeCsvObjects(data, options?)`  | Write objects → CSV string                   |
-| `detectDelimiter(input)`           | Auto-detect delimiter character              |
-| `streamCsvRows(input, options?)`   | Generator yielding CSV rows                  |
-| `CsvStreamWriter`                  | Class for incremental CSV writing            |
-| `writeTsv(rows, options?)`         | Write TSV (tab-separated)                    |
-| `fetchCsv(url, options?)`          | Fetch and parse CSV from URL                 |
+| Function                           | Description                                       |
+| ---------------------------------- | ------------------------------------------------- |
+| `parseCsv(input, options?)`        | Parse CSV string → `CellValue[][]`                |
+| `parseCsvObjects(input, options?)` | Parse CSV with headers → `{ data, headers }`      |
+| `writeCsv(rows, options?)`         | Write `CellValue[][]` → CSV string                |
+| `writeCsvObjects(data, options?)`  | Write objects → CSV string                        |
+| `detectDelimiter(input)`           | Auto-detect delimiter character                   |
+| `streamCsvRows(input, options?)`   | Generator yielding CSV rows                       |
+| `writeCsvStream(rows, options?)`   | Constant-memory CSV writing → `ReadableStream`    |
+| `CsvStreamWriter`                  | Incremental CSV writing; buffers until `finish()` |
+| `writeTsv(rows, options?)`         | Write TSV (tab-separated)                         |
+| `fetchCsv(url, options?)`          | Fetch and parse CSV from URL                      |
 
 ### JSON
 
-| Function                          | Description                                                    |
-| --------------------------------- | -------------------------------------------------------------- |
-| `parseJson(input, options?)`      | Parse JSON string/Uint8Array → `{ data, headers }`             |
-| `parseValue(value, options?)`     | Same on already-parsed JSON                                    |
-| `parseNdjson(input, options?)`    | Parse NDJSON / JSON Lines (`onError` skips invalid)            |
-| `writeJson(data, options?)`       | Serialize rows to a JSON string                                |
-| `writeNdjson(data, options?)`     | Serialize rows to NDJSON, one object per line                  |
-| `workbookToJson(wb, options?)`    | Convert a `Workbook` to JSON (single-sheet array or per-sheet) |
-| `readNdjsonStream(stream, opts?)` | Async generator over a `ReadableStream<Uint8Array>`            |
-| `NdjsonStreamWriter`              | Incremental writer with `toStream(): ReadableStream`           |
+| Function                          | Description                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| `parseJson(input, options?)`      | Parse JSON string/Uint8Array → `{ data, headers }`              |
+| `parseValue(value, options?)`     | Same on already-parsed JSON                                     |
+| `parseNdjson(input, options?)`    | Parse NDJSON / JSON Lines (`onError` skips invalid)             |
+| `writeJson(data, options?)`       | Serialize rows to a JSON string                                 |
+| `writeNdjson(data, options?)`     | Serialize rows to NDJSON, one object per line                   |
+| `workbookToJson(wb, options?)`    | Convert a `Workbook` to JSON (single-sheet array or per-sheet)  |
+| `readNdjsonStream(stream, opts?)` | Async generator over a `ReadableStream<Uint8Array>`             |
+| `NdjsonStreamWriter`              | Incremental writer; `toStream()` releases rows as they are sent |
 
 ### XML
 

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,4 +8,5 @@ export {
   formatCsvValue,
   fetchCsv,
 } from "./csv/index"
-export { streamCsvRows, CsvStreamWriter } from "./csv/stream"
+export { streamCsvRows, CsvStreamWriter, writeCsvStream } from "./csv/stream"
+export type { CsvStreamRow } from "./csv/stream"

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -1,9 +1,23 @@
 // ── CSV Streaming ────────────────────────────────────────────────────
 // Stream CSV rows as a synchronous generator (line by line).
-// Stream CSV writer builds output incrementally.
+//
+// Two writers share the row formatter below:
+//
+// • `CsvStreamWriter` — incremental. Formats each row on arrival but
+//   retains every line until `finish()` joins them, so peak memory is
+//   O(data).
+//
+// • `writeCsvStream()` — genuinely streaming. Rows are pulled from a
+//   source on demand and encoded lines are flushed as they accumulate,
+//   so peak memory is independent of the row count.
 
 import type { CellValue, CsvReadOptions, CsvWriteOptions } from "../_types"
 import { stripBom, detectDelimiter } from "./reader"
+
+const TEXT_ENCODER = /* @__PURE__ */ new TextEncoder()
+
+/** Flush the line accumulator once it crosses this many characters. */
+const CHUNK_THRESHOLD = 64 * 1024
 
 // ── Type inference (duplicated from reader to avoid coupling) ────────
 
@@ -230,17 +244,18 @@ export function* streamCsvRows(
 
 const UTF8_BOM = "\uFEFF"
 
-export class CsvStreamWriter {
-  private delimiter: string
-  private lineSeparator: string
+/**
+ * Turns row values into a CSV line. Both writers share one of these so
+ * their output stays character-identical.
+ */
+class CsvRowFormatter {
+  readonly delimiter: string
+  readonly lineSeparator: string
+  readonly bom: boolean
   private quote: string
   private quoteStyle: "all" | "required" | "none"
-  private bom: boolean
   private dateFormat: string | undefined
   private nullValue: string
-  private lines: string[] = []
-  private headerWritten = false
-  private headers: string[] | boolean | undefined
 
   constructor(options?: CsvWriteOptions) {
     this.delimiter = options?.delimiter ?? ","
@@ -250,36 +265,17 @@ export class CsvStreamWriter {
     this.bom = options?.bom ?? false
     this.dateFormat = options?.dateFormat
     this.nullValue = options?.nullValue ?? ""
-    this.headers = options?.headers
-
-    // Write header row immediately if string array provided
-    if (Array.isArray(this.headers) && !this.headerWritten) {
-      const headerLine = this.headers.map((h) => this.quoteField(h)).join(this.delimiter)
-      this.lines.push(headerLine)
-      this.headerWritten = true
-    }
   }
 
-  /** Add a row of values */
-  addRow(values: CellValue[]): void {
-    const line = values.map((v) => this.formatAndQuote(v)).join(this.delimiter)
-    this.lines.push(line)
+  /** Format one row of values into a delimited line. */
+  formatRow(values: CellValue[]): string {
+    return values.map((v) => this.formatAndQuote(v)).join(this.delimiter)
   }
 
-  /** Finalize and return the CSV string */
-  finish(): string {
-    const parts: string[] = []
-
-    if (this.bom) {
-      parts.push(UTF8_BOM)
-    }
-
-    parts.push(this.lines.join(this.lineSeparator))
-
-    return parts.join("")
+  /** Format a header line — plain strings, quoted by the same rules. */
+  formatHeader(headers: string[]): string {
+    return headers.map((h) => this.quoteField(h)).join(this.delimiter)
   }
-
-  // ── Private helpers ───────────────────────────────────────────────
 
   private formatAndQuote(value: CellValue): string {
     if (value === null || value === undefined) {
@@ -354,4 +350,180 @@ export class CsvStreamWriter {
       .replace("mm", String(minutes).padStart(2, "0"))
       .replace("ss", String(seconds).padStart(2, "0"))
   }
+}
+
+// ── Incremental CSV Writer (buffered) ────────────────────────────────
+
+/**
+ * Incremental CSV writer.
+ *
+ * Each `addRow()` is formatted immediately, but every line is retained
+ * until {@link CsvStreamWriter.finish} joins them, so peak memory scales
+ * with the data. For constant-memory output use {@link writeCsvStream}.
+ */
+export class CsvStreamWriter {
+  private formatter: CsvRowFormatter
+  private lineSeparator: string
+  private bom: boolean
+  private lines: string[] = []
+  private headerWritten = false
+  private headers: string[] | boolean | undefined
+
+  constructor(options?: CsvWriteOptions) {
+    this.formatter = new CsvRowFormatter(options)
+    this.lineSeparator = this.formatter.lineSeparator
+    this.bom = this.formatter.bom
+    this.headers = options?.headers
+
+    // Write header row immediately if string array provided
+    if (Array.isArray(this.headers) && !this.headerWritten) {
+      this.lines.push(this.formatter.formatHeader(this.headers))
+      this.headerWritten = true
+    }
+  }
+
+  /** Add a row of values */
+  addRow(values: CellValue[]): void {
+    this.lines.push(this.formatter.formatRow(values))
+  }
+
+  /** Finalize and return the CSV string */
+  finish(): string {
+    const parts: string[] = []
+
+    if (this.bom) {
+      parts.push(UTF8_BOM)
+    }
+
+    parts.push(this.lines.join(this.lineSeparator))
+
+    return parts.join("")
+  }
+}
+
+// ── True Streaming CSV Writer ────────────────────────────────────────
+
+/** A streamed row: positional values, or an object read through headers. */
+export type CsvStreamRow = CellValue[] | Record<string, CellValue>
+
+/**
+ * Write CSV as a byte stream, pulling rows from `rows` only as the
+ * consumer reads.
+ *
+ * Peak memory is independent of the row count — lines are formatted,
+ * encoded, and flushed as they accumulate, and nothing is retained.
+ *
+ * ```ts
+ * return new Response(writeCsvStream(rowCursor, { headers: ["id", "name"] }), {
+ *   headers: { "content-type": "text/csv; charset=utf-8" },
+ * })
+ * ```
+ *
+ * Object rows are projected through a column order resolved the same way
+ * {@link writeCsvObjects} resolves it: `columns` if given, else an
+ * explicit `headers` array, else the keys of the first row. A header line
+ * is emitted unless `headers: false`.
+ */
+export function writeCsvStream(
+  rows: AsyncIterable<CsvStreamRow> | Iterable<CsvStreamRow>,
+  options?: CsvWriteOptions,
+): ReadableStream<Uint8Array> {
+  const chunks = csvStreamChunks(rows, options)
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await chunks.next()
+        if (done) {
+          controller.close()
+          return
+        }
+        controller.enqueue(value)
+      } catch (err) {
+        controller.error(err)
+      }
+    },
+    async cancel(reason) {
+      await chunks.return?.(reason)
+    },
+  })
+}
+
+/** Format rows into ~64 KB encoded chunks, pulling lazily. */
+async function* csvStreamChunks(
+  rows: AsyncIterable<CsvStreamRow> | Iterable<CsvStreamRow>,
+  options?: CsvWriteOptions,
+): AsyncGenerator<Uint8Array> {
+  const formatter = new CsvRowFormatter(options)
+  const lineSeparator = formatter.lineSeparator
+
+  let pending = ""
+  let wroteAnyLine = false
+
+  const push = (line: string): Uint8Array | undefined => {
+    // `finish()` joins with the separator rather than terminating each
+    // line, so the separator goes *before* every line but the first.
+    pending += wroteAnyLine ? lineSeparator + line : line
+    wroteAnyLine = true
+    if (pending.length < CHUNK_THRESHOLD) return undefined
+    const chunk = TEXT_ENCODER.encode(pending)
+    pending = ""
+    return chunk
+  }
+
+  if (formatter.bom) pending += UTF8_BOM
+
+  const iterator: AsyncIterator<CsvStreamRow> | Iterator<CsvStreamRow> =
+    Symbol.asyncIterator in Object(rows)
+      ? (rows as AsyncIterable<CsvStreamRow>)[Symbol.asyncIterator]()
+      : (rows as Iterable<CsvStreamRow>)[Symbol.iterator]()
+
+  // Column order for object rows, resolved on the first one seen.
+  const explicitColumns = options?.columns
+  const headerOption = options?.headers
+  let columns: string[] | undefined =
+    explicitColumns ?? (Array.isArray(headerOption) ? headerOption : undefined)
+  let headerEmitted = false
+
+  const emitHeader = (names: string[]): Uint8Array | undefined => {
+    headerEmitted = true
+    if (headerOption === false) return undefined
+    return push(formatter.formatHeader(names))
+  }
+
+  // An explicit column order means the header line is known up front, so
+  // it goes out before the first row is even pulled.
+  if (columns) {
+    const chunk = emitHeader(columns)
+    if (chunk) yield chunk
+  }
+
+  try {
+    for (;;) {
+      const result = await iterator.next()
+      if (result.done) break
+      const row = result.value
+
+      let values: CellValue[]
+      if (Array.isArray(row)) {
+        values = row
+      } else {
+        if (!columns) {
+          columns = Object.keys(row)
+          if (!headerEmitted) {
+            const chunk = emitHeader(columns)
+            if (chunk) yield chunk
+          }
+        }
+        values = columns.map((key) => row[key] ?? null)
+      }
+
+      const chunk = push(formatter.formatRow(values))
+      if (chunk) yield chunk
+    }
+  } finally {
+    await iterator.return?.()
+  }
+
+  if (pending.length > 0) yield TEXT_ENCODER.encode(pending)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,8 @@ export {
   formatCsvValue,
   fetchCsv,
 } from "./csv/index"
-export { streamCsvRows, CsvStreamWriter } from "./csv/stream"
+export { streamCsvRows, CsvStreamWriter, writeCsvStream } from "./csv/stream"
+export type { CsvStreamRow } from "./csv/stream"
 
 // ── JSON ───────────────────────────────────────────────────────────
 export {

--- a/src/json/stream.ts
+++ b/src/json/stream.ts
@@ -52,17 +52,24 @@ export class NdjsonStreamWriter {
   /**
    * Expose the writer as a `ReadableStream<Uint8Array>`. The stream
    * remains open until {@link end} is called.
+   *
+   * Consumed rows are released as they are enqueued, so a writer that is
+   * only ever drained through the stream holds no more than the rows
+   * written since the last pull. Note that {@link toString} then has
+   * nothing left to return — pick one drain or the other.
    */
   toStream(): ReadableStream<Uint8Array> {
     const buffer = this.buffer
     const isDone = () => this.done
-    let cursor = 0
 
     return new ReadableStream<Uint8Array>({
       pull: (controller) => {
-        while (cursor < buffer.length) {
-          controller.enqueue(TEXT_ENCODER.encode(buffer[cursor]!))
-          cursor++
+        // Detach rather than walk a cursor: holding on to already-sent
+        // rows would make the stream O(total) instead of O(pending).
+        if (buffer.length > 0) {
+          for (const row of buffer.splice(0, buffer.length)) {
+            controller.enqueue(TEXT_ENCODER.encode(row))
+          }
         }
         if (isDone()) {
           controller.close()

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -437,6 +437,7 @@ export const WORKER_SAFE_FUNCTIONS: string[] = [
   "formatCsvValue",
   "streamCsvRows",
   "CsvStreamWriter",
+  "writeCsvStream",
   // Schema
   "validateWithSchema",
   // Date utilities

--- a/test/csv-stream-write.test.ts
+++ b/test/csv-stream-write.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest"
+import { writeCsvStream, CsvStreamWriter } from "../src/csv/stream"
+import { writeCsv, writeCsvObjects } from "../src/csv/writer"
+import { parseCsv } from "../src/csv/reader"
+import { NdjsonStreamWriter } from "../src/json/stream"
+import type { CellValue, CsvWriteOptions } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
+  // ignoreBOM, or the decoder silently eats the BOM we are asserting on.
+  const dec = new TextDecoder("utf-8", { ignoreBOM: true })
+  const reader = stream.getReader()
+  let out = ""
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += dec.decode(value, { stream: true })
+  }
+  out += dec.decode()
+  return out
+}
+
+async function collectChunks(stream: ReadableStream<Uint8Array>): Promise<Uint8Array[]> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  return chunks
+}
+
+async function* asyncRows<T>(rows: T[]): AsyncGenerator<T> {
+  for (const row of rows) {
+    await Promise.resolve()
+    yield row
+  }
+}
+
+/** Same rows through the buffered writer, for parity assertions. */
+function buffered(rows: CellValue[][], options?: CsvWriteOptions): string {
+  const writer = new CsvStreamWriter(options)
+  for (const row of rows) writer.addRow(row)
+  return writer.finish()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("writeCsvStream", () => {
+  it("matches writeCsv byte for byte", async () => {
+    const rows: CellValue[][] = [
+      ["id", "name"],
+      [1, "Alice"],
+      [2, "Bob"],
+    ]
+    expect(await collect(writeCsvStream(rows))).toBe(writeCsv(rows))
+  })
+
+  it("matches the buffered writer across option combinations", async () => {
+    const rows: CellValue[][] = [
+      [1, "plain"],
+      [2, 'has "quotes"'],
+      [3, "has,comma"],
+      [4, "has\nnewline"],
+      [5, null],
+      [6, true],
+      [7, new Date(Date.UTC(2024, 0, 15, 12, 30))],
+      [8, 1e-9],
+      [9, 1e16],
+    ]
+
+    const cases: CsvWriteOptions[] = [
+      {},
+      { delimiter: ";" },
+      { lineSeparator: "\n" },
+      { quoteStyle: "all" },
+      { quoteStyle: "none" },
+      { quote: "'" },
+      { nullValue: "NULL" },
+      { bom: true },
+      { dateFormat: "YYYY-MM-DD HH:mm:ss" },
+      { headers: ["a", "b"] },
+    ]
+
+    for (const options of cases) {
+      expect(await collect(writeCsvStream(rows, options)), JSON.stringify(options)).toBe(
+        buffered(rows, options),
+      )
+    }
+  })
+
+  it("accepts an async row source", async () => {
+    const out = await collect(
+      writeCsvStream(
+        asyncRows([
+          [1, "a"],
+          [2, "b"],
+        ]),
+      ),
+    )
+    expect(out).toBe("1,a\r\n2,b")
+  })
+
+  it("emits the BOM before the first line", async () => {
+    const out = await collect(writeCsvStream([[1]], { bom: true }))
+    expect(out.charCodeAt(0)).toBe(0xfeff)
+    expect(out).toBe("﻿1")
+  })
+
+  it("writes an explicit header array even when no rows arrive", async () => {
+    expect(await collect(writeCsvStream([], { headers: ["id", "name"] }))).toBe("id,name")
+  })
+
+  it("emits nothing for an empty source", async () => {
+    expect(await collect(writeCsvStream([]))).toBe("")
+  })
+
+  it("emits only the BOM for an empty source when asked", async () => {
+    expect(await collect(writeCsvStream([], { bom: true }))).toBe("﻿")
+  })
+
+  describe("object rows", () => {
+    const data = [
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]
+
+    it("derives the header from the first row's keys", async () => {
+      expect(await collect(writeCsvStream(data))).toBe(writeCsvObjects(data))
+    })
+
+    it("honours an explicit column order", async () => {
+      const options: CsvWriteOptions = { columns: ["name", "id"] }
+      expect(await collect(writeCsvStream(data, options))).toBe(writeCsvObjects(data, options))
+    })
+
+    it("skips the header line when headers is false", async () => {
+      const out = await collect(writeCsvStream(data, { headers: false }))
+      expect(out).toBe("1,Alice\r\n2,Bob")
+    })
+
+    it("fills missing keys with the null value", async () => {
+      const out = await collect(
+        writeCsvStream([{ id: 1, name: "Alice" }, { id: 2 }] as Array<Record<string, CellValue>>),
+      )
+      expect(parseCsv(out)).toEqual([
+        ["id", "name"],
+        ["1", "Alice"],
+        ["2", ""],
+      ])
+    })
+  })
+
+  it("round-trips through parseCsv", async () => {
+    const rows: CellValue[][] = [
+      ["id", "note"],
+      [1, 'quoted "value"'],
+      [2, "with,comma"],
+      [3, "multi\nline"],
+    ]
+    const out = await collect(writeCsvStream(rows))
+    expect(parseCsv(out)).toEqual([
+      ["id", "note"],
+      ["1", 'quoted "value"'],
+      ["2", "with,comma"],
+      ["3", "multi\nline"],
+    ])
+  })
+
+  it("streams incrementally rather than emitting one blob", async () => {
+    const rows: CellValue[][] = []
+    for (let i = 0; i < 40_000; i++) rows.push([i, `value-${i}`, i * 1.5])
+
+    const chunks = await collectChunks(writeCsvStream(rows))
+    // Output spans many 64 KB flushes; a buffered writer would emit one.
+    expect(chunks.length).toBeGreaterThan(10)
+  })
+
+  it("pulls rows lazily and stops when the consumer cancels", async () => {
+    let produced = 0
+    function* infinite(): Generator<CellValue[]> {
+      for (;;) {
+        produced++
+        yield [produced, "x".repeat(100)]
+      }
+    }
+
+    const reader = writeCsvStream(infinite()).getReader()
+    await reader.read()
+    await reader.cancel()
+
+    const afterCancel = produced
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(produced).toBe(afterCancel)
+    expect(produced).toBeLessThan(100_000)
+  })
+
+  it("closes a generator source on cancel", async () => {
+    let closed = false
+    function* rows(): Generator<CellValue[]> {
+      try {
+        for (;;) yield [1]
+      } finally {
+        closed = true
+      }
+    }
+
+    const reader = writeCsvStream(rows()).getReader()
+    await reader.read()
+    await reader.cancel()
+    expect(closed).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("NdjsonStreamWriter.toStream", () => {
+  it("releases rows once they are enqueued", async () => {
+    const writer = new NdjsonStreamWriter()
+    for (let i = 0; i < 50; i++) writer.write({ i })
+
+    const reader = writer.toStream().getReader()
+    await reader.read()
+
+    // Nothing already sent is still held — the stream is O(pending),
+    // not O(total written).
+    const internal = writer as unknown as { buffer: string[] }
+    expect(internal.buffer).toHaveLength(0)
+    await reader.cancel()
+  })
+
+  it("still delivers everything written before end()", async () => {
+    const writer = new NdjsonStreamWriter()
+    writer.write({ a: 1 })
+    writer.write({ a: 2 })
+    writer.end()
+
+    const dec = new TextDecoder()
+    const reader = writer.toStream().getReader()
+    let out = ""
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      out += dec.decode(value)
+    }
+    expect(out).toBe('{"a":1}\n{"a":2}\n')
+  })
+
+  it("delivers rows written after the stream is already being drained", async () => {
+    const writer = new NdjsonStreamWriter()
+    const dec = new TextDecoder()
+    const reader = writer.toStream().getReader()
+
+    writer.write({ a: 1 })
+    const first = await reader.read()
+    expect(dec.decode(first.value)).toBe('{"a":1}\n')
+
+    writer.write({ a: 2 })
+    const second = await reader.read()
+    expect(dec.decode(second.value)).toBe('{"a":2}\n')
+
+    writer.end()
+    await reader.cancel()
+  })
+})


### PR DESCRIPTION
Applies the #347 finding to the other formats.

## CSV had the same shape

`CsvStreamWriter` formats each row on arrival but retains every line in `this.lines` until `finish()` joins them into one string — peak memory scales with the data. Unlike the XLSX case the docs were honest about this ("Class for incremental CSV writing"), so nothing was misleading; the gap was that there was no constant-memory option at all, for the format where streaming export is the most common ask.

`writeCsvStream(rows, options)` returns a `ReadableStream<Uint8Array>`, mirroring `writeXlsxStream`:

```ts
return new Response(writeCsvStream(dbCursor, { headers: ["id", "name"] }), {
  headers: { "content-type": "text/csv; charset=utf-8" },
})
```

- Rows are pulled from any `Iterable` or `AsyncIterable` as the consumer reads; lines are formatted, encoded, and flushed in ~64 KB chunks.
- Formatting moved into a shared `CsvRowFormatter` so both writers emit **character-identical** output. Asserted across `delimiter`, `lineSeparator`, `quote`, `quoteStyle`, `nullValue`, `bom`, `dateFormat`, and `headers` — including the detail that `finish()` *joins* with the separator rather than terminating each line, so the separator goes before every line but the first.
- Object rows resolve their column order the way `writeCsvObjects` does: `columns`, else an explicit `headers` array, else the first row's keys. A header line is emitted unless `headers: false`.
- Cancelling the consumer closes the source iterator (`return()`), so a generator's `finally` runs.

**Measured**: writing 3,000,000 rows — 254 MB of CSV — under `--max-old-space-size=128`, the stream completes; `CsvStreamWriter` dies with a heap OOM. (Peak-heap sampling is noisy here because it tracks GC timing rather than retention, so the hard cap is the honest demonstration.)

## NDJSON stream leaked what it had already sent

`NdjsonStreamWriter.toStream()` walked a `cursor` over its buffer and never released the rows behind it. A writer drained purely through the stream — the exact pattern the README's Cloudflare Workers example shows — still held every row ever written.

It now detaches the pending rows on each pull, making the stream `O(pending)` instead of `O(total)`. Probed before and after: 50 rows written, one `read()` taken, buffer length was 50, now 0. `toString()` and `toStream()` are now alternative drains rather than both being readable; that's documented on the method, and no existing test or example used both.

I checked for a busy-loop while I was in there — `pull()` returning with an empty queue could in principle spin — but it doesn't: 4 ms of CPU across a 500 ms idle wait on a pending read. No change needed.

## Verification

- 18 new tests in `test/csv-stream-write.test.ts`: parity with `writeCsv`/`writeCsvObjects`, the option matrix, BOM placement, object-row header resolution, empty sources, `parseCsv` round-trip, chunk granularity, lazy pull, cancel-closes-source, plus the three NDJSON cases.
- Full suite 7,680 tests / 109 files green; lint, typecheck, and build clean.

ODS has no streaming writer to fix — `src/ods/stream.ts` is read-only (`streamOdsRows`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
