### PR TITLE
refactor!: make headerRow mean one thing, drop inert ReadOptions — #365

### DIFF
--- a/src/_schema.ts
+++ b/src/_schema.ts
@@ -22,16 +22,42 @@ import { serialToDate, parseDate } from "./_date"
  * @param options - Validation options
  * @returns Object with validated data and any errors
  */
+/**
+ * Options for {@link validateWithSchema}.
+ *
+ * Named and exported rather than inline so callers can build one in a
+ * typed variable — it was an anonymous object type.
+ */
+export interface SchemaValidateOptions {
+  /**
+   * 0-based index of the header row, or `-1` when the rows carry no
+   * header at all (schemas keyed by `columnIndex`). Default: 0.
+   *
+   * This was 1-based until v1 — the only place in the library that was.
+   * Every other `headerRow`, on the `*Objects` readers, `sheetToObjects`
+   * and the JSON exporters, is 0-based, and one option name meaning two
+   * different things is an off-by-one that only surfaces in user data.
+   *
+   * Two migrations, both mechanical:
+   * - `headerRow: N` for N >= 1 becomes `N - 1`. The default still means
+   *   the first row, so code relying on it is unaffected.
+   * - `headerRow: 0`, which used to mean "no header row", becomes `-1`.
+   *   The two concepts were conflated by the old 1-based numbering; they
+   *   are now distinct.
+   */
+  headerRow?: number
+  /** Skip rows where every cell is null or empty. Default: false. */
+  skipEmptyRows?: boolean
+  /** Collect errors alongside the data, or throw on the first. Default: "collect". */
+  errorMode?: "collect" | "throw"
+}
+
 export function validateWithSchema<T extends Record<string, unknown> = Record<string, unknown>>(
   rows: CellValue[][],
   schema: SchemaDefinition,
-  options?: {
-    headerRow?: number
-    skipEmptyRows?: boolean
-    errorMode?: "collect" | "throw"
-  },
+  options?: SchemaValidateOptions,
 ): { data: T[]; errors: SchemaValidationIssue[] } {
-  const headerRowNum = options?.headerRow ?? 1
+  const headerRowIndex = options?.headerRow ?? 0
   const skipEmptyRows = options?.skipEmptyRows ?? false
   const errorMode = options?.errorMode ?? "collect"
 
@@ -49,8 +75,7 @@ export function validateWithSchema<T extends Record<string, unknown> = Record<st
 
   // ── Step 1: Build column index mapping ──────────────────────────
 
-  // Extract headers from the header row (0-based index)
-  const headerRowIndex = headerRowNum - 1
+  // Extract headers from the header row
   const headerRow = headerRowIndex >= 0 && headerRowIndex < rows.length ? rows[headerRowIndex]! : []
 
   // Build a map: normalized header name → column index

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1293,6 +1293,27 @@ export interface SheetFilterInfo {
  */
 export type SheetFilter = (info: SheetFilterInfo, index: number) => boolean
 
+/**
+ * Options accepted by every reader.
+ *
+ * Support is not uniform, and the type cannot express that — so it is
+ * stated here rather than left for a caller to discover:
+ *
+ * | option       | xlsx | ods | xlsb | xls |
+ * | ------------ | ---- | --- | ---- | --- |
+ * | `sheets`     | yes  | yes | no   | no  |
+ * | `dateSystem` | yes  | no  | yes  | yes |
+ * | `readStyles` | yes  | yes | no   | no  |
+ * | `password`   | yes  | no  | yes  | no  |
+ * | `maxRows`    | yes  | no  | no   | no  |
+ * | `range`      | yes  | no  | no   | no  |
+ *
+ * `maxInputBytes` applies wherever the input is a `ReadableStream`.
+ *
+ * `headerRow` and `schema` used to live here and were honoured by no
+ * reader at all; they were removed before v1 rather than frozen. Header
+ * selection belongs on the `*Objects` readers, which do implement it.
+ */
 export interface ReadOptions {
   /**
    * Which sheets to read.
@@ -1305,10 +1326,6 @@ export interface ReadOptions {
    * Default: all sheets.
    */
   sheets?: Array<number | string> | SheetFilter
-  /** Which row is the header row (1-based). Default: none */
-  headerRow?: number
-  /** Schema for validation and type coercion */
-  schema?: SchemaDefinition
   /** Date system override. Default: auto-detect from file */
   dateSystem?: "1900" | "1904" | "auto"
   /** Whether to read styles. Default: false (faster without) */

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,7 +296,8 @@ const validateCommand = defineCommand({
     }
 
     const sheet = workbook.sheets[sheetIdx]!
-    const result = validateWithSchema(sheet.rows, schema, { headerRow: 1 })
+    // headerRow is 0-based since v1 — the first row (#365).
+    const result = validateWithSchema(sheet.rows, schema, { headerRow: 0 })
 
     if (result.errors.length === 0) {
       consola.success(`Valid! ${result.data.length} row(s) passed validation.`)

--- a/src/export/html.ts
+++ b/src/export/html.ts
@@ -5,7 +5,15 @@ export interface HtmlExportOptions {
   styles?: boolean
   /** Add CSS classes for cell types (num, bool, date, null). Default: true */
   classes?: boolean
-  /** Use first row as <thead>. Default: false */
+  /**
+   * Treat the first row as the table header (`<thead>`). Default: false.
+   *
+   * Renamed from `headerRow`, which elsewhere in the library is a 0-based
+   * row *index*. One name meaning both "which row" and "is there one"
+   * was the sharpest edge in the option set. See #365.
+   */
+  hasHeaderRow?: boolean
+  /** @deprecated Renamed to {@link HtmlExportOptions.hasHeaderRow}. */
   headerRow?: boolean
   /** Custom CSS class prefix. Default: "hucre" */
   classPrefix?: string
@@ -171,12 +179,23 @@ function buildMergeMap(
 /**
  * Export a sheet as an HTML <table> string.
  */
+/**
+ * Options after defaults are applied. `headerRow` is absent: it is the
+ * deprecated spelling of `hasHeaderRow` and is folded into it, so the
+ * resolved shape carries one field rather than two that can disagree.
+ */
+type ResolvedHtmlOptions = Required<
+  Omit<HtmlExportOptions, "caption" | "ariaLabel" | "headerRow">
+> &
+  Pick<HtmlExportOptions, "caption" | "ariaLabel">
+
 export function toHtml(sheet: Sheet, options?: HtmlExportOptions): string {
-  const opts: Required<Omit<HtmlExportOptions, "caption" | "ariaLabel">> &
-    Pick<HtmlExportOptions, "caption" | "ariaLabel"> = {
+  const opts: ResolvedHtmlOptions = {
     styles: options?.styles ?? false,
     classes: options?.classes ?? true,
-    headerRow: options?.headerRow ?? false,
+    // Accept the deprecated name for one major so existing calls keep
+    // working. See #365.
+    hasHeaderRow: options?.hasHeaderRow ?? options?.headerRow ?? false,
     classPrefix: options?.classPrefix ?? "hucre",
     includeStyleTag: options?.includeStyleTag ?? false,
     caption: options?.caption,
@@ -186,7 +205,7 @@ export function toHtml(sheet: Sheet, options?: HtmlExportOptions): string {
   const prefix = opts.classPrefix
   const tableAttrs: string[] = []
   if (opts.includeStyleTag) tableAttrs.push(`class="${prefix}-table"`)
-  if (opts.headerRow) tableAttrs.push(`role="table"`)
+  if (opts.hasHeaderRow) tableAttrs.push(`role="table"`)
   if (opts.ariaLabel) tableAttrs.push(`aria-label="${escapeHtml(opts.ariaLabel)}"`)
   const tableAttrStr = tableAttrs.length > 0 ? " " + tableAttrs.join(" ") : ""
 
@@ -215,10 +234,10 @@ export function toHtml(sheet: Sheet, options?: HtmlExportOptions): string {
     parts.push(`<caption>${escapeHtml(opts.caption)}</caption>`)
   }
 
-  const startRow = opts.headerRow ? 1 : 0
+  const startRow = opts.hasHeaderRow ? 1 : 0
 
   // Header row
-  if (opts.headerRow && rows.length > 0) {
+  if (opts.hasHeaderRow && rows.length > 0) {
     parts.push("<thead>")
     parts.push("<tr>")
     const row = rows[0]
@@ -262,8 +281,7 @@ function buildCellAttrs(
   row: number,
   col: number,
   sheet: Sheet,
-  opts: Required<Omit<HtmlExportOptions, "caption" | "ariaLabel">> &
-    Pick<HtmlExportOptions, "caption" | "ariaLabel">,
+  opts: ResolvedHtmlOptions,
   mergeInfo: { colspan?: number; rowspan?: number; hidden?: boolean } | undefined,
 ): string {
   const attrs: string[] = []

--- a/src/export/markdown.ts
+++ b/src/export/markdown.ts
@@ -1,7 +1,14 @@
 import type { Sheet, CellValue } from "../_types"
 
 export interface MarkdownExportOptions {
-  /** Use first row as header. Default: true */
+  /**
+   * Treat the first row as the table header. Default: true.
+   *
+   * Renamed from `headerRow`, which elsewhere in the library is a 0-based
+   * row *index*. See #365.
+   */
+  hasHeaderRow?: boolean
+  /** @deprecated Renamed to {@link MarkdownExportOptions.hasHeaderRow}. */
   headerRow?: boolean
   /** Alignment per column. Default: left for strings, right for numbers */
   alignment?: Array<"left" | "center" | "right">
@@ -85,8 +92,11 @@ function padCell(value: string, width: number, align: "left" | "center" | "right
  * Export a sheet as a Markdown table string.
  */
 export function toMarkdown(sheet: Sheet, options?: MarkdownExportOptions): string {
-  const opts: Required<MarkdownExportOptions> = {
-    headerRow: options?.headerRow ?? true,
+  // `headerRow` is omitted: deprecated spelling of `hasHeaderRow`,
+  // folded into it below.
+  const opts: Required<Omit<MarkdownExportOptions, "headerRow">> = {
+    // Accept the deprecated name for one major. See #365.
+    hasHeaderRow: options?.hasHeaderRow ?? options?.headerRow ?? true,
     alignment: options?.alignment ?? [],
     maxWidth: options?.maxWidth ?? 50,
   }
@@ -112,7 +122,7 @@ export function toMarkdown(sheet: Sheet, options?: MarkdownExportOptions): strin
   })
 
   // Determine the data start row (skip header if headerRow is true)
-  const dataStartRow = opts.headerRow ? 1 : 0
+  const dataStartRow = opts.hasHeaderRow ? 1 : 0
 
   // Determine alignments
   const alignments: Array<"left" | "center" | "right"> = []
@@ -136,7 +146,7 @@ export function toMarkdown(sheet: Sheet, options?: MarkdownExportOptions): strin
 
   const lines: string[] = []
 
-  if (opts.headerRow) {
+  if (opts.hasHeaderRow) {
     // Header row
     const headerCells = formatted[0].map((val, c) => padCell(val, widths[c], alignments[c]))
     lines.push("|" + headerCells.join("|") + "|")

--- a/test/read-options-semantics.test.ts
+++ b/test/read-options-semantics.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+import { validateWithSchema } from "../src/_schema"
+import { toHtml } from "../src/export/html"
+import { toMarkdown } from "../src/export/markdown"
+import type { CellValue, SchemaDefinition, Sheet } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const sheetOf = (rows: CellValue[][]): Sheet => ({ name: "S", rows })
+
+const namedSchema: SchemaDefinition = {
+  name: { column: "Name", type: "string" },
+  price: { column: "Price", type: "number" },
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// #365 — `headerRow` meant four different things across the public
+// options types: 1-based here, 0-based on the *Objects readers and the
+// JSON exporters, and a boolean on the HTML and Markdown exporters. An
+// option name that means two things is an off-by-one that only shows up
+// in someone's data.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("validateWithSchema headerRow is 0-based", () => {
+  const rows: CellValue[][] = [["This is a title row"], ["Name", "Price"], ["Widget", 9.99]]
+
+  it("treats headerRow: 1 as the second row", () => {
+    const { data, errors } = validateWithSchema(rows, namedSchema, { headerRow: 1 })
+    expect(errors).toHaveLength(0)
+    expect(data).toEqual([{ name: "Widget", price: 9.99 }])
+  })
+
+  it("defaults to the first row", () => {
+    const withHeaderFirst: CellValue[][] = [
+      ["Name", "Price"],
+      ["Widget", 9.99],
+    ]
+    // The old default was 1 under 1-based numbering and the new default
+    // is 0 under 0-based — both mean the first row, so callers relying
+    // on the default are unaffected.
+    const { data } = validateWithSchema(withHeaderFirst, namedSchema)
+    expect(data).toEqual([{ name: "Widget", price: 9.99 }])
+  })
+
+  it("uses -1 for rows that carry no header at all", () => {
+    // `0` used to be the "no header row" sentinel, because 1-based
+    // numbering had no other way to say it. The two concepts are
+    // separate now.
+    const byIndex: SchemaDefinition = { val: { columnIndex: 0, type: "string" } }
+    const { data } = validateWithSchema([[42], [7]], byIndex, { headerRow: -1 })
+    expect(data).toEqual([{ val: "42" }, { val: "7" }])
+  })
+
+  it("consumes the first row as a header when headerRow is 0", () => {
+    const byIndex: SchemaDefinition = { val: { columnIndex: 0, type: "string" } }
+    const { data } = validateWithSchema([["Header"], [42]], byIndex, { headerRow: 0 })
+    expect(data).toEqual([{ val: "42" }])
+  })
+})
+
+describe("hasHeaderRow on the exporters", () => {
+  const rows: CellValue[][] = [
+    ["Name", "Qty"],
+    ["Widget", 2],
+  ]
+
+  it("toHtml emits a thead when asked", () => {
+    expect(toHtml(sheetOf(rows), { hasHeaderRow: true })).toContain("<thead>")
+    expect(toHtml(sheetOf(rows), { hasHeaderRow: false })).not.toContain("<thead>")
+  })
+
+  it("toMarkdown uses the first row as the header when asked", () => {
+    // Markdown tables always carry a separator row, so the flag shows up
+    // in *what* the header is: the real first row, or a generated 1/2/3.
+    expect(toMarkdown(sheetOf(rows), { hasHeaderRow: true })).toContain("| Name")
+    expect(toMarkdown(sheetOf(rows), { hasHeaderRow: false })).toContain("| 1 ")
+  })
+
+  it("still accepts the deprecated headerRow spelling", () => {
+    // Renamed rather than removed, so existing calls keep working for
+    // one major.
+    expect(toHtml(sheetOf(rows), { headerRow: true })).toContain("<thead>")
+    expect(toMarkdown(sheetOf(rows), { headerRow: false })).toContain("| 1 ")
+  })
+
+  it("prefers the new spelling when both are given", () => {
+    expect(toHtml(sheetOf(rows), { hasHeaderRow: true, headerRow: false })).toContain("<thead>")
+  })
+
+  it("keeps its own default when neither is given", () => {
+    // HTML defaults to false, Markdown to true — unchanged.
+    expect(toHtml(sheetOf(rows))).not.toContain("<thead>")
+    expect(toMarkdown(sheetOf(rows))).toContain("| Name")
+  })
+})

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -90,14 +90,15 @@ describe("header matching", () => {
     expect(data[0]!.price).toBeNull()
   })
 
-  it("should use header row at different position (headerRow: 2)", () => {
+  it("should use header row at a different position", () => {
     const rows: CellValue[][] = [["This is a title row"], ["Name", "Price"], ["Widget", 9.99]]
     const schema: SchemaDefinition = {
       name: { column: "Name", type: "string" },
       price: { column: "Price", type: "number" },
     }
+    // 0-based since v1: the second row. See #365.
     const { data, errors } = validateWithSchema(rows, schema, {
-      headerRow: 2,
+      headerRow: 1,
     })
     expect(errors).toHaveLength(0)
     expect(data).toEqual([{ name: "Widget", price: 9.99 }])
@@ -112,29 +113,29 @@ describe("type coercion — string", () => {
   })
 
   it("should convert number to string: 42 → '42'", () => {
-    const { data } = validateWithSchema([[42]], mkSchema(), { headerRow: 0 })
+    const { data } = validateWithSchema([[42]], mkSchema(), { headerRow: -1 })
     expect(data[0]!.val).toBe("42")
   })
 
   it("should convert boolean to string: true → 'true'", () => {
-    const { data } = validateWithSchema([[true]], mkSchema(), { headerRow: 0 })
+    const { data } = validateWithSchema([[true]], mkSchema(), { headerRow: -1 })
     expect(data[0]!.val).toBe("true")
   })
 
   it("should convert Date to ISO string", () => {
     const d = new Date(Date.UTC(2024, 0, 15))
-    const { data } = validateWithSchema([[d]], mkSchema(), { headerRow: 0 })
+    const { data } = validateWithSchema([[d]], mkSchema(), { headerRow: -1 })
     expect(data[0]!.val).toBe(d.toISOString())
   })
 
   it("should convert null to null (empty string → null since isEmpty)", () => {
-    const { data } = validateWithSchema([[null]], mkSchema(), { headerRow: 0 })
+    const { data } = validateWithSchema([[null]], mkSchema(), { headerRow: -1 })
     expect(data[0]!.val).toBeNull()
   })
 
   it("should keep string as-is but trim", () => {
     const { data } = validateWithSchema([["  hello  "]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.val).toBe("hello")
   })
@@ -149,7 +150,7 @@ describe("type coercion — number", () => {
 
   it('should convert string "42" → 42', () => {
     const { data, errors } = validateWithSchema([["42"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBe(42)
@@ -157,21 +158,21 @@ describe("type coercion — number", () => {
 
   it('should convert string "3.14" → 3.14', () => {
     const { data } = validateWithSchema([["3.14"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.val).toBe(3.14)
   })
 
   it('should convert string "-10" → -10', () => {
     const { data } = validateWithSchema([["-10"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.val).toBe(-10)
   })
 
   it('should error on string "abc"', () => {
     const { errors } = validateWithSchema([["abc"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Expected number")
@@ -180,7 +181,7 @@ describe("type coercion — number", () => {
 
   it("should return null for empty string (not required)", () => {
     const { data, errors } = validateWithSchema([[""]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBeNull()
@@ -192,7 +193,7 @@ describe("type coercion — number", () => {
       b: { columnIndex: 1, type: "number" },
     }
     const { data } = validateWithSchema([[true, false]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.a).toBe(1)
     expect(data[0]!.b).toBe(0)
@@ -200,14 +201,14 @@ describe("type coercion — number", () => {
 
   it("should keep number as-is", () => {
     const { data } = validateWithSchema([[42.5]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.val).toBe(42.5)
   })
 
   it("should return null for null (not required)", () => {
     const { data, errors } = validateWithSchema([[null]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBeNull()
@@ -215,7 +216,7 @@ describe("type coercion — number", () => {
 
   it('should strip commas: "1,234.56" → 1234.56', () => {
     const { data, errors } = validateWithSchema([["1,234.56"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBe(1234.56)
@@ -231,7 +232,7 @@ describe("type coercion — integer", () => {
 
   it('should convert string "42" → 42', () => {
     const { data, errors } = validateWithSchema([["42"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBe(42)
@@ -239,7 +240,7 @@ describe("type coercion — integer", () => {
 
   it('should error on string "3.14" (not integer)', () => {
     const { errors } = validateWithSchema([["3.14"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Expected integer")
@@ -247,7 +248,7 @@ describe("type coercion — integer", () => {
 
   it("should error on number 3.14", () => {
     const { errors } = validateWithSchema([[3.14]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Expected integer")
@@ -255,7 +256,7 @@ describe("type coercion — integer", () => {
 
   it("should allow number 42.0 → 42", () => {
     const { data, errors } = validateWithSchema([[42.0]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBe(42)
@@ -263,7 +264,7 @@ describe("type coercion — integer", () => {
 
   it('should error on string "abc"', () => {
     const { errors } = validateWithSchema([["abc"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Expected integer")
@@ -280,7 +281,7 @@ describe("type coercion — boolean", () => {
   it('should convert "true"/"TRUE"/"True" → true', () => {
     for (const v of ["true", "TRUE", "True"]) {
       const { data, errors } = validateWithSchema([[v]], mkSchema(), {
-        headerRow: 0,
+        headerRow: -1,
       })
       expect(errors).toHaveLength(0)
       expect(data[0]!.val).toBe(true)
@@ -290,7 +291,7 @@ describe("type coercion — boolean", () => {
   it('should convert "false"/"FALSE"/"False" → false', () => {
     for (const v of ["false", "FALSE", "False"]) {
       const { data, errors } = validateWithSchema([[v]], mkSchema(), {
-        headerRow: 0,
+        headerRow: -1,
       })
       expect(errors).toHaveLength(0)
       expect(data[0]!.val).toBe(false)
@@ -303,7 +304,7 @@ describe("type coercion — boolean", () => {
       b: { columnIndex: 1, type: "boolean" },
     }
     const { data } = validateWithSchema([["yes", "no"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.a).toBe(true)
     expect(data[0]!.b).toBe(false)
@@ -315,7 +316,7 @@ describe("type coercion — boolean", () => {
       b: { columnIndex: 1, type: "boolean" },
     }
     const { data } = validateWithSchema([["1", "0"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.a).toBe(true)
     expect(data[0]!.b).toBe(false)
@@ -326,14 +327,14 @@ describe("type coercion — boolean", () => {
       a: { columnIndex: 0, type: "boolean" },
       b: { columnIndex: 1, type: "boolean" },
     }
-    const { data } = validateWithSchema([[1, 0]], schema, { headerRow: 0 })
+    const { data } = validateWithSchema([[1, 0]], schema, { headerRow: -1 })
     expect(data[0]!.a).toBe(true)
     expect(data[0]!.b).toBe(false)
   })
 
   it('should error on string "abc"', () => {
     const { errors } = validateWithSchema([["abc"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Expected boolean")
@@ -345,7 +346,7 @@ describe("type coercion — boolean", () => {
       b: { columnIndex: 1, type: "boolean" },
     }
     const { data, errors } = validateWithSchema([[true, false]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.a).toBe(true)
@@ -363,7 +364,7 @@ describe("type coercion — date", () => {
   it("should pass through Date objects", () => {
     const d = new Date(Date.UTC(2024, 0, 15))
     const { data, errors } = validateWithSchema([[d]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBeInstanceOf(Date)
@@ -374,7 +375,7 @@ describe("type coercion — date", () => {
     const serial = 45307 // some Excel serial
     const expected = serialToDate(serial)
     const { data, errors } = validateWithSchema([[serial]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBeInstanceOf(Date)
@@ -382,7 +383,7 @@ describe("type coercion — date", () => {
   })
 
   it("should parse ISO date string", () => {
-    const { data, errors } = validateWithSchema([["2024-01-15"]], mkSchema(), { headerRow: 0 })
+    const { data, errors } = validateWithSchema([["2024-01-15"]], mkSchema(), { headerRow: -1 })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBeInstanceOf(Date)
     expect((data[0]!.val as Date).toISOString()).toContain("2024-01-15")
@@ -390,7 +391,7 @@ describe("type coercion — date", () => {
 
   it('should error on unparseable string "abc"', () => {
     const { errors } = validateWithSchema([["abc"]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Expected date")
@@ -398,7 +399,7 @@ describe("type coercion — date", () => {
 
   it("should return null for null (not required)", () => {
     const { data, errors } = validateWithSchema([[null]], mkSchema(), {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.val).toBeNull()
@@ -412,7 +413,7 @@ describe("required validation", () => {
     const schema: SchemaDefinition = {
       name: { columnIndex: 0, type: "string", required: true },
     }
-    const { errors } = validateWithSchema([[null]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([[null]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.row).toBe(1)
     expect(errors[0]!.message).toContain("Required field")
@@ -423,7 +424,7 @@ describe("required validation", () => {
       name: { columnIndex: 0, type: "string" },
     }
     const { data, errors } = validateWithSchema([[null]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.name).toBeNull()
@@ -433,7 +434,7 @@ describe("required validation", () => {
     const schema: SchemaDefinition = {
       name: { columnIndex: 0, type: "string", required: true },
     }
-    const { errors } = validateWithSchema([[""]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([[""]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Required field")
   })
@@ -443,7 +444,7 @@ describe("required validation", () => {
       count: { columnIndex: 0, type: "number", required: true },
     }
     const { data, errors } = validateWithSchema([[0]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.count).toBe(0)
@@ -454,7 +455,7 @@ describe("required validation", () => {
       active: { columnIndex: 0, type: "boolean", required: true },
     }
     const { data, errors } = validateWithSchema([[false]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.active).toBe(false)
@@ -472,7 +473,7 @@ describe("pattern validation", () => {
         pattern: /^[^@]+@[^@]+$/,
       },
     }
-    const { errors } = validateWithSchema([["user@example.com"]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([["user@example.com"]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(0)
   })
 
@@ -485,7 +486,7 @@ describe("pattern validation", () => {
       },
     }
     const { errors } = validateWithSchema([["invalid"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("does not match pattern")
@@ -500,7 +501,7 @@ describe("pattern validation", () => {
       },
     }
     // After number coercion, value is a number, not a string. Pattern is skipped.
-    const { errors } = validateWithSchema([["42"]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([["42"]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(0)
   })
 })
@@ -512,7 +513,7 @@ describe("min/max validation", () => {
     const schema: SchemaDefinition = {
       price: { columnIndex: 0, type: "number", min: 0 },
     }
-    const { errors } = validateWithSchema([[-1]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([[-1]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("below minimum")
   })
@@ -521,7 +522,7 @@ describe("min/max validation", () => {
     const schema: SchemaDefinition = {
       qty: { columnIndex: 0, type: "number", max: 10 },
     }
-    const { errors } = validateWithSchema([[42]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([[42]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("exceeds maximum")
   })
@@ -530,7 +531,7 @@ describe("min/max validation", () => {
     const schema: SchemaDefinition = {
       qty: { columnIndex: 0, type: "number", min: 0, max: 100 },
     }
-    const { errors } = validateWithSchema([[50]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([[50]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(0)
   })
 
@@ -538,7 +539,7 @@ describe("min/max validation", () => {
     const schema: SchemaDefinition = {
       code: { columnIndex: 0, type: "string", min: 3 },
     }
-    const { errors } = validateWithSchema([["ab"]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([["ab"]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("below minimum")
   })
@@ -548,7 +549,7 @@ describe("min/max validation", () => {
       code: { columnIndex: 0, type: "string", max: 5 },
     }
     const { errors } = validateWithSchema([["toolong"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("exceeds maximum")
@@ -559,7 +560,7 @@ describe("min/max validation", () => {
       code: { columnIndex: 0, type: "string", min: 2, max: 10 },
     }
     const { errors } = validateWithSchema([["hello"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
   })
@@ -577,7 +578,7 @@ describe("enum validation", () => {
       },
     }
     const { errors } = validateWithSchema([["active"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
   })
@@ -591,7 +592,7 @@ describe("enum validation", () => {
       },
     }
     const { errors } = validateWithSchema([["deleted"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("must be one of")
@@ -612,7 +613,7 @@ describe("custom validate function", () => {
       },
     }
     const { errors } = validateWithSchema([["SKU-001"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
   })
@@ -625,7 +626,7 @@ describe("custom validate function", () => {
         validate: () => false,
       },
     }
-    const { errors } = validateWithSchema([["BAD"]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([["BAD"]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toContain("Custom validation failed")
   })
@@ -639,7 +640,7 @@ describe("custom validate function", () => {
           typeof v === "string" && v.startsWith("SKU-") ? true : "SKU must start with 'SKU-'",
       },
     }
-    const { errors } = validateWithSchema([["BAD"]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([["BAD"]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     expect(errors[0]!.message).toBe("SKU must start with 'SKU-'")
   })
@@ -657,7 +658,7 @@ describe("transform function", () => {
       },
     }
     const { data, errors } = validateWithSchema([["hello"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(0)
     expect(data[0]!.code).toBe("HELLO")
@@ -671,7 +672,7 @@ describe("transform function", () => {
         transform: (v) => Math.round((v as number) * 100),
       },
     }
-    const { data } = validateWithSchema([[9.99]], schema, { headerRow: 0 })
+    const { data } = validateWithSchema([[9.99]], schema, { headerRow: -1 })
     expect(data[0]!.price).toBe(999)
   })
 })
@@ -683,7 +684,7 @@ describe("default values", () => {
     const schema: SchemaDefinition = {
       status: { columnIndex: 0, type: "string", default: "active" },
     }
-    const { data } = validateWithSchema([[null]], schema, { headerRow: 0 })
+    const { data } = validateWithSchema([[null]], schema, { headerRow: -1 })
     expect(data[0]!.status).toBe("active")
   })
 
@@ -693,7 +694,7 @@ describe("default values", () => {
     }
     // Row only has 1 column, so index 5 is out of bounds (→ null)
     const { data } = validateWithSchema([["Widget"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.status).toBe("active")
   })
@@ -702,7 +703,7 @@ describe("default values", () => {
     const schema: SchemaDefinition = {
       status: { columnIndex: 0, type: "string", default: "active" },
     }
-    const { data } = validateWithSchema([[""]], schema, { headerRow: 0 })
+    const { data } = validateWithSchema([[""]], schema, { headerRow: -1 })
     expect(data[0]!.status).toBe("active")
   })
 
@@ -711,7 +712,7 @@ describe("default values", () => {
       status: { columnIndex: 0, type: "string", default: "active" },
     }
     const { data } = validateWithSchema([["inactive"]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(data[0]!.status).toBe("inactive")
   })
@@ -727,7 +728,7 @@ describe("skip empty rows", () => {
   it("should skip row with all nulls", () => {
     const rows: CellValue[][] = [["Alice"], [null], ["Bob"]]
     const { data } = validateWithSchema(rows, schema, {
-      headerRow: 0,
+      headerRow: -1,
       skipEmptyRows: true,
     })
     expect(data).toHaveLength(2)
@@ -738,7 +739,7 @@ describe("skip empty rows", () => {
   it("should skip row with all empty strings", () => {
     const rows: CellValue[][] = [["Alice"], [""], ["Bob"]]
     const { data } = validateWithSchema(rows, schema, {
-      headerRow: 0,
+      headerRow: -1,
       skipEmptyRows: true,
     })
     expect(data).toHaveLength(2)
@@ -755,7 +756,7 @@ describe("skip empty rows", () => {
       ["Bob", "Brown"],
     ]
     const { data } = validateWithSchema(rows, schema2, {
-      headerRow: 0,
+      headerRow: -1,
       skipEmptyRows: true,
     })
     expect(data).toHaveLength(3)
@@ -771,7 +772,7 @@ describe("error collection", () => {
       price: { columnIndex: 1, type: "number", required: true },
     }
     const { errors } = validateWithSchema([[null, null]], schema, {
-      headerRow: 0,
+      headerRow: -1,
     })
     expect(errors).toHaveLength(2)
   })
@@ -781,7 +782,7 @@ describe("error collection", () => {
       price: { columnIndex: 0, type: "number" },
     }
     const rows: CellValue[][] = [["abc"], ["def"]]
-    const { errors } = validateWithSchema(rows, schema, { headerRow: 0 })
+    const { errors } = validateWithSchema(rows, schema, { headerRow: -1 })
     expect(errors).toHaveLength(2)
     expect(errors[0]!.row).toBe(1)
     expect(errors[1]!.row).toBe(2)
@@ -791,7 +792,7 @@ describe("error collection", () => {
     const schema: SchemaDefinition = {
       price: { column: "Price", columnIndex: 0, type: "number" },
     }
-    const { errors } = validateWithSchema([["abc"]], schema, { headerRow: 0 })
+    const { errors } = validateWithSchema([["abc"]], schema, { headerRow: -1 })
     expect(errors).toHaveLength(1)
     const err = errors[0]!
     expect(err.row).toBe(1)
@@ -808,7 +809,7 @@ describe("error collection", () => {
     }
     expect(() =>
       validateWithSchema([[null, null]], schema, {
-        headerRow: 0,
+        headerRow: -1,
         errorMode: "throw",
       }),
     ).toThrow(ValidationError)
@@ -820,7 +821,7 @@ describe("error collection", () => {
       price: { columnIndex: 1, type: "number", required: true },
     }
     const { errors } = validateWithSchema([[null, null]], schema, {
-      headerRow: 0,
+      headerRow: -1,
       errorMode: "collect",
     })
     expect(errors).toHaveLength(2)
@@ -856,7 +857,7 @@ describe("edge cases", () => {
       name: { columnIndex: 0, type: "string" },
     }
     const rows: CellValue[][] = [["Alice", "extra1", "extra2"]]
-    const { data } = validateWithSchema(rows, schema, { headerRow: 0 })
+    const { data } = validateWithSchema(rows, schema, { headerRow: -1 })
     expect(data).toHaveLength(1)
     expect(data[0]!.name).toBe("Alice")
     expect(Object.keys(data[0]!)).toEqual(["name"])
@@ -869,7 +870,7 @@ describe("edge cases", () => {
       c: { columnIndex: 2, type: "string" },
     }
     const rows: CellValue[][] = [["only-one"]]
-    const { data } = validateWithSchema(rows, schema, { headerRow: 0 })
+    const { data } = validateWithSchema(rows, schema, { headerRow: -1 })
     expect(data[0]!.a).toBe("only-one")
     expect(data[0]!.b).toBeNull()
     expect(data[0]!.c).toBeNull()


### PR DESCRIPTION
Items 3 and 4 from #365. Part of #352. **Contains breaking changes**, taken deliberately because v1 freezes the surface.

## `headerRow` meant four different things

| Where | Type | Semantics |
| --- | --- | --- |
| `ReadOptions.headerRow` | number | 1-based — and honoured by **no reader at all** |
| `validateWithSchema` | number | 1-based, with `0` overloaded to mean "no header row" |
| `Xlsx`/`OdsObjectsReadOptions` | number | 0-based |
| `WorkbookToJsonOptions`, `JsonExportOptions` | number | 0-based |
| `sheetToObjects` | number | 0-based |
| `Html`/`MarkdownExportOptions` | **boolean** | "use the first row as a header" |

An option name that means two things is an off-by-one that only surfaces in someone's data, and v1 would freeze it.

## `ReadOptions.headerRow` and `.schema` are deleted

Verified by grep: **zero** references in `readXlsx`, `readOds`, `readXlsb`, `readXls`, or the dispatcher. They were declared, documented, and inert. Header selection belongs on the `*Objects` readers, which actually implement it.

While there, `ReadOptions` now carries a table of **which reader honours which option** — the type cannot express it, and a caller should not have to discover it by experiment:

| option | xlsx | ods | xlsb | xls |
| --- | --- | --- | --- | --- |
| `sheets` | yes | yes | no | no |
| `dateSystem` | yes | no | yes | yes |
| `readStyles` | yes | yes | no | no |
| `password` | yes | no | yes | no |
| `maxRows` | yes | no | no | no |
| `range` | yes | no | no | no |

Making those uniform is real work per format and is not this PR; documenting them accurately costs nothing and stops the type from lying.

## `validateWithSchema` becomes 0-based

The last 1-based holdout. **Two migrations, both mechanical:**

- `headerRow: N` for N ≥ 1 → `N - 1`. The old default of `1` and the new default of `0` both mean the first row, so anything relying on the default is unaffected.
- `headerRow: 0` → `-1`. This is the subtle one: `0` used to mean **"no header row"**, because 1-based numbering had no other way to say it. The two concepts were conflated. Now `0` means "the first row is the header", like everywhere else, and `-1` says there is no header — which the existing index arithmetic already handled.

66 assertions in `test/schema.test.ts` used `headerRow: 0` as that sentinel, with `columnIndex`-keyed schemas. Each was migrated to `-1`, preserving intent rather than chasing green.

Its options object was also anonymous; it is now an exported `SchemaValidateOptions`, so callers can build one in a typed variable.

## The two booleans become `hasHeaderRow`

Renamed on `HtmlExportOptions` and `MarkdownExportOptions`. The old name still works for one major — both exporters read `hasHeaderRow ?? headerRow ?? default` — and is marked `@deprecated`. The internal resolved options carry only the new field, so the two can never disagree.

## Verification

Nine tests in `test/read-options-semantics.test.ts`: both directions of the numbering change, the `-1` sentinel, the unchanged default, the deprecated spellings still working, precedence when both are given, and each exporter's own default.

One assertion needed checking rather than assuming — my first version asserted Markdown emits no separator row with the header off. It always emits one; the flag changes **what the header is** (the real first row, or a generated `1 | 2`). Measured, then asserted.

Full suite **8,040 tests / 125 files** green; lint, typecheck clean.

## Still open in #365

The `*Objects` return-shape split and the stream-writer class surfaces are in flight separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
