### PR TITLE
fix(xlsx): preserve sheet background images through saveXlsx — closes #367

### DIFF
--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -119,6 +119,7 @@ const REL_COMMENTS = "http://schemas.openxmlformats.org/officeDocument/2006/rela
 const REL_VML_DRAWING =
   "http://schemas.openxmlformats.org/officeDocument/2006/relationships/vmlDrawing"
 const REL_TABLE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table"
+const REL_IMAGE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image"
 const REL_SLICER = "http://schemas.microsoft.com/office/2007/relationships/slicer"
 const REL_TIMELINE = "http://schemas.microsoft.com/office/2011/relationships/timeline"
 const REL_THREADED_COMMENT =
@@ -259,11 +260,7 @@ export async function saveXlsx(
     outlineProperties: sheet.outlineProperties,
     sparklines: sheet.sparklines,
     textBoxes: sheet.textBoxes,
-    // `backgroundImage` is deliberately NOT forwarded. It needs a media
-    // part and a `<picture>` relationship, and this path emits neither —
-    // forwarding it produces a sheet referencing an rId that was never
-    // written, which Excel reports as corrupt. Losing the image is worse
-    // than it should be, but better than that. Tracked separately.
+    backgroundImage: sheet.backgroundImage,
   }))
 
   // Create shared collectors
@@ -323,6 +320,21 @@ export async function saveXlsx(
       globalImageIndex += images.length
     } else {
       drawingResults.push(null)
+    }
+  }
+
+  // Background images live in xl/media alongside drawing images, so the
+  // index has to come from the same counter — numbering them
+  // independently would collide. This mirrors writer.ts. See #367.
+  const backgroundImagePaths: Array<string | null> = []
+  for (const sheet of writeSheets) {
+    if (sheet.backgroundImage) {
+      const bgPath = `xl/media/image${globalImageIndex}.png`
+      backgroundImagePaths.push(bgPath)
+      imageExtensions.add("png")
+      globalImageIndex++
+    } else {
+      backgroundImagePaths.push(null)
     }
   }
 
@@ -915,6 +927,10 @@ export async function saveXlsx(
     // the reference below.
     const modelDrawing = modelChartDrawings[i]
     const hasModelChartDrawing = modelDrawing !== null
+    // The worksheet writer emits <picture r:id> whenever the sheet has a
+    // background image; without the matching relationship and media part
+    // that reference dangles, which Excel reports as corrupt. See #367.
+    const hasPicture = result.pictureRId !== null && backgroundImagePaths[i] !== null
     let worksheetXml = result.xml
 
     if (
@@ -927,7 +943,8 @@ export async function saveXlsx(
       hasThreadedComments ||
       hasSheetPivotTables ||
       hasPreservedDrawing ||
-      hasModelChartDrawing
+      hasModelChartDrawing ||
+      hasPicture
     ) {
       const relElements: string[] = []
       // Track the highest existing rId so newly added slicer/timeline
@@ -993,6 +1010,21 @@ export async function saveXlsx(
           }),
         )
         bumpToAfter(tableEntry.rId)
+      }
+
+      // Background image (picture) relationship. The worksheet writer has
+      // already emitted <picture r:id> pointing at this rId. See #367.
+      if (hasPicture && result.pictureRId && backgroundImagePaths[i]) {
+        const bgMediaPath = backgroundImagePaths[i]!
+        relElements.push(
+          xmlSelfClose("Relationship", {
+            Id: result.pictureRId,
+            Type: REL_IMAGE,
+            // "xl/media/imageN.png" → "../media/imageN.png"
+            Target: `../${bgMediaPath.slice(3)}`,
+          }),
+        )
+        bumpToAfter(result.pictureRId)
       }
 
       // Re-emit slicer relationships read from the original sheet rels.
