### PR TITLE
fix: validate sheet names and unrepresentable values on write — #364

### DIFF
--- a/src/_validate.ts
+++ b/src/_validate.ts
@@ -1,0 +1,99 @@
+// ── Write-path validation ────────────────────────────────────────────
+// Every check hucre performs used to be on the read side. The write path
+// trusted the caller completely, so an ordinary mistake — a sheet named
+// after a date range, a name copied from a report title — produced a file
+// Excel opens with "unreadable content" and no warning from hucre.
+//
+// These run before any bytes are produced, so a rejected workbook leaves
+// no half-written output.
+
+import { InvalidArgumentError } from "./errors"
+
+/**
+ * Excel's hard limit on a sheet name. Enforced by Excel's UI, by the
+ * XLSX format, and by LibreOffice for ODS.
+ */
+export const MAX_SHEET_NAME_LENGTH = 31
+
+/**
+ * Characters Excel forbids in a sheet name. They collide with range
+ * syntax (`Sheet1!A1`, `[Book1]Sheet1`) or with path separators.
+ */
+const FORBIDDEN_SHEET_NAME_CHARS = /[[\]:*?/\\]/
+
+/**
+ * Reserved by Excel for the change-tracking sheet. Case-insensitive —
+ * Excel rejects `history` just as firmly as `History`.
+ */
+const RESERVED_SHEET_NAME = "history"
+
+/**
+ * Validate one sheet name against Excel's rules.
+ *
+ * Throws rather than sanitizing: silently truncating a 40-character name
+ * or stripping its colons produces a workbook whose sheets are not the
+ * ones the caller asked for, and range references built against the
+ * original names would then dangle.
+ */
+export function validateSheetName(name: string, index: number): void {
+  const where = `sheet ${index + 1}`
+
+  if (typeof name !== "string" || name.length === 0) {
+    throw new InvalidArgumentError(`Sheet name is empty (${where}); Excel requires a name`)
+  }
+
+  if (name.length > MAX_SHEET_NAME_LENGTH) {
+    throw new InvalidArgumentError(
+      `Sheet name "${name}" is ${name.length} characters (${where}); ` +
+        `Excel allows at most ${MAX_SHEET_NAME_LENGTH}`,
+    )
+  }
+
+  const forbidden = name.match(FORBIDDEN_SHEET_NAME_CHARS)
+  if (forbidden) {
+    throw new InvalidArgumentError(
+      `Sheet name "${name}" contains ${JSON.stringify(forbidden[0])} (${where}); ` +
+        `Excel forbids [ ] : * ? / \\ in sheet names`,
+    )
+  }
+
+  // A leading or trailing apostrophe breaks quoted range references —
+  // 'My Sheet'!A1 becomes unparseable.
+  if (name.startsWith("'") || name.endsWith("'")) {
+    throw new InvalidArgumentError(
+      `Sheet name "${name}" starts or ends with an apostrophe (${where}); ` +
+        `Excel forbids it because it breaks quoted range references`,
+    )
+  }
+
+  if (name.toLowerCase() === RESERVED_SHEET_NAME) {
+    throw new InvalidArgumentError(
+      `Sheet name "${name}" is reserved by Excel for change tracking (${where})`,
+    )
+  }
+}
+
+/**
+ * Validate every sheet name in a workbook, including uniqueness.
+ *
+ * Excel compares sheet names case-insensitively, so `Data` and `data`
+ * collide — a workbook carrying both opens as damaged.
+ */
+export function validateSheetNames(sheets: ReadonlyArray<{ name: string }>): void {
+  const seen = new Map<string, number>()
+
+  for (let i = 0; i < sheets.length; i++) {
+    const name = sheets[i]!.name
+    validateSheetName(name, i)
+
+    const key = name.toLowerCase()
+    const previous = seen.get(key)
+    if (previous !== undefined) {
+      throw new InvalidArgumentError(
+        `Duplicate sheet name "${name}" (sheets ${previous + 1} and ${i + 1}); ` +
+          `Excel compares sheet names case-insensitively`,
+      )
+    }
+    seen.set(key, i)
+  }
+}

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -353,6 +353,9 @@ class CsvRowFormatter {
 
   private formatDate(d: Date): string {
     if (!this.dateFormat) {
+      // See #364 — an unparseable Date threw a raw RangeError, and in a
+      // streaming writer that lands after bytes have gone to the client.
+      if (Number.isNaN(d.getTime())) return ""
       return d.toISOString()
     }
 

--- a/src/csv/writer.ts
+++ b/src/csv/writer.ts
@@ -267,6 +267,8 @@ function formatNumber(n: number): string {
 
 function formatDate(d: Date, format?: string): string {
   if (!format) {
+    // See #364 — an unparseable Date threw a raw RangeError mid-write.
+    if (Number.isNaN(d.getTime())) return ""
     return d.toISOString()
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -47,6 +47,19 @@ export class ValidationError extends DefterError {
   }
 }
 
+/**
+ * A caller passed something the format cannot represent — an illegal
+ * sheet name, an out-of-range coordinate, a value past a hard limit.
+ *
+ * Distinct from {@link ValidationError}, whose constructor takes a list
+ * of row/column schema failures and models *imported data* being wrong.
+ * This one models *arguments* being wrong, and is thrown before any
+ * output is produced rather than collected alongside it.
+ */
+export class InvalidArgumentError extends DefterError {
+  override name = "InvalidArgumentError"
+}
+
 export class UnsupportedFormatError extends DefterError {
   override name = "UnsupportedFormatError"
 

--- a/src/export/html.ts
+++ b/src/export/html.ts
@@ -114,6 +114,10 @@ function styleToCss(style: CellStyle): string {
 function formatCellValue(value: CellValue): string {
   if (value === null || value === undefined) return ""
   if (value instanceof Date) {
+    // An unparseable Date threw a raw RangeError from toISOString,
+    // untyped and mid-write. Empty matches what the XLSX and ODS
+    // writers emit for a value the format cannot represent. See #364.
+    if (Number.isNaN(value.getTime())) return ""
     return value.toISOString().slice(0, 10)
   }
   if (typeof value === "boolean") return String(value)

--- a/src/export/markdown.ts
+++ b/src/export/markdown.ts
@@ -22,6 +22,8 @@ function escapePipe(str: string): string {
 function formatCellValue(value: CellValue): string {
   if (value === null || value === undefined) return ""
   if (value instanceof Date) {
+    // See #364 — an unparseable Date threw a raw RangeError mid-write.
+    if (Number.isNaN(value.getTime())) return ""
     return value.toISOString().slice(0, 10)
   }
   if (typeof value === "boolean") return String(value)

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,6 +252,7 @@ export {
   ZipError,
   XmlError,
   ValidationError,
+  InvalidArgumentError,
   UnsupportedFormatError,
   EncryptedFileError,
   DecryptionError,

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -12,6 +12,7 @@ import type {
   MergeRange,
 } from "../_types"
 import { ZipWriter } from "../zip/writer"
+import { validateSheetNames } from "../_validate"
 import { unwrapCellValue } from "../xlsx/hyperlink"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 import { replaceA1Ranges } from "../cell-utils"
@@ -540,6 +541,12 @@ function cellToOds(value: CellValue, ctx?: CellContext): string {
   }
 
   if (typeof value === "number") {
+    // NaN / Infinity are not valid ODF floats — office:value="NaN" makes
+    // LibreOffice read garbage. The XLSX writer already emits an empty
+    // cell for these; ODS never got the same treatment. See #364.
+    if (!Number.isFinite(value)) {
+      return xmlElement("table:table-cell", attrs, [])
+    }
     attrs["office:value-type"] = "float"
     attrs["office:value"] = String(value)
     children.push(xmlElement("text:p", undefined, formatNumberDisplay(value)))
@@ -554,6 +561,12 @@ function cellToOds(value: CellValue, ctx?: CellContext): string {
   }
 
   if (value instanceof Date) {
+    // An unparseable Date produced office:date-value="NaN-NaN-NaNT..."
+    // — a corrupt file rather than an error. Emit an empty cell, the same
+    // way non-finite numbers are handled. See #364.
+    if (Number.isNaN(value.getTime())) {
+      return xmlElement("table:table-cell", attrs, [])
+    }
     const dateStr = formatOdsDateValue(value)
     attrs["office:value-type"] = "date"
     attrs["office:date-value"] = dateStr
@@ -976,6 +989,10 @@ function writeManifestXml(): string {
  * Returns a Uint8Array containing the ZIP archive.
  */
 export async function writeOds(options: WriteOptions): Promise<WriteOutput> {
+  // Same rules as XLSX: LibreOffice enforces Excel's sheet-name limits
+  // for interoperability. See #364.
+  validateSheetNames(options.sheets)
+
   const zip = new ZipWriter()
 
   // mimetype MUST be the first entry and MUST be stored uncompressed

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -21,6 +21,8 @@ import { createSharedStrings, writeSharedStringsXml } from "./worksheet-writer"
 import { cellRef } from "./worksheet-writer"
 import type { SharedStringsCollector } from "./worksheet-writer"
 import { writeThemeXml } from "./theme-writer"
+import { validateSheetName } from "../_validate"
+import { InvalidArgumentError } from "../errors"
 import { dateToSerial } from "../_date"
 import { xmlDocument, xmlDeclaration, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 
@@ -344,7 +346,7 @@ function headerFromColumns(columns: ColumnDef[] | undefined): CellValue[] | null
 
 function validateMaxRowsPerSheet(value: number): void {
   if (value < 2) {
-    throw new Error("maxRowsPerSheet must be at least 2 (one header + one data row)")
+    throw new InvalidArgumentError("maxRowsPerSheet must be at least 2 (one header + one data row)")
   }
 }
 
@@ -391,6 +393,10 @@ export class XlsxStreamWriter {
       dateSystem: this.dateSystem,
     })
 
+    // The base name is the caller's; rollover names are generated, and
+    // those are still truncated below because the `_2` suffix can push a
+    // legal 31-character base over the limit. See #364.
+    validateSheetName(this.sheetName, 0)
     validateMaxRowsPerSheet(this.maxRowsPerSheet)
 
     // If columns have headers, write the header row immediately
@@ -557,6 +563,13 @@ export function writeXlsxStream(
   options: XlsxWriteStreamOptions,
   rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
 ): ReadableStream<Uint8Array> {
+  // Validate before returning the stream, not inside the generator.
+  // Generator bodies do not run until first pull, so a deferred throw
+  // would surface only after the caller had already handed the stream to
+  // a Response — too late to do anything about. See #364.
+  validateSheetName(options.name, 0)
+  validateMaxRowsPerSheet(options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET)
+
   return zipStream(xlsxStreamEntries(options, rows), { zip64: options.zip64 })
 }
 
@@ -571,8 +584,6 @@ async function* xlsxStreamEntries(
   const inlineStrings = options.inlineStrings ?? true
   const compress = options.compress ?? true
   const columns = options.columns
-
-  validateMaxRowsPerSheet(maxRowsPerSheet)
 
   const serializer = new RowSerializer({ columns, dateSystem, inlineStrings })
   const prelude = buildSheetPrelude(columns, options.freezePane).join("")

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -32,6 +32,7 @@ import type { PivotWriteResult } from "./pivot-writer"
 import { xmlDocument, xmlSelfClose } from "../xml/writer"
 import { writeCoreProperties, writeAppProperties, writeCustomProperties } from "./doc-props-writer"
 import { writeThemeXml } from "./theme-writer"
+import { validateSheetNames } from "../_validate"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
 
@@ -71,6 +72,10 @@ function effectiveProperties(options: WriteOptions): WorkbookProperties | undefi
  */
 export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
   const { sheets, defaultFont, dateSystem, namedRanges, activeSheet, workbookProtection } = options
+
+  // Before any bytes are produced, so a rejected workbook leaves no
+  // half-written output. See #364.
+  validateSheetNames(sheets)
 
   const properties = effectiveProperties(options)
 

--- a/src/xml/data-writer.ts
+++ b/src/xml/data-writer.ts
@@ -36,7 +36,8 @@ function escapeAttr(s: string): string {
 
 function valueToString(value: CellValue): string {
   if (value === null || value === undefined) return ""
-  if (value instanceof Date) return value.toISOString()
+  // See #364 — an unparseable Date threw a raw RangeError mid-write.
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? "" : value.toISOString()
   return String(value)
 }
 

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -82,6 +82,7 @@ exports[`export surface snapshot > root 1`] = `
   "DecryptionError",
   "DefterError",
   "EncryptedFileError",
+  "InvalidArgumentError",
   "NdjsonStreamWriter",
   "ParseError",
   "REL_CELL_IMAGES",

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -191,16 +191,18 @@ describe("XLSX Writer Edge Cases", () => {
     expect(wb.sheets[0].name).toBe(specialName)
   })
 
-  it("multiple sheets with same-looking names (case variation)", async () => {
-    const wb = await writeAndRead([
-      { name: "Sheet1", rows: [["a"]] },
-      { name: "sheet1", rows: [["b"]] },
-      { name: "SHEET1", rows: [["c"]] },
-    ])
-    expect(wb.sheets).toHaveLength(3)
-    expect(wb.sheets[0].name).toBe("Sheet1")
-    expect(wb.sheets[1].name).toBe("sheet1")
-    expect(wb.sheets[2].name).toBe("SHEET1")
+  it("rejects sheet names that differ only in case", async () => {
+    // Excel compares sheet names case-insensitively, so a workbook
+    // carrying all three opens as damaged. ExcelJS agrees — it refuses
+    // the second with "Worksheet name already exists". This test used to
+    // assert the opposite; see #364.
+    await expect(
+      writeAndRead([
+        { name: "Sheet1", rows: [["a"]] },
+        { name: "sheet1", rows: [["b"]] },
+        { name: "SHEET1", rows: [["c"]] },
+      ]),
+    ).rejects.toThrow(/Duplicate sheet name/)
   })
 
   it("column XFD (16383 = max Excel column)", async () => {

--- a/test/write-validation.test.ts
+++ b/test/write-validation.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeOds } from "../src/ods/writer"
+import { writeCsv } from "../src/csv/writer"
+import { writeXml } from "../src/xml/data-writer"
+import { toHtml } from "../src/export/html"
+import { toMarkdown } from "../src/export/markdown"
+import { XlsxStreamWriter, writeXlsxStream } from "../src/xlsx/stream-writer"
+import { ZipReader } from "../src/zip/reader"
+import { InvalidArgumentError } from "../src/errors"
+import { MAX_SHEET_NAME_LENGTH } from "../src/_validate"
+import type { Sheet } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function odsContent(rows: unknown[][]): Promise<string> {
+  const buf = await writeOds({ sheets: [{ name: "S", rows: rows as never }] })
+  return new TextDecoder().decode(await new ZipReader(buf).extract("content.xml"))
+}
+
+const sheetOf = (rows: unknown[][]): Sheet => ({ name: "S", rows: rows as never })
+
+// ═══════════════════════════════════════════════════════════════════════
+// #364 — every check hucre performed was on the read side. The write
+// path trusted the caller, so ordinary mistakes produced files Excel
+// calls corrupt, with no warning.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sheet name validation", () => {
+  const illegal: Array<[string, string]> = [
+    ["Sales: Q1/Q2", "a name copied from a report title"],
+    ["Data[2024]", "square brackets"],
+    ["What?", "a question mark"],
+    ["a*b", "an asterisk"],
+    ["a\\b", "a backslash"],
+  ]
+
+  for (const [name, why] of illegal) {
+    it(`rejects ${why}: ${JSON.stringify(name)}`, async () => {
+      await expect(writeXlsx({ sheets: [{ name, rows: [["a"]] }] })).rejects.toThrow(
+        InvalidArgumentError,
+      )
+    })
+  }
+
+  it("rejects a name past Excel's 31-character limit", async () => {
+    const name = "x".repeat(MAX_SHEET_NAME_LENGTH + 1)
+    await expect(writeXlsx({ sheets: [{ name, rows: [["a"]] }] })).rejects.toThrow(
+      /32 characters.*at most 31/,
+    )
+  })
+
+  it("accepts a name exactly at the limit", async () => {
+    const name = "x".repeat(MAX_SHEET_NAME_LENGTH)
+    await expect(writeXlsx({ sheets: [{ name, rows: [["a"]] }] })).resolves.toBeInstanceOf(
+      Uint8Array,
+    )
+  })
+
+  it("rejects an empty name", async () => {
+    await expect(writeXlsx({ sheets: [{ name: "", rows: [["a"]] }] })).rejects.toThrow(/is empty/)
+  })
+
+  it("rejects leading and trailing apostrophes", async () => {
+    // They break quoted range references: 'My Sheet'!A1.
+    for (const name of ["'Data", "Data'"]) {
+      await expect(writeXlsx({ sheets: [{ name, rows: [["a"]] }] })).rejects.toThrow(/apostrophe/)
+    }
+  })
+
+  it("rejects the reserved History name, in any case", async () => {
+    for (const name of ["History", "history", "HISTORY"]) {
+      await expect(writeXlsx({ sheets: [{ name, rows: [["a"]] }] })).rejects.toThrow(/reserved/)
+    }
+  })
+
+  it("still accepts the punctuation Excel allows", async () => {
+    const name = "Sheet (1) - Test & 2"
+    await expect(writeXlsx({ sheets: [{ name, rows: [["a"]] }] })).resolves.toBeInstanceOf(
+      Uint8Array,
+    )
+  })
+
+  it("names the sheet position in the message", async () => {
+    await expect(
+      writeXlsx({
+        sheets: [
+          { name: "Fine", rows: [["a"]] },
+          { name: "Bad:Name", rows: [["b"]] },
+        ],
+      }),
+    ).rejects.toThrow(/sheet 2/)
+  })
+})
+
+describe("duplicate sheet names", () => {
+  it("rejects exact duplicates", async () => {
+    await expect(
+      writeXlsx({
+        sheets: [
+          { name: "Data", rows: [["a"]] },
+          { name: "Data", rows: [["b"]] },
+        ],
+      }),
+    ).rejects.toThrow(/Duplicate sheet name/)
+  })
+
+  it("rejects names differing only in case", async () => {
+    // Excel compares case-insensitively; ExcelJS refuses the second with
+    // "Worksheet name already exists".
+    await expect(
+      writeXlsx({
+        sheets: [
+          { name: "Data", rows: [["a"]] },
+          { name: "DATA", rows: [["b"]] },
+        ],
+      }),
+    ).rejects.toThrow(/Duplicate sheet name/)
+  })
+
+  it("points at both offending positions", async () => {
+    await expect(
+      writeXlsx({
+        sheets: [
+          { name: "A", rows: [["a"]] },
+          { name: "B", rows: [["b"]] },
+          { name: "a", rows: [["c"]] },
+        ],
+      }),
+    ).rejects.toThrow(/sheets 1 and 3/)
+  })
+})
+
+describe("sheet name validation applies to every writer", () => {
+  it("writeOds", async () => {
+    await expect(writeOds({ sheets: [{ name: "Bad:Name", rows: [["a"]] }] })).rejects.toThrow(
+      InvalidArgumentError,
+    )
+  })
+
+  it("XlsxStreamWriter", () => {
+    expect(() => new XlsxStreamWriter({ name: "Bad:Name" })).toThrow(InvalidArgumentError)
+  })
+
+  it("writeXlsxStream", () => {
+    expect(() => writeXlsxStream({ name: "x".repeat(40) }, [])).toThrow(InvalidArgumentError)
+  })
+
+  it("still allows the streaming writer to truncate its own generated names", async () => {
+    // A legal 31-character base plus a "_2" suffix exceeds the limit, so
+    // rollover names are still truncated — that truncation is hucre's,
+    // not the caller's.
+    const base = "x".repeat(MAX_SHEET_NAME_LENGTH)
+    const writer = new XlsxStreamWriter({ name: base, maxRowsPerSheet: 2 })
+    for (let i = 0; i < 5; i++) writer.addRow([i])
+
+    const zip = new ZipReader(await writer.finish())
+    const workbookXml = new TextDecoder().decode(await zip.extract("xl/workbook.xml"))
+    for (const match of workbookXml.matchAll(/<sheet name="([^"]+)"/g)) {
+      expect(match[1]!.length).toBeLessThanOrEqual(MAX_SHEET_NAME_LENGTH)
+    }
+  })
+})
+
+describe("values the format cannot represent", () => {
+  it("ODS emits an empty cell for NaN and Infinity, like XLSX", async () => {
+    // office:value="NaN" is not a valid ODF float — LibreOffice reads
+    // garbage. The XLSX writer already guarded this; ODS did not.
+    const xml = await odsContent([[Number.NaN, Number.POSITIVE_INFINITY, 42]])
+    expect(xml).not.toContain("NaN")
+    expect(xml).not.toContain("Infinity")
+    expect(xml).toContain('office:value="42"')
+  })
+
+  it("ODS emits an empty cell for an unparseable Date", async () => {
+    // It used to write office:date-value="NaN-NaN-NaNTNaN:NaN:NaN".
+    const xml = await odsContent([[new Date("nope")]])
+    expect(xml).not.toContain("NaN")
+  })
+
+  it("the text writers no longer throw a raw RangeError", () => {
+    // Four writers called toISOString() unguarded, so an unparseable Date
+    // aborted the write with an untyped error — in the streaming writer,
+    // after bytes had already gone out.
+    const bad = new Date("nope")
+
+    expect(() => writeCsv([[bad]])).not.toThrow()
+    expect(() => toHtml(sheetOf([[bad]]))).not.toThrow()
+    expect(() => toMarkdown(sheetOf([[bad]]))).not.toThrow()
+    expect(() => writeXml([{ d: bad }] as never)).not.toThrow()
+  })
+
+  it("keeps writing valid dates", () => {
+    const good = new Date(Date.UTC(2024, 0, 15))
+    expect(writeCsv([[good]])).toContain("2024-01-15")
+    expect(toMarkdown(sheetOf([[good]]))).toContain("2024-01-15")
+  })
+
+  it("XLSX keeps its existing empty-cell behaviour for non-finite numbers", async () => {
+    const buf = await writeXlsx({ sheets: [{ name: "S", rows: [[Number.NaN, 7]] }] })
+    const xml = new TextDecoder().decode(
+      await new ZipReader(buf).extract("xl/worksheets/sheet1.xml"),
+    )
+    expect(xml).not.toContain("NaN")
+    expect(xml).toContain(">7<")
+  })
+})

--- a/test/xlsx-stream-write.test.ts
+++ b/test/xlsx-stream-write.test.ts
@@ -251,10 +251,13 @@ describe("writeXlsxStream", () => {
     expect(workbook.sheets[0].rows).toEqual([])
   })
 
-  it("rejects a maxRowsPerSheet below 2", () => {
-    expect(() =>
-      collect(writeXlsxStream({ name: "S", maxRowsPerSheet: 1 }, [[1]])),
-    ).rejects.toThrow(/maxRowsPerSheet must be at least 2/)
+  it("rejects a maxRowsPerSheet below 2, before returning a stream", () => {
+    // Validation moved ahead of the generator (#364): a deferred throw
+    // would surface only after the caller had handed the stream to a
+    // Response, too late to act on.
+    expect(() => writeXlsxStream({ name: "S", maxRowsPerSheet: 1 }, [[1]])).toThrow(
+      /maxRowsPerSheet must be at least 2/,
+    )
   })
 
   it("carries freeze panes and column widths onto every sheet", async () => {


### PR DESCRIPTION
Addresses most of #364. Part of #352.

Every check hucre performed was on the read side. The write path trusted the caller completely, so an ordinary mistake — a sheet named after a report title, a `NaN` from a division — produced a file Excel opens with "unreadable content" and no warning. Unlike the DoS work in #363, no attacker is needed; this is the failure mode a careful user hits.

## Verified first

```
"Sales: Q1/Q2"   → written as "Sales: Q1/Q2"
"x" * 60         → written as "xxxxxxxx…" (60 chars)
""               → written as ""
"a[b]c"          → written as "a[b]c"
"History"        → written as "History"
duplicates       → accepted silently
ODS NaN/Infinity → office:value="NaN" / "Infinity"
```

## Sheet names

`src/_validate.ts` runs **before any bytes are produced**, so a rejected workbook leaves no half-written output. Wired into `writeXlsx`, `writeOds`, `XlsxStreamWriter`, and `writeXlsxStream`. Excel's rules: non-empty, ≤31 characters, none of `[ ] : * ? / \`, no leading or trailing apostrophe (they break quoted range references like `'My Sheet'!A1`), not the reserved `History`, and unique.

**Uniqueness is case-insensitive, which changes an existing test.** `test/edge-cases.test.ts` asserted `Sheet1` / `sheet1` / `SHEET1` could coexist. Excel compares sheet names case-insensitively, so that workbook opens as damaged. I checked rather than assumed, because the test looked deliberate — ExcelJS refuses the second with `Worksheet name already exists`. Two independent implementations agreeing was enough to change it.

**It throws rather than sanitizing.** Truncating a 40-character name or stripping its colons produces a workbook whose sheets are not the ones the caller asked for, and any range reference built against the original names would then dangle. ExcelJS truncates with a `console.warn`; that seemed the worse trade — silent data loss to avoid an error.

Generated rollover names in the streaming writer are *still* truncated, and there is a test for it: a legal 31-character base plus a `_2` suffix exceeds the limit, and that truncation is hucre's own, not the caller's.

## Values the format cannot represent

Now handled by one rule — **emit an empty cell** — which is what the XLSX writer has always done for non-finite numbers. XLSX behaviour is unchanged; everything else was aligned to it.

- **ODS** wrote `office:value="NaN"` and `office:value="Infinity"`, neither a valid ODF float, and `office:date-value="NaN-NaN-NaNTNaN:NaN:NaN"` for an unparseable `Date` — a corrupt file rather than an error.
- **`writeCsv`, `toHtml`, `toMarkdown`, `writeXml`, and the streaming CSV writer** called `toISOString()` unguarded, throwing a raw `RangeError: Invalid time value` mid-write. Untyped, escaping the `DefterError` hierarchy — and in the streaming writer, landing after bytes had already gone to the client.

An invalid `Date` carries no information to preserve, so emptying it loses nothing; that is why this differs from, say, dropping a background image.

Worth noting the audit's claim here was *partly wrong*: it listed `writeXlsx` and `writeOds` among the throwing sites. Neither throws — `writeXlsx` already handled it correctly via its non-finite guard, and `writeOds` wrote garbage instead. I checked each of the six writers individually rather than fixing the list as given.

## Two things that fell out

- **`writeXlsxStream` validated inside its async generator**, whose body does not run until the first pull — so a bad option surfaced only *after* the caller had handed the stream to a `Response`. Validation moved ahead of the return. One of my own tests from #348 asserted the deferred behaviour and is updated.
- **`errors.ts` gains `InvalidArgumentError`.** `ValidationError`'s constructor requires a list of row/column schema failures and models *imported data* being wrong; this models *arguments* being wrong. The streaming writer's bare `throw new Error` for `maxRowsPerSheet` now uses it. Adding it to the root exports also tripped the export snapshot from #370 — the guard doing its job.

## Still open in #364

Cell text length (Excel caps at 32,767), formula length, defined-name length, and `colToLetter` producing structurally invalid refs for `NaN` / negative / out-of-range columns. Those carry real information, so the throw-vs-truncate question is sharper and worth settling separately.

## Verification

24 new tests in `test/write-validation.test.ts`: each illegal character class, the length boundary in both directions, empty, apostrophes, `History` in three cases, punctuation Excel *does* allow, the sheet position named in the message, exact and case-variant duplicates with both positions reported, all four writer entry points, generated-name truncation still working, and the value cases including "XLSX keeps its existing behaviour".

Full suite **7,999 tests / 121 files** green; lint, typecheck, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
