### PR TITLE
fix(csv): align streamCsvRows with parseCsv — closes #353

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .env
 .env.local
 .vercel
+coverage

--- a/README.md
+++ b/README.md
@@ -1433,18 +1433,18 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 
 ### CSV
 
-| Function                           | Description                                       |
-| ---------------------------------- | ------------------------------------------------- |
-| `parseCsv(input, options?)`        | Parse CSV string → `CellValue[][]`                |
-| `parseCsvObjects(input, options?)` | Parse CSV with headers → `{ data, headers }`      |
-| `writeCsv(rows, options?)`         | Write `CellValue[][]` → CSV string                |
-| `writeCsvObjects(data, options?)`  | Write objects → CSV string                        |
-| `detectDelimiter(input)`           | Auto-detect delimiter character                   |
-| `streamCsvRows(input, options?)`   | Generator yielding CSV rows                       |
-| `writeCsvStream(rows, options?)`   | Constant-memory CSV writing → `ReadableStream`    |
-| `CsvStreamWriter`                  | Incremental CSV writing; buffers until `finish()` |
-| `writeTsv(rows, options?)`         | Write TSV (tab-separated)                         |
-| `fetchCsv(url, options?)`          | Fetch and parse CSV from URL                      |
+| Function                           | Description                                             |
+| ---------------------------------- | ------------------------------------------------------- |
+| `parseCsv(input, options?)`        | Parse CSV string → `CellValue[][]`                      |
+| `parseCsvObjects(input, options?)` | Parse CSV with headers → `{ data, headers }`            |
+| `writeCsv(rows, options?)`         | Write `CellValue[][]` → CSV string                      |
+| `writeCsvObjects(data, options?)`  | Write objects → CSV string                              |
+| `detectDelimiter(input)`           | Auto-detect delimiter character                         |
+| `streamCsvRows(input, options?)`   | Generator yielding CSV rows; same options as `parseCsv` |
+| `writeCsvStream(rows, options?)`   | Constant-memory CSV writing → `ReadableStream`          |
+| `CsvStreamWriter`                  | Incremental CSV writing; buffers until `finish()`       |
+| `writeTsv(rows, options?)`         | Write TSV (tab-separated)                               |
+| `fetchCsv(url, options?)`          | Fetch and parse CSV from URL                            |
 
 ### JSON
 

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1463,6 +1463,15 @@ export interface CsvReadOptions {
   transformValue?: (value: CellValue, header: string, row: number, col: number) => CellValue
   /** Fast mode: skip quote handling and just split by delimiter/newlines. Faster for files known to have no quoted fields. Default: false */
   fastMode?: boolean
+  /**
+   * Drop the header row from the output instead of yielding it.
+   *
+   * `header: true` only marks the first row as a header — it is still
+   * returned, and only used to name columns for {@link transformValue}.
+   * Set this when you want the header consumed rather than emitted.
+   * Default: false
+   */
+  skipHeaderRow?: boolean
 }
 
 export interface CsvWriteOptions {

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -86,14 +86,16 @@ export function* streamCsvRows(
   const skipEmptyRows = options?.skipEmptyRows ?? false
   const commentChar = options?.comment
   const isHeaderMode = options?.header ?? false
+  const skipHeaderRow = options?.skipHeaderRow ?? false
   // Align inferType default with parseCsv (defaults to true).
   const preserveLeadingZeros = options?.preserveLeadingZeros !== false
   const maxRows = options?.maxRows
   const skipLines = options?.skipLines ?? 0
-  // NOTE: transformValue, transformHeader, onRow and fastMode are NOT yet
-  // wired into the streaming reader. TODO: thread them through to reach full
-  // parity with parseCsv. For now we honor maxRows, skipLines and
-  // preserveLeadingZeros, which are the most impactful for correctness.
+  const transformValue = options?.transformValue
+  const onRow = options?.onRow
+  // Fast mode trades quote handling for speed, exactly as in parseCsv —
+  // fields are split on the delimiter with no quote awareness at all.
+  const fastMode = options?.fastMode ?? false
 
   if (skipBom) {
     input = stripBom(input)
@@ -106,7 +108,7 @@ export function* streamCsvRows(
 
   let i = 0
   let isFirstRow = true
-  let _headerRow: string[] | null = null
+  let headerRow: string[] | null = null
   let physicalLine = 0 // counts every parsed physical row (for skipLines)
   let emittedDataRows = 0 // counts rows yielded (for maxRows)
 
@@ -178,8 +180,10 @@ export function* streamCsvRows(
         continue
       }
 
-      // Start of quoted field
-      if (ch === quote && currentField === "") {
+      // Start of quoted field. In fast mode the quote char is just another
+      // character, so `inQuoted` is never entered and the branches above
+      // stay dead — matching parseFast's plain split.
+      if (!fastMode && ch === quote && currentField === "") {
         inQuoted = true
         fieldWasQuoted = true
         i++
@@ -216,27 +220,44 @@ export function* streamCsvRows(
       continue
     }
 
-    // Handle header row
-    if (isFirstRow && isHeaderMode) {
-      _headerRow = row
-      isFirstRow = false
-      continue
+    // Capture the header row. Like parseCsv, `header: true` only marks it —
+    // the row is still yielded, and is used to name columns for
+    // transformValue. `skipHeaderRow` is the opt-in that consumes it.
+    const isHeaderRowNow = isFirstRow && isHeaderMode
+    if (isHeaderRowNow) {
+      headerRow = row
     }
     isFirstRow = false
+
+    if (isHeaderRowNow && skipHeaderRow) continue
 
     // Honor maxRows (counts data rows yielded)
     if (maxRows !== undefined && maxRows >= 0 && emittedDataRows >= maxRows) {
       return
     }
+    const rowIndex = emittedDataRows
     emittedDataRows++
 
     // Apply type inference if requested
-    if (doTypeInference) {
-      const typedRow: CellValue[] = row.map((v) => inferType(v, preserveLeadingZeros))
-      yield typedRow
-    } else {
-      yield row
+    let outRow: CellValue[] = doTypeInference
+      ? row.map((v) => inferType(v, preserveLeadingZeros))
+      : row
+
+    // transformValue — after type inference, matching parseCsv's ordering.
+    if (transformValue) {
+      outRow = outRow.map((val, colIdx) =>
+        transformValue(
+          val,
+          headerRow ? String(headerRow[colIdx] ?? colIdx) : String(colIdx),
+          rowIndex,
+          colIdx,
+        ),
+      )
     }
+
+    onRow?.(outRow, rowIndex)
+
+    yield outRow
   }
 }
 

--- a/test/csv-stream-read-parity.test.ts
+++ b/test/csv-stream-read-parity.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest"
+import { parseCsv } from "../src/csv/reader"
+import { streamCsvRows } from "../src/csv/stream"
+import type { CellValue, CsvReadOptions } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function stream(input: string, options?: CsvReadOptions): CellValue[][] {
+  return Array.from(streamCsvRows(input, options))
+}
+
+const SIMPLE = "name,qty\r\nfoo,1\r\nbar,2\r\n"
+const QUOTED = 'a,"b,c"\r\n"x""y",z\r\n'
+const MESSY = [
+  "# leading comment",
+  "name;qty;when",
+  "foo;1;2024-01-15",
+  "",
+  '"semi;colon";02;true',
+  "bar;3;x",
+].join("\n")
+
+// ═══════════════════════════════════════════════════════════════════════
+// streamCsvRows must agree with parseCsv on the shared option set.
+// Regression guard for the divergence documented in #353.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("streamCsvRows / parseCsv parity", () => {
+  const inputs: Array<[string, string]> = [
+    ["simple", SIMPLE],
+    ["quoted", QUOTED],
+    ["messy", MESSY],
+  ]
+
+  const optionCases: Array<[string, CsvReadOptions]> = [
+    ["defaults", {}],
+    ["header", { header: true }],
+    ["typeInference", { typeInference: true }],
+    ["typeInference + header", { typeInference: true, header: true }],
+    ["preserveLeadingZeros off", { typeInference: true, preserveLeadingZeros: false }],
+    ["fastMode", { fastMode: true }],
+    ["fastMode + typeInference", { fastMode: true, typeInference: true }],
+    ["maxRows 1", { maxRows: 1 }],
+    ["maxRows 0", { maxRows: 0 }],
+    ["skipLines 1", { skipLines: 1 }],
+    ["skipEmptyRows", { skipEmptyRows: true }],
+    ["comment", { comment: "#" }],
+    ["delimiter ;", { delimiter: ";" }],
+    ["skipBom off", { skipBom: false }],
+  ]
+
+  for (const [inputLabel, input] of inputs) {
+    for (const [optionLabel, options] of optionCases) {
+      it(`${inputLabel} — ${optionLabel}`, () => {
+        expect(stream(input, options)).toEqual(parseCsv(input, options))
+      })
+    }
+  }
+})
+
+describe("streamCsvRows — fastMode", () => {
+  it("splits without quote handling, like parseCsv", () => {
+    expect(stream(QUOTED, { fastMode: true })).toEqual(parseCsv(QUOTED, { fastMode: true }))
+    // And that really is different from the RFC 4180 parse.
+    expect(stream(QUOTED, { fastMode: true })).not.toEqual(stream(QUOTED))
+  })
+
+  it("treats the quote char as ordinary content", () => {
+    expect(stream('a,"b,c"\r\n', { fastMode: true })).toEqual([["a", '"b', 'c"']])
+  })
+})
+
+describe("streamCsvRows — transformValue", () => {
+  it("applies to every cell, like parseCsv", () => {
+    const upper = (v: CellValue) => (typeof v === "string" ? v.toUpperCase() : v)
+    expect(stream(SIMPLE, { transformValue: upper })).toEqual(
+      parseCsv(SIMPLE, { transformValue: upper }),
+    )
+  })
+
+  it("names columns from the header row when header is set", () => {
+    const seen: string[] = []
+    stream(SIMPLE, {
+      header: true,
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["name", "qty", "name", "qty", "name", "qty"])
+  })
+
+  it("falls back to the column index without a header", () => {
+    const seen: string[] = []
+    stream(SIMPLE, {
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(new Set(seen)).toEqual(new Set(["0", "1"]))
+  })
+
+  it("runs after type inference", () => {
+    const types: string[] = []
+    stream("1\r\n", {
+      typeInference: true,
+      transformValue: (v) => {
+        types.push(typeof v)
+        return v
+      },
+    })
+    expect(types).toEqual(["number"])
+  })
+
+  it("reports row and column indices", () => {
+    const coords: Array<[number, number]> = []
+    stream(SIMPLE, {
+      transformValue: (v, _h, row, col) => {
+        coords.push([row, col])
+        return v
+      },
+    })
+    expect(coords).toEqual([
+      [0, 0],
+      [0, 1],
+      [1, 0],
+      [1, 1],
+      [2, 0],
+      [2, 1],
+    ])
+  })
+})
+
+describe("streamCsvRows — onRow", () => {
+  it("fires once per yielded row, like parseCsv", () => {
+    const streamed: Array<[number, CellValue[]]> = []
+    stream(SIMPLE, { onRow: (row, i) => streamed.push([i, row]) })
+
+    const parsed: Array<[number, CellValue[]]> = []
+    parseCsv(SIMPLE, { onRow: (row, i) => parsed.push([i, row]) })
+
+    expect(streamed).toEqual(parsed)
+  })
+
+  it("sees the transformed row", () => {
+    const seen: CellValue[][] = []
+    stream("a\r\n", {
+      transformValue: () => "REPLACED",
+      onRow: (row) => seen.push(row),
+    })
+    expect(seen).toEqual([["REPLACED"]])
+  })
+
+  it("does not fire for rows past maxRows", () => {
+    let count = 0
+    stream(SIMPLE, { maxRows: 1, onRow: () => count++ })
+    expect(count).toBe(1)
+  })
+})
+
+describe("streamCsvRows — skipHeaderRow", () => {
+  it("drops the header row when asked", () => {
+    expect(stream(SIMPLE, { header: true, skipHeaderRow: true })).toEqual([
+      ["foo", "1"],
+      ["bar", "2"],
+    ])
+  })
+
+  it("keeps the header row by default, matching parseCsv", () => {
+    expect(stream(SIMPLE, { header: true })).toEqual(parseCsv(SIMPLE, { header: true }))
+    expect(stream(SIMPLE, { header: true })[0]).toEqual(["name", "qty"])
+  })
+
+  it("is inert without header: true", () => {
+    expect(stream(SIMPLE, { skipHeaderRow: true })).toEqual(stream(SIMPLE))
+  })
+
+  it("still names transformValue columns from the consumed header", () => {
+    const seen: string[] = []
+    stream(SIMPLE, {
+      header: true,
+      skipHeaderRow: true,
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["name", "qty", "name", "qty"])
+  })
+
+  it("counts maxRows against emitted rows only", () => {
+    expect(stream(SIMPLE, { header: true, skipHeaderRow: true, maxRows: 1 })).toEqual([
+      ["foo", "1"],
+    ])
+  })
+})

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -942,7 +942,18 @@ describe("streamCsvRows", () => {
     const csv = "name,age\nAlice,30\nBob,25"
     const rows = collectSyncRows(streamCsvRows(csv, { header: true }))
 
-    // Header row should be consumed, not yielded
+    // `header: true` marks the header row without consuming it, matching
+    // parseCsv — see #353. Use skipHeaderRow to drop it.
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toEqual(["name", "age"])
+    expect(rows[1]).toEqual(["Alice", "30"])
+    expect(rows[2]).toEqual(["Bob", "25"])
+  })
+
+  it("skipHeaderRow consumes the header row", () => {
+    const csv = "name,age\nAlice,30\nBob,25"
+    const rows = collectSyncRows(streamCsvRows(csv, { header: true, skipHeaderRow: true }))
+
     expect(rows).toHaveLength(2)
     expect(rows[0]).toEqual(["Alice", "30"])
     expect(rows[1]).toEqual(["Bob", "25"])


### PR DESCRIPTION
Closes #353. Part of #352.

`streamCsvRows` and `parseCsv` accept the same `CsvReadOptions` and were documented as interchangeable, but four options behaved differently. `src/csv/stream.ts:93` acknowledged part of it in a comment; the real divergence was wider, and one case changed the returned data rather than just skipping a callback.

All four were measured against `main` before fixing — see #353 for the reproductions.

| Option | Before | Now |
| --- | --- | --- |
| `header: true` | stream **dropped** the header row, parseCsv **kept** it | both keep it; `skipHeaderRow` drops it |
| `onRow` | never fired | fires once per yielded row |
| `transformValue` | ignored | applied after type inference, same column-naming rules |
| `fastMode` | inert — stream always did full quote handling | splits without quote handling, like `parseCsv` |

## The `header` change is a deliberate break

`streamCsvRows(input, { header: true })` now yields the header row, because that is what `parseCsv` does — `header` marks the row and names columns for `transformValue`, it does not consume it. Callers who want it dropped add `skipHeaderRow: true`.

I went this direction rather than changing `parseCsv` because `parseCsv` is the root API that `parseCsvObjects` and the schema path build on; bending it to match the streaming reader would have rippled much further. Doing it now is the point of a pre-v1 audit — after v1 this is off the table.

One existing test encoded the old contract (`test/streaming.test.ts`, "header row handling"). It is updated to the new behaviour, with a companion test covering `skipHeaderRow` so the old output stays under test.

## `transformHeader` is not part of this

The source comment listed it alongside the others, but it only affects `parseCsvObjects` — neither `parseCsv` nor `streamCsvRows` applies it, so there is nothing to reconcile. The misleading comment is removed rather than acted on.

## Verification

- New `test/csv-stream-read-parity.test.ts` runs a **42-case parity matrix** — 3 inputs (simple, quoted, messy with comments/empties/semicolons) × 14 option sets — asserting `streamCsvRows` and `parseCsv` return identical rows. This is the guard that stops the two drifting again.
- Plus targeted tests for each newly wired option: `fastMode` quote semantics, `transformValue` ordering/indices/column naming, `onRow` firing and interaction with `maxRows`, and the four `skipHeaderRow` cases.
- 57 new tests. Full suite 7,738 tests / 110 files green; lint, typecheck, and build clean.

Also adds `coverage/` to `.gitignore` — it was untracked-but-uncommitted noise that nearly landed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
