### PR TITLE
fix: add colIndex to readXml.transformValue, parse outlinePr — closes #384

### DIFF
--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -170,6 +170,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   // Sheet view settings (gridlines, zoom, RTL, tab color)
   let sheetView: SheetView | undefined
   let inSheetPr = false
+  let outlineProperties: import("../_types").OutlineProperties | undefined
 
   // Freeze/Split pane parsed from <pane> element
   let freezePane: FreezePane | undefined
@@ -447,6 +448,23 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
           break
         case "sheetPr":
           inSheetPr = true
+          break
+        case "outlinePr":
+          // Write-only until now: the type and the writer existed, but
+          // nothing parsed it, so Sheet.outlineProperties was always
+          // undefined and open -> save could not preserve it. See #359.
+          if (inSheetPr) {
+            const outline: import("../_types").OutlineProperties = {}
+            if (attrs["summaryBelow"] !== undefined) {
+              outline.summaryBelow =
+                attrs["summaryBelow"] === "1" || attrs["summaryBelow"] === "true"
+            }
+            if (attrs["summaryRight"] !== undefined) {
+              outline.summaryRight =
+                attrs["summaryRight"] === "1" || attrs["summaryRight"] === "true"
+            }
+            if (Object.keys(outline).length > 0) outlineProperties = outline
+          }
           break
         case "tabColor":
           if (inSheetPr) {
@@ -1181,6 +1199,11 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   // Attach sparklines
   if (sparklines.length > 0) {
     sheet.sparklines = sparklines
+  }
+
+  // Attach outline properties
+  if (outlineProperties) {
+    sheet.outlineProperties = outlineProperties
   }
 
   return sheet

--- a/src/xml/data-reader.ts
+++ b/src/xml/data-reader.ts
@@ -26,7 +26,19 @@ export interface XmlReadOptions {
   /** Transform header keys. */
   transformHeader?: (header: string, index: number) => string
   /** Transform cell values. */
-  transformValue?: (value: CellValue, header: string, rowIndex: number) => CellValue
+  /**
+   * Transform each cell value. The `colIndex` argument was missing here
+   * while every other `transformValue` in the library had it, so a
+   * four-argument callback silently lost its last parameter when moved
+   * to `readXml` — and TypeScript accepts a function that takes fewer
+   * arguments, so nothing flagged it. See #384.
+   */
+  transformValue?: (
+    value: CellValue,
+    header: string,
+    rowIndex: number,
+    colIndex: number,
+  ) => CellValue
   /** Maximum number of rows. */
   maxRows?: number
 }
@@ -61,10 +73,15 @@ function splitTag(tag: string): { local: string; prefix: string } {
  * picks the most-frequent tag.
  */
 export function readXml<T extends Record<string, CellValue> = Record<string, CellValue>>(
-  input: string,
+  input: string | Uint8Array,
   options?: XmlReadOptions,
 ): XmlReadResult<T> {
-  if (input.trim() === "") {
+  // XML feeds arrive as bytes at least as often as JSON does, and
+  // parseJson has always accepted both — this forced a decode at the
+  // call site for no reason. See #384.
+  const xml = typeof input === "string" ? input : new TextDecoder("utf-8").decode(input)
+
+  if (xml.trim() === "") {
     return { data: [], headers: [], rowTag: options?.rowTag ?? "" }
   }
 
@@ -74,13 +91,13 @@ export function readXml<T extends Record<string, CellValue> = Record<string, Cel
   const textKey = options?.textKey ?? "#text"
 
   const requestedRowTag = options?.rowTag
-  const rowTag = requestedRowTag ?? detectRowTag(input, stripNs)
+  const rowTag = requestedRowTag ?? detectRowTag(xml, stripNs)
 
   if (!rowTag) {
     return { data: [], headers: [], rowTag: "" }
   }
 
-  const rows = collectRows(input, rowTag, stripNs)
+  const rows = collectRows(xml, rowTag, stripNs)
 
   const flatOpts = { attrPrefix, flatten, textKey, stripNs }
   const limit = options?.maxRows ?? Infinity
@@ -123,10 +140,11 @@ export function readXml<T extends Record<string, CellValue> = Record<string, Cel
   for (let r = 0; r < flatRows.length; r++) {
     const src = flatRows[r]!
     const obj: Record<string, CellValue> = {}
-    for (const h of headers) {
+    for (let c = 0; c < headers.length; c++) {
+      const h = headers[c]!
       let val = src[h] ?? null
       if (options?.transformValue) {
-        val = options.transformValue(val, h, r)
+        val = options.transformValue(val, h, r, c)
       }
       obj[h] = val
     }

--- a/test/xml-transform-and-outline.test.ts
+++ b/test/xml-transform-and-outline.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+import { readXml } from "../src/xml/data-reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import type { CellValue } from "../src/_types"
+
+const FEED = `<?xml version="1.0"?><products>
+  <product><sku>A1</sku><qty>2</qty></product>
+  <product><sku>B2</sku><qty>5</qty></product>
+</products>`
+
+// ═══════════════════════════════════════════════════════════════════════
+// #384 — readXml's transformValue was the only one in the library
+// missing colIndex, and TypeScript accepts a callback that takes fewer
+// arguments, so nothing flagged a four-argument function silently
+// losing its last parameter here.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readXml transformValue", () => {
+  it("passes the column index", () => {
+    const seen: Array<[string, number, number]> = []
+    readXml(FEED, {
+      transformValue: (value, header, rowIndex, colIndex) => {
+        seen.push([header, rowIndex, colIndex])
+        return value
+      },
+    })
+
+    expect(seen).toEqual([
+      ["sku", 0, 0],
+      ["qty", 0, 1],
+      ["sku", 1, 0],
+      ["qty", 1, 1],
+    ])
+  })
+
+  it("matches the signature the other readers use", () => {
+    // A callback written for parseCsv / readXlsxObjects must work here
+    // unchanged — that is the whole point of the fix.
+    const byColumn = (value: CellValue, _h: string, _r: number, colIndex: number): CellValue =>
+      colIndex === 1 ? Number(value) * 10 : value
+
+    const { data } = readXml(FEED, { transformValue: byColumn })
+    expect(data).toEqual([
+      { sku: "A1", qty: 20 },
+      { sku: "B2", qty: 50 },
+    ])
+  })
+
+  it("still transforms without using the new argument", () => {
+    const { data } = readXml(FEED, {
+      transformValue: (value) => (typeof value === "string" ? value.toLowerCase() : value),
+    })
+    expect(data[0]).toMatchObject({ sku: "a1" })
+  })
+})
+
+describe("readXml input", () => {
+  it("accepts a Uint8Array, like parseJson", () => {
+    const bytes = new TextEncoder().encode(FEED)
+    const { data, headers } = readXml(bytes)
+
+    expect(headers).toEqual(["sku", "qty"])
+    expect(data).toHaveLength(2)
+  })
+
+  it("returns the same result for bytes and string", () => {
+    const fromString = readXml(FEED)
+    const fromBytes = readXml(new TextEncoder().encode(FEED))
+    expect(fromBytes).toEqual(fromString)
+  })
+
+  it("handles empty bytes", () => {
+    expect(readXml(new Uint8Array()).data).toEqual([])
+  })
+
+  it("decodes multi-byte characters correctly", () => {
+    // A naive byte-per-char decode would mangle these.
+    const xml = `<rows><row><city>İstanbul</city></row></rows>`
+    const { data } = readXml(new TextEncoder().encode(xml))
+    expect(data[0]).toEqual({ city: "İstanbul" })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// #359 — outlineProperties was write-only: the type and the writer
+// existed, nothing ever parsed <outlinePr>, so the field was always
+// undefined after a read and open → save could not preserve it.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("outlineProperties", () => {
+  it("survives a write → read cycle", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          outlineProperties: { summaryBelow: false, summaryRight: false },
+        },
+      ],
+    })
+
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0].outlineProperties).toEqual({
+      summaryBelow: false,
+      summaryRight: false,
+    })
+  })
+
+  it("reads the true case too", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        { name: "S", rows: [["a"]], outlineProperties: { summaryBelow: true, summaryRight: true } },
+      ],
+    })
+    expect((await readXlsx(buf)).sheets[0].outlineProperties).toEqual({
+      summaryBelow: true,
+      summaryRight: true,
+    })
+  })
+
+  it("stays undefined when the sheet has no outlinePr", async () => {
+    const buf = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] })
+    expect((await readXlsx(buf)).sheets[0].outlineProperties).toBeUndefined()
+  })
+
+  it("survives openXlsx → saveXlsx", async () => {
+    // The field was already in the roundtrip map (#366), but forwarding
+    // an always-undefined value did nothing. It carries a value now.
+    const original = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]], outlineProperties: { summaryBelow: false } }],
+    })
+
+    const saved = await saveXlsx(await openXlsx(original))
+    expect((await readXlsx(saved)).sheets[0].outlineProperties).toEqual({ summaryBelow: false })
+  })
+})


