### PR TITLE
fix: input ceiling, zip-bomb caps on the streaming paths, and SAX cleanup — closes #363

### DIFF
--- a/src/_input.ts
+++ b/src/_input.ts
@@ -13,6 +13,7 @@
 
 import type { ReadInput } from "./_types"
 import { EncryptedFileError, ParseError } from "./errors"
+import { MAX_INPUT_BYTES } from "./limits"
 
 // ── OLE2 / Compound File Binary container detection ──────────────────
 //
@@ -63,33 +64,63 @@ export function assertNotEncrypted(data: Uint8Array, format: "xlsx" | "ods"): vo
  * Drain a {@link ReadableStream} of byte chunks into a single
  * {@link Uint8Array}. Allocates only one extra buffer when the stream
  * yields more than one chunk.
+ *
+ * `maxBytes` bounds the *total* buffered size (default
+ * {@link MAX_INPUT_BYTES}) — the individual chunks are whatever size the
+ * source hands out, so only the running total is meaningful. Exceeding it
+ * throws {@link ParseError} instead of growing until the process dies.
+ * The source is always cancelled on the way out, including on the error
+ * path, so an aborted read doesn't leave a socket or file handle open.
  */
 export async function bufferReadableStream(
   stream: ReadableStream<Uint8Array>,
+  maxBytes: number = MAX_INPUT_BYTES,
 ): Promise<Uint8Array> {
+  const cap = Number.isFinite(maxBytes) && maxBytes > 0 ? maxBytes : MAX_INPUT_BYTES
   const reader = stream.getReader()
   const chunks: Uint8Array[] = []
   let totalLen = 0
 
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) break
-    if (value) {
-      chunks.push(value)
-      totalLen += value.length
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      if (value) {
+        totalLen += value.length
+        if (totalLen > cap) {
+          throw new ParseError(
+            `Input stream exceeds the maximum of ${cap} bytes. ` +
+              "Raise `maxInputBytes` if the file really is this large.",
+          )
+        }
+        chunks.push(value)
+      }
+    }
+
+    if (chunks.length === 0) return new Uint8Array(0)
+    if (chunks.length === 1) return chunks[0]!
+
+    const result = new Uint8Array(totalLen)
+    let offset = 0
+    for (const chunk of chunks) {
+      result.set(chunk, offset)
+      offset += chunk.length
+    }
+    return result
+  } finally {
+    // Cancelling a stream that already ended is a no-op; cancelling one we
+    // abandoned mid-read is the whole point.
+    try {
+      await reader.cancel()
+    } catch {
+      // The source is already errored / closed — nothing left to release.
+    }
+    try {
+      reader.releaseLock()
+    } catch {
+      // ignore
     }
   }
-
-  if (chunks.length === 0) return new Uint8Array(0)
-  if (chunks.length === 1) return chunks[0]!
-
-  const result = new Uint8Array(totalLen)
-  let offset = 0
-  for (const chunk of chunks) {
-    result.set(chunk, offset)
-    offset += chunk.length
-  }
-  return result
 }
 
 /**
@@ -108,13 +139,18 @@ function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
 
 /**
  * Normalize a {@link ReadInput} into a {@link Uint8Array}. Buffers any
- * `ReadableStream<Uint8Array>` input fully. Throws {@link ParseError}
- * for unsupported input shapes.
+ * `ReadableStream<Uint8Array>` input fully, up to `maxBytes` (default
+ * {@link MAX_INPUT_BYTES}) — past that the read fails with a
+ * {@link ParseError} rather than exhausting memory. Throws
+ * {@link ParseError} for unsupported input shapes.
  */
