### PR TITLE
fix(test): correct SheetImage shape in the media-collision test

### DIFF
--- a/test/roundtrip-preservation.test.ts
+++ b/test/roundtrip-preservation.test.ts
@@ -83,7 +83,7 @@ describe("openXlsx → saveXlsx preserves sheet features", () => {
       sheets: [
         sheetWith({
           backgroundImage: png,
-          images: [{ data: png, extension: "png", anchor: { from: { row: 0, col: 0 } } }],
+          images: [{ data: png, type: "png", anchor: { from: { row: 0, col: 0 } } }],
         }),
       ],
     })


### PR DESCRIPTION
Main is red at the typecheck step. `extension: "png"` is not a field on `SheetImage` — the discriminator is `type`.

Mine, twice over: the verification step before #380 ran `pnpm lint` and `npx vitest run` but **not** `pnpm typecheck`, and vitest does not typecheck, so the error was invisible locally. The merge command was then chained after the CI check with `;` instead of `&&`, so a red build did not stop the merge.

`pnpm test` (lint + typecheck + vitest) is green: 8,041 tests / 125 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD