### PR TITLE
fix(xlsx): bound <col> range expansion — closes #355

### DIFF
--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -85,6 +85,28 @@ export function parseCellRef(ref: string): { row: number; col: number } {
 }
 
 /**
+ * Bound a 1-based `<col min>` / `<col max>` attribute so it can safely
+ * drive a loop.
+ *
+ * Without this a single `max="1e999"` makes the expansion loop run
+ * forever (#355). An overflowing magnitude and outright garbage are
+ * treated differently on purpose: `1e999` parses to `Infinity`, which
+ * says "wider than representable", so it clamps to the last column the
+ * same way an absurd-but-finite `99999999` does. A value that is not a
+ * number at all carries no such intent and collapses to `fallback`,
+ * dropping the malformed element.
+ */
+function clampColumnBound(raw: string | undefined, fallback: number): number {
+  const value = Number(raw ?? "")
+  if (Number.isNaN(value)) return fallback
+  // Math.trunc leaves ±Infinity intact, so -Infinity fails the `< 1`
+  // guard below and +Infinity is capped by the Math.min.
+  const truncated = Math.trunc(value)
+  if (truncated < 1) return fallback
+  return Math.min(truncated, MAX_COL_INDEX + 1)
+}
+
+/**
  * Parse a range reference like "A1:B2" into start and end positions.
  */
 function parseRangeRef(ref: string): MergeRange {
@@ -276,8 +298,14 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
           break
         case "col":
           if (inCols) {
-            const minCol = Number(attrs["min"] || "0")
-            const maxCol2 = Number(attrs["max"] || "0")
+            // `min`/`max` are 1-based and drive the loop below, so they are
+            // bounded before use: `max="1e999"` parses to Infinity and would
+            // spin forever, and any finite value past Excel's column count
+            // would allocate until the heap gives out. A range wider than the
+            // sheet can hold is malformed, so it is clamped rather than
+            // honoured. See #355.
+            const minCol = clampColumnBound(attrs["min"], 1)
+            const maxCol2 = clampColumnBound(attrs["max"], 0)
             const width = attrs["width"] ? Number(attrs["width"]) : undefined
             const hidden = attrs["hidden"] === "1" || attrs["hidden"] === "true"
             const outlineLevel = attrs["outlineLevel"] ? Number(attrs["outlineLevel"]) : undefined

--- a/test/xlsx-col-range-bounds.test.ts
+++ b/test/xlsx-col-range-bounds.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { MAX_COL_INDEX } from "../src/limits"
+
+const enc = new TextEncoder()
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+
+/**
+ * Smallest workbook that carries a `<cols>` block — the payload under
+ * test is the `<col>` element, everything else is scaffolding.
+ */
+async function workbookWithCols(colsXml: string): Promise<Uint8Array> {
+  const sheet =
+    `<?xml version="1.0"?><worksheet ${NS} ${R}>` +
+    `<cols>${colsXml}</cols>` +
+    `<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>x</t></is></c></row></sheetData>` +
+    `</worksheet>`
+
+  const zip = new ZipWriter()
+  zip.add(
+    "[Content_Types].xml",
+    enc.encode(
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+        `<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+        `</Types>`,
+    ),
+  )
+  zip.add(
+    "_rels/.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/workbook.xml",
+    enc.encode(
+      `<?xml version="1.0"?><workbook ${NS} ${R}><sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    ),
+  )
+  zip.add(
+    "xl/_rels/workbook.xml.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`,
+    ),
+  )
+  zip.add("xl/worksheets/sheet1.xml", enc.encode(sheet))
+
+  return zip.build()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Regression guard for #355 — an unbounded <col> range hung readXlsx
+// forever on a 1.4 KB file. These must all complete, not just pass.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("<col> range bounds", () => {
+  it("does not hang on max=1e999 (Infinity)", async () => {
+    const buf = await workbookWithCols('<col min="1" max="1e999" width="10"/>')
+    const workbook = await readXlsx(buf)
+    // Data survives; the range is simply clamped.
+    expect(workbook.sheets[0].rows).toEqual([["x"]])
+    expect(workbook.sheets[0].columns!.length).toBeLessThanOrEqual(MAX_COL_INDEX + 1)
+  }, 10_000)
+
+  it("clamps a finite range past Excel's last column", async () => {
+    const buf = await workbookWithCols('<col min="1" max="99999999" width="10"/>')
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0].columns!.length).toBe(MAX_COL_INDEX + 1)
+  }, 10_000)
+
+  it("handles a NaN max without looping", async () => {
+    const buf = await workbookWithCols('<col min="1" max="abc" width="10"/>')
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0].rows).toEqual([["x"]])
+  }, 10_000)
+
+  it("handles a negative or zero range", async () => {
+    for (const attrs of ['min="-5" max="-1"', 'min="0" max="0"', 'min="5" max="1"']) {
+      const workbook = await readXlsx(await workbookWithCols(`<col ${attrs} width="10"/>`))
+      expect(workbook.sheets[0].rows).toEqual([["x"]])
+    }
+  }, 10_000)
+
+  it("still reads an ordinary column range", async () => {
+    const buf = await workbookWithCols('<col min="2" max="4" width="25" hidden="1"/>')
+    const workbook = await readXlsx(buf)
+    const columns = workbook.sheets[0].columns!
+
+    // 1-based min/max → 0-based indices 1..3.
+    expect(columns[0]).toEqual({})
+    for (const idx of [1, 2, 3]) {
+      expect(columns[idx]).toMatchObject({ width: 25, hidden: true })
+    }
+  })
+
+  it("truncates a fractional bound rather than rejecting it", async () => {
+    const buf = await workbookWithCols('<col min="1.7" max="3.9" width="12"/>')
+    const workbook = await readXlsx(buf)
+    const columns = workbook.sheets[0].columns!
+    // min 1.7 → 1, max 3.9 → 3, so 0-based 0..2 carry the width.
+    expect(columns[0]).toMatchObject({ width: 12 })
+    expect(columns[2]).toMatchObject({ width: 12 })
+  })
+
+  it("survives many oversized <col> elements without unbounded growth", async () => {
+    const cols = Array.from({ length: 50 }, () => '<col min="1" max="1e999" width="10"/>').join("")
+    const workbook = await readXlsx(await workbookWithCols(cols))
+    // The shared array stays capped no matter how many elements ask for more.
+    expect(workbook.sheets[0].columns!.length).toBeLessThanOrEqual(MAX_COL_INDEX + 1)
+  }, 20_000)
+})


