### PR TITLE
fix(xlsx): stop saveXlsx dropping modeled sheet and workbook state — #359

### DIFF
--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -27,6 +27,7 @@ import {
 import { parseRelationships } from "./relationships"
 import { createStylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer"
+import { writeFeaturePropertyBagXml } from "./feature-property-bag"
 import type { WorksheetResult } from "./worksheet-writer"
 import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
@@ -196,6 +197,20 @@ export async function saveXlsx(
     veryHidden: sheet.veryHidden,
     tables: sheet.tables,
     rowDefs: sheet.rowDefs,
+    // Everything below is read by the reader and understood by the
+    // writer, and was simply missing from this map — so opening a
+    // workbook and saving it back destroyed it. See #359.
+    splitPane: sheet.splitPane,
+    rowBreaks: sheet.rowBreaks,
+    colBreaks: sheet.colBreaks,
+    outlineProperties: sheet.outlineProperties,
+    sparklines: sheet.sparklines,
+    textBoxes: sheet.textBoxes,
+    // `backgroundImage` is deliberately NOT forwarded. It needs a media
+    // part and a `<picture>` relationship, and this path emits neither —
+    // forwarding it produces a sheet referencing an rId that was never
+    // written, which Excel reports as corrupt. Losing the image is worse
+    // than it should be, but better than that. Tracked separately.
   }))
 
   // Create shared collectors
