### PR TITLE
fix: three bugs found while raising coverage on weak modules

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -31,6 +31,11 @@ const PLACEHOLDER_RE = /\{\{\s*([^}\s]+)\s*\}\}/g
  * ```
  */
 export function fillTemplate(workbook: Workbook, data: Record<string, CellValue>): Workbook {
+  // Every lookup below uses Object.hasOwn rather than `key in data`.
+  // `in` walks the prototype chain, so a template containing
+  // `{{toString}}` used to resolve to Object.prototype.toString and put
+  // a *function* into a cell — outside CellValue entirely. `constructor`,
+  // `valueOf`, `hasOwnProperty` and `__proto__` behaved the same way.
   for (const sheet of workbook.sheets) {
     for (let r = 0; r < sheet.rows.length; r++) {
       const row = sheet.rows[r]!
@@ -45,7 +50,7 @@ export function fillTemplate(workbook: Workbook, data: Record<string, CellValue>
         const singleMatch = val.match(/^\{\{\s*([^}\s]+)\s*\}\}$/)
         if (singleMatch) {
           const key = singleMatch[1]!
-          if (key in data) {
+          if (Object.hasOwn(data, key)) {
             row[c] = data[key]!
           }
           // If key not in data, leave as-is
@@ -54,7 +59,7 @@ export function fillTemplate(workbook: Workbook, data: Record<string, CellValue>
 
         // Multiple placeholders or mixed text: string replacement
         const replaced = val.replace(PLACEHOLDER_RE, (match, key: string) => {
-          if (key in data) {
+          if (Object.hasOwn(data, key)) {
             const replacement = data[key]
             if (replacement === null) return ""
             if (replacement instanceof Date) return replacement.toISOString()
@@ -76,7 +81,7 @@ export function fillTemplate(workbook: Workbook, data: Record<string, CellValue>
         const singleMatch = cell.value.match(/^\{\{\s*([^}\s]+)\s*\}\}$/)
         if (singleMatch) {
           const dataKey = singleMatch[1]!
-          if (dataKey in data) {
+          if (Object.hasOwn(data, dataKey)) {
             cell.value = data[dataKey]!
             // Update cell type based on value
             if (typeof cell.value === "number") cell.type = "number"
@@ -88,7 +93,7 @@ export function fillTemplate(workbook: Workbook, data: Record<string, CellValue>
         }
 
         cell.value = cell.value.replace(PLACEHOLDER_RE, (match, k: string) => {
-          if (k in data) {
+          if (Object.hasOwn(data, k)) {
             const replacement = data[k]
             if (replacement === null) return ""
             if (replacement instanceof Date) return replacement.toISOString()

--- a/src/xlsx/shared-strings.ts
+++ b/src/xlsx/shared-strings.ts
@@ -121,7 +121,17 @@ function parseRunProperties(rPr: XmlElement): FontStyle {
         break
       case "color":
         font.color = {}
-        if (child.attrs["rgb"]) font.color.rgb = child.attrs["rgb"].replace(/^FF/, "")
+        if (child.attrs["rgb"]) {
+          // Strip the alpha channel positionally, matching styles.ts and
+          // the inline-string path in worksheet.ts. A `replace(/^FF/, "")`
+          // here mangled anything that merely started with FF: the 6-digit
+          // "FF0000" became "0000", and a non-opaque "80FF0000" kept its
+          // alpha, violating Color.rgb's "hex RGB without '#'". The same
+          // run parsed differently depending on whether it lived in
+          // sharedStrings.xml or an inline <is>.
+          const raw = child.attrs["rgb"]
+          font.color.rgb = raw.length === 8 ? raw.slice(2) : raw
+        }
         if (child.attrs["theme"]) font.color.theme = Number(child.attrs["theme"])
         if (child.attrs["tint"]) font.color.tint = Number(child.attrs["tint"])
         if (child.attrs["indexed"]) font.color.indexed = Number(child.attrs["indexed"])

--- a/src/xlsx/styles.ts
+++ b/src/xlsx/styles.ts
@@ -543,15 +543,22 @@ export function isDateStyle(styles: ParsedStyles, styleIndex: number): boolean {
 
   const numFmtId = xf.numFmtId
 
-  // Check built-in date format IDs
-  if (DATE_FMT_IDS.has(numFmtId)) {
-    return true
-  }
-
-  // Check custom number formats
+  // A workbook may redefine a built-in id (ECMA-376 §18.8.30), and
+  // resolveStyle already honours that — `numFmts.get(id) ?? BUILTIN[id]`.
+  // Consulting DATE_FMT_IDS first disagreed with it: a file redefining
+  // id 14 as "#,##0" resolved to a numeric format *and* reported as a
+  // date, so the reader converted the serial to a Date and then formatted
+  // it numerically. The reverse — id 3 redefined as "yyyy-mm-dd" — was
+  // missed entirely. Same precedence in both functions.
   const customFmt = styles.numFmts.get(numFmtId)
   if (customFmt) {
     return isDateFormat(customFmt)
+  }
+
+  // Built-in date format IDs, several of which are locale-dependent and
+  // carry no format string to inspect.
+  if (DATE_FMT_IDS.has(numFmtId)) {
+    return true
   }
 
   // Check built-in format string

--- a/test/shared-strings.test.ts
+++ b/test/shared-strings.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest"
+import { parseSharedStrings } from "../src/xlsx/shared-strings"
+import { parseStyles } from "../src/xlsx/styles"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const SST_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+/** Wrap `<si>` fragments in a real `<sst>` document, as Excel writes it. */
+function sst(inner: string): ReturnType<typeof parseSharedStrings> {
+  return parseSharedStrings(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="${SST_NS}">${inner}</sst>`)
+}
+
+/**
+ * Parse one rich-text run built from the given `<rPr>` body. The fragment is
+ * indented on purpose: pretty-printed sharedStrings.xml puts text nodes
+ * between every element, so the run and run-property walkers must step over
+ * them to find the elements they care about.
+ */
+function runFont(rPrBody: string) {
+  const entries = sst(
+    `<si>\n  <r>\n    <rPr>\n      ${rPrBody}\n    </rPr>\n    <t>text</t>\n  </r>\n</si>`,
+  )
+  return entries[0].richText![0].font
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Document level: only <si> children are entries. Everything else in an
+// <sst> (the count/uniqueCount attributes, a trailing <extLst>, and the
+// indentation text nodes between elements) must be ignored rather than
+// shifting every shared-string index by one.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSharedStrings — document structure", () => {
+  it("returns an empty table for an <sst> with no entries", () => {
+    expect(sst("")).toEqual([])
+    expect(parseSharedStrings(`<sst xmlns="${SST_NS}" count="0" uniqueCount="0"/>`)).toEqual([])
+  })
+
+  it("ignores non-<si> siblings so indices stay aligned", () => {
+    const strings = sst(`
+      <si><t>first</t></si>
+      <extLst><ext uri="{ABC}"><whatever/></ext></extLst>
+      <si><t>second</t></si>
+    `)
+    expect(strings.map((s) => s.text)).toEqual(["first", "second"])
+  })
+
+  it("ignores whitespace text nodes between entries", () => {
+    // The indentation between <si> elements arrives as string children of
+    // the root; treating one as an entry would corrupt every index.
+    const strings = sst("\n  <si><t>a</t></si>\n  <si><t>b</t></si>\n")
+    expect(strings).toHaveLength(2)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <si> shapes. CT_Rst allows a bare <t>, a sequence of <r> runs, and
+// phonetic hints (<rPh>, <phoneticPr>) that must never leak into text.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSharedStrings — <si> shapes", () => {
+  it("reads an empty <si/> as an empty string", () => {
+    // Excel emits a bare <si/> for a shared blank; dropping it would shift
+    // every later index.
+    const strings = sst("<si/>")
+    expect(strings).toHaveLength(1)
+    expect(strings[0]).toEqual({ text: "" })
+  })
+
+  it("reads a self-closing <t/> as an empty string", () => {
+    expect(sst("<si><t/></si>")[0]).toEqual({ text: "" })
+  })
+
+  it('preserves whitespace under xml:space="preserve"', () => {
+    const strings = sst(`<si><t xml:space="preserve">  padded  </t></si>`)
+    expect(strings[0].text).toBe("  padded  ")
+  })
+
+  it("ignores phonetic runs so only the base text is returned", () => {
+    // Japanese workbooks carry furigana in <rPh>; its <t> must not be
+    // concatenated onto the visible value.
+    const strings = sst(
+      `<si><t>東京</t><rPh sb="0" eb="2"><t>とうきょう</t></rPh><phoneticPr fontId="1"/></si>`,
+    )
+    expect(strings[0].text).toBe("東京")
+    expect(strings[0].richText).toBeUndefined()
+  })
+
+  it("decodes OOXML _xHHHH_ escapes in a simple string", () => {
+    expect(sst("<si><t>a_x000D__x000A_b</t></si>")[0].text).toBe("a\r\nb")
+  })
+
+  it("decodes XML entities in a simple string", () => {
+    expect(sst("<si><t>Tom &amp; &quot;Jerry&quot; &lt;x&gt;</t></si>")[0].text).toBe(
+      'Tom & "Jerry" <x>',
+    )
+  })
+
+  it("leaves richText undefined for a plain string", () => {
+    // Consumers branch on `richText` to decide between <t> and <r> output;
+    // an empty array here would round-trip a plain string as rich text.
+    expect(sst("<si><t>plain</t></si>")[0].richText).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Rich text: <r> runs. `text` is the concatenation of the runs and must
+// stay consistent with the per-run text.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSharedStrings — rich text runs", () => {
+  it("concatenates run text into the flat `text` field", () => {
+    const strings = sst("<si><r><t>Hello</t></r><r><t>, </t></r><r><t>world</t></r></si>")
+    expect(strings[0].text).toBe("Hello, world")
+    expect(strings[0].richText!.map((r) => r.text)).toEqual(["Hello", ", ", "world"])
+  })
+
+  it("omits `font` on runs without <rPr>", () => {
+    const strings = sst("<si><r><t>bare</t></r></si>")
+    expect(strings[0].richText![0]).toEqual({ text: "bare" })
+    expect("font" in strings[0].richText![0]).toBe(false)
+  })
+
+  it("keeps an empty run rather than collapsing it", () => {
+    // A run with formatting but no text is where Excel parks a cursor
+    // format; dropping it changes the run count on round-trip.
+    const strings = sst("<si><r><rPr><b/></rPr></r><r><t>x</t></r></si>")
+    expect(strings[0].richText).toHaveLength(2)
+    expect(strings[0].richText![0].text).toBe("")
+    expect(strings[0].richText![0].font?.bold).toBe(true)
+    expect(strings[0].text).toBe("x")
+  })
+
+  it("decodes escapes per run, not across the joined text", () => {
+    const strings = sst("<si><r><t>a_x000A_</t></r><r><t>_x0009_b</t></r></si>")
+    expect(strings[0].richText!.map((r) => r.text)).toEqual(["a\n", "\tb"])
+    expect(strings[0].text).toBe("a\n\tb")
+  })
+
+  it("ignores unknown children inside a run", () => {
+    const strings = sst('<si><r><rPr><b/></rPr><unknown val="1"/><t>ok</t></r></si>')
+    expect(strings[0].richText![0].text).toBe("ok")
+    expect(strings[0].richText![0].font?.bold).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <rPr> run properties. Each toggle in ECMA-376 §18.8.x defaults to *on*
+// when the element is present without a `val`, and off only for
+// val="0"/"false" — the accept-or-drop grammar the parser implements.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSharedStrings — <rPr> boolean toggles", () => {
+  it("treats a bare <b/>, <i/>, <strike/> as on", () => {
+    const font = runFont("<b/><i/><strike/>")
+    expect(font).toMatchObject({ bold: true, italic: true, strikethrough: true })
+  })
+
+  it('treats val="1" and val="true" as on', () => {
+    expect(runFont('<b val="1"/><i val="true"/><strike val="1"/>')).toMatchObject({
+      bold: true,
+      italic: true,
+      strikethrough: true,
+    })
+  })
+
+  it('treats val="0" and val="false" as off', () => {
+    // These appear when a run explicitly cancels inherited cell formatting;
+    // reading them as `true` would bold text Excel renders plain.
+    expect(runFont('<b val="0"/><i val="false"/><strike val="0"/>')).toMatchObject({
+      bold: false,
+      italic: false,
+      strikethrough: false,
+    })
+  })
+})
+
+describe("parseSharedStrings — <rPr> underline", () => {
+  it("maps a bare <u/> to true", () => {
+    expect(runFont("<u/>")?.underline).toBe(true)
+  })
+
+  it('maps val="single" to true', () => {
+    expect(runFont('<u val="single"/>')?.underline).toBe(true)
+  })
+
+  it("maps the three named accounting/double variants", () => {
+    expect(runFont('<u val="double"/>')?.underline).toBe("double")
+    expect(runFont('<u val="singleAccounting"/>')?.underline).toBe("singleAccounting")
+    expect(runFont('<u val="doubleAccounting"/>')?.underline).toBe("doubleAccounting")
+  })
+
+  it('reads val="none" as underlined — a known lossy fallback', () => {
+    // <u val="none"/> is legal and means "not underlined", but the parser
+    // funnels every unrecognised token into `true`. Documented here so the
+    // behaviour is a deliberate choice rather than an accident.
+    expect(runFont('<u val="none"/>')?.underline).toBe(true)
+  })
+})
+
+describe("parseSharedStrings — <rPr> scalar properties", () => {
+  it("reads sz as a number", () => {
+    expect(runFont('<sz val="11.5"/>')?.size).toBe(11.5)
+  })
+
+  it("ignores sz with no val", () => {
+    expect(runFont("<sz/>")?.size).toBeUndefined()
+  })
+
+  it("reads the font name from <rFont>, not <name>", () => {
+    // Runs spell the typeface `<rFont>`; `<name>` is the styles.xml form
+    // and must not be honoured here.
+    expect(runFont('<rFont val="Cambria"/>')?.name).toBe("Cambria")
+    expect(runFont('<name val="Cambria"/>')?.name).toBeUndefined()
+  })
+
+  it("ignores rFont with no val", () => {
+    expect(runFont("<rFont/>")?.name).toBeUndefined()
+  })
+
+  it("reads family and charset as numbers", () => {
+    const font = runFont('<family val="2"/><charset val="204"/>')
+    expect(font?.family).toBe(2)
+    expect(font?.charset).toBe(204)
+  })
+
+  it("ignores family and charset with no val", () => {
+    const font = runFont("<family/><charset/>")
+    expect(font?.family).toBeUndefined()
+    expect(font?.charset).toBeUndefined()
+  })
+
+  it("accepts only the enumerated vertAlign tokens", () => {
+    expect(runFont('<vertAlign val="superscript"/>')?.vertAlign).toBe("superscript")
+    expect(runFont('<vertAlign val="subscript"/>')?.vertAlign).toBe("subscript")
+    // "baseline" is the default and carries no information; anything else
+    // is invalid. Both are dropped rather than widening the union type.
+    expect(runFont('<vertAlign val="baseline"/>')?.vertAlign).toBeUndefined()
+    expect(runFont("<vertAlign/>")?.vertAlign).toBeUndefined()
+  })
+
+  it("accepts only the enumerated scheme tokens", () => {
+    expect(runFont('<scheme val="major"/>')?.scheme).toBe("major")
+    expect(runFont('<scheme val="minor"/>')?.scheme).toBe("minor")
+    expect(runFont('<scheme val="none"/>')?.scheme).toBe("none")
+    expect(runFont('<scheme val="bogus"/>')?.scheme).toBeUndefined()
+  })
+
+  it("ignores unknown <rPr> children", () => {
+    expect(runFont('<outline/><shadow/><condense val="1"/>')).toEqual({})
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Run colours. `Color` is documented as "hex RGB without '#'", and the
+// same `<color>` grammar appears in styles.xml, in inline strings, and
+// here — all three must agree.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSharedStrings — <rPr> colour", () => {
+  it("strips the opaque FF alpha from an 8-digit ARGB value", () => {
+    expect(runFont('<color rgb="FFFF0000"/>')?.color).toEqual({ rgb: "FF0000" })
+  })
+
+  it("reads theme, tint and indexed colours", () => {
+    expect(runFont('<color theme="4" tint="-0.25"/>')?.color).toEqual({ theme: 4, tint: -0.25 })
+    expect(runFont('<color indexed="64"/>')?.color).toEqual({ indexed: 64 })
+  })
+
+  it("reads theme 0 and a zero tint", () => {
+    // theme="0" / tint="0" are falsy-looking strings; an `if (attr)` guard
+    // that coerced to number first would drop them.
+    expect(runFont('<color theme="0" tint="0"/>')?.color).toEqual({ theme: 0, tint: 0 })
+  })
+
+  it("emits an empty colour object for a valueless <color/>", () => {
+    expect(runFont("<color/>")?.color).toEqual({})
+  })
+
+  // ── KNOWN BUG ──────────────────────────────────────────────────────
+  // src/xlsx/shared-strings.ts:124 uses `rgb.replace(/^FF/, "")`, which
+  // strips a *literal* leading "FF" instead of the ARGB alpha byte. Both
+  // sibling implementations — src/xlsx/styles.ts:232 and the inline-string
+  // path at src/xlsx/worksheet.ts:1686 — use
+  // `rgb.length === 8 ? rgb.slice(2) : rgb`. Consequences below.
+  it.skip("must not mutate a 6-digit RGB value that has no alpha byte", () => {
+    // rgb="FF0000" (plain red, written by several non-Excel producers)
+    // currently becomes "0000".
+    expect(runFont('<color rgb="FF0000"/>')?.color).toEqual({ rgb: "FF0000" })
+  })
+
+  it.skip("must strip a non-opaque alpha byte like every other colour parser", () => {
+    // rgb="80FF0000" currently stays 8 characters long, so `Color.rgb`
+    // stops being a hex RGB triplet.
+    expect(runFont('<color rgb="80FF0000"/>')?.color).toEqual({ rgb: "FF0000" })
+  })
+
+  it.skip("must agree with the styles.xml colour parser on identical input", () => {
+    const cases = ["FFFF0000", "80FF0000", "00FF00FF", "FF0000"]
+    const styles = parseStyles(
+      `<styleSheet xmlns="${SST_NS}"><fonts>${cases
+        .map((rgb) => `<font><color rgb="${rgb}"/></font>`)
+        .join("")}</fonts></styleSheet>`,
+    )
+    const fromRuns = cases.map((rgb) => runFont(`<color rgb="${rgb}"/>`)?.color?.rgb)
+    expect(fromRuns).toEqual(styles.fonts.map((f) => f.color?.rgb))
+  })
+})

--- a/test/shared-strings.test.ts
+++ b/test/shared-strings.test.ts
@@ -285,19 +285,19 @@ describe("parseSharedStrings — <rPr> colour", () => {
   // sibling implementations — src/xlsx/styles.ts:232 and the inline-string
   // path at src/xlsx/worksheet.ts:1686 — use
   // `rgb.length === 8 ? rgb.slice(2) : rgb`. Consequences below.
-  it.skip("must not mutate a 6-digit RGB value that has no alpha byte", () => {
+  it("must not mutate a 6-digit RGB value that has no alpha byte", () => {
     // rgb="FF0000" (plain red, written by several non-Excel producers)
     // currently becomes "0000".
     expect(runFont('<color rgb="FF0000"/>')?.color).toEqual({ rgb: "FF0000" })
   })
 
-  it.skip("must strip a non-opaque alpha byte like every other colour parser", () => {
+  it("must strip a non-opaque alpha byte like every other colour parser", () => {
     // rgb="80FF0000" currently stays 8 characters long, so `Color.rgb`
     // stops being a hex RGB triplet.
     expect(runFont('<color rgb="80FF0000"/>')?.color).toEqual({ rgb: "FF0000" })
   })
 
-  it.skip("must agree with the styles.xml colour parser on identical input", () => {
+  it("must agree with the styles.xml colour parser on identical input", () => {
     const cases = ["FFFF0000", "80FF0000", "00FF00FF", "FF0000"]
     const styles = parseStyles(
       `<styleSheet xmlns="${SST_NS}"><fonts>${cases

--- a/test/styles-parser.test.ts
+++ b/test/styles-parser.test.ts
@@ -662,7 +662,7 @@ describe("isDateStyle", () => {
   // *before* consulting numFmts, so the two disagree: a cell redefining id
   // 14 as "#,##0" is formatted as a number yet still converted to a Date by
   // the reader. Fix: look up styles.numFmts first in isDateStyle too.
-  it.skip("must let a redefined built-in id override the date-id table", () => {
+  it("must let a redefined built-in id override the date-id table", () => {
     const styles = styleSheet(`
       <numFmts count="2">
         <numFmt numFmtId="14" formatCode="#,##0"/>

--- a/test/styles-parser.test.ts
+++ b/test/styles-parser.test.ts
@@ -1,0 +1,761 @@
+import { describe, expect, it } from "vitest"
+import { isDateStyle, parseStyles, resolveStyle } from "../src/xlsx/styles"
+import type { GradientFill, PatternFill } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+
+/** Wrap styles.xml fragments in a real `<styleSheet>` document. */
+function styleSheet(inner: string): ReturnType<typeof parseStyles> {
+  return parseStyles(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="${MAIN_NS}">${inner}</styleSheet>`)
+}
+
+// The fragment helpers below indent their bodies on purpose: styles.xml
+// from LibreOffice and most XML pretty-printers is whitespace-formatted, so
+// every container parser has to walk past text children to find elements.
+
+/** Parse a single `<font>` from its child elements. */
+function font(body: string) {
+  return styleSheet(`<fonts count="1">\n  <font>\n    ${body}\n  </font>\n</fonts>`).fonts[0]
+}
+
+/** Parse a single `<fill>` from its child elements. */
+function fill(body: string) {
+  return styleSheet(`<fills count="1">\n  <fill>\n    ${body}\n  </fill>\n</fills>`).fills[0]
+}
+
+/** Parse a single `<border>` from an attribute string plus children. */
+function border(attrs: string, body: string) {
+  return styleSheet(
+    `<borders count="1">\n  <border ${attrs}>\n    ${body}\n  </border>\n</borders>`,
+  ).borders[0]
+}
+
+/** Parse a single `<xf>` from an attribute string plus children. */
+function xf(attrs: string, body = "") {
+  return styleSheet(`<cellXfs count="1">\n  <xf ${attrs}>\n    ${body}\n  </xf>\n</cellXfs>`)
+    .cellXfs[0]
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Document level. styles.xml carries a dozen sibling sections
+// (cellStyleXfs, dxfs, tableStyles, colors, extLst …) that this parser
+// deliberately does not model; they must be skipped, not mistaken for the
+// sections it does read.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — document structure", () => {
+  it("returns empty collections for a bare <styleSheet/>", () => {
+    const styles = parseStyles(`<styleSheet xmlns="${MAIN_NS}"/>`)
+    expect(styles.numFmts.size).toBe(0)
+    expect(styles.fonts).toEqual([])
+    expect(styles.fills).toEqual([])
+    expect(styles.borders).toEqual([])
+    expect(styles.cellXfs).toEqual([])
+  })
+
+  it("ignores sections it does not model and reads cellXfs, not cellStyleXfs", () => {
+    // cellStyleXfs has an identical <xf> grammar. Reading it as well would
+    // shift every `s="n"` cell reference by the named-style count.
+    const styles = styleSheet(`
+      <cellStyleXfs count="1"><xf numFmtId="14" fontId="9"/></cellStyleXfs>
+      <cellXfs count="1"><xf numFmtId="3" fontId="0"/></cellXfs>
+      <cellStyles count="1"><cellStyle name="Normal" xfId="0"/></cellStyles>
+      <dxfs count="1"><dxf><font><b/></font></dxf></dxfs>
+      <tableStyles count="0"/>
+      <extLst><ext uri="{X}"/></extLst>
+    `)
+    expect(styles.cellXfs).toHaveLength(1)
+    expect(styles.cellXfs[0].numFmtId).toBe(3)
+    // The <font> nested in <dxfs> must not join the workbook font table.
+    expect(styles.fonts).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <numFmts>. Entries are keyed by numeric id; a malformed id is worse than
+// useless because it would collide with every other malformed entry.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — number formats", () => {
+  it("indexes custom formats by numFmtId", () => {
+    const styles = styleSheet(`<numFmts count="2">
+      <numFmt numFmtId="164" formatCode="yyyy-mm-dd"/>
+      <numFmt numFmtId="165" formatCode="0.000&quot; kg&quot;"/>
+    </numFmts>`)
+    expect(styles.numFmts.get(164)).toBe("yyyy-mm-dd")
+    expect(styles.numFmts.get(165)).toBe('0.000" kg"')
+  })
+
+  it("drops entries whose numFmtId is missing or not a number", () => {
+    const styles = styleSheet(`<numFmts count="2">
+      <numFmt formatCode="0.00"/>
+      <numFmt numFmtId="abc" formatCode="0.00"/>
+      <numFmt numFmtId="164" formatCode="0.00"/>
+    </numFmts>`)
+    expect([...styles.numFmts.keys()]).toEqual([164])
+  })
+
+  it("stores an empty formatCode when the attribute is absent", () => {
+    const styles = styleSheet(`<numFmts count="1"><numFmt numFmtId="165"/></numFmts>`)
+    expect(styles.numFmts.get(165)).toBe("")
+  })
+
+  it("lets a later duplicate id win", () => {
+    const styles = styleSheet(`<numFmts count="2">
+      <numFmt numFmtId="166" formatCode="first"/>
+      <numFmt numFmtId="166" formatCode="second"/>
+    </numFmts>`)
+    expect(styles.numFmts.get(166)).toBe("second")
+  })
+
+  it("ignores non-<numFmt> children of <numFmts>", () => {
+    const styles = styleSheet(`<numFmts count="1"><junk numFmtId="1"/></numFmts>`)
+    expect(styles.numFmts.size).toBe(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <font>. Same accept-or-drop grammar as run properties, but the typeface
+// element is <name> here rather than <rFont>.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — fonts", () => {
+  it('treats bare toggles as on and val="0"/"false" as off', () => {
+    expect(font("<b/><i/><strike/>")).toMatchObject({
+      bold: true,
+      italic: true,
+      strikethrough: true,
+    })
+    expect(font('<b val="0"/><i val="false"/><strike val="0"/>')).toMatchObject({
+      bold: false,
+      italic: false,
+      strikethrough: false,
+    })
+  })
+
+  it("maps every underline token", () => {
+    expect(font("<u/>").underline).toBe(true)
+    expect(font('<u val="single"/>').underline).toBe(true)
+    expect(font('<u val="double"/>').underline).toBe("double")
+    expect(font('<u val="singleAccounting"/>').underline).toBe("singleAccounting")
+    expect(font('<u val="doubleAccounting"/>').underline).toBe("doubleAccounting")
+  })
+
+  it("reads the typeface from <name>, not <rFont>", () => {
+    expect(font('<name val="Calibri"/>').name).toBe("Calibri")
+    expect(font('<rFont val="Calibri"/>').name).toBeUndefined()
+  })
+
+  it("ignores valueless scalar elements", () => {
+    expect(font("<sz/><name/><family/><charset/>")).toEqual({})
+  })
+
+  it("reads sz, family and charset as numbers", () => {
+    expect(font('<sz val="9.5"/><family val="2"/><charset val="238"/>')).toMatchObject({
+      size: 9.5,
+      family: 2,
+      charset: 238,
+    })
+  })
+
+  it("accepts only the enumerated vertAlign and scheme tokens", () => {
+    expect(font('<vertAlign val="superscript"/>').vertAlign).toBe("superscript")
+    expect(font('<vertAlign val="subscript"/>').vertAlign).toBe("subscript")
+    expect(font('<vertAlign val="baseline"/>').vertAlign).toBeUndefined()
+    expect(font('<scheme val="major"/>').scheme).toBe("major")
+    expect(font('<scheme val="minor"/>').scheme).toBe("minor")
+    expect(font('<scheme val="none"/>').scheme).toBe("none")
+    expect(font('<scheme val="unexpected"/>').scheme).toBeUndefined()
+  })
+
+  it("ignores unmodelled font children", () => {
+    expect(font("<outline/><shadow/><extend/><condense/>")).toEqual({})
+  })
+
+  it("ignores non-<font> children of <fonts>", () => {
+    expect(styleSheet('<fonts count="1"><notAFont/></fonts>').fonts).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <color>. `Color.rgb` is documented as hex RGB with no '#', so the ARGB
+// alpha byte is dropped by length, not by matching a particular alpha.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — colors", () => {
+  it("strips the alpha byte from any 8-digit ARGB value", () => {
+    expect(font('<color rgb="FFFF0000"/>').color).toEqual({ rgb: "FF0000" })
+    // A non-opaque alpha must be stripped just the same — the rule is
+    // positional, not "starts with FF".
+    expect(font('<color rgb="80FF0000"/>').color).toEqual({ rgb: "FF0000" })
+    expect(font('<color rgb="00FF00FF"/>').color).toEqual({ rgb: "FF00FF" })
+  })
+
+  it("passes a 6-digit RGB value through unchanged", () => {
+    expect(font('<color rgb="FF0000"/>').color).toEqual({ rgb: "FF0000" })
+  })
+
+  it("reads theme, tint and indexed", () => {
+    expect(font('<color theme="4" tint="-0.499984740745262"/>').color).toEqual({
+      theme: 4,
+      tint: -0.499984740745262,
+    })
+    expect(font('<color indexed="64"/>').color).toEqual({ indexed: 64 })
+  })
+
+  it("reads theme 0 and tint 0 rather than treating them as absent", () => {
+    expect(font('<color theme="0" tint="0" indexed="0"/>').color).toEqual({
+      theme: 0,
+      tint: 0,
+      indexed: 0,
+    })
+  })
+
+  it("returns an empty Color for a valueless <color/>", () => {
+    expect(font("<color/>").color).toEqual({})
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <fill>. Index 0 (none) and 1 (gray125) are mandated by the spec, so real
+// files always start with them; indices 2+ are the interesting ones.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — fills", () => {
+  it("reads a solid pattern fill with fg and bg colors", () => {
+    const f = fill(
+      '<patternFill patternType="solid"><fgColor rgb="FFFFC000"/><bgColor indexed="64"/></patternFill>',
+    ) as PatternFill
+    expect(f).toEqual({
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { rgb: "FFC000" },
+      bgColor: { indexed: 64 },
+    })
+  })
+
+  it('defaults a patternFill with no patternType to "none"', () => {
+    expect(fill("<patternFill/>")).toEqual({ type: "pattern", pattern: "none" })
+  })
+
+  it("falls back to a none pattern for a <fill> with no recognised child", () => {
+    // Malformed or future fill types must still occupy their index so the
+    // fillId → fills[] mapping stays correct.
+    expect(fill("")).toEqual({ type: "pattern", pattern: "none" })
+    expect(fill("<somethingElse/>")).toEqual({ type: "pattern", pattern: "none" })
+  })
+
+  it("reads a gradient fill with degree and stops", () => {
+    const f = fill(`<gradientFill degree="90">
+      <stop position="0"><color rgb="FFFFFFFF"/></stop>
+      <stop position="1"><color theme="4"/></stop>
+    </gradientFill>`) as GradientFill
+    expect(f.type).toBe("gradient")
+    expect(f.degree).toBe(90)
+    expect(f.stops).toEqual([
+      { position: 0, color: { rgb: "FFFFFF" } },
+      { position: 1, color: { theme: 4 } },
+    ])
+  })
+
+  it("leaves degree undefined when the attribute is absent", () => {
+    const f = fill(
+      '<gradientFill><stop position="0.5"><color indexed="1"/></stop></gradientFill>',
+    ) as GradientFill
+    expect(f.degree).toBeUndefined()
+    expect(f.stops[0].position).toBe(0.5)
+  })
+
+  it("defaults a stop with no position to 0 and skips stops with no <color>", () => {
+    const f = fill(
+      '<gradientFill><stop/><stop><color rgb="FF00FF00"/></stop></gradientFill>',
+    ) as GradientFill
+    expect(f.stops).toEqual([{ position: 0, color: { rgb: "00FF00" } }])
+  })
+
+  it("takes the first recognised child when both fill types are present", () => {
+    // Invalid per CT_Fill, but a reader should pick one deterministically.
+    expect(fill('<patternFill patternType="solid"/><gradientFill degree="45"/>')).toEqual({
+      type: "pattern",
+      pattern: "solid",
+    })
+  })
+
+  it("ignores unknown children inside patternFill and inside a stop", () => {
+    expect(
+      fill('<patternFill patternType="solid">\n  <unknownColor rgb="FF000000"/>\n</patternFill>'),
+    ).toEqual({ type: "pattern", pattern: "solid" })
+    const gradient = fill(
+      '<gradientFill>\n  <stop position="0">\n    <notAColor/>\n    <color rgb="FF112233"/>\n  </stop>\n</gradientFill>',
+    ) as GradientFill
+    expect(gradient.stops).toEqual([{ position: 0, color: { rgb: "112233" } }])
+  })
+
+  it("ignores non-<fill> children of <fills>", () => {
+    expect(styleSheet('<fills count="1"><notAFill/></fills>').fills).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <border>. A side element with no `style` attribute means "no border on
+// that edge" — the single most common shape in real files, since Excel
+// writes <left/><right/><top/><bottom/><diagonal/> for border 0.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — borders", () => {
+  it("returns an empty BorderStyle for the default all-empty border", () => {
+    expect(border("", "<left/><right/><top/><bottom/><diagonal/>")).toEqual({})
+  })
+
+  it("reads each side's style and color", () => {
+    const b = border(
+      "",
+      `<left style="thin"><color indexed="64"/></left>
+       <right style="medium"><color rgb="FF0000FF"/></right>
+       <top style="dashed"/>
+       <bottom style="double"><color theme="1"/></bottom>`,
+    )
+    expect(b.left).toEqual({ style: "thin", color: { indexed: 64 } })
+    expect(b.right).toEqual({ style: "medium", color: { rgb: "0000FF" } })
+    expect(b.top).toEqual({ style: "dashed" })
+    expect(b.bottom).toEqual({ style: "double", color: { theme: 1 } })
+  })
+
+  it("reads the diagonal side together with its direction flags", () => {
+    const b = border('diagonalUp="1" diagonalDown="1"', '<diagonal style="thin"/>')
+    expect(b.diagonal).toEqual({ style: "thin" })
+    expect(b.diagonalUp).toBe(true)
+    expect(b.diagonalDown).toBe(true)
+  })
+
+  it('accepts "true" as well as "1" for the diagonal flags', () => {
+    const b = border('diagonalUp="true" diagonalDown="true"', "")
+    expect(b.diagonalUp).toBe(true)
+    expect(b.diagonalDown).toBe(true)
+  })
+
+  it('omits the diagonal flags for "0"/"false" instead of storing false', () => {
+    // Absent-means-false keeps the parsed object minimal so round-tripped
+    // borders compare equal to freshly built ones.
+    expect(border('diagonalUp="0" diagonalDown="false"', "")).toEqual({})
+  })
+
+  it("ignores side elements it does not model", () => {
+    // <vertical>/<horizontal> only apply to dxf borders, not cell borders.
+    expect(border("", '<vertical style="thin"/><horizontal style="thin"/>')).toEqual({})
+  })
+
+  it("ignores unknown children inside a side element", () => {
+    expect(border("", '<top style="thin">\n  <notAColor val="1"/>\n</top>')).toEqual({
+      top: { style: "thin" },
+    })
+  })
+
+  it("ignores non-<border> children of <borders>", () => {
+    expect(styleSheet('<borders count="1"><notABorder/></borders>').borders).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <xf>. The apply* flags are booleans in "1"/"true" form; the id attributes
+// all default to 0 when absent.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — cell XFs", () => {
+  it("defaults every id to 0 when the attributes are absent", () => {
+    expect(xf("")).toEqual({ numFmtId: 0, fontId: 0, fillId: 0, borderId: 0 })
+  })
+
+  it("reads all four id attributes", () => {
+    expect(xf('numFmtId="164" fontId="2" fillId="3" borderId="4"')).toMatchObject({
+      numFmtId: 164,
+      fontId: 2,
+      fillId: 3,
+      borderId: 4,
+    })
+  })
+
+  it('accepts "1" and "true" for every apply* flag', () => {
+    const one = xf(
+      'applyNumberFormat="1" applyFont="1" applyFill="1" applyBorder="1" applyAlignment="1" applyProtection="1"',
+    )
+    const word = xf(
+      'applyNumberFormat="true" applyFont="true" applyFill="true" applyBorder="true" applyAlignment="true" applyProtection="true"',
+    )
+    for (const parsed of [one, word]) {
+      expect(parsed).toMatchObject({
+        applyNumberFormat: true,
+        applyFont: true,
+        applyFill: true,
+        applyBorder: true,
+        applyAlignment: true,
+        applyProtection: true,
+      })
+    }
+  })
+
+  it('leaves apply* flags undefined for "0"', () => {
+    expect(xf('applyFont="0" applyFill="false"')).toEqual({
+      numFmtId: 0,
+      fontId: 0,
+      fillId: 0,
+      borderId: 0,
+    })
+  })
+
+  it("reads every alignment attribute", () => {
+    const parsed = xf(
+      "",
+      '<alignment horizontal="centerContinuous" vertical="distributed" wrapText="1" shrinkToFit="true" textRotation="45" indent="2"/>',
+    )
+    expect(parsed.alignment).toEqual({
+      horizontal: "centerContinuous",
+      vertical: "distributed",
+      wrapText: true,
+      shrinkToFit: true,
+      textRotation: 45,
+      indent: 2,
+    })
+  })
+
+  it("maps readingOrder 1/2 to ltr/rtl and anything else to context", () => {
+    expect(xf("", '<alignment readingOrder="1"/>').alignment?.readingOrder).toBe("ltr")
+    expect(xf("", '<alignment readingOrder="2"/>').alignment?.readingOrder).toBe("rtl")
+    // 0 is the spec's "context dependent" value.
+    expect(xf("", '<alignment readingOrder="0"/>').alignment?.readingOrder).toBe("context")
+  })
+
+  it("omits alignment flags that are off", () => {
+    expect(xf("", '<alignment wrapText="0" shrinkToFit="false"/>').alignment).toEqual({})
+  })
+
+  it("reads locked and hidden protection in both true and false form", () => {
+    expect(xf("", '<protection locked="1" hidden="true"/>').protection).toEqual({
+      locked: true,
+      hidden: true,
+    })
+    // Explicit `false` must be preserved: unlocking a cell is the whole
+    // point of the element on a protected sheet.
+    expect(xf("", '<protection locked="0" hidden="false"/>').protection).toEqual({
+      locked: false,
+      hidden: false,
+    })
+  })
+
+  it("omits protection keys that are not present", () => {
+    expect(xf("", '<protection locked="1"/>').protection).toEqual({ locked: true })
+    expect(xf("", "<protection/>").protection).toEqual({})
+  })
+
+  it("detects the Excel 2024 checkbox extension by its feature URI", () => {
+    const parsed = xf(
+      "",
+      '<extLst><ext uri="{C7286773-470A-42A8-94C5-96B5CB345126}" xmlns:xfpb="http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag"><xfpb:xfComplement i="0"/></ext></extLst>',
+    )
+    expect(parsed.hasCheckboxFeature).toBe(true)
+  })
+
+  it("ignores an extLst carrying some other extension", () => {
+    const parsed = xf("", '<extLst><ext uri="{SOMETHING-ELSE}"><x/></ext></extLst>')
+    expect(parsed.hasCheckboxFeature).toBeUndefined()
+  })
+
+  it("ignores an empty extLst and non-<ext> children", () => {
+    expect(xf("", "<extLst/>").hasCheckboxFeature).toBeUndefined()
+    expect(xf("", "<extLst>\n  <notAnExt/>\n</extLst>").hasCheckboxFeature).toBeUndefined()
+  })
+
+  it("finds the checkbox ext among several indented siblings", () => {
+    const parsed = xf(
+      "",
+      `<extLst>
+        <ext uri="{OTHER-EXTENSION}"><x/></ext>
+        <ext uri="{C7286773-470A-42A8-94C5-96B5CB345126}"><y/></ext>
+      </extLst>`,
+    )
+    expect(parsed.hasCheckboxFeature).toBe(true)
+  })
+
+  it("ignores unmodelled <xf> children", () => {
+    expect(xf("", "<somethingNew/>")).toEqual({
+      numFmtId: 0,
+      fontId: 0,
+      fillId: 0,
+      borderId: 0,
+    })
+  })
+
+  it("ignores non-<xf> children of <cellXfs>", () => {
+    expect(styleSheet('<cellXfs count="1"><notAnXf/></cellXfs>').cellXfs).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// resolveStyle — turning an `s="n"` index into a CellStyle. It emits only
+// properties that actually deviate from the workbook default, which is what
+// keeps a plain round-trip from decorating every cell.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("resolveStyle", () => {
+  const styles = styleSheet(`
+    <numFmts count="1"><numFmt numFmtId="164" formatCode="0.000"/></numFmts>
+    <fonts count="2"><font><sz val="11"/></font><font><b/></font></fonts>
+    <fills count="3">
+      <fill><patternFill patternType="none"/></fill>
+      <fill><patternFill patternType="gray125"/></fill>
+      <fill><patternFill patternType="solid"><fgColor rgb="FFFFFF00"/></patternFill></fill>
+    </fills>
+    <borders count="2">
+      <border><left/><right/><top/><bottom/><diagonal/></border>
+      <border><left style="thin"/></border>
+    </borders>
+    <cellXfs count="9">
+      <xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>
+      <xf numFmtId="164" fontId="1" fillId="2" borderId="1"/>
+      <xf numFmtId="9" fontId="0" fillId="1" borderId="0"/>
+      <xf numFmtId="999" fontId="0" fillId="0" borderId="0"/>
+      <xf numFmtId="0" fontId="99" fillId="0" borderId="0"/>
+      <xf numFmtId="0" fontId="0" fillId="99" borderId="0"/>
+      <xf numFmtId="0" fontId="0" fillId="0" borderId="99"/>
+      <xf numFmtId="0" fontId="0" fillId="0" borderId="0"><alignment horizontal="right"/><protection hidden="1"/></xf>
+      <xf numFmtId="0" fontId="1" fillId="2" borderId="1"/>
+    </cellXfs>
+  `)
+
+  it("returns an empty style for the default xf", () => {
+    // numFmt 0 (General), font 0, fill 0 and border 0 are all the workbook
+    // defaults, so a plain cell carries no style at all.
+    expect(resolveStyle(styles, 0)).toEqual({})
+  })
+
+  it("resolves custom format, font, fill and border together", () => {
+    const style = resolveStyle(styles, 1)
+    expect(style.numFmt).toBe("0.000")
+    expect(style.font).toEqual({ bold: true })
+    expect(style.fill).toMatchObject({ type: "pattern", pattern: "solid" })
+    expect(style.border).toEqual({ left: { style: "thin" } })
+  })
+
+  it("resolves a built-in numFmtId through the built-in table", () => {
+    expect(resolveStyle(styles, 2).numFmt).toBe("0%")
+  })
+
+  it("skips fill index 1 — the mandatory gray125 placeholder", () => {
+    // Every styles.xml declares gray125 at index 1 whether or not anything
+    // uses it; surfacing it would paint cells with a grey hatch.
+    expect(resolveStyle(styles, 2).fill).toBeUndefined()
+  })
+
+  it("omits numFmt for an id that exists in neither table", () => {
+    expect(resolveStyle(styles, 3).numFmt).toBeUndefined()
+  })
+
+  it("ignores font, fill and border ids past the end of their tables", () => {
+    // Truncated or hand-edited files point past the table; reading
+    // undefined into CellStyle would crash consumers instead.
+    expect(resolveStyle(styles, 4).font).toBeUndefined()
+    expect(resolveStyle(styles, 5).fill).toBeUndefined()
+    expect(resolveStyle(styles, 6).border).toBeUndefined()
+  })
+
+  it("passes alignment and protection through unchanged", () => {
+    const style = resolveStyle(styles, 7)
+    expect(style.alignment).toEqual({ horizontal: "right" })
+    expect(style.protection).toEqual({ hidden: true })
+  })
+
+  it("returns an empty style for an out-of-range or negative index", () => {
+    expect(resolveStyle(styles, 99)).toEqual({})
+    expect(resolveStyle(styles, -1)).toEqual({})
+  })
+
+  it("shares the parsed font/fill/border instances between cells", () => {
+    // Deliberate: the tables are parsed once and referenced, not cloned.
+    // Callers that mutate a resolved style would affect every other cell
+    // using the same xf, so this identity is part of the contract.
+    const a = resolveStyle(styles, 1)
+    const b = resolveStyle(styles, 8)
+    expect(a.font).toBe(b.font)
+    expect(a.fill).toBe(b.fill)
+    expect(a.border).toBe(b.border)
+    expect(a.font).toBe(styles.fonts[1])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// isDateStyle — decides whether a numeric cell value is a serial date.
+// A false positive turns a quantity into a 1900-era timestamp, so the
+// boundaries matter more than most.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("isDateStyle", () => {
+  it("returns false for an unknown style index", () => {
+    const styles = styleSheet('<cellXfs count="1"><xf numFmtId="14"/></cellXfs>')
+    expect(isDateStyle(styles, 5)).toBe(false)
+    expect(isDateStyle(styles, -1)).toBe(false)
+  })
+
+  it("recognises the locale-specific built-in date ids 27-36 and 50-58", () => {
+    // These ids have no entry in the built-in format table — only the id
+    // set identifies them, and East-Asian locale files rely on it.
+    const ids = [27, 30, 36, 50, 55, 58]
+    const styles = styleSheet(
+      `<cellXfs count="${ids.length}">${ids
+        .map((id) => `<xf numFmtId="${id}"/>`)
+        .join("")}</cellXfs>`,
+    )
+    ids.forEach((_id, i) => expect(isDateStyle(styles, i)).toBe(true))
+  })
+
+  it("recognises the elapsed-time built-ins 45, 46 and 47", () => {
+    const ids = [45, 46, 47]
+    const styles = styleSheet(
+      `<cellXfs count="3">${ids.map((id) => `<xf numFmtId="${id}"/>`).join("")}</cellXfs>`,
+    )
+    ids.forEach((_id, i) => expect(isDateStyle(styles, i)).toBe(true))
+  })
+
+  it("rejects the numeric built-ins that sit between the date ranges", () => {
+    const ids = [23, 24, 25, 26, 37, 38, 39, 40, 48, 49]
+    const styles = styleSheet(
+      `<cellXfs count="${ids.length}">${ids
+        .map((id) => `<xf numFmtId="${id}"/>`)
+        .join("")}</cellXfs>`,
+    )
+    ids.forEach((_id, i) => expect(isDateStyle(styles, i)).toBe(false))
+  })
+
+  it("analyses a custom format string when the id is not a known date id", () => {
+    const styles = styleSheet(`
+      <numFmts count="4">
+        <numFmt numFmtId="164" formatCode="dd/mm/yyyy"/>
+        <numFmt numFmtId="165" formatCode="[$-409]h:mm:ss AM/PM"/>
+        <numFmt numFmtId="166" formatCode="#,##0.00&quot; kg&quot;"/>
+        <numFmt numFmtId="167" formatCode="0.00%"/>
+      </numFmts>
+      <cellXfs count="4">
+        <xf numFmtId="164"/><xf numFmtId="165"/><xf numFmtId="166"/><xf numFmtId="167"/>
+      </cellXfs>
+    `)
+    expect(isDateStyle(styles, 0)).toBe(true)
+    expect(isDateStyle(styles, 1)).toBe(true)
+    expect(isDateStyle(styles, 2)).toBe(false)
+    expect(isDateStyle(styles, 3)).toBe(false)
+  })
+
+  it("returns false for a custom id with no format code at all", () => {
+    const styles = styleSheet(`
+      <numFmts count="1"><numFmt numFmtId="170"/></numFmts>
+      <cellXfs count="2"><xf numFmtId="170"/><xf numFmtId="171"/></cellXfs>
+    `)
+    expect(isDateStyle(styles, 0)).toBe(false)
+    expect(isDateStyle(styles, 1)).toBe(false)
+  })
+
+  // ── KNOWN BUG ──────────────────────────────────────────────────────
+  // ECMA-376 §18.8.30 allows a <numFmt> entry to redefine a built-in id.
+  // resolveStyle (src/xlsx/styles.ts:502) gives the custom formatCode
+  // priority, but isDateStyle (src/xlsx/styles.ts:547) checks DATE_FMT_IDS
+  // *before* consulting numFmts, so the two disagree: a cell redefining id
+  // 14 as "#,##0" is formatted as a number yet still converted to a Date by
+  // the reader. Fix: look up styles.numFmts first in isDateStyle too.
+  it.skip("must let a redefined built-in id override the date-id table", () => {
+    const styles = styleSheet(`
+      <numFmts count="2">
+        <numFmt numFmtId="14" formatCode="#,##0"/>
+        <numFmt numFmtId="3" formatCode="yyyy-mm-dd"/>
+      </numFmts>
+      <cellXfs count="2"><xf numFmtId="14"/><xf numFmtId="3"/></cellXfs>
+    `)
+    // resolveStyle already honours the redefinition …
+    expect(resolveStyle(styles, 0).numFmt).toBe("#,##0")
+    expect(resolveStyle(styles, 1).numFmt).toBe("yyyy-mm-dd")
+    // … isDateStyle must agree.
+    expect(isDateStyle(styles, 0)).toBe(false)
+    expect(isDateStyle(styles, 1)).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// A complete styles.xml as Excel writes it, parsed end to end. Guards the
+// section ordering and the index arithmetic that the fragment tests above
+// deliberately isolate away.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseStyles — realistic workbook stylesheet", () => {
+  const XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="${MAIN_NS}">
+  <numFmts count="1"><numFmt numFmtId="164" formatCode="&quot;$&quot;#,##0.00"/></numFmts>
+  <fonts count="3">
+    <font><sz val="11"/><color theme="1"/><name val="Calibri"/><family val="2"/><scheme val="minor"/></font>
+    <font><b/><sz val="11"/><color theme="0"/><name val="Calibri"/><family val="2"/><scheme val="minor"/></font>
+    <font><i/><u/><sz val="10"/><color rgb="FF7F7F7F"/><name val="Arial"/></font>
+  </fonts>
+  <fills count="3">
+    <fill><patternFill patternType="none"/></fill>
+    <fill><patternFill patternType="gray125"/></fill>
+    <fill><patternFill patternType="solid"><fgColor rgb="FF4472C4"/><bgColor indexed="64"/></patternFill></fill>
+  </fills>
+  <borders count="2">
+    <border><left/><right/><top/><bottom/><diagonal/></border>
+    <border><left style="thin"><color indexed="64"/></left><right style="thin"><color indexed="64"/></right><top style="thin"><color indexed="64"/></top><bottom style="thin"><color indexed="64"/></bottom><diagonal/></border>
+  </borders>
+  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+  <cellXfs count="4">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+    <xf numFmtId="0" fontId="1" fillId="2" borderId="1" xfId="0" applyFont="1" applyFill="1" applyBorder="1" applyAlignment="1">
+      <alignment horizontal="center" vertical="center" wrapText="1"/>
+    </xf>
+    <xf numFmtId="164" fontId="0" fillId="0" borderId="1" xfId="0" applyNumberFormat="1" applyBorder="1"/>
+    <xf numFmtId="14" fontId="2" fillId="0" borderId="0" xfId="0" applyNumberFormat="1" applyFont="1"/>
+  </cellXfs>
+  <cellStyles count="1"><cellStyle name="Normal" xfId="0" builtinId="0"/></cellStyles>
+  <dxfs count="0"/>
+  <tableStyles count="0" defaultTableStyle="TableStyleMedium2" defaultPivotStyle="PivotStyleLight16"/>
+</styleSheet>`
+
+  it("parses every section with the right cardinality", () => {
+    const styles = parseStyles(XML)
+    expect(styles.numFmts.size).toBe(1)
+    expect(styles.fonts).toHaveLength(3)
+    expect(styles.fills).toHaveLength(3)
+    expect(styles.borders).toHaveLength(2)
+    expect(styles.cellXfs).toHaveLength(4)
+  })
+
+  it("resolves the header style (xf 1) end to end", () => {
+    const style = resolveStyle(parseStyles(XML), 1)
+    expect(style.font).toEqual({
+      bold: true,
+      size: 11,
+      color: { theme: 0 },
+      name: "Calibri",
+      family: 2,
+      scheme: "minor",
+    })
+    expect(style.fill).toEqual({
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { rgb: "4472C4" },
+      bgColor: { indexed: 64 },
+    })
+    expect(style.border?.top).toEqual({ style: "thin", color: { indexed: 64 } })
+    expect(style.alignment).toEqual({ horizontal: "center", vertical: "center", wrapText: true })
+    expect(style.numFmt).toBeUndefined()
+  })
+
+  it("resolves the currency style (xf 2) without treating it as a date", () => {
+    const styles = parseStyles(XML)
+    expect(resolveStyle(styles, 2).numFmt).toBe('"$"#,##0.00')
+    expect(isDateStyle(styles, 2)).toBe(false)
+  })
+
+  it("resolves the date style (xf 3) from the built-in table", () => {
+    const styles = parseStyles(XML)
+    expect(resolveStyle(styles, 3).numFmt).toBe("m/d/yyyy")
+    expect(isDateStyle(styles, 3)).toBe(true)
+  })
+})

--- a/test/template-cells.test.ts
+++ b/test/template-cells.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from "vitest"
+import { fillTemplate } from "../src/template"
+import { writeXlsx } from "../src/xlsx/writer"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { readXlsx } from "../src/xlsx/reader"
+import type { Cell, CellValue, Sheet, Workbook } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * A workbook shaped the way the XLSX reader hands it back: `rows` carries
+ * the plain values and `cells` carries the rich record for the same
+ * coordinate. `fillTemplate` walks both, so both must be exercised.
+ */
+function workbookWithCells(entries: Array<[string, Cell]>, rows: CellValue[][] = [[]]): Workbook {
+  const sheet: Sheet = { name: "Sheet1", rows, cells: new Map(entries) }
+  return { sheets: [sheet] }
+}
+
+function cell(value: CellValue, type: Cell["type"] = "string"): Cell {
+  return { value, type }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// The `cells` Map — the rich-cell half of the template engine.
+// `rows` alone is what most callers see, but every workbook produced by
+// `openXlsx({ readStyles: true })` also carries `cells`, and a placeholder
+// that is only substituted in `rows` would be written back out unfilled.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fillTemplate — cells Map substitution", () => {
+  it("replaces a whole-cell placeholder in the cells Map", () => {
+    const wb = workbookWithCells([["0,0", cell("{{company}}")]])
+    fillTemplate(wb, { company: "Acme Corp" })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("Acme Corp")
+  })
+
+  it("leaves a whole-cell placeholder untouched when the key is absent", () => {
+    const wb = workbookWithCells([["0,0", cell("{{missing}}")]])
+    fillTemplate(wb, { present: "x" })
+    const c = wb.sheets[0].cells!.get("0,0")!
+    // Both value *and* type must survive: an unfilled template should be
+    // re-savable and still look like the original template.
+    expect(c.value).toBe("{{missing}}")
+    expect(c.type).toBe("string")
+  })
+
+  it("skips cells whose value is not a string", () => {
+    const wb = workbookWithCells([
+      ["0,0", cell(42, "number")],
+      ["0,1", cell(null, "empty")],
+      ["0,2", cell(true, "boolean")],
+    ])
+    fillTemplate(wb, { anything: "x" })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe(42)
+    expect(wb.sheets[0].cells!.get("0,1")!.value).toBe(null)
+    expect(wb.sheets[0].cells!.get("0,2")!.value).toBe(true)
+  })
+
+  it("leaves a whole-cell placeholder in `rows` untouched when the key is absent", () => {
+    // The rows path has its own single-placeholder shortcut; an unknown key
+    // there must fall through to "leave as-is" and not become `undefined`.
+    const wb: Workbook = { sheets: [{ name: "S", rows: [["{{missing}}", "{{present}}"]] }] }
+    fillTemplate(wb, { present: "ok" })
+    expect(wb.sheets[0].rows[0][0]).toBe("{{missing}}")
+    expect(wb.sheets[0].rows[0][1]).toBe("ok")
+  })
+
+  it("skips string cells that contain no opening braces", () => {
+    const wb = workbookWithCells([["0,0", cell("plain text }} with a stray close")]])
+    fillTemplate(wb, { anything: "x" })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("plain text }} with a stray close")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Type synchronisation. A Cell carries both `value` and `type`; writing a
+// number into `value` while leaving `type: "string"` would make the writer
+// emit `<c t="s">` for a numeric value and corrupt the file.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fillTemplate — cells Map keeps `type` in sync with `value`", () => {
+  it("retypes to number for a numeric replacement", () => {
+    const wb = workbookWithCells([["0,0", cell("{{total}}")]])
+    fillTemplate(wb, { total: 12500 })
+    const c = wb.sheets[0].cells!.get("0,0")!
+    expect(c.value).toBe(12500)
+    expect(c.type).toBe("number")
+  })
+
+  it("retypes to boolean for a boolean replacement", () => {
+    const wb = workbookWithCells([["0,0", cell("{{active}}")]])
+    fillTemplate(wb, { active: false })
+    const c = wb.sheets[0].cells!.get("0,0")!
+    expect(c.value).toBe(false)
+    expect(c.type).toBe("boolean")
+  })
+
+  it("retypes to date for a Date replacement", () => {
+    const due = new Date("2025-03-01T00:00:00Z")
+    const wb = workbookWithCells([["0,0", cell("{{due}}", "number")]])
+    fillTemplate(wb, { due })
+    const c = wb.sheets[0].cells!.get("0,0")!
+    expect(c.value).toBeInstanceOf(Date)
+    expect(c.type).toBe("date")
+  })
+
+  it("retypes back to string when the replacement is a string", () => {
+    const wb = workbookWithCells([["0,0", cell("{{name}}", "number")]])
+    fillTemplate(wb, { name: "Acme" })
+    const c = wb.sheets[0].cells!.get("0,0")!
+    expect(c.value).toBe("Acme")
+    expect(c.type).toBe("string")
+  })
+
+  it("stores a null replacement as a null value", () => {
+    // The `type` for a null replacement falls through to "string"; the
+    // writer keys off the null value, so the cell still serialises blank.
+    const wb = workbookWithCells([["0,0", cell("{{blank}}")]])
+    fillTemplate(wb, { blank: null })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe(null)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Mixed text in the cells Map goes through the same stringification rules
+// as `rows`: null collapses to "", Date renders ISO-8601, everything else
+// goes through String().
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fillTemplate — cells Map mixed text", () => {
+  it("stringifies numbers embedded in surrounding text", () => {
+    const wb = workbookWithCells([["0,0", cell("Total: {{amount}} USD")]])
+    fillTemplate(wb, { amount: 500 })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("Total: 500 USD")
+  })
+
+  it("renders an embedded Date as an ISO-8601 string", () => {
+    const wb = workbookWithCells([["0,0", cell("Due {{due}}.")]])
+    fillTemplate(wb, { due: new Date("2025-03-01T00:00:00Z") })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("Due 2025-03-01T00:00:00.000Z.")
+  })
+
+  it("renders an embedded null as an empty string", () => {
+    const wb = workbookWithCells([["0,0", cell("[{{nothing}}]")]])
+    fillTemplate(wb, { nothing: null })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("[]")
+  })
+
+  it("keeps unmatched placeholders while substituting matched ones", () => {
+    const wb = workbookWithCells([["0,0", cell("{{known}} / {{unknown}}")]])
+    fillTemplate(wb, { known: "yes" })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("yes / {{unknown}}")
+  })
+
+  it("substitutes every occurrence of a repeated placeholder", () => {
+    // PLACEHOLDER_RE is a module-level /g regex reused across calls — a
+    // leaked lastIndex would make the second occurrence (or the second
+    // call) silently skip. Two cells in one pass catch that.
+    const wb = workbookWithCells([
+      ["0,0", cell("{{x}}-{{x}}-{{x}}")],
+      ["0,1", cell("{{x}}!")],
+    ])
+    fillTemplate(wb, { x: "A" })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("A-A-A")
+    expect(wb.sheets[0].cells!.get("0,1")!.value).toBe("A!")
+  })
+
+  it("does not leak regex state between successive fillTemplate calls", () => {
+    const first = workbookWithCells([["0,0", cell("{{a}} {{a}}")]])
+    const second = workbookWithCells([["0,0", cell("{{a}} {{a}}")]])
+    fillTemplate(first, { a: "1" })
+    fillTemplate(second, { a: "2" })
+    expect(second.sheets[0].cells!.get("0,0")!.value).toBe("2 2")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Structural edge cases — a template workbook is user-supplied data, so
+// unusual shapes must not throw.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fillTemplate — structural edge cases", () => {
+  it("handles a workbook with no sheets", () => {
+    const wb: Workbook = { sheets: [] }
+    expect(fillTemplate(wb, { a: 1 })).toBe(wb)
+  })
+
+  it("handles a sheet with no rows and no cells Map", () => {
+    const wb: Workbook = { sheets: [{ name: "Empty", rows: [] }] }
+    expect(() => fillTemplate(wb, { a: 1 })).not.toThrow()
+  })
+
+  it("handles an empty cells Map", () => {
+    const wb = workbookWithCells([])
+    expect(() => fillTemplate(wb, { a: 1 })).not.toThrow()
+  })
+
+  it("skips holes in a sparse row without throwing", () => {
+    const sparse: CellValue[] = ["{{a}}"]
+    sparse[3] = "{{a}}"
+    const wb: Workbook = { sheets: [{ name: "S", rows: [sparse] }] }
+    fillTemplate(wb, { a: "filled" })
+    expect(wb.sheets[0].rows[0][0]).toBe("filled")
+    expect(wb.sheets[0].rows[0][3]).toBe("filled")
+    expect(wb.sheets[0].rows[0][1]).toBeUndefined()
+  })
+
+  it("mutates and returns the same workbook instance", () => {
+    const wb = workbookWithCells([["0,0", cell("{{a}}")]], [["{{a}}"]])
+    expect(fillTemplate(wb, { a: "x" })).toBe(wb)
+  })
+
+  it("fills the cells Map on every sheet, not just the first", () => {
+    const wb: Workbook = {
+      sheets: [
+        { name: "One", rows: [[]], cells: new Map([["0,0", cell("{{a}}")]]) },
+        { name: "Two", rows: [[]], cells: new Map([["0,0", cell("Hi {{a}}")]]) },
+      ],
+    }
+    fillTemplate(wb, { a: "there" })
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("there")
+    expect(wb.sheets[1].cells!.get("0,0")!.value).toBe("Hi there")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Prototype-chain keys.
+//
+// KNOWN BUG — src/template.ts:48, :57, :79, :91 use `key in data`, which
+// walks Object.prototype. A template containing `{{toString}}` therefore
+// resolves to `Object.prototype.toString` and the *function object* is
+// written into the cell (in the cells-Map path `type` is even set to
+// "string" alongside it). See the report accompanying these tests.
+// Fix: `Object.hasOwn(data, key)`.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fillTemplate — inherited Object.prototype keys", () => {
+  it.skip("leaves {{toString}} alone when `data` has no own `toString`", () => {
+    const wb = workbookWithCells([["0,0", cell("{{toString}}")]], [["{{toString}}"]])
+    fillTemplate(wb, { name: "Acme" })
+    expect(wb.sheets[0].rows[0][0]).toBe("{{toString}}")
+    expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("{{toString}}")
+  })
+
+  it.skip("leaves an inherited key alone inside mixed text", () => {
+    const wb: Workbook = { sheets: [{ name: "S", rows: [["Hi {{constructor}}"]] }] }
+    fillTemplate(wb, { name: "Acme" })
+    expect(wb.sheets[0].rows[0][0]).toBe("Hi {{constructor}}")
+  })
+
+  it.skip("leaves {{__proto__}} alone rather than injecting Object.prototype", () => {
+    const wb: Workbook = { sheets: [{ name: "S", rows: [["{{__proto__}}"]] }] }
+    fillTemplate(wb, {})
+    expect(wb.sheets[0].rows[0][0]).toBe("{{__proto__}}")
+  })
+
+  it("honours an own property that shadows a prototype key", () => {
+    const wb: Workbook = { sheets: [{ name: "S", rows: [["{{toString}}"]] }] }
+    fillTemplate(wb, { toString: "explicitly provided" })
+    expect(wb.sheets[0].rows[0][0]).toBe("explicitly provided")
+  })
+
+  it("fills from a null-prototype data object", () => {
+    // The documented escape hatch for the bug above, and the shape a caller
+    // gets from `JSON.parse` reviver / `Object.create(null)` pipelines.
+    const data = Object.create(null) as Record<string, CellValue>
+    data["name"] = "Acme"
+    const wb: Workbook = { sheets: [{ name: "S", rows: [["{{name}} / {{toString}}"]] }] }
+    fillTemplate(wb, data)
+    expect(wb.sheets[0].rows[0][0]).toBe("Acme / {{toString}}")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// End-to-end: a real XLSX template opened with `openXlsx`, filled, saved,
+// and re-read. This is the documented usage in the fillTemplate JSDoc and
+// the only path that exercises `rows` and `cells` on the same workbook.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fillTemplate — XLSX round-trip", () => {
+  it("fills a styled template and survives openXlsx → fill → saveXlsx", async () => {
+    const templateBytes = await writeXlsx({
+      sheets: [
+        {
+          name: "Invoice",
+          rows: [
+            ["Customer", "{{customer}}"],
+            ["Total", "{{total}}"],
+            ["Note", "Due {{due}} — thanks {{customer}}"],
+          ],
+          // Styling the placeholder cells is what makes the reader emit a
+          // `cells` Map for them, so this covers both substitution paths.
+          cells: new Map([
+            ["0,1", { style: { font: { bold: true } } }],
+            ["1,1", { style: { font: { italic: true } } }],
+          ]),
+        },
+      ],
+    })
+
+    const wb = await openXlsx(templateBytes, { readStyles: true })
+    expect(wb.sheets[0].cells).toBeDefined()
+    expect(wb.sheets[0].cells!.get("0,1")!.value).toBe("{{customer}}")
+
+    fillTemplate(wb, {
+      customer: "Acme Corp",
+      total: 1250.5,
+      due: new Date("2025-03-01T00:00:00Z"),
+    })
+
+    // The cells Map entry is substituted *and* retyped, not just `rows`.
+    const filledCell = wb.sheets[0].cells!.get("1,1")!
+    expect(filledCell.value).toBe(1250.5)
+    expect(filledCell.type).toBe("number")
+    expect(filledCell.style?.font?.italic).toBe(true)
+
+    const out = await saveXlsx(wb)
+    const reread = await readXlsx(out, { readStyles: true })
+    expect(reread.sheets[0].rows[0]).toEqual(["Customer", "Acme Corp"])
+    expect(reread.sheets[0].rows[1]).toEqual(["Total", 1250.5])
+    expect(reread.sheets[0].rows[2][1]).toBe("Due 2025-03-01T00:00:00.000Z — thanks Acme Corp")
+    // Styling from the template must not be lost by the fill.
+    expect(reread.sheets[0].cells!.get("0,1")!.style?.font?.bold).toBe(true)
+  })
+})

--- a/test/template-cells.test.ts
+++ b/test/template-cells.test.ts
@@ -236,20 +236,20 @@ describe("fillTemplate — structural edge cases", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("fillTemplate — inherited Object.prototype keys", () => {
-  it.skip("leaves {{toString}} alone when `data` has no own `toString`", () => {
+  it("leaves {{toString}} alone when `data` has no own `toString`", () => {
     const wb = workbookWithCells([["0,0", cell("{{toString}}")]], [["{{toString}}"]])
     fillTemplate(wb, { name: "Acme" })
     expect(wb.sheets[0].rows[0][0]).toBe("{{toString}}")
     expect(wb.sheets[0].cells!.get("0,0")!.value).toBe("{{toString}}")
   })
 
-  it.skip("leaves an inherited key alone inside mixed text", () => {
+  it("leaves an inherited key alone inside mixed text", () => {
     const wb: Workbook = { sheets: [{ name: "S", rows: [["Hi {{constructor}}"]] }] }
     fillTemplate(wb, { name: "Acme" })
     expect(wb.sheets[0].rows[0][0]).toBe("Hi {{constructor}}")
   })
 
-  it.skip("leaves {{__proto__}} alone rather than injecting Object.prototype", () => {
+  it("leaves {{__proto__}} alone rather than injecting Object.prototype", () => {
     const wb: Workbook = { sheets: [{ name: "S", rows: [["{{__proto__}}"]] }] }
     fillTemplate(wb, {})
     expect(wb.sheets[0].rows[0][0]).toBe("{{__proto__}}")


### PR DESCRIPTION
Part of #352 — the coverage track. Raising three weak modules to the v1 bar turned up **three genuine bugs**. Each was reproduced independently before being fixed, and each fix un-skips the test that documented it.

## 1. `fillTemplate` walked `Object.prototype`

Four lookups used `key in data`, which walks the prototype chain.

```ts
fillTemplate(workbook, { name: "Acme" })
// cell "{{toString}}"        → typeof is "function"  ← Object.prototype.toString
// cell "Hi {{constructor}}"  → "Hi function Object() { [native code] }"
// cell "{{__proto__}}"       → Object.prototype
```

A function is not a `CellValue`. The cells-Map path additionally set `cell.type = "string"` beside the function value, handing the writer a type/value pair it cannot serialize. Any template with a placeholder named `toString`, `valueOf`, `constructor`, `hasOwnProperty`, or `__proto__` corrupted its output silently.

Now `Object.hasOwn`.

## 2. Rich-text colours parsed differently in `sharedStrings.xml` than anywhere else

`shared-strings.ts` stripped the alpha channel with `.replace(/^FF/, "")`; `styles.ts` and the inline-string path in `worksheet.ts` strip it positionally. Measured on identical input:

| `rgb=` | sharedStrings | styles.ts / worksheet.ts |
| --- | --- | --- |
| `FFFF0000` | `FF0000` | `FF0000` |
| `FF0000` | **`0000`** | `FF0000` |
| `80FF0000` | **`80FF0000`** | `FF0000` |
| `00FF00FF` | **`00FF00FF`** | `FF00FF` |

So the same run parsed to a different colour depending on whether it lived in the shared string table or an inline `<is>` — and two of those outputs violate `Color.rgb`'s documented "hex RGB without `#`" by keeping eight characters.

## 3. `isDateStyle` and `resolveStyle` disagreed about `numFmt` precedence

`resolveStyle` does `numFmts.get(id) ?? BUILTIN[id]`, honouring a workbook that redefines a built-in id — which ECMA-376 §18.8.30 allows. `isDateStyle` checked `DATE_FMT_IDS` *first*.

For `<numFmt numFmtId="14" formatCode="#,##0"/>`, verified: `resolveStyle → { numFmt: "#,##0" }` **and** `isDateStyle → true`. Since `worksheet.ts` uses `isDateStyle` to decide serial-date conversion, the cell was converted to a `Date` and then formatted numerically. The reverse case — id `3` redefined as `"yyyy-mm-dd"` — was missed entirely.

Both functions use the same precedence now.

## Coverage

| module | statements | branches |
| --- | --- | --- |
| `src/template.ts` | 52.6% → **100%** | 38.9% → **100%** |
| `src/xlsx/shared-strings.ts` | 56.8% → **100%** | 40.2% → **95.2%** |
| `src/xlsx/styles.ts` | 66.5% → **100%** | 55.1% → **94.5%** |

Repo totals: 91.6% → **92.4%** statements, 84.2% → **85.3%** branches. The branches still uncovered in these files need a tag whose local name is empty (`<a:>`), which well-formed XML cannot produce.

## Behaviour now pinned

Beyond the bugs, the tests lock in things that were documented but unverified — the category that produced all three findings above:

- `fillTemplate` retypes `Cell.type` to match a substituted number/boolean/Date, and leaves both value **and** type alone when a key is absent, so an unfilled template stays re-savable.
- The module-level `/g` placeholder regex does not leak `lastIndex` across cells or across calls.
- A bare `<si/>` still yields an entry — dropping it would shift every shared-string index. `<rPh>` furigana never leaks into `text`.
- `val="0"` / `"false"` toggles read as *off*; that is how a run cancels inherited cell formatting.
- `<u val="none"/>` currently reads as underlined — a lossy fallback, now pinned so it is a choice rather than an accident.
- `resolveStyle` skips fill index 1 (the mandatory `gray125` placeholder) and ignores font/fill/border ids past the end of their tables; `parseStyles` reads `cellXfs` but not the identically-shaped `cellStyleXfs`/`dxfs`.
- `isDateStyle` boundaries: the locale-only built-ins 27–36 / 50–58, elapsed-time 45–47, and the numeric ids sitting between the date ranges.

## One contract locked in rather than flagged

`resolveStyle` returns the **shared** parsed `FontStyle`/`FillStyle`/`BorderStyle` instances rather than copies, so a caller mutating `cell.style.font` restyles every other cell using the same `xf`. That reads as deliberate parse-once behaviour, so the test states it as a contract. If the intent was to clone, flip that test — it is exactly the kind of thing worth settling before v1 freezes it.

Full suite **7,975 tests / 120 files** green; lint, typecheck, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
