### PR TITLE
fix(cli): bundle the CLI so the published binary runs — closes #357

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,5 @@ jobs:
         run: pnpm test
       - name: Build
         run: pnpm build
+      - name: Verify packaged artifact
+        run: node scripts/verify-package.mjs

--- a/build.config.ts
+++ b/build.config.ts
@@ -7,6 +7,21 @@ export default defineBuildConfig({
       input: "./src",
       outDir: "./dist",
       dts: true,
+      // The CLI is bundled separately (below) so its dependencies land in
+      // the shipped file. Transforming it here as well would emit a second
+      // dist/cli.mjs carrying bare `citty` / `consola` imports — which is
+      // exactly how the published binary ended up broken. See #357.
+      filter: (filePath) => !filePath.endsWith("cli.ts"),
+    },
+    {
+      // The library keeps zero runtime dependencies, so the CLI's own deps
+      // have to be baked into the binary rather than resolved from
+      // node_modules at run time.
+      type: "bundle",
+      input: "./src/cli.ts",
+      outDir: "./dist",
+      dts: false,
+      minify: true,
     },
   ],
 })

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "scripts": {
     "build": "obuild",
+    "verify:package": "pnpm build && node scripts/verify-package.mjs",
     "dev": "vitest",
     "lint": "oxlint . && oxfmt --check .",
     "lint:fix": "oxlint . --fix && oxfmt .",

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// ── Packaged-artifact verification ──────────────────────────────────
+// Packs the library exactly as npm would publish it, installs the
+// tarball into a throwaway project, and exercises it from there.
+//
+// This exists because `pnpm test` only ever sees `src/`. The published
+// CLI was dead across two releases — `dist/cli.mjs` imported `citty` and
+// `consola` while `package.json` declared no runtime dependencies — and
+// nothing caught it, because nothing ran the packaged binary (#357).
+//
+// Run: node scripts/verify-package.mjs
+
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url))
+
+let failures = 0
+let workDir
+
+function check(label, fn) {
+  try {
+    fn()
+    console.log(`  ok    ${label}`)
+  } catch (error) {
+    failures++
+    console.log(`  FAIL  ${label}`)
+    console.log(`        ${error.message.split("\n")[0]}`)
+  }
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  })
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message)
+}
+
+// ── Static check: no bare specifiers survive into the CLI ───────────
+//
+// Cheap and precise — this is the exact shape of the #357 regression,
+// and it fails before the slower install-based checks below.
+
+check("dist/cli.mjs imports nothing outside node: and its own dist", () => {
+  const source = readFileSync(join(repoRoot, "dist/cli.mjs"), "utf8")
+  const specifiers = [
+    ...source.matchAll(/(?:^|[\s;])(?:import|export)[^'"]*?from\s*["']([^"']+)["']/g),
+  ]
+    .map((match) => match[1])
+    .concat([...source.matchAll(/\bimport\s*\(\s*["']([^"']+)["']\s*\)/g)].map((m) => m[1]))
+
+  const external = specifiers.filter(
+    (specifier) => !specifier.startsWith(".") && !specifier.startsWith("node:"),
+  )
+
+  assert(
+    external.length === 0,
+    `bare imports would not resolve for an installed user: ${[...new Set(external)].join(", ")}`,
+  )
+})
+
+check("package.json declares no runtime dependencies", () => {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"))
+  const deps = Object.keys(pkg.dependencies ?? {})
+  assert(deps.length === 0, `unexpected runtime dependencies: ${deps.join(", ")}`)
+})
+
+// ── Install the tarball and use it like a consumer ─────────────────
+
+try {
+  workDir = mkdtempSync(join(tmpdir(), "hucre-pkg-"))
+
+  const packOutput = run("npm", ["pack", "--silent", "--pack-destination", workDir], {
+    cwd: repoRoot,
+  })
+  const tarball = packOutput.trim().split("\n").pop()
+
+  writeFileSync(join(workDir, "package.json"), JSON.stringify({ name: "consumer", private: true }))
+  run("npm", ["install", "--silent", "--no-audit", "--no-fund", join(workDir, tarball)], {
+    cwd: workDir,
+  })
+
+  const cli = join(workDir, "node_modules/.bin/hucre")
+
+  check("installing the tarball pulls in no transitive packages", () => {
+    const installed = run("ls", [join(workDir, "node_modules")])
+      .split("\n")
+      .filter((name) => name && !name.startsWith("."))
+    assert(
+      installed.length === 1 && installed[0] === "hucre",
+      `expected only hucre, got: ${installed.join(", ")}`,
+    )
+  })
+
+  check("hucre --help runs", () => {
+    const output = run(cli, ["--help"])
+    assert(output.includes("convert"), "help output does not list the convert command")
+  })
+
+  check("hucre convert produces a readable workbook", () => {
+    writeFileSync(join(workDir, "in.csv"), "name,qty\nfoo,1\nbar,2\n")
+    run(cli, ["convert", join(workDir, "in.csv"), join(workDir, "out.xlsx")])
+    const output = run(cli, ["inspect", join(workDir, "out.xlsx")])
+    assert(output.includes("3 rows"), `inspect did not report 3 rows:\n${output}`)
+  })
+
+  check("the library entry points import cleanly from an install", () => {
+    const probe = join(workDir, "probe.mjs")
+    writeFileSync(
+      probe,
+      [
+        `import { readXlsx, writeXlsx } from "hucre"`,
+        `import { writeXlsx as x } from "hucre/xlsx"`,
+        `import { parseCsv } from "hucre/csv"`,
+        `import { readOds } from "hucre/ods"`,
+        `import { parseJson } from "hucre/json"`,
+        `if (!readXlsx || !writeXlsx || !x || !parseCsv || !readOds || !parseJson) {`,
+        `  throw new Error("an entry point resolved to undefined")`,
+        `}`,
+        `console.log("entry points ok")`,
+      ].join("\n"),
+    )
+    const output = run("node", [probe], { cwd: workDir })
+    assert(output.includes("entry points ok"), output)
+  })
+} catch (error) {
+  failures++
+  console.log(`  FAIL  packaging harness`)
+  console.log(`        ${error.message.split("\n")[0]}`)
+} finally {
+  if (workDir) rmSync(workDir, { recursive: true, force: true })
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} packaged-artifact check(s) failed.`)
+  process.exit(1)
+}
+console.log("\nPackaged artifact verified.")

--- a/test/chart-text.test.ts
+++ b/test/chart-text.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest"
+import { parseXml } from "../src/xml/parser"
+import {
+  FONT_SIZE_MAX_PT,
+  FONT_SIZE_MIN_PT,
+  FONT_SZ_PER_POINT,
+  ROTATION_MAX_DEG,
+  ROTATION_MIN_DEG,
+  TXPR_ROT_PER_DEGREE,
+  makeFontSizeNormalizer,
+  normalizeBoolFlag,
+  normalizeFontFamily,
+  normalizeFontSizePt,
+  parseFontFamilyFromDefRPr,
+  parseFontSizeFromDefRPr,
+  readBoolAttrValue,
+  readStrikeToken,
+  readUnderlineToken,
+} from "../src/xlsx/chart/text"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Build a real `<a:defRPr>` through the project's parser, not a literal. */
+function defRPr(inner: string): ReturnType<typeof parseXml> {
+  return parseXml(
+    `<a:defRPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"${inner}`,
+  )
+}
+
+/** `<a:defRPr sz="..."/>` with the attribute spelled exactly as given. */
+function withSz(raw: string): ReturnType<typeof parseXml> {
+  return defRPr(` sz="${raw}"/>`)
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Constants
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("chart/text constants", () => {
+  it("matches the OOXML units the JSDoc documents", () => {
+    expect(FONT_SZ_PER_POINT).toBe(100)
+    expect(TXPR_ROT_PER_DEGREE).toBe(60000)
+    expect(FONT_SIZE_MIN_PT).toBe(1)
+    expect(FONT_SIZE_MAX_PT).toBe(400)
+    expect(ROTATION_MIN_DEG).toBe(-90)
+    expect(ROTATION_MAX_DEG).toBe(90)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseFontSizeFromDefRPr
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseFontSizeFromDefRPr", () => {
+  it("converts 100ths of a point to points", () => {
+    expect(parseFontSizeFromDefRPr(withSz("1200"))).toBe(12)
+    expect(parseFontSizeFromDefRPr(withSz("1800"))).toBe(18)
+  })
+
+  it("returns undefined when sz is absent", () => {
+    expect(parseFontSizeFromDefRPr(defRPr("/>"))).toBeUndefined()
+  })
+
+  it("returns undefined for an empty or whitespace-only sz", () => {
+    expect(parseFontSizeFromDefRPr(withSz(""))).toBeUndefined()
+    expect(parseFontSizeFromDefRPr(withSz("   "))).toBeUndefined()
+  })
+
+  it("returns undefined for a non-numeric sz", () => {
+    expect(parseFontSizeFromDefRPr(withSz("abc"))).toBeUndefined()
+    expect(parseFontSizeFromDefRPr(withSz("+"))).toBeUndefined()
+  })
+
+  it("snaps to the half-point grid Excel's UI exposes", () => {
+    // 12.25pt is not on the grid — rounds to 12.5.
+    expect(parseFontSizeFromDefRPr(withSz("1225"))).toBe(12.5)
+    // 12.24pt rounds down to 12.
+    expect(parseFontSizeFromDefRPr(withSz("1224"))).toBe(12)
+    expect(parseFontSizeFromDefRPr(withSz("1250"))).toBe(12.5)
+  })
+
+  it("accepts the inclusive band boundaries", () => {
+    expect(parseFontSizeFromDefRPr(withSz("100"))).toBe(FONT_SIZE_MIN_PT)
+    expect(parseFontSizeFromDefRPr(withSz("40000"))).toBe(FONT_SIZE_MAX_PT)
+  })
+
+  it("drops values outside the band rather than clamping", () => {
+    // A reader that clamped here would surface a size the writer never emits.
+    expect(parseFontSizeFromDefRPr(withSz("50"))).toBeUndefined()
+    expect(parseFontSizeFromDefRPr(withSz("40100"))).toBeUndefined()
+    expect(parseFontSizeFromDefRPr(withSz("-1200"))).toBeUndefined()
+    expect(parseFontSizeFromDefRPr(withSz("0"))).toBeUndefined()
+  })
+
+  it("tolerates trailing junk the way parseInt does", () => {
+    expect(parseFontSizeFromDefRPr(withSz("1200pt"))).toBe(12)
+    // Fractional input truncates before the unit conversion.
+    expect(parseFontSizeFromDefRPr(withSz("1200.9"))).toBe(12)
+  })
+
+  it("tolerates surrounding whitespace", () => {
+    expect(parseFontSizeFromDefRPr(withSz("  1400  "))).toBe(14)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// makeFontSizeNormalizer / normalizeFontSizePt
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("makeFontSizeNormalizer", () => {
+  const normalize = makeFontSizeNormalizer(8, 20)
+
+  it("snaps to the half-point grid", () => {
+    expect(normalize(12)).toBe(12)
+    expect(normalize(12.25)).toBe(12.5)
+    expect(normalize(12.24)).toBe(12)
+    expect(normalize(12.75)).toBe(13)
+  })
+
+  it("clamps to the supplied band instead of dropping", () => {
+    // Unlike the parser, the writer-side normalizer clamps — an
+    // out-of-band authored value still produces a valid file.
+    expect(normalize(1)).toBe(8)
+    expect(normalize(999)).toBe(20)
+  })
+
+  it("passes the band boundaries through", () => {
+    expect(normalize(8)).toBe(8)
+    expect(normalize(20)).toBe(20)
+  })
+
+  it("returns undefined for non-finite and non-numeric input", () => {
+    expect(normalize(undefined)).toBeUndefined()
+    expect(normalize(Number.NaN)).toBeUndefined()
+    expect(normalize(Number.POSITIVE_INFINITY)).toBeUndefined()
+    expect(normalize(Number.NEGATIVE_INFINITY)).toBeUndefined()
+    expect(normalize("12" as unknown as number)).toBeUndefined()
+    expect(normalize(null as unknown as number)).toBeUndefined()
+  })
+
+  it("builds independent normalizers", () => {
+    const wide = makeFontSizeNormalizer(1, 400)
+    expect(wide(1)).toBe(1)
+    expect(normalize(1)).toBe(8)
+  })
+})
+
+describe("normalizeFontSizePt", () => {
+  it("uses the standard 1..400 pt band", () => {
+    expect(normalizeFontSizePt(0.4)).toBe(FONT_SIZE_MIN_PT)
+    expect(normalizeFontSizePt(1000)).toBe(FONT_SIZE_MAX_PT)
+    expect(normalizeFontSizePt(11)).toBe(11)
+    expect(normalizeFontSizePt(undefined)).toBeUndefined()
+  })
+
+  it("agrees with the parser on values that round-trip", () => {
+    for (const raw of ["100", "1200", "1250", "40000"]) {
+      const parsed = parseFontSizeFromDefRPr(withSz(raw))
+      expect(normalizeFontSizePt(parsed)).toBe(parsed)
+    }
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Font family
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseFontFamilyFromDefRPr", () => {
+  it("reads the typeface off <a:latin>", () => {
+    expect(parseFontFamilyFromDefRPr(defRPr('><a:latin typeface="Calibri"/></a:defRPr>'))).toBe(
+      "Calibri",
+    )
+  })
+
+  it("trims surrounding whitespace", () => {
+    expect(parseFontFamilyFromDefRPr(defRPr('><a:latin typeface="  Arial  "/></a:defRPr>'))).toBe(
+      "Arial",
+    )
+  })
+
+  it("returns undefined when <a:latin> is absent", () => {
+    expect(parseFontFamilyFromDefRPr(defRPr("/>"))).toBeUndefined()
+    expect(
+      parseFontFamilyFromDefRPr(
+        defRPr('><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill></a:defRPr>'),
+      ),
+    ).toBeUndefined()
+  })
+
+  it("returns undefined when typeface is missing or blank", () => {
+    expect(parseFontFamilyFromDefRPr(defRPr("><a:latin/></a:defRPr>"))).toBeUndefined()
+    expect(parseFontFamilyFromDefRPr(defRPr('><a:latin typeface=""/></a:defRPr>'))).toBeUndefined()
+    expect(
+      parseFontFamilyFromDefRPr(defRPr('><a:latin typeface="   "/></a:defRPr>')),
+    ).toBeUndefined()
+  })
+
+  it("ignores a non-latin child that carries a typeface", () => {
+    expect(
+      parseFontFamilyFromDefRPr(defRPr('><a:ea typeface="MS Gothic"/></a:defRPr>')),
+    ).toBeUndefined()
+  })
+})
+
+describe("normalizeFontFamily", () => {
+  it("trims and passes through", () => {
+    expect(normalizeFontFamily("Calibri")).toBe("Calibri")
+    expect(normalizeFontFamily("  Arial  ")).toBe("Arial")
+  })
+
+  it("drops blank and non-string tokens", () => {
+    expect(normalizeFontFamily(undefined)).toBeUndefined()
+    expect(normalizeFontFamily("")).toBeUndefined()
+    expect(normalizeFontFamily("   ")).toBeUndefined()
+    expect(normalizeFontFamily(12 as unknown as string)).toBeUndefined()
+    expect(normalizeFontFamily(null as unknown as string)).toBeUndefined()
+  })
+
+  it("agrees with the parser, so a parsed family survives a rewrite", () => {
+    const parsed = parseFontFamilyFromDefRPr(defRPr('><a:latin typeface=" Verdana "/></a:defRPr>'))
+    expect(normalizeFontFamily(parsed)).toBe("Verdana")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Boolean-style attributes
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readBoolAttrValue", () => {
+  it("accepts both OOXML spellings", () => {
+    expect(readBoolAttrValue("1")).toBe(true)
+    expect(readBoolAttrValue("true")).toBe(true)
+    expect(readBoolAttrValue("0")).toBe(false)
+    expect(readBoolAttrValue("false")).toBe(false)
+  })
+
+  it("returns undefined for anything else", () => {
+    expect(readBoolAttrValue(undefined)).toBeUndefined()
+    expect(readBoolAttrValue("")).toBeUndefined()
+    expect(readBoolAttrValue("TRUE")).toBeUndefined()
+    expect(readBoolAttrValue("False")).toBeUndefined()
+    expect(readBoolAttrValue(" 1 ")).toBeUndefined()
+    expect(readBoolAttrValue("yes")).toBeUndefined()
+    expect(readBoolAttrValue("2")).toBeUndefined()
+  })
+})
+
+describe("normalizeBoolFlag", () => {
+  it("passes literal booleans through", () => {
+    expect(normalizeBoolFlag(true)).toBe(true)
+    expect(normalizeBoolFlag(false)).toBe(false)
+  })
+
+  it("drops everything else, including truthy escapes from untyped callers", () => {
+    expect(normalizeBoolFlag(undefined)).toBeUndefined()
+    expect(normalizeBoolFlag(null as unknown as boolean)).toBeUndefined()
+    expect(normalizeBoolFlag(1 as unknown as boolean)).toBeUndefined()
+    expect(normalizeBoolFlag(0 as unknown as boolean)).toBeUndefined()
+    expect(normalizeBoolFlag("true" as unknown as boolean)).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Underline / strike
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readUnderlineToken", () => {
+  it("maps the two tokens Excel's UI authors", () => {
+    expect(readUnderlineToken("sng")).toBe(true)
+    expect(readUnderlineToken("none")).toBe(false)
+  })
+
+  it("drops the vocabulary Excel never authors", () => {
+    // Dropping rather than coercing is what makes absence and the OOXML
+    // default round-trip identically through cloneChart.
+    for (const token of ["dbl", "words", "heavy", "dotted", "wavy", "sngStrike", ""]) {
+      expect(readUnderlineToken(token), token).toBeUndefined()
+    }
+    expect(readUnderlineToken(undefined)).toBeUndefined()
+  })
+})
+
+describe("readStrikeToken", () => {
+  it("maps the two tokens Excel's UI authors", () => {
+    expect(readStrikeToken("sngStrike")).toBe(true)
+    expect(readStrikeToken("noStrike")).toBe(false)
+  })
+
+  it("drops dblStrike and every other token", () => {
+    for (const token of ["dblStrike", "sng", "none", "", "strike"]) {
+      expect(readStrikeToken(token), token).toBeUndefined()
+    }
+    expect(readStrikeToken(undefined)).toBeUndefined()
+  })
+
+  it("does not share a vocabulary with the underline reader", () => {
+    expect(readUnderlineToken("sngStrike")).toBeUndefined()
+    expect(readStrikeToken("sng")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #357. Part of #352.

`npx hucre` did not work for anyone who installed the package. Verified by packing the tree exactly as npm publishes it and installing the tarball into an empty project:

```
$ npm install ./hucre-0.6.2.tgz
$ ls node_modules
hucre                       # ← nothing else

$ ./node_modules/.bin/hucre --help
code: 'ERR_MODULE_NOT_FOUND'
```

`dist/cli.mjs` opens with bare `citty` and `consola` imports; `package.json` declares no runtime dependencies. The build runs `obuild` in `transform` mode — a per-file transpile — so those specifiers survive verbatim into the shipped binary.

## How it got here

A regression from #346. #345 correctly reported that the "zero-dependency" headline was false because npm was installing `citty` and `consola`. Moving them to `devDependencies` made the headline true and killed the CLI at the same time. Both halves of that trade-off were reasonable; the mistake was shipping one of them broken.

## Fix

Add a `bundle` build entry for `src/cli.ts` so its dependencies are inlined, and `filter` the CLI out of the `transform` entry so only one `dist/cli.mjs` is emitted. The library keeps zero runtime dependencies **and** the binary works.

The bundled CLI carries its own copy of the library (~380 KB extra in the tarball). Keeping the library imports external would avoid that, but the transform entry rewrites specifiers to `.mjs` while a bundle entry would emit them unrewritten, so they wouldn't resolve. A self-contained binary also can't break from a future change to the `dist/` layout. That seemed the better trade at this size.

## The actual finding

Nothing exercised the **packaged** artifact. `pnpm test` only ever sees `src/`, which is why a dead binary shipped across two releases unnoticed. That gap matters more than the bug.

`scripts/verify-package.mjs` packs the library as npm would publish it, installs the tarball into a throwaway project, and asserts from there:

- no bare imports survive into `dist/cli.mjs` (the exact shape of this regression)
- `package.json` declares no runtime dependencies
- installing pulls in no transitive packages
- `hucre --help` runs
- `hucre convert in.csv out.xlsx` round-trips through `hucre inspect`
- all five entry points (`hucre`, `/xlsx`, `/csv`, `/ods`, `/json`) import cleanly

**I checked the guard actually fails on the bug.** Against the previous build config it reports 3 failures — naming `citty, consola` — and against this one all 6 pass. A guard that can't fail isn't a guard.

Wired into CI after the build step, and available locally as `pnpm verify:package`.

## One unrelated file

`test/chart-text.test.ts` rode along in this commit. It is 34 tests for `src/xlsx/chart/text.ts`, which had 10.4% statement and **0% branch** coverage — font-size band clamping, the accept-or-drop token grammars for underline/strike, font-family trimming. All 34 passed on the first run, so the module was untested rather than broken. Happy to split it out if you'd rather review it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
