### PR TITLE
refactor!: one result shape for *Objects, one surface for the stream writers — #365

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,31 @@ that discards the bytes (Node 24):
 | 1,000,000 |                       67 MB |                     1,037 MB |
 | 3,000,000 |                       70 MB |                   not viable |
 
+#### One surface across the incremental writers
+
+`XlsxStreamWriter`, `CsvStreamWriter`, and `NdjsonStreamWriter` share one
+vocabulary, so a format-agnostic export helper can be written once:
+
+| Method            | Behaviour                                                         |
+| ----------------- | ----------------------------------------------------------------- |
+| `addRow(values)`  | Append positional values                                          |
+| `addObject(item)` | Append an object, projected through the writer's column order     |
+| `finish()`        | Close the writer and return its output (`string` or `Uint8Array`) |
+| `toStream()`      | Output as a `ReadableStream<Uint8Array>`                          |
+
+Two caveats worth stating plainly:
+
+- `toStream()` on `XlsxStreamWriter` and `CsvStreamWriter` **does not bound
+  memory**. Both buffer everything until `finish()`; the stream just hands
+  you the finished bytes. `writeXlsxStream` / `writeCsvStream` are the
+  constant-memory paths. `NdjsonStreamWriter.toStream()` is the only live
+  drain — it releases rows as they are enqueued and stays open until
+  `finish()`.
+- `NdjsonStreamWriter.addRow` needs `columns` (`new NdjsonStreamWriter({
+columns: [...] })`), because NDJSON rows are objects and positional
+  values have no key names otherwise. It throws rather than guessing.
+  Its old `write()` / `end()` are kept as `@deprecated` aliases.
+
 Streaming trade-offs worth knowing:
 
 - Strings are written inline (`t="inlineStr"`) by default. A shared