-export async function readInputToUint8Array(input: ReadInput): Promise<Uint8Array> {
+export async function readInputToUint8Array(
+  input: ReadInput,
+  maxBytes?: number,
+): Promise<Uint8Array> {
   if (input instanceof Uint8Array) return input
   if (input instanceof ArrayBuffer) return new Uint8Array(input)
-  if (isReadableStream(input)) return bufferReadableStream(input)
+  if (isReadableStream(input)) return bufferReadableStream(input, maxBytes)
   throw new ParseError(
     "Unsupported input type. Expected Uint8Array, ArrayBuffer, or ReadableStream<Uint8Array>.",
   )

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1319,6 +1319,14 @@ export interface ReadOptions {
   maxRows?: number
   /** Cell range to read (e.g. "A1:D10"). Only cells within this range are returned. */
   range?: string
+  /**
+   * Maximum number of bytes buffered from a `ReadableStream` input.
+   * Default: 1 GiB ({@link MAX_INPUT_BYTES}). A stream that exceeds it
+   * fails with a `ParseError` instead of growing until the process runs
+   * out of memory. Ignored for `Uint8Array` / `ArrayBuffer` input, which
+   * the caller has already allocated.
+   */
+  maxInputBytes?: number
 }
 
 // ── Write Options ──────────────────────────────────────────────────

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -87,7 +87,7 @@ function detectFormat(data: Uint8Array): "xlsx" | "ods" {
  * ReadableStream input is buffered fully before format detection runs.
  */
 export async function read(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  let data = await readInputToUint8Array(input)
+  let data = await readInputToUint8Array(input, options?.maxInputBytes)
 
   // Password-protected workbooks arrive as an OLE2/CFB envelope. With a
   // password we decrypt the inner package (then `detectFormat` works on

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -9,6 +9,24 @@
  */
 export const MAX_DECOMPRESSED_BYTES: number = 2 * 1024 * 1024 * 1024
 
+/**
+ * Cap on the number of bytes buffered out of a `ReadableStream` input.
+ *
+ * Every format entry point funnels stream input through
+ * `readInputToUint8Array`, which used to accumulate chunks with no ceiling
+ * at all — so `read(response.body)` grew until V8 died, long before the
+ * ZIP layer's {@link MAX_DECOMPRESSED_BYTES} could apply to anything.
+ * Bounding each chunk would be useless here: chunks are individually tiny,
+ * it is the running total that has to be checked.
+ *
+ * 1 GiB is far above any real workbook (the largest spreadsheets in the
+ * wild are tens of MB, and a container this size already decompresses past
+ * what the readers can hold), while keeping the peak cost of buffering —
+ * chunks plus the single joined copy — inside a default Node heap. Callers
+ * with genuinely larger input can raise it with `maxInputBytes`.
+ */
+export const MAX_INPUT_BYTES: number = 1024 * 1024 * 1024
+
 /** Maximum row index (0-based) — Excel supports 1,048,576 rows. */
 export const MAX_ROW_INDEX = 1_048_575
 

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -718,7 +718,7 @@ function parseMetaXml(xml: string): Partial<WorkbookProperties> {
  * because the ZIP central directory lives at the end of the archive.
  */
 export async function readOds(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  const data = await readInputToUint8Array(input)
+  const data = await readInputToUint8Array(input, options?.maxInputBytes)
 
   // ODF supports password-encrypted documents via the same OLE2 / CFB
   // envelope Office uses for XLSX. Catch it before the ZIP reader does

--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -34,7 +34,7 @@ export async function readXls(
   input: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
   options?: ReadOptions,
 ): Promise<Workbook> {
-  const data = await readInputToUint8Array(input)
+  const data = await readInputToUint8Array(input, options?.maxInputBytes)
   let streams: Map<string, Uint8Array>
   try {
     streams = readCfb(data)
@@ -132,7 +132,12 @@ function parseWorkbookRecords(stream: Uint8Array, options?: ReadOptions): Workbo
           if (records[j].id !== SID.CONTINUE) break
           blocks.push(records[j].data)
         }
-        sst.push(...parseSst(blocks))
+        // A loop, not `push(...parseSst(blocks))`: spreading an array as
+        // arguments puts one stack slot per element, so a workbook with a
+        // few hundred thousand shared strings — an ordinary large .xls —
+        // threw `RangeError: Maximum call stack size exceeded`, which the
+        // caller reported as "malformed or truncated".
+        for (const s of parseSst(blocks)) sst.push(s)
         break
       }
       default:

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -111,7 +111,7 @@ function dirname(path: string): string {
  * you need row-level streaming with low per-row memory.
  */
 export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise<Workbook> {
-  let data = await readInputToUint8Array(input)
+  let data = await readInputToUint8Array(input, options?.maxInputBytes)
 
   // Password-protected workbooks arrive as an OLE2/CFB envelope. With a
   // password we decrypt the inner OOXML ZIP and continue; without one we

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -732,35 +732,44 @@ async function prepareStreaming(
 ): Promise<PrepareResult> {
   const zr = new ZipStreamReader(input)
   const parts = new Map<string, Uint8Array>()
+  const maxInputBytes = options?.maxInputBytes
   let resolved: ResolvedMeta | null = null
 
-  for (;;) {
-    const entry = await zr.nextEntry()
-    if (!entry) {
-      // Reached the central directory without streaming the target — fall
-      // back so the buffered path handles resolution / "sheet not found".
-      return { mode: "fallback", data: await zr.drainToBuffer() }
-    }
-    if (!entry.streamable) {
-      return { mode: "fallback", data: await zr.drainToBuffer() }
-    }
-
-    if (isWorksheetEntry(entry.name)) {
-      if (!resolved) resolved = resolveFromParts(parts, options)
-      if (!resolved) return { mode: "fallback", data: await zr.drainToBuffer() }
-      if (entry.name === resolved.wsPath) {
-        const wsStream = zr.entryStream(entry)
-        return { mode: "stream", wsStream, meta: resolved }
+  // Anything that escapes this loop abandons the reader mid-archive. Without
+  // the close() the source stayed locked forever — the caller could neither
+  // retry nor release whatever backs the stream.
+  try {
+    for (;;) {
+      const entry = await zr.nextEntry()
+      if (!entry) {
+        // Reached the central directory without streaming the target — fall
+        // back so the buffered path handles resolution / "sheet not found".
+        return { mode: "fallback", data: await zr.drainToBuffer(maxInputBytes) }
       }
-      await zr.skipEntry()
-      continue
-    }
+      if (!entry.streamable) {
+        return { mode: "fallback", data: await zr.drainToBuffer(maxInputBytes) }
+      }
 
-    if (shouldCollectEntry(entry.name)) {
-      parts.set(entry.name, await zr.readEntryBytes(entry))
-    } else {
-      await zr.skipEntry()
+      if (isWorksheetEntry(entry.name)) {
+        if (!resolved) resolved = resolveFromParts(parts, options)
+        if (!resolved) return { mode: "fallback", data: await zr.drainToBuffer(maxInputBytes) }
+        if (entry.name === resolved.wsPath) {
+          const wsStream = zr.entryStream(entry)
+          return { mode: "stream", wsStream, meta: resolved }
+        }
+        await zr.skipEntry()
+        continue
+      }
+
+      if (shouldCollectEntry(entry.name)) {
+        parts.set(entry.name, await zr.readEntryBytes(entry))
+      } else {
+        await zr.skipEntry()
+      }
     }
+  } catch (err) {
+    await zr.close()
+    throw err
   }
 }
 

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -90,7 +90,7 @@ export async function readXlsb(
   input: Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
   options?: ReadOptions,
 ): Promise<Workbook> {
-  let data = await readInputToUint8Array(input)
+  let data = await readInputToUint8Array(input, options?.maxInputBytes)
   if (isOle2Container(data)) {
     if (options?.password) data = await decryptAgile(data, options.password)
     else throw new EncryptedFileError("xlsx")

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -19,6 +19,13 @@ export type XmlNode = XmlElement | string
 export interface SaxHandlers {
   onOpenTag?: (tag: string, attrs: Record<string, string>) => void
   onCloseTag?: (tag: string) => void
+  /**
+   * Text content. {@link parseSaxStream} may split a *very* long run
+   * (larger than {@link SAX_TEXT_FLUSH_CHARS}) across several calls rather
+   * than holding it all in one buffer, so handlers should accumulate text
+   * until the enclosing element closes instead of assigning it. Splits
+   * never land inside an entity reference or a surrogate pair.
+   */
   onText?: (text: string) => void
   onCData?: (text: string) => void
 }
@@ -271,24 +278,80 @@ export async function parseSaxStream(
   let buf = ""
   let bomStripped = false
 
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) break
-    buf += decoder.decode(value, { stream: true })
+  // Handlers are expected to throw (the XLSX row parser aborts that way),
+  // and so is the source stream. Either way the reader has to be released,
+  // or the ZIP / decompression stream underneath it stays locked for the
+  // life of the process.
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buf += decoder.decode(value, { stream: true })
 
-    if (!bomStripped) {
-      if (buf.charCodeAt(0) === 0xfeff) buf = buf.slice(1)
-      bomStripped = true
+      if (!bomStripped) {
+        if (buf.charCodeAt(0) === 0xfeff) buf = buf.slice(1)
+        bomStripped = true
+      }
+
+      buf = processSaxBuffer(buf, handlers, false)
     }
 
-    buf = processSaxBuffer(buf, handlers, false)
+    // Flush remaining decoder state
+    buf += decoder.decode()
+    if (buf.length > 0) {
+      processSaxBuffer(buf, handlers, true)
+    }
+  } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      // Already closed or errored — nothing left to release.
+    }
+    try {
+      reader.releaseLock()
+    } catch {
+      // ignore
+    }
   }
+}
 
-  // Flush remaining decoder state
-  buf += decoder.decode()
-  if (buf.length > 0) {
-    processSaxBuffer(buf, handlers, true)
+/**
+ * How much text may pile up at the end of a chunk before the streaming
+ * parser flushes it instead of carrying it into the next chunk.
+ *
+ * The carried remainder is re-copied on every chunk, so a single text run
+ * that spans the whole document costs O(n²): measured, one 32 MiB run took
+ * 25 s against 0.4 s for 4 MiB. Flushing bounds the remainder and makes it
+ * linear.
+ *
+ * 256 KiB is well past any legitimate single text node in a spreadsheet
+ * part (an Excel cell tops out at 32,767 characters), so ordinary
+ * documents still see exactly one `onText` call per run and nothing about
+ * their parse changes.
+ */
+export const SAX_TEXT_FLUSH_CHARS = 256 * 1024
+
+/** Longest run treated as a possibly-incomplete entity reference (`&#x1F600;` is 9). */
+const MAX_ENTITY_CHARS = 64
+
+/**
+ * Largest index in `[from, to)` at which a text run can be cut without
+ * corrupting it: never inside an entity reference, never between the two
+ * halves of a surrogate pair. Returns `from` when no safe cut exists.
+ */
+function safeTextSplit(buf: string, from: number, to: number): number {
+  let cut = to
+  // An unterminated '&' near the end may be the start of an entity that
+  // continues in the next chunk — hold it back. Beyond MAX_ENTITY_CHARS it
+  // cannot be one, and backing off forever would restore the O(n²) we're
+  // fixing.
+  const amp = buf.lastIndexOf("&", cut - 1)
+  if (amp >= from && to - amp <= MAX_ENTITY_CHARS && buf.indexOf(";", amp) === -1) {
+    cut = amp
   }
+  const last = cut > from ? buf.charCodeAt(cut - 1) : 0
+  if (last >= 0xd800 && last <= 0xdbff) cut-- // don't orphan a high surrogate
+  return cut > from ? cut : from
 }
 
 /**
@@ -408,7 +471,16 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
     while (i < len && buf.charCodeAt(i) !== 60 /* < */) i++
 
     if (i >= len && !final) {
-      // Text might continue in next chunk — hold it
+      // Text might continue in the next chunk — hold it. A run longer than
+      // SAX_TEXT_FLUSH_CHARS would be re-copied on every chunk from here on
+      // (quadratic), so flush what is safe to emit and keep only the tail.
+      if (len - textStart > SAX_TEXT_FLUSH_CHARS) {
+        const cut = safeTextSplit(buf, textStart, len)
+        if (cut > textStart) {
+          handlers.onText?.(decodeEntities(buf.slice(textStart, cut)))
+          return buf.slice(cut)
+        }
+      }
       return buf.slice(textStart)
     }
 

--- a/src/zip/byte-limit.ts
+++ b/src/zip/byte-limit.ts
@@ -1,0 +1,35 @@
+// ── Decompressed-size ceiling for streaming ZIP paths ────────────────
+//
+// The buffered decompressors count bytes as they go and stop at
+// `MAX_DECOMPRESSED_BYTES` (or the entry's declared uncompressed size,
+// whichever is smaller). The streaming paths hand a native
+// `DecompressionStream` straight to the consumer, which counts nothing —
+// so the exact same zip bomb that the buffered reader rejects expanded
+// without limit as soon as the caller used a stream. This transform puts
+// the two paths back on the same footing.
+//
+// The check has to be on the running total, not on each chunk: a bomb
+// arrives as an endless sequence of perfectly ordinary 64 KiB chunks.
+
+import { ZipError } from "../errors"
+
+/**
+ * A pass-through {@link TransformStream} that errors the stream once more
+ * than `maxBytes` decompressed bytes have flowed through it. Erroring
+ * (rather than truncating) means the consumer sees a typed
+ * {@link ZipError} instead of a silently short read.
+ */
+export function byteLimitStream(maxBytes: number): TransformStream<Uint8Array, Uint8Array> {
+  let total = 0
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      total += chunk.length
+      if (total > maxBytes) {
+        throw new ZipError(
+          `Decompressed size exceeds limit of ${maxBytes} bytes (possible zip bomb)`,
+        )
+      }
+      controller.enqueue(chunk)
+    },
+  })
+}

--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -4,6 +4,7 @@
 
 import { ZipError } from "../errors"
 import { MAX_DECOMPRESSED_BYTES } from "../limits"
+import { byteLimitStream } from "./byte-limit"
 import { crc32, inflate } from "./deflate"
 
 // ── ZIP Signatures ──────────────────────────────────────────────────
@@ -63,9 +64,13 @@ async function decompressDeflateRaw(
       const writer = ds.writable.getWriter()
       const reader = ds.readable.getReader()
 
-      // Write data and close
-      writer.write(data as unknown as BufferSource)
-      writer.close()
+      // Write data and close. Both promises are deliberately not awaited
+      // (awaiting the write before reading would deadlock on backpressure),
+      // but they must still be handled: when the size cap below cancels the
+      // reader, they reject with AbortError, and an unhandled rejection
+      // takes the whole process down instead of surfacing the ZipError.
+      void writer.write(data as unknown as BufferSource).catch(() => {})
+      void writer.close().catch(() => {})
 
       // Read all chunks
       const chunks: Uint8Array[] = []
@@ -519,6 +524,15 @@ export class ZipReader {
         })
       }
 
+      // Bound the output by the declared uncompressed size (when present)
+      // and the absolute cap — exactly what the buffered path does. Without
+      // it the native DecompressionStream below happily expanded a bomb the
+      // buffered reader rejects.
+      const declaredCap =
+        entry.uncompressedSize > 0
+          ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
+          : MAX_DECOMPRESSED_BYTES
+
       if (checkDecompressionStream()) {
         const inputStream = new ReadableStream({
           start(controller) {
@@ -526,16 +540,14 @@ export class ZipReader {
             controller.close()
           },
         })
-        return inputStream.pipeThrough(
-          new DecompressionStream("deflate-raw"),
-        ) as ReadableStream<Uint8Array>
+        return (
+          inputStream.pipeThrough(
+            new DecompressionStream("deflate-raw"),
+          ) as ReadableStream<Uint8Array>
+        ).pipeThrough(byteLimitStream(declaredCap))
       }
 
       // Fallback: inflate synchronously and emit as stream
-      const declaredCap =
-        entry.uncompressedSize > 0
-          ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
-          : MAX_DECOMPRESSED_BYTES
       const inflated = inflate(compressedData, declaredCap)
       return new ReadableStream<Uint8Array>({
         start(controller) {

--- a/src/zip/stream-reader.ts
+++ b/src/zip/stream-reader.ts
@@ -16,9 +16,10 @@
 // recover the bytes consumed so far via {@link ZipStreamReader.drainToBuffer}
 // and fall back to the random-access {@link ZipReader}.
 
+import { byteLimitStream } from "./byte-limit"
 import { inflate } from "./deflate"
-import { ZipError } from "../errors"
-import { MAX_DECOMPRESSED_BYTES } from "../limits"
+import { ParseError, ZipError } from "../errors"
+import { MAX_DECOMPRESSED_BYTES, MAX_INPUT_BYTES } from "../limits"
 
 const SIG_LOCAL_FILE = 0x04034b50
 const SIG_CENTRAL_DIR = 0x02014b50
@@ -222,13 +223,22 @@ export class ZipStreamReader {
       },
     })
     if (entry.compressionMethod === 0) return raw
+    // Same ceiling on both branches: the declared uncompressed size when the
+    // header states one, the absolute cap otherwise. The native path used to
+    // enforce neither, so a bomb streamed out unbounded.
+    const cap =
+      entry.uncompressedSize > 0
+        ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
+        : MAX_DECOMPRESSED_BYTES
     if (checkDecompressionStream()) {
-      return raw.pipeThrough(
-        new DecompressionStream("deflate-raw") as unknown as ReadableWritablePair<
-          Uint8Array,
-          Uint8Array
-        >,
-      ) as ReadableStream<Uint8Array>
+      return (
+        raw.pipeThrough(
+          new DecompressionStream("deflate-raw") as unknown as ReadableWritablePair<
+            Uint8Array,
+            Uint8Array
+          >,
+        ) as ReadableStream<Uint8Array>
+      ).pipeThrough(byteLimitStream(cap))
     }
     // No DecompressionStream — buffer the compressed body and inflate once.
     return new ReadableStream<Uint8Array>({
@@ -240,10 +250,6 @@ export class ZipStreamReader {
           if (done) break
           if (value) chunks.push(value)
         }
-        const cap =
-          entry.uncompressedSize > 0
-            ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
-            : MAX_DECOMPRESSED_BYTES
         controller.enqueue(inflate(concat(chunks), cap))
         controller.close()
       },
@@ -255,26 +261,54 @@ export class ZipStreamReader {
    * rest of the source) so the caller can fall back to a random-access
    * reader. Only valid while the fallback log is intact (before
    * {@link entryStream} has been called).
+   *
+   * Buffering is bounded by `maxBytes` (default {@link MAX_INPUT_BYTES}):
+   * this is the one place the streaming reader gives up on streaming and
+   * holds the whole archive, so it needs the same ceiling as the buffered
+   * entry points.
    */
-  async drainToBuffer(): Promise<Uint8Array> {
+  async drainToBuffer(maxBytes: number = MAX_INPUT_BYTES): Promise<Uint8Array> {
     if (!this.fallbackLog) {
       throw new ZipError("ZipStreamReader: cannot fall back after streaming started")
     }
+    const cap = Number.isFinite(maxBytes) && maxBytes > 0 ? maxBytes : MAX_INPUT_BYTES
     const chunks = this.fallbackLog
     this.fallbackLog = null
+    let total = 0
+    for (const c of chunks) total += c.length
     // Pull whatever remains from the source (stop logging — we own `chunks`).
     for (;;) {
       const { value, done } = await this.reader.read()
       if (done) break
-      if (value) chunks.push(value)
+      if (value) {
+        total += value.length
+        if (total > cap) {
+          throw new ParseError(
+            `Input stream exceeds the maximum of ${cap} bytes. ` +
+              "Raise `maxInputBytes` if the file really is this large.",
+          )
+        }
+        chunks.push(value)
+      }
     }
     return concat(chunks)
   }
 
-  /** Release the underlying reader lock. */
+  /**
+   * Cancel the source and release the underlying reader lock. Safe to call
+   * more than once, and on an already-exhausted stream. Callers must invoke
+   * it when they abandon the reader (an error mid-parse, most commonly),
+   * otherwise the source stays locked and whatever backs it — a socket, a
+   * file handle — is never released.
+   */
   async close(): Promise<void> {
     try {
       await this.reader.cancel()
+    } catch {
+      // ignore
+    }
+    try {
+      this.reader.releaseLock()
     } catch {
       // ignore
     }

--- a/test/stream-limits.test.ts
+++ b/test/stream-limits.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { ZipReader } from "../src/zip/reader"
+import { ZipStreamReader } from "../src/zip/stream-reader"
+import { readXlsx } from "../src/xlsx/reader"
+import { streamXlsxRows } from "../src/xlsx/stream-reader"
+import { readXls } from "../src/xls/reader"
+import { writeCfb } from "../src/xlsx/crypto/cfb"
+import { parseSaxStream } from "../src/xml/parser"
+import { bufferReadableStream } from "../src/_input"
+import { ParseError, XmlError, ZipError } from "../src/errors"
+import { MAX_INPUT_BYTES } from "../src/limits"
+
+const enc = new TextEncoder()
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+async function xlsxWithSheetData(sheetData: string): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  zip.add(
+    "[Content_Types].xml",
+    enc.encode(
+      `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+        `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+        `<Default Extension="xml" ContentType="application/xml"/>` +
+        `<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>` +
+        `<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>` +
+        `</Types>`,
+    ),
+  )
+  zip.add(
+    "_rels/.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/workbook.xml",
+    enc.encode(
+      `<?xml version="1.0"?><workbook ${NS} ${R}><sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets></workbook>`,
+    ),
+  )
+  zip.add(
+    "xl/_rels/workbook.xml.rels",
+    enc.encode(
+      `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">` +
+        `<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`,
+    ),
+  )
+  zip.add(
+    "xl/worksheets/sheet1.xml",
+    enc.encode(
+      `<?xml version="1.0"?><worksheet ${NS} ${R}><sheetData>${sheetData}</sheetData></worksheet>`,
+    ),
+  )
+  return zip.build()
+}
+
+/** A stream that hands out `bytes` in `chunk`-sized pieces and records cancellation. */
+function streamOf(bytes: Uint8Array, chunk = 4096): ReadableStream<Uint8Array> {
+  let pos = 0
+  return new ReadableStream<Uint8Array>({
+    pull(c) {
+      if (pos >= bytes.length) {
+        c.close()
+        return
+      }
+      c.enqueue(bytes.subarray(pos, pos + chunk))
+      pos += chunk
+    },
+  })
+}
+
+/**
+ * A stream of `totalMiB` MiB in 64 KiB pieces, tracking how much was
+ * actually pulled and whether it was cancelled.
+ *
+ * Deliberately finite: the real-world shape is an unbounded `response.body`,
+ * but a test that never ends would hang CI on regression instead of failing
+ * it. Anything past the cap is still never pulled, which is the property
+ * being asserted.
+ */
+function boundedStream(totalMiB: number): {
+  stream: ReadableStream<Uint8Array>
+  pulled: () => number
+  cancelled: () => boolean
+} {
+  const chunk = 64 * 1024
+  const chunks = (totalMiB * 1024 * 1024) / chunk
+  let sent = 0
+  let cancelled = false
+  const stream = new ReadableStream<Uint8Array>({
+    pull(c) {
+      if (sent >= chunks) {
+        c.close()
+        return
+      }
+      sent++
+      c.enqueue(new Uint8Array(chunk))
+    },
+    cancel() {
+      cancelled = true
+    },
+  })
+  return { stream, pulled: () => sent * chunk, cancelled: () => cancelled }
+}
+
+/**
+ * A ZIP holding one DEFLATE entry that really expands to `realBytes` while
+ * its headers claim `claimedBytes` — the shape of every zip bomb.
+ */
+async function lyingZip(realBytes: number, claimedBytes: number): Promise<Uint8Array> {
+  const w = new ZipWriter()
+  w.add("big.bin", new Uint8Array(realBytes))
+  const zip = await w.build()
+  const v = new DataView(zip.buffer, zip.byteOffset, zip.byteLength)
+  v.setUint32(22, claimedBytes, true) // local file header
+  for (let i = 0; i + 46 <= zip.length; i++) {
+    if (v.getUint32(i, true) === 0x02014b50) v.setUint32(i + 24, claimedBytes, true)
+  }
+  return zip
+}
+
+/**
+ * Buffer a stream and report only how many bytes came back. Returning the
+ * buffer itself would make a *failing* assertion try to pretty-print a
+ * multi-megabyte typed array, which OOMs the worker and hides the failure.
+ */
+async function bufferedLength(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes?: number,
+): Promise<number> {
+  return (await bufferReadableStream(stream, maxBytes)).length
+}
+
+async function drainStream(stream: ReadableStream<Uint8Array>): Promise<number> {
+  const r = stream.getReader()
+  let total = 0
+  for (;;) {
+    const { done, value } = await r.read()
+    if (done) break
+    total += value!.length
+  }
+  return total
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// #363, batch 3 — the remaining unbounded paths: input buffering, the two
+// native DecompressionStream paths, an argument-spread loop bound, and two
+// stream readers that were never released. Each test asserts *completion*
+// or a *typed throw*, never a value, because the failure mode is a hang, an
+// OOM, or a raw RangeError.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("input stream size ceiling", () => {
+  it("stops a stream past the cap instead of buffering until the process dies", async () => {
+    // Uncapped, a stream that keeps yielding is buffered forever: a probe
+    // fed 72 GiB in 90 s without the reader complaining once.
+    const { stream } = boundedStream(16)
+    await expect(bufferedLength(stream, 1 << 20)).rejects.toThrow(ParseError)
+  }, 20_000)
+
+  it("cancels the source it gave up on, without draining it first", async () => {
+    const { stream, pulled, cancelled } = boundedStream(16)
+    await expect(bufferedLength(stream, 1 << 20)).rejects.toThrow(
+      /exceeds the maximum of 1048576 bytes/,
+    )
+    expect(cancelled()).toBe(true)
+    expect(pulled()).toBeLessThan(4 * 1024 * 1024)
+  }, 20_000)
+
+  it("releases the reader after a successful read", async () => {
+    // The final copy used to run outside any try/finally, so a throw there
+    // left the source locked for the life of the process.
+    const stream = streamOf(new Uint8Array(10_000))
+    const out = await bufferReadableStream(stream)
+    expect(out.length).toBe(10_000)
+    expect(stream.locked).toBe(false)
+  }, 20_000)
+
+  it("is reachable from a reader entry point via maxInputBytes", async () => {
+    const bytes = await xlsxWithSheetData(
+      `<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c></row>`,
+    )
+    await expect(readXlsx(streamOf(bytes), { maxInputBytes: 64 })).rejects.toThrow(ParseError)
+  }, 20_000)
+
+  it("still reads a stream that fits under the cap", async () => {
+    const bytes = await xlsxWithSheetData(
+      `<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c></row>`,
+    )
+    const workbook = await readXlsx(streamOf(bytes))
+    expect(workbook.sheets[0].rows[0][0]).toBe("a")
+  }, 20_000)
+
+  it("leaves room for real files", () => {
+    // A cap that rejects legitimate input is itself the bug: the biggest
+    // real-world workbooks are tens of MB.
+    expect(MAX_INPUT_BYTES).toBeGreaterThanOrEqual(256 * 1024 * 1024)
+  })
+})
+
+describe("zip bomb ceiling on the streaming decompression paths", () => {
+  // 8 MiB of zeros against a 4 KiB declaration — 2000x, from a 8 KiB archive.
+  const REAL = 8 * 1024 * 1024
+  const CLAIMED = 4096
+
+  it("stops ZipReader.extractStream, like the buffered path already did", async () => {
+    const zip = await lyingZip(REAL, CLAIMED)
+    await expect(new ZipReader(zip).extract("big.bin")).rejects.toThrow(ZipError)
+    await expect(drainStream(new ZipReader(zip).extractStream("big.bin"))).rejects.toThrow(ZipError)
+  }, 30_000)
+
+  it("stops ZipStreamReader.entryStream", async () => {
+    const zip = await lyingZip(REAL, CLAIMED)
+    const zr = new ZipStreamReader(streamOf(zip, 1 << 16))
+    const entry = await zr.nextEntry()
+    expect(entry?.name).toBe("big.bin")
+    await expect(drainStream(zr.entryStream(entry!))).rejects.toThrow(
+      /Decompressed size exceeds limit/,
+    )
+  }, 30_000)
+
+  it("still streams an honest entry end to end", async () => {
+    const w = new ZipWriter()
+    w.add("ok.txt", enc.encode("hello ".repeat(50_000)))
+    const zip = await w.build()
+    expect(await drainStream(new ZipReader(zip).extractStream("ok.txt"))).toBe(300_000)
+
+    const zr = new ZipStreamReader(streamOf(zip, 1 << 16))
+    const entry = await zr.nextEntry()
+    expect(await drainStream(zr.entryStream(entry!))).toBe(300_000)
+  }, 30_000)
+})
+
+describe("XLS shared string table size", () => {
+  // Minimal BIFF8 builder — just enough globals for a big SST.
+  const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff]
+  const u32 = (n: number): number[] => [
+    n & 0xff,
+    (n >> 8) & 0xff,
+    (n >> 16) & 0xff,
+    (n >>> 24) & 0xff,
+  ]
+  const rec = (sid: number, data: number[]): number[] => [...u16(sid), ...u16(data.length), ...data]
+  const bof = (dt: number): number[] =>
+    rec(0x0809, [...u16(0x0600), ...u16(dt), ...u16(0), ...u16(0), ...u32(0), ...u32(0)])
+  const eof = (): number[] => rec(0x000a, [])
+
+  /** SST + CONTINUE records holding `count` one-character strings. */
+  function sstRecords(count: number): number[] {
+    const out: number[] = []
+    let body: number[] = [...u32(count), ...u32(count)]
+    let budget = 8224 - body.length
+    let first = true
+    for (let i = 0; i < count; i++) {
+      if (budget < 4) {
+        out.push(...rec(first ? 0x00fc : 0x003c, body))
+        first = false
+        body = []
+        budget = 8224
+      }
+      body.push(...u16(1), 0, 97 + (i % 26))
+      budget -= 4
+    }
+    if (body.length > 0) out.push(...rec(first ? 0x00fc : 0x003c, body))
+    return out
+  }
+
+  function xlsWithSharedStrings(count: number): Uint8Array {
+    const sheet = [...bof(0x0010), ...eof()]
+    const globals = (sheetPos: number): number[] => [
+      ...bof(0x0005),
+      ...sstRecords(count),
+      ...rec(0x0085, [...u32(sheetPos), 0, 0, 6, 0, ...[..."Sheet1"].map((c) => c.charCodeAt(0))]),
+      ...eof(),
+    ]
+    const stream = [...globals(globals(0).length), ...sheet]
+    return writeCfb([{ name: "Workbook", data: new Uint8Array(stream) }])
+  }
+
+  it("reads a workbook with more shared strings than fit in an argument list", async () => {
+    // `sst.push(...parseSst(blocks))` overflows the call stack somewhere
+    // above 100k strings, and the RangeError was reported as "malformed or
+    // truncated" — a valid file rejected with a misleading message.
+    const workbook = await readXls(xlsWithSharedStrings(200_000))
+    expect(workbook.sheets).toHaveLength(1)
+  }, 30_000)
+
+  it("still reads a small shared string table", async () => {
+    const workbook = await readXls(xlsWithSharedStrings(10))
+    expect(workbook.sheets[0].name).toBe("Sheet1")
+  }, 20_000)
+})
+
+describe("parseSaxStream cleanup", () => {
+  it("cancels the source when a handler throws", async () => {
+    // The XLSX row parser aborts by throwing out of a handler, which left
+    // the ZIP/decompression stream underneath locked forever.
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode("<root><a/><b/>"))
+        c.enqueue(enc.encode("<c/></root>"))
+        c.close()
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+
+    await expect(
+      parseSaxStream(stream, {
+        onOpenTag(tag) {
+          if (tag === "b") throw new XmlError("handler abort")
+        },
+      }),
+    ).rejects.toThrow(XmlError)
+    expect(stream.locked).toBe(false)
+    expect(cancelled).toBe(true)
+  }, 20_000)
+
+  it("releases the reader on a clean parse too", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode("<root>ok</root>"))
+        c.close()
+      },
+    })
+    await parseSaxStream(stream, {})
+    expect(stream.locked).toBe(false)
+  }, 20_000)
+
+  it("parses one very long text run in linear time", async () => {
+    // Carrying the run across chunks re-copied it every time: 4 MiB took
+    // 0.4 s, 32 MiB took 25 s. The assertion is completion inside the
+    // timeout — this input took ~1 s after the fix and over a minute
+    // before it, so a regression to O(n^2) blows straight through.
+    const size = 48 * 1024 * 1024
+    const bytes = enc.encode(`<r>${"x".repeat(size)}</r>`)
+    let chars = 0
+    await parseSaxStream(streamOf(bytes, 64 * 1024), {
+      onText: (t) => {
+        chars += t.length
+      },
+    })
+    expect(chars).toBe(size)
+  }, 20_000)
+
+  it("never splits a long run inside an entity or a surrogate pair", async () => {
+    const pad = "a".repeat(400_000)
+    const xml = `<r>${pad}&amp;${pad}&lt;t&gt;${"&amp;".repeat(20_000)}\u{1F600}</r>`
+    let out = ""
+    await parseSaxStream(streamOf(enc.encode(xml), 64 * 1024), {
+      onText: (t) => {
+        out += t
+      },
+    })
+    expect(out).toBe(`${pad}&${pad}<t>${"&".repeat(20_000)}\u{1F600}`)
+  }, 20_000)
+
+  it("delivers ordinary text in a single callback", async () => {
+    const calls: string[] = []
+    await parseSaxStream(streamOf(enc.encode("<r>hello &amp; goodbye</r>")), {
+      onText: (t) => calls.push(t),
+    })
+    expect(calls).toEqual(["hello & goodbye"])
+  }, 20_000)
+})
+
+describe("ZipStreamReader release on failure", () => {
+  it("cancels the source when streaming XLSX fails mid-archive", async () => {
+    // ZipStreamReader.close() existed but nothing called it, so an error in
+    // prepareStreaming left the source locked with the archive half-read.
+    const w = new ZipWriter()
+    w.add("[Content_Types].xml", enc.encode("<Types><Default></Wrong></Types>"))
+    w.add("_rels/.rels", enc.encode("<Relationships/>"))
+    w.add("xl/worksheets/sheet1.xml", enc.encode("<worksheet><sheetData/></worksheet>"))
+    // Incompressible tail so the source still has bytes left when we bail.
+    w.add("xl/tail.bin", new Uint8Array(512 * 1024), { compress: false })
+    const bytes = await w.build()
+
+    let cancelled = false
+    let pos = 0
+    const stream = new ReadableStream<Uint8Array>({
+      pull(c) {
+        if (pos >= bytes.length) {
+          c.close()
+          return
+        }
+        c.enqueue(bytes.subarray(pos, pos + 4096))
+        pos += 4096
+      },
+      cancel() {
+        cancelled = true
+      },
+    })
+
+    const drain = async (): Promise<void> => {
+      for await (const _ of streamXlsxRows(stream)) {
+        // consume
+      }
+    }
+    await expect(drain()).rejects.toThrow(XmlError)
+    expect(cancelled).toBe(true)
+    expect(stream.locked).toBe(false)
+    expect(pos).toBeLessThan(bytes.length)
+  }, 20_000)
+})


### PR DESCRIPTION
Closes #363. Part of #352. Third and final batch, after #368 and #369.

Every item below was reproduced before being fixed, and **every new test was run against the unfixed sources** — 10 of the 17 fail there, including the long-text case, which times out at 58 s against its 20 s limit.

## 1. No input-size ceiling

`bufferReadableStream` accepted **72 GiB in 90 s** without complaint. Every format entry point funnels through it, so `read(response.body)` OOMs long before the ZIP layer's cap applies.

`MAX_INPUT_BYTES` (1 GiB), checked against the **running total** — the individual chunks are tiny, so a per-chunk check would never fire — with a `ParseError` pointing at the new `ReadOptions.maxInputBytes`, threaded through `read`, `readXlsx`, `readOds`, `readXlsb`, and `readXls`. The missing `finally` that cancels and releases the reader is added.

The same ceiling now applies to `ZipStreamReader.drainToBuffer`, the one place the *streaming* XLSX reader gives up and buffers the whole archive — it had the identical hole.

## 2. The zip-bomb cap covered 3 of 4 paths

An 8 KiB archive declaring 4 KiB uncompressed: the buffered `extract` threw `ZipError`, while `ZipReader.extractStream` and `ZipStreamReader.entryStream` both delivered the full **8 MiB — 2000×** the declared size. Those are the paths a large-file user actually hits.

A counting `TransformStream` (`src/zip/byte-limit.ts`) now enforces the same declared-size and absolute caps on both native paths. All three throw the identical `ZipError`; honest entries still stream.

**Bonus bug found while testing this.** Tripping the cap on the *buffered* path raised an unhandled `AbortError` from `decompressDeflateRaw`'s floating `writer.write` / `writer.close`, which **killed the process** instead of surfacing the `ZipError`. It crashed the probe and showed up as an unhandled error in vitest. Both promises are handled now.

## 3. A valid large .xls was rejected with a misleading message

`sst.push(...parseSst(blocks))`. 120k shared strings read fine; 200k threw `RangeError: Maximum call stack size exceeded`, which the upstream catch reported as `Failed to parse XLS workbook (malformed or truncated)`. Replaced with a loop — the same 200k-string workbook now reads in 180 ms.

## 4. `parseSaxStream` — both halves reproduced

A throwing handler (which `processCell` does by design) left `cancel()` uncalled and the stream locked. Now wrapped in `try/finally`.

The O(n²) was real and steep — single text runs of 4/8/16/32 MiB took **0.42 / 1.8 / 6.4 / 25.5 s**. Runs past 256 KiB are now flushed instead of carried, with cuts that never land inside an entity reference or a surrogate pair (verified against entity-dense, emoji, and degenerate `&&&&` inputs). 32 MiB is now **0.3 s**, scaling linearly. Text under 256 KiB is still delivered in exactly one `onText` call, so the only in-repo consumer is unaffected; `SaxHandlers.onText` documents this.

**Deliberately not changed:** the same quadratic re-scan exists for a single unterminated tag, comment, or CDATA. Bounding those means *rejecting* input rather than splitting it, and no threshold could be picked with confidence that it never rejects a legitimate part. Left alone rather than guessed at.

## 5. `ZipStreamReader.close()` was never called

An XML error inside `prepareStreaming` left `cancel()` uncalled and `stream.locked === true`, with only 8 KiB of a 1 MB archive consumed. Now closed on any throw out of the loop; `close()` also releases the lock.

## Verification

17 tests in `test/stream-limits.test.ts`, asserting completion or a typed throw, using a **finite** oversized stream so a regression fails rather than hangs CI, and returning byte counts rather than buffers (asserting on a 16 MiB `Uint8Array` OOMs vitest's pretty-printer on failure).

Full suite **8,028 tests / 123 files** green; lint, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
