### PR TITLE
fix(xlsx): stop pageSetup silently disabling print gridlines — closes #360

### DIFF
--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -478,9 +478,16 @@ export function writeWorksheetXml(
     parts.push(hyperlinksXml)
   }
 
-  // ── Print Options (only when pageSetup exists) ──
-  if (sheet.pageSetup) {
-    parts.push(xmlSelfClose("printOptions", { headings: 0, gridLines: 0 }))
+  // ── Print Options ──
+  // Per ECMA-376 these four live on <printOptions>, not <pageSetup>, and
+  // every attribute defaults to false — so the element is emitted only
+  // when something is actually non-default. It used to be written
+  // unconditionally with hardcoded zeros whenever any pageSetup existed,
+  // which meant setting a page margin silently turned off printed
+  // gridlines and headings. See #360.
+  const printOptionsXml = serializePrintOptions(sheet.pageSetup)
+  if (printOptionsXml) {
+    parts.push(printOptionsXml)
   }
 
   // ── Page Margins ──
@@ -1099,6 +1106,31 @@ function serializePageMargins(margins?: PageMargins): string {
   })
 }
 
+// ── Print Options Serialization ──────────────────────────────────────
+
+/**
+ * Serialize `<printOptions>`, or return `""` when everything is at its
+ * OOXML default.
+ *
+ * `gridLines` and `headings` control what appears on *paper*, and both
+ * default to false. `horizontalCentered` / `verticalCentered` belong here
+ * too — hucre used to read and write them on `<pageSetup>`, which
+ * round-tripped through hucre only because it was consistently wrong in
+ * both directions; Excel ignored them entirely.
+ */
+function serializePrintOptions(ps: PageSetup | undefined): string {
+  if (!ps) return ""
+
+  const attrs: Record<string, string | number> = {}
+  if (ps.showGridLines) attrs["gridLines"] = 1
+  if (ps.showRowColHeaders) attrs["headings"] = 1
+  if (ps.horizontalCentered) attrs["horizontalCentered"] = 1
+  if (ps.verticalCentered) attrs["verticalCentered"] = 1
+
+  if (Object.keys(attrs).length === 0) return ""
+  return xmlSelfClose("printOptions", attrs)
+}
+
 // ── Page Setup Serialization ─────────────────────────────────────────
 
 function serializePageSetup(ps: PageSetup): string {
@@ -1126,14 +1158,6 @@ function serializePageSetup(ps: PageSetup): string {
     if (ps.fitToHeight !== undefined) {
       attrs["fitToHeight"] = ps.fitToHeight
     }
-  }
-
-  if (ps.horizontalCentered) {
-    attrs["horizontalCentered"] = 1
-  }
-
-  if (ps.verticalCentered) {
-    attrs["verticalCentered"] = 1
   }
 
   // Only emit if there are attributes beyond default

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -609,7 +609,17 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
           pageMargins = parsePageMarginsAttrs(attrs)
           break
         case "pageSetup":
-          pageSetup = parsePageSetupAttrs(attrs)
+          // Merge, don't replace: <printOptions> is written before
+          // <pageSetup> in a worksheet, so assigning here dropped
+          // whatever it had already contributed. See #360.
+          pageSetup = { ...pageSetup, ...parsePageSetupAttrs(attrs) }
+          break
+        case "printOptions":
+          // <printOptions> was never parsed, so showGridLines and
+          // showRowColHeaders were write-only fields that always read back
+          // as undefined. It can appear before or after <pageSetup>, so
+          // merge rather than assign. See #360.
+          pageSetup = applyPrintOptionsAttrs(pageSetup, attrs)
           break
         case "headerFooter":
           inHeaderFooter = true
@@ -1739,6 +1749,28 @@ const PAPER_SIZE_REVERSE: Record<number, PaperSize> = {
   13: "b5",
 }
 
+/**
+ * Merge `<printOptions>` attributes into the sheet's page setup.
+ *
+ * The element can appear either side of `<pageSetup>` in a worksheet, so
+ * this merges into whatever exists rather than replacing it — and creates
+ * the object when `<printOptions>` comes first.
+ */
+function applyPrintOptionsAttrs(
+  existing: PageSetup | undefined,
+  attrs: Record<string, string>,
+): PageSetup {
+  const ps: PageSetup = existing ?? {}
+  const isTrue = (value: string | undefined): boolean => value === "1" || value === "true"
+
+  if (isTrue(attrs["gridLines"])) ps.showGridLines = true
+  if (isTrue(attrs["headings"])) ps.showRowColHeaders = true
+  if (isTrue(attrs["horizontalCentered"])) ps.horizontalCentered = true
+  if (isTrue(attrs["verticalCentered"])) ps.verticalCentered = true
+
+  return ps
+}
+
 function parsePageSetupAttrs(attrs: Record<string, string>): PageSetup {
   const ps: PageSetup = {}
 
@@ -1762,6 +1794,9 @@ function parsePageSetupAttrs(attrs: Record<string, string>): PageSetup {
     if (attrs["fitToHeight"]) ps.fitToHeight = Number(attrs["fitToHeight"])
   }
 
+  // Excel writes the centering flags on <printOptions>; hucre used to
+  // write them here. Keep accepting them from <pageSetup> so files from
+  // older versions still round-trip. See #360.
   if (attrs["horizontalCentered"] === "1" || attrs["horizontalCentered"] === "true") {
     ps.horizontalCentered = true
   }

--- a/test/batch-fixes.test.ts
+++ b/test/batch-fixes.test.ts
@@ -164,7 +164,10 @@ describe("#128: Worksheet element ordering per OOXML spec", () => {
       view: { tabColor: { rgb: "FF0000" } },
       autoFilter: { range: "A1:B2" },
       merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
-      pageSetup: { orientation: "landscape" },
+      // showGridLines keeps <printOptions> in the output. It is emitted
+      // only when something is non-default now (#360), and the point of
+      // this test is the ordering, not the emission rule.
+      pageSetup: { orientation: "landscape", showGridLines: true },
     }
 
     const xml = writeXml(sheet)

--- a/test/print-options.test.ts
+++ b/test/print-options.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { ZipReader } from "../src/zip/reader"
+import type { PageSetup, WriteOptions } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function roundTrip(pageSetup: PageSetup): Promise<PageSetup | undefined> {
+  const options: WriteOptions = { sheets: [{ name: "S", rows: [["a"]], pageSetup }] }
+  const workbook = await readXlsx(await writeXlsx(options))
+  return workbook.sheets[0].pageSetup
+}
+
+async function sheetXml(pageSetup: PageSetup): Promise<string> {
+  const buf = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]], pageSetup }] })
+  const zip = new ZipReader(buf)
+  return new TextDecoder().decode(await zip.extract("xl/worksheets/sheet1.xml"))
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// #360 — <printOptions> was written unconditionally with hardcoded
+// zeros whenever any pageSetup existed, so setting a page margin turned
+// printed gridlines and headings off. The two type fields backing it
+// were never parsed, making them write-only and inert.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("print gridlines and headings", () => {
+  it("survives a write → read cycle", async () => {
+    const result = await roundTrip({ showGridLines: true, showRowColHeaders: true })
+    expect(result?.showGridLines).toBe(true)
+    expect(result?.showRowColHeaders).toBe(true)
+  })
+
+  it("is not turned off by an unrelated page setting", async () => {
+    // The original bug in one line: ask for landscape, lose your
+    // gridlines.
+    const xml = await sheetXml({ orientation: "landscape" })
+    expect(xml).not.toContain('gridLines="0"')
+    expect(xml).not.toContain('headings="0"')
+  })
+
+  it("emits nothing when both are at their OOXML default", async () => {
+    const xml = await sheetXml({ orientation: "landscape", scale: 80 })
+    expect(xml).not.toContain("<printOptions")
+  })
+
+  it("emits only the attributes that were set", async () => {
+    const xml = await sheetXml({ showGridLines: true })
+    expect(xml).toContain('gridLines="1"')
+    expect(xml).not.toContain("headings=")
+  })
+
+  it("reads a file that has printOptions before pageSetup", async () => {
+    // Both orders are valid in a worksheet, so the reader merges rather
+    // than assigns.
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          pageSetup: { showGridLines: true, orientation: "landscape" },
+        },
+      ],
+    })
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0].pageSetup).toMatchObject({
+      showGridLines: true,
+      orientation: "landscape",
+    })
+  })
+})
+
+describe("print centering", () => {
+  it("is written on printOptions, where ECMA-376 puts it", async () => {
+    // hucre used to read and write these on <pageSetup>. That
+    // round-tripped through hucre only because it was consistently wrong
+    // in both directions — Excel ignored them entirely.
+    const xml = await sheetXml({ horizontalCentered: true, verticalCentered: true })
+
+    const printOptions = xml.slice(xml.indexOf("<printOptions"))
+    const printOptionsTag = printOptions.slice(0, printOptions.indexOf(">") + 1)
+    expect(printOptionsTag).toContain('horizontalCentered="1"')
+    expect(printOptionsTag).toContain('verticalCentered="1"')
+
+    const pageSetupTag = xml.slice(xml.indexOf("<pageSetup"))
+    expect(pageSetupTag.slice(0, pageSetupTag.indexOf(">") + 1)).not.toContain("Centered")
+  })
+
+  it("survives a write → read cycle", async () => {
+    const result = await roundTrip({ horizontalCentered: true, verticalCentered: true })
+    expect(result?.horizontalCentered).toBe(true)
+    expect(result?.verticalCentered).toBe(true)
+  })
+
+  it("still accepts the attributes from pageSetup, for files hucre wrote before", async () => {
+    const legacy = (await sheetXml({ orientation: "landscape" })).replace(
+      "<pageSetup ",
+      '<pageSetup horizontalCentered="1" verticalCentered="1" ',
+    )
+
+    // Rebuild the workbook around the patched sheet.
+    const original = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]], pageSetup: { orientation: "landscape" } }],
+    })
+    const zip = new ZipReader(original)
+    const { ZipWriter } = await import("../src/zip/writer")
+    const rebuilt = new ZipWriter()
+    for (const path of zip.entries()) {
+      rebuilt.add(
+        path,
+        path === "xl/worksheets/sheet1.xml"
+          ? new TextEncoder().encode(legacy)
+          : await zip.extract(path),
+      )
+    }
+
+    const workbook = await readXlsx(await rebuilt.build())
+    expect(workbook.sheets[0].pageSetup?.horizontalCentered).toBe(true)
+    expect(workbook.sheets[0].pageSetup?.verticalCentered).toBe(true)
+  })
+})
+
+describe("openXlsx → saveXlsx", () => {
+  it("preserves print options rather than resetting them", async () => {
+    const original = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          pageSetup: {
+            orientation: "landscape",
+            showGridLines: true,
+            showRowColHeaders: true,
+            horizontalCentered: true,
+          },
+        },
+      ],
+    })
+
+    const saved = await saveXlsx(await openXlsx(original))
+    const workbook = await readXlsx(saved)
+
+    expect(workbook.sheets[0].pageSetup).toMatchObject({
+      showGridLines: true,
+      showRowColHeaders: true,
+      horizontalCentered: true,
+    })
+  })
+})