@@ -1084,6 +1116,13 @@ export async function saveXlsx(
     // Worksheet body — added after rels processing so the chart
     // re-anchor injection above can patch the XML before it's written.
     zip.add(`xl/worksheets/sheet${i + 1}.xml`, encoder.encode(worksheetXml))
+
+    // Background image bytes. Stored uncompressed — PNG/JPEG are already
+    // compressed, so deflating again only costs time.
+    const bgPath = backgroundImagePaths[i]
+    if (hasPicture && bgPath && writeSheets[i]!.backgroundImage) {
+      zip.add(bgPath, writeSheets[i]!.backgroundImage!, { compress: false })
+    }
 
     // Add drawing files
     if (drawing) {

--- a/test/roundtrip-preservation.test.ts
+++ b/test/roundtrip-preservation.test.ts
@@ -48,22 +48,50 @@ describe("openXlsx → saveXlsx preserves sheet features", () => {
     expect(workbook.sheets[0].colBreaks).toEqual([3])
   })
 
-  it("drops the background image rather than emitting a dangling reference", async () => {
-    // Known gap: this path writes neither the media part nor the picture
-    // relationship, so forwarding backgroundImage would emit a <picture>
-    // pointing at an rId that does not exist — a file Excel calls
-    // corrupt. Until the media plumbing lands, losing it is the safer
-    // failure. This test pins that choice so it is deliberate, not drift.
+  it("keeps the background image, with its media part and relationship", async () => {
+    // This used to be dropped, because forwarding it alone emitted a
+    // <picture> pointing at an rId that was never written — a file Excel
+    // calls corrupt. The media path and relationship exist now (#367).
     const png = new Uint8Array([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
       0x52,
     ])
     const { saved, workbook } = await cycle({ sheets: [sheetWith({ backgroundImage: png })] })
-    expect(workbook.sheets[0].backgroundImage).toBeUndefined()
+
+    expect(workbook.sheets[0].backgroundImage).toBeInstanceOf(Uint8Array)
+    expect(Array.from(workbook.sheets[0].backgroundImage!)).toEqual(Array.from(png))
 
     const zip = new ZipReader(saved)
     const sheetXml = new TextDecoder().decode(await zip.extract("xl/worksheets/sheet1.xml"))
-    expect(sheetXml).not.toContain("<picture")
+    expect(sheetXml).toContain("<picture")
+
+    // The reference has to resolve: both the relationship and the bytes.
+    const rels = new TextDecoder().decode(await zip.extract("xl/worksheets/_rels/sheet1.xml.rels"))
+    const target = rels.match(/Target="\.\.\/(media\/[^"]+)"/)
+    expect(target, "no image relationship in the sheet rels").not.toBeNull()
+    expect(zip.has(`xl/${target![1]}`)).toBe(true)
+  })
+
+  it("does not collide a background image with drawing images", async () => {
+    // Both live in xl/media and are numbered from one shared counter;
+    // numbering them independently would overwrite one with the other.
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52,
+    ])
+    const { saved } = await cycle({
+      sheets: [
+        sheetWith({
+          backgroundImage: png,
+          images: [{ data: png, extension: "png", anchor: { from: { row: 0, col: 0 } } }],
+        }),
+      ],
+    })
+
+    const zip = new ZipReader(saved)
+    const media = zip.entries().filter((e) => e.startsWith("xl/media/"))
+    expect(new Set(media).size).toBe(media.length)
+    expect(media.length).toBe(2)
   })
 
   it("keeps sparklines", async () => {


### PR DESCRIPTION
Closes #367. Part of #352. Split out of #366, where forwarding the field alone made things *worse*.

## What was wrong

The worksheet writer emits `<picture r:id="rIdN"/>` whenever a sheet has a background image. `saveXlsx` had **no `pictureRId` handling at all** — a repo-wide grep for it in `roundtrip.ts` returned nothing.

So simply adding `backgroundImage` to the `Sheet` → `WriteSheet` map produced:

```
saved entries:                    xl/worksheets/sheet1.xml
saved sheet has picture element:  true          ← no xl/media/*, no sheet rels
```

A reference that does not resolve is a file Excel reports as corrupt — worse than the silent data loss it replaced. That is why #366 left the field out with a test pinning the drop, and filed this instead.

## The three missing pieces

Mirroring what `writer.ts` already does:

1. **Media index allocation**, sharing the drawing loop's `globalImageIndex`. Background images and drawing images both live in `xl/media`, so numbering them independently would have one overwrite the other. There is a test for exactly that.
2. **The picture relationship** in the per-sheet rels block — including `hasPicture` in the condition that decides whether a rels part is emitted at all, since a sheet whose *only* relationship is the background image previously got no rels part.
3. **The bytes**, stored uncompressed: PNG and JPEG are already compressed, so deflating again only costs time.

Content types needed nothing — registering `"png"` in `imageExtensions` during allocation covers the `Default` extension entry.

## Verification

The pinned test flips to asserting the image survives, and now checks that **the reference resolves** — the relationship exists *and* its target is in the archive — rather than just that a `<picture>` element appears. That distinction is the entire bug: the element was always there; what was missing was everything it pointed at.

Plus a collision test: a sheet with both a background image and a drawing image must produce two distinct `xl/media` entries.

Measured after the fix: `xl/media/image1.png` present, sheet rels present, 16 bytes round-tripped intact, and every part declared in `[Content_Types].xml` exists.

Full suite **8,041 tests / 125 files** green; lint, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