@@ -238,15 +253,21 @@ export async function saveXlsx(
 
   for (let i = 0; i < writeSheets.length; i++) {
     const sheet = writeSheets[i]
-    if (sheet.images && sheet.images.length > 0) {
-      const result = writeDrawing(sheet.images, globalImageIndex)
+    const images = sheet.images ?? []
+    const hasTextBoxes = sheet.textBoxes !== undefined && sheet.textBoxes.length > 0
+    // A drawing part hosts images *and* text boxes. Gating on images
+    // alone meant a text-box-only sheet produced no drawing, and a sheet
+    // with both produced one that silently dropped the text boxes —
+    // writer.ts has always handled both. See #359.
+    if (images.length > 0 || hasTextBoxes) {
+      const result = writeDrawing(images, globalImageIndex, sheet.textBoxes)
       drawingResults.push(result)
       drawingIndices.push(i + 1)
       for (const img of result.images) {
         const ext = img.path.split(".").pop()
         if (ext) imageExtensions.add(ext)
       }
-      globalImageIndex += sheet.images.length
+      globalImageIndex += images.length
     } else {
       drawingResults.push(null)
     }
@@ -710,6 +731,10 @@ export async function saveXlsx(
   // Excel doesn't see the preserved bytes as orphan.
   const allDrawingIndices = mergeSortedUnique(drawingIndices, preservedDrawingNumbers)
   const allChartIndices = mergeSortedUnique(chartIndices, newModelChartIndices)
+  // Worksheets are already serialized by this point, so the collector
+  // knows whether any cell asked for a checkbox xf. Previously hardcoded
+  // false, which dropped Excel 2024 checkboxes on every round trip (#359).
+  const hasFeaturePropertyBag = styles.hasCheckboxFeature()
   const ctOpts: ContentTypesOptions = {
     sheetCount: writeSheets.length,
     hasSharedStrings,
@@ -737,6 +762,7 @@ export async function saveXlsx(
     hasCoreProps: true,
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
+    hasFeaturePropertyBag,
   }
   zip.add("[Content_Types].xml", encoder.encode(writeContentTypes(ctOpts)))
 
@@ -757,7 +783,10 @@ export async function saveXlsx(
         allNamedRanges.length > 0 ? allNamedRanges : undefined,
         dateSystem,
         activeSheet,
-        undefined,
+        // The reader populates this; passing undefined here silently
+        // unlocked every structurally-protected workbook that went
+        // through open → save. See #359.
+        workbook.workbookProtection,
         externalLinkRels.length > 0 ? externalLinkRels : undefined,
         pivotCacheRefs.length > 0 ? pivotCacheRefs : undefined,
         slicerCacheRels.length > 0 ? slicerCacheRels : undefined,
@@ -774,7 +803,7 @@ export async function saveXlsx(
         writeSheets.length,
         hasSharedStrings,
         workbook.hasMacros,
-        false, // hasFeaturePropertyBag — not yet roundtripped
+        hasFeaturePropertyBag,
         hasPersons,
         externalLinkRels.length > 0 ? externalLinkRels : undefined,
         pivotCacheRels.length > 0 ? pivotCacheRels : undefined,
@@ -787,6 +816,15 @@ export async function saveXlsx(
 
   // xl/styles.xml
   zip.add("xl/styles.xml", encoder.encode(styles.toXml()))
+
+  // xl/featurePropertyBag/featurePropertyBag.xml — declared above, so
+  // the part has to exist.
+  if (hasFeaturePropertyBag) {
+    zip.add(
+      "xl/featurePropertyBag/featurePropertyBag.xml",
+      encoder.encode(writeFeaturePropertyBagXml()),
+    )
+  }
 
   // xl/sharedStrings.xml
   if (hasSharedStrings) {

--- a/test/roundtrip-preservation.test.ts
+++ b/test/roundtrip-preservation.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { ZipReader } from "../src/zip/reader"
+import type { WriteSheet, WriteOptions } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** write → open → save → read, i.e. one full preservation cycle. */
+async function cycle(options: WriteOptions) {
+  const original = await writeXlsx(options)
+  const opened = await openXlsx(original)
+  const saved = await saveXlsx(opened)
+  return { saved, workbook: await readXlsx(saved) }
+}
+
+function sheetWith(extra: Partial<WriteSheet>): WriteSheet {
+  return {
+    name: "S",
+    rows: [
+      ["a", "b"],
+      [1, 2],
+    ],
+    ...extra,
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Regression guard for #359 — saveXlsx rebuilt each sheet from a
+// hand-written field map that omitted nine things the reader and writer
+// both understood, so open → save destroyed them.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("openXlsx → saveXlsx preserves sheet features", () => {
+  it("keeps split panes", async () => {
+    const { workbook } = await cycle({
+      sheets: [sheetWith({ splitPane: { xSplit: 2000, ySplit: 1500 } })],
+    })
+    expect(workbook.sheets[0].splitPane).toMatchObject({ xSplit: 2000, ySplit: 1500 })
+  })
+
+  it("keeps manual page breaks", async () => {
+    const { workbook } = await cycle({
+      sheets: [sheetWith({ rowBreaks: [5, 10], colBreaks: [3] })],
+    })
+    expect(workbook.sheets[0].rowBreaks).toEqual([5, 10])
+    expect(workbook.sheets[0].colBreaks).toEqual([3])
+  })
+
+  it("drops the background image rather than emitting a dangling reference", async () => {
+    // Known gap: this path writes neither the media part nor the picture
+    // relationship, so forwarding backgroundImage would emit a <picture>
+    // pointing at an rId that does not exist — a file Excel calls
+    // corrupt. Until the media plumbing lands, losing it is the safer
+    // failure. This test pins that choice so it is deliberate, not drift.
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52,
+    ])
+    const { saved, workbook } = await cycle({ sheets: [sheetWith({ backgroundImage: png })] })
+    expect(workbook.sheets[0].backgroundImage).toBeUndefined()
+
+    const zip = new ZipReader(saved)
+    const sheetXml = new TextDecoder().decode(await zip.extract("xl/worksheets/sheet1.xml"))
+    expect(sheetXml).not.toContain("<picture")
+  })
+
+  it("keeps sparklines", async () => {
+    const { workbook } = await cycle({
+      sheets: [
+        sheetWith({
+          sparklines: [{ type: "column", location: "D1", dataRange: "S!A1:C1", color: "FF0000" }],
+        }),
+      ],
+    })
+    const sparklines = workbook.sheets[0].sparklines
+    expect(sparklines).toHaveLength(1)
+    expect(sparklines![0]).toMatchObject({
+      type: "column",
+      location: "D1",
+      dataRange: "S!A1:C1",
+      color: "FF0000",
+    })
+  })
+
+  it("keeps text boxes", async () => {
+    const { workbook } = await cycle({
+      sheets: [
+        sheetWith({
+          textBoxes: [
+            { text: "Note", anchor: { from: { col: 3, row: 1 }, to: { col: 6, row: 4 } } },
+          ],
+        }),
+      ],
+    })
+    expect(workbook.sheets[0].textBoxes).toHaveLength(1)
+    expect(workbook.sheets[0].textBoxes![0].text).toBe("Note")
+  })
+
+  it("keeps several of them at once", async () => {
+    const { workbook } = await cycle({
+      sheets: [
+        sheetWith({
+          rowBreaks: [4],
+          colBreaks: [2],
+          sparklines: [{ type: "column", location: "D2", dataRange: "S!A2:C2" }],
+          splitPane: { xSplit: 1000, ySplit: 1000 },
+        }),
+      ],
+    })
+    const sheet = workbook.sheets[0]
+    expect(sheet.rowBreaks).toEqual([4])
+    expect(sheet.colBreaks).toEqual([2])
+    expect(sheet.sparklines).toHaveLength(1)
+    expect(sheet.splitPane).toBeDefined()
+  })
+})
+
+describe("openXlsx → saveXlsx preserves workbook-level state", () => {
+  it("keeps workbook protection", async () => {
+    // The security-relevant one: a structurally locked workbook used to
+    // come back unlocked, with nothing in the output to say so.
+    const { workbook } = await cycle({
+      sheets: [sheetWith({})],
+      workbookProtection: { lockStructure: true, lockWindows: true },
+    })
+    expect(workbook.workbookProtection).toMatchObject({
+      lockStructure: true,
+      lockWindows: true,
+    })
+  })
+
+  it("keeps a structure lock that carries a password hash", async () => {
+    const { workbook } = await cycle({
+      sheets: [sheetWith({})],
+      workbookProtection: { lockStructure: true, password: "secret" },
+    })
+    expect(workbook.workbookProtection?.lockStructure).toBe(true)
+  })
+
+  it("does not invent protection where there was none", async () => {
+    const { workbook } = await cycle({ sheets: [sheetWith({})] })
+    expect(workbook.workbookProtection).toBeUndefined()
+  })
+
+  it("keeps Excel 2024 checkboxes", async () => {
+    const { saved, workbook } = await cycle({
+      sheets: [
+        {
+          name: "S",
+          rows: [["flag"]],
+          cells: new Map([["1,0", { value: true, type: "boolean", checkbox: true }]]),
+        },
+      ],
+    })
+
+    // The cell keeps its checkbox flag...
+    expect(workbook.sheets[0].cells?.get("1,0")?.checkbox).toBe(true)
+
+    // ...and the part it depends on is actually in the archive, not just
+    // declared. A dangling declaration is what Excel calls corrupt.
+    const zip = new ZipReader(saved)
+    expect(zip.has("xl/featurePropertyBag/featurePropertyBag.xml")).toBe(true)
+  })
+
+  it("does not emit a featurePropertyBag part when nothing uses one", async () => {
+    const { saved } = await cycle({ sheets: [sheetWith({})] })
+    const zip = new ZipReader(saved)
+    expect(zip.has("xl/featurePropertyBag/featurePropertyBag.xml")).toBe(false)
+  })
+})
+
+describe("saveXlsx output integrity", () => {
+  it("ships every part its content types declare", async () => {
+    const { saved } = await cycle({
+      sheets: [
+        sheetWith({
+          rowBreaks: [3],
+          sparklines: [{ type: "line", location: "D1", dataRange: "S!A1:C1" }],
+          textBoxes: [{ text: "x", anchor: { from: { col: 3, row: 1 }, to: { col: 5, row: 3 } } }],
+          cells: new Map([["2,0", { value: false, type: "boolean", checkbox: true }]]),
+        }),
+      ],
+      workbookProtection: { lockStructure: true },
+    })
+
+    const zip = new ZipReader(saved)
+    const contentTypes = new TextDecoder().decode(await zip.extract("[Content_Types].xml"))
+
+    for (const match of contentTypes.matchAll(/PartName="\/([^"]+)"/g)) {
+      expect(zip.has(match[1]!), `missing part ${match[1]}`).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
Addresses most of #359. Part of #352.

`saveXlsx` rebuilds each sheet from a hand-written `Sheet` → `WriteSheet` map at `src/xlsx/roundtrip.ts:181`. The map listed 20 fields. Several things **the reader and the writer both already understood** were not among them, so open → save destroyed them.

## Sheet-level

Forwarded: `splitPane`, `rowBreaks`, `colBreaks`, `outlineProperties`, `sparklines`, `textBoxes`.

`textBoxes` needed more than a map entry, and finding that out is the reason this PR has a probe-driven history. Adding the field alone changed nothing, so I isolated it:

```
DIRECT  write→read  textBoxes : [{"text":"Note", ...}]
ROUNDTRIP           textBoxes : undefined
```

The drawing part was generated only `if (sheet.images && sheet.images.length > 0)`, and `writeDrawing` was called **without** its `textBoxes` argument. So a text-box-only sheet produced no drawing at all, and a sheet with both produced one that silently dropped the boxes. `writer.ts` has always gated on images-or-text-boxes-or-charts and passed them through; this path never did.

`outlineProperties` is forwarded for completeness but is inert today — the type and the writer exist, nothing ever parses it, so `Sheet.outlineProperties` is always `undefined`. Worth noting so nobody reads its presence here as coverage.

## Workbook-level

- **`workbookProtection`** was passed as `undefined`. The reader populates it and `writeWorkbookXml` accepts it, so a structurally locked workbook came back **unlocked**, with nothing in the output to indicate it.
- **`hasFeaturePropertyBag`** was hardcoded `false`, dropping Excel 2024 checkboxes. Now derived from the style collector the same way `writer.ts` derives it — and the part itself is emitted, so the content-type declaration isn't left dangling.

## What I deliberately did not fix, and why

`backgroundImage` is **not** forwarded. I added it, and it made things worse.

With it in the map, the saved sheet XML contains a `<picture>` element — but this path writes neither the media part nor the picture relationship. Verified on the output:

```
saved entries: xl/worksheets/sheet1.xml          ← no xl/media/*, no sheet1.xml.rels
saved sheet has picture element: true
```

That is a sheet referencing an `rId` that was never written: a file Excel reports as corrupt. `writer.ts` has a whole `backgroundImagePaths` mechanism plus rels emission plus the media zip entry; `roundtrip.ts` has no `pictureRId` handling at all.

Silently losing the image is worse than it should be. Producing a broken file is worse still. So the field stays out until the media plumbing lands, and a test pins that so it reads as a decision rather than drift. I'll open a follow-up with this diagnosis.

## Verification

12 new round-trip tests in `test/roundtrip-preservation.test.ts`, each going write → open → save → read and asserting the value survives — split panes, page breaks, sparklines (with a non-default `type`, since `line` is OOXML's default and is never written out), text boxes, several at once, workbook protection with and without a password, no-protection staying absent, checkboxes plus the presence of the part they depend on, and no `featurePropertyBag` part when nothing uses one.

Plus one test walking every `PartName` in `[Content_Types].xml` and asserting the entry exists — the check that would have caught the background-image problem on its own.

Full suite 7,791 tests / 113 files green; lint, typecheck, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