--- a/test/quick-fixes.test.ts
+++ b/test/quick-fixes.test.ts
@@ -76,11 +76,11 @@ describe("#101: <dimension> element", () => {
 // ── #102: printOptions element ───────────────────────────────────────
 
 describe("#102: <printOptions> element", () => {
-  it("emits <printOptions> when pageSetup exists", () => {
+  it("emits <printOptions> carrying the values that were set", () => {
     const sheet: WriteSheet = {
       name: "Test",
       rows: [["Data"]],
-      pageSetup: { orientation: "landscape" },
+      pageSetup: { orientation: "landscape", showGridLines: true, showRowColHeaders: true },
     }
 
     const xml = writeXml(sheet)
@@ -88,8 +88,23 @@ describe("#102: <printOptions> element", () => {
 
     const printOptions = findChild(doc, "printOptions")
     expect(printOptions).toBeDefined()
-    expect(printOptions.attrs["headings"]).toBe("0")
-    expect(printOptions.attrs["gridLines"]).toBe("0")
+    expect(printOptions.attrs["gridLines"]).toBe("1")
+    expect(printOptions.attrs["headings"]).toBe("1")
+  })
+
+  it("omits <printOptions> when a pageSetup carries none of its values", () => {
+    // It used to be written unconditionally with hardcoded zeros, so
+    // setting an unrelated page option turned printed gridlines off. Those
+    // zeros are also OOXML's defaults, which makes the element pure noise
+    // when nothing was asked for. See #360.
+    const sheet: WriteSheet = {
+      name: "Test",
+      rows: [["Data"]],
+      pageSetup: { orientation: "landscape" },
+    }
+
+    const doc = parseSheet(writeXml(sheet))
+    expect(findChild(doc, "printOptions")).toBeUndefined()
   })
 
   it("does not emit <printOptions> when pageSetup is absent", () => {


### PR DESCRIPTION
Closes #360. Part of #352.

```ts
// src/xlsx/worksheet-writer.ts, before
if (sheet.pageSetup) {
  parts.push(xmlSelfClose("printOptions", { headings: 0, gridLines: 0 }))
}
```

Both attributes hardcoded to `0`. So a caller who set page margins, orientation, or fit-to-width **also turned off printed gridlines and row/column headings** — with nothing in the API to suggest the two were connected, and nothing in the output to say it happened. Round-tripping a workbook that had them on turned them off.

## The type said otherwise

`PageSetup.showGridLines` and `.showRowColHeaders` existed and did nothing in either direction: the writer ignored them in favour of the constants above, and the reader never parsed `<printOptions>` at all, so they always read back as `undefined`. Two public fields, inert on both sides.

## Changes

- Emit `<printOptions>` from the type fields, and **only when something is non-default**. All four attributes default to `false` in OOXML, so the common case now emits nothing instead of noise.
- Parse `<printOptions>` on read, so the fields stop being write-only.
- Move `horizontalCentered` / `verticalCentered` onto `<printOptions>`, where ECMA-376 puts them. They were read *and* written on `<pageSetup>`, which round-tripped through hucre only because it was consistently wrong in both directions — Excel ignored them entirely, so the setting never actually worked in a spreadsheet. The reader still accepts them from `<pageSetup>` so files written by earlier hucre versions keep working.

## Merging matters in both directions

`<printOptions>` is written *before* `<pageSetup>` in a worksheet. My first attempt merged only in the `printOptions` case and assigned in the `pageSetup` case — which quietly dropped `showGridLines` whenever `orientation` was also set. Two of my own new tests caught it. Both cases merge now.

## Two existing tests encoded the old behaviour

Neither was wrong to exist; both pinned output that has changed.

- **#102's test** asserted `headings="0" gridLines="0"` — precisely the destructive output. It now asserts the values that were actually set, with a companion test covering the omit-when-default case. #102's second test ("does not emit when pageSetup is absent") passes unchanged.
- **#128's element-ordering test** needed a non-default print option in its fixture to keep `<printOptions>` in the output. The ordering assertion itself is untouched.

## Verification

Nine new tests in `test/print-options.test.ts`, including the one that states the bug plainly — asking for landscape must not emit `gridLines="0"` — plus write→read round-trips for both pairs, the attribute-placement check (on `<printOptions>`, absent from `<pageSetup>`), backward compatibility with files that carry the centering flags on `<pageSetup>`, and an `openXlsx` → `saveXlsx` preservation test.

Full suite 7,837 tests / 117 files green; lint, typecheck, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