### PR DESCRIPTION
Closes #355. Part of #352.

A **1,484-byte** XLSX could hang `readXlsx` forever. Reproduced on `main`: terminated at 20 s with no output.

```xml
<cols><col min="1" max="1e999"/></cols>
```

`Number("1e999")` is `Infinity`, and the range-expansion loop at `src/xlsx/worksheet.ts:287` has no upper bound, so `c <= maxCol2` never becomes false and the loop pushes into `columnDefs` until the process dies.

The caller cannot defend against this: it is not an exception, so `try/catch` does nothing, and it is synchronous, so a timeout in calling code never gets to run. `src/limits.ts` already defines `MAX_COL_INDEX` and `processCell` bound-checks individual cell coordinates — this path simply never consulted it.

## The fix, and one judgement call in it

Both endpoints are bounded before the loop. Overflow and garbage are deliberately **not** treated the same:

| `max` | Parses to | Result | Why |
| --- | --- | --- | --- |
| `1e999` | `Infinity` | clamp to last column | expresses "wider than representable" — same intent as an absurd finite value |
| `99999999` | finite | clamp to last column | already the behaviour a sane reader wants |
| `abc` | `NaN` | drop the element | not a number at all; no magnitude to honour |
| `-5` | negative | drop the element | below the 1-based floor |

Collapsing `Infinity` and `NaN` together was my first attempt and it read wrong: it made a numeric overflow and a typo behave identically, and left `max="1e999"` silently dropping column widths while `max="99999999"` kept them. Splitting them keeps the two malformed-but-different inputs distinguishable.

Clamping is safe because the target is bounded: `columnDefs` tops out at 16,384 entries no matter how many `<col>` elements ask for more — there is one shared array, so N oversized elements cost the same as one. There is a test for exactly that.

## Latent bug fixed in passing

The old expression was `Number(attrs["min"] || "0")`, so a `<col>` with no `min` defaulted to **0**. That produced `idx = -1`, made `while (columnDefs.length <= -1)` a no-op, and then assigned `columnDefs[-1] = def` — a string-keyed property on the array, invisible to every consumer. `min` is 1-based in OOXML, so it now defaults to 1.

## Verification

Seven regression tests that build the minimal workbook from scratch (`test/xlsx-col-range-bounds.test.ts`), each with an explicit timeout so a regression shows up as a failure rather than a hung CI job:

- `max="1e999"` completes and preserves cell data
- `max="99999999"` clamps to exactly `MAX_COL_INDEX + 1`
- `max="abc"`, negative ranges, and `min > max` all complete
- an ordinary `min="2" max="4"` range still applies width and `hidden` to the right 0-based indices
- fractional bounds truncate rather than reject
- **50 oversized `<col>` elements in one sheet** stay capped

Full suite 7,721 tests / 111 files green; lint, typecheck, build clean.

## Scope

This is the first of several findings from the v1 robustness audit — there are more places where file-supplied values drive a loop bound, an allocation, or a `String.repeat` with no cap. They are being filed separately. This one went first because it is the only confirmed **unrecoverable hang** rather than a catchable error, and the fix is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