### PR DESCRIPTION
Closes #384. Also closes the last open half of #359. Part of #352.

Two leftovers from the v1 audits, both the same shape: a contract that existed on paper and not in the code.

## `readXml.transformValue` was missing `colIndex`

Every other `transformValue` in the library takes `(value, header, rowIndex, colIndex)`. This one took three arguments.

The failure mode is quiet: TypeScript **accepts a function that takes fewer parameters than the signature declares**, so a callback written for `parseCsv` or `readXlsxObjects` compiles fine when moved to `readXml` and then reads `undefined` — or misbehaves silently if the fourth argument was only used inside a branch.

There is a test asserting a callback written against the four-argument form now works here unchanged, and another asserting three-argument callbacks still do.

## `readXml` accepts `Uint8Array`

`parseJson` has always taken `string | Uint8Array`. XML feeds arrive as bytes at least as often as JSON does, so this forced a `TextDecoder` at the call site for no reason. Additive, not breaking.

Tested including multi-byte characters, since a naive decode would mangle them.

## `Sheet.outlineProperties` was write-only

The type existed and the writer emitted `<outlinePr>`, but **nothing ever parsed it** — so the field was always `undefined` after a read.

That is why #366 could add it to the roundtrip map and change nothing: it was forwarding a value that never existed. The reader parses it now, so the value actually travels, and there is a round-trip test through both `writeXlsx` and `openXlsx` → `saveXlsx`.

This closes the item #366 explicitly left open.

## Verification

11 tests in `test/xml-transform-and-outline.test.ts`. Full suite **8,088 tests / 128 files** green; lint, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
