### PR TITLE
fix: bound the cell bounding box, not just each coordinate — #363

### DIFF
--- a/src/limits.ts
+++ b/src/limits.ts
@@ -16,6 +16,22 @@ export const MAX_ROW_INDEX = 1_048_575
 export const MAX_COL_INDEX = 16_383
 
 /**
+ * Cap on the number of cells a single sheet may be normalized into.
+ *
+ * Readers hand back `rows: CellValue[][]`, a dense rectangle, so a sheet's
+ * cost is its bounding box rather than its cell count. Bounding each
+ * coordinate separately is not enough: two entirely legal cells at `A1`
+ * and `XFD1048576` describe a 1,048,576 x 16,384 rectangle — 1.7e10 slots
+ * — from a few hundred bytes of XML, which V8 answers with a fatal OOM
+ * that no caller can catch.
+ *
+ * 20 million comfortably covers real spreadsheets (Excel's own row limit
+ * at 20 columns is 21 million) while refusing the sparse-corner case with
+ * a typed error instead of killing the process.
+ */
+export const MAX_TOTAL_CELLS = 20_000_000
+
+/**
  * Upper bound on the password-derivation spin count accepted from an
  * encrypted workbook. Office uses 100,000; we allow a generous ceiling
  * so a hostile file cannot pin a CPU for minutes.

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -17,7 +17,7 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseXml } from "../xml/parser"
-import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../limits"
+import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 import type { XmlElement } from "../xml/parser"
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -578,6 +578,14 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
       // on a one-cell row to force millions of allocations — clamp to Excel's
       // row limit.
       const effectiveRowRepeat = rowData.length > 0 ? Math.min(rowRepeat, MAX_ROW_INDEX + 1) : 0
+
+      // Each repeat attribute is capped on its own, but the aggregate is
+      // not: one row of 16,384 cells repeated 1,048,576 times is 1.7e10
+      // slots from a couple hundred bytes of content.xml. See #363.
+      const projected = (rows.length + effectiveRowRepeat) * rowData.length
+      if (projected > MAX_TOTAL_CELLS) {
+        throw new ParseError(`Sheet spans ${projected} cells, over the ${MAX_TOTAL_CELLS} limit`)
+      }
 
       for (let r = 0; r < effectiveRowRepeat; r++) {
         rows.push(effectiveRowRepeat === 1 && r === 0 ? rowData : [...rowData])

--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -6,6 +6,7 @@
 
 import type { CellValue, MergeRange, ReadOptions, Sheet, Workbook } from "../_types"
 import { ParseError } from "../errors"
+import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 import { readInputToUint8Array } from "../_input"
 import { readCfb } from "../xlsx/crypto/cfb"
 import { isDateFormat, serialToDate } from "../_date"
@@ -172,7 +173,28 @@ function parseSheet(
   const rows: CellValue[][] = []
   const merges: MergeRange[] = []
 
+  // BIFF row/col are u16, so each is bounded at 65,535 on its own — but
+  // their product is not, and `rows` is a dense rectangle. 65,535 rows of
+  // 65,536 slots is 4.3e9 allocations from a few hundred KB of input.
+  // The XLSB reader already guards its coordinates this way; this one did
+  // not. See #363.
+  let widestCol = 0
   const setCell = (row: number, col: number, value: CellValue): void => {
+    if (row < 0 || row > MAX_ROW_INDEX) {
+      throw new ParseError(
+        `Cell row ${row} is outside the supported sheet bounds (max ${MAX_ROW_INDEX + 1})`,
+      )
+    }
+    if (col < 0 || col > MAX_COL_INDEX) {
+      throw new ParseError(
+        `Cell column ${col} is outside the supported sheet bounds (max ${MAX_COL_INDEX + 1})`,
+      )
+    }
+    if (col >= widestCol) widestCol = col + 1
+    const boundingBox = Math.max(rows.length, row + 1) * widestCol
+    if (boundingBox > MAX_TOTAL_CELLS) {
+      throw new ParseError(`Sheet spans ${boundingBox} cells, over the ${MAX_TOTAL_CELLS} limit`)
+    }
     let r = rows[row]
     if (!r) r = rows[row] = []
     while (r.length < col) r.push(null)

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -32,7 +32,7 @@ import type { Relationship } from "./relationships"
 import { resolveStyle, isDateStyle } from "./styles"
 import { serialToDate } from "../_date"
 import { parseSax, decodeOoxmlEscapes } from "../xml/parser"
-import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../limits"
+import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 import { ParseError } from "../errors"
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -1036,6 +1036,18 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   // Ensure all rows have consistent length
   if (hasCells) {
     const colCount = maxCol + 1
+    // The cost of a sheet is its bounding box, not its cell count — the
+    // loop below fills every slot in it. Two in-bounds cells at opposite
+    // corners describe 1.7e10 slots, which V8 answers with an OOM the
+    // caller cannot catch, so the product is checked before allocating.
+    const totalCells = (maxRow + 1) * colCount
+    if (totalCells > MAX_TOTAL_CELLS) {
+      throw new ParseError(
+        `Sheet "${name}" spans ${maxRow + 1} rows x ${colCount} columns ` +
+          `(${totalCells} cells), over the ${MAX_TOTAL_CELLS} limit. ` +
+          `Use the \`range\` or \`maxRows\` read option to bound the area read.`,
+      )
+    }
     for (let r = 0; r <= maxRow; r++) {
       if (!rows[r]) {
         rows[r] = Array.from({ length: colCount }, () => null) as CellValue[]

--- a/test/cell-count-limits.test.ts
+++ b/test/cell-count-limits.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { readOds } from "../src/ods/reader"
+import { ParseError } from "../src/errors"
+import { MAX_TOTAL_CELLS } from "../src/limits"
+
+const enc = new TextEncoder()
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+async function xlsxWithSheetData(sheetData: string): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  zip.add(
+    "[Content_Types].xml",
+    enc.encode(
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+        `<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+        `</Types>`,
+    ),
+  )
+  zip.add(
+    "_rels/.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/workbook.xml",
+    enc.encode(
+      `<?xml version="1.0"?><workbook ${NS} ${R}><sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    ),
+  )
+  zip.add(
+    "xl/_rels/workbook.xml.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/worksheets/sheet1.xml",
+    enc.encode(
+      `<?xml version="1.0"?><worksheet ${NS} ${R}><sheetData>${sheetData}</sheetData></worksheet>`,
+    ),
+  )
+  return zip.build()
+}
+
+async function odsWithRows(rowsXml: string): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  zip.add("mimetype", enc.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+    compress: false,
+  })
+  zip.add(
+    "META-INF/manifest.xml",
+    enc.encode(
+      `<?xml version="1.0"?><manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">` +
+        `<manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/>` +
+        `<manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/></manifest:manifest>`,
+    ),
+  )
+  zip.add(
+    "content.xml",
+    enc.encode(
+      `<?xml version="1.0"?><office:document-content ` +
+        `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+        `xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" ` +
+        `xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0">` +
+        `<office:body><office:spreadsheet><table:table table:name="S">${rowsXml}` +
+        `</table:table></office:spreadsheet></office:body></office:document-content>`,
+    ),
+  )
+  return zip.build()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Regression guard for #363. A reader hands back `rows: CellValue[][]`,
+// a dense rectangle — so a sheet costs its bounding box, not its cell
+// count. Bounding each coordinate separately is not enough, and the gap
+// was a fatal V8 OOM (SIGABRT, uncatchable) from a ~1.5 KB file.
+//
+// Every test here asserts a *catchable* ParseError, not a value.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("XLSX bounding-box limit", () => {
+  it("rejects two legal cells at opposite corners instead of dying", async () => {
+    // Both A1 and XFD1048576 are inside Excel's own limits, so the
+    // per-coordinate check passes them. Their product is 1.7e10 slots.
+    const buf = await xlsxWithSheetData(
+      `<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c></row>` +
+        `<row r="1048576"><c r="XFD1048576" t="inlineStr"><is><t>z</t></is></c></row>`,
+    )
+
+    await expect(readXlsx(buf)).rejects.toThrow(ParseError)
+    await expect(readXlsx(buf)).rejects.toThrow(/over the .* limit/)
+  }, 20_000)
+
+  it("names the sheet and the actual dimensions", async () => {
+    const buf = await xlsxWithSheetData(
+      `<row r="1048576"><c r="XFD1048576" t="inlineStr"><is><t>z</t></is></c></row>`,
+    )
+    await expect(readXlsx(buf)).rejects.toThrow(/Sheet "S" spans 1048576 rows x 16384 columns/)
+  }, 20_000)
+
+  it("points at the options that bound the read", async () => {
+    const buf = await xlsxWithSheetData(
+      `<row r="1048576"><c r="XFD1048576" t="inlineStr"><is><t>z</t></is></c></row>`,
+    )
+    await expect(readXlsx(buf)).rejects.toThrow(/`range` or `maxRows`/)
+  }, 20_000)
+
+  it("still reads an ordinary sparse sheet", async () => {
+    const buf = await xlsxWithSheetData(
+      `<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c></row>` +
+        `<row r="500"><c r="J500" t="inlineStr"><is><t>z</t></is></c></row>`,
+    )
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0].rows).toHaveLength(500)
+    expect(workbook.sheets[0].rows[0][0]).toBe("a")
+    expect(workbook.sheets[0].rows[499][9]).toBe("z")
+  })
+
+  it("admits a wide-but-shallow sheet under the cap", async () => {
+    // 1 row x 16,384 columns is 16,384 cells — nowhere near the limit,
+    // even though it uses the very last column.
+    const buf = await xlsxWithSheetData(
+      `<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c>` +
+        `<c r="XFD1" t="inlineStr"><is><t>z</t></is></c></row>`,
+    )
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0].rows[0]).toHaveLength(16384)
+  })
+})
+
+describe("ODS bounding-box limit", () => {
+  it("rejects a wide row repeated across the whole sheet", async () => {
+    // Each repeat attribute is individually capped; the product is what
+    // was unbounded.
+    const rows =
+      `<table:table-row table:number-rows-repeated="1048576">` +
+      `<table:table-cell table:number-columns-repeated="16384">` +
+      `<text:p>x</text:p></table:table-cell></table:table-row>`
+
+    await expect(readOds(await odsWithRows(rows))).rejects.toThrow(ParseError)
+    await expect(readOds(await odsWithRows(rows))).rejects.toThrow(/over the .* limit/)
+  }, 20_000)
+
+  it("still reads an ordinary repeated row", async () => {
+    const rows =
+      `<table:table-row table:number-rows-repeated="3">` +
+      `<table:table-cell><text:p>x</text:p></table:table-cell></table:table-row>`
+    const workbook = await readOds(await odsWithRows(rows))
+    expect(workbook.sheets[0].rows).toHaveLength(3)
+    expect(workbook.sheets[0].rows[0][0]).toBe("x")
+  })
+})
+
+describe("MAX_TOTAL_CELLS", () => {
+  it("leaves room for real spreadsheets", () => {
+    // Excel's row limit at 16 columns is ~16.8M cells; the cap has to sit
+    // above realistic files or it becomes the bug.
+    expect(MAX_TOTAL_CELLS).toBeGreaterThanOrEqual(16_777_216)
+  })
+})


### PR DESCRIPTION
First item of #363. Part of #352.

`readXlsx` could be **killed** — not thrown from, killed — by a 1,487-byte file containing two entirely legal cells.

```
$ NODE_OPTIONS=--max-old-space-size=512 tsx probe.ts sparse.xlsx
<--- Last few GCs --->
...
exit=134          # SIGABRT — fatal V8 OOM
```

The file's entire unusual content:

```xml
<row r="1"><c r="A1">…</c></row>
<row r="1048576"><c r="XFD1048576">…</c></row>
```

## Why the existing guard didn't catch it

Readers hand back `rows: CellValue[][]`, a **dense rectangle**. A sheet therefore costs its bounding box, not its cell count.

`A1` and `XFD1048576` are both inside Excel's own limits, so both pass the per-coordinate `MAX_ROW_INDEX` / `MAX_COL_INDEX` check at `worksheet.ts:1428`. Then `worksheet.ts:1039` fills 1,048,576 × 16,384 = 1.7e10 slots.

The per-coordinate guard made this *harder* to spot, not easier — reading that code, the bound looks handled.

No `try/catch` helps here. The process is gone.

## Fix

`MAX_TOTAL_CELLS` (20,000,000), checked before allocating, in the three readers that materialize a dense rectangle:

- **`xlsx/worksheet.ts`** — checks `(maxRow + 1) * colCount` before the fill loop. The error names the sheet, the real dimensions, and the `range` / `maxRows` options that bound a read, so it tells you what to do rather than just what went wrong.
- **`ods/reader.ts`** — checks the projected total before pushing repeated rows. The individual repeat attributes were already capped by earlier hardening; their **product** was not, so one 16,384-cell row repeated 1,048,576 times costs the same 1.7e10 slots. Same shape, different file format.
- **`xls/reader.ts`** — had no bounds at all, while its XLSB sibling throws `ParseError` for both coordinates. Adds the coordinate guards *and* the bounding-box check. BIFF row/col are u16, so each is bounded at 65,535 alone — but 65,535 × 65,536 is still 4.3e9.

## Choosing the number

20M has to sit above realistic files or the cap becomes the bug. Excel's row limit at 16 columns is ~16.8M cells, so that is the floor; a test pins it so nobody tightens it below a legitimate workbook.

Files above the cap now get a clear error instead of a crash — which is a strict improvement, since previously they OOMed anyway, just fatally.

## Verification

8 tests in `test/cell-count-limits.test.ts`, all asserting a **catchable `ParseError`** rather than a value, with explicit timeouts so a regression fails rather than hangs CI:

- the opposite-corners case for XLSX, and the equivalent repeated-row case for ODS
- the error names the sheet and dimensions, and points at `range` / `maxRows`
- an ordinary sparse sheet (500 × 10) still reads
- a wide-but-shallow sheet — 1 row × 16,384 columns, using the very last column — is admitted, since it is only 16,384 cells
- an ordinary ODS repeated row still reads
- `MAX_TOTAL_CELLS` is at least 16,777,216

Same file after the fix: catchable `ParseError` in 144 ms.

Full suite 7,787 tests / 113 files green; lint, typecheck, build clean.

Remaining items in #363 — the ODS `String.repeat` vectors, the streaming reader's missing column bound, the two uncapped `DecompressionStream` paths, the missing input-size ceiling, and `fromHtml` span caps — are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