@@ -460,7 +485,7 @@ const encrypted = await writeXlsx({
 const wb = await readXlsx(encrypted, { password: "hunter2" })
 
 // Works through every read entry point: read(), readObjects(), streamXlsxRows()
-const rows = await readObjects(encrypted, { password: "hunter2" })
+const { data: rows } = await readObjects(encrypted, { password: "hunter2" })
 
 // Without a password an encrypted file throws EncryptedFileError;
 // with the wrong password it throws DecryptionError.
@@ -964,8 +989,15 @@ import { read, write, readObjects, writeObjects } from "hucre"
 // Auto-detect XLSX vs ODS
 const wb = await read(buffer)
 
-// Quick: file → array of objects
-const products = await readObjects<{ name: string; price: number }>(buffer)
+// Quick: file → objects, plus the headers they were keyed by. Same
+// { data, headers } shape — and the same options — as readXlsxObjects /
+// readOdsObjects / parseCsvObjects.
+const { data: products, headers } = await readObjects<{ name: string; price: number }>(buffer, {
+  sheet: 0, // index or name (default: 0)
+  headerRow: 0, // 0-based (default: 0)
+  skipEmptyRows: true, // default
+  maxRows: 1000, // optional cap on the returned rows
+})
 
 // Quick: objects → XLSX
 const xlsx = await writeObjects(products, { sheetName: "Products" })
@@ -1178,6 +1210,15 @@ const xlsx = await writeXlsxObjects(
 )
 ```
 
+Every `*Objects` reader — `readObjects`, `readXlsxObjects`,
+`readOdsObjects`, `parseCsvObjects`, `parseJson`, `readXml` — returns the
+same `{ data, headers }` shape, under a named type
+(`XlsxObjectsResult`, `OdsObjectsResult`, `CsvObjectsResult`,
+`ReadObjectsResult`, `SheetObjectsResult`, `JsonReadResult`). `readObjects`
+is the format-agnostic one: it takes the same options as the two above and
+applies them to whatever `read()` detected, so `maxRows` and `skipEmptyRows`
+work for ODS and XLS too.
+
 ### JSON / NDJSON
 
 ```ts
@@ -1213,8 +1254,8 @@ const json = workbookToJson(wb, { pretty: true })
 
 // Streaming write — works in Cloudflare Workers / Deno / Node 18+
 const writer = new NdjsonStreamWriter()
-for await (const row of source) writer.write(row)
-writer.end()
+for await (const row of source) writer.addObject(row)
+writer.finish() // `write()` / `end()` still work as deprecated aliases
 return new Response(writer.toStream(), {
   headers: { "content-type": "application/x-ndjson" },
 })
@@ -1419,42 +1460,42 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 
 ### High-level
 
-| Function                       | Description                                       |
-| ------------------------------ | ------------------------------------------------- |
-| `read(input, options?)`        | Auto-detect format (XLSX/ODS), returns `Workbook` |
-| `write(options)`               | Write XLSX or ODS (via `format` option)           |
-| `readObjects(input, options?)` | File → array of objects (first row = headers)     |
-| `writeObjects(data, options?)` | Objects → XLSX/ODS                                |
+| Function                       | Description                                                    |
+| ------------------------------ | -------------------------------------------------------------- |
+| `read(input, options?)`        | Auto-detect format (XLSX/ODS), returns `Workbook`              |
+| `write(options)`               | Write XLSX or ODS (via `format` option)                        |
+| `readObjects(input, options?)` | File → `{ data, headers }` (format-agnostic `*Objects` reader) |
+| `writeObjects(data, options?)` | Objects → XLSX/ODS                                             |
 
 ### XLSX
 
-| Function                           | Description                                                                 |
-| ---------------------------------- | --------------------------------------------------------------------------- |
-| `readXlsx(input, options?)`        | Parse XLSX from `Uint8Array \| ArrayBuffer \| ReadableStream<Uint8Array>`   |
-| `writeXlsx(options)`               | Generate XLSX, returns `Uint8Array`                                         |
-| `readXlsxObjects(input, options?)` | Read sheet as `{ data, headers }` — mirror of CSV                           |
-| `writeXlsxObjects(data, options?)` | Write objects to XLSX (auto-derives headers from keys)                      |
-| `openXlsx(input, options?)`        | Open for round-trip (preserves unknown parts)                               |
-| `saveXlsx(workbook)`               | Save round-trip workbook back to XLSX                                       |
-| `streamXlsxRows(input, options?)`  | AsyncGenerator yielding rows one at a time                                  |
-| `writeXlsxStream(rows, options)`   | Constant-memory XLSX writing — returns a `ReadableStream<Uint8Array>`       |
-| `XlsxStreamWriter`                 | Incremental row-by-row XLSX writing; auto-splits past `maxRowsPerSheet`     |
-| `XLSX_MAX_ROWS_PER_SHEET`          | Excel hard row limit (1,048,576) — exported constant                        |
-| `parseExternalLink(xml, relsXml?)` | Parse `xl/externalLinks/externalLinkN.xml` → `ExternalLink`                 |
-| `parseCellImages(xml)`             | Parse `xl/cellimages.xml` → `ParsedCellImageRef[]` (WPS DISPIMG)            |
-| `assembleCellImages(refs, media)`  | Combine parsed refs with resolved media bytes → `CellImage[]`               |
-| `parseSlicers(xml)`                | Parse `xl/slicers/slicerN.xml` → `Slicer[]`                                 |
-| `parseSlicerCache(xml)`            | Parse `xl/slicerCaches/slicerCacheN.xml` → `SlicerCache \| undefined`       |
-| `parseTimelines(xml)`              | Parse `xl/timelines/timelineN.xml` → `Timeline[]`                           |
-| `parseTimelineCache(xml)`          | Parse `xl/timelineCaches/timelineCacheN.xml` → `TimelineCache \| undefined` |
-| `parsePivotTable(xml)`             | Parse `xl/pivotTables/pivotTableN.xml` → `PivotTable \| undefined`          |
-| `parsePivotCacheDefinition(xml)`   | Parse `xl/pivotCache/pivotCacheDefinitionN.xml` → `PivotCache \| undefined` |
-| `attachPivotCacheFields(pt, c)`    | Overlay `PivotCache.fieldNames` onto a `PivotTable.fields[].name`           |
-| `parseChart(xml)`                  | Parse `xl/charts/chartN.xml` → `Chart \| undefined`                         |
-| `cloneChart(source, options)`      | Convert a parsed `Chart` into a writer-ready `SheetChart`                   |
-| `chartKindToWriteKind(kind)`       | Map a read-side `ChartKind` onto its writable counterpart, if any           |
-| `getCharts(workbook)`              | Enumerate every chart anchored on the workbook with its sheet context       |
-| `addChart(sheet, chart)`           | Append a `SheetChart` to a `WriteSheet`, lazily creating the array          |
+| Function                           | Description                                                                         |
+| ---------------------------------- | ----------------------------------------------------------------------------------- |
+| `readXlsx(input, options?)`        | Parse XLSX from `Uint8Array \| ArrayBuffer \| ReadableStream<Uint8Array>`           |
+| `writeXlsx(options)`               | Generate XLSX, returns `Uint8Array`                                                 |
+| `readXlsxObjects(input, options?)` | Read sheet as `{ data, headers }` — mirror of CSV                                   |
+| `writeXlsxObjects(data, options?)` | Write objects to XLSX (auto-derives headers from keys)                              |
+| `openXlsx(input, options?)`        | Open for round-trip (preserves unknown parts)                                       |
+| `saveXlsx(workbook)`               | Save round-trip workbook back to XLSX                                               |
+| `streamXlsxRows(input, options?)`  | AsyncGenerator yielding rows one at a time                                          |
+| `writeXlsxStream(rows, options)`   | Constant-memory XLSX writing — returns a `ReadableStream<Uint8Array>`               |
+| `XlsxStreamWriter`                 | Incremental XLSX writing (`addRow`/`addObject`); auto-splits past `maxRowsPerSheet` |
+| `XLSX_MAX_ROWS_PER_SHEET`          | Excel hard row limit (1,048,576) — exported constant                                |
+| `parseExternalLink(xml, relsXml?)` | Parse `xl/externalLinks/externalLinkN.xml` → `ExternalLink`                         |
+| `parseCellImages(xml)`             | Parse `xl/cellimages.xml` → `ParsedCellImageRef[]` (WPS DISPIMG)                    |
+| `assembleCellImages(refs, media)`  | Combine parsed refs with resolved media bytes → `CellImage[]`                       |
+| `parseSlicers(xml)`                | Parse `xl/slicers/slicerN.xml` → `Slicer[]`                                         |
+| `parseSlicerCache(xml)`            | Parse `xl/slicerCaches/slicerCacheN.xml` → `SlicerCache \| undefined`               |
+| `parseTimelines(xml)`              | Parse `xl/timelines/timelineN.xml` → `Timeline[]`                                   |
+| `parseTimelineCache(xml)`          | Parse `xl/timelineCaches/timelineCacheN.xml` → `TimelineCache \| undefined`         |
+| `parsePivotTable(xml)`             | Parse `xl/pivotTables/pivotTableN.xml` → `PivotTable \| undefined`                  |
+| `parsePivotCacheDefinition(xml)`   | Parse `xl/pivotCache/pivotCacheDefinitionN.xml` → `PivotCache \| undefined`         |
+| `attachPivotCacheFields(pt, c)`    | Overlay `PivotCache.fieldNames` onto a `PivotTable.fields[].name`                   |
+| `parseChart(xml)`                  | Parse `xl/charts/chartN.xml` → `Chart \| undefined`                                 |
+| `cloneChart(source, options)`      | Convert a parsed `Chart` into a writer-ready `SheetChart`                           |
+| `chartKindToWriteKind(kind)`       | Map a read-side `ChartKind` onto its writable counterpart, if any                   |
+| `getCharts(workbook)`              | Enumerate every chart anchored on the workbook with its sheet context               |
+| `addChart(sheet, chart)`           | Append a `SheetChart` to a `WriteSheet`, lazily creating the array                  |
 
 ### ODS
 
@@ -1468,31 +1509,31 @@ Zero dependencies. Pure TypeScript. The ZIP engine uses `CompressionStream`/`Dec
 
 ### CSV
 
-| Function                           | Description                                             |
-| ---------------------------------- | ------------------------------------------------------- |
-| `parseCsv(input, options?)`        | Parse CSV string → `CellValue[][]`                      |
-| `parseCsvObjects(input, options?)` | Parse CSV with headers → `{ data, headers }`            |
-| `writeCsv(rows, options?)`         | Write `CellValue[][]` → CSV string                      |
-| `writeCsvObjects(data, options?)`  | Write objects → CSV string                              |
-| `detectDelimiter(input)`           | Auto-detect delimiter character                         |
-| `streamCsvRows(input, options?)`   | Generator yielding CSV rows; same options as `parseCsv` |
-| `writeCsvStream(rows, options?)`   | Constant-memory CSV writing → `ReadableStream`          |
-| `CsvStreamWriter`                  | Incremental CSV writing; buffers until `finish()`       |
-| `writeTsv(rows, options?)`         | Write TSV (tab-separated)                               |
-| `fetchCsv(url, options?)`          | Fetch and parse CSV from URL                            |
+| Function                           | Description                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| `parseCsv(input, options?)`        | Parse CSV string → `CellValue[][]`                                       |
+| `parseCsvObjects(input, options?)` | Parse CSV with headers → `CsvObjectsResult` (`{ data, headers }`)        |
+| `writeCsv(rows, options?)`         | Write `CellValue[][]` → CSV string                                       |
+| `writeCsvObjects(data, options?)`  | Write objects → CSV string                                               |
+| `detectDelimiter(input)`           | Auto-detect delimiter character                                          |
+| `streamCsvRows(input, options?)`   | Generator yielding CSV rows; same options as `parseCsv`                  |
+| `writeCsvStream(rows, options?)`   | Constant-memory CSV writing → `ReadableStream`                           |
+| `CsvStreamWriter`                  | Incremental CSV writing (`addRow`/`addObject`); buffers until `finish()` |
+| `writeTsv(rows, options?)`         | Write TSV (tab-separated)                                                |
+| `fetchCsv(url, options?)`          | Fetch and parse CSV from URL                                             |
 
 ### JSON
 
-| Function                          | Description                                                     |
-| --------------------------------- | --------------------------------------------------------------- |
-| `parseJson(input, options?)`      | Parse JSON string/Uint8Array → `{ data, headers }`              |
-| `parseValue(value, options?)`     | Same on already-parsed JSON                                     |
-| `parseNdjson(input, options?)`    | Parse NDJSON / JSON Lines (`onError` skips invalid)             |
-| `writeJson(data, options?)`       | Serialize rows to a JSON string                                 |
-| `writeNdjson(data, options?)`     | Serialize rows to NDJSON, one object per line                   |
-| `workbookToJson(wb, options?)`    | Convert a `Workbook` to JSON (single-sheet array or per-sheet)  |
-| `streamNdjsonRows(stream, opts?)` | Async generator over a `ReadableStream<Uint8Array>`             |
-| `NdjsonStreamWriter`              | Incremental writer; `toStream()` releases rows as they are sent |
+| Function                          | Description                                                                            |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| `parseJson(input, options?)`      | Parse JSON string/Uint8Array → `{ data, headers }`                                     |
+| `parseValue(value, options?)`     | Same on already-parsed JSON                                                            |
+| `parseNdjson(input, options?)`    | Parse NDJSON / JSON Lines (`onError` skips invalid)                                    |
+| `writeJson(data, options?)`       | Serialize rows to a JSON string                                                        |
+| `writeNdjson(data, options?)`     | Serialize rows to NDJSON, one object per line                                          |
+| `workbookToJson(wb, options?)`    | Convert a `Workbook` to JSON (single-sheet array or per-sheet)                         |
+| `streamNdjsonRows(stream, opts?)` | Async generator over a `ReadableStream<Uint8Array>`                                    |
+| `NdjsonStreamWriter`              | Incremental writer (`addRow`/`addObject`); `toStream()` releases rows as they are sent |
 
 ### XML
 

--- a/src/_objects.ts
+++ b/src/_objects.ts
@@ -1,0 +1,117 @@
+// ── Shared row → object projection ──────────────────────────────────
+//
+// Every `*Objects` reader (`readObjects`, `readXlsxObjects`,
+// `readOdsObjects`, `parseCsvObjects`, `sheetToObjects`) turns a 2D row
+// array into `{ data, headers }` the same way. Keeping one implementation
+// here is what makes them behave identically — three near-copies of this
+// loop is how they drifted apart in the first place (#365).
+//
+// Internal: not exported from any entry point.
+
+import type { CellValue, Sheet, Workbook } from "./_types"
+import { ParseError } from "./errors"
+
+/** The projection knobs shared by the object readers. */
+export interface RowsToObjectsOptions {
+  /** Row index to use as headers. Callers resolve the default. */
+  headerRow: number
+  /** Skip rows where every cell is null/undefined/"". */
+  skipEmptyRows: boolean
+  /** Transform header values (after String/trim normalization). */
+  transformHeader?: (header: string, index: number) => string
+  /** Transform each cell value. */
+  transformValue?: (
+    value: CellValue,
+    header: string,
+    rowIndex: number,
+    colIndex: number,
+  ) => CellValue
+  /** Maximum number of data rows to return (after the header row). */
+  maxRows?: number
+}
+
+/** The result shape every `*Objects` reader returns. */
+export interface ObjectsResult<T extends Record<string, CellValue> = Record<string, CellValue>> {
+  data: T[]
+  headers: string[]
+}
+
+/**
+ * Project `rows` onto objects keyed by the header row.
+ *
+ * `rowIndex` handed to `transformValue` is the index into `rows`, not the
+ * index into the returned data — the row's position in the source is what
+ * callers reach for when reporting problems.
+ */
+export function rowsToObjects<T extends Record<string, CellValue> = Record<string, CellValue>>(
+  rows: CellValue[][],
+  options: RowsToObjectsOptions,
+): ObjectsResult<T> {
+  const {
+    headerRow: headerRowIdx,
+    skipEmptyRows,
+    transformHeader,
+    transformValue,
+    maxRows,
+  } = options
+
+  if (headerRowIdx < 0 || rows.length <= headerRowIdx) {
+    return { data: [], headers: [] }
+  }
+
+  let headers = rows[headerRowIdx]!.map((h) => {
+    if (h === null || h === undefined) return ""
+    return String(h).trim()
+  })
+
+  if (transformHeader) {
+    headers = headers.map((h, i) => transformHeader(h, i))
+  }
+
+  const data: T[] = []
+  for (let i = headerRowIdx + 1; i < rows.length; i++) {
+    if (maxRows !== undefined && data.length >= maxRows) break
+    const row = rows[i]!
+
+    if (skipEmptyRows && row.every((v) => v === null || v === undefined || v === "")) {
+      continue
+    }
+
+    const obj: Record<string, CellValue> = {}
+    for (let j = 0; j < headers.length; j++) {
+      let val: CellValue = j < row.length ? (row[j] ?? null) : null
+      if (transformValue) {
+        val = transformValue(val, headers[j]!, i, j)
+      }
+      obj[headers[j]!] = val
+    }
+    data.push(obj as T)
+  }
+
+  return { data, headers }
+}
+
+/**
+ * Resolve a `sheet` selector (0-based index or name) against a workbook,
+ * throwing the same typed errors from every reader that accepts one.
+ */
+export function selectSheet(workbook: Workbook, selector: number | string): Sheet {
+  if (workbook.sheets.length === 0) {
+    throw new ParseError("Workbook contains no sheets")
+  }
+
+  const sheet =
+    typeof selector === "number"
+      ? workbook.sheets[selector]
+      : workbook.sheets.find((s) => s.name === selector)
+
+  if (!sheet) {
+    throw new ParseError(
+      typeof selector === "number"
+        ? `Sheet index ${selector} out of range (workbook has ${workbook.sheets.length} sheet(s))`
+        : `Sheet "${selector}" not found`,
+    )
+  }
+
+  return sheet
+}

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -8,8 +8,9 @@ export {
   formatCsvValue,
   fetchCsv,
 } from "./csv/index"
+export type { CsvObjectsResult } from "./csv/index"
 export { streamCsvRows, CsvStreamWriter, writeCsvStream } from "./csv/stream"
-export type { CsvStreamRow } from "./csv/stream"
+export type { CsvStreamRow, CsvStreamWriterOptions } from "./csv/stream"
 
 // ── Shared types used by this entry point's signatures ──────────────
 export type { CellValue, CsvReadOptions, CsvWriteOptions } from "./_types"

--- a/src/csv/index.ts
+++ b/src/csv/index.ts
@@ -1,3 +1,4 @@
 export { parseCsv, parseCsvObjects, detectDelimiter, stripBom } from "./reader"
+export type { CsvObjectsResult } from "./reader"
 export { writeCsv, writeCsvObjects, formatCsvValue } from "./writer"
 export { fetchCsv } from "./fetch"

--- a/src/csv/reader.ts
+++ b/src/csv/reader.ts
@@ -1,4 +1,5 @@
 import type { CellValue, CsvReadOptions } from "../_types"
+import { rowsToObjects } from "../_objects"
 
 // ── Public API ───────────────────────────────────────────────────────
 
@@ -162,13 +163,26 @@ export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][]
 }
 
 /**
+ * Result shape for {@link parseCsvObjects}, mirroring `XlsxObjectsResult`
+ * and `OdsObjectsResult`.
+ *
+ * Named rather than inline so callers can annotate a variable, a function
+ * return, or a Promise with it — the anonymous shape could not be spelled
+ * at all (#365).
+ */
+export interface CsvObjectsResult<T extends Record<string, CellValue> = Record<string, CellValue>> {
+  data: T[]
+  headers: string[]
+}
+
+/**
  * Parse CSV with a header row, returning an array of objects
  * and the detected headers.
  */
 export function parseCsvObjects<T extends Record<string, CellValue> = Record<string, CellValue>>(
   input: string,
   options?: CsvReadOptions & { header: true },
-): { data: T[]; headers: string[] } {
+): CsvObjectsResult<T> {
   // Pass through without transformValue/transformHeader to parseCsv — we handle them here
   const { transformHeader, transformValue, ...restOptions } = options ?? {}
   const rows = parseCsv(input, {
@@ -178,36 +192,15 @@ export function parseCsvObjects<T extends Record<string, CellValue> = Record<str
     transformHeader: undefined,
   })
 
-  if (rows.length === 0) {
-    return { data: [], headers: [] }
-  }
-
-  const headerRow = rows[0]!
-  let headers = headerRow.map((h) => {
-    if (h === null) return ""
-    return String(h).trim()
+  // `skipEmptyRows` is a `parseCsv` option applied above, so the row set
+  // handed over here is already filtered — projecting it must not filter
+  // a second time.
+  return rowsToObjects<T>(rows, {
+    headerRow: 0,
+    skipEmptyRows: false,
+    transformHeader,
+    transformValue,
   })
-
-  // Apply transformHeader callback
-  if (transformHeader) {
-    headers = headers.map((h, i) => transformHeader(h, i))
-  }
-
-  const data: T[] = []
-  for (let i = 1; i < rows.length; i++) {
-    const row = rows[i]!
-    const obj: Record<string, CellValue> = {}
-    for (let j = 0; j < headers.length; j++) {
-      let val: CellValue = j < row.length ? row[j]! : null
-      if (transformValue) {
-        val = transformValue(val, headers[j]!, i, j)
-      }
-      obj[headers[j]!] = val
-    }
-    data.push(obj as T)
-  }
-
-  return { data, headers }
 }
 
 // ── Fast parser (no quote handling) ──────────────────────────────────

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -379,6 +379,15 @@ class CsvRowFormatter {
 // ── Incremental CSV Writer (buffered) ────────────────────────────────
 
 /**
+ * Constructor options for {@link CsvStreamWriter} — the same options
+ * `writeCsv` / `writeCsvStream` take.
+ *
+ * Exists as a name of its own so every stream writer in the library has
+ * one (`XlsxStreamWriterOptions`, `NdjsonStreamWriterOptions`).
+ */
+export type CsvStreamWriterOptions = CsvWriteOptions
+
+/**
  * Incremental CSV writer.
  *
  * Each `addRow()` is formatted immediately, but every line is retained
@@ -392,12 +401,15 @@ export class CsvStreamWriter {
   private lines: string[] = []
   private headerWritten = false
   private headers: string[] | boolean | undefined
+  /** Column order for object rows, resolved on the first one seen. */
+  private columns: string[] | undefined
 
-  constructor(options?: CsvWriteOptions) {
+  constructor(options?: CsvStreamWriterOptions) {
     this.formatter = new CsvRowFormatter(options)
     this.lineSeparator = this.formatter.lineSeparator
     this.bom = this.formatter.bom
     this.headers = options?.headers
+    this.columns = options?.columns ?? (Array.isArray(this.headers) ? this.headers : undefined)
 
     // Write header row immediately if string array provided
     if (Array.isArray(this.headers) && !this.headerWritten) {
@@ -411,6 +423,25 @@ export class CsvStreamWriter {
     this.lines.push(this.formatter.formatRow(values))
   }
 
+  /**
+   * Add a row from an object, projected through a column order resolved
+   * exactly as {@link writeCsvStream} resolves it: `columns` if given,
+   * else an explicit `headers` array, else the keys of the first object.
+   *
+   * A header line is emitted before the first object row unless one was
+   * already written or `headers: false` was passed.
+   */
+  addObject(item: Record<string, CellValue>): void {
+    if (!this.columns) {
+      this.columns = Object.keys(item)
+    }
+    if (!this.headerWritten && this.headers !== false) {
+      this.lines.push(this.formatter.formatHeader(this.columns))
+      this.headerWritten = true
+    }
+    this.addRow(this.columns.map((key) => item[key] ?? null))
+  }
+
   /** Finalize and return the CSV string */
   finish(): string {
     const parts: string[] = []
@@ -422,6 +453,32 @@ export class CsvStreamWriter {
     parts.push(this.lines.join(this.lineSeparator))
 
     return parts.join("")
+  }
+
+  /**
+   * Emit the finished CSV as a `ReadableStream<Uint8Array>`.
+   *
+   * **This is not a constant-memory stream.** Every row added so far is
+   * still buffered; {@link finish} runs first and the whole result is
+   * enqueued as one chunk. It exists so a writer can be handed to a
+   * `Response` body or a file sink without a manual encode step — not to
+   * bound memory. For output whose peak memory is independent of the row
+   * count, use {@link writeCsvStream}, which pulls rows from an iterable
+   * and flushes as it goes.
+   *
+   * `finish()` runs when the stream is first read, so rows added between
+   * `toStream()` and the first pull are still included, and the stream
+   * closes right after — no separate `finish()` call is needed (though
+   * one is harmless: `finish()` is idempotent here).
+   */
+  toStream(): ReadableStream<Uint8Array> {
+    const finish = (): Uint8Array => TEXT_ENCODER.encode(this.finish())
+    return new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(finish())
+        controller.close()
+      },
+    })
   }
 }
 

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -14,6 +14,7 @@ import type {
   TableDefinition,
   TableColumn,
 } from "./_types"
+import { rowsToObjects, selectSheet } from "./_objects"
 import { readXlsx } from "./xlsx/reader"
 import { readXlsb, looksLikeXlsb } from "./xlsx/xlsb/reader"
 import { readXls, looksLikeXls } from "./xls/reader"
@@ -144,50 +145,85 @@ export async function write(
 }
 
 /**
- * Quick helper: read a file and get the first sheet as array of objects.
- * Assumes first row is headers.
+ * Options for {@link readObjects}.
+ *
+ * The projection knobs are the same set — and the same defaults — as
+ * `XlsxObjectsReadOptions` and `OdsObjectsReadOptions`. They are applied
+ * to the workbook `read()` returns, so every one of them is honoured for
+ * every format `read()` can detect (XLSX, XLSB, XLS, ODS).
+ *
+ * The inherited {@link ReadOptions} fields are a different story: they are
+ * handed to the format reader and are honoured as unevenly as ever (see
+ * #365 item 4). `sheets` is omitted because {@link sheet} supersedes it.
+ */
+export interface ReadObjectsOptions extends Omit<ReadOptions, "sheets"> {
+  /** Sheet to read from. Index (0-based) or sheet name. Default: 0. */
+  sheet?: number | string
+  /** 0-based row index to use as headers. Default: 0. */
+  headerRow?: number
+  /** Skip rows where every cell is null/empty. Default: true. */
+  skipEmptyRows?: boolean
+  /** Transform header values (after String/trim normalization). */
+  transformHeader?: (header: string, index: number) => string
+  /** Transform each cell value. */
+  transformValue?: (
+    value: CellValue,
+    header: string,
+    rowIndex: number,
+    colIndex: number,
+  ) => CellValue
+  /**
+   * Maximum number of data rows to return (after the header row).
+   *
+   * Shadows `ReadOptions.maxRows` — this one is applied to the projected
+   * rows for every format, rather than to the XLSX parse only. The
+   * format reader is never handed a `maxRows`.
+   */
+  maxRows?: number
+}
+
+/**
+ * Result shape for {@link readObjects} — the same `{ data, headers }`
+ * every other `*Objects` reader returns.
+ */
+export interface ReadObjectsResult<
+  T extends Record<string, CellValue> = Record<string, CellValue>,
+> {
+  data: T[]
+  headers: string[]
+}
+
+/**
+ * Quick helper: read a file and get a sheet as objects keyed by a header
+ * row, plus the detected headers.
+ *
+ * Format-agnostic counterpart to `readXlsxObjects` / `readOdsObjects` —
+ * same options, same defaults, same `{ data, headers }` result.
  */
 export async function readObjects<T extends Record<string, CellValue> = Record<string, CellValue>>(
   input: ReadInput,
-  options?: ReadOptions,
-): Promise<T[]> {
-  const workbook = await read(input, options)
+  options?: ReadObjectsOptions,
+): Promise<ReadObjectsResult<T>> {
+  const {
+    sheet: sheetSelector = 0,
+    headerRow = 0,
+    skipEmptyRows = true,
+    transformHeader,
+    transformValue,
+    maxRows,
+    ...readOpts
+  } = options ?? {}
 
-  if (workbook.sheets.length === 0) {
-    return []
-  }
+  const workbook = await read(input, readOpts)
+  const sheet = selectSheet(workbook, sheetSelector)
 
-  const sheet = workbook.sheets[0]!
-  const rows = sheet.rows
-
-  if (rows.length === 0) {
-    return []
-  }
-
-  // First row is headers
-  const headerRow = rows[0]!
-  const headers = headerRow.map((h) => {
-    if (h === null || h === undefined) return ""
-    return String(h).trim()
+  return rowsToObjects<T>(sheet.rows, {
+    headerRow,
+    skipEmptyRows,
+    transformHeader,
+    transformValue,
+    maxRows,
   })
-
-  if (headers.length === 0) {
-    return []
-  }
-
-  const data: T[] = []
-  for (let i = 1; i < rows.length; i++) {
-    const row = rows[i]!
-    const obj: Record<string, CellValue> = {}
-    for (let j = 0; j < headers.length; j++) {
-      const key = headers[j]!
-      if (key === "") continue
-      obj[key] = j < row.length ? (row[j] ?? null) : null
-    }
-    data.push(obj as T)
-  }
-
-  return data
 }
 
 /** Options for writeObjects table generation */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // ── High-Level API ──────────────────────────────────────────────────
 export { read, write, readObjects, writeObjects } from "./defter"
-export type { WriteObjectsTableOption } from "./defter"
+export type { ReadObjectsOptions, ReadObjectsResult, WriteObjectsTableOption } from "./defter"
 
 // ── XLSX ────────────────────────────────────────────────────────────
 export { readXlsx } from "./xlsx/reader"
@@ -18,6 +18,7 @@ export type { StreamRow } from "./xlsx/stream-reader"
 export { XlsxStreamWriter, writeXlsxStream, XLSX_MAX_ROWS_PER_SHEET } from "./xlsx/stream-writer"
 export type {
   StreamWriterOptions,
+  XlsxStreamWriterOptions,
   XlsxWriteStreamOptions,
   XlsxStreamRow,
 } from "./xlsx/stream-writer"
@@ -46,8 +47,9 @@ export {
   formatCsvValue,
   fetchCsv,
 } from "./csv/index"
+export type { CsvObjectsResult } from "./csv/index"
 export { streamCsvRows, CsvStreamWriter, writeCsvStream } from "./csv/stream"
-export type { CsvStreamRow } from "./csv/stream"
+export type { CsvStreamRow, CsvStreamWriterOptions } from "./csv/stream"
 
 // ── JSON ───────────────────────────────────────────────────────────
 export {
@@ -72,6 +74,7 @@ export type {
   JsonWriteOptions,
   WorkbookToJsonOptions,
   NdjsonStreamReadOptions,
+  NdjsonStreamWriterOptions,
   FlattenOptions,
 } from "./json"
 
@@ -237,6 +240,7 @@ export {
 
 // ── Sheet Utilities ──────────────────────────────────────────────
 export { sheetToObjects, sheetToArrays } from "./sheet-utils"
+export type { SheetObjectsResult, SheetToObjectsOptions } from "./sheet-utils"
 
 // ── Export (HTML / Markdown / JSON / TSV) ────────────────────────────
 export { toHtml, toMarkdown, toJson, fromHtml } from "./export/index"

--- a/src/json.ts
+++ b/src/json.ts
@@ -8,7 +8,7 @@ export { writeJson, writeNdjson, workbookToJson } from "./json/writer"
 export type { JsonWriteOptions, WorkbookToJsonOptions } from "./json/writer"
 
 export { NdjsonStreamWriter, streamNdjsonRows, readNdjsonStream } from "./json/stream"
-export type { NdjsonStreamReadOptions } from "./json/stream"
+export type { NdjsonStreamReadOptions, NdjsonStreamWriterOptions } from "./json/stream"
 
 export { flattenValue, collectHeaders } from "./json/flatten"
 export type { FlattenOptions } from "./json/flatten"

--- a/src/json/stream.ts
+++ b/src/json/stream.ts
@@ -2,44 +2,113 @@
 // CF Workers / Deno / Node 18+ compatible: uses WHATWG ReadableStream only.
 
 import type { CellValue } from "../_types"
-import { ParseError } from "../errors"
+import { InvalidArgumentError, ParseError } from "../errors"
 import { flattenValue, type FlattenOptions } from "./flatten"
 
 const TEXT_ENCODER = new TextEncoder()
 const TEXT_DECODER = new TextDecoder("utf-8")
 
 /**
- * Incremental NDJSON writer. Each call to {@link write} appends one JSON
- * object terminated by `\n`. Use {@link toStream} to expose the output as
- * a `ReadableStream<Uint8Array>` for piping to a `Response` body, file,
- * or another stream.
+ * Constructor options for {@link NdjsonStreamWriter}.
+ */
+export interface NdjsonStreamWriterOptions {
+  // `Date` values always serialize as ISO strings. There used to be an
+  // `isoDates` option and it never did anything: JSON.stringify calls
+  // Date.prototype.toJSON before consulting the replacer, so a replacer
+  // testing `value instanceof Date` is never reached. Removed before v1
+  // rather than frozen; see the note in json/writer.ts.
+  /**
+   * Column names for {@link NdjsonStreamWriter.addRow}. Positional rows
+   * are zipped against this list to produce each object's keys.
+   *
+   * NDJSON has no positional row concept of its own, so `addRow` throws
+   * without it rather than guessing a key order.
+   */
+  columns?: string[]
+}
+
+/**
+ * Incremental NDJSON writer. Each call to {@link addObject} appends one
+ * JSON object terminated by `\n`. Use {@link toStream} to expose the
+ * output as a `ReadableStream<Uint8Array>` for piping to a `Response`
+ * body, file, or another stream.
  *
  * ```ts
  * const w = new NdjsonStreamWriter()
- * for await (const row of source) w.write(row)
- * w.end()
- * return new Response(w.toStream(), { headers: { 'content-type': 'application/x-ndjson' } })
+ * const body = w.toStream()
+ * for await (const row of source) w.addObject(row)
+ * w.finish() // closes the stream once it has drained
+ * return new Response(body, { headers: { 'content-type': 'application/x-ndjson' } })
  * ```
  */
 export class NdjsonStreamWriter {
   private buffer: string[] = []
   private done = false
-  private isoDates: boolean
+  private columns: string[] | undefined
 
-  constructor(options?: { isoDates?: boolean }) {
-    this.isoDates = options?.isoDates ?? true
+  constructor(options?: NdjsonStreamWriterOptions) {
+    this.columns = options?.columns
   }
 
-  /** Append one row. */
-  write(row: Record<string, CellValue>): void {
+  /**
+   * Append one row from an object — one NDJSON line per call.
+   */
+  addObject(row: Record<string, CellValue>): void {
     if (this.done) {
-      throw new Error("Cannot write to NdjsonStreamWriter after end()")
+      throw new Error("Cannot write to NdjsonStreamWriter after finish()/end()")
     }
-    const replacer = this.isoDates ? dateReplacer : undefined
-    this.buffer.push(JSON.stringify(row, replacer) + "\n")
+    this.buffer.push(JSON.stringify(row) + "\n")
   }
 
-  /** Mark the writer finished. Subsequent writes throw. */
+  /**
+   * Append one row of positional values, keyed by the `columns` passed to
+   * the constructor.
+   *
+   * Throws when no `columns` were configured — the same contract as
+   * `XlsxStreamWriter.addObject`, which needs `columns[].key` to map the
+   * other direction.
+   */
+  addRow(values: CellValue[]): void {
+    if (!this.columns) {
+      throw new InvalidArgumentError(
+        "addRow requires `columns` — NDJSON rows are objects, so positional values need key names. Pass `new NdjsonStreamWriter({ columns: [...] })` or use addObject().",
+      )
+    }
+    const row: Record<string, CellValue> = {}
+    for (let i = 0; i < this.columns.length; i++) {
+      row[this.columns[i]!] = values[i] ?? null
+    }
+    this.addObject(row)
+  }
+
+  /**
+   * Mark the writer finished and return the buffered output.
+   *
+   * Subsequent `addRow`/`addObject` calls throw, and a stream handed out
+   * by {@link toStream} closes once it has drained. Note that a writer
+   * already drained through `toStream()` has nothing left to return here
+   * — pick one drain or the other.
+   */
+  finish(): string {
+    this.done = true
+    return this.toString()
+  }
+
+  /**
+   * @deprecated Renamed to {@link addObject} so all three stream writers
+   * share `addRow` / `addObject` / `finish`. Same behaviour; this alias
+   * will be removed in a future major.
+   */
+  write(row: Record<string, CellValue>): void {
+    this.addObject(row)
+  }
+
+  /**
+   * Mark the writer finished. Subsequent writes throw.
+   *
+   * @deprecated Use {@link finish}, which does the same and returns the
+   * buffered output. This alias will be removed in a future major.
+   */
   end(): void {
     this.done = true
   }
@@ -51,7 +120,11 @@ export class NdjsonStreamWriter {
 
   /**
    * Expose the writer as a `ReadableStream<Uint8Array>`. The stream
-   * remains open until {@link end} is called.
+   * remains open until {@link finish} is called.
+   *
+   * Unlike `CsvStreamWriter.toStream()` / `XlsxStreamWriter.toStream()`,
+   * which encode an already-finished buffer, this one is a live drain:
+   * rows written while the consumer reads are delivered as they arrive.
    *
    * Consumed rows are released as they are enqueued, so a writer that is
    * only ever drained through the stream holds no more than the rows
@@ -169,11 +242,6 @@ function tryParseLine(
       { cause: err },
     )
   }
-}
-
-function dateReplacer(_key: string, value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  return value
 }
 
 /**

--- a/src/json/writer.ts
+++ b/src/json/writer.ts
@@ -2,13 +2,21 @@
 
 import type { CellValue, Workbook } from "../_types"
 
+/**
+ * `Date` values always serialize as ISO strings.
+ *
+ * There used to be an `isoDates` option here, and it never did anything:
+ * `JSON.stringify` calls `Date.prototype.toJSON` *before* consulting the
+ * replacer, so a replacer testing `value instanceof Date` is never
+ * reached. `isoDates: false` produced byte-identical output. Removed
+ * before v1 rather than frozen — and there is no honest alternative
+ * behaviour to give it, since JSON cannot carry a Date at all.
+ */
 export interface JsonWriteOptions {
   /** Pretty-print with 2-space indent. Default: false. */
   pretty?: boolean
   /** Indent string when `pretty` is true. Default: "  ". */
   indent?: string
-  /** Convert `Date` cells to ISO strings. Default: true. */
-  isoDates?: boolean
 }
 
 /**
@@ -17,22 +25,16 @@ export interface JsonWriteOptions {
 export function writeJson(data: Record<string, CellValue>[], options?: JsonWriteOptions): string {
   const pretty = options?.pretty ?? false
   const indent = options?.indent ?? "  "
-  const isoDates = options?.isoDates ?? true
-  return JSON.stringify(data, isoDates ? dateReplacer : undefined, pretty ? indent : undefined)
+  return JSON.stringify(data, undefined, pretty ? indent : undefined)
 }
 
 /**
  * Serialize an array of row objects to NDJSON / JSON Lines.
  * One JSON object per line, terminated by `\n`.
  */
-export function writeNdjson(
-  data: Record<string, CellValue>[],
-  options?: { isoDates?: boolean },
-): string {
-  const isoDates = options?.isoDates ?? true
+export function writeNdjson(data: Record<string, CellValue>[]): string {
   if (data.length === 0) return ""
-  const replacer = isoDates ? dateReplacer : undefined
-  return data.map((row) => JSON.stringify(row, replacer)).join("\n") + "\n"
+  return data.map((row) => JSON.stringify(row)).join("\n") + "\n"
 }
 
 /**
@@ -79,8 +81,7 @@ export function workbookToJson(wb: Workbook, options?: WorkbookToJsonOptions): s
 
   const pretty = options?.pretty ?? false
   const indent = options?.indent ?? "  "
-  const isoDates = options?.isoDates ?? true
-  return JSON.stringify(all, isoDates ? dateReplacer : undefined, pretty ? indent : undefined)
+  return JSON.stringify(all, undefined, pretty ? indent : undefined)
 }
 
 function sheetToRowObjects(rows: CellValue[][], headerRowIdx: number): Record<string, CellValue>[] {
@@ -98,9 +99,4 @@ function sheetToRowObjects(rows: CellValue[][], headerRowIdx: number): Record<st
     result.push(obj)
   }
   return result
-}
-
-function dateReplacer(_key: string, value: unknown): unknown {
-  if (value instanceof Date) return value.toISOString()
-  return value
 }

--- a/src/ods/objects.ts
+++ b/src/ods/objects.ts
@@ -2,7 +2,7 @@
 // Header-row-based read/write helpers that mirror parseCsvObjects ergonomics.
 
 import type { CellValue, ReadInput, ReadOptions, WriteOutput } from "../_types"
-import { ParseError } from "../errors"
+import { rowsToObjects, selectSheet } from "../_objects"
 import { readOds } from "./reader"
 import { writeOds } from "./writer"
 
@@ -44,14 +44,10 @@ export interface OdsObjectsResult<T extends Record<string, CellValue> = Record<s
 export async function readOdsObjects<
   T extends Record<string, CellValue> = Record<string, CellValue>,
 >(input: ReadInput, options?: OdsObjectsReadOptions): Promise<OdsObjectsResult<T>> {
-  const headerRowIdx = options?.headerRow ?? 0
-  const skipEmpty = options?.skipEmptyRows ?? true
-  const sheetSelector = options?.sheet ?? 0
-
   const {
-    sheet: _sheet,
-    headerRow: _hr,
-    skipEmptyRows: _se,
+    sheet: sheetSelector = 0,
+    headerRow = 0,
+    skipEmptyRows = true,
     transformHeader,
     transformValue,
     maxRows,
@@ -59,58 +55,15 @@ export async function readOdsObjects<
   } = options ?? {}
 
   const wb = await readOds(input, readOpts)
-  if (wb.sheets.length === 0) {
-    throw new ParseError("Workbook contains no sheets")
-  }
+  const sheet = selectSheet(wb, sheetSelector)
 
-  const sheet =
-    typeof sheetSelector === "number"
-      ? wb.sheets[sheetSelector]
-      : wb.sheets.find((s) => s.name === sheetSelector)
-
-  if (!sheet) {
-    throw new ParseError(
-      typeof sheetSelector === "number"
-        ? `Sheet index ${sheetSelector} out of range (workbook has ${wb.sheets.length} sheet(s))`
-        : `Sheet "${sheetSelector}" not found`,
-    )
-  }
-
-  if (sheet.rows.length <= headerRowIdx) {
-    return { data: [], headers: [] }
-  }
-
-  const headerRow = sheet.rows[headerRowIdx]!
-  let headers = headerRow.map((h) => {
-    if (h === null || h === undefined) return ""
-    return String(h).trim()
+  return rowsToObjects<T>(sheet.rows, {
+    headerRow,
+    skipEmptyRows,
+    transformHeader,
+    transformValue,
+    maxRows,
   })
-
-  if (transformHeader) {
-    headers = headers.map((h, i) => transformHeader(h, i))
-  }
-
-  const data: T[] = []
-  for (let i = headerRowIdx + 1; i < sheet.rows.length; i++) {
-    if (maxRows !== undefined && data.length >= maxRows) break
-    const row = sheet.rows[i]!
-
-    if (skipEmpty && row.every((v) => v === null || v === undefined || v === "")) {
-      continue
-    }
-
-    const obj: Record<string, CellValue> = {}
-    for (let j = 0; j < headers.length; j++) {
-      let val: CellValue = j < row.length ? (row[j] ?? null) : null
-      if (transformValue) {
-        val = transformValue(val, headers[j]!, i, j)
-      }
-      obj[headers[j]!] = val
-    }
-    data.push(obj as T)
-  }
-
-  return { data, headers }
 }
 
 /**

--- a/src/sheet-utils.ts
+++ b/src/sheet-utils.ts
@@ -2,41 +2,47 @@
 // Helper functions to convert Sheet data into objects or arrays.
 
 import type { CellValue, Sheet } from "./_types"
+import { rowsToObjects } from "./_objects"
 
 /**
- * Convert sheet rows to an array of objects using a row as headers.
+ * Options for {@link sheetToObjects}.
+ */
+export interface SheetToObjectsOptions {
+  /** 0-based row index to use as headers. Default: 0. */
+  headerRow?: number
+}
+
+/**
+ * Result shape for {@link sheetToObjects}, mirroring `XlsxObjectsResult`
+ * and `OdsObjectsResult`.
+ */
+export interface SheetObjectsResult<
+  T extends Record<string, CellValue> = Record<string, CellValue>,
+> {
+  data: T[]
+  headers: string[]
+}
+
+/**
+ * Convert sheet rows to objects keyed by a header row, plus the detected
+ * headers.
+ *
+ * Every row after the header row is returned as-is: this is a pure
+ * in-memory projection with no filtering or transform hooks. For
+ * `skipEmptyRows` / `transformHeader` / `transformValue` / `maxRows`, read
+ * through `readXlsxObjects`, `readOdsObjects`, or `readObjects` instead.
  *
  * @param sheet - The sheet to convert
- * @param options.headerRow - 0-based row index to use as headers (default: 0)
- * @returns Array of objects keyed by header values
+ * @returns `{ data, headers }` — the same shape every `*Objects` reader returns
  */
-export function sheetToObjects<T = Record<string, CellValue>>(
+export function sheetToObjects<T extends Record<string, CellValue> = Record<string, CellValue>>(
   sheet: Sheet,
-  options?: { headerRow?: number },
-): T[] {
-  const headerRowIdx = options?.headerRow ?? 0
-
-  if (sheet.rows.length <= headerRowIdx) {
-    return []
-  }
-
-  const headerRow = sheet.rows[headerRowIdx]!
-  const headers = headerRow.map((h) => {
-    if (h === null || h === undefined) return ""
-    return String(h).trim()
+  options?: SheetToObjectsOptions,
+): SheetObjectsResult<T> {
+  return rowsToObjects<T>(sheet.rows, {
+    headerRow: options?.headerRow ?? 0,
+    skipEmptyRows: false,
   })
-
-  const result: T[] = []
-  for (let i = headerRowIdx + 1; i < sheet.rows.length; i++) {
-    const row = sheet.rows[i]!
-    const obj: Record<string, CellValue> = {}
-    for (let j = 0; j < headers.length; j++) {
-      obj[headers[j]!] = j < row.length ? (row[j] ?? null) : null
-    }
-    result.push(obj as T)
-  }
-
-  return result
 }
 
 /**

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -21,6 +21,7 @@ export type { StreamRow } from "./xlsx/stream-reader"
 export { XlsxStreamWriter, writeXlsxStream, XLSX_MAX_ROWS_PER_SHEET } from "./xlsx/stream-writer"
 export type {
   StreamWriterOptions,
+  XlsxStreamWriterOptions,
   XlsxWriteStreamOptions,
   XlsxStreamRow,
 } from "./xlsx/stream-writer"

--- a/src/xlsx/objects.ts
+++ b/src/xlsx/objects.ts
@@ -2,7 +2,7 @@
 // Header-row-based read/write helpers that mirror parseCsvObjects ergonomics.
 
 import type { CellValue, ReadInput, ReadOptions, WriteOutput } from "../_types"
-import { ParseError } from "../errors"
+import { rowsToObjects, selectSheet } from "../_objects"
 import { readXlsx } from "./reader"
 import { writeXlsx } from "./writer"
 
@@ -50,14 +50,10 @@ export interface XlsxObjectsResult<
 export async function readXlsxObjects<
   T extends Record<string, CellValue> = Record<string, CellValue>,
 >(input: ReadInput, options?: XlsxObjectsReadOptions): Promise<XlsxObjectsResult<T>> {
-  const headerRowIdx = options?.headerRow ?? 0
-  const skipEmpty = options?.skipEmptyRows ?? true
-  const sheetSelector = options?.sheet ?? 0
-
   const {
-    sheet: _sheet,
-    headerRow: _hr,
-    skipEmptyRows: _se,
+    sheet: sheetSelector = 0,
+    headerRow = 0,
+    skipEmptyRows = true,
     transformHeader,
     transformValue,
     maxRows,
@@ -65,58 +61,15 @@ export async function readXlsxObjects<
   } = options ?? {}
 
   const wb = await readXlsx(input, readOpts)
-  if (wb.sheets.length === 0) {
-    throw new ParseError("Workbook contains no sheets")
-  }
+  const sheet = selectSheet(wb, sheetSelector)
 
-  const sheet =
-    typeof sheetSelector === "number"
-      ? wb.sheets[sheetSelector]
-      : wb.sheets.find((s) => s.name === sheetSelector)
-
-  if (!sheet) {
-    throw new ParseError(
-      typeof sheetSelector === "number"
-        ? `Sheet index ${sheetSelector} out of range (workbook has ${wb.sheets.length} sheet(s))`
-        : `Sheet "${sheetSelector}" not found`,
-    )
-  }
-
-  if (sheet.rows.length <= headerRowIdx) {
-    return { data: [], headers: [] }
-  }
-
-  const headerRow = sheet.rows[headerRowIdx]!
-  let headers = headerRow.map((h) => {
-    if (h === null || h === undefined) return ""
-    return String(h).trim()
+  return rowsToObjects<T>(sheet.rows, {
+    headerRow,
+    skipEmptyRows,
+    transformHeader,
+    transformValue,
+    maxRows,
   })
-
-  if (transformHeader) {
-    headers = headers.map((h, i) => transformHeader(h, i))
-  }
-
-  const data: T[] = []
-  for (let i = headerRowIdx + 1; i < sheet.rows.length; i++) {
-    if (maxRows !== undefined && data.length >= maxRows) break
-    const row = sheet.rows[i]!
-
-    if (skipEmpty && row.every((v) => v === null || v === undefined || v === "")) {
-      continue
-    }
-
-    const obj: Record<string, CellValue> = {}
-    for (let j = 0; j < headers.length; j++) {
-      let val: CellValue = j < row.length ? (row[j] ?? null) : null
-      if (transformValue) {
-        val = transformValue(val, headers[j]!, i, j)
-      }
-      obj[headers[j]!] = val
-    }
-    data.push(obj as T)
-  }
-
-  return { data, headers }
 }
 
 /**

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -61,6 +61,15 @@ export interface StreamWriterOptions {
   repeatHeaders?: boolean
 }
 
+/**
+ * Constructor options for {@link XlsxStreamWriter}.
+ *
+ * Alias of {@link StreamWriterOptions}, which occupies a generic name for
+ * an XLSX-only type (#365 item 8). Prefer this one — every stream writer
+ * in the library names its options `<Writer>Options`.
+ */
+export type XlsxStreamWriterOptions = StreamWriterOptions
+
 export interface XlsxWriteStreamOptions extends StreamWriterOptions {
   /**
    * Write strings as inline `<is><t>` cells instead of routing them
@@ -381,7 +390,7 @@ export class XlsxStreamWriter {
   /** Captured for `repeatHeaders`. Set when the first row is written. */
   private headerRowValues: CellValue[] | null = null
 
-  constructor(options: StreamWriterOptions) {
+  constructor(options: XlsxStreamWriterOptions) {
     this.sheetName = options.name
     this.columns = options.columns
     this.freezePane = options.freezePane
@@ -527,6 +536,34 @@ export class XlsxStreamWriter {
     )
 
     return zip.build()
+  }
+
+  /**
+   * Emit the finished workbook as a `ReadableStream<Uint8Array>`.
+   *
+   * **This is not a constant-memory stream.** Every serialized row is
+   * still buffered; {@link finish} runs first and the whole archive is
+   * enqueued as one chunk. It exists so a writer can be handed to a
+   * `Response` body or a file sink without a manual buffer step — not to
+   * bound memory. For output whose peak memory is independent of the row
+   * count, use {@link writeXlsxStream}, which pulls rows from an iterable
+   * and emits the ZIP chunk by chunk.
+   *
+   * `finish()` runs when the stream is first read, so rows added between
+   * `toStream()` and the first pull are still included, and the stream
+   * closes right after — no separate `finish()` call is needed (though
+   * one is harmless: `finish()` is idempotent here).
+   */
+  toStream(): ReadableStream<Uint8Array> {
+    const finish = (): Promise<Uint8Array> => this.finish()
+    return new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        // A rejected `pull` errors the stream, so a failing `finish()`
+        // surfaces to the consumer rather than hanging it.
+        controller.enqueue(await finish())
+        controller.close()
+      },
+    })
   }
 }
 

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -149,30 +149,29 @@ describe("write()", () => {
 // ── readObjects() ───────────────────────────────────────────────────
 
 describe("readObjects()", () => {
-  it("returns array of objects with headers as keys", async () => {
+  it("returns { data, headers } — the same shape as every other *Objects reader", async () => {
     const xlsx = await makeXlsx([
       ["Name", "Age", "Active"],
       ["Alice", 30, true],
       ["Bob", 25, false],
     ])
 
-    const objects = await readObjects(xlsx)
+    const { data, headers } = await readObjects(xlsx)
 
-    expect(objects).toHaveLength(2)
-    expect(objects[0]).toEqual({ Name: "Alice", Age: 30, Active: true })
-    expect(objects[1]).toEqual({ Name: "Bob", Age: 25, Active: false })
+    expect(headers).toEqual(["Name", "Age", "Active"])
+    expect(data).toHaveLength(2)
+    expect(data[0]).toEqual({ Name: "Alice", Age: 30, Active: true })
+    expect(data[1]).toEqual({ Name: "Bob", Age: 25, Active: false })
   })
 
-  it("returns empty array for empty sheet", async () => {
+  it("returns empty data and headers for an empty sheet", async () => {
     const xlsx = await makeXlsx([])
-    const objects = await readObjects(xlsx)
-    expect(objects).toEqual([])
+    expect(await readObjects(xlsx)).toEqual({ data: [], headers: [] })
   })
 
-  it("returns empty array for header-only sheet", async () => {
+  it("returns the headers but no data for a header-only sheet", async () => {
     const xlsx = await makeXlsx([["Name", "Age"]])
-    const objects = await readObjects(xlsx)
-    expect(objects).toEqual([])
+    expect(await readObjects(xlsx)).toEqual({ data: [], headers: ["Name", "Age"] })
   })
 
   it("handles null values in data rows", async () => {
@@ -182,11 +181,11 @@ describe("readObjects()", () => {
       [null, 100],
     ])
 
-    const objects = await readObjects(xlsx)
+    const { data } = await readObjects(xlsx)
 
-    expect(objects).toHaveLength(2)
-    expect(objects[0]).toEqual({ Name: "Alice", Score: null })
-    expect(objects[1]).toEqual({ Name: null, Score: 100 })
+    expect(data).toHaveLength(2)
+    expect(data[0]).toEqual({ Name: "Alice", Score: null })
+    expect(data[1]).toEqual({ Name: null, Score: 100 })
   })
 
   it("works with ODS input", async () => {
@@ -195,37 +194,110 @@ describe("readObjects()", () => {
       ["Pen", 1.5],
     ])
 
-    const objects = await readObjects(ods)
+    const { data, headers } = await readObjects(ods)
 
-    expect(objects).toHaveLength(1)
-    expect(objects[0]).toEqual({ Product: "Pen", Price: 1.5 })
+    expect(headers).toEqual(["Product", "Price"])
+    expect(data).toHaveLength(1)
+    expect(data[0]).toEqual({ Product: "Pen", Price: 1.5 })
   })
 
-  it("skips empty-string headers", async () => {
+  it("keys empty-string headers like the format-specific readers do", async () => {
+    // Pre-v1 this reader — and only this reader — dropped "" keys. The
+    // XLSX/ODS/CSV readers all keep them, so it converged on those.
     const xlsx = await makeXlsx([
       ["Name", "", "Age"],
       ["Alice", "ignore", 30],
     ])
 
-    const objects = await readObjects(xlsx)
+    const { data, headers } = await readObjects(xlsx)
 
-    expect(objects).toHaveLength(1)
-    // Empty header key should be skipped
-    expect(objects[0]!["Name"]).toBe("Alice")
-    expect(objects[0]!["Age"]).toBe(30)
-    expect(objects[0]![""]).toBeUndefined()
+    expect(headers).toEqual(["Name", "", "Age"])
+    expect(data).toHaveLength(1)
+    expect(data[0]!["Name"]).toBe("Alice")
+    expect(data[0]!["Age"]).toBe(30)
+    expect(data[0]![""]).toBe("ignore")
   })
 
-  it("returns empty array when workbook has no sheets", async () => {
-    // Edge case: workbook with empty sheets array
-    // We can't really create a file with zero sheets, but we can create one
-    // with an empty first sheet
+  it("returns empty data for a workbook whose first sheet has no rows", async () => {
     const xlsx = await writeXlsx({
       sheets: [{ name: "Empty", rows: [] }],
     })
 
-    const objects = await readObjects(xlsx)
-    expect(objects).toEqual([])
+    expect(await readObjects(xlsx)).toEqual({ data: [], headers: [] })
+  })
+
+  // ── option parity with readXlsxObjects / readOdsObjects ───────────
+
+  it("selects a sheet by index and by name", async () => {
+    const xlsx = await writeXlsx({
+      sheets: [
+        { name: "First", rows: [["A"], [1]] },
+        { name: "Second", rows: [["B"], [2]] },
+      ],
+    })
+
+    expect((await readObjects(xlsx, { sheet: 1 })).data).toEqual([{ B: 2 }])
+    expect((await readObjects(xlsx, { sheet: "Second" })).data).toEqual([{ B: 2 }])
+  })
+
+  it("throws for a sheet selector that resolves to nothing", async () => {
+    const xlsx = await makeXlsx([["A"], [1]])
+    await expect(readObjects(xlsx, { sheet: 9 })).rejects.toThrow(/out of range/)
+    await expect(readObjects(xlsx, { sheet: "Nope" })).rejects.toThrow(/not found/)
+  })
+
+  it("honours headerRow", async () => {
+    const xlsx = await makeXlsx([["report title"], ["Name", "Score"], ["Alice", 100]])
+    const { data, headers } = await readObjects(xlsx, { headerRow: 1 })
+    expect(headers).toEqual(["Name", "Score"])
+    expect(data).toEqual([{ Name: "Alice", Score: 100 }])
+  })
+
+  it("skips fully empty rows by default, and keeps them when asked", async () => {
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [
+            ["A", "B"],
+            [null, null],
+            ["x", "y"],
+          ],
+        },
+      ],
+    })
+
+    expect((await readObjects(xlsx)).data).toEqual([{ A: "x", B: "y" }])
+    expect((await readObjects(xlsx, { skipEmptyRows: false })).data).toEqual([
+      { A: null, B: null },
+      { A: "x", B: "y" },
+    ])
+  })
+
+  it("honours transformHeader and transformValue", async () => {
+    const xlsx = await makeXlsx([
+      ["First Name", "Score"],
+      ["Alice", "100"],
+    ])
+
+    const { data, headers } = await readObjects(xlsx, {
+      transformHeader: (h) => h.toLowerCase().replace(/ /g, "_"),
+      transformValue: (v, header) => (header === "score" ? Number(v) : v),
+    })
+
+    expect(headers).toEqual(["first_name", "score"])
+    expect(data).toEqual([{ first_name: "Alice", score: 100 }])
+  })
+
+  it("honours maxRows on the projected rows, for every format", async () => {
+    const rows = [["N"], [1], [2], [3]]
+    const xlsx = await makeXlsx(rows)
+    const ods = await makeOds(rows)
+
+    expect((await readObjects(xlsx, { maxRows: 2 })).data).toEqual([{ N: 1 }, { N: 2 }])
+    // ReadOptions.maxRows is XLSX-only; this one is applied after the read,
+    // so ODS honours it too.
+    expect((await readObjects(ods, { maxRows: 2 })).data).toEqual([{ N: 1 }, { N: 2 }])
   })
 })
 
@@ -347,8 +419,8 @@ describe("round-trip", () => {
     ]
 
     const output = await writeObjects(original)
-    const result = await readObjects(output)
+    const { data } = await readObjects(output)
 
-    expect(result).toEqual(original)
+    expect(data).toEqual(original)
   })
 })

--- a/test/encryption.test.ts
+++ b/test/encryption.test.ts
@@ -92,8 +92,8 @@ describe("decryption across the read entry points", () => {
 
   it("readObjects() decrypts", async () => {
     const enc = await writeXlsx({ ...book(), encryption: { password: "pw", spinCount: 64 } })
-    const objs = await readObjects<{ Name: string; Score: number }>(enc, { password: "pw" })
-    expect(objs).toEqual([
+    const { data } = await readObjects<{ Name: string; Score: number }>(enc, { password: "pw" })
+    expect(data).toEqual([
       { Name: "Ada", Score: 95 },
       { Name: "Linus", Score: 88 },
     ])

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -31,8 +31,11 @@ import type {
   DataValidation,
   MergeRange,
   PaperSize,
+  ReadObjectsOptions,
+  ReadObjectsResult,
   ReadOptions,
   Sheet,
+  SheetObjectsResult,
   SheetTextBox,
   Sparkline,
   TableColumn,
@@ -43,9 +46,15 @@ import type {
   WriteOptions,
   WriteSheet,
 } from "../src/index"
-import type { CsvReadOptions, CsvWriteOptions } from "../src/csv"
-import type { OdsStreamRow } from "../src/ods"
-import type { XlsxObjectsResult } from "../src/xlsx"
+import type {
+  CsvObjectsResult,
+  CsvReadOptions,
+  CsvStreamWriterOptions,
+  CsvWriteOptions,
+} from "../src/csv"
+import type { OdsObjectsResult, OdsStreamRow } from "../src/ods"
+import type { JsonReadResult, NdjsonStreamWriterOptions } from "../src/json"
+import type { XlsxObjectsResult, XlsxStreamWriterOptions } from "../src/xlsx"
 
 /** Referencing each type keeps the imports load-bearing rather than unused. */
 type _SurfaceCheck = [
@@ -59,14 +68,24 @@ type _SurfaceCheck = [
   ColumnDef,
   ConditionalRule,
   ConditionalRuleType,
+  // Every `*Objects` reader's result type is nameable, and they are all
+  // the same `{ data, headers }` shape (#365 item 6).
+  CsvObjectsResult,
   CsvReadOptions,
+  CsvStreamWriterOptions,
   CsvWriteOptions,
   DataValidation,
+  JsonReadResult,
   MergeRange,
+  NdjsonStreamWriterOptions,
+  OdsObjectsResult,
   OdsStreamRow,
   PaperSize,
+  ReadObjectsOptions,
+  ReadObjectsResult,
   ReadOptions,
   Sheet,
+  SheetObjectsResult,
   SheetTextBox,
   Sparkline,
   TableColumn,
@@ -77,6 +96,22 @@ type _SurfaceCheck = [
   WriteOptions,
   WriteSheet,
   XlsxObjectsResult,
+  XlsxStreamWriterOptions,
+]
+
+/**
+ * #365 item 6: every `*Objects` reader returns the *same* `{ data, headers }`
+ * type, not merely a similar one. `tsc --noEmit` is the assertion.
+ */
+type Assert<T extends true> = T
+type Mutual<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false
+
+type _ObjectsResultsAgree = [
+  Assert<Mutual<ReadObjectsResult, XlsxObjectsResult>>,
+  Assert<Mutual<ReadObjectsResult, OdsObjectsResult>>,
+  Assert<Mutual<ReadObjectsResult, CsvObjectsResult>>,
+  Assert<Mutual<ReadObjectsResult, SheetObjectsResult>>,
+  Assert<Mutual<ReadObjectsResult, JsonReadResult>>,
 ]
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/test/objects-result-shape.test.ts
+++ b/test/objects-result-shape.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import { readObjects } from "../src/defter"
+import { readXlsxObjects } from "../src/xlsx/objects"
+import { readOdsObjects } from "../src/ods/objects"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeOds } from "../src/ods/writer"
+import { parseCsvObjects } from "../src/csv/reader"
+import { parseJson } from "../src/json/reader"
+import { readXml } from "../src/xml/data-reader"
+import { sheetToObjects } from "../src/sheet-utils"
+
+// ── One result shape for every *Objects reader (#365 item 6) ─────────
+// `readObjects` and `sheetToObjects` used to return a bare `T[]`, so the
+// same "read a table as objects" idea had two incompatible shapes. v1
+// freezes one: `{ data, headers }`.
+
+const ROWS = [
+  ["Name", "Age"],
+  ["Alice", 30],
+  ["Bob", 25],
+]
+
+const EXPECTED = [
+  { Name: "Alice", Age: 30 },
+  { Name: "Bob", Age: 25 },
+]
+
+describe("every *Objects reader returns { data, headers }", () => {
+  it("readObjects", async () => {
+    const result = await readObjects(await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] }))
+    expect(Object.keys(result).sort()).toEqual(["data", "headers"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual(EXPECTED)
+  })
+
+  it("readXlsxObjects", async () => {
+    const result = await readXlsxObjects(await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] }))
+    expect(Object.keys(result).sort()).toEqual(["data", "headers"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual(EXPECTED)
+  })
+
+  it("readOdsObjects", async () => {
+    const result = await readOdsObjects(await writeOds({ sheets: [{ name: "S", rows: ROWS }] }))
+    expect(Object.keys(result).sort()).toEqual(["data", "headers"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual(EXPECTED)
+  })
+
+  it("parseCsvObjects", () => {
+    const result = parseCsvObjects("Name,Age\nAlice,30\nBob,25", {
+      header: true,
+      typeInference: true,
+    })
+    expect(Object.keys(result).sort()).toEqual(["data", "headers"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual(EXPECTED)
+  })
+
+  it("parseJson", () => {
+    const result = parseJson(JSON.stringify(EXPECTED))
+    expect(Object.keys(result).sort()).toEqual(["data", "headers"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual(EXPECTED)
+  })
+
+  it("readXml", () => {
+    const result = readXml(
+      "<rows><row><Name>Alice</Name><Age>30</Age></row><row><Name>Bob</Name><Age>25</Age></row></rows>",
+      { rowTag: "row" },
+    )
+    // The one superset: readXml also reports the row tag it used.
+    expect(Object.keys(result).sort()).toEqual(["data", "headers", "rowTag"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    // readXml has no type inference, so values stay strings.
+    expect(result.data).toEqual([
+      { Name: "Alice", Age: "30" },
+      { Name: "Bob", Age: "25" },
+    ])
+  })
+
+  it("sheetToObjects", () => {
+    const result = sheetToObjects({ name: "S", rows: ROWS })
+    expect(Object.keys(result).sort()).toEqual(["data", "headers"])
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual(EXPECTED)
+  })
+})
+
+describe("shared projection semantics", () => {
+  it("readObjects, readXlsxObjects and readOdsObjects agree on the same table", async () => {
+    const rows = [
+      ["A", "B"],
+      [null, null],
+      [1, 2],
+    ]
+    const xlsx = await writeXlsx({ sheets: [{ name: "S", rows }] })
+    const ods = await writeOds({ sheets: [{ name: "S", rows }] })
+
+    const viaRead = await readObjects(xlsx)
+    const viaXlsx = await readXlsxObjects(xlsx)
+    const viaOds = await readOdsObjects(ods)
+
+    expect(viaRead).toEqual(viaXlsx)
+    expect(viaRead).toEqual(viaOds)
+    // Empty rows skipped by default, in all three.
+    expect(viaRead.data).toEqual([{ A: 1, B: 2 }])
+  })
+
+  it("keeps empty-string header keys everywhere", async () => {
+    const rows = [
+      ["A", "", "B"],
+      [1, 2, 3],
+    ]
+    const xlsx = await writeXlsx({ sheets: [{ name: "S", rows }] })
+
+    const viaRead = await readObjects(xlsx)
+    const viaXlsx = await readXlsxObjects(xlsx)
+    const viaCsv = parseCsvObjects("A,,B\n1,2,3", { header: true, typeInference: true })
+
+    expect(viaRead).toEqual(viaXlsx)
+    expect(viaRead.data).toEqual([{ A: 1, "": 2, B: 3 }])
+    expect(viaCsv.data).toEqual([{ A: 1, "": 2, B: 3 }])
+  })
+})

--- a/test/readable-stream-input.test.ts
+++ b/test/readable-stream-input.test.ts
@@ -153,9 +153,9 @@ describe("read() — ReadableStream input", () => {
   it("readObjects accepts a stream", async () => {
     const xlsx = await writeXlsx({ sheets: SAMPLE_SHEETS })
 
-    const objects = await readObjects(toReadableStream(xlsx))
+    const { data } = await readObjects(toReadableStream(xlsx))
 
-    expect(objects).toEqual([
+    expect(data).toEqual([
       { id: 1, name: "alpha", amount: 10.5 },
       { id: 2, name: "beta", amount: 20.25 },
     ])

--- a/test/stream-writer-surface.test.ts
+++ b/test/stream-writer-surface.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest"
+import { CsvStreamWriter } from "../src/csv/stream"
+import { NdjsonStreamWriter } from "../src/json/stream"
+import { XlsxStreamWriter } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { InvalidArgumentError } from "../src/errors"
+import type { CellValue } from "../src/_types"
+
+// ── One surface for the three stream writers (#365 item 7) ───────────
+// Before v1 these had three different vocabularies — `addRow`/`addObject`,
+// `addRow` alone, and `write`/`end` — so no format-agnostic export helper
+// could be written against them. These tests pin the shared surface.
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = stream.getReader()
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+describe("stream writer surface parity", () => {
+  it("every writer exposes addRow / addObject / finish / toStream", () => {
+    const writers = [
+      new XlsxStreamWriter({ name: "S", columns: [{ key: "a", header: "A" }] }),
+      new CsvStreamWriter(),
+      new NdjsonStreamWriter({ columns: ["a"] }),
+    ]
+
+    for (const writer of writers) {
+      for (const method of ["addRow", "addObject", "finish", "toStream"] as const) {
+        expect(typeof (writer as unknown as Record<string, unknown>)[method]).toBe("function")
+      }
+    }
+  })
+
+  it("a format-agnostic export helper can be written against the shared surface", async () => {
+    // The point of the whole convergence: one function, three formats.
+    interface AnyStreamWriter {
+      addObject(item: Record<string, CellValue>): void
+      finish(): string | Promise<Uint8Array>
+      toStream(): ReadableStream<Uint8Array>
+    }
+
+    async function exportAll(
+      writer: AnyStreamWriter,
+      rows: Record<string, CellValue>[],
+    ): Promise<Uint8Array> {
+      for (const row of rows) writer.addObject(row)
+      // `finish()` marks the writer done; `toStream()` then yields the
+      // bytes and closes. NdjsonStreamWriter's stream is a live drain, so
+      // without the finish() it would stay open waiting for more rows.
+      await writer.finish()
+      return drain(writer.toStream())
+    }
+
+    const rows = [
+      { id: 1, name: "alpha" },
+      { id: 2, name: "beta" },
+    ]
+
+    const csv = new TextDecoder().decode(
+      await exportAll(new CsvStreamWriter({ lineSeparator: "\n" }), rows),
+    )
+    expect(csv).toBe("id,name\n1,alpha\n2,beta")
+
+    const ndjson = new TextDecoder().decode(await exportAll(new NdjsonStreamWriter(), rows))
+    expect(ndjson).toBe('{"id":1,"name":"alpha"}\n{"id":2,"name":"beta"}\n')
+
+    const xlsx = await exportAll(
+      new XlsxStreamWriter({
+        name: "S",
+        columns: [
+          { key: "id", header: "id" },
+          { key: "name", header: "name" },
+        ],
+      }),
+      rows,
+    )
+    const wb = await readXlsx(xlsx)
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["id", "name"],
+      [1, "alpha"],
+      [2, "beta"],
+    ])
+  })
+})
+
+// ── CsvStreamWriter.addObject ────────────────────────────────────────
+
+describe("CsvStreamWriter.addObject", () => {
+  it("derives the column order from the first object and emits a header", () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n" })
+    writer.addObject({ name: "Alice", age: 30 })
+    writer.addObject({ name: "Bob", age: 25 })
+    expect(writer.finish()).toBe("name,age\nAlice,30\nBob,25")
+  })
+
+  it("projects through an explicit `columns` order", () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n", columns: ["age", "name"] })
+    writer.addObject({ name: "Alice", age: 30, extra: "dropped" })
+    expect(writer.finish()).toBe("age,name\n30,Alice")
+  })
+
+  it("uses an explicit `headers` array as the column order without repeating it", () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n", headers: ["age", "name"] })
+    writer.addObject({ name: "Alice", age: 30 })
+    expect(writer.finish()).toBe("age,name\n30,Alice")
+  })
+
+  it("emits no header line when headers: false", () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n", headers: false })
+    writer.addObject({ name: "Alice", age: 30 })
+    expect(writer.finish()).toBe("Alice,30")
+  })
+
+  it("fills missing keys with the null representation", () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n" })
+    writer.addObject({ a: 1, b: 2 })
+    writer.addObject({ a: 3 })
+    expect(writer.finish()).toBe("a,b\n1,2\n3,")
+  })
+})
+
+// ── toStream() on the buffering writers ──────────────────────────────
+
+describe("buffering writers' toStream()", () => {
+  it("CsvStreamWriter.toStream emits exactly what finish() returns", async () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n" })
+    writer.addRow(["a", "b"])
+    writer.addRow([1, 2])
+
+    const streamed = new TextDecoder().decode(await drain(writer.toStream()))
+    expect(streamed).toBe(writer.finish())
+    expect(streamed).toBe("a,b\n1,2")
+  })
+
+  it("CsvStreamWriter.toStream keeps the BOM", async () => {
+    const writer = new CsvStreamWriter({ lineSeparator: "\n", bom: true })
+    writer.addRow(["a"])
+    const bytes = await drain(writer.toStream())
+    expect([bytes[0], bytes[1], bytes[2]]).toEqual([0xef, 0xbb, 0xbf])
+  })
+
+  it("XlsxStreamWriter.toStream emits a readable workbook", async () => {
+    const writer = new XlsxStreamWriter({ name: "Streamed" })
+    writer.addRow(["Name", "Score"])
+    writer.addRow(["Alice", 95])
+
+    const wb = await readXlsx(await drain(writer.toStream()))
+    expect(wb.sheets[0]!.name).toBe("Streamed")
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["Name", "Score"],
+      ["Alice", 95],
+    ])
+  })
+
+  it("XlsxStreamWriter.toStream buffers — it is not a constant-memory stream", async () => {
+    // Documented explicitly because #347 was filed over a buffering writer
+    // described as streaming. The whole archive arrives in one chunk.
+    const writer = new XlsxStreamWriter({ name: "S" })
+    for (let i = 0; i < 500; i++) writer.addRow([i, `row ${i}`])
+
+    const reader = writer.toStream().getReader()
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    expect(first.value!.length).toBeGreaterThan(0)
+    expect((await reader.read()).done).toBe(true)
+  })
+
+  it("XlsxStreamWriter.toStream surfaces a failing finish() to the consumer", async () => {
+    const writer = new XlsxStreamWriter({ name: "S" })
+    writer.addRow([1])
+    const boom = new Error("finish exploded")
+    ;(writer as unknown as { finish: () => Promise<Uint8Array> }).finish = () =>
+      Promise.reject(boom)
+
+    await expect(drain(writer.toStream())).rejects.toThrow("finish exploded")
+  })
+})
+
+// ── NdjsonStreamWriter ───────────────────────────────────────────────
+
+describe("NdjsonStreamWriter", () => {
+  it("addObject + finish returns the buffered NDJSON", () => {
+    const writer = new NdjsonStreamWriter()
+    writer.addObject({ a: 1 })
+    writer.addObject({ a: 2 })
+    expect(writer.finish()).toBe('{"a":1}\n{"a":2}\n')
+  })
+
+  it("finish() closes the writer", () => {
+    const writer = new NdjsonStreamWriter()
+    writer.finish()
+    expect(() => writer.addObject({ a: 1 })).toThrow()
+  })
+
+  it("addRow keys positional values by the configured columns", () => {
+    const writer = new NdjsonStreamWriter({ columns: ["id", "name"] })
+    writer.addRow([1, "alpha"])
+    writer.addRow([2])
+    expect(writer.finish()).toBe('{"id":1,"name":"alpha"}\n{"id":2,"name":null}\n')
+  })
+
+  it("addRow throws without columns rather than guessing key names", () => {
+    const writer = new NdjsonStreamWriter()
+    expect(() => writer.addRow([1, 2])).toThrow(InvalidArgumentError)
+  })
+
+  it("finish() closes a stream that is still being drained", async () => {
+    const writer = new NdjsonStreamWriter()
+    const reader = writer.toStream().getReader()
+    writer.addObject({ a: 1 })
+    expect(new TextDecoder().decode((await reader.read()).value)).toBe('{"a":1}\n')
+    writer.finish()
+    expect((await reader.read()).done).toBe(true)
+  })
+
+  // ── deprecated aliases ─────────────────────────────────────────────
+
+  it("write() still appends, as a deprecated alias of addObject", () => {
+    const writer = new NdjsonStreamWriter()
+    writer.write({ a: 1 })
+    writer.addObject({ a: 2 })
+    expect(writer.toString()).toBe('{"a":1}\n{"a":2}\n')
+  })
+
+  it("end() still closes, as a deprecated alias of finish", () => {
+    const writer = new NdjsonStreamWriter()
+    writer.write({ a: 1 })
+    writer.end()
+    expect(writer.toString()).toBe('{"a":1}\n')
+    expect(() => writer.write({ a: 2 })).toThrow()
+    expect(() => writer.addObject({ a: 2 })).toThrow()
+  })
+
+  it("serializes Dates identically through addObject and the write() alias", () => {
+    const d = new Date("2025-04-25T00:00:00Z")
+
+    const viaAddObject = new NdjsonStreamWriter()
+    viaAddObject.addObject({ at: d })
+
+    const viaWrite = new NdjsonStreamWriter()
+    viaWrite.write({ at: d })
+
+    expect(viaAddObject.finish()).toBe(viaWrite.finish())
+    expect(viaAddObject.toString().trim()).toBe(`{"at":"${d.toISOString()}"}`)
+  })
+})

--- a/test/utilities.test.ts
+++ b/test/utilities.test.ts
@@ -138,8 +138,9 @@ describe("sheetToObjects", () => {
         ["Bob", 25, "Paris"],
       ],
     })
-    const result = sheetToObjects(sheet)
-    expect(result).toEqual([
+    const { data, headers } = sheetToObjects(sheet)
+    expect(headers).toEqual(["Name", "Age", "City"])
+    expect(data).toEqual([
       { Name: "Alice", Age: 30, City: "London" },
       { Name: "Bob", Age: 25, City: "Paris" },
     ])
@@ -149,16 +150,17 @@ describe("sheetToObjects", () => {
     const sheet = makeSheet({
       rows: [["metadata row"], ["Name", "Score"], ["Alice", 100], ["Bob", 85]],
     })
-    const result = sheetToObjects(sheet, { headerRow: 1 })
-    expect(result).toEqual([
+    const { data, headers } = sheetToObjects(sheet, { headerRow: 1 })
+    expect(headers).toEqual(["Name", "Score"])
+    expect(data).toEqual([
       { Name: "Alice", Score: 100 },
       { Name: "Bob", Score: 85 },
     ])
   })
 
-  it("should return empty array for empty sheet", () => {
+  it("should return empty data and headers for empty sheet", () => {
     const sheet = makeSheet({ rows: [] })
-    expect(sheetToObjects(sheet)).toEqual([])
+    expect(sheetToObjects(sheet)).toEqual({ data: [], headers: [] })
   })
 
   it("should handle null header values as empty string keys", () => {
@@ -168,16 +170,32 @@ describe("sheetToObjects", () => {
         ["Alice", "x", 30],
       ],
     })
-    const result = sheetToObjects(sheet)
-    expect(result).toEqual([{ Name: "Alice", "": "x", Age: 30 }])
+    const { data, headers } = sheetToObjects(sheet)
+    expect(headers).toEqual(["Name", "", "Age"])
+    expect(data).toEqual([{ Name: "Alice", "": "x", Age: 30 }])
   })
 
   it("should fill missing columns with null", () => {
     const sheet = makeSheet({
       rows: [["A", "B", "C"], ["x"]],
     })
-    const result = sheetToObjects(sheet)
-    expect(result).toEqual([{ A: "x", B: null, C: null }])
+    const { data } = sheetToObjects(sheet)
+    expect(data).toEqual([{ A: "x", B: null, C: null }])
+  })
+
+  it("should keep empty rows — it is a pure projection with no filtering", () => {
+    const sheet = makeSheet({
+      rows: [
+        ["A", "B"],
+        [null, null],
+        ["x", "y"],
+      ],
+    })
+    const { data } = sheetToObjects(sheet)
+    expect(data).toEqual([
+      { A: null, B: null },
+      { A: "x", B: "y" },
+    ])
   })
 })
 


### PR DESCRIPTION
Items 6 and 7 of #365, plus a dead option found along the way. Part of #352. **Contains breaking changes**, taken deliberately because v1 freezes the surface.

## One result shape

`readObjects` — the flagship high-level helper — and `sheetToObjects` returned a bare `T[]`, while `readXlsxObjects`, `readOdsObjects`, `parseCsvObjects`, `parseJson`, and `readXml` all returned `{ data, headers }`. Both now match.

- Named, exported result types throughout. `CsvObjectsResult` was **anonymous** and could not be referenced at all; `SheetToObjectsOptions` / `SheetObjectsResult` and `ReadObjectsOptions` / `ReadObjectsResult` are new alongside it.
- `sheetToObjects<T extends Record<string, CellValue>>` gains the constraint every sibling already had.
- `readObjects` gains `sheet`, `headerRow`, `skipEmptyRows`, `transformHeader`, `transformValue`, `maxRows`.

**Every one of those is honoured for every format.** They apply to the workbook `read()` returns rather than being forwarded to a format reader — so ODS, XLS, and XLSB get `maxRows` and `skipEmptyRows` too, unlike the XLSX-only `ReadOptions.maxRows`, which this deliberately shadows and never forwards. Nothing added here is silently inert, which is the specific failure #365 is about. The *inherited* `ReadOptions` fields remain as uneven as they were, and the JSDoc now says so.

Three behaviour changes fall out of `readObjects` joining the family, all of them making it match its siblings rather than diverge:

| | before | now |
| --- | --- | --- |
| empty-string header keys | dropped (only here) | kept |
| fully empty rows | kept | skipped by default |
| missing sheet | returned `[]` | throws `ParseError` |

A new internal `src/_objects.ts` holds one projection loop and one sheet selector. Three near-copies were the mechanism by which those defaults drifted apart in the first place.

## One stream writer surface

`XlsxStreamWriter`, `CsvStreamWriter`, and `NdjsonStreamWriter` converge on `addRow` / `addObject` / `finish()` / `toStream()`, with named constructor options for each — `NdjsonStreamWriter`'s were anonymous. Its `write` / `end` remain as `@deprecated` aliases, with tests.

`NdjsonStreamWriter.addRow` requires `columns` and throws `InvalidArgumentError` otherwise rather than inventing a key order, mirroring the existing `XlsxStreamWriter.addObject` contract.

### `toStream()` on Csv and Xlsx is the honest version

Those two buffer until `finish()`. Their `toStream()` emits the *finished bytes* as a stream and is **not** constant memory. Both JSDocs say so in bold and name `writeCsvStream` / `writeXlsxStream` as the constant-memory path, the README says the same, and **a test asserts the whole XLSX archive arrives in a single chunk** — #347 was filed precisely because a buffering writer was documented as streaming, and this must not become the second instance.

It also cannot be perfectly uniform, which is worth stating rather than papering over: `NdjsonStreamWriter.toStream()` is a **live drain** that stays open until `finish()`, while the other two are terminal snapshots. A generic helper must therefore call `finish()` before draining. That recipe is in both JSDocs and in a test.

## `isoDates` never did anything

Found while unifying the writers, and verified independently:

```
writeNdjson isoDates: true  → {"at":"2024-01-15T00:00:00.000Z"}
writeNdjson isoDates: false → {"at":"2024-01-15T00:00:00.000Z"}

JSON.stringify({ d }, (_k, v) => v instanceof Date ? "SAW-DATE" : v)
  → {"d":"2024-01-15T00:00:00.000Z"}      ← the replacer never sees a Date
```

`JSON.stringify` calls `Date.prototype.toJSON` **before** consulting the replacer, so `dateReplacer`'s `value instanceof Date` is never reached. The option was inert in all four places it appeared — `writeJson`, `writeNdjson`, `workbookToJson`, `NdjsonStreamWriter`.

Removed rather than frozen. There is no honest alternative semantic to give it either: JSON cannot carry a `Date`. Output is byte-identical before and after, verified across all four.

## Verification

Full suite **8,077 tests / 127 files** green; lint, typecheck clean; `scripts/verify-package.mjs` passes all six packaged-artifact checks.

The export snapshot did **not** change, correctly — everything added is a type or a method, not a new module export. A compile-time mutual-assignability assertion was added in `test/exports.test.ts` instead, so the result types must stay interchangeable rather than merely look alike.

## Noted, not fixed

`readXml.transformValue` takes `(value, header, rowIndex)` — no `colIndex` — unlike every other `transformValue` in the library. Out of scope here, but it is another inconsistency that v1 would freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
