### PR TITLE
fix: cap file-driven repeats and spans; surface streaming parse errors — #363

### DIFF
--- a/src/export/html-import.ts
+++ b/src/export/html-import.ts
@@ -1,5 +1,18 @@
 import type { Sheet, CellValue, MergeRange } from "../_types"
 import { parseSax } from "../xml/parser"
+import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_SPAN_CELLS } from "../limits"
+
+/**
+ * Bound a `colspan` / `rowspan` attribute. Non-numeric and non-positive
+ * values collapse to 1, which is the HTML default; anything past the
+ * sheet's own limit is clamped, since a span wider than the grid cannot
+ * mean anything useful.
+ */
+function clampSpan(raw: string | undefined, max: number): number {
+  const value = Number(raw ?? "1")
+  if (!Number.isFinite(value) || value < 1) return 1
+  return Math.min(Math.trunc(value), max)
+}
 
 /**
  * Parse an HTML table string into a Sheet.
@@ -50,8 +63,17 @@ export function fromHtml(html: string, options?: { sheetName?: string }): Sheet 
       if ((local === "td" || local === "th") && inRow) {
         inCell = true
         currentCellText = ""
-        currentCellColspan = attrs.colspan ? parseInt(attrs.colspan, 10) || 1 : 1
-        currentCellRowspan = attrs.rowspan ? parseInt(attrs.rowspan, 10) || 1 : 1
+        // fromHtml exists to consume markup the caller did not write, so
+        // spans are bounded: rowspan x colspan drives a nested loop of Set
+        // insertions, and 100000 x 100000 is 1e10 of them. See #363.
+        currentCellColspan = clampSpan(attrs.colspan, MAX_COL_INDEX + 1)
+        currentCellRowspan = clampSpan(attrs.rowspan, MAX_ROW_INDEX + 1)
+        // Clamping each span alone is not enough: the reservation below
+        // is a nested loop, so the cost is their product. Shrink the
+        // rowspan until the rectangle fits.
+        if (currentCellColspan * currentCellRowspan > MAX_SPAN_CELLS) {
+          currentCellRowspan = Math.max(1, Math.floor(MAX_SPAN_CELLS / currentCellColspan))
+        }
       }
     },
 

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -32,6 +32,30 @@ export const MAX_COL_INDEX = 16_383
 export const MAX_TOTAL_CELLS = 20_000_000
 
 /**
+ * Cap on any `String.repeat` count taken from file content.
+ *
+ * ODS expresses runs of spaces as `<text:s text:c="N"/>` and decimal
+ * precision as `number:decimal-places="N"`, both free-form integers. A
+ * single `text:c="900000000"` reaches a raw `RangeError: Invalid string
+ * length`; half that succeeds and allocates a gigabyte for one cell.
+ *
+ * 100,000 is far past any legitimate run of spaces or decimal places
+ * while keeping the worst case at a few hundred KB.
+ */
+export const MAX_REPEAT_COUNT = 100_000
+
+/**
+ * Cap on the number of grid cells one HTML table cell may reserve
+ * through `rowspan` x `colspan`.
+ *
+ * The reservation is a nested loop of Set insertions, so the cost is the
+ * product — clamping each span on its own still leaves 16,384 x
+ * 1,048,576. `fromHtml` exists to consume markup the caller did not
+ * write, which makes this the cheapest hang in the library to trigger.
+ */
+export const MAX_SPAN_CELLS = 1_000_000
+
+/**
  * Upper bound on the password-derivation spin count accepted from an
  * encrypted workbook. Office uses 100,000; we allow a generous ceiling
  * so a hostile file cannot pin a CPU for minutes.

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -17,7 +17,18 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseXml } from "../xml/parser"
-import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
+import { MAX_COL_INDEX, MAX_REPEAT_COUNT, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
+
+/**
+ * Bound a repeat count taken from the file so it can drive
+ * `String.repeat` safely. Non-numeric and non-positive values collapse
+ * to 1, matching the ODF default for an omitted `text:c`.
+ */
+function clampRepeat(raw: string | undefined): number {
+  const value = Number(raw ?? "1")
+  if (!Number.isFinite(value) || value < 1) return 1
+  return Math.min(Math.trunc(value), MAX_REPEAT_COUNT)
+}
 import type { XmlElement } from "../xml/parser"
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -166,7 +177,11 @@ function serializeDataStyleChildren(
     if (typeof child === "string") continue
     const local = child.local || child.tag
     if (local === "number") {
-      const decimals = parseInt(child.attrs["number:decimal-places"] ?? "0", 10)
+      // Reached while parsing styles.xml, before any cell data.
+      const decimals = Math.min(
+        parseInt(child.attrs["number:decimal-places"] ?? "0", 10) || 0,
+        MAX_REPEAT_COUNT,
+      )
       const grouping = child.attrs["number:grouping"] === "true"
       const integerPart = grouping ? "#,##0" : "0"
       out += decimals > 0 ? `${integerPart}.${"0".repeat(decimals)}` : integerPart
@@ -293,8 +308,10 @@ function collectText(el: XmlElement): string {
       const local = child.local || child.tag
       if (local === "s") {
         // <text:s/> or <text:s text:c="N"/> — space characters
-        const count = Number(child.attrs["text:c"] ?? "1")
-        text += " ".repeat(count > 0 ? count : 1)
+        // Free-form integer from the file — uncapped it reaches a raw
+        // RangeError, or allocates a gigabyte for one cell. See #363.
+        const count = clampRepeat(child.attrs["text:c"])
+        text += " ".repeat(count)
       } else if (local === "line-break") {
         // <text:line-break/> — newline
         text += "\n"

--- a/src/ods/stream.ts
+++ b/src/ods/stream.ts
@@ -6,7 +6,7 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseSax } from "../xml/parser"
-import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../limits"
+import { MAX_COL_INDEX, MAX_REPEAT_COUNT, MAX_ROW_INDEX } from "../limits"
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -112,8 +112,12 @@ function* parseContentRows(xml: string): Generator<OdsStreamRow, void, undefined
         // the streaming and batch readers return the same string for a cell.
         case "s":
           if (inP && inCell) {
-            const count = Number(attrs["text:c"] ?? "1")
-            cellText += " ".repeat(count > 0 ? count : 1)
+            // Same cap as the batch reader — an uncapped text:c reaches
+            // a raw RangeError. See #363.
+            const raw = Number(attrs["text:c"] ?? "1")
+            const count =
+              !Number.isFinite(raw) || raw < 1 ? 1 : Math.min(Math.trunc(raw), MAX_REPEAT_COUNT)
+            cellText += " ".repeat(count)
           }
           break
         case "line-break":

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -8,6 +8,7 @@ import type { SharedString } from "./shared-strings"
 import type { ParsedStyles } from "./styles"
 import type { Relationship } from "./relationships"
 import { EncryptedFileError, ParseError, ZipError } from "../errors"
+import { MAX_COL_INDEX } from "../limits"
 import { isOle2Container } from "../_input"
 import { decryptAgile } from "./crypto/agile"
 import { ZipReader } from "../zip/reader"
@@ -229,6 +230,15 @@ function createRowSaxState(): RowSaxState {
 function buildRowFromCells(cells: Array<{ col: number; value: CellValue }>): CellValue[] {
   // Use reduce instead of Math.max(...spread) to avoid RangeError on wide rows (>65K cols)
   const maxCol = cells.reduce((m, c) => (c.col > m ? c.col : m), -1)
+  // The batch reader bound-checks cell coordinates; this one did not, so
+  // `<c r="AAAAAA1">` allocated a 12M-element array per row and a longer
+  // reference reached a raw RangeError, escaping the typed-error
+  // contract. See #363.
+  if (maxCol > MAX_COL_INDEX) {
+    throw new ParseError(
+      `Cell column ${maxCol} is outside the supported sheet bounds (max ${MAX_COL_INDEX + 1})`,
+    )
+  }
   const values: CellValue[] = maxCol >= 0 ? Array.from({ length: maxCol + 1 }, () => null) : []
   for (const cell of cells) {
     values[cell.col] = cell.value
@@ -443,7 +453,7 @@ async function* parseWorksheetRowsStreaming(
   const maxRows = filters.maxRows ?? 0
   const range = filters.range
 
-  const parsePromise = parseSaxStream(cancellable, {
+  const parsePromiseRaw = parseSaxStream(cancellable, {
     onOpenTag(tag, attrs) {
       if (aborted) return
       handleOpenTag(tag, attrs, s)
@@ -460,6 +470,7 @@ async function* parseWorksheetRowsStreaming(
         // worksheet rows are written in ascending order in valid OOXML.
         if (range && row.index > range.endRow) {
           aborted = true
+          stoppedEarly = true
           cancelSource()
           if (resolve) {
             resolve()
@@ -477,17 +488,34 @@ async function* parseWorksheetRowsStreaming(
           }
           if (maxRows > 0 && emittedDataRows >= maxRows) {
             aborted = true
+            stoppedEarly = true
             cancelSource()
           }
         }
       }
     },
-  }).then(() => {
+  })
+  // Both settlements have to wake the consumer loop below. Handling only
+  // fulfilment left `done` false forever on a parse error, so the loop
+  // awaited a promise nobody would ever resolve — the generator hung
+  // instead of surfacing the error. See #363.
+  let parseError: unknown
+  let parseFailed = false
+  // `aborted` is also set by the generator's finally block, so it cannot
+  // tell a deliberate early stop from ordinary completion. Track the
+  // former separately, since only then is a parser error expected.
+  let stoppedEarly = false
+  const wake = (): void => {
     done = true
     if (resolve) {
       resolve()
       resolve = null
     }
+  }
+  const parsePromise = parsePromiseRaw.then(wake, (err: unknown) => {
+    parseError = err
+    parseFailed = true
+    wake()
   })
 
   try {
@@ -508,7 +536,12 @@ async function* parseWorksheetRowsStreaming(
     cancelSource()
   }
 
-  await parsePromise.catch(() => {})
+  await parsePromise
+  // A parse failure used to be swallowed here, so a malformed sheet
+  // looked like a short-but-successful read. Cancellation is different:
+  // when we stopped the source ourselves for maxRows/range, whatever the
+  // parser reports on the way down is expected, not an error.
+  if (parseFailed && !stoppedEarly) throw parseError
 }
 
 // ── Cell value resolution (streaming — no Cell objects) ──────────────

--- a/test/dos-limits.test.ts
+++ b/test/dos-limits.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { readOds } from "../src/ods/reader"
+import { streamOdsRows } from "../src/ods/stream"
+import { streamXlsxRows } from "../src/xlsx/stream-reader"
+import { fromHtml } from "../src/export/html-import"
+import { ParseError } from "../src/errors"
+import { MAX_COL_INDEX, MAX_SPAN_CELLS } from "../src/limits"
+import type { CellValue } from "../src/_types"
+
+const enc = new TextEncoder()
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+async function odsWithContent(bodyXml: string, stylesXml?: string): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  zip.add("mimetype", enc.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+    compress: false,
+  })
+  zip.add(
+    "META-INF/manifest.xml",
+    enc.encode(
+      `<?xml version="1.0"?><manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0">` +
+        `<manifest:file-entry manifest:full-path="/" manifest:media-type="application/vnd.oasis.opendocument.spreadsheet"/>` +
+        `</manifest:manifest>`,
+    ),
+  )
+  zip.add(
+    "content.xml",
+    enc.encode(
+      `<?xml version="1.0"?><office:document-content ` +
+        `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+        `xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" ` +
+        `xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" ` +
+        `xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" ` +
+        `xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0">` +
+        `<office:body><office:spreadsheet><table:table table:name="S">${bodyXml}` +
+        `</table:table></office:spreadsheet></office:body></office:document-content>`,
+    ),
+  )
+  if (stylesXml) zip.add("styles.xml", enc.encode(stylesXml))
+  return zip.build()
+}
+
+async function xlsxWithSheetData(sheetData: string): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  zip.add(
+    "[Content_Types].xml",
+    enc.encode(
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+        `<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+        `</Types>`,
+    ),
+  )
+  zip.add(
+    "_rels/.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/workbook.xml",
+    enc.encode(
+      `<?xml version="1.0"?><workbook ${NS} ${R}><sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    ),
+  )
+  zip.add(
+    "xl/_rels/workbook.xml.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/worksheets/sheet1.xml",
+    enc.encode(
+      `<?xml version="1.0"?><worksheet ${NS} ${R}><sheetData>${sheetData}</sheetData></worksheet>`,
+    ),
+  )
+  return zip.build()
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// #363 — values read from a file driving an allocation, a loop bound, or
+// a String.repeat with no cap. Every test asserts *completion* rather
+// than a value, because the failure mode is a hang or a raw RangeError.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS <text:s> repeat count", () => {
+  it("does not allocate a gigabyte for one cell", async () => {
+    // Uncapped this reaches a raw RangeError: Invalid string length.
+    const body =
+      `<table:table-row><table:table-cell><text:p>` +
+      `<text:s text:c="900000000"/>x</text:p></table:table-cell></table:table-row>`
+
+    const workbook = await readOds(await odsWithContent(body))
+    const value = workbook.sheets[0].rows[0][0] as string
+    expect(typeof value).toBe("string")
+    expect(value.length).toBeLessThan(1_000_000)
+  }, 20_000)
+
+  it("still expands an ordinary run of spaces", async () => {
+    const body =
+      `<table:table-row><table:table-cell><text:p>` +
+      `a<text:s text:c="3"/>b</text:p></table:table-cell></table:table-row>`
+    const workbook = await readOds(await odsWithContent(body))
+    expect(workbook.sheets[0].rows[0][0]).toBe("a   b")
+  })
+
+  it("treats a missing or malformed count as one space", async () => {
+    for (const attr of ["", ' text:c="0"', ' text:c="abc"', ' text:c="-5"']) {
+      const body =
+        `<table:table-row><table:table-cell><text:p>` +
+        `a<text:s${attr}/>b</text:p></table:table-cell></table:table-row>`
+      const workbook = await readOds(await odsWithContent(body))
+      expect(workbook.sheets[0].rows[0][0], attr).toBe("a b")
+    }
+  })
+
+  it("is capped in the streaming reader too", async () => {
+    const body =
+      `<table:table-row><table:table-cell><text:p>` +
+      `<text:s text:c="900000000"/>x</text:p></table:table-cell></table:table-row>`
+
+    const rows: CellValue[][] = []
+    for await (const row of streamOdsRows(await odsWithContent(body))) {
+      rows.push(row.values)
+    }
+    expect((rows[0][0] as string).length).toBeLessThan(1_000_000)
+  }, 20_000)
+})
+
+describe("ODS number:decimal-places", () => {
+  it("does not build a two-gigabyte format string", async () => {
+    // Reached while parsing styles, before any cell data exists.
+    const styles =
+      `<?xml version="1.0"?><office:document-styles ` +
+      `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+      `xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" ` +
+      `xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0">` +
+      `<office:styles><number:number-style style:name="N1">` +
+      `<number:number number:decimal-places="2000000000"/>` +
+      `</number:number-style></office:styles></office:document-styles>`
+
+    const body = `<table:table-row><table:table-cell><text:p>1</text:p></table:table-cell></table:table-row>`
+    const workbook = await readOds(await odsWithContent(body, styles), { readStyles: true })
+    expect(workbook.sheets[0].rows[0][0]).toBeDefined()
+  }, 20_000)
+})
+
+describe("streaming XLSX column bounds", () => {
+  it("rejects a cell reference past the last column", async () => {
+    // The batch reader has always bound-checked this; the streaming one
+    // allocated a 12-million-element array per row instead.
+    const buf = await xlsxWithSheetData(
+      `<row r="1"><c r="AAAAAA1" t="inlineStr"><is><t>x</t></is></c></row>`,
+    )
+
+    const drain = async () => {
+      for await (const _ of streamXlsxRows(buf)) {
+        // consume
+      }
+    }
+    await expect(drain()).rejects.toThrow(ParseError)
+    await expect(drain()).rejects.toThrow(/outside the supported sheet bounds/)
+  }, 20_000)
+
+  it("throws a typed error rather than a raw RangeError", async () => {
+    // A longer reference used to overflow past Array's own limit.
+    const buf = await xlsxWithSheetData(
+      `<row r="1"><c r="AAAAAAAAAA1" t="inlineStr"><is><t>x</t></is></c></row>`,
+    )
+    const drain = async () => {
+      for await (const _ of streamXlsxRows(buf)) {
+        // consume
+      }
+    }
+    await expect(drain()).rejects.toThrow(ParseError)
+  }, 20_000)
+
+  it("still streams a row using the last legal column", async () => {
+    const buf = await xlsxWithSheetData(
+      `<row r="1"><c r="XFD1" t="inlineStr"><is><t>x</t></is></c></row>`,
+    )
+    const rows: CellValue[][] = []
+    for await (const row of streamXlsxRows(buf)) rows.push(row.values)
+    expect(rows[0]).toHaveLength(MAX_COL_INDEX + 1)
+    expect(rows[0][MAX_COL_INDEX]).toBe("x")
+  })
+})
+
+describe("fromHtml span bounds", () => {
+  it("does not hang on a hostile rowspan x colspan", () => {
+    // 100000 x 100000 is 1e10 Set insertions. Clamping each span alone
+    // still leaves 16384 x 1048576 — the product is what matters.
+    const started = Date.now()
+    const sheet = fromHtml('<table><tr><td rowspan="100000" colspan="100000">x</td></tr></table>')
+    expect(Date.now() - started).toBeLessThan(10_000)
+
+    const merge = sheet.merges![0]
+    const cells = (merge.endRow - merge.startRow + 1) * (merge.endCol - merge.startCol + 1)
+    expect(cells).toBeLessThanOrEqual(MAX_SPAN_CELLS)
+  }, 20_000)
+
+  it("leaves ordinary spans untouched", () => {
+    const sheet = fromHtml(
+      '<table><tr><td rowspan="2" colspan="3">x</td><td>y</td></tr><tr><td>z</td></tr></table>',
+    )
+    expect(sheet.merges![0]).toMatchObject({
+      startRow: 0,
+      startCol: 0,
+      endRow: 1,
+      endCol: 2,
+    })
+  })
+
+  it("treats malformed spans as 1", () => {
+    const sheet = fromHtml('<table><tr><td rowspan="abc" colspan="-4">x</td></tr></table>')
+    expect(sheet.merges).toBeUndefined()
+    expect(sheet.rows[0]).toEqual(["x"])
+  })
+})


### PR DESCRIPTION
Second batch from #363, after #368. Part of #352. Same class throughout: a value read from the file drives an allocation or a loop bound with no cap.

## ODS `String.repeat` vectors the earlier hardening missed

The previous ODS work capped `number-columns-repeated` / `number-rows-repeated`. Two other file-driven repeats were not:

- **`<text:s text:c="N"/>`** in both `ods/reader.ts` and `ods/stream.ts`. Uncapped, `text:c="900000000"` reaches a raw `RangeError: Invalid string length`; half that succeeds and allocates a gigabyte for a single cell.
- **`number:decimal-places`** in `ods/reader.ts`, reached while parsing styles — before any cell data exists.

Both now go through `MAX_REPEAT_COUNT` (100,000), which is far past any legitimate run of spaces or decimal places.

## The streaming XLSX reader had no column bound

The batch reader has always bound-checked cell coordinates. The streaming one did not, so `<c r="AAAAAA1">` resolved to column 12,356,630 and allocated a 12-million-element array **per row**; a longer reference reached a raw `RangeError`, escaping the typed-error contract entirely.

## `fromHtml` spans — and a mistake worth recording

Clamping `colspan` and `rowspan` separately is **not enough**. The reservation is a nested loop, so the cost is their product: clamped to the sheet's own limits, that is still 16,384 × 1,048,576 ≈ 1.7e10 `Set` insertions.

I wrote the per-span clamp first and it passed typecheck and the suite — the same shape of mistake #368 is about, made one commit after diagnosing it. `MAX_SPAN_CELLS` bounds the rectangle instead. The `rowspan="100000" colspan="100000"` case now returns in **325 ms**.

## What the column bound uncovered

Adding it made a test hang for 41 seconds and then report an **unhandled rejection** rather than a failure. Two worse bugs in the streaming reader, both fixed here:

1. `parseSaxStream`'s promise was consumed with `.then(onFulfilled)` only. On rejection the `done` flag stayed `false` forever, so the consumer loop awaited a promise nobody would ever resolve — **the generator hung instead of failing**.
2. Whatever survived that was then swallowed by `await parsePromise.catch(() => {})`, so a malformed sheet looked like a short-but-successful read.

Errors now reject the iterator.

Getting that right needed one more distinction: the generator's `finally` block sets `aborted = true` unconditionally, so it cannot tell a deliberate early stop from ordinary completion. My first attempt guarded on `!aborted` and therefore never fired. A separate `stoppedEarly` flag, set only by the `maxRows` / `range` paths, keeps cancellation quiet while letting real failures through.

That bug was strictly more serious than the missing bound I set out to add — any parse error during a streaming read was silently swallowed.

## Verification

11 tests in `test/dos-limits.test.ts`, each asserting **completion or a typed throw** rather than a value, with explicit timeouts so a regression fails instead of hanging CI:

- the `text:c` bomb in both the batch and streaming ODS readers, plus ordinary runs and malformed counts still behaving as one space
- `number:decimal-places` at two billion
- the streaming column bound, the longer reference that used to produce a raw `RangeError`, and a row using the last legal column still streaming
- the hostile `rowspan × colspan`, ordinary spans untouched, malformed spans treated as 1

Full suite 7,802 tests / 114 files green; lint, typecheck, build clean.

Still open in #363: the two uncapped `DecompressionStream` paths, the missing input-size ceiling in `_input.ts`, the `xls` SST spread-push, and the `parseSaxStream` reader-cleanup / O(n²) items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
