### PR TITLE
test: reach the v1 coverage bar — and eight bugs it found

### DIFF
--- a/test/coverage-binary-formats.test.ts
+++ b/test/coverage-binary-formats.test.ts
@@ -1,0 +1,964 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { readXls } from "../src/xls/reader"
+import { readXlsb } from "../src/xlsx/xlsb/reader"
+import { readCfb, writeCfb } from "../src/xlsx/crypto/cfb"
+import { decryptAgile, encryptAgile } from "../src/xlsx/crypto/agile"
+import { parseRelationships } from "../src/xlsx/relationships"
+import { parseContentTypes } from "../src/xlsx/content-types"
+import { fetchCsv } from "../src/csv/fetch"
+import { ZipWriter } from "../src/zip/writer"
+import { DecryptionError, EncryptedFileError, ZipError } from "../src/errors"
+
+const enc = new TextEncoder()
+
+function concat(parts: Array<number[] | Uint8Array>): Uint8Array {
+  let len = 0
+  for (const p of parts) len += p.length
+  const out = new Uint8Array(len)
+  let off = 0
+  for (const p of parts) {
+    out.set(p instanceof Uint8Array ? p : new Uint8Array(p), off)
+    off += p.length
+  }
+  return out
+}
+
+const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff]
+const u32 = (n: number): number[] => [
+  n & 0xff,
+  (n >> 8) & 0xff,
+  (n >> 16) & 0xff,
+  (n >>> 24) & 0xff,
+]
+function f64(n: number): number[] {
+  const b = new Uint8Array(8)
+  new DataView(b.buffer).setFloat64(0, n, true)
+  return [...b]
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// XLS (BIFF8)
+// ═══════════════════════════════════════════════════════════════════════
+
+// ── Minimal BIFF8 builder ────────────────────────────────────────────
+
+const SID = {
+  FORMULA: 0x0006,
+  EOF: 0x000a,
+  CONTINUE: 0x003c,
+  DATEMODE: 0x0022,
+  NUMBER: 0x0203,
+  LABEL: 0x0204,
+  BOOLERR: 0x0205,
+  STRING: 0x0207,
+  ROW: 0x0208,
+  RK: 0x027e,
+  MULRK: 0x00bd,
+  LABELSST: 0x00fd,
+  SST: 0x00fc,
+  XF: 0x00e0,
+  FORMAT: 0x041e,
+  BOUNDSHEET: 0x0085,
+  BOF: 0x0809,
+}
+
+function record(sid: number, data: number[]): number[] {
+  return [...u16(sid), ...u16(data.length), ...data]
+}
+const bof = (dt: number): number[] =>
+  record(SID.BOF, [...u16(0x0600), ...u16(dt), ...u16(0), ...u16(0), ...u32(0), ...u32(0)])
+const eof = (): number[] => record(SID.EOF, [])
+const chars = (s: string): number[] => [...s].map((c) => c.charCodeAt(0))
+/** XLUnicodeString (u16 cch + grbit + chars), compressed 8-bit. */
+const xlStr = (s: string): number[] => [...u16(s.length), 0, ...chars(s)]
+/** ShortXLUnicodeString (u8 cch + grbit + chars), compressed 8-bit. */
+const shortStr = (s: string): number[] => [s.length, 0, ...chars(s)]
+const xf = (ifmt: number): number[] =>
+  record(SID.XF, [...u16(0), ...u16(ifmt), ...Array.from({ length: 16 }, () => 0)])
+
+/**
+ * Assemble a Workbook stream: globals substream (BOF … EOF, with one
+ * BOUNDSHEET per sheet) followed by each sheet substream. BOUNDSHEET
+ * positions are resolved in a second pass once the globals size is known.
+ */
+function buildWorkbookStream(opts: {
+  globals?: number[]
+  sheets?: Array<{ name: string; records: number[]; positionOverride?: number }>
+}): Uint8Array {
+  const sheets = opts.sheets ?? []
+  const make = (positions: number[]): number[] => [
+    ...bof(0x0005),
+    ...(opts.globals ?? []),
+    ...sheets
+      .map((s, i) =>
+        record(SID.BOUNDSHEET, [
+          ...u32(s.positionOverride ?? positions[i]),
+          0,
+          0,
+          ...shortStr(s.name),
+        ]),
+      )
+      .flat(),
+    ...eof(),
+  ]
+  const globalsLen = make(sheets.map(() => 0)).length
+  const positions: number[] = []
+  let pos = globalsLen
+  for (const s of sheets) {
+    positions.push(pos)
+    pos += s.records.length
+  }
+  return concat([make(positions), ...sheets.map((s) => s.records)])
+}
+
+function xlsFile(opts: Parameters<typeof buildWorkbookStream>[0], streamName = "Workbook") {
+  return writeCfb([{ name: streamName, data: buildWorkbookStream(opts) }])
+}
+
+describe("readXls — container and version gates", () => {
+  it("reads a workbook stored under the legacy 'Book' stream name", async () => {
+    // Excel 95 named the stream "Book"; some BIFF8 producers kept the name.
+    const data = xlsFile(
+      {
+        sheets: [
+          {
+            name: "S",
+            records: [
+              ...bof(0x0010),
+              ...record(SID.LABEL, [...u16(0), ...u16(0), ...u16(0), ...xlStr("Hi")]),
+              ...eof(),
+            ],
+          },
+        ],
+      },
+      "Book",
+    )
+    const wb = await readXls(data)
+    expect(wb.sheets[0].rows[0][0]).toBe("Hi")
+  })
+
+  it("rejects an OLE2 container with no workbook stream", async () => {
+    const data = writeCfb([{ name: "SummaryInformation", data: new Uint8Array(64) }])
+    await expect(readXls(data)).rejects.toThrow(/missing Workbook stream/)
+  })
+
+  it("rejects a workbook stream that does not open with a BOF record", async () => {
+    const data = writeCfb([{ name: "Workbook", data: new Uint8Array(record(SID.EOF, [])) }])
+    await expect(readXls(data)).rejects.toThrow(/missing BOF record/)
+  })
+
+  it("accepts a BOF record too short to carry a version field", async () => {
+    // Nothing to gate on — parse it rather than guessing at the version.
+    const stream = concat([record(SID.BOF, []), eof()])
+    const wb = await readXls(writeCfb([{ name: "Workbook", data: stream }]))
+    expect(wb.sheets).toEqual([])
+  })
+
+  it("surfaces a non-OLE2 input as a ParseError", async () => {
+    await expect(readXls(new Uint8Array(600))).rejects.toThrow(/not a valid OLE2 container/)
+  })
+})
+
+describe("readXls — globals substream", () => {
+  it("honours the DATEMODE record when the caller asks for auto detection", async () => {
+    // dateSystem:"auto" must consult DATEMODE; 1 selects the 1904 epoch.
+    const data = xlsFile({
+      globals: [...record(SID.DATEMODE, u16(1)), ...xf(14)],
+      sheets: [
+        {
+          name: "S",
+          records: [
+            ...bof(0x0010),
+            ...record(SID.NUMBER, [...u16(0), ...u16(0), ...u16(0), ...f64(1)]),
+            ...eof(),
+          ],
+        },
+      ],
+    })
+    const auto = await readXls(data, { dateSystem: "auto" })
+    const forced = await readXls(data, { dateSystem: "1900" })
+    expect(auto.sheets[0].rows[0][0]).toBeInstanceOf(Date)
+    expect((auto.sheets[0].rows[0][0] as Date).getUTCFullYear()).toBe(1904)
+    expect((forced.sheets[0].rows[0][0] as Date).getUTCFullYear()).toBe(1900)
+    expect(auto.sheets[0].rows[0][0]).not.toEqual(forced.sheets[0].rows[0][0])
+  })
+
+  it("treats a cell as a date when a custom FORMAT record says so", async () => {
+    // Format ids >= 164 are workbook-defined and only resolvable through
+    // the FORMAT records.
+    const data = xlsFile({
+      globals: [...record(SID.FORMAT, [...u16(200), ...xlStr("dd/mm/yyyy")]), ...xf(200), ...xf(0)],
+      sheets: [
+        {
+          name: "S",
+          records: [
+            ...bof(0x0010),
+            ...record(SID.NUMBER, [...u16(0), ...u16(0), ...u16(0), ...f64(45000)]),
+            ...record(SID.NUMBER, [...u16(0), ...u16(1), ...u16(1), ...f64(45000)]),
+            ...eof(),
+          ],
+        },
+      ],
+    })
+    const wb = await readXls(data)
+    expect(wb.sheets[0].rows[0][0]).toBeInstanceOf(Date)
+    expect(wb.sheets[0].rows[0][1]).toBe(45000)
+  })
+
+  it("returns an empty sheet when BOUNDSHEET points at no record", async () => {
+    const data = xlsFile({
+      sheets: [{ name: "Ghost", records: [...bof(0x0010), ...eof()], positionOverride: 0xdead }],
+    })
+    const wb = await readXls(data)
+    expect(wb.sheets).toEqual([{ name: "Ghost", rows: [] }])
+  })
+})
+
+describe("readXls — cell records", () => {
+  function sheetWith(records: number[], globals?: number[]) {
+    return xlsFile({
+      globals: globals ?? [...xf(0)],
+      sheets: [{ name: "S", records: [...bof(0x0010), ...records, ...eof()] }],
+    })
+  }
+
+  it("falls back to an empty string for an out-of-range shared-string index", async () => {
+    const data = sheetWith(record(SID.LABELSST, [...u16(0), ...u16(0), ...u16(0), ...u32(99)]))
+    expect((await readXls(data)).sheets[0].rows[0][0]).toBe("")
+  })
+
+  it("falls back to #ERR! for an error code it does not know", async () => {
+    const data = sheetWith(record(SID.BOOLERR, [...u16(0), ...u16(0), ...u16(0), 0x55, 1]))
+    expect((await readXls(data)).sheets[0].rows[0][0]).toBe("#ERR!")
+  })
+
+  it("decodes an RK number stored as a truncated double", async () => {
+    // fInt clear: the 30 high bits are the top of an IEEE-754 double.
+    // 0x3FF00000 is 1.0, and the fX100 flag divides it by 100.
+    const data = sheetWith(
+      concat([
+        record(SID.RK, [...u16(0), ...u16(0), ...u16(0), ...u32(0x3ff00000)]),
+        record(SID.RK, [...u16(0), ...u16(1), ...u16(0), ...u32(0x3ff00001)]),
+      ]) as unknown as number[],
+    )
+    const rows = (await readXls(data)).sheets[0].rows
+    expect(rows[0][0]).toBe(1)
+    expect(rows[0][1]).toBeCloseTo(0.01, 6)
+  })
+
+  it("decodes an uncompressed (UTF-16) label", async () => {
+    // grbit bit 0 set means the characters are 16-bit, not codepage bytes.
+    const wide = [...u16(2), 1, ...u16(0x00c9), ...u16(0x011f)] // "Éğ"
+    const data = sheetWith(record(SID.LABEL, [...u16(0), ...u16(0), ...u16(0), ...wide]))
+    expect((await readXls(data)).sheets[0].rows[0][0]).toBe("Éğ")
+  })
+
+  it("ignores record types it has no decoder for", async () => {
+    const data = sheetWith(
+      concat([
+        record(SID.ROW, [...u16(0), ...u16(0), ...u16(1), ...u16(255), ...u32(0), ...u32(0)]),
+        record(SID.LABEL, [...u16(0), ...u16(0), ...u16(0), ...xlStr("ok")]),
+      ]) as unknown as number[],
+    )
+    expect((await readXls(data)).sheets[0].rows[0][0]).toBe("ok")
+  })
+
+  it("stops parsing at the padding record that ends the stream", async () => {
+    // Trailing zero bytes in the CFB sector look like a record with id 0 and
+    // length 0; treating them as data would append junk records forever.
+    const stream = concat([
+      buildWorkbookStream({
+        globals: [...xf(0)],
+        sheets: [
+          {
+            name: "S",
+            records: [
+              ...bof(0x0010),
+              ...record(SID.LABEL, [...u16(0), ...u16(0), ...u16(0), ...xlStr("ok")]),
+              ...eof(),
+            ],
+          },
+        ],
+      }),
+      new Uint8Array(64),
+    ])
+    const wb = await readXls(writeCfb([{ name: "Workbook", data: stream }]))
+    expect(wb.sheets[0].rows[0][0]).toBe("ok")
+  })
+
+  it("rejects a column index outside the supported sheet bounds", async () => {
+    const data = sheetWith(record(SID.LABEL, [...u16(0), ...u16(20000), ...u16(0), ...xlStr("x")]))
+    await expect(readXls(data)).rejects.toThrow(/outside the supported sheet bounds/)
+  })
+
+  it("rejects a sheet whose bounding box exceeds the cell budget", async () => {
+    // Two legal BIFF coordinates can describe a rectangle of 20M+ slots.
+    const data = sheetWith(
+      concat([
+        record(SID.LABEL, [...u16(0), ...u16(16000), ...u16(0), ...xlStr("x")]),
+        record(SID.LABEL, [...u16(1300), ...u16(0), ...u16(0), ...xlStr("y")]),
+      ]) as unknown as number[],
+    )
+    await expect(readXls(data)).rejects.toThrow(/over the 20000000 limit/)
+  })
+})
+
+describe("readXls — FORMULA cached values", () => {
+  /** A FORMULA record whose 8-byte cached value is given verbatim. */
+  const formula = (row: number, col: number, cached: number[]): number[] =>
+    record(SID.FORMULA, [
+      ...u16(row),
+      ...u16(col),
+      ...u16(0),
+      ...cached,
+      ...u16(0),
+      ...u32(0),
+      ...u16(0),
+    ])
+
+  async function read(records: number[]) {
+    const data = xlsFile({
+      globals: [...xf(0)],
+      sheets: [{ name: "S", records: [...bof(0x0010), ...records, ...eof()] }],
+    })
+    return (await readXls(data)).sheets[0].rows
+  }
+
+  it("decodes a cached boolean", async () => {
+    const rows = await read(formula(0, 0, [1, 0, 1, 0, 0, 0, 0xff, 0xff]))
+    expect(rows[0][0]).toBe(true)
+  })
+
+  it("decodes a cached error", async () => {
+    const rows = await read(formula(0, 0, [2, 0, 0x17, 0, 0, 0, 0xff, 0xff]))
+    expect(rows[0][0]).toBe("#REF!")
+  })
+
+  it("falls back to #ERR! for an unknown cached error code", async () => {
+    const rows = await read(formula(0, 0, [2, 0, 0x55, 0, 0, 0, 0xff, 0xff]))
+    expect(rows[0][0]).toBe("#ERR!")
+  })
+
+  it("takes a cached string from the STRING record that follows", async () => {
+    const rows = await read([
+      ...formula(0, 0, [0, 0, 0, 0, 0, 0, 0xff, 0xff]),
+      ...record(SID.STRING, xlStr("computed")),
+    ])
+    expect(rows[0][0]).toBe("computed")
+  })
+
+  it("leaves the cell empty when the STRING record is missing", async () => {
+    const rows = await read(formula(0, 0, [0, 0, 0, 0, 0, 0, 0xff, 0xff]))
+    expect(rows[0]).toBeUndefined()
+  })
+
+  it("leaves the cell empty for a cached blank", async () => {
+    const rows = await read(formula(0, 0, [3, 0, 0, 0, 0, 0, 0xff, 0xff]))
+    expect(rows[0]).toBeUndefined()
+  })
+
+  it("decodes a cached number", async () => {
+    const rows = await read(formula(0, 0, f64(12.5)))
+    expect(rows[0][0]).toBeCloseTo(12.5, 6)
+  })
+})
+
+describe("parseSst — rich, phonetic, wide and continued strings", () => {
+  it("decodes every SST string flavour, including one split across CONTINUE", async () => {
+    // Layout per MS-XLS §2.4.265: cch, grbit, [cRun], [cbExt], characters,
+    // then the rich-run and phonetic trailers the reader has to skip.
+    const plain = [...u16(4), 0, ...chars("Name")]
+    const rich = [...u16(4), 0x08, ...u16(1), ...chars("Rich"), 0, 0, 0, 0]
+    const phonetic = [...u16(4), 0x04, ...u32(6), ...chars("Phon"), 0, 0, 0, 0, 0, 0]
+    const wide = [...u16(3), 0x01, ...u16(0x00dc), ...u16(0x011f), ...u16(0x015f)]
+    // Last in the SST record: only the first three characters fit, the rest
+    // resume in the CONTINUE record behind a fresh option byte.
+    const splitHead = [...u16(6), 0, ...chars("Con")]
+    const splitTail = [0, ...chars("tin")]
+
+    const sst = record(SID.SST, [
+      ...u32(5),
+      ...u32(5),
+      ...plain,
+      ...rich,
+      ...phonetic,
+      ...wide,
+      ...splitHead,
+    ])
+    const cont = record(SID.CONTINUE, splitTail)
+
+    const labels = [0, 1, 2, 3, 4].map((i) =>
+      record(SID.LABELSST, [...u16(0), ...u16(i), ...u16(0), ...u32(i)]),
+    )
+    const data = xlsFile({
+      globals: [...xf(0), ...sst, ...cont],
+      sheets: [{ name: "S", records: [...bof(0x0010), ...labels.flat(), ...eof()] }],
+    })
+
+    const rows = (await readXls(data)).sheets[0].rows
+    expect(rows[0]).toEqual(["Name", "Rich", "Phon", "Üğş", "Contin"])
+  })
+
+  // BUG (reported): BlockStream.skip in src/xls/biff.ts:166-175 spins
+  // forever once every block is exhausted — `ensure()` cannot advance past
+  // the last block, `remainingInBlock()` then returns 0 (biff.ts:131), and
+  // `left` never decreases. readSstString reaches it with an untrusted cRun
+  // (biff.ts:222) or cbExt (biff.ts:223), so an .xls whose rich-run count
+  // overruns the record hangs the process. Un-skipping this test hangs the
+  // suite; the wrapping try/catch in readXls cannot help with a live lock.
+  it.skip("does not hang on a rich-run count that overruns the record", async () => {
+    const rich = [...u16(1), 0x08, ...u16(0xffff), ...chars("A")]
+    const sst = record(SID.SST, [...u32(1), ...u32(1), ...rich])
+    const data = xlsFile({
+      globals: [...xf(0), ...sst],
+      sheets: [{ name: "S", records: [...bof(0x0010), ...eof()] }],
+    })
+    await expect(readXls(data)).rejects.toThrow()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// XLSB
+// ═══════════════════════════════════════════════════════════════════════
+
+// ── Minimal XLSB builder ─────────────────────────────────────────────
+
+const REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+const NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+function wstr(s: string): Uint8Array {
+  const out = new Uint8Array(4 + s.length * 2)
+  const dv = new DataView(out.buffer)
+  dv.setUint32(0, s.length, true)
+  for (let i = 0; i < s.length; i++) dv.setUint16(4 + i * 2, s.charCodeAt(i), true)
+  return out
+}
+const nwstr = (s: string | null): Uint8Array =>
+  s === null ? new Uint8Array(u32(0xffffffff)) : wstr(s)
+
+function varint(n: number): number[] {
+  const out: number[] = []
+  let s = n
+  do {
+    let b = s & 0x7f
+    s >>>= 7
+    if (s) b |= 0x80
+    out.push(b)
+  } while (s)
+  return out
+}
+function rec(id: number, payload: Uint8Array | number[]): Uint8Array {
+  const body = payload instanceof Uint8Array ? payload : new Uint8Array(payload)
+  const idBytes = id < 0x80 ? [id] : [(id & 0x7f) | 0x80, (id >> 7) & 0x7f]
+  return concat([idBytes, varint(body.length), body])
+}
+const cellPrefix = (col: number, style: number): number[] => [...u32(col), ...u32(style & 0xffffff)]
+
+const Brt = {
+  RowHdr: 0,
+  CellBlank: 1,
+  CellRk: 2,
+  CellError: 3,
+  CellBool: 4,
+  CellReal: 5,
+  CellSt: 6,
+  CellIsst: 7,
+  SSTItem: 19,
+  Fmt: 44,
+  XF: 47,
+  BundleSh: 156,
+  BeginCellXFs: 617,
+  EndCellXFs: 618,
+  BeginSst: 159,
+}
+
+const relsXml = (rels: string) =>
+  `<?xml version="1.0"?><Relationships xmlns="${NS}">${rels}</Relationships>`
+
+async function buildXlsbPackage(parts: Record<string, Uint8Array | string>): Promise<Uint8Array> {
+  const zw = new ZipWriter()
+  for (const [path, body] of Object.entries(parts)) {
+    zw.add(path, typeof body === "string" ? enc.encode(body) : body)
+  }
+  return zw.build()
+}
+
+describe("readXlsb — package layout", () => {
+  it("resolves a workbook part that lives at the package root", async () => {
+    const pkg = await buildXlsbPackage({
+      "_rels/.rels": relsXml(
+        `<Relationship Id="r" Type="${REL}/officeDocument" Target="workbook.bin"/>`,
+      ),
+      // A BrtBeginBook-style record ahead of the sheet bundle: the reader
+      // must walk past records it does not care about.
+      "workbook.bin": concat([
+        rec(131, []),
+        rec(Brt.BundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")])),
+      ]),
+      "_rels/workbook.bin.rels": relsXml(
+        `<Relationship Id="rId1" Type="${REL}/worksheet" Target="sheet1.bin"/>`,
+      ),
+      "sheet1.bin": concat([
+        rec(Brt.RowHdr, u32(0)),
+        rec(Brt.CellSt, concat([cellPrefix(0, 0), wstr("root")])),
+      ]),
+    })
+    const wb = await readXlsb(pkg)
+    expect(wb.sheets[0].rows[0][0]).toBe("root")
+  })
+
+  it("resolves package-absolute relationship targets", async () => {
+    const pkg = await buildXlsbPackage({
+      "_rels/.rels": relsXml(
+        `<Relationship Id="r" Type="${REL}/officeDocument" Target="/xl/workbook.bin"/>`,
+      ),
+      "xl/workbook.bin": rec(Brt.BundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")])),
+      "xl/_rels/workbook.bin.rels": relsXml(
+        `<Relationship Id="rId1" Type="${REL}/worksheet" Target="/xl/worksheets/sheet1.bin"/>`,
+      ),
+      "xl/worksheets/sheet1.bin": concat([
+        rec(Brt.RowHdr, u32(0)),
+        rec(Brt.CellSt, concat([cellPrefix(0, 0), wstr("absolute")])),
+      ]),
+    })
+    expect((await readXlsb(pkg)).sheets[0].rows[0][0]).toBe("absolute")
+  })
+
+  it("normalises '..' and '.' segments in a relationship target", async () => {
+    const pkg = await buildXlsbPackage({
+      "_rels/.rels": relsXml(
+        `<Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/>`,
+      ),
+      "xl/workbook.bin": rec(Brt.BundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")])),
+      "xl/_rels/workbook.bin.rels": relsXml(
+        `<Relationship Id="rId1" Type="${REL}/worksheet" Target="../xl/./worksheets/sheet1.bin"/>`,
+      ),
+      "xl/worksheets/sheet1.bin": concat([
+        rec(Brt.RowHdr, u32(0)),
+        rec(Brt.CellSt, concat([cellPrefix(0, 0), wstr("relative")])),
+      ]),
+    })
+    expect((await readXlsb(pkg)).sheets[0].rows[0][0]).toBe("relative")
+  })
+
+  it("rejects a package whose workbook part is missing", async () => {
+    const pkg = await buildXlsbPackage({
+      "_rels/.rels": relsXml(
+        `<Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/>`,
+      ),
+    })
+    await expect(readXlsb(pkg)).rejects.toThrow(/missing workbook at xl\/workbook\.bin/)
+  })
+
+  it("surfaces a non-ZIP input as a ZipError", async () => {
+    await expect(readXlsb(enc.encode("not a zip at all"))).rejects.toBeInstanceOf(ZipError)
+  })
+
+  it("refuses an encrypted container without a password", async () => {
+    const container = writeCfb([
+      { name: "EncryptionInfo", data: new Uint8Array(64) },
+      { name: "EncryptedPackage", data: new Uint8Array(64) },
+    ])
+    await expect(readXlsb(container)).rejects.toBeInstanceOf(EncryptedFileError)
+    await expect(readXlsb(container, { password: "pw" })).rejects.toBeInstanceOf(DecryptionError)
+  })
+
+  it("returns an empty sheet when the relationship does not resolve", async () => {
+    const pkg = await buildXlsbPackage({
+      "_rels/.rels": relsXml(
+        `<Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/>`,
+      ),
+      "xl/workbook.bin": concat([
+        rec(Brt.BundleSh, concat([u32(0), u32(0), nwstr("rIdGone"), wstr("Dangling")])),
+        rec(Brt.BundleSh, concat([u32(0), u32(0), nwstr(null), wstr("NoRel")])),
+      ]),
+      "xl/_rels/workbook.bin.rels": relsXml(""),
+    })
+    const wb = await readXlsb(pkg)
+    expect(wb.sheets).toEqual([
+      { name: "Dangling", rows: [] },
+      { name: "NoRel", rows: [] },
+    ])
+  })
+})
+
+describe("readXlsb — record decoding", () => {
+  async function sheetPackage(
+    sheetBin: Uint8Array,
+    extra?: { sst?: Uint8Array; styles?: Uint8Array },
+  ) {
+    const wbRels = [
+      `<Relationship Id="rId1" Type="${REL}/worksheet" Target="worksheets/sheet1.bin"/>`,
+      extra?.sst
+        ? `<Relationship Id="rId2" Type="${REL}/sharedStrings" Target="sharedStrings.bin"/>`
+        : "",
+      extra?.styles ? `<Relationship Id="rId3" Type="${REL}/styles" Target="styles.bin"/>` : "",
+    ].join("")
+    const parts: Record<string, Uint8Array | string> = {
+      "_rels/.rels": relsXml(
+        `<Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/>`,
+      ),
+      "xl/workbook.bin": rec(Brt.BundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")])),
+      "xl/_rels/workbook.bin.rels": relsXml(wbRels),
+      "xl/worksheets/sheet1.bin": sheetBin,
+    }
+    if (extra?.sst) parts["xl/sharedStrings.bin"] = extra.sst
+    if (extra?.styles) parts["xl/styles.bin"] = extra.styles
+    return readXlsb(await buildXlsbPackage(parts))
+  }
+
+  it("skips records it has no decoder for, including blank cells", async () => {
+    const wb = await sheetPackage(
+      concat([
+        rec(Brt.RowHdr, u32(0)),
+        rec(Brt.CellBlank, cellPrefix(0, 0)),
+        rec(999, [1, 2, 3]),
+        rec(Brt.CellSt, concat([cellPrefix(1, 0), wstr("kept")])),
+      ]),
+    )
+    expect(wb.sheets[0].rows[0]).toEqual([null, "kept"])
+  })
+
+  it("decodes an RK number stored as a truncated double", async () => {
+    const wb = await sheetPackage(
+      concat([
+        rec(Brt.RowHdr, u32(0)),
+        rec(Brt.CellRk, concat([cellPrefix(0, 0), u32(0x3ff00000)])),
+      ]),
+    )
+    expect(wb.sheets[0].rows[0][0]).toBe(1)
+  })
+
+  it("falls back to #ERR! for an unknown error code", async () => {
+    const wb = await sheetPackage(
+      concat([rec(Brt.RowHdr, u32(0)), rec(Brt.CellError, concat([cellPrefix(0, 0), [0x55]]))]),
+    )
+    expect(wb.sheets[0].rows[0][0]).toBe("#ERR!")
+  })
+
+  it("falls back to an empty string for an out-of-range shared-string index", async () => {
+    const wb = await sheetPackage(
+      concat([rec(Brt.RowHdr, u32(0)), rec(Brt.CellIsst, concat([cellPrefix(0, 0), u32(42)]))]),
+      { sst: rec(Brt.SSTItem, concat([[0], wstr("only")])) },
+    )
+    expect(wb.sheets[0].rows[0][0]).toBe("")
+  })
+
+  it("reads shared strings longer than a one-byte record size", async () => {
+    // Record sizes are 7-bit varints; a 200-character string needs two bytes.
+    const long = "s".repeat(200)
+    const wb = await sheetPackage(
+      concat([rec(Brt.RowHdr, u32(0)), rec(Brt.CellIsst, concat([cellPrefix(0, 0), u32(1)]))]),
+      {
+        sst: concat([
+          rec(Brt.BeginSst, u32(2)),
+          rec(Brt.SSTItem, concat([[0], wstr("short")])),
+          rec(Brt.SSTItem, concat([[0], wstr(long)])),
+        ]),
+      },
+    )
+    expect(wb.sheets[0].rows[0][0]).toBe(long)
+  })
+
+  it("treats a cell as a date when a custom number format says so", async () => {
+    // Only the XF records between BeginCellXFs/EndCellXFs are cell formats;
+    // the ones outside describe named styles and must not shift the indices.
+    const styles = concat([
+      rec(Brt.Fmt, concat([u16(200), wstr("yyyy-mm-dd")])),
+      rec(Brt.XF, concat([u16(0), u16(14), u16(0), u16(0), u16(0), [0, 0]])), // style xf, ignored
+      rec(Brt.BeginCellXFs, u32(1)),
+      rec(Brt.XF, concat([u16(0), u16(200), u16(0), u16(0), u16(0), [0, 0]])),
+      rec(Brt.EndCellXFs, []),
+      rec(Brt.XF, concat([u16(0), u16(14), u16(0), u16(0), u16(0), [0, 0]])), // also ignored
+    ])
+    const wb = await sheetPackage(
+      concat([
+        rec(Brt.RowHdr, u32(0)),
+        rec(Brt.CellReal, concat([cellPrefix(0, 0), new Uint8Array(f64(45000))])),
+      ]),
+      { styles },
+    )
+    expect(wb.sheets[0].rows[0][0]).toBeInstanceOf(Date)
+  })
+
+  it("rejects a column index outside the supported sheet bounds", async () => {
+    await expect(
+      sheetPackage(
+        concat([
+          rec(Brt.RowHdr, u32(0)),
+          rec(Brt.CellSt, concat([cellPrefix(20000, 0), wstr("x")])),
+        ]),
+      ),
+    ).rejects.toThrow(/Cell column 20000 is outside the supported sheet bounds/)
+  })
+
+  it("rejects a row index outside the supported sheet bounds", async () => {
+    await expect(sheetPackage(rec(Brt.RowHdr, u32(2_000_000)))).rejects.toThrow(
+      /Cell row 2000000 is outside the supported sheet bounds/,
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// CFB container
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readCfb / writeCfb", () => {
+  it("rejects a file that is large enough but not a CFB", () => {
+    expect(() => readCfb(new Uint8Array(1024))).toThrow(/CFB: bad signature/)
+  })
+
+  it("rejects a file too small to hold a header", () => {
+    expect(() => readCfb(new Uint8Array(16))).toThrow(/CFB: file too small/)
+  })
+
+  it("round-trips a container with no streams at all", () => {
+    expect(readCfb(writeCfb([])).size).toBe(0)
+  })
+
+  it("falls back to the standard 4096-byte mini cutoff when the header says 0", () => {
+    // Some writers leave the mini-stream cutoff field zeroed; assuming 0
+    // would route every small stream through the regular FAT and read
+    // garbage.
+    const file = writeCfb([{ name: "Small", data: enc.encode("tiny payload") }])
+    new DataView(file.buffer, file.byteOffset, file.byteLength).setUint32(56, 0, true)
+    expect(new TextDecoder().decode(readCfb(file).get("Small")!)).toBe("tiny payload")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Agile encryption
+// ═══════════════════════════════════════════════════════════════════════
+
+const FAST = { spinCount: 64 }
+
+/** Rebuild an encrypted container with its EncryptionInfo XML rewritten. */
+function rewriteEncryptionInfo(container: Uint8Array, edit: (xml: string) => string): Uint8Array {
+  const streams = readCfb(container)
+  const info = streams.get("EncryptionInfo")!
+  const xml = edit(new TextDecoder().decode(info.subarray(8)))
+  return writeCfb([
+    { name: "EncryptionInfo", data: concat([info.subarray(0, 8), enc.encode(xml)]) },
+    { name: "EncryptedPackage", data: streams.get("EncryptedPackage")! },
+  ])
+}
+
+describe("decryptAgile — malformed containers", () => {
+  it("rejects input that is not a CFB container", async () => {
+    await expect(decryptAgile(enc.encode("plain text"), "pw")).rejects.toThrow(
+      /Not a valid encrypted workbook container/,
+    )
+  })
+
+  it("rejects a container missing the encryption streams", async () => {
+    const container = writeCfb([{ name: "Workbook", data: new Uint8Array(64) }])
+    await expect(decryptAgile(container, "pw")).rejects.toThrow(
+      /missing EncryptionInfo\/EncryptedPackage/,
+    )
+  })
+
+  it("rejects a non-Agile encryption version", async () => {
+    // 3.2 is ECMA-376 Standard encryption (RC4/AES with a different layout).
+    const info = new Uint8Array(8)
+    const dv = new DataView(info.buffer)
+    dv.setUint16(0, 3, true)
+    dv.setUint16(2, 2, true)
+    const container = writeCfb([
+      { name: "EncryptionInfo", data: info },
+      { name: "EncryptedPackage", data: new Uint8Array(64) },
+    ])
+    await expect(decryptAgile(container, "pw")).rejects.toThrow(
+      /Unsupported encryption \(version 3\.2\)/,
+    )
+  })
+})
+
+describe("decryptAgile — EncryptionInfo XML", () => {
+  async function encrypted(): Promise<Uint8Array> {
+    return encryptAgile(enc.encode("PK" + "payload ".repeat(600)), "pw", FAST)
+  }
+
+  it("rejects EncryptionInfo with no password key encryptor", async () => {
+    const bad = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/<p:encryptedKey[^>]*\/>/, ""),
+    )
+    await expect(decryptAgile(bad, "pw")).rejects.toThrow(/missing encryptedKey/)
+  })
+
+  it("rejects EncryptionInfo with no keyData element", async () => {
+    const bad = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/<keyData[^>]*\/>/, ""),
+    )
+    await expect(decryptAgile(bad, "pw")).rejects.toThrow(/missing keyData/)
+  })
+
+  it("rejects a spinCount that is not a number", async () => {
+    const bad = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/spinCount="\d+"/, `spinCount="many"`),
+    )
+    await expect(decryptAgile(bad, "pw")).rejects.toThrow(/invalid spinCount/)
+  })
+
+  it("assumes SHA-512 for a hash name it does not recognise", async () => {
+    // The hash name is only a lookup key and SHA-512 is the documented
+    // default, so an unrecognised name must not crash the parse — this file
+    // really is SHA-512 and still decrypts.
+    const odd = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(
+        /hashAlgorithm="SHA512" saltValue="([^"]*)" encryptedVerifierHashInput/,
+        `hashAlgorithm="RIPEMD160" saltValue="$1" encryptedVerifierHashInput`,
+      ),
+    )
+    expect(new TextDecoder().decode(await decryptAgile(odd, "pw"))).toContain("payload")
+  })
+
+  it("treats a missing verifier attribute as empty rather than crashing", async () => {
+    const bad = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/encryptedVerifierHashInput="[^"]*" /, ""),
+    )
+    await expect(decryptAgile(bad, "pw")).rejects.toThrow(DecryptionError)
+  })
+})
+
+describe("decryptAgile — data integrity", () => {
+  async function encrypted(): Promise<Uint8Array> {
+    return encryptAgile(enc.encode("PK" + "payload ".repeat(600)), "pw", FAST)
+  }
+
+  it("skips the HMAC check when no dataIntegrity element is present", async () => {
+    // Older writers omit it entirely; that is not an error.
+    const without = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/<dataIntegrity[^>]*\/>/, ""),
+    )
+    expect(new TextDecoder().decode(await decryptAgile(without, "pw"))).toContain("payload")
+  })
+
+  it("skips the HMAC check when the integrity attributes are empty", async () => {
+    const empty = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/encryptedHmacKey="[^"]*"/, `encryptedHmacKey=""`),
+    )
+    expect(new TextDecoder().decode(await decryptAgile(empty, "pw"))).toContain("payload")
+  })
+
+  it("skips the HMAC check when keyData uses a hash other than SHA-512", async () => {
+    // Only SHA-512 HMAC is implemented, so the check is bypassed — the
+    // package still decrypts rather than failing integrity.
+    const other = rewriteEncryptionInfo(await encrypted(), (xml) =>
+      xml.replace(/<keyData([^>]*)hashAlgorithm="SHA512"/, `<keyData$1hashAlgorithm="SHA384"`),
+    )
+    await expect(decryptAgile(other, "pw")).resolves.toBeInstanceOf(Uint8Array)
+  })
+
+  it("rejects a package whose ciphertext has been tampered with", async () => {
+    const container = await encrypted()
+    const streams = readCfb(container)
+    const pkg = streams.get("EncryptedPackage")!.slice()
+    pkg[pkg.length - 1] ^= 0xff
+    const tampered = writeCfb([
+      { name: "EncryptionInfo", data: streams.get("EncryptionInfo")! },
+      { name: "EncryptedPackage", data: pkg },
+    ])
+    await expect(decryptAgile(tampered, "pw")).rejects.toThrow(/failed integrity check/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// OPC part parsers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseRelationships", () => {
+  it("drops relationships that are missing a required attribute", () => {
+    const xml = relsXml(
+      `<Relationship Type="${REL}/worksheet" Target="sheet1.xml"/>` +
+        `<Relationship Id="rId2" Target="sheet2.xml"/>` +
+        `<Relationship Id="rId3" Type="${REL}/worksheet"/>` +
+        `<Relationship Id="rId4" Type="${REL}/worksheet" Target="sheet4.xml"/>`,
+    )
+    expect(parseRelationships(xml)).toEqual([
+      { id: "rId4", type: `${REL}/worksheet`, target: "sheet4.xml" },
+    ])
+  })
+
+  it("keeps TargetMode for external relationships", () => {
+    const xml = relsXml(
+      `<Relationship Id="rId1" Type="${REL}/hyperlink" Target="https://example.com" TargetMode="External"/>`,
+    )
+    expect(parseRelationships(xml)[0].targetMode).toBe("External")
+  })
+
+  it("ignores elements that are not relationships", () => {
+    const xml = relsXml(
+      `<Note>ignored</Note><Relationship Id="rId1" Type="${REL}/styles" Target="styles.xml"/>`,
+    )
+    expect(parseRelationships(xml).map((r) => r.id)).toEqual(["rId1"])
+  })
+})
+
+describe("parseContentTypes", () => {
+  const CT_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
+
+  it("drops Default and Override entries that are missing an attribute", () => {
+    const xml =
+      `<?xml version="1.0"?><Types xmlns="${CT_NS}">` +
+      `<Default Extension="bin"/>` +
+      `<Default ContentType="application/xml"/>` +
+      `<Override PartName="/xl/workbook.xml"/>` +
+      `<Override ContentType="application/xml"/>` +
+      `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+      `<Override PartName="/xl/styles.xml" ContentType="application/styles"/>` +
+      `</Types>`
+    const ct = parseContentTypes(xml)
+    expect([...ct.defaults.keys()]).toEqual(["rels"])
+    expect([...ct.overrides.keys()]).toEqual(["/xl/styles.xml"])
+  })
+
+  it("ignores elements that are neither Default nor Override", () => {
+    const xml = `<?xml version="1.0"?><Types xmlns="${CT_NS}"><Comment>hi</Comment></Types>`
+    const ct = parseContentTypes(xml)
+    expect(ct.defaults.size).toBe(0)
+    expect(ct.overrides.size).toBe(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// fetchCsv
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("fetchCsv", () => {
+  // A `data:` URL is a real fetch with a real Response, so this exercises
+  // the function end to end without depending on a network peer.
+  const url = (csv: string) => `data:text/csv,${encodeURIComponent(csv)}`
+
+  it("parses a CSV fetched from a URL", async () => {
+    expect(await fetchCsv(url("Name,Score\nAda,95\n"))).toEqual([
+      ["Name", "Score"],
+      ["Ada", "95"],
+    ])
+  })
+
+  it("passes reader options through to the parser", async () => {
+    expect(
+      await fetchCsv(url("Name;Score\nAda;95\n"), { delimiter: ";", typeInference: true }),
+    ).toEqual([
+      ["Name", "Score"],
+      ["Ada", 95],
+    ])
+  })
+
+  // The failure path is what a caller actually has to handle, and the status
+  // code is the only diagnostic it gets. No URL scheme Node's fetch accepts
+  // can produce a non-2xx `Response` without a live peer, so this is the one
+  // place the global is stubbed — with a *real* `Response`, so everything
+  // after the `ok` check is still the genuine WHATWG object.
+  it("reports the HTTP status when the server refuses the request", async () => {
+    vi.stubGlobal("fetch", async () => new Response("nope", { status: 503 }))
+    try {
+      await expect(fetchCsv("https://example.invalid/data.csv")).rejects.toThrow(
+        "Failed to fetch: 503",
+      )
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/test/coverage-chart-axis.test.ts
+++ b/test/coverage-chart-axis.test.ts
@@ -1,0 +1,2094 @@
+import { describe, expect, it } from "vitest"
+import type {
+  ChartAxisDispUnits,
+  ChartAxisGridlines,
+  ChartAxisNumberFormat,
+  ChartAxisScale,
+  ChartLegendEntry,
+  SheetChart,
+} from "../src/_types"
+import { type XmlElement, parseXml } from "../src/xml/parser"
+import {
+  applyAutoOverride,
+  applyAxisTitleBoldOverride,
+  applyAxisTitleItalicOverride,
+  applyAxisTitleOverlayOverride,
+  applyAxisTitleStrikeOverride,
+  applyAxisTitleUnderlineOverride,
+  applyCrossBetweenOverride,
+  applyCrossesOverride,
+  applyDispUnitsOverride,
+  applyGridlinesOverride,
+  applyHiddenOverride,
+  applyLabelBoldOverride,
+  applyLabelColorOverride,
+  applyLabelFontFamilyOverride,
+  applyLabelFontSizeOverride,
+  applyLabelItalicOverride,
+  applyLabelStrikeOverride,
+  applyLabelUnderlineOverride,
+  applyLblAlgnOverride,
+  applyLblOffsetOverride,
+  applyNoMultiLvlLblOverride,
+  applyNumberFormatOverride,
+  applyScaleOverride,
+  applySkipOverride,
+  applyTickLblPosOverride,
+  applyTickMarkOverride,
+  buildAxisDispUnits,
+  cloneScale,
+  normalizeAxisDispUnits,
+  normalizeAxisNumberFormat,
+  normalizeAxisSkip,
+  normalizeDispUnits,
+  parseAxisAuto,
+  parseAxisCrossBetween,
+  parseAxisCrosses,
+  parseAxisDispUnits,
+  parseAxisGridlines,
+  parseAxisHidden,
+  parseAxisInfo,
+  parseAxisLabelBold,
+  parseAxisLabelColor,
+  parseAxisLabelFontSize,
+  parseAxisLabelItalic,
+  parseAxisLabelFontFamily,
+  parseAxisLabelRotation,
+  parseAxisLabelStrike,
+  parseAxisLabelUnderline,
+  parseAxisLblAlgn,
+  parseAxisLblOffset,
+  parseAxisNoMultiLvlLbl,
+  parseAxisNumberFormat,
+  parseAxisReverse,
+  parseAxisScale,
+  parseAxisSkip,
+  parseAxisTickLblPos,
+  parseAxisTickMark,
+  parseAxisTitle,
+  parseAxisTitleBold,
+  parseAxisTitleColor,
+  parseAxisTitleFontFamily,
+  parseAxisTitleFontSize,
+  parseAxisTitleItalic,
+  parseAxisTitleOverlay,
+  parseAxisTitleRotation,
+  parseAxisTitleStrike,
+  parseAxisTitleUnderline,
+  resolveAxes,
+} from "../src/xlsx/chart/axis"
+import {
+  parseLegend,
+  parseLegendBold,
+  parseLegendBorderCap,
+  parseLegendBorderColor,
+  parseLegendBorderCompound,
+  parseLegendBorderDash,
+  parseLegendBorderWidth,
+  parseLegendEntries,
+  parseLegendFillColor,
+  parseLegendFontColor,
+  parseLegendFontFamily,
+  parseLegendFontSize,
+  parseLegendItalic,
+  parseLegendLayout,
+  parseLegendOverlay,
+  parseLegendStrikethrough,
+  parseLegendUnderline,
+  resolveLegendEntries,
+  resolveLegendPosition,
+} from "../src/xlsx/chart/legend"
+import {
+  parseTitle,
+  parseTitleBold,
+  parseTitleColor,
+  parseTitleFontFamily,
+  parseTitleFontSize,
+  parseTitleItalic,
+  parseTitleRotation,
+  parseTitleStrike,
+  parseTitleUnderline,
+} from "../src/xlsx/chart/title"
+import {
+  applyOverride,
+  childElements,
+  elementText,
+  findChild,
+  findDescendant,
+  formulaText,
+  parseBoolAttr,
+  parseNumericChildVal,
+  readBoolAttr,
+  readBoolVal,
+} from "../src/xlsx/chart/util"
+import {
+  normalizeChartColor,
+  parseSchemeClr,
+  resolveChartColor,
+  resolveLineCap,
+  resolveLineCompound,
+} from "../src/xlsx/chart/shape"
+import {
+  buildPieChart,
+  buildPlotArea,
+  parseBarGrouping,
+  parseFirstSliceAng,
+  parseGapWidth,
+  parseHoleSize,
+  parseLineAreaGrouping,
+  parseOverlap,
+  parseUpDownBarsGapWidth,
+} from "../src/xlsx/chart/plotArea"
+import {
+  buildManualLayout,
+  normalizeLayoutCoordinate,
+  parseManualLayout,
+  readLayoutCoordinate,
+} from "../src/xlsx/chart/layout"
+import {
+  buildFloorThickness,
+  parseBackWallThickness,
+  parseFloorThickness,
+  parseSideWallThickness,
+  parseView3D,
+} from "../src/xlsx/chart/walls"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const NS =
+  'xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" ' +
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+
+/** Build a chart-namespace element through the project's parser. */
+function el(tag: string, inner = ""): XmlElement {
+  return parseXml(`<c:${tag} ${NS}>${inner}</c:${tag}>`)
+}
+
+/** A `<c:valAx>` carrying the supplied children. */
+function axis(inner: string): XmlElement {
+  return el("valAx", inner)
+}
+
+/** A `<c:chart>` carrying the supplied children. */
+function chartEl(inner: string): XmlElement {
+  return el("chart", inner)
+}
+
+/**
+ * The `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr>` chain every
+ * title reader walks. `depth` truncates it link by link.
+ */
+function titleChain(depth: 0 | 1 | 2 | 3 | 4 | 5, defRPrAttrs = "", defRPrBody = ""): string {
+  const inner = [
+    "<c:title/>",
+    "<c:title><c:tx/></c:title>",
+    "<c:title><c:tx><c:rich/></c:tx></c:title>",
+    "<c:title><c:tx><c:rich><a:p/></c:rich></c:tx></c:title>",
+    "<c:title><c:tx><c:rich><a:p><a:pPr/></a:p></c:rich></c:tx></c:title>",
+    `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr${defRPrAttrs}>${defRPrBody}</a:defRPr>` +
+      "</a:pPr></a:p></c:rich></c:tx></c:title>",
+  ]
+  return inner[depth]
+}
+
+/** The `<c:txPr><a:p><a:pPr><a:defRPr>` chain, truncated at `depth`. */
+function txPrChain(depth: 0 | 1 | 2 | 3, defRPrAttrs = "", defRPrBody = ""): string {
+  const inner = [
+    "<c:txPr/>",
+    "<c:txPr><a:p/></c:txPr>",
+    "<c:txPr><a:p><a:pPr/></a:p></c:txPr>",
+    `<c:txPr><a:p><a:pPr><a:defRPr${defRPrAttrs}>${defRPrBody}</a:defRPr></a:pPr></a:p></c:txPr>`,
+  ]
+  return inner[depth]
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// chart/util — the XML walk every per-host reader is built on
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("findChild / findDescendant / childElements", () => {
+  const tree = el("plotArea", 'text<c:valAx><c:scaling><c:min val="0"/></c:scaling></c:valAx>')
+
+  it("matches on the local name, ignoring the namespace prefix", () => {
+    expect(findChild(tree, "valAx")?.local).toBe("valAx")
+    expect(findChild(tree, "scaling")).toBeUndefined()
+  })
+
+  it("returns the element itself when it already matches", () => {
+    expect(findDescendant(tree, "plotArea")).toBe(tree)
+  })
+
+  it("descends through text nodes to reach a nested match", () => {
+    expect(findDescendant(tree, "min")?.attrs.val).toBe("0")
+    expect(findDescendant(tree, "logBase")).toBeUndefined()
+  })
+
+  it("skips text nodes when listing children", () => {
+    expect(childElements(tree).map((c) => c.local)).toEqual(["valAx"])
+  })
+})
+
+describe("elementText", () => {
+  it("concatenates nested run text, not just the direct children", () => {
+    // `<a:t>` bodies can be split across entity boundaries, so the walk
+    // has to recurse rather than read a single text node.
+    expect(elementText(el("v", "a<c:x>b</c:x>c"))).toBe("abc")
+    expect(elementText(el("v", ""))).toBe("")
+  })
+})
+
+describe("formulaText", () => {
+  it("prefers <c:numRef>/<c:strRef> but falls back to a direct <c:f>", () => {
+    expect(formulaText(el("val", "<c:numRef><c:f>Sheet1!$A$1:$A$3</c:f></c:numRef>"))).toBe(
+      "Sheet1!$A$1:$A$3",
+    )
+    expect(formulaText(el("cat", "<c:strRef><c:f>Sheet1!$B$1</c:f></c:strRef>"))).toBe(
+      "Sheet1!$B$1",
+    )
+    // Some writers hoist `<c:f>` straight onto the wrapper.
+    expect(formulaText(el("val", "<c:f>Sheet1!$C$1</c:f>"))).toBe("Sheet1!$C$1")
+  })
+
+  it("returns undefined for literal data and for blank formulas", () => {
+    expect(formulaText(undefined)).toBeUndefined()
+    expect(
+      formulaText(el("val", '<c:numLit><c:pt idx="0"><c:v>1</c:v></c:pt></c:numLit>')),
+    ).toBeUndefined()
+    expect(formulaText(el("val", "<c:numRef><c:f>  </c:f></c:numRef>"))).toBeUndefined()
+    expect(formulaText(el("val", "<c:numRef/>"))).toBeUndefined()
+    expect(formulaText(el("val", "<c:f>   </c:f>"))).toBeUndefined()
+  })
+})
+
+describe("parseNumericChildVal", () => {
+  it("admits any finite xsd:double, including exponent notation", () => {
+    const parent = el("scaling", '<c:min val="-2.5"/><c:max val="1e3"/><c:logBase val=" 10 "/>')
+    expect(parseNumericChildVal(parent, "min")).toBe(-2.5)
+    expect(parseNumericChildVal(parent, "max")).toBe(1000)
+    expect(parseNumericChildVal(parent, "logBase")).toBe(10)
+  })
+
+  it("drops absence, a missing val, a blank val, and non-numeric tokens", () => {
+    const parent = el("scaling", '<c:min/><c:max val="  "/><c:logBase val="ten"/>')
+    expect(parseNumericChildVal(parent, "orientation")).toBeUndefined()
+    expect(parseNumericChildVal(parent, "min")).toBeUndefined()
+    expect(parseNumericChildVal(parent, "max")).toBeUndefined()
+    expect(parseNumericChildVal(parent, "logBase")).toBeUndefined()
+  })
+})
+
+describe("parseBoolAttr / readBoolAttr / readBoolVal", () => {
+  it("parseBoolAttr accepts the OOXML spellings case-insensitively after trimming", () => {
+    expect(parseBoolAttr(" TRUE ")).toBe(true)
+    expect(parseBoolAttr("1")).toBe(true)
+    expect(parseBoolAttr("False")).toBe(false)
+    expect(parseBoolAttr("0")).toBe(false)
+    expect(parseBoolAttr("yes")).toBeUndefined()
+    expect(parseBoolAttr(1)).toBeUndefined()
+    expect(parseBoolAttr(undefined)).toBeUndefined()
+  })
+
+  it("readBoolAttr treats anything but a truthy spelling as false, never undefined", () => {
+    // `<c:smooth val="0"/>` and `<c:smooth val="junk"/>` both mean "off"
+    // to Excel, so the element-level reader collapses them together.
+    expect(readBoolAttr(parseXml(`<c:smooth ${NS} val="1"/>`))).toBe(true)
+    expect(readBoolAttr(parseXml(`<c:smooth ${NS} val="TRUE"/>`))).toBe(true)
+    expect(readBoolAttr(parseXml(`<c:smooth ${NS} val="0"/>`))).toBe(false)
+    expect(readBoolAttr(parseXml(`<c:smooth ${NS} val="junk"/>`))).toBe(false)
+    expect(readBoolAttr(parseXml(`<c:smooth ${NS}/>`))).toBeUndefined()
+  })
+
+  it("readBoolVal is exact-match only — no trimming, no case folding", () => {
+    expect(readBoolVal("1")).toBe(true)
+    expect(readBoolVal("true")).toBe(true)
+    expect(readBoolVal("0")).toBe(false)
+    expect(readBoolVal("false")).toBe(false)
+    expect(readBoolVal("True")).toBeUndefined()
+    expect(readBoolVal(" 1")).toBeUndefined()
+    expect(readBoolVal(undefined)).toBeUndefined()
+  })
+})
+
+describe("applyOverride", () => {
+  it("implements the inherit / suppress / replace grammar every clone resolver shares", () => {
+    expect(applyOverride("src", undefined)).toBe("src")
+    expect(applyOverride("src", null)).toBeUndefined()
+    expect(applyOverride("src", "ov")).toBe("ov")
+    // A falsy replacement still replaces — only `null` suppresses.
+    expect(applyOverride(1, 0)).toBe(0)
+    expect(applyOverride(undefined, undefined)).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// chart/shape — <a:schemeClr> and the cap / compound resolvers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSchemeClr", () => {
+  it("reads every supported modifier that lands in its percentage band", () => {
+    const clr = parseXml(
+      `<a:schemeClr ${NS} val="accent1"><a:lumMod val="75000"/><a:lumOff val="25000"/>` +
+        '<a:tint val="40000"/><a:shade val="60000"/><a:alpha val="50000"/></a:schemeClr>',
+    )
+    expect(parseSchemeClr(clr)).toEqual({
+      theme: "accent1",
+      lumMod: 75000,
+      lumOff: 25000,
+      tint: 40000,
+      shade: 60000,
+      alpha: 50000,
+    })
+  })
+
+  it("drops a modifier whose val is missing, non-numeric, or out of band", () => {
+    // A garbage modifier must not sink the whole colour — the theme
+    // reference still round-trips, just without the bad mod.
+    const clr = parseXml(
+      `<a:schemeClr ${NS} val="tx1"><a:lumMod/><a:lumOff val="nope"/>` +
+        '<a:alpha val="500000"/></a:schemeClr>',
+    )
+    expect(parseSchemeClr(clr)).toEqual({ theme: "tx1" })
+  })
+
+  it("drops the element when val is absent or not an ST_SchemeColorVal name", () => {
+    expect(parseSchemeClr(parseXml(`<a:schemeClr ${NS}/>`))).toBeUndefined()
+    expect(parseSchemeClr(parseXml(`<a:schemeClr ${NS} val="accent9"/>`))).toBeUndefined()
+  })
+})
+
+describe("resolveChartColor / resolveLineCap / resolveLineCompound", () => {
+  it("follows the inherit / drop / replace grammar and normalizes both sides", () => {
+    expect(resolveChartColor("#ff0000", undefined)).toBe("FF0000")
+    expect(resolveChartColor("FF0000", null)).toBeUndefined()
+    expect(resolveChartColor("FF0000", "#00ff00")).toBe("00FF00")
+    expect(resolveChartColor("FF0000", "nothex")).toBeUndefined()
+  })
+
+  it("collapses the OOXML defaults cap=flat and cmpd=sng on both source and override", () => {
+    expect(resolveLineCap("rnd", undefined)).toBe("rnd")
+    expect(resolveLineCap("rnd", null)).toBeUndefined()
+    expect(resolveLineCap("rnd", "flat")).toBeUndefined()
+    expect(resolveLineCap("rnd", "bevel" as never)).toBeUndefined()
+    expect(resolveLineCompound("dbl", undefined)).toBe("dbl")
+    expect(resolveLineCompound("dbl", null)).toBeUndefined()
+    expect(resolveLineCompound("dbl", "sng")).toBeUndefined()
+    expect(resolveLineCompound("dbl", "quad" as never)).toBeUndefined()
+  })
+
+  it("normalizeChartColor keeps a theme reference but drops an unknown theme name", () => {
+    expect(normalizeChartColor({ theme: "bg1" })).toEqual({ theme: "bg1" })
+    expect(normalizeChartColor({ theme: "accent9" as never })).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// chart/layout — <c:manualLayout> (CT_ManualLayout, §21.2.2.115)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readLayoutCoordinate", () => {
+  it("admits only a finite xsd:double inside the 0..1 chart-frame band", () => {
+    const read = (attr: string): number | undefined =>
+      readLayoutCoordinate(parseXml(`<c:x ${NS} ${attr}/>`))
+    expect(read('val="0.25"')).toBe(0.25)
+    expect(read('val="0"')).toBe(0)
+    expect(read('val="1"')).toBe(1)
+    expect(read('val="1.5"')).toBeUndefined()
+    expect(read('val="-0.1"')).toBeUndefined()
+    expect(read('val="  "')).toBeUndefined()
+    expect(read('val="half"')).toBeUndefined()
+    expect(read("")).toBeUndefined()
+    expect(readLayoutCoordinate(undefined)).toBeUndefined()
+  })
+})
+
+describe("parseManualLayout / buildManualLayout", () => {
+  it("collapses to undefined when every coordinate dropped on normalization", () => {
+    expect(parseManualLayout(el("legend", ""))).toBeUndefined()
+    expect(parseManualLayout(el("legend", "<c:layout/>"))).toBeUndefined()
+    expect(
+      parseManualLayout(
+        el("legend", '<c:layout><c:manualLayout><c:x val="9"/></c:manualLayout></c:layout>'),
+      ),
+    ).toBeUndefined()
+  })
+
+  it("emits an xMode/yMode edge pair before the coordinates, per CT_ManualLayout order", () => {
+    const xml = buildManualLayout({ x: 0.1, h: 0.4 })
+    expect(xml).toBe(
+      "<c:layout><c:manualLayout>" +
+        '<c:xMode val="edge"/><c:hMode val="edge"/><c:x val="0.1"/><c:h val="0.4"/>' +
+        "</c:manualLayout></c:layout>",
+    )
+  })
+
+  it("returns undefined rather than a bare <c:layout> shell", () => {
+    expect(buildManualLayout(undefined)).toBeUndefined()
+    expect(buildManualLayout({})).toBeUndefined()
+    expect(normalizeLayoutCoordinate("0.5")).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// chart/walls — <c:view3D> / <c:floor> / <c:sideWall> / <c:backWall>
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseView3D", () => {
+  it('surfaces <c:rAngAx val="0"/> as an explicit false', () => {
+    // Excel writes `rAngAx="0"` when the user turns off "Right Angle
+    // Axes" on a 3-D chart, so the literal false has to survive.
+    expect(parseView3D(chartEl('<c:view3D><c:rAngAx val="0"/></c:view3D>'))).toEqual({
+      rAngAx: false,
+    })
+    expect(parseView3D(chartEl('<c:view3D><c:rAngAx val="false"/></c:view3D>'))).toEqual({
+      rAngAx: false,
+    })
+    expect(parseView3D(chartEl('<c:view3D><c:rAngAx val="1"/></c:view3D>'))).toEqual({
+      rAngAx: true,
+    })
+    expect(parseView3D(chartEl('<c:view3D><c:rAngAx val="maybe"/></c:view3D>'))).toEqual({})
+    expect(parseView3D(chartEl("<c:view3D><c:rAngAx/></c:view3D>"))).toEqual({})
+  })
+
+  it("preserves a bare <c:view3D/> shell as an empty record", () => {
+    // `buildView3D` re-emits `{}` as `<c:view3D/>`, so the reader keeps
+    // the empty object rather than collapsing the element away.
+    expect(parseView3D(chartEl("<c:view3D/>"))).toEqual({})
+  })
+
+  it("drops a <c:rotX> digit string so long it overflows to Infinity", () => {
+    // `Number("9".repeat(400))` is `Infinity` — it passes the signed-
+    // integer regex but is not an integer, so the guard behind the
+    // regex is what keeps it out.
+    const huge = "9".repeat(400)
+    expect(parseView3D(chartEl(`<c:view3D><c:rotX val="${huge}"/></c:view3D>`))).toEqual({})
+  })
+
+  it("returns undefined when the chart declares no <c:view3D>", () => {
+    expect(parseView3D(chartEl(""))).toBeUndefined()
+  })
+})
+
+describe("wall / floor thickness readers", () => {
+  const readers: Array<[string, string, (e: XmlElement) => number | undefined]> = [
+    ["floor", "floor", parseFloorThickness],
+    ["sideWall", "sideWall", parseSideWallThickness],
+    ["backWall", "backWall", parseBackWallThickness],
+  ]
+
+  it("reads ST_Thickness as a strict unsigned integer, collapsing the default 0", () => {
+    for (const [name, tag, read] of readers) {
+      expect(read(chartEl(`<c:${tag}><c:thickness val="25"/></c:${tag}>`)), name).toBe(25)
+      expect(read(chartEl(`<c:${tag}><c:thickness val="0"/></c:${tag}>`)), name).toBeUndefined()
+      expect(read(chartEl(`<c:${tag}><c:thickness val="-5"/></c:${tag}>`)), name).toBeUndefined()
+      expect(read(chartEl(`<c:${tag}><c:thickness val="2.5"/></c:${tag}>`)), name).toBeUndefined()
+      expect(read(chartEl(`<c:${tag}><c:thickness/></c:${tag}>`)), name).toBeUndefined()
+      expect(read(chartEl(`<c:${tag}/>`)), name).toBeUndefined()
+      expect(read(chartEl("")), name).toBeUndefined()
+    }
+  })
+
+  it("drops a digit string so long it overflows to Infinity", () => {
+    // `Number("9".repeat(400))` is `Infinity`, which passes the digits-
+    // only regex but is not an integer — the guard after the regex is
+    // what stops it reaching the range check.
+    const huge = "9".repeat(400)
+    for (const [name, tag, read] of readers) {
+      expect(
+        read(chartEl(`<c:${tag}><c:thickness val="${huge}"/></c:${tag}>`)),
+        name,
+      ).toBeUndefined()
+    }
+  })
+
+  it("clamps nothing on the write side — out-of-band values elide the element", () => {
+    expect(buildFloorThickness(25)).toBe('<c:floor><c:thickness val="25"/></c:floor>')
+    expect(buildFloorThickness(0)).toBeUndefined()
+    expect(buildFloorThickness(101)).toBeUndefined()
+    expect(buildFloorThickness(2.5)).toBeUndefined()
+    expect(buildFloorThickness(Number.NaN)).toBeUndefined()
+    expect(buildFloorThickness("25" as never)).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// chart/plotArea — per-family numeric and grouping readers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseBarGrouping / parseLineAreaGrouping", () => {
+  it("maps the ST_BarGrouping tokens Excel's UI exposes", () => {
+    const g = (v: string): unknown => parseBarGrouping(el("barChart", `<c:grouping val="${v}"/>`))
+    expect(g("stacked")).toBe("stacked")
+    expect(g("percentStacked")).toBe("percentStacked")
+    expect(g("clustered")).toBe("clustered")
+    // `standard` renders side-by-side exactly like `clustered`, so it
+    // collapses and the cloned chart inherits the writer's default.
+    expect(g("standard")).toBeUndefined()
+    expect(g("pyramid")).toBeUndefined()
+    expect(parseBarGrouping(el("barChart", "<c:grouping/>"))).toBeUndefined()
+    expect(parseBarGrouping(el("barChart", ""))).toBeUndefined()
+  })
+
+  it("maps the ST_Grouping tokens for line and area, dropping the default", () => {
+    const g = (v: string): unknown =>
+      parseLineAreaGrouping(el("lineChart", `<c:grouping val="${v}"/>`))
+    expect(g("stacked")).toBe("stacked")
+    expect(g("percentStacked")).toBe("percentStacked")
+    expect(g("standard")).toBeUndefined()
+    expect(g("clustered")).toBeUndefined()
+    expect(parseLineAreaGrouping(el("lineChart", "<c:grouping/>"))).toBeUndefined()
+    expect(parseLineAreaGrouping(el("lineChart", ""))).toBeUndefined()
+  })
+})
+
+describe("plot-area numeric readers", () => {
+  it("accepts the full 1..99 <c:holeSize> schema band, wider than Excel's UI", () => {
+    const h = (v: string): number | undefined =>
+      parseHoleSize(el("doughnutChart", `<c:holeSize val="${v}"/>`))
+    expect(h("1")).toBe(1)
+    expect(h("99")).toBe(99)
+    expect(h("0")).toBeUndefined()
+    expect(h("100")).toBeUndefined()
+    expect(h("half")).toBeUndefined()
+    expect(parseHoleSize(el("doughnutChart", "<c:holeSize/>"))).toBeUndefined()
+    expect(parseHoleSize(el("doughnutChart", ""))).toBeUndefined()
+  })
+
+  it("drops an out-of-band <c:gapWidth> rather than clamp it", () => {
+    // A clamp would silently rewrite a corrupt template as a different
+    // gap; dropping lets the writer's default take over instead.
+    const g = (v: string): number | undefined =>
+      parseGapWidth(el("barChart", `<c:gapWidth val="${v}"/>`))
+    expect(g("0")).toBe(0)
+    expect(g("500")).toBe(500)
+    expect(g("150")).toBeUndefined() // ST_GapAmount default
+    expect(g("501")).toBeUndefined()
+    expect(g("-1")).toBeUndefined()
+    expect(g("wide")).toBeUndefined()
+    expect(parseGapWidth(el("barChart", "<c:gapWidth/>"))).toBeUndefined()
+    expect(parseGapWidth(el("barChart", ""))).toBeUndefined()
+  })
+
+  it("applies the same band to the up/down-bars <c:gapWidth>", () => {
+    const g = (v: string): number | undefined =>
+      parseUpDownBarsGapWidth(el("upDownBars", `<c:gapWidth val="${v}"/>`))
+    expect(g("100")).toBe(100)
+    expect(g("150")).toBeUndefined()
+    expect(g("600")).toBeUndefined()
+    expect(g("x")).toBeUndefined()
+    expect(parseUpDownBarsGapWidth(el("upDownBars", "<c:gapWidth/>"))).toBeUndefined()
+    expect(parseUpDownBarsGapWidth(el("upDownBars", ""))).toBeUndefined()
+  })
+
+  it("surfaces the literal <c:overlap>, including Excel's stacked-chart 100", () => {
+    const o = (v: string): number | undefined =>
+      parseOverlap(el("barChart", `<c:overlap val="${v}"/>`))
+    expect(o("100")).toBe(100)
+    expect(o("-100")).toBe(-100)
+    expect(o("0")).toBeUndefined() // ST_Overlap default
+    expect(o("101")).toBeUndefined()
+    expect(o("-101")).toBeUndefined()
+    expect(o("none")).toBeUndefined()
+    expect(parseOverlap(el("barChart", "<c:overlap/>"))).toBeUndefined()
+    expect(parseOverlap(el("barChart", ""))).toBeUndefined()
+  })
+
+  it("treats <c:firstSliceAng> 0 and 360 as the same 12-o'clock default", () => {
+    const a = (v: string): number | undefined =>
+      parseFirstSliceAng(el("pieChart", `<c:firstSliceAng val="${v}"/>`))
+    expect(a("90")).toBe(90)
+    expect(a("0")).toBeUndefined()
+    expect(a("360")).toBeUndefined()
+    expect(a("361")).toBeUndefined()
+    expect(a("-1")).toBeUndefined()
+    expect(a("north")).toBeUndefined()
+    expect(parseFirstSliceAng(el("pieChart", "<c:firstSliceAng/>"))).toBeUndefined()
+    expect(parseFirstSliceAng(el("pieChart", ""))).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// axis — scaling, tick marks, skips and number formats
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseAxisTickMark", () => {
+  it("drops the per-element OOXML default so absence and the default match", () => {
+    // CT_CatAx defaults majorTickMark to "out" and minorTickMark to "none".
+    expect(
+      parseAxisTickMark(axis('<c:majorTickMark val="out"/>'), "majorTickMark", "out"),
+    ).toBeUndefined()
+    expect(parseAxisTickMark(axis('<c:majorTickMark val="cross"/>'), "majorTickMark", "out")).toBe(
+      "cross",
+    )
+    expect(
+      parseAxisTickMark(axis('<c:minorTickMark val="none"/>'), "minorTickMark", "none"),
+    ).toBeUndefined()
+    expect(parseAxisTickMark(axis('<c:minorTickMark val=" in "/>'), "minorTickMark", "none")).toBe(
+      "in",
+    )
+  })
+
+  it("drops absence, a missing val, and tokens outside ST_TickMark", () => {
+    expect(parseAxisTickMark(axis(""), "majorTickMark", "out")).toBeUndefined()
+    expect(parseAxisTickMark(axis("<c:majorTickMark/>"), "majorTickMark", "out")).toBeUndefined()
+    expect(
+      parseAxisTickMark(axis('<c:majorTickMark val="both"/>'), "majorTickMark", "out"),
+    ).toBeUndefined()
+  })
+})
+
+describe("parseAxisTickLblPos", () => {
+  it("drops the ST_TickLblPos default `nextTo` and unknown tokens", () => {
+    expect(parseAxisTickLblPos(axis('<c:tickLblPos val="low"/>'))).toBe("low")
+    expect(parseAxisTickLblPos(axis('<c:tickLblPos val="nextTo"/>'))).toBeUndefined()
+    expect(parseAxisTickLblPos(axis('<c:tickLblPos val="outside"/>'))).toBeUndefined()
+    expect(parseAxisTickLblPos(axis("<c:tickLblPos/>"))).toBeUndefined()
+    expect(parseAxisTickLblPos(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisReverse", () => {
+  it("surfaces true only for the ST_Orientation value maxMin", () => {
+    expect(parseAxisReverse(axis('<c:scaling><c:orientation val="maxMin"/></c:scaling>'))).toBe(
+      true,
+    )
+    // `minMax` is the default — collapsing it keeps absence and the
+    // default indistinguishable on re-emit.
+    expect(
+      parseAxisReverse(axis('<c:scaling><c:orientation val="minMax"/></c:scaling>')),
+    ).toBeUndefined()
+    expect(
+      parseAxisReverse(axis('<c:scaling><c:orientation val="upDown"/></c:scaling>')),
+    ).toBeUndefined()
+    expect(parseAxisReverse(axis("<c:scaling><c:orientation/></c:scaling>"))).toBeUndefined()
+    expect(parseAxisReverse(axis("<c:scaling/>"))).toBeUndefined()
+    expect(parseAxisReverse(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisSkip", () => {
+  it("admits only the ST_SkipIntervals band 1..32767, minus the default 1", () => {
+    const s = (v: string): number | undefined =>
+      parseAxisSkip(axis(`<c:tickLblSkip val="${v}"/>`), "tickLblSkip")
+    expect(s("2")).toBe(2)
+    expect(s("32767")).toBe(32767)
+    expect(s("1")).toBeUndefined()
+    expect(s("0")).toBeUndefined()
+    expect(s("32768")).toBeUndefined()
+    expect(s("  ")).toBeUndefined()
+    expect(s("every")).toBeUndefined()
+    expect(parseAxisSkip(axis("<c:tickLblSkip/>"), "tickLblSkip")).toBeUndefined()
+    expect(parseAxisSkip(axis(""), "tickMarkSkip")).toBeUndefined()
+  })
+})
+
+describe("parseAxisLblOffset", () => {
+  it("admits only the ST_LblOffsetPercent band 0..1000, minus the default 100", () => {
+    const o = (v: string): number | undefined =>
+      parseAxisLblOffset(axis(`<c:lblOffset val="${v}"/>`))
+    expect(o("0")).toBe(0)
+    expect(o("1000")).toBe(1000)
+    expect(o("100")).toBeUndefined()
+    expect(o("1001")).toBeUndefined()
+    expect(o("-1")).toBeUndefined()
+    expect(o("   ")).toBeUndefined()
+    expect(o("far")).toBeUndefined()
+    expect(parseAxisLblOffset(axis("<c:lblOffset/>"))).toBeUndefined()
+    expect(parseAxisLblOffset(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisLblAlgn", () => {
+  it("drops the ST_LblAlgn default `ctr` and unknown tokens", () => {
+    expect(parseAxisLblAlgn(axis('<c:lblAlgn val="l"/>'))).toBe("l")
+    expect(parseAxisLblAlgn(axis('<c:lblAlgn val=" r "/>'))).toBe("r")
+    expect(parseAxisLblAlgn(axis('<c:lblAlgn val="ctr"/>'))).toBeUndefined()
+    expect(parseAxisLblAlgn(axis('<c:lblAlgn val="just"/>'))).toBeUndefined()
+    expect(parseAxisLblAlgn(axis("<c:lblAlgn/>"))).toBeUndefined()
+    expect(parseAxisLblAlgn(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisNoMultiLvlLbl / parseAxisAuto / parseAxisHidden", () => {
+  it("each collapses its own OOXML default and surfaces only the opposite state", () => {
+    // `<c:noMultiLvlLbl>` and `<c:delete>` default to false; `<c:auto>`
+    // defaults to true — so `auto` is the one that collapses `true`.
+    expect(parseAxisNoMultiLvlLbl(axis('<c:noMultiLvlLbl val="1"/>'))).toBe(true)
+    expect(parseAxisNoMultiLvlLbl(axis('<c:noMultiLvlLbl val="0"/>'))).toBeUndefined()
+    expect(parseAxisAuto(axis('<c:auto val="0"/>'))).toBe(false)
+    expect(parseAxisAuto(axis('<c:auto val="1"/>'))).toBeUndefined()
+    expect(parseAxisHidden(axis('<c:delete val="true"/>'))).toBe(true)
+    expect(parseAxisHidden(axis('<c:delete val="false"/>'))).toBeUndefined()
+  })
+
+  it("drops absence, a missing val, and unknown tokens on all three", () => {
+    expect(parseAxisNoMultiLvlLbl(axis("<c:noMultiLvlLbl/>"))).toBeUndefined()
+    expect(parseAxisNoMultiLvlLbl(axis('<c:noMultiLvlLbl val="on"/>'))).toBeUndefined()
+    expect(parseAxisNoMultiLvlLbl(axis(""))).toBeUndefined()
+    expect(parseAxisAuto(axis("<c:auto/>"))).toBeUndefined()
+    expect(parseAxisAuto(axis('<c:auto val="on"/>'))).toBeUndefined()
+    expect(parseAxisAuto(axis(""))).toBeUndefined()
+    expect(parseAxisHidden(axis("<c:delete/>"))).toBeUndefined()
+    expect(parseAxisHidden(axis('<c:delete val="on"/>'))).toBeUndefined()
+    expect(parseAxisHidden(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisScale", () => {
+  it("reads min/max/logBase from <c:scaling> but the units from the axis itself", () => {
+    // CT_ValAx places `<c:majorUnit>` / `<c:minorUnit>` as siblings of
+    // `<c:scaling>`, not inside it.
+    const scale = parseAxisScale(
+      axis(
+        '<c:scaling><c:min val="0"/><c:max val="100"/><c:logBase val="10"/></c:scaling>' +
+          '<c:majorUnit val="20"/><c:minorUnit val="5"/>',
+      ),
+    )
+    expect(scale).toEqual({ min: 0, max: 100, logBase: 10, majorUnit: 20, minorUnit: 5 })
+  })
+
+  it("drops non-positive tick units and surfaces nothing for an orientation-only scaling", () => {
+    expect(parseAxisScale(axis('<c:majorUnit val="0"/><c:minorUnit val="-1"/>'))).toBeUndefined()
+    expect(
+      parseAxisScale(axis('<c:scaling><c:orientation val="minMax"/></c:scaling>')),
+    ).toBeUndefined()
+    expect(parseAxisScale(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisNumberFormat", () => {
+  it("requires a non-empty formatCode and reads sourceLinked as xsd:boolean", () => {
+    expect(parseAxisNumberFormat(axis('<c:numFmt formatCode="0.00%" sourceLinked="1"/>'))).toEqual({
+      formatCode: "0.00%",
+      sourceLinked: true,
+    })
+    expect(
+      parseAxisNumberFormat(axis('<c:numFmt formatCode="General" sourceLinked="0"/>')),
+    ).toEqual({ formatCode: "General" })
+    expect(parseAxisNumberFormat(axis('<c:numFmt formatCode=""/>'))).toBeUndefined()
+    expect(parseAxisNumberFormat(axis("<c:numFmt/>"))).toBeUndefined()
+    expect(parseAxisNumberFormat(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisGridlines", () => {
+  it("flips a flag on the mere presence of the element, empty body included", () => {
+    expect(parseAxisGridlines(axis("<c:majorGridlines/>"))).toEqual({ major: true })
+    expect(parseAxisGridlines(axis("<c:minorGridlines><c:spPr/></c:minorGridlines>"))).toEqual({
+      minor: true,
+    })
+    expect(parseAxisGridlines(axis("<c:majorGridlines/><c:minorGridlines/>"))).toEqual({
+      major: true,
+      minor: true,
+    })
+    // Never surface `{ major: false, minor: false }` — it would
+    // round-trip into a redundant write.
+    expect(parseAxisGridlines(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisCrossBetween", () => {
+  it("admits only the two ST_CrossBetween tokens", () => {
+    expect(parseAxisCrossBetween(axis('<c:crossBetween val="midCat"/>'))).toBe("midCat")
+    expect(parseAxisCrossBetween(axis('<c:crossBetween val=" between "/>'))).toBe("between")
+    expect(parseAxisCrossBetween(axis('<c:crossBetween val="onTick"/>'))).toBeUndefined()
+    expect(parseAxisCrossBetween(axis("<c:crossBetween/>"))).toBeUndefined()
+    expect(parseAxisCrossBetween(axis(""))).toBeUndefined()
+  })
+})
+
+describe("parseAxisCrosses", () => {
+  it("prefers an explicit <c:crossesAt> over the <c:crosses> enum", () => {
+    // CT_ValAx puts the two in an `xsd:choice`; a template that pins
+    // both resolves to the literal coordinate.
+    expect(parseAxisCrosses(axis('<c:crossesAt val="-5.5"/><c:crosses val="max"/>'))).toEqual({
+      crossesAt: -5.5,
+    })
+  })
+
+  it("falls back to <c:crosses> when the coordinate is missing or unusable", () => {
+    expect(parseAxisCrosses(axis('<c:crossesAt/><c:crosses val="max"/>'))).toEqual({
+      crosses: "max",
+    })
+    expect(parseAxisCrosses(axis('<c:crossesAt val="  "/><c:crosses val="min"/>'))).toEqual({
+      crosses: "min",
+    })
+    expect(parseAxisCrosses(axis('<c:crossesAt val="edge"/><c:crosses val="min"/>'))).toEqual({
+      crosses: "min",
+    })
+  })
+
+  it("surfaces nothing when neither child is usable", () => {
+    expect(parseAxisCrosses(axis(""))).toEqual({})
+    expect(parseAxisCrosses(axis("<c:crosses/>"))).toEqual({})
+    expect(parseAxisCrosses(axis('<c:crosses val="sideways"/>'))).toEqual({})
+    // `autoZero` is the OOXML default, so it collapses.
+    expect(parseAxisCrosses(axis('<c:crosses val="autoZero"/>'))).toEqual({})
+  })
+})
+
+describe("parseAxisDispUnits", () => {
+  it("prefers <c:custUnit> over <c:builtInUnit> when a template declares both", () => {
+    // The OOXML choice forbids both; a corrupt template that pins both
+    // resolves the same way in the reader and the writer.
+    expect(
+      parseAxisDispUnits(
+        axis('<c:dispUnits><c:custUnit val="500"/><c:builtInUnit val="millions"/></c:dispUnits>'),
+      ),
+    ).toEqual({ custUnit: 500 })
+  })
+
+  it("falls back to <c:builtInUnit> when the custom divisor is unusable", () => {
+    expect(
+      parseAxisDispUnits(
+        axis('<c:dispUnits><c:custUnit val="0"/><c:builtInUnit val="thousands"/></c:dispUnits>'),
+      ),
+    ).toEqual({ unit: "thousands" })
+    expect(
+      parseAxisDispUnits(
+        axis('<c:dispUnits><c:custUnit/><c:builtInUnit val=" billions "/></c:dispUnits>'),
+      ),
+    ).toEqual({ unit: "billions" })
+  })
+
+  it("drops the block when neither child resolves", () => {
+    expect(parseAxisDispUnits(axis("<c:dispUnits/>"))).toBeUndefined()
+    expect(
+      parseAxisDispUnits(axis('<c:dispUnits><c:builtInUnit val="gazillions"/></c:dispUnits>')),
+    ).toBeUndefined()
+    expect(parseAxisDispUnits(axis("<c:dispUnits><c:builtInUnit/></c:dispUnits>"))).toBeUndefined()
+    expect(parseAxisDispUnits(axis(""))).toBeUndefined()
+  })
+
+  it("joins a rich <c:dispUnitsLbl> label across runs and paragraphs", () => {
+    const parsed = parseAxisDispUnits(
+      axis(
+        '<c:dispUnits><c:builtInUnit val="millions"/><c:dispUnitsLbl><c:tx><c:rich>' +
+          "<a:p><a:r><a:t>in </a:t></a:r><a:r><a:t>millions</a:t></a:r></a:p>" +
+          "<a:p><a:r><a:t>(USD)</a:t></a:r></a:p>" +
+          "</c:rich></c:tx></c:dispUnitsLbl></c:dispUnits>",
+      ),
+    )
+    expect(parsed).toEqual({ unit: "millions", showLabel: true, customLabel: "in millions\n(USD)" })
+  })
+
+  it("ignores stray text and non-run children while walking the label body", () => {
+    // A rich body can legitimately carry whitespace text nodes plus
+    // `<a:pPr>` / `<a:rPr>` / `<a:endParaRPr>` siblings; only
+    // `<a:p><a:r><a:t>` contributes to the label text.
+    const parsed = parseAxisDispUnits(
+      axis(
+        '<c:dispUnits><c:builtInUnit val="millions"/><c:dispUnitsLbl><c:tx><c:rich>' +
+          "  <a:bodyPr/>" +
+          "<a:p><a:pPr/>  <a:r><a:rPr/>x<a:t>M</a:t></a:r><a:endParaRPr/></a:p>" +
+          "</c:rich></c:tx></c:dispUnitsLbl></c:dispUnits>",
+      ),
+    )
+    expect(parsed).toEqual({ unit: "millions", showLabel: true, customLabel: "M" })
+  })
+
+  it("ignores element children nested inside an <a:t> run", () => {
+    // `<a:t>` is plain text per CT_TextBody; a stray element child
+    // contributes nothing to the label rather than stringifying.
+    const parsed = parseAxisDispUnits(
+      axis(
+        '<c:dispUnits><c:builtInUnit val="millions"/><c:dispUnitsLbl><c:tx><c:rich>' +
+          "<a:p><a:r><a:t>M<a:br/></a:t></a:r></a:p>" +
+          "</c:rich></c:tx></c:dispUnitsLbl></c:dispUnits>",
+      ),
+    )
+    expect(parsed).toEqual({ unit: "millions", showLabel: true, customLabel: "M" })
+  })
+
+  it("surfaces showLabel with no customLabel for a bare or blank label element", () => {
+    const bare = axis('<c:dispUnits><c:builtInUnit val="millions"/><c:dispUnitsLbl/></c:dispUnits>')
+    expect(parseAxisDispUnits(bare)).toEqual({ unit: "millions", showLabel: true })
+    const blank = axis(
+      '<c:dispUnits><c:builtInUnit val="millions"/><c:dispUnitsLbl><c:tx><c:rich>' +
+        "<a:p><a:r><a:t>   </a:t></a:r></a:p><a:p/></c:rich></c:tx></c:dispUnitsLbl></c:dispUnits>",
+    )
+    expect(parseAxisDispUnits(blank)).toEqual({ unit: "millions", showLabel: true })
+    const noRich = axis(
+      '<c:dispUnits><c:builtInUnit val="millions"/><c:dispUnitsLbl><c:tx/></c:dispUnitsLbl></c:dispUnits>',
+    )
+    expect(parseAxisDispUnits(noRich)).toEqual({ unit: "millions", showLabel: true })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// axis — tick-label typography (<c:txPr>)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("axis tick-label typography readers", () => {
+  const readers: Array<[string, (e: XmlElement) => unknown]> = [
+    ["fontSize", parseAxisLabelFontSize],
+    ["bold", parseAxisLabelBold],
+    ["italic", parseAxisLabelItalic],
+    ["color", parseAxisLabelColor],
+    ["underline", parseAxisLabelUnderline],
+    ["strike", parseAxisLabelStrike],
+    ["fontFamily", parseAxisLabelFontFamily],
+  ]
+
+  it("bails at every broken link of the <c:txPr><a:p><a:pPr><a:defRPr> chain", () => {
+    for (const [name, read] of readers) {
+      for (const depth of [0, 1, 2, 3] as const) {
+        expect(read(axis(txPrChain(depth))), `${name}@${depth}`).toBeUndefined()
+      }
+      expect(read(axis("")), name).toBeUndefined()
+    }
+  })
+
+  it("converts <a:defRPr sz> from OOXML hundredths onto the 0.5pt grid", () => {
+    const size = (sz: string): number | undefined =>
+      parseAxisLabelFontSize(axis(txPrChain(3, ` sz="${sz}"`)))
+    expect(size("900")).toBe(9)
+    expect(size("925")).toBe(9.5)
+    expect(size("100")).toBe(1)
+    expect(size("40000")).toBe(400)
+    expect(size("50")).toBeUndefined()
+    expect(size("40100")).toBeUndefined()
+    expect(size("  ")).toBeUndefined()
+    expect(size("big")).toBeUndefined()
+  })
+
+  it("surfaces bold / italic only on the truthy spelling", () => {
+    expect(parseAxisLabelBold(axis(txPrChain(3, ' b="true"')))).toBe(true)
+    expect(parseAxisLabelBold(axis(txPrChain(3, ' b="0"')))).toBeUndefined()
+    expect(parseAxisLabelItalic(axis(txPrChain(3, ' i="1"')))).toBe(true)
+    expect(parseAxisLabelItalic(axis(txPrChain(3, ' i="false"')))).toBeUndefined()
+  })
+
+  it("surfaces underline / strike only for the single-line UI variants", () => {
+    // The writer emits `u="sng"` / `strike="sngStrike"` only, so
+    // reporting `dbl` / `dblStrike` as true would silently downgrade
+    // the choice to a single line on re-emit.
+    expect(parseAxisLabelUnderline(axis(txPrChain(3, ' u="sng"')))).toBe(true)
+    expect(parseAxisLabelUnderline(axis(txPrChain(3, ' u="dbl"')))).toBeUndefined()
+    expect(parseAxisLabelUnderline(axis(txPrChain(3, ' u="none"')))).toBeUndefined()
+    expect(parseAxisLabelStrike(axis(txPrChain(3, ' strike="sngStrike"')))).toBe(true)
+    expect(parseAxisLabelStrike(axis(txPrChain(3, ' strike="dblStrike"')))).toBeUndefined()
+    expect(parseAxisLabelStrike(axis(txPrChain(3, ' strike="noStrike"')))).toBeUndefined()
+  })
+
+  it("trims the tick-label <a:latin typeface> and drops a blank one", () => {
+    expect(
+      parseAxisLabelFontFamily(axis(txPrChain(3, "", '<a:latin typeface=" Consolas "/>'))),
+    ).toBe("Consolas")
+    expect(
+      parseAxisLabelFontFamily(axis(txPrChain(3, "", '<a:latin typeface="  "/>'))),
+    ).toBeUndefined()
+    expect(parseAxisLabelFontFamily(axis(txPrChain(3, "", "<a:latin/>")))).toBeUndefined()
+    expect(parseAxisLabelFontFamily(axis(txPrChain(3)))).toBeUndefined()
+  })
+
+  it("lifts an <a:schemeClr> tick-label color when no literal sRGB is present", () => {
+    expect(
+      parseAxisLabelColor(
+        axis(txPrChain(3, "", '<a:solidFill><a:schemeClr val="lt2"/></a:solidFill>')),
+      ),
+    ).toEqual({ theme: "lt2" })
+    expect(
+      parseAxisLabelColor(axis(txPrChain(3, "", "<a:solidFill><a:hslClr/></a:solidFill>"))),
+    ).toBeUndefined()
+    expect(parseAxisLabelColor(axis(txPrChain(3, "", "<a:noFill/>")))).toBeUndefined()
+  })
+
+  it("converts <a:bodyPr rot> from 60000ths of a degree and clamps to -90..90", () => {
+    const rot = (r: string): number | undefined =>
+      parseAxisLabelRotation(axis(`<c:txPr><a:bodyPr rot="${r}"/></c:txPr>`))
+    expect(rot("-2700000")).toBe(-45)
+    expect(rot("2700000")).toBe(45)
+    // Beyond the UI band Excel snaps to the endpoint rather than wrap.
+    expect(rot("9000000")).toBe(90)
+    expect(rot("-9000000")).toBe(-90)
+    expect(rot("0")).toBeUndefined()
+    expect(rot("  ")).toBeUndefined()
+    expect(rot("tilted")).toBeUndefined()
+    expect(parseAxisLabelRotation(axis("<c:txPr><a:bodyPr/></c:txPr>"))).toBeUndefined()
+    expect(parseAxisLabelRotation(axis("<c:txPr/>"))).toBeUndefined()
+    expect(parseAxisLabelRotation(axis(""))).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// axis — <c:title> readers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("axis title readers", () => {
+  const readers: Array<[string, (e: XmlElement) => unknown, 3 | 5]> = [
+    ["rotation", parseAxisTitleRotation, 3],
+    ["fontSize", parseAxisTitleFontSize, 5],
+    ["bold", parseAxisTitleBold, 5],
+    ["italic", parseAxisTitleItalic, 5],
+    ["color", parseAxisTitleColor, 5],
+    ["strike", parseAxisTitleStrike, 5],
+    ["underline", parseAxisTitleUnderline, 5],
+    ["fontFamily", parseAxisTitleFontFamily, 5],
+  ]
+
+  it("bails at every broken link of the <c:title><c:tx><c:rich>... chain", () => {
+    for (const [name, read, deepest] of readers) {
+      for (let depth = 0; depth < deepest; depth++) {
+        expect(read(axis(titleChain(depth as 0))), `${name}@${depth}`).toBeUndefined()
+      }
+      expect(read(axis("")), name).toBeUndefined()
+    }
+  })
+
+  it("returns undefined for a <c:strRef> axis title with no <c:rich> body", () => {
+    // A formula-bound axis title has no `<a:p>` slot for typography.
+    const strRef = axis(
+      "<c:title><c:tx><c:strRef><c:f>Sheet1!$A$1</c:f><c:strCache>" +
+        '<c:pt idx="0"><c:v>Quarter</c:v></c:pt></c:strCache></c:strRef></c:tx></c:title>',
+    )
+    expect(parseAxisTitle(strRef)).toBe("Quarter")
+    expect(parseAxisTitleFontSize(strRef)).toBeUndefined()
+    expect(parseAxisTitleBold(strRef)).toBeUndefined()
+  })
+
+  it("reads the title text out of a rich body and out of a string cache", () => {
+    expect(
+      parseAxisTitle(
+        axis(
+          "<c:title><c:tx><c:rich><a:p><a:r><a:t> Revenue </a:t></a:r></a:p></c:rich></c:tx></c:title>",
+        ),
+      ),
+    ).toBe("Revenue")
+    // A blank rich body is indistinguishable from no title at all.
+    expect(
+      parseAxisTitle(
+        axis(
+          "<c:title><c:tx><c:rich><a:p><a:r><a:t>  </a:t></a:r></a:p></c:rich></c:tx></c:title>",
+        ),
+      ),
+    ).toBeUndefined()
+    expect(
+      parseAxisTitle(axis("<c:title><c:tx><c:strRef><c:strCache/></c:strRef></c:tx></c:title>")),
+    ).toBeUndefined()
+    // A cache entry with no `<c:v>` (or a blank one) keeps scanning
+    // rather than reporting the empty string as the title.
+    expect(
+      parseAxisTitle(
+        axis(
+          "<c:title><c:tx><c:strRef><c:strCache>" +
+            '<c:ptCount val="2"/><c:pt idx="0"/><c:pt idx="1"><c:v>  </c:v></c:pt>' +
+            "</c:strCache></c:strRef></c:tx></c:title>",
+        ),
+      ),
+    ).toBeUndefined()
+    expect(parseAxisTitle(axis("<c:title><c:tx/></c:title>"))).toBeUndefined()
+    // A `<c:title>` with no `<c:tx>` at all (Excel writes this when the
+    // title is styled but its text is auto-derived) has nothing to read.
+    expect(parseAxisTitle(axis("<c:title/>"))).toBeUndefined()
+    expect(parseAxisTitle(axis(""))).toBeUndefined()
+  })
+
+  it("clamps the axis-title rotation to the -90..90 band", () => {
+    const rot = (r: string): number | undefined =>
+      parseAxisTitleRotation(
+        axis(`<c:title><c:tx><c:rich><a:bodyPr rot="${r}"/></c:rich></c:tx></c:title>`),
+      )
+    expect(rot("-5400000")).toBe(-90)
+    expect(rot("-16200000")).toBe(-90)
+    expect(rot("16200000")).toBe(90)
+    expect(rot("0")).toBeUndefined()
+    expect(rot("   ")).toBeUndefined()
+    expect(rot("sideways")).toBeUndefined()
+    expect(
+      parseAxisTitleRotation(axis("<c:title><c:tx><c:rich><a:bodyPr/></c:rich></c:tx></c:title>")),
+    ).toBeUndefined()
+  })
+
+  it("surfaces the axis-title underline / strike only for the single-line variants", () => {
+    expect(parseAxisTitleUnderline(axis(titleChain(5, ' u="sng"')))).toBe(true)
+    expect(parseAxisTitleUnderline(axis(titleChain(5, ' u="dbl"')))).toBeUndefined()
+    expect(parseAxisTitleStrike(axis(titleChain(5, ' strike="sngStrike"')))).toBe(true)
+    expect(parseAxisTitleStrike(axis(titleChain(5, ' strike="dblStrike"')))).toBeUndefined()
+  })
+
+  it("lifts an <a:schemeClr> axis-title color when no literal sRGB is present", () => {
+    expect(
+      parseAxisTitleColor(
+        axis(titleChain(5, "", '<a:solidFill><a:schemeClr val="accent5"/></a:solidFill>')),
+      ),
+    ).toEqual({ theme: "accent5" })
+    expect(
+      parseAxisTitleColor(
+        axis(titleChain(5, "", '<a:solidFill><a:srgbClr val="0f0f0f"/></a:solidFill>')),
+      ),
+    ).toBe("0F0F0F")
+    expect(
+      parseAxisTitleColor(axis(titleChain(5, "", "<a:solidFill><a:sysClr/></a:solidFill>"))),
+    ).toBeUndefined()
+    expect(parseAxisTitleColor(axis(titleChain(5)))).toBeUndefined()
+  })
+
+  it("trims the <a:latin typeface> and drops a blank one", () => {
+    expect(
+      parseAxisTitleFontFamily(axis(titleChain(5, "", '<a:latin typeface=" Cambria "/>'))),
+    ).toBe("Cambria")
+    expect(
+      parseAxisTitleFontFamily(axis(titleChain(5, "", '<a:latin typeface="  "/>'))),
+    ).toBeUndefined()
+    expect(parseAxisTitleFontFamily(axis(titleChain(5, "", "<a:latin/>")))).toBeUndefined()
+    expect(parseAxisTitleFontFamily(axis(titleChain(5)))).toBeUndefined()
+  })
+
+  it("reads <c:title><c:overlay> as an xsd:boolean, collapsing the default", () => {
+    const ov = (attr: string): boolean | undefined =>
+      parseAxisTitleOverlay(axis(`<c:title><c:overlay ${attr}/></c:title>`))
+    expect(ov('val="1"')).toBe(true)
+    expect(ov('val="true"')).toBe(true)
+    expect(ov('val="0"')).toBeUndefined()
+    expect(ov('val="false"')).toBeUndefined()
+    expect(ov('val="maybe"')).toBeUndefined()
+    expect(ov("")).toBeUndefined()
+    expect(parseAxisTitleOverlay(axis("<c:title/>"))).toBeUndefined()
+    expect(parseAxisTitleOverlay(axis(""))).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// axis — writer-side normalizers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("normalizeAxisSkip / normalizeAxisNumberFormat", () => {
+  it("rounds a skip then drops it outside 1..32767 and at the default 1", () => {
+    expect(normalizeAxisSkip(2.4)).toBe(2)
+    expect(normalizeAxisSkip(32767)).toBe(32767)
+    expect(normalizeAxisSkip(1)).toBeUndefined()
+    expect(normalizeAxisSkip(0)).toBeUndefined()
+    expect(normalizeAxisSkip(40000)).toBeUndefined()
+    expect(normalizeAxisSkip(Number.NaN)).toBeUndefined()
+    expect(normalizeAxisSkip(undefined)).toBeUndefined()
+  })
+
+  it("collapses a number format whose formatCode is empty or non-string", () => {
+    // Excel rejects `<c:numFmt formatCode=""/>` outright.
+    expect(normalizeAxisNumberFormat({ formatCode: "0.0", sourceLinked: true })).toEqual({
+      formatCode: "0.0",
+      sourceLinked: true,
+    })
+    expect(normalizeAxisNumberFormat({ formatCode: "" })).toBeUndefined()
+    expect(normalizeAxisNumberFormat({ formatCode: 5 as never })).toBeUndefined()
+    expect(normalizeAxisNumberFormat(undefined)).toBeUndefined()
+    expect(normalizeAxisNumberFormat({ formatCode: "0", sourceLinked: false })).toEqual({
+      formatCode: "0",
+    })
+  })
+})
+
+describe("normalizeAxisDispUnits / normalizeDispUnits / buildAxisDispUnits", () => {
+  for (const [label, normalize] of [
+    ["writer", normalizeAxisDispUnits],
+    ["clone", normalizeDispUnits],
+  ] as const) {
+    it(`accepts the bare ST_BuiltInUnit string form (${label})`, () => {
+      expect(normalize("millions")).toEqual({ unit: "millions" })
+      expect(normalize("gazillions" as never)).toBeUndefined()
+    })
+
+    it(`drops a record with no usable child (${label})`, () => {
+      // A bare `<c:dispUnits/>` shell fails Excel's strict validator.
+      expect(normalize({})).toBeUndefined()
+      expect(normalize({ unit: "zillions" as never, custUnit: 0 })).toBeUndefined()
+      expect(normalize({ custUnit: Number.NaN })).toBeUndefined()
+      expect(normalize(undefined)).toBeUndefined()
+      expect(normalize(null as never)).toBeUndefined()
+    })
+
+    it(`keeps both children so a clone can append a custUnit override (${label})`, () => {
+      expect(
+        normalize({ unit: "thousands", custUnit: 250, showLabel: true, customLabel: "  k  " }),
+      ).toEqual({ unit: "thousands", custUnit: 250, showLabel: true, customLabel: "k" })
+      expect(normalize({ unit: "thousands", customLabel: "   " })).toEqual({ unit: "thousands" })
+    })
+  }
+
+  it("emits <c:custUnit> in preference to <c:builtInUnit> when both survive", () => {
+    const xml = buildAxisDispUnits({ unit: "millions", custUnit: 500 })
+    expect(xml).toEqual(['<c:dispUnits><c:custUnit val="500"/></c:dispUnits>'])
+    expect(buildAxisDispUnits({ unit: "millions" })).toEqual([
+      '<c:dispUnits><c:builtInUnit val="millions"/></c:dispUnits>',
+    ])
+  })
+
+  it("refuses to ship a bare <c:dispUnits> shell", () => {
+    expect(buildAxisDispUnits(undefined)).toEqual([])
+    expect(buildAxisDispUnits({} as ChartAxisDispUnits)).toEqual([])
+  })
+
+  it("emits a rich <c:dispUnitsLbl> only when a custom label survives trimming", () => {
+    const rich = buildAxisDispUnits({ unit: "millions", customLabel: "R&D <m>" })
+    expect(rich.join("")).toContain("<a:t>R&amp;D &lt;m&gt;</a:t>")
+    // showLabel alone gets Excel's automatic annotation, no rich body.
+    expect(buildAxisDispUnits({ unit: "millions", showLabel: true }).join("")).toContain(
+      "<c:dispUnitsLbl/>",
+    )
+    expect(
+      buildAxisDispUnits({ unit: "millions", showLabel: true, customLabel: "  " }).join(""),
+    ).toContain("<c:dispUnitsLbl/>")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// axis — clone-side apply*Override resolvers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("axis clone overrides", () => {
+  it("applySkipOverride validates both the inherited and the replacing value", () => {
+    expect(applySkipOverride(3, undefined)).toBe(3)
+    expect(applySkipOverride(2.6, undefined)).toBe(3)
+    expect(applySkipOverride(1, undefined)).toBeUndefined()
+    expect(applySkipOverride(99999, undefined)).toBeUndefined()
+    expect(applySkipOverride(Number.NaN, undefined)).toBeUndefined()
+    expect(applySkipOverride(3, null)).toBeUndefined()
+    expect(applySkipOverride(3, 5)).toBe(5)
+    expect(applySkipOverride(3, 1)).toBeUndefined()
+    expect(applySkipOverride(3, "5" as never)).toBeUndefined()
+  })
+
+  it("applyLblOffsetOverride collapses the OOXML default 100 on both sides", () => {
+    expect(applyLblOffsetOverride(250, undefined)).toBe(250)
+    expect(applyLblOffsetOverride(100, undefined)).toBeUndefined()
+    expect(applyLblOffsetOverride(2000, undefined)).toBeUndefined()
+    expect(applyLblOffsetOverride(Number.NaN, undefined)).toBeUndefined()
+    expect(applyLblOffsetOverride(250, null)).toBeUndefined()
+    expect(applyLblOffsetOverride(250, 100)).toBeUndefined()
+    expect(applyLblOffsetOverride(250, -5)).toBeUndefined()
+    expect(applyLblOffsetOverride(250, 0)).toBe(0)
+    expect(applyLblOffsetOverride(250, "0" as never)).toBeUndefined()
+  })
+
+  it("applyLblAlgnOverride collapses the OOXML default `ctr` on both sides", () => {
+    expect(applyLblAlgnOverride("l", undefined)).toBe("l")
+    expect(applyLblAlgnOverride("ctr", undefined)).toBeUndefined()
+    expect(applyLblAlgnOverride("just" as never, undefined)).toBeUndefined()
+    expect(applyLblAlgnOverride("l", null)).toBeUndefined()
+    expect(applyLblAlgnOverride("l", "r")).toBe("r")
+    expect(applyLblAlgnOverride("l", "ctr")).toBeUndefined()
+    expect(applyLblAlgnOverride("l", "just" as never)).toBeUndefined()
+  })
+
+  it("applyNoMultiLvlLbl / applyAuto / applyHidden each keep only their non-default state", () => {
+    expect(applyNoMultiLvlLblOverride(true, undefined)).toBe(true)
+    expect(applyNoMultiLvlLblOverride(false, undefined)).toBeUndefined()
+    expect(applyNoMultiLvlLblOverride(true, null)).toBeUndefined()
+    expect(applyNoMultiLvlLblOverride(false, true)).toBe(true)
+    expect(applyNoMultiLvlLblOverride(true, false)).toBeUndefined()
+    // `<c:auto>` defaults to true, so it is the inverse of the other two.
+    expect(applyAutoOverride(false, undefined)).toBe(false)
+    expect(applyAutoOverride(true, undefined)).toBeUndefined()
+    expect(applyAutoOverride(false, null)).toBeUndefined()
+    expect(applyAutoOverride(true, false)).toBe(false)
+    expect(applyAutoOverride(false, true)).toBeUndefined()
+    expect(applyHiddenOverride(true, undefined)).toBe(true)
+    expect(applyHiddenOverride(false, undefined)).toBeUndefined()
+    expect(applyHiddenOverride(true, null)).toBeUndefined()
+    expect(applyHiddenOverride(false, true)).toBe(true)
+    expect(applyHiddenOverride(true, false)).toBeUndefined()
+  })
+
+  it("applyGridlinesOverride drops an all-false record on both sides", () => {
+    const both: ChartAxisGridlines = { major: true, minor: true }
+    expect(applyGridlinesOverride(both, undefined)).toEqual(both)
+    expect(applyGridlinesOverride({ major: false, minor: false }, undefined)).toBeUndefined()
+    expect(applyGridlinesOverride(undefined, undefined)).toBeUndefined()
+    expect(applyGridlinesOverride(both, null)).toBeUndefined()
+    expect(applyGridlinesOverride(both, { minor: true })).toEqual({ minor: true })
+    expect(applyGridlinesOverride(both, {})).toBeUndefined()
+  })
+
+  it("applyScaleOverride replaces wholesale rather than merging field by field", () => {
+    const source: ChartAxisScale = { min: 0, majorUnit: 20 }
+    expect(applyScaleOverride(source, undefined)).toEqual(source)
+    expect(applyScaleOverride(undefined, undefined)).toBeUndefined()
+    expect(applyScaleOverride(source, null)).toBeUndefined()
+    // `{ min: 0 }` + `{ max: 100 }` is `{ max: 100 }`, not the union.
+    expect(applyScaleOverride(source, { max: 100 })).toEqual({ max: 100 })
+  })
+
+  it("cloneScale keeps only finite bounds and positive tick units", () => {
+    expect(
+      cloneScale({
+        min: Number.NaN,
+        max: Number.POSITIVE_INFINITY,
+        majorUnit: 0,
+        minorUnit: -1,
+        logBase: Number.NaN,
+      }),
+    ).toBeUndefined()
+    expect(cloneScale({ min: -5, max: 5, majorUnit: 1, minorUnit: 0.5, logBase: 2 })).toEqual({
+      min: -5,
+      max: 5,
+      majorUnit: 1,
+      minorUnit: 0.5,
+      logBase: 2,
+    })
+  })
+
+  it("applyNumberFormatOverride requires a usable formatCode on both sides", () => {
+    const fmt: ChartAxisNumberFormat = { formatCode: "0.0%", sourceLinked: true }
+    expect(applyNumberFormatOverride(fmt, undefined)).toEqual(fmt)
+    expect(applyNumberFormatOverride({ formatCode: "" }, undefined)).toBeUndefined()
+    expect(applyNumberFormatOverride(undefined, undefined)).toBeUndefined()
+    expect(applyNumberFormatOverride(fmt, null)).toBeUndefined()
+    expect(applyNumberFormatOverride(fmt, { formatCode: "" })).toBeUndefined()
+    expect(applyNumberFormatOverride(fmt, { formatCode: "General" })).toEqual({
+      formatCode: "General",
+    })
+    expect(applyNumberFormatOverride(fmt, { formatCode: "0", sourceLinked: true })).toEqual({
+      formatCode: "0",
+      sourceLinked: true,
+    })
+  })
+
+  it("applyTickMark / applyTickLblPos reject tokens outside their enums", () => {
+    expect(applyTickMarkOverride("cross", undefined)).toBe("cross")
+    expect(applyTickMarkOverride("both" as never, undefined)).toBeUndefined()
+    expect(applyTickMarkOverride(undefined, undefined)).toBeUndefined()
+    expect(applyTickMarkOverride("cross", null)).toBeUndefined()
+    expect(applyTickMarkOverride("cross", "in")).toBe("in")
+    expect(applyTickMarkOverride("cross", "both" as never)).toBeUndefined()
+    expect(applyTickLblPosOverride("high", undefined)).toBe("high")
+    expect(applyTickLblPosOverride("outside" as never, undefined)).toBeUndefined()
+    expect(applyTickLblPosOverride(undefined, undefined)).toBeUndefined()
+    expect(applyTickLblPosOverride("high", null)).toBeUndefined()
+    expect(applyTickLblPosOverride("high", "low")).toBe("low")
+    expect(applyTickLblPosOverride("high", "outside" as never)).toBeUndefined()
+  })
+
+  it("the tick-label typography overrides share one inherit / drop / replace grammar", () => {
+    const flags = [
+      applyLabelBoldOverride,
+      applyLabelItalicOverride,
+      applyLabelUnderlineOverride,
+      applyLabelStrikeOverride,
+    ]
+    for (const apply of flags) {
+      expect(apply(true, undefined)).toBe(true)
+      expect(apply(false, undefined)).toBe(false)
+      expect(apply(undefined, undefined)).toBeUndefined()
+      expect(apply(true, null)).toBeUndefined()
+      expect(apply(true, false)).toBe(false)
+      // A typed escape from an untyped caller must not reach the writer.
+      expect(apply(true, 1 as never)).toBeUndefined()
+      expect(apply("yes" as never, undefined)).toBeUndefined()
+    }
+  })
+
+  it("the axis-title flag overrides share the same grammar as the tick-label ones", () => {
+    const flags = [
+      applyAxisTitleBoldOverride,
+      applyAxisTitleItalicOverride,
+      applyAxisTitleStrikeOverride,
+      applyAxisTitleUnderlineOverride,
+      applyAxisTitleOverlayOverride,
+    ]
+    for (const apply of flags) {
+      expect(apply(true, undefined)).toBe(true)
+      expect(apply(false, undefined)).toBe(false)
+      expect(apply(undefined, undefined)).toBeUndefined()
+      expect(apply(true, null)).toBeUndefined()
+      expect(apply(true, false)).toBe(false)
+      expect(apply(false, true)).toBe(true)
+      expect(apply(true, 1 as never)).toBeUndefined()
+      expect(apply("yes" as never, undefined)).toBeUndefined()
+    }
+  })
+
+  it("applyLabelFontSize / Color / FontFamily normalize both sides", () => {
+    expect(applyLabelFontSizeOverride(12.25, undefined)).toBe(12.5)
+    expect(applyLabelFontSizeOverride(12, null)).toBeUndefined()
+    // Out-of-band sizes drop rather than clamp: the writer would emit a
+    // token Excel rejects, and a silent clamp would mask the mistake.
+    expect(applyLabelFontSizeOverride(12, 9999)).toBeUndefined()
+    expect(applyLabelFontSizeOverride(12, 400)).toBe(400)
+    expect(applyLabelColorOverride("#abcdef", undefined)).toBe("ABCDEF")
+    expect(applyLabelColorOverride("ABCDEF", null)).toBeUndefined()
+    expect(applyLabelColorOverride("ABCDEF", "nothex")).toBeUndefined()
+    expect(applyLabelFontFamilyOverride("  Arial  ", undefined)).toBe("Arial")
+    expect(applyLabelFontFamilyOverride("Arial", null)).toBeUndefined()
+    expect(applyLabelFontFamilyOverride("Arial", "   ")).toBeUndefined()
+    expect(applyLabelFontFamilyOverride("Arial", "Verdana")).toBe("Verdana")
+  })
+
+  it("applyCrossesOverride keeps the two crossing knobs independent", () => {
+    // `<c:crosses>` and `<c:crossesAt>` are separate CT_ValAx children,
+    // so an override may replace one and inherit the other.
+    expect(applyCrossesOverride({ crosses: "max" }, {})).toEqual({ crosses: "max" })
+    expect(applyCrossesOverride({ crosses: "autoZero" }, {})).toEqual({})
+    expect(applyCrossesOverride({ crosses: "sideways" as never }, {})).toEqual({})
+    expect(applyCrossesOverride({ crosses: "max" }, { crosses: null })).toEqual({})
+    expect(applyCrossesOverride({ crosses: "max" }, { crosses: "min" })).toEqual({
+      crosses: "min",
+    })
+    expect(applyCrossesOverride({ crosses: "max" }, { crosses: "autoZero" })).toEqual({})
+    expect(applyCrossesOverride({ crossesAt: 5 }, {})).toEqual({ crossesAt: 5 })
+    expect(applyCrossesOverride({ crossesAt: Number.NaN }, {})).toEqual({})
+    expect(applyCrossesOverride({ crossesAt: 5 }, { crossesAt: null })).toEqual({})
+    expect(applyCrossesOverride({ crossesAt: 5 }, { crossesAt: 0 })).toEqual({ crossesAt: 0 })
+    expect(applyCrossesOverride({ crossesAt: 5 }, { crossesAt: Number.NaN })).toEqual({})
+  })
+
+  it("applyDispUnits / applyCrossBetween normalize both sides", () => {
+    expect(applyDispUnitsOverride({ unit: "millions" }, undefined)).toEqual({ unit: "millions" })
+    expect(applyDispUnitsOverride({ unit: "millions" }, null)).toBeUndefined()
+    expect(applyDispUnitsOverride({ unit: "millions" }, "thousands")).toEqual({ unit: "thousands" })
+    expect(applyDispUnitsOverride({ unit: "millions" }, {})).toBeUndefined()
+    expect(applyCrossBetweenOverride("midCat", undefined)).toBe("midCat")
+    expect(applyCrossBetweenOverride("onTick" as never, undefined)).toBeUndefined()
+    expect(applyCrossBetweenOverride(undefined, undefined)).toBeUndefined()
+    expect(applyCrossBetweenOverride("midCat", null)).toBeUndefined()
+    expect(applyCrossBetweenOverride("midCat", "between")).toBe("between")
+    expect(applyCrossBetweenOverride("midCat", "onTick" as never)).toBeUndefined()
+  })
+})
+
+describe("resolveAxes", () => {
+  it("carries every parsed X-axis knob through an override-free clone", () => {
+    // `cloneChart` with no `axes` override must reproduce the source
+    // axis verbatim — this is the path that silently drops a field
+    // when a new knob is added to the reader but not to the resolver.
+    const resolved = resolveAxes(
+      {
+        x: {
+          scale: { min: 0, max: 100, majorUnit: 25 },
+          numberFormat: { formatCode: "0.0", sourceLinked: true },
+          majorTickMark: "cross",
+          minorTickMark: "in",
+          crosses: "max",
+        },
+      },
+      undefined,
+      "bar",
+    )
+    expect(resolved?.x).toMatchObject({
+      scale: { min: 0, max: 100, majorUnit: 25 },
+      numberFormat: { formatCode: "0.0", sourceLinked: true },
+      majorTickMark: "cross",
+      minorTickMark: "in",
+      crosses: "max",
+    })
+  })
+
+  it("returns undefined when neither axis carries anything to emit", () => {
+    expect(resolveAxes(undefined, undefined, "bar")).toBeUndefined()
+  })
+})
+
+describe("parseAxisInfo", () => {
+  it("threads the axis-title border cap and compound onto the parsed record", () => {
+    // `<c:catAx><c:title><c:spPr><a:ln cap=".." cmpd=".."/>` is the only
+    // route these two knobs reach `ChartAxisInfo`.
+    const info = parseAxisInfo(
+      el(
+        "catAx",
+        '<c:title><c:spPr><a:ln cap="rnd" cmpd="thickThin"/></c:spPr>' +
+          "<c:tx><c:rich><a:p><a:r><a:t>Quarter</a:t></a:r></a:p></c:rich></c:tx></c:title>",
+      ),
+      "between",
+    )
+    expect(info).toMatchObject({
+      title: "Quarter",
+      axisTitleBorderCap: "rnd",
+      axisTitleBorderCompound: "thickThin",
+    })
+  })
+
+  it("returns undefined for an axis that pins nothing the writer models", () => {
+    expect(parseAxisInfo(el("catAx", ""), "between")).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// legend — <c:legend> (CT_Legend, §21.2.2.114)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("legend readers on a chart with no <c:legend>", () => {
+  // Every legend reader is called unconditionally by `parseChart`, so
+  // each one has to survive a chart that never declared a legend.
+  const readers: Array<[string, (e: XmlElement) => unknown]> = [
+    ["position", parseLegend],
+    ["overlay", parseLegendOverlay],
+    ["entries", parseLegendEntries],
+    ["fontSize", parseLegendFontSize],
+    ["bold", parseLegendBold],
+    ["italic", parseLegendItalic],
+    ["underline", parseLegendUnderline],
+    ["strikethrough", parseLegendStrikethrough],
+    ["fontColor", parseLegendFontColor],
+    ["fontFamily", parseLegendFontFamily],
+    ["layout", parseLegendLayout],
+    ["fillColor", parseLegendFillColor],
+    ["borderColor", parseLegendBorderColor],
+    ["borderWidth", parseLegendBorderWidth],
+    ["borderDash", parseLegendBorderDash],
+    ["borderCap", parseLegendBorderCap],
+    ["borderCompound", parseLegendBorderCompound],
+  ]
+
+  it("returns undefined from every reader", () => {
+    const bare = chartEl("<c:plotArea/>")
+    for (const [name, read] of readers) {
+      expect(read(bare), name).toBeUndefined()
+    }
+  })
+})
+
+describe("parseLegend", () => {
+  it("maps every ST_LegendPos token onto the writer-side vocabulary", () => {
+    const pos = (v: string): unknown =>
+      parseLegend(chartEl(`<c:legend><c:legendPos val="${v}"/></c:legend>`))
+    expect(pos("t")).toBe("top")
+    expect(pos("b")).toBe("bottom")
+    expect(pos("l")).toBe("left")
+    expect(pos("r")).toBe("right")
+    expect(pos("tr")).toBe("topRight")
+    expect(pos("middle")).toBeUndefined()
+  })
+
+  it("falls back to Excel's default `right` when <c:legendPos> is absent or bare", () => {
+    expect(parseLegend(chartEl("<c:legend/>"))).toBe("right")
+    expect(parseLegend(chartEl("<c:legend><c:legendPos/></c:legend>"))).toBe("right")
+  })
+
+  it('reports false for the canonical <c:delete val="1"/> hidden marker', () => {
+    expect(parseLegend(chartEl('<c:legend><c:delete val="1"/></c:legend>'))).toBe(false)
+    expect(parseLegend(chartEl('<c:legend><c:delete val="true"/></c:legend>'))).toBe(false)
+    // `<c:delete val="0"/>` means the legend renders — fall through.
+    expect(
+      parseLegend(chartEl('<c:legend><c:delete val="0"/><c:legendPos val="b"/></c:legend>')),
+    ).toBe("bottom")
+  })
+})
+
+describe("parseLegendOverlay", () => {
+  it("surfaces only the explicit truthy spelling", () => {
+    const ov = (attr: string): boolean | undefined =>
+      parseLegendOverlay(chartEl(`<c:legend><c:overlay ${attr}/></c:legend>`))
+    expect(ov('val="1"')).toBe(true)
+    expect(ov('val="true"')).toBe(true)
+    // The OOXML default collapses so absence and `val="0"` round-trip
+    // identically through cloneChart.
+    expect(ov('val="0"')).toBeUndefined()
+    expect(ov('val="false"')).toBeUndefined()
+    expect(ov('val="on"')).toBeUndefined()
+    expect(ov("")).toBeUndefined()
+    expect(parseLegendOverlay(chartEl("<c:legend/>"))).toBeUndefined()
+  })
+})
+
+describe("parseLegendEntries", () => {
+  const legend = (inner: string): XmlElement => chartEl(`<c:legend>${inner}</c:legend>`)
+
+  it("requires a non-negative <c:idx> selector on every entry", () => {
+    expect(parseLegendEntries(legend("<c:legendEntry/>"))).toBeUndefined()
+    expect(parseLegendEntries(legend("<c:legendEntry><c:idx/></c:legendEntry>"))).toBeUndefined()
+    expect(
+      parseLegendEntries(legend('<c:legendEntry><c:idx val="-1"/></c:legendEntry>')),
+    ).toBeUndefined()
+    expect(
+      parseLegendEntries(legend('<c:legendEntry><c:idx val="x"/></c:legendEntry>')),
+    ).toBeUndefined()
+    expect(parseLegendEntries(legend(""))).toBeUndefined()
+  })
+
+  it("keeps the first of duplicate idx values", () => {
+    // Reading first-wins pairs with the writer's last-wins dedupe so a
+    // clone override that appends an entry still beats the parsed one.
+    const entries = parseLegendEntries(
+      legend(
+        '<c:legendEntry><c:idx val="0"/><c:delete val="1"/></c:legendEntry>' +
+          '<c:legendEntry><c:idx val="0"/><c:delete val="0"/></c:legendEntry>',
+      ),
+    )
+    expect(entries).toEqual([{ idx: 0, delete: true }])
+  })
+
+  it("defaults <c:delete> to false when absent or malformed", () => {
+    expect(
+      parseLegendEntries(
+        legend(
+          '<c:legendEntry><c:idx val="1"/></c:legendEntry>' +
+            '<c:legendEntry><c:idx val="2"/><c:delete val="junk"/></c:legendEntry>',
+        ),
+      ),
+    ).toEqual([
+      { idx: 1, delete: false },
+      { idx: 2, delete: false },
+    ])
+  })
+
+  it("bails at every broken link of the per-entry <c:txPr> chain", () => {
+    for (const chain of [
+      "",
+      "<c:txPr/>",
+      "<c:txPr><a:p/></c:txPr>",
+      "<c:txPr><a:p><a:pPr/></a:p></c:txPr>",
+    ]) {
+      const entries = parseLegendEntries(
+        legend(`<c:legendEntry><c:idx val="0"/>${chain}</c:legendEntry>`),
+      )
+      expect(entries, chain).toEqual([{ idx: 0, delete: false }])
+    }
+  })
+
+  it("reads the per-entry typography off <a:defRPr>", () => {
+    const entries = parseLegendEntries(
+      legend(
+        '<c:legendEntry><c:idx val="3"/><c:txPr><a:p><a:pPr>' +
+          '<a:defRPr sz="1100" b="1" i="true" u="sng" strike="sngStrike">' +
+          '<a:solidFill><a:srgbClr val="#aabbcc"/></a:solidFill>' +
+          '<a:latin typeface="  Georgia  "/></a:defRPr>' +
+          "</a:pPr></a:p></c:txPr></c:legendEntry>",
+      ),
+    )
+    expect(entries).toEqual([
+      {
+        idx: 3,
+        delete: false,
+        fontSize: 11,
+        bold: true,
+        italic: true,
+        underline: true,
+        strikethrough: true,
+        color: "AABBCC",
+        fontFamily: "Georgia",
+      },
+    ])
+  })
+
+  it("drops per-entry typography the writer cannot re-emit", () => {
+    const entries = parseLegendEntries(
+      legend(
+        '<c:legendEntry><c:idx val="0"/><c:txPr><a:p><a:pPr>' +
+          '<a:defRPr sz="50" b="0" i="0" u="dbl" strike="dblStrike">' +
+          '<a:solidFill><a:srgbClr val="nothex"/></a:solidFill>' +
+          '<a:latin typeface="   "/></a:defRPr>' +
+          "</a:pPr></a:p></c:txPr></c:legendEntry>",
+      ),
+    )
+    expect(entries).toEqual([{ idx: 0, delete: false }])
+  })
+
+  it("drops a per-entry <a:srgbClr> with no val and an <a:latin> with no typeface", () => {
+    const entries = parseLegendEntries(
+      legend(
+        '<c:legendEntry><c:idx val="0"/><c:txPr><a:p><a:pPr><a:defRPr>' +
+          "<a:solidFill><a:srgbClr/></a:solidFill><a:latin/></a:defRPr>" +
+          "</a:pPr></a:p></c:txPr></c:legendEntry>",
+      ),
+    )
+    expect(entries).toEqual([{ idx: 0, delete: false }])
+  })
+
+  it("drops a per-entry size that is blank or non-numeric", () => {
+    for (const sz of ["", "   ", "abc"]) {
+      const entries = parseLegendEntries(
+        legend(
+          `<c:legendEntry><c:idx val="0"/><c:txPr><a:p><a:pPr><a:defRPr sz="${sz}"/>` +
+            "</a:pPr></a:p></c:txPr></c:legendEntry>",
+        ),
+      )
+      expect(entries?.[0].fontSize, sz).toBeUndefined()
+    }
+  })
+
+  it("skips an <a:solidFill> that carries no <a:srgbClr>", () => {
+    const entries = parseLegendEntries(
+      legend(
+        '<c:legendEntry><c:idx val="0"/><c:txPr><a:p><a:pPr><a:defRPr>' +
+          '<a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:defRPr>' +
+          "</a:pPr></a:p></c:txPr></c:legendEntry>",
+      ),
+    )
+    expect(entries?.[0].color).toBeUndefined()
+  })
+})
+
+describe("legend typography readers", () => {
+  const legendWith = (inner: string): XmlElement => chartEl(`<c:legend>${inner}</c:legend>`)
+  const readers: Array<[string, (e: XmlElement) => unknown]> = [
+    ["fontSize", parseLegendFontSize],
+    ["bold", parseLegendBold],
+    ["italic", parseLegendItalic],
+    ["underline", parseLegendUnderline],
+    ["strikethrough", parseLegendStrikethrough],
+    ["fontColor", parseLegendFontColor],
+    ["fontFamily", parseLegendFontFamily],
+  ]
+
+  it("bails at every broken link of the <c:txPr><a:p><a:pPr><a:defRPr> chain", () => {
+    for (const [name, read] of readers) {
+      for (const depth of [0, 1, 2, 3] as const) {
+        expect(read(legendWith(txPrChain(depth))), `${name}@${depth}`).toBeUndefined()
+      }
+      expect(read(legendWith("")), name).toBeUndefined()
+    }
+  })
+
+  it("reads the whole typography block off a single <a:defRPr>", () => {
+    const legend = legendWith(
+      txPrChain(
+        3,
+        ' sz="900" b="1" i="true" u="sng" strike="sngStrike"',
+        '<a:solidFill><a:srgbClr val="112233"/></a:solidFill><a:latin typeface=" Calibri "/>',
+      ),
+    )
+    expect(parseLegendFontSize(legend)).toBe(9)
+    expect(parseLegendBold(legend)).toBe(true)
+    expect(parseLegendItalic(legend)).toBe(true)
+    expect(parseLegendUnderline(legend)).toBe(true)
+    expect(parseLegendStrikethrough(legend)).toBe(true)
+    expect(parseLegendFontColor(legend)).toBe("112233")
+    expect(parseLegendFontFamily(legend)).toBe("Calibri")
+  })
+
+  it("collapses the OOXML defaults and the non-UI variants", () => {
+    const legend = legendWith(
+      txPrChain(3, ' sz="40100" b="0" i="false" u="dbl" strike="dblStrike"'),
+    )
+    expect(parseLegendFontSize(legend)).toBeUndefined()
+    expect(parseLegendBold(legend)).toBeUndefined()
+    expect(parseLegendItalic(legend)).toBeUndefined()
+    // Reporting `dbl` as `true` would silently downgrade to a single
+    // line on re-emit, since the writer only ever emits `sng`.
+    expect(parseLegendUnderline(legend)).toBeUndefined()
+    expect(parseLegendStrikethrough(legend)).toBeUndefined()
+  })
+
+  it("lifts an <a:schemeClr> legend font color when no literal sRGB is present", () => {
+    expect(
+      parseLegendFontColor(
+        legendWith(txPrChain(3, "", '<a:solidFill><a:schemeClr val="accent4"/></a:solidFill>')),
+      ),
+    ).toEqual({ theme: "accent4" })
+    expect(
+      parseLegendFontColor(legendWith(txPrChain(3, "", "<a:solidFill><a:sysClr/></a:solidFill>"))),
+    ).toBeUndefined()
+    expect(parseLegendFontColor(legendWith(txPrChain(3)))).toBeUndefined()
+  })
+
+  it("drops a blank <a:latin typeface>", () => {
+    expect(
+      parseLegendFontFamily(legendWith(txPrChain(3, "", '<a:latin typeface="  "/>'))),
+    ).toBeUndefined()
+    expect(parseLegendFontFamily(legendWith(txPrChain(3, "", "<a:latin/>")))).toBeUndefined()
+  })
+})
+
+describe("legend <c:spPr> readers", () => {
+  const legendWith = (inner: string): XmlElement => chartEl(`<c:legend>${inner}</c:legend>`)
+
+  it("reads the fill, stroke, width, dash, cap and compound off one <c:spPr>", () => {
+    const legend = legendWith(
+      '<c:spPr><a:solidFill><a:srgbClr val="ffffff"/></a:solidFill>' +
+        '<a:ln w="19050" cap="rnd" cmpd="dbl"><a:solidFill><a:srgbClr val="333333"/></a:solidFill>' +
+        '<a:prstDash val="sysDash"/></a:ln></c:spPr>',
+    )
+    expect(parseLegendFillColor(legend)).toBe("FFFFFF")
+    expect(parseLegendBorderColor(legend)).toBe("333333")
+    // 19050 EMU = 1.5 pt at 12 700 EMU per point.
+    expect(parseLegendBorderWidth(legend)).toBe(1.5)
+    expect(parseLegendBorderDash(legend)).toBe("sysDash")
+    expect(parseLegendBorderCap(legend)).toBe("rnd")
+    expect(parseLegendBorderCompound(legend)).toBe("dbl")
+  })
+
+  it("lifts an <a:schemeClr> legend fill and stroke", () => {
+    const legend = legendWith(
+      '<c:spPr><a:solidFill><a:schemeClr val="bg2"/></a:solidFill>' +
+        '<a:ln><a:solidFill><a:schemeClr val="accent6"><a:shade val="50000"/>' +
+        "</a:schemeClr></a:solidFill></a:ln></c:spPr>",
+    )
+    expect(parseLegendFillColor(legend)).toEqual({ theme: "bg2" })
+    expect(parseLegendBorderColor(legend)).toEqual({ theme: "accent6", shade: 50000 })
+    // A fill the writer cannot reproduce drops rather than approximate.
+    expect(
+      parseLegendFillColor(legendWith("<c:spPr><a:solidFill><a:hslClr/></a:solidFill></c:spPr>")),
+    ).toBeUndefined()
+    expect(
+      parseLegendBorderColor(
+        legendWith("<c:spPr><a:ln><a:solidFill><a:sysClr/></a:solidFill></a:ln></c:spPr>"),
+      ),
+    ).toBeUndefined()
+  })
+
+  it("drops the OOXML defaults cap=flat, cmpd=sng and dash=solid", () => {
+    const legend = legendWith(
+      '<c:spPr><a:ln cap="flat" cmpd="sng"><a:prstDash val="solid"/></a:ln></c:spPr>',
+    )
+    expect(parseLegendBorderCap(legend)).toBeUndefined()
+    expect(parseLegendBorderCompound(legend)).toBeUndefined()
+    expect(parseLegendBorderDash(legend)).toBeUndefined()
+  })
+
+  it("reads <c:legend><c:layout><c:manualLayout> as a 0..1 fraction set", () => {
+    expect(
+      parseLegendLayout(
+        legendWith(
+          '<c:layout><c:manualLayout><c:xMode val="edge"/><c:x val="0.7"/>' +
+            '<c:y val="0.1"/></c:manualLayout></c:layout>',
+        ),
+      ),
+    ).toEqual({ x: 0.7, y: 0.1 })
+    expect(parseLegendLayout(legendWith("<c:layout/>"))).toBeUndefined()
+  })
+})
+
+describe("resolveLegendPosition", () => {
+  it("maps every writer-side position onto its ST_LegendPos token", () => {
+    const pos = (legend: SheetChart["legend"]): unknown =>
+      resolveLegendPosition({ legend } as SheetChart)
+    expect(pos("top")).toBe("t")
+    expect(pos("bottom")).toBe("b")
+    expect(pos("left")).toBe("l")
+    expect(pos("right")).toBe("r")
+    expect(pos("topRight")).toBe("tr")
+    expect(pos(false)).toBeNull()
+  })
+
+  it("defaults scatter to the bottom and every other family to the right", () => {
+    // Excel's own new-chart defaults — a scatter legend sits below the
+    // plot so the square plot area keeps its aspect ratio.
+    expect(resolveLegendPosition({ type: "scatter" } as SheetChart)).toBe("b")
+    expect(resolveLegendPosition({ type: "bar" } as SheetChart)).toBe("r")
+  })
+})
+
+describe("resolveLegendEntries", () => {
+  it("dedupes on idx with last-wins and emits in ascending order", () => {
+    const entries = resolveLegendEntries({
+      legendEntries: [
+        { idx: 2, delete: true },
+        { idx: 0, delete: false },
+        { idx: 2, delete: false },
+      ],
+    } as SheetChart)
+    expect(entries).toEqual([
+      { idx: 0, delete: false },
+      { idx: 2, delete: false },
+    ])
+  })
+
+  it("drops entries whose idx cannot land on a real series", () => {
+    expect(
+      resolveLegendEntries({
+        legendEntries: [
+          { idx: -1 },
+          { idx: 1.5 },
+          { idx: Number.NaN },
+          { idx: "0" as never },
+          null as never,
+        ] as ChartLegendEntry[],
+      } as SheetChart),
+    ).toEqual([])
+    expect(resolveLegendEntries({} as SheetChart)).toEqual([])
+    expect(resolveLegendEntries({ legendEntries: [] } as unknown as SheetChart)).toEqual([])
+  })
+
+  it("keeps a literal false on each per-entry flag so a clone can turn one off", () => {
+    expect(
+      resolveLegendEntries({
+        legendEntries: [
+          {
+            idx: 0,
+            bold: false,
+            italic: false,
+            underline: false,
+            strikethrough: false,
+            fontSize: 10.25,
+            color: "#aabbcc",
+            fontFamily: "  Arial  ",
+          },
+        ],
+      } as SheetChart),
+    ).toEqual([
+      {
+        idx: 0,
+        delete: false,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikethrough: false,
+        fontSize: 10.5,
+        color: "AABBCC",
+        fontFamily: "Arial",
+      },
+    ])
+  })
+
+  it("drops out-of-band sizes, malformed colours and blank typefaces", () => {
+    expect(
+      resolveLegendEntries({
+        legendEntries: [
+          { idx: 0, fontSize: 999, color: "nothex", fontFamily: "   " },
+          { idx: 1, fontSize: Number.NaN },
+        ],
+      } as SheetChart),
+    ).toEqual([
+      { idx: 0, delete: false },
+      { idx: 1, delete: false },
+    ])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// title — chart-level <c:title> readers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("chart title readers", () => {
+  const readers: Array<[string, (e: XmlElement) => unknown, number]> = [
+    ["rotation", parseTitleRotation, 3],
+    ["fontSize", parseTitleFontSize, 5],
+    ["bold", parseTitleBold, 5],
+    ["italic", parseTitleItalic, 5],
+    ["color", parseTitleColor, 5],
+    ["strike", parseTitleStrike, 5],
+    ["underline", parseTitleUnderline, 5],
+    ["fontFamily", parseTitleFontFamily, 5],
+  ]
+
+  it("bails at every broken link of the <c:title><c:tx><c:rich>... chain", () => {
+    for (const [name, read, deepest] of readers) {
+      for (let depth = 0; depth < deepest; depth++) {
+        expect(read(chartEl(titleChain(depth as 0))), `${name}@${depth}`).toBeUndefined()
+      }
+      expect(read(chartEl("")), name).toBeUndefined()
+    }
+  })
+
+  it("returns undefined for a formula-bound title with no <c:rich> body", () => {
+    const strRef = chartEl(
+      "<c:title><c:tx><c:strRef><c:f>Sheet1!$A$1</c:f><c:strCache>" +
+        '<c:pt idx="0"><c:v>Sales</c:v></c:pt></c:strCache></c:strRef></c:tx></c:title>',
+    )
+    expect(parseTitle(strRef)).toBe("Sales")
+    expect(parseTitleFontSize(strRef)).toBeUndefined()
+    expect(parseTitleBold(strRef)).toBeUndefined()
+    expect(parseTitleColor(strRef)).toBeUndefined()
+  })
+
+  it("keeps scanning the <c:strCache> past entries with no usable <c:v>", () => {
+    expect(
+      parseTitle(
+        chartEl(
+          "<c:title><c:tx><c:strRef><c:strCache>" +
+            '<c:ptCount val="3"/><c:pt idx="0"/><c:pt idx="1"><c:v> </c:v></c:pt>' +
+            '<c:pt idx="2"><c:v>Q1</c:v></c:pt></c:strCache></c:strRef></c:tx></c:title>',
+        ),
+      ),
+    ).toBe("Q1")
+  })
+
+  it("returns undefined for a title with no <c:tx>, a blank body, or an empty cache", () => {
+    expect(parseTitle(chartEl("<c:title/>"))).toBeUndefined()
+    expect(
+      parseTitle(
+        chartEl(
+          "<c:title><c:tx><c:rich><a:p><a:r><a:t>  </a:t></a:r></a:p></c:rich></c:tx></c:title>",
+        ),
+      ),
+    ).toBeUndefined()
+    expect(
+      parseTitle(chartEl("<c:title><c:tx><c:strRef><c:strCache/></c:strRef></c:tx></c:title>")),
+    ).toBeUndefined()
+    expect(parseTitle(chartEl("<c:title><c:tx><c:strRef/></c:tx></c:title>"))).toBeUndefined()
+    // `<c:tx>` must hold one of the two choices; neither means no title.
+    expect(parseTitle(chartEl("<c:title><c:tx/></c:title>"))).toBeUndefined()
+    expect(parseTitle(chartEl(""))).toBeUndefined()
+  })
+
+  it("reads the whole typography block off a single <a:defRPr>", () => {
+    const title = chartEl(
+      titleChain(
+        5,
+        ' sz="1600" b="1" i="1" u="sng" strike="sngStrike"',
+        '<a:solidFill><a:srgbClr val="ff8800"/></a:solidFill><a:latin typeface=" Cambria "/>',
+      ),
+    )
+    expect(parseTitleFontSize(title)).toBe(16)
+    expect(parseTitleBold(title)).toBe(true)
+    expect(parseTitleItalic(title)).toBe(true)
+    expect(parseTitleUnderline(title)).toBe(true)
+    expect(parseTitleStrike(title)).toBe(true)
+    expect(parseTitleColor(title)).toBe("FF8800")
+    expect(parseTitleFontFamily(title)).toBe("Cambria")
+  })
+
+  it("collapses the OOXML defaults and the non-UI dbl variants", () => {
+    const title = chartEl(titleChain(5, ' b="0" i="0" u="dbl" strike="dblStrike"'))
+    expect(parseTitleBold(title)).toBeUndefined()
+    expect(parseTitleItalic(title)).toBeUndefined()
+    expect(parseTitleUnderline(title)).toBeUndefined()
+    expect(parseTitleStrike(title)).toBeUndefined()
+  })
+
+  it("lifts an <a:schemeClr> title color when no literal sRGB is present", () => {
+    expect(
+      parseTitleColor(
+        chartEl(titleChain(5, "", '<a:solidFill><a:schemeClr val="dk1"/></a:solidFill>')),
+      ),
+    ).toEqual({ theme: "dk1" })
+    expect(
+      parseTitleColor(chartEl(titleChain(5, "", "<a:solidFill><a:prstClr/></a:solidFill>"))),
+    ).toBeUndefined()
+    expect(parseTitleColor(chartEl(titleChain(5)))).toBeUndefined()
+  })
+
+  it("trims the typeface and drops a blank one", () => {
+    expect(
+      parseTitleFontFamily(chartEl(titleChain(5, "", '<a:latin typeface="   "/>'))),
+    ).toBeUndefined()
+    expect(parseTitleFontFamily(chartEl(titleChain(5, "", "<a:latin/>")))).toBeUndefined()
+  })
+
+  it("clamps the title rotation to the -90..90 band", () => {
+    const rot = (r: string): number | undefined =>
+      parseTitleRotation(
+        chartEl(`<c:title><c:tx><c:rich><a:bodyPr rot="${r}"/></c:rich></c:tx></c:title>`),
+      )
+    expect(rot("-2700000")).toBe(-45)
+    expect(rot("20000000")).toBe(90)
+    expect(rot("-20000000")).toBe(-90)
+    expect(rot("0")).toBeUndefined()
+    expect(rot("   ")).toBeUndefined()
+    expect(rot("up")).toBeUndefined()
+    expect(
+      parseTitleRotation(chartEl("<c:title><c:tx><c:rich><a:bodyPr/></c:rich></c:tx></c:title>")),
+    ).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// plotArea — writer entry points
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("buildPlotArea", () => {
+  it('emits <c:delete val="1"/> on a scatter value axis the caller hid', () => {
+    // `axes.y.hidden` is Excel's "Format Axis -> Labels -> None" plus
+    // the axis-line removal; the writer flips `<c:delete>` on the
+    // matching `<c:valAx>` rather than omitting the element (Excel
+    // still needs the axis id to bind the series to an axis pair).
+    const xml = buildPlotArea(
+      {
+        type: "scatter",
+        series: [{ values: "Sheet1!$B$2:$B$5" }],
+        axes: { y: { hidden: true } },
+      } as SheetChart,
+      "Sheet1",
+    )
+    expect(xml).toContain('<c:delete val="1"/>')
+  })
+})
+
+describe("buildPieChart", () => {
+  it("emits only <c:varyColors> for a chart with no series at all", () => {
+    // A pie chart paints its first series only; with none there is
+    // nothing to emit beyond the required colour-variation toggle.
+    expect(buildPieChart({ type: "pie", series: [] } as unknown as SheetChart, "Sheet1")).toBe(
+      '<c:pieChart><c:varyColors val="1"/></c:pieChart>',
+    )
+  })
+})

--- a/test/coverage-chart-series.test.ts
+++ b/test/coverage-chart-series.test.ts
@@ -1,0 +1,1288 @@
+import { describe, expect, it } from "vitest"
+import type {
+  ChartDataLabels,
+  ChartDataPoint,
+  ChartErrorBars,
+  ChartSeries,
+  ChartTrendline,
+} from "../src/_types"
+import { type XmlElement, parseXml } from "../src/xml/parser"
+import {
+  buildAllErrorBars,
+  buildDataPoints,
+  buildErrorBars,
+  buildShape3D,
+  buildTrendline,
+  buildTrendlines,
+  cloneAllErrorBars,
+  cloneDataPoint,
+  cloneDataPoints,
+  cloneErrorBars,
+  cloneTrendline,
+  cloneTrendlines,
+  normalizeShape3D,
+  parseBubbleSizeRef,
+  parseDataPoints,
+  parseErrorBars,
+  parseShape3D,
+  parseTrendlines,
+  resolveDataPoints,
+  resolveErrorBars,
+  resolveTrendlines,
+} from "../src/xlsx/chart/seriesExtras"
+import {
+  buildSeries,
+  buildSeriesSpPr,
+  mergeSeries,
+  parseMarker,
+  parseSeries,
+  parseSeriesColor,
+  parseSeriesName,
+  parseSeriesStroke,
+} from "../src/xlsx/chart/series"
+import {
+  buildDataLabelsBody,
+  parseDataLabels,
+  parseDataLabelsBold,
+  parseDataLabelsFontColor,
+  parseDataLabelsFontFamily,
+  parseDataLabelsFontSize,
+  parseDataLabelsItalic,
+  parseDataLabelsStrikethrough,
+  parseDataLabelsUnderline,
+} from "../src/xlsx/chart/dataLabels"
+import {
+  parseDataTable,
+  parseDataTableBold,
+  parseDataTableFlag,
+  parseDataTableFontColor,
+  parseDataTableFontFamily,
+  parseDataTableFontSize,
+  parseDataTableItalic,
+  parseDataTableStrikethrough,
+  parseDataTableUnderline,
+} from "../src/xlsx/chart/dataTable"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const NS =
+  'xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" ' +
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+
+/** Build a real `<c:ser>` through the project's parser, not a literal. */
+function ser(inner: string): XmlElement {
+  return parseXml(`<c:ser ${NS}>${inner}</c:ser>`)
+}
+
+/** Build an arbitrary chart-namespace element, e.g. `<c:dLbls>`. */
+function el(tag: string, inner: string): XmlElement {
+  return parseXml(`<c:${tag} ${NS}>${inner}</c:${tag}>`)
+}
+
+/**
+ * The five-link `<c:txPr><a:p><a:pPr><a:defRPr>` chain every chart
+ * typography reader walks. `depth` truncates it so a test can assert
+ * the reader bails on the first missing link.
+ */
+function txPrChain(depth: 0 | 1 | 2 | 3, defRPrAttrs = ""): string {
+  if (depth === 0) return "<c:txPr/>"
+  if (depth === 1) return "<c:txPr><a:p/></c:txPr>"
+  if (depth === 2) return "<c:txPr><a:p><a:pPr/></a:p></c:txPr>"
+  return `<c:txPr><a:p><a:pPr><a:defRPr${defRPrAttrs}/></a:pPr></a:p></c:txPr>`
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// seriesExtras — <c:shape> (ST_Shape, §21.2.3.34)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseShape3D", () => {
+  it("reads every ST_Shape token Excel's 3-D bar UI exposes", () => {
+    for (const token of ["cone", "coneToMax", "box", "cylinder", "pyramid", "pyramidToMax"]) {
+      expect(parseShape3D(ser(`<c:shape val="${token}"/>`)), token).toBe(token)
+    }
+  })
+
+  it("tolerates surrounding whitespace on the val token", () => {
+    expect(parseShape3D(ser('<c:shape val="  cylinder  "/>'))).toBe("cylinder")
+  })
+
+  it("drops absence, a missing val, and tokens outside ST_Shape", () => {
+    // Excel falls back to "box" for all three, so surfacing nothing keeps
+    // absence and the default indistinguishable on re-emit.
+    expect(parseShape3D(ser(""))).toBeUndefined()
+    expect(parseShape3D(ser("<c:shape/>"))).toBeUndefined()
+    expect(parseShape3D(ser('<c:shape val="sphere"/>'))).toBeUndefined()
+    expect(parseShape3D(ser('<c:shape val=""/>'))).toBeUndefined()
+  })
+})
+
+describe("normalizeShape3D / buildShape3D", () => {
+  it("emits only recognized tokens so the writer can elide the element", () => {
+    expect(buildShape3D("cone")).toBe('<c:shape val="cone"/>')
+    expect(buildShape3D(undefined)).toBeUndefined()
+    expect(buildShape3D("sphere" as never)).toBeUndefined()
+    expect(normalizeShape3D(42 as never)).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// seriesExtras — <c:bubbleSize> (CT_NumDataSource, §21.2.2.30)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseBubbleSizeRef", () => {
+  it("walks <c:bubbleSize><c:numRef><c:f> to the formula text", () => {
+    expect(
+      parseBubbleSizeRef(
+        ser("<c:bubbleSize><c:numRef><c:f>Sheet1!$C$2:$C$5</c:f></c:numRef></c:bubbleSize>"),
+      ),
+    ).toBe("Sheet1!$C$2:$C$5")
+  })
+
+  it("returns undefined for an embedded <c:numLit> with no formula", () => {
+    expect(
+      parseBubbleSizeRef(
+        ser('<c:bubbleSize><c:numLit><c:pt idx="0"><c:v>4</c:v></c:pt></c:numLit></c:bubbleSize>'),
+      ),
+    ).toBeUndefined()
+    expect(parseBubbleSizeRef(ser(""))).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// seriesExtras — <c:dPt> (CT_DPt, §21.2.2.52)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseDataPoints", () => {
+  it("requires a well-formed <c:idx> selector on every point", () => {
+    // `<c:idx>` is the required CT_DPt selector — without a usable index
+    // the override cannot land on a slice, so the whole `<c:dPt>` drops
+    // rather than surface a fabricated index 0.
+    expect(parseDataPoints(ser('<c:dPt><c:bubble3D val="1"/></c:dPt>'))).toBeUndefined()
+    expect(parseDataPoints(ser("<c:dPt><c:idx/></c:dPt>"))).toBeUndefined()
+    expect(parseDataPoints(ser('<c:dPt><c:idx val="-1"/></c:dPt>'))).toBeUndefined()
+    expect(parseDataPoints(ser('<c:dPt><c:idx val="abc"/></c:dPt>'))).toBeUndefined()
+  })
+
+  it("returns undefined when the series declares no <c:dPt> at all", () => {
+    expect(parseDataPoints(ser('<c:idx val="0"/>'))).toBeUndefined()
+  })
+
+  it("rounds <c:explosion> and drops the OOXML default 0", () => {
+    const points = parseDataPoints(
+      ser(
+        '<c:dPt><c:idx val="0"/><c:explosion val="24.6"/></c:dPt>' +
+          '<c:dPt><c:idx val="1"/><c:explosion val="0"/></c:dPt>' +
+          '<c:dPt><c:idx val="2"/><c:explosion val="-5"/></c:dPt>' +
+          '<c:dPt><c:idx val="3"/><c:explosion val="0.4"/></c:dPt>' +
+          '<c:dPt><c:idx val="4"/><c:explosion/></c:dPt>',
+      ),
+    )
+    expect(points?.map((p) => p.explosion)).toEqual([
+      25,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ])
+  })
+
+  it("surfaces <c:bubble3D> only for the explicit truthy spelling", () => {
+    const points = parseDataPoints(
+      ser(
+        '<c:dPt><c:idx val="0"/><c:bubble3D val="1"/></c:dPt>' +
+          '<c:dPt><c:idx val="1"/><c:bubble3D val="0"/></c:dPt>',
+      ),
+    )
+    expect(points?.map((p) => p.bubble3D)).toEqual([true, undefined])
+  })
+
+  it("bails at each broken link of the <c:spPr><a:solidFill><a:srgbClr> fill chain", () => {
+    const cases = [
+      "",
+      "<c:spPr/>",
+      "<c:spPr><a:noFill/></c:spPr>",
+      "<c:spPr><a:solidFill/></c:spPr>",
+      '<c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></c:spPr>',
+    ]
+    for (const body of cases) {
+      const points = parseDataPoints(ser(`<c:dPt><c:idx val="0"/>${body}</c:dPt>`))
+      expect(points?.[0].fillColor, body).toBeUndefined()
+    }
+    const ok = parseDataPoints(
+      ser(
+        '<c:dPt><c:idx val="0"/><c:spPr><a:solidFill><a:srgbClr val="ff0000"/>' +
+          "</a:solidFill></c:spPr></c:dPt>",
+      ),
+    )
+    expect(ok?.[0].fillColor).toBe("FF0000")
+  })
+
+  it("bails at each broken link of the <a:ln><a:solidFill><a:srgbClr> border chain", () => {
+    const cases = [
+      "<c:spPr/>",
+      "<c:spPr><a:ln/></c:spPr>",
+      "<c:spPr><a:ln><a:noFill/></a:ln></c:spPr>",
+      "<c:spPr><a:ln><a:solidFill/></a:ln></c:spPr>",
+    ]
+    for (const body of cases) {
+      const points = parseDataPoints(ser(`<c:dPt><c:idx val="0"/>${body}</c:dPt>`))
+      expect(points?.[0].borderColor, body).toBeUndefined()
+    }
+  })
+
+  it("reads the per-point border colour off <c:spPr><a:ln><a:solidFill>", () => {
+    const points = parseDataPoints(
+      ser(
+        '<c:dPt><c:idx val="4"/><c:spPr><a:ln><a:solidFill>' +
+          '<a:srgbClr val="#00FF7F"/></a:solidFill><a:prstDash val="dashDot"/></a:ln>' +
+          "</c:spPr></c:dPt>",
+      ),
+    )
+    expect(points).toEqual([{ idx: 4, borderColor: "00FF7F", borderDash: "dashDot" }])
+  })
+
+  it("converts <a:ln w=..> from EMU to points and clamps to Excel's 0.25..13.5pt band", () => {
+    const read = (w: string): number | undefined =>
+      parseDataPoints(ser(`<c:dPt><c:idx val="0"/><c:spPr><a:ln w="${w}"/></c:spPr></c:dPt>`))?.[0]
+        .borderWidth
+    // 1 pt = 12 700 EMU per CT_LineProperties (§20.1.2.3.24).
+    expect(read("25400")).toBe(2)
+    // Below the UI minimum clamps up; above the maximum clamps down.
+    expect(read("1000")).toBe(0.25)
+    expect(read("1000000")).toBe(13.5)
+    // Zero is Excel's "no border" marker, which this field does not model.
+    expect(read("0")).toBeUndefined()
+    expect(read("-25400")).toBeUndefined()
+    expect(read("wide")).toBeUndefined()
+    expect(
+      parseDataPoints(ser('<c:dPt><c:idx val="0"/><c:spPr><a:ln/></c:spPr></c:dPt>'))?.[0]
+        .borderWidth,
+    ).toBeUndefined()
+  })
+
+  it("drops the OOXML default dash `solid` and every unrecognized token", () => {
+    const read = (body: string): string | undefined =>
+      parseDataPoints(
+        ser(`<c:dPt><c:idx val="0"/><c:spPr><a:ln>${body}</a:ln></c:spPr></c:dPt>`),
+      )?.[0].borderDash
+    expect(read('<a:prstDash val="dash"/>')).toBe("dash")
+    expect(read('<a:prstDash val="solid"/>')).toBeUndefined()
+    expect(read('<a:prstDash val="zigzag"/>')).toBeUndefined()
+    expect(read("<a:prstDash/>")).toBeUndefined()
+    expect(read("")).toBeUndefined()
+  })
+
+  it("lifts a per-point <c:marker> through the shared series-marker reader", () => {
+    const points = parseDataPoints(
+      ser('<c:dPt><c:idx val="2"/><c:marker><c:symbol val="diamond"/></c:marker></c:dPt>'),
+    )
+    expect(points?.[0]).toEqual({ idx: 2, marker: { symbol: "diamond" } })
+  })
+})
+
+describe("buildDataPoints", () => {
+  it("emits <c:explosion> only on the pie family", () => {
+    const dp: ChartDataPoint[] = [{ idx: 0, explosion: 25 }]
+    expect(buildDataPoints(dp, "pie")[0]).toContain('<c:explosion val="25"/>')
+    expect(buildDataPoints(dp, "doughnut")[0]).toContain('<c:explosion val="25"/>')
+    expect(buildDataPoints(dp, "pie3D")[0]).toContain('<c:explosion val="25"/>')
+    // Bar / column / line have no `<c:explosion>` slot on CT_DPt's
+    // per-family sequence, so a pinned value is dropped rather than
+    // emitted where Excel's validator would reject it.
+    expect(buildDataPoints(dp, "bar")[0]).not.toContain("c:explosion")
+  })
+
+  it("clamps explosion to the 0..400 band and drops the default 0", () => {
+    expect(buildDataPoints([{ idx: 0, explosion: 900 }], "pie")[0]).toContain(
+      '<c:explosion val="400"/>',
+    )
+    expect(buildDataPoints([{ idx: 0, explosion: 0 }], "pie")[0]).not.toContain("c:explosion")
+    expect(buildDataPoints([{ idx: 0, explosion: Number.NaN }], "pie")[0]).not.toContain(
+      "c:explosion",
+    )
+  })
+
+  it("always emits <c:bubble3D> because CT_DPt lists it as required", () => {
+    expect(buildDataPoints([{ idx: 0 }], "bar")[0]).toContain('<c:bubble3D val="0"/>')
+    expect(buildDataPoints([{ idx: 0, bubble3D: true }], "bar")[0]).toContain(
+      '<c:bubble3D val="1"/>',
+    )
+  })
+
+  it("self-closes <a:ln> when only the width lands on the wire", () => {
+    // No `<a:solidFill>` / `<a:prstDash>` children means the element has
+    // nothing to wrap, so the writer emits the attribute-only form.
+    const xml = buildDataPoints([{ idx: 0, borderWidth: 2 }], "bar")[0]
+    expect(xml).toContain('<a:ln w="25400"/>')
+  })
+
+  it("wraps <a:ln> with no width attribute at all when only a colour is pinned", () => {
+    const xml = buildDataPoints([{ idx: 0, borderColor: "112233", borderDash: "dot" }], "bar")[0]
+    expect(xml).toContain('<a:ln><a:solidFill><a:srgbClr val="112233"/></a:solidFill>')
+    expect(xml).toContain('<a:prstDash val="dot"/>')
+    expect(xml).not.toContain("<a:ln w=")
+  })
+
+  it("skips points whose idx cannot land on a real data point", () => {
+    expect(buildDataPoints([{ idx: -1 }, { idx: Number.NaN }], "bar")).toEqual([])
+    expect(buildDataPoints(undefined, "bar")).toEqual([])
+    expect(buildDataPoints([], "bar")).toEqual([])
+    // A fractional index floors rather than drops — Excel indexes points
+    // with `xsd:unsignedInt`.
+    expect(buildDataPoints([{ idx: 2.9 }], "bar")[0]).toContain('<c:idx val="2"/>')
+  })
+})
+
+describe("cloneDataPoint / resolveDataPoints", () => {
+  it("keeps only the fields the writer can re-emit", () => {
+    expect(
+      cloneDataPoint({
+        idx: 1,
+        explosion: Number.NaN,
+        bubble3D: false,
+        borderWidth: Number.POSITIVE_INFINITY,
+        marker: {},
+      } as ChartDataPoint),
+    ).toEqual({ idx: 1 })
+  })
+
+  it("follows the inherit / drop / replace override grammar", () => {
+    const source: ChartDataPoint[] = [{ idx: 0, fillColor: "FF0000" }]
+    expect(resolveDataPoints(source, undefined)).toEqual(source)
+    expect(resolveDataPoints(source, null)).toBeUndefined()
+    expect(resolveDataPoints(source, [{ idx: 3 }])).toEqual([{ idx: 3 }])
+    expect(resolveDataPoints(source, [])).toBeUndefined()
+    expect(cloneDataPoints(undefined)).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// seriesExtras — <c:trendline> (CT_Trendline, §21.2.2.211)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseTrendlines", () => {
+  const one = (inner: string): ChartTrendline | undefined =>
+    parseTrendlines(ser(`<c:trendline>${inner}</c:trendline>`))?.[0]
+
+  it("requires a recognized ST_TrendlineType before admitting the block", () => {
+    expect(parseTrendlines(ser("<c:trendline/>"))).toBeUndefined()
+    expect(parseTrendlines(ser("<c:trendline><c:trendlineType/></c:trendline>"))).toBeUndefined()
+    expect(
+      parseTrendlines(ser('<c:trendline><c:trendlineType val="spline"/></c:trendline>')),
+    ).toBeUndefined()
+    for (const t of ["linear", "log", "exp", "power", "poly", "movingAvg"]) {
+      expect(one(`<c:trendlineType val="${t}"/>`)?.type, t).toBe(t)
+    }
+  })
+
+  it("reads the display name off <c:name>'s text content", () => {
+    expect(one('<c:trendlineType val="linear"/><c:name>  Trend A  </c:name>')?.name).toBe("Trend A")
+    // `<c:name>` is plain text — an element child contributes nothing.
+    expect(one('<c:trendlineType val="linear"/><c:name>Trend<c:extLst/></c:name>')?.name).toBe(
+      "Trend",
+    )
+    // A whitespace-only name is indistinguishable from absence to Excel.
+    expect(one('<c:trendlineType val="linear"/><c:name>   </c:name>')?.name).toBeUndefined()
+    expect(one('<c:trendlineType val="linear"/><c:name/>')?.name).toBeUndefined()
+  })
+
+  it("admits <c:order> only inside the 2..6 polynomial band Excel's UI exposes", () => {
+    const order = (v: string): number | undefined =>
+      one(`<c:trendlineType val="poly"/><c:order val="${v}"/>`)?.order
+    expect(order("2")).toBe(2)
+    expect(order("6")).toBe(6)
+    expect(order("3.4")).toBe(3)
+    expect(order("1")).toBeUndefined()
+    expect(order("7")).toBeUndefined()
+    expect(order("")).toBeUndefined()
+    expect(one('<c:trendlineType val="poly"/><c:order/>')?.order).toBeUndefined()
+  })
+
+  it("admits <c:period> only inside the 2..100 moving-average band", () => {
+    const period = (v: string): number | undefined =>
+      one(`<c:trendlineType val="movingAvg"/><c:period val="${v}"/>`)?.period
+    expect(period("2")).toBe(2)
+    expect(period("100")).toBe(100)
+    expect(period("1")).toBeUndefined()
+    expect(period("101")).toBeUndefined()
+    expect(one('<c:trendlineType val="movingAvg"/><c:period/>')?.period).toBeUndefined()
+  })
+
+  it("accepts any finite forecast / intercept, including negatives", () => {
+    const t = one(
+      '<c:trendlineType val="linear"/><c:forward val="2.5"/><c:backward val="-1"/>' +
+        '<c:intercept val="0"/>',
+    )
+    expect(t).toMatchObject({ forward: 2.5, backward: -1, intercept: 0 })
+    const empty = one('<c:trendlineType val="linear"/><c:forward/><c:backward/><c:intercept/>')
+    expect(empty).toEqual({ type: "linear" })
+  })
+
+  it("surfaces <c:dispEq> / <c:dispRSqr> only on the explicit truthy spelling", () => {
+    expect(
+      one('<c:trendlineType val="linear"/><c:dispEq val="1"/><c:dispRSqr val="true"/>'),
+    ).toMatchObject({ dispEquation: true, dispRSquared: true })
+    expect(one('<c:trendlineType val="linear"/><c:dispEq val="0"/><c:dispRSqr val="0"/>')).toEqual({
+      type: "linear",
+    })
+  })
+
+  it("bails at each broken link of the <c:spPr><a:ln> stroke chain", () => {
+    for (const body of ["<c:spPr/>", "<c:spPr><a:ln/></c:spPr>", ""]) {
+      expect(one(`<c:trendlineType val="linear"/>${body}`), body).toEqual({ type: "linear" })
+    }
+    expect(
+      one('<c:trendlineType val="linear"/><c:spPr><a:ln><a:solidFill/></a:ln></c:spPr>'),
+    ).toEqual({ type: "linear" })
+  })
+
+  it("clamps the stroke width into the 0.25..13.5pt band on both ends", () => {
+    const width = (w: string): number | undefined =>
+      one(`<c:trendlineType val="linear"/><c:spPr><a:ln w="${w}"/></c:spPr>`)?.lineWidth
+    expect(width("25400")).toBe(2)
+    expect(width("100")).toBe(0.25)
+    expect(width("9999999")).toBe(13.5)
+    expect(width("0")).toBeUndefined()
+    expect(width("thick")).toBeUndefined()
+  })
+
+  it("reads the line color and dash, dropping the OOXML default `solid`", () => {
+    const t = one(
+      '<c:trendlineType val="linear"/><c:spPr><a:ln>' +
+        '<a:solidFill><a:srgbClr val="#00ff00"/></a:solidFill>' +
+        '<a:prstDash val="sysDot"/></a:ln></c:spPr>',
+    )
+    expect(t).toMatchObject({ lineColor: "00FF00", lineDash: "sysDot" })
+    expect(
+      one(
+        '<c:trendlineType val="linear"/><c:spPr><a:ln>' +
+          '<a:solidFill><a:srgbClr val="nothex"/></a:solidFill>' +
+          '<a:prstDash val="solid"/></a:ln></c:spPr>',
+      ),
+    ).toEqual({ type: "linear" })
+    expect(
+      one('<c:trendlineType val="linear"/><c:spPr><a:ln><a:prstDash/></a:ln></c:spPr>'),
+    ).toEqual({ type: "linear" })
+  })
+})
+
+describe("buildTrendline", () => {
+  it("scopes <c:order> to poly and <c:period> to movingAvg", () => {
+    // Excel rejects `<c:order>` on a linear trendline — the writer drops
+    // the field rather than emit an element outside its schema slot.
+    expect(buildTrendline({ type: "linear", order: 3, period: 5 })).not.toContain("c:order")
+    expect(buildTrendline({ type: "poly", order: 3 })).toContain('<c:order val="3"/>')
+    expect(buildTrendline({ type: "movingAvg", period: 5 })).toContain('<c:period val="5"/>')
+  })
+
+  it("clamps rather than drops an out-of-band order / period on the write side", () => {
+    // A reader drops out-of-band values; the writer clamps so an
+    // authored-but-invalid value still produces a file Excel opens.
+    expect(buildTrendline({ type: "poly", order: 99 })).toContain('<c:order val="6"/>')
+    expect(buildTrendline({ type: "poly", order: 0 })).toContain('<c:order val="2"/>')
+    expect(buildTrendline({ type: "movingAvg", period: 9999 })).toContain('<c:period val="100"/>')
+    expect(buildTrendline({ type: "movingAvg", period: 1 })).toContain('<c:period val="2"/>')
+  })
+
+  it("escapes the display name so an ampersand cannot break the document", () => {
+    expect(buildTrendline({ type: "linear", name: "R&D <2024>" })).toContain(
+      "<c:name>R&amp;D &lt;2024&gt;</c:name>",
+    )
+    expect(buildTrendline({ type: "linear", name: "   " })).not.toContain("c:name")
+  })
+
+  it("self-closes <a:ln> when only the width is pinned", () => {
+    expect(buildTrendline({ type: "linear", lineWidth: 1 })).toContain('<a:ln w="12700"/>')
+    // With a color child the element must wrap, keeping `w` as an attribute.
+    expect(buildTrendline({ type: "linear", lineWidth: 1, lineColor: "FF0000" })).toContain(
+      '<a:ln w="12700">',
+    )
+    // A colour-only stroke wraps with no `w` attribute at all.
+    expect(buildTrendline({ type: "linear", lineColor: "FF0000", lineDash: "dash" })).toContain(
+      "<a:ln><a:solidFill>",
+    )
+    // No stroke knob at all elides the whole `<c:spPr>`.
+    expect(buildTrendline({ type: "linear" })).not.toContain("c:spPr")
+  })
+
+  it("refuses to emit a block whose type is outside ST_TrendlineType", () => {
+    expect(buildTrendline({ type: "spline" as never })).toBeUndefined()
+    expect(buildTrendlines([{ type: "spline" as never }, { type: "linear" }])).toHaveLength(1)
+    expect(buildTrendlines(undefined)).toEqual([])
+    expect(buildTrendlines([])).toEqual([])
+  })
+})
+
+describe("cloneTrendline / resolveTrendlines", () => {
+  it("drops a trendline whose type no longer validates", () => {
+    expect(cloneTrendline({ type: "spline" as never })).toBeUndefined()
+    expect(cloneTrendlines([{ type: "spline" as never }])).toBeUndefined()
+    expect(cloneTrendlines(undefined)).toBeUndefined()
+    expect(cloneTrendlines([])).toBeUndefined()
+  })
+
+  it("keeps only finite numerics and non-empty strings", () => {
+    expect(
+      cloneTrendline({
+        type: "poly",
+        name: "",
+        order: Number.NaN,
+        period: Number.POSITIVE_INFINITY,
+        forward: Number.NaN,
+        backward: Number.NaN,
+        intercept: Number.NaN,
+        lineWidth: Number.NaN,
+      }),
+    ).toEqual({ type: "poly" })
+  })
+
+  it("follows the inherit / drop / replace override grammar", () => {
+    const source: ChartTrendline[] = [{ type: "linear" }]
+    expect(resolveTrendlines(source, undefined)).toEqual(source)
+    expect(resolveTrendlines(source, null)).toBeUndefined()
+    expect(resolveTrendlines(source, [{ type: "exp" }])).toEqual([{ type: "exp" }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// seriesExtras — <c:errBars> (CT_ErrBars, §21.2.2.55)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseErrorBars", () => {
+  const HEAD = '<c:errDir val="y"/><c:errBarType val="both"/><c:errValType val="fixedVal"/>'
+  const one = (inner: string): ChartErrorBars | undefined =>
+    parseErrorBars(ser(`<c:errBars>${inner}</c:errBars>`))?.[0]
+
+  it("requires all three ST_Err* selectors before admitting the block", () => {
+    // CT_ErrBars makes errDir / errBarType / errValType the identity of
+    // the block; a partial header cannot be rendered, so it drops.
+    const partials = [
+      "",
+      '<c:errDir val="y"/>',
+      "<c:errDir/>",
+      '<c:errDir val="z"/>',
+      '<c:errDir val="y"/><c:errBarType/>',
+      '<c:errDir val="y"/><c:errBarType val="sideways"/>',
+      '<c:errDir val="y"/><c:errBarType val="both"/>',
+      '<c:errDir val="y"/><c:errBarType val="both"/><c:errValType/>',
+      '<c:errDir val="y"/><c:errBarType val="both"/><c:errValType val="guess"/>',
+    ]
+    for (const p of partials) {
+      expect(parseErrorBars(ser(`<c:errBars>${p}</c:errBars>`)), p).toBeUndefined()
+    }
+    expect(one(HEAD)).toEqual({ direction: "y", type: "both", valType: "fixedVal" })
+  })
+
+  it("reads <c:val> only when it parses to a finite number", () => {
+    expect(one(`${HEAD}<c:val val="1.5"/>`)?.value).toBe(1.5)
+    expect(one(`${HEAD}<c:val/>`)?.value).toBeUndefined()
+    expect(one(`${HEAD}<c:val val="x"/>`)?.value).toBeUndefined()
+  })
+
+  it("surfaces <c:noEndCap> only on the explicit truthy spelling", () => {
+    expect(one(`${HEAD}<c:noEndCap val="1"/>`)?.noEndCap).toBe(true)
+    expect(one(`${HEAD}<c:noEndCap val="0"/>`)?.noEndCap).toBeUndefined()
+  })
+
+  it("bails at each broken link of the <c:spPr><a:ln> stroke chain", () => {
+    for (const body of ["<c:spPr/>", "<c:spPr><a:ln/></c:spPr>"]) {
+      expect(one(`${HEAD}${body}`), body).toEqual({
+        direction: "y",
+        type: "both",
+        valType: "fixedVal",
+      })
+    }
+    expect(one(`${HEAD}<c:spPr><a:ln><a:solidFill/></a:ln></c:spPr>`)?.lineColor).toBeUndefined()
+    expect(one(`${HEAD}<c:spPr><a:ln><a:prstDash/></a:ln></c:spPr>`)?.lineDash).toBeUndefined()
+  })
+
+  it("clamps the stroke width into the 0.25..13.5pt band on both ends", () => {
+    const width = (w: string): number | undefined =>
+      one(`${HEAD}<c:spPr><a:ln w="${w}"/></c:spPr>`)?.lineWidth
+    expect(width("12700")).toBe(1)
+    expect(width("100")).toBe(0.25)
+    expect(width("9999999")).toBe(13.5)
+    expect(width("0")).toBeUndefined()
+    expect(width("thin")).toBeUndefined()
+  })
+
+  it("drops the OOXML default dash `solid` and unrecognized colors", () => {
+    expect(
+      one(
+        `${HEAD}<c:spPr><a:ln><a:solidFill><a:srgbClr val="123456"/></a:solidFill>` +
+          '<a:prstDash val="dot"/></a:ln></c:spPr>',
+      ),
+    ).toMatchObject({ lineColor: "123456", lineDash: "dot" })
+    expect(
+      one(
+        `${HEAD}<c:spPr><a:ln><a:solidFill><a:srgbClr val="zz"/></a:solidFill>` +
+          '<a:prstDash val="solid"/></a:ln></c:spPr>',
+      ),
+    ).toEqual({ direction: "y", type: "both", valType: "fixedVal" })
+  })
+})
+
+describe("buildErrorBars", () => {
+  const base: ChartErrorBars = { direction: "y", type: "both", valType: "fixedVal" }
+
+  it("refuses a block whose direction / type / valType is outside its enum", () => {
+    expect(buildErrorBars({ ...base, direction: "z" as never })).toBeUndefined()
+    expect(buildErrorBars({ ...base, type: "sideways" as never })).toBeUndefined()
+    expect(buildErrorBars({ ...base, valType: "guess" as never })).toBeUndefined()
+  })
+
+  it("omits <c:val> for the value types that derive their own magnitude", () => {
+    // `stdErr` computes from the data and `cust` reads `<c:plus>` /
+    // `<c:minus>` ranges — a `<c:val>` alongside either is meaningless.
+    expect(buildErrorBars({ ...base, valType: "stdErr", value: 3 })).not.toContain("c:val ")
+    expect(buildErrorBars({ ...base, valType: "cust", value: 3 })).not.toContain("c:val ")
+    expect(buildErrorBars({ ...base, value: 3 })).toContain('<c:val val="3"/>')
+    expect(buildErrorBars({ ...base, value: Number.NaN })).not.toContain("c:val ")
+  })
+
+  it("emits <c:noEndCap> only when explicitly pinned", () => {
+    expect(buildErrorBars({ ...base, noEndCap: true })).toContain('<c:noEndCap val="1"/>')
+    expect(buildErrorBars({ ...base, noEndCap: false })).not.toContain("c:noEndCap")
+  })
+
+  it("self-closes <a:ln> when only the width is pinned", () => {
+    expect(buildErrorBars({ ...base, lineWidth: 1 })).toContain('<a:ln w="12700"/>')
+    expect(buildErrorBars({ ...base, lineDash: "dash" })).toContain("<a:ln>")
+    expect(buildErrorBars(base)).not.toContain("c:spPr")
+  })
+
+  it("skips invalid entries when building the whole list", () => {
+    expect(buildAllErrorBars([{ ...base, direction: "z" as never }, base])).toHaveLength(1)
+    expect(buildAllErrorBars(undefined)).toEqual([])
+    expect(buildAllErrorBars([])).toEqual([])
+  })
+})
+
+describe("cloneErrorBars / resolveErrorBars", () => {
+  const base: ChartErrorBars = { direction: "x", type: "plus", valType: "percentage" }
+
+  it("drops a record whose enum fields no longer validate", () => {
+    expect(cloneErrorBars({ ...base, direction: "z" as never })).toBeUndefined()
+    expect(cloneErrorBars({ ...base, type: "sideways" as never })).toBeUndefined()
+    expect(cloneErrorBars({ ...base, valType: "guess" as never })).toBeUndefined()
+    expect(cloneAllErrorBars([{ ...base, direction: "z" as never }])).toBeUndefined()
+    expect(cloneAllErrorBars(undefined)).toBeUndefined()
+    expect(cloneAllErrorBars([])).toBeUndefined()
+  })
+
+  it("keeps only finite numerics and literal booleans", () => {
+    expect(
+      cloneErrorBars({
+        ...base,
+        value: Number.NaN,
+        lineWidth: Number.POSITIVE_INFINITY,
+        noEndCap: false,
+      }),
+    ).toEqual(base)
+    expect(
+      cloneErrorBars({
+        ...base,
+        value: 5,
+        lineWidth: 2,
+        noEndCap: true,
+        lineColor: "112233",
+        lineDash: "dash",
+      }),
+    ).toEqual({
+      ...base,
+      value: 5,
+      lineWidth: 2,
+      noEndCap: true,
+      lineColor: "112233",
+      lineDash: "dash",
+    })
+  })
+
+  it("follows the inherit / drop / replace override grammar", () => {
+    expect(resolveErrorBars([base], undefined)).toEqual([base])
+    expect(resolveErrorBars([base], null)).toBeUndefined()
+    expect(resolveErrorBars([base], [{ ...base, direction: "y" }])).toEqual([
+      { ...base, direction: "y" },
+    ])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// series — per-family gating on <c:ser>
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSeries family gating", () => {
+  const EXTRAS =
+    '<c:trendline><c:trendlineType val="linear"/></c:trendline>' +
+    '<c:errBars><c:errDir val="y"/><c:errBarType val="both"/>' +
+    '<c:errValType val="fixedVal"/></c:errBars>' +
+    "<c:bubbleSize><c:numRef><c:f>Sheet1!$D$2:$D$4</c:f></c:numRef></c:bubbleSize>" +
+    '<c:shape val="cylinder"/>'
+
+  it("reads <c:bubbleSize> only on a bubble series", () => {
+    expect(parseSeries(ser(EXTRAS), "bubble", 0).bubbleSizeRef).toBe("Sheet1!$D$2:$D$4")
+    // A stray `<c:bubbleSize>` on a bar template has no CT_BarSer slot.
+    expect(parseSeries(ser(EXTRAS), "bar", 0).bubbleSizeRef).toBeUndefined()
+  })
+
+  it("reads <c:shape> only on a bar3D series", () => {
+    expect(parseSeries(ser(EXTRAS), "bar3D", 0).shape3D).toBe("cylinder")
+    expect(parseSeries(ser(EXTRAS), "bar", 0).shape3D).toBeUndefined()
+  })
+
+  it("leaves bubbleSizeRef and shape3D unset when the series declares neither", () => {
+    expect(parseSeries(ser('<c:idx val="0"/>'), "bubble", 0).bubbleSizeRef).toBeUndefined()
+    expect(parseSeries(ser('<c:idx val="0"/>'), "bar3D", 0).shape3D).toBeUndefined()
+  })
+
+  it("drops a <c:dLbls> block that carries nothing the writer models", () => {
+    // `<c:dLbls>` with only OOXML defaults collapses in the reader, so
+    // the parsed series must not carry an empty `dataLabels` record.
+    expect(
+      parseSeries(ser('<c:dLbls><c:showVal val="0"/></c:dLbls>'), "bar", 0).dataLabels,
+    ).toBeUndefined()
+  })
+
+  it("drops trendlines and error bars on pie, which has no slot for either", () => {
+    const pie = parseSeries(ser(EXTRAS), "pie", 0)
+    expect(pie.trendlines).toBeUndefined()
+    expect(pie.errorBars).toBeUndefined()
+    const bar = parseSeries(ser(EXTRAS), "bar", 0)
+    expect(bar.trendlines).toHaveLength(1)
+    expect(bar.errorBars).toHaveLength(1)
+  })
+})
+
+describe("parseSeriesColor", () => {
+  it("lifts an <a:schemeClr> theme reference when no literal sRGB is present", () => {
+    expect(
+      parseSeriesColor(
+        ser(
+          '<c:spPr><a:solidFill><a:schemeClr val="accent2"><a:lumMod val="75000"/>' +
+            "</a:schemeClr></a:solidFill></c:spPr>",
+        ),
+      ),
+    ).toEqual({ theme: "accent2", lumMod: 75000 })
+  })
+
+  it("drops an <a:srgbClr> with no val attribute", () => {
+    expect(
+      parseSeriesColor(ser("<c:spPr><a:solidFill><a:srgbClr/></a:solidFill></c:spPr>")),
+    ).toBeUndefined()
+  })
+
+  it("drops a fill the writer cannot reproduce", () => {
+    expect(
+      parseSeriesColor(
+        ser('<c:spPr><a:solidFill><a:sysClr val="windowText"/></a:solidFill></c:spPr>'),
+      ),
+    ).toBeUndefined()
+    expect(parseSeriesColor(ser("<c:spPr><a:noFill/></c:spPr>"))).toBeUndefined()
+    expect(parseSeriesColor(ser(""))).toBeUndefined()
+  })
+})
+
+describe("parseSeriesStroke", () => {
+  it("clamps the stroke width up to the 0.25pt UI minimum", () => {
+    expect(parseSeriesStroke(ser('<c:spPr><a:ln w="500"/></c:spPr>'))).toEqual({ width: 0.25 })
+    expect(parseSeriesStroke(ser('<c:spPr><a:ln w="9999999"/></c:spPr>'))).toEqual({ width: 13.5 })
+  })
+
+  it("collapses the OOXML defaults cap=flat and cmpd=sng to absence", () => {
+    expect(
+      parseSeriesStroke(ser('<c:spPr><a:ln w="12700" cap="flat" cmpd="sng"/></c:spPr>')),
+    ).toEqual({ width: 1 })
+    expect(parseSeriesStroke(ser('<c:spPr><a:ln cap="rnd" cmpd="dbl"/></c:spPr>'))).toEqual({
+      cap: "rnd",
+      compound: "dbl",
+    })
+  })
+
+  it("returns undefined when the <a:ln> carries nothing the writer models", () => {
+    expect(parseSeriesStroke(ser("<c:spPr><a:ln/></c:spPr>"))).toBeUndefined()
+    // Zero is Excel's "no line" marker and is not modelled as a width.
+    expect(parseSeriesStroke(ser('<c:spPr><a:ln w="0"/></c:spPr>'))).toBeUndefined()
+    expect(parseSeriesStroke(ser('<c:spPr><a:ln w="thick"/></c:spPr>'))).toBeUndefined()
+    expect(
+      parseSeriesStroke(ser('<c:spPr><a:ln><a:prstDash val="zigzag"/></a:ln></c:spPr>')),
+    ).toBeUndefined()
+    expect(
+      parseSeriesStroke(ser('<c:spPr><a:ln cap="bevel" cmpd="quad"/></c:spPr>')),
+    ).toBeUndefined()
+    expect(parseSeriesStroke(ser("<c:spPr/>"))).toBeUndefined()
+    expect(parseSeriesStroke(ser(""))).toBeUndefined()
+  })
+})
+
+describe("parseMarker", () => {
+  it("clamps <c:size> into the ST_MarkerSize 2..72 band", () => {
+    expect(parseMarker(ser('<c:marker><c:size val="1"/></c:marker>'))).toEqual({ size: 2 })
+    expect(parseMarker(ser('<c:marker><c:size val="99"/></c:marker>'))).toEqual({ size: 72 })
+    expect(parseMarker(ser('<c:marker><c:size val="7"/></c:marker>'))).toEqual({ size: 7 })
+    expect(parseMarker(ser('<c:marker><c:size val="big"/></c:marker>'))).toBeUndefined()
+    expect(parseMarker(ser("<c:marker><c:size/></c:marker>"))).toBeUndefined()
+  })
+
+  it("drops a symbol outside ST_MarkerStyle", () => {
+    expect(parseMarker(ser('<c:marker><c:symbol val="blob"/></c:marker>'))).toBeUndefined()
+    expect(parseMarker(ser("<c:marker><c:symbol/></c:marker>"))).toBeUndefined()
+  })
+
+  it("collapses an empty <c:marker/> to absence", () => {
+    expect(parseMarker(ser("<c:marker/>"))).toBeUndefined()
+    expect(parseMarker(ser(""))).toBeUndefined()
+  })
+
+  it("drops a marker fill / outline the writer cannot reproduce", () => {
+    const read = (spPr: string): unknown => parseMarker(ser(`<c:marker>${spPr}</c:marker>`))
+    // `<c:spPr>` with no fill and an `<a:ln>` with no fill of its own.
+    expect(read("<c:spPr><a:noFill/><a:ln><a:noFill/></a:ln></c:spPr>")).toBeUndefined()
+    // An `<a:srgbClr>` with no val, and one whose val is not 6 hex digits.
+    expect(read("<c:spPr><a:solidFill><a:srgbClr/></a:solidFill></c:spPr>")).toBeUndefined()
+    expect(
+      read('<c:spPr><a:solidFill><a:srgbClr val="12345"/></a:solidFill></c:spPr>'),
+    ).toBeUndefined()
+    expect(
+      read('<c:spPr><a:ln><a:solidFill><a:srgbClr val="nothex"/></a:solidFill></a:ln></c:spPr>'),
+    ).toBeUndefined()
+    expect(
+      read("<c:spPr><a:ln><a:solidFill><a:srgbClr/></a:solidFill></a:ln></c:spPr>"),
+    ).toBeUndefined()
+  })
+
+  it("reads the fill and outline off <c:spPr> and <c:spPr><a:ln>", () => {
+    expect(
+      parseMarker(
+        ser(
+          '<c:marker><c:spPr><a:solidFill><a:srgbClr val="#abcdef"/></a:solidFill>' +
+            '<a:ln><a:solidFill><a:srgbClr val="112233"/></a:solidFill></a:ln>' +
+            "</c:spPr></c:marker>",
+        ),
+      ),
+    ).toEqual({ fill: "ABCDEF", line: "112233" })
+    // A non-sRGB marker fill has no lossless writer form.
+    expect(
+      parseMarker(
+        ser(
+          '<c:marker><c:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></c:spPr></c:marker>',
+        ),
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe("parseSeriesName", () => {
+  it("falls back to the formula when <c:strCache> holds no usable value", () => {
+    expect(
+      parseSeriesName(ser("<c:tx><c:strRef><c:f>Sheet1!$B$1</c:f><c:strCache/></c:strRef></c:tx>")),
+    ).toBe("Sheet1!$B$1")
+    expect(
+      parseSeriesName(
+        ser(
+          "<c:tx><c:strRef><c:f>Sheet1!$B$1</c:f><c:strCache>" +
+            '<c:pt idx="0"><c:v>  </c:v></c:pt></c:strCache></c:strRef></c:tx>',
+        ),
+      ),
+    ).toBe("Sheet1!$B$1")
+  })
+
+  it("keeps scanning the cache past entries with no usable <c:v>", () => {
+    expect(
+      parseSeriesName(
+        ser(
+          "<c:tx><c:strRef><c:f>Sheet1!$B$1</c:f><c:strCache>" +
+            '<c:ptCount val="2"/><c:pt idx="0"/><c:pt idx="1"><c:v>Units</c:v></c:pt>' +
+            "</c:strCache></c:strRef></c:tx>",
+        ),
+      ),
+    ).toBe("Units")
+  })
+
+  it("prefers the cached literal over the formula", () => {
+    expect(
+      parseSeriesName(
+        ser(
+          "<c:tx><c:strRef><c:f>Sheet1!$B$1</c:f><c:strCache>" +
+            '<c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache></c:strRef></c:tx>',
+        ),
+      ),
+    ).toBe("Revenue")
+  })
+
+  it("returns undefined when <c:tx> holds nothing readable", () => {
+    expect(parseSeriesName(ser(""))).toBeUndefined()
+    expect(parseSeriesName(ser("<c:tx/>"))).toBeUndefined()
+    expect(parseSeriesName(ser("<c:tx><c:v>  </c:v></c:tx>"))).toBeUndefined()
+    expect(parseSeriesName(ser("<c:tx><c:strRef><c:f>  </c:f></c:strRef></c:tx>"))).toBeUndefined()
+  })
+})
+
+describe("buildSeriesSpPr", () => {
+  it("emits <a:schemeClr> for a theme-color reference rather than a hex triple", () => {
+    const xml = buildSeriesSpPr({ theme: "accent3", lumMod: 60000 }, undefined)
+    expect(xml).toContain('<a:schemeClr val="accent3">')
+    expect(xml).toContain('<a:lumMod val="60000"/>')
+  })
+
+  it("drops a malformed hex and an unrecognized theme name alike", () => {
+    expect(buildSeriesSpPr("nothex", undefined)).toBeUndefined()
+    expect(buildSeriesSpPr({ theme: "accent9" as never }, undefined)).toBeUndefined()
+  })
+
+  it("omits cap / cmpd when they carry the OOXML defaults", () => {
+    // `cap="flat"` and `cmpd="sng"` are the schema defaults, so emitting
+    // them would make absence and the default differ byte-for-byte.
+    const xml = buildSeriesSpPr(undefined, { width: 1, cap: "flat", compound: "sng" })
+    expect(xml).toContain('<a:ln w="12700"/>')
+    expect(xml).not.toContain("cap=")
+    expect(xml).not.toContain("cmpd=")
+  })
+
+  it("emits an attribute-only <a:ln> when a cap or compound stands alone", () => {
+    expect(buildSeriesSpPr(undefined, { cap: "sq" })).toContain('<a:ln cap="sq"/>')
+    expect(buildSeriesSpPr(undefined, { compound: "thickThin" })).toContain(
+      '<a:ln cmpd="thickThin"/>',
+    )
+  })
+
+  it("returns undefined when neither fill nor stroke carries anything", () => {
+    expect(buildSeriesSpPr(undefined, undefined)).toBeUndefined()
+    expect(buildSeriesSpPr(undefined, {})).toBeUndefined()
+  })
+})
+
+describe("buildSeries", () => {
+  const values = "Sheet1!$B$2:$B$5"
+
+  it("emits <c:shape> at the tail of a bar3D series", () => {
+    const xml = buildSeries({ values } as ChartSeries, 0, "Data", false, {
+      chartType: "bar",
+      shape3D: "pyramid",
+    })
+    expect(xml).toContain('<c:shape val="pyramid"/>')
+    // An unrecognized token elides the element entirely.
+    expect(
+      buildSeries({ values } as ChartSeries, 0, "Data", false, {
+        chartType: "bar",
+        shape3D: "sphere" as never,
+      }),
+    ).not.toContain("c:shape")
+  })
+
+  it("drops trendlines and error bars on the pie family, which has no slot", () => {
+    const extras = {
+      trendlines: [{ type: "linear" as const }],
+      errorBars: [{ direction: "y" as const, type: "both" as const, valType: "fixedVal" as const }],
+    }
+    const pie = buildSeries({ values } as ChartSeries, 0, "Data", false, {
+      chartType: "pie",
+      ...extras,
+    })
+    expect(pie).not.toContain("c:trendline")
+    expect(pie).not.toContain("c:errBars")
+    expect(
+      buildSeries({ values } as ChartSeries, 0, "Data", false, {
+        chartType: "doughnut",
+        ...extras,
+      }),
+    ).not.toContain("c:trendline")
+    const bar = buildSeries({ values } as ChartSeries, 0, "Data", false, {
+      chartType: "bar",
+      ...extras,
+    })
+    expect(bar).toContain("<c:trendline>")
+    expect(bar).toContain("<c:errBars>")
+  })
+
+  it("qualifies a bare <c:bubbleSize> range with the owning sheet", () => {
+    const xml = buildSeries({ values } as ChartSeries, 0, "My Data", false, {
+      chartType: "scatter",
+      bubbleSize: "D2:D5",
+    })
+    expect(xml).toContain("<c:bubbleSize><c:numRef><c:f>'My Data'!D2:D5</c:f>")
+    // An empty range is indistinguishable from absence.
+    expect(
+      buildSeries({ values } as ChartSeries, 0, "Data", false, {
+        chartType: "scatter",
+        bubbleSize: "",
+      }),
+    ).not.toContain("c:bubbleSize")
+  })
+})
+
+describe("mergeSeries", () => {
+  it("treats an explicit bubbleSize / shape3D override as replace-or-drop", () => {
+    const src = { valuesRef: "Sheet1!$B$2:$B$5", bubbleSizeRef: "Sheet1!$D$2:$D$5" } as never
+    // Absent key inherits the source reference.
+    expect(mergeSeries(src, undefined, 0).bubbleSize).toBe("Sheet1!$D$2:$D$5")
+    // Present-but-null drops it.
+    expect(mergeSeries(src, { bubbleSize: null } as never, 0).bubbleSize).toBeUndefined()
+    // Present-and-string replaces it.
+    expect(mergeSeries(src, { bubbleSize: "Sheet1!$E$2:$E$5" } as never, 0).bubbleSize).toBe(
+      "Sheet1!$E$2:$E$5",
+    )
+  })
+
+  it("applies the same grammar to shape3D", () => {
+    const src = { valuesRef: "Sheet1!$B$2:$B$5", shape3D: "cone" } as never
+    expect(mergeSeries(src, undefined, 0).shape3D).toBe("cone")
+    expect(mergeSeries(src, { shape3D: null } as never, 0).shape3D).toBeUndefined()
+    expect(mergeSeries(src, { shape3D: "box" } as never, 0).shape3D).toBe("box")
+  })
+
+  it("inherits the source's parsed per-point overrides", () => {
+    const src = {
+      valuesRef: "Sheet1!$B$2:$B$5",
+      dataPoints: [{ idx: 0, fillColor: "FF0000" }],
+    } as never
+    expect(mergeSeries(src, undefined, 0).dataPoints).toEqual([{ idx: 0, fillColor: "FF0000" }])
+  })
+
+  it("throws when neither the source nor the override supplies a values range", () => {
+    expect(() => mergeSeries(undefined, undefined, 2)).toThrow(/series #2 has no values reference/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// dataLabels — <c:dLbls> (CT_DLbls, §21.2.2.50)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("data-label typography readers", () => {
+  // Every reader walks `<c:txPr><a:p><a:pPr><a:defRPr>` and must bail on
+  // the first missing link rather than fabricate a value.
+  const readers: Array<[string, (e: XmlElement) => unknown]> = [
+    ["fontSize", parseDataLabelsFontSize],
+    ["fontColor", parseDataLabelsFontColor],
+    ["bold", parseDataLabelsBold],
+    ["italic", parseDataLabelsItalic],
+    ["underline", parseDataLabelsUnderline],
+    ["strikethrough", parseDataLabelsStrikethrough],
+    ["fontFamily", parseDataLabelsFontFamily],
+  ]
+
+  it("bails at every broken link of the <c:txPr><a:p><a:pPr><a:defRPr> chain", () => {
+    for (const [name, read] of readers) {
+      for (const depth of [0, 1, 2, 3] as const) {
+        expect(read(el("dLbls", txPrChain(depth))), `${name}@${depth}`).toBeUndefined()
+      }
+      expect(read(el("dLbls", "")), name).toBeUndefined()
+    }
+  })
+
+  it("reads the whole typography block off a single <a:defRPr>", () => {
+    const dLbls = el(
+      "dLbls",
+      '<c:txPr><a:p><a:pPr><a:defRPr sz="1050" b="1" i="1" u="sng" strike="sngStrike">' +
+        '<a:solidFill><a:srgbClr val="336699"/></a:solidFill>' +
+        '<a:latin typeface="  Consolas  "/></a:defRPr></a:pPr></a:p></c:txPr>',
+    )
+    expect(parseDataLabelsFontSize(dLbls)).toBe(10.5)
+    expect(parseDataLabelsFontColor(dLbls)).toBe("336699")
+    expect(parseDataLabelsBold(dLbls)).toBe(true)
+    expect(parseDataLabelsItalic(dLbls)).toBe(true)
+    expect(parseDataLabelsUnderline(dLbls)).toBe(true)
+    expect(parseDataLabelsStrikethrough(dLbls)).toBe(true)
+    expect(parseDataLabelsFontFamily(dLbls)).toBe("Consolas")
+  })
+
+  it("lifts an <a:schemeClr> font color when no literal sRGB is present", () => {
+    expect(
+      parseDataLabelsFontColor(
+        el(
+          "dLbls",
+          "<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>" +
+            '<a:schemeClr val="tx1"><a:alpha val="50000"/></a:schemeClr>' +
+            "</a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>",
+        ),
+      ),
+    ).toEqual({ theme: "tx1", alpha: 50000 })
+  })
+
+  it("drops an <a:latin> with no typeface attribute", () => {
+    expect(
+      parseDataLabelsFontFamily(
+        el("dLbls", "<c:txPr><a:p><a:pPr><a:defRPr><a:latin/></a:defRPr></a:pPr></a:p></c:txPr>"),
+      ),
+    ).toBeUndefined()
+  })
+
+  it("drops an <a:solidFill> that carries neither an sRGB nor a theme colour", () => {
+    expect(
+      parseDataLabelsFontColor(
+        el(
+          "dLbls",
+          "<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:hslClr/></a:solidFill>" +
+            "</a:defRPr></a:pPr></a:p></c:txPr>",
+        ),
+      ),
+    ).toBeUndefined()
+  })
+
+  it("drops an out-of-band or non-numeric sz", () => {
+    const size = (sz: string): number | undefined =>
+      parseDataLabelsFontSize(el("dLbls", txPrChain(3, ` sz="${sz}"`)))
+    expect(size("1200")).toBe(12)
+    // The band is 1..400 pt = 100..40000 in OOXML hundredths.
+    expect(size("50")).toBeUndefined()
+    expect(size("40100")).toBeUndefined()
+    expect(size("   ")).toBeUndefined()
+    expect(size("abc")).toBeUndefined()
+  })
+})
+
+describe("parseDataLabels", () => {
+  it("surfaces the <a:ln> cap and compound off the <c:spPr> block", () => {
+    const parsed = parseDataLabels(
+      el("dLbls", '<c:spPr><a:ln cap="rnd" cmpd="thickThin"/></c:spPr>'),
+    )
+    expect(parsed).toMatchObject({ borderCap: "rnd", borderCompound: "thickThin" })
+  })
+
+  it("drops an empty <c:separator> and a <c:numFmt> with no sourceLinked", () => {
+    const parsed = parseDataLabels(
+      el("dLbls", '<c:numFmt formatCode="0.0%"/><c:separator></c:separator>'),
+    )
+    expect(parsed).toEqual({ numberFormat: { formatCode: "0.0%" } })
+  })
+
+  it("collapses a block carrying nothing the writer models", () => {
+    // A `<c:dLbls>` with only the OOXML defaults has no visible effect,
+    // so it must not round-trip into a redundant write.
+    expect(
+      parseDataLabels(el("dLbls", '<c:spPr><a:ln cap="flat" cmpd="sng"/></c:spPr>')),
+    ).toBeUndefined()
+    expect(parseDataLabels(el("dLbls", ""))).toBeUndefined()
+  })
+})
+
+describe("buildDataLabelsBody", () => {
+  it("emits every show* toggle in CT_DLbls order, defaulting each to 0", () => {
+    const xml = buildDataLabelsBody({} as ChartDataLabels, "bar")
+    const order = [
+      "c:showLegendKey",
+      "c:showVal",
+      "c:showCatName",
+      "c:showSerName",
+      "c:showPercent",
+      "c:showBubbleSize",
+    ]
+    let cursor = -1
+    for (const tag of order) {
+      const at = xml.indexOf(tag)
+      expect(at, tag).toBeGreaterThan(cursor)
+      cursor = at
+    }
+    expect(xml).toContain('<c:showSerName val="0"/>')
+  })
+
+  it("flips <c:showSerName> only for a literal true", () => {
+    expect(buildDataLabelsBody({ showSeriesName: true } as ChartDataLabels, "bar")).toContain(
+      '<c:showSerName val="1"/>',
+    )
+    expect(buildDataLabelsBody({ showSeriesName: false } as ChartDataLabels, "bar")).toContain(
+      '<c:showSerName val="0"/>',
+    )
+  })
+
+  it("scopes <c:showLeaderLines> to the pie family and to an explicit false", () => {
+    // The OOXML default is `true` (Excel paints leader lines), so only
+    // an explicit `false` needs to reach the wire.
+    const off = { showLeaderLines: false } as ChartDataLabels
+    expect(buildDataLabelsBody(off, "pie")).toContain('<c:showLeaderLines val="0"/>')
+    expect(buildDataLabelsBody(off, "doughnut")).toContain('<c:showLeaderLines val="0"/>')
+    // Bar / column route through EG_DLblsShared, which has no slot for it.
+    expect(buildDataLabelsBody(off, "bar")).not.toContain("c:showLeaderLines")
+    expect(buildDataLabelsBody({ showLeaderLines: true } as ChartDataLabels, "pie")).not.toContain(
+      "c:showLeaderLines",
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// dataTable — <c:dTable> (CT_DTable, §21.2.2.54)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("data-table typography readers", () => {
+  const readers: Array<[string, (e: XmlElement) => unknown]> = [
+    ["bold", parseDataTableBold],
+    ["italic", parseDataTableItalic],
+    ["underline", parseDataTableUnderline],
+    ["strikethrough", parseDataTableStrikethrough],
+    ["fontFamily", parseDataTableFontFamily],
+    ["fontColor", parseDataTableFontColor],
+    ["fontSize", parseDataTableFontSize],
+  ]
+
+  it("bails at every broken link of the <c:txPr><a:p><a:pPr><a:defRPr> chain", () => {
+    for (const [name, read] of readers) {
+      for (const depth of [0, 1, 2, 3] as const) {
+        expect(read(el("dTable", txPrChain(depth))), `${name}@${depth}`).toBeUndefined()
+      }
+    }
+  })
+
+  it('round-trips an explicit b="0" / i="0" rather than collapsing it', () => {
+    // Unlike the title / legend readers, the data-table readers surface
+    // the literal `false` so a clone target can override an upstream
+    // `b="1"` without the flag silently reverting to inherit.
+    const dTable = el("dTable", txPrChain(3, ' b="0" i="false"'))
+    expect(parseDataTableBold(dTable)).toBe(false)
+    expect(parseDataTableItalic(dTable)).toBe(false)
+    expect(parseDataTableBold(el("dTable", txPrChain(3, ' b="yes"')))).toBeUndefined()
+  })
+
+  it("drops a data-table <a:solidFill> with neither an sRGB nor a theme colour", () => {
+    expect(
+      parseDataTableFontColor(
+        el(
+          "dTable",
+          "<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill><a:prstClr/></a:solidFill>" +
+            "</a:defRPr></a:pPr></a:p></c:txPr>",
+        ),
+      ),
+    ).toBeUndefined()
+    // A blank `sz` is indistinguishable from absence.
+    expect(parseDataTableFontSize(el("dTable", txPrChain(3, ' sz="   "')))).toBeUndefined()
+  })
+
+  it("lifts an <a:schemeClr> font color when no literal sRGB is present", () => {
+    expect(
+      parseDataTableFontColor(
+        el(
+          "dTable",
+          "<c:txPr><a:p><a:pPr><a:defRPr><a:solidFill>" +
+            '<a:schemeClr val="dk2"/></a:solidFill></a:defRPr></a:pPr></a:p></c:txPr>',
+        ),
+      ),
+    ).toEqual({ theme: "dk2" })
+  })
+})
+
+describe("parseDataTableFlag", () => {
+  it("accepts both OOXML boolean spellings and drops everything else", () => {
+    const dTable = el(
+      "dTable",
+      '<c:showHorzBorder val="1"/><c:showVertBorder val="false"/>' +
+        '<c:showOutline val="maybe"/><c:showKeys/>',
+    )
+    expect(parseDataTableFlag(dTable, "showHorzBorder")).toBe(true)
+    expect(parseDataTableFlag(dTable, "showVertBorder")).toBe(false)
+    expect(parseDataTableFlag(dTable, "showOutline")).toBeUndefined()
+    expect(parseDataTableFlag(dTable, "showKeys")).toBeUndefined()
+    // A missing element is absence, not a fabricated default.
+    expect(parseDataTableFlag(dTable, "showLegendKey")).toBeUndefined()
+  })
+})
+
+describe("parseDataTable", () => {
+  it("surfaces the <a:ln> cap and compound off the <c:spPr> block", () => {
+    const parsed = parseDataTable(
+      el("plotArea", '<c:dTable><c:spPr><a:ln cap="sq" cmpd="dbl"/></c:spPr></c:dTable>'),
+    )
+    expect(parsed).toMatchObject({ borderCap: "sq", borderCompound: "dbl" })
+  })
+
+  it("returns undefined when the plot area declares no <c:dTable>", () => {
+    expect(parseDataTable(el("plotArea", ""))).toBeUndefined()
+  })
+})

--- a/test/coverage-core-model.test.ts
+++ b/test/coverage-core-model.test.ts
@@ -1,0 +1,478 @@
+import { describe, expect, it } from "vitest"
+import type { Cell, CellValue, SchemaFieldType, Sheet, SheetTextBox, Workbook } from "../src/_types"
+import { audit } from "../src/a11y"
+import { selectSheet } from "../src/_objects"
+import { validateWithSchema } from "../src/_schema"
+import { WorkbookBuilder } from "../src/builder"
+import { letterToCol } from "../src/cell-utils"
+import { read, writeObjects } from "../src/defter"
+import { ParseError, UnsupportedFormatError, ValidationError } from "../src/errors"
+import { imageFromBase64 } from "../src/image"
+import { sheetToArrays } from "../src/sheet-utils"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function sheet(overrides: Partial<Sheet> = {}): Sheet {
+  return { name: "Sheet1", rows: [], ...overrides }
+}
+
+function workbook(...sheets: Sheet[]): Workbook {
+  return { sheets, properties: { title: "T", description: "D" } }
+}
+
+/** A styled cell override, the shape the contrast audit walks. */
+function styled(value: CellValue, fontRgb?: string, fillRgb?: string): Cell {
+  return {
+    value,
+    type: typeof value === "number" ? "number" : "string",
+    style: {
+      font: fontRgb ? { color: { rgb: fontRgb } } : {},
+      fill: { type: "pattern", pattern: "solid", fgColor: fillRgb ? { rgb: fillRgb } : undefined },
+    },
+  }
+}
+
+const decoder = new TextDecoder("utf-8")
+
+async function extractXml(data: Uint8Array, path: string): Promise<string> {
+  return decoder.decode(await new ZipReader(data).extract(path))
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// _schema — errorMode: "throw"
+// ═══════════════════════════════════════════════════════════════════════
+
+// Every validation stage collects into `errors` by default and throws a
+// `ValidationError` carrying that one issue under `errorMode: "throw"`.
+// Only the required-field stage had a test for the throwing path.
+describe('validateWithSchema — errorMode "throw"', () => {
+  const rows: CellValue[][] = [["value"], ["x"]]
+
+  function expectThrow(field: Parameters<typeof validateWithSchema>[1]["f"], message: RegExp) {
+    let caught: unknown
+    try {
+      validateWithSchema(rows, { f: { column: "value", ...field } }, { errorMode: "throw" })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(ValidationError)
+    expect((caught as ValidationError).message).toMatch(message)
+    expect((caught as ValidationError).errors).toHaveLength(1)
+  }
+
+  it("throws on a type coercion failure", () => {
+    expectThrow({ type: "number" }, /Expected number/)
+  })
+
+  it("throws on a pattern mismatch", () => {
+    expectThrow({ type: "string", pattern: /^\d+$/ }, /does not match pattern/)
+  })
+
+  it("throws on a min/max violation", () => {
+    expectThrow({ type: "string", min: 5 }, /below minimum 5/)
+  })
+
+  it("throws on a value outside the enum", () => {
+    expectThrow({ type: "string", enum: ["a", "b"] }, /must be one of: a, b/)
+  })
+
+  it("throws on a custom validate() rejection", () => {
+    expectThrow({ validate: () => "nope" }, /nope/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// _schema — coercion edge cases
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("validateWithSchema — coercion edges", () => {
+  // A cell holding only a thousands separator is non-empty (so the
+  // required/empty check lets it through) but strips to nothing.
+  it("rejects a value that is nothing but thousands separators", () => {
+    const num = validateWithSchema([["n"], [","]], { n: { type: "number" } })
+    expect(num.errors[0]!.message).toBe("Expected number for 'n', got ''")
+    expect(num.data[0]!.n).toBeNull()
+
+    const int = validateWithSchema([["n"], [",,"]], { n: { type: "integer" } })
+    expect(int.errors[0]!.message).toBe("Expected integer for 'n', got ''")
+  })
+
+  // A completely empty row (`[]`, which is what a trailing `\n` or a blank
+  // `<row/>` yields) counts as empty for `skipEmptyRows`.
+  it("skips zero-length rows when skipEmptyRows is set", () => {
+    const rows: CellValue[][] = [["n"], [1], [], [2]]
+    const kept = validateWithSchema(rows, { n: { type: "number" } }, { skipEmptyRows: true })
+    expect(kept.data.map((d) => d.n)).toEqual([1, 2])
+
+    const all = validateWithSchema(rows, { n: { type: "number" } })
+    expect(all.data.map((d) => d.n)).toEqual([1, null, 2])
+  })
+
+  // JS callers are not held to the `SchemaFieldType` union; an unrecognised
+  // type name passes the raw cell value through instead of throwing.
+  it("passes the value through for an unrecognised field type", () => {
+    const result = validateWithSchema([["v"], ["kept"]], {
+      v: { type: "uuid" as SchemaFieldType },
+    })
+    expect(result.errors).toEqual([])
+    expect(result.data[0]!.v).toBe("kept")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// _objects — selectSheet
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("selectSheet", () => {
+  it("reports an empty workbook before blaming the selector", () => {
+    expect(() => selectSheet({ sheets: [] }, 0)).toThrow(ParseError)
+    expect(() => selectSheet({ sheets: [] }, "Data")).toThrow(/no sheets/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// a11y.audit
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("a11y.audit — sheet emptiness", () => {
+  // A sheet can carry all of its content in the per-cell override Map with
+  // an empty `rows` array (that is what the streaming writers accept), and
+  // it is not an empty sheet.
+  it("does not call a sheet empty when its content lives in the cells Map", () => {
+    const wb = workbook(
+      sheet({ rows: [], cells: new Map([["0,0", { value: "Header", type: "string" } as Cell]]) }),
+    )
+
+    const codes = audit(wb, { skipContrast: true }).map((i) => i.code)
+
+    expect(codes).not.toContain("empty-sheet")
+    expect(codes).toContain("no-header-row")
+  })
+
+  it("does not report blank rows when every row is blank", () => {
+    const wb = workbook(
+      sheet({
+        rows: [
+          [null, null],
+          ["", ""],
+        ],
+        cells: new Map([["0,0", { value: "x", type: "string" } as Cell]]),
+        a11y: { headerRow: 0 },
+      }),
+    )
+
+    expect(audit(wb, { skipContrast: true }).filter((i) => i.code === "blank-row-in-data")).toEqual(
+      [],
+    )
+  })
+
+  // `rows[5] = [...]` on a fresh array leaves holes; a hole is a blank row,
+  // not a crash.
+  it("treats a hole in the rows array as a blank row", () => {
+    const rows: CellValue[][] = []
+    rows[0] = ["a"]
+    rows[2] = ["b"]
+    const wb = workbook(sheet({ rows, a11y: { headerRow: 0 } }))
+
+    const issue = audit(wb, { skipContrast: true }).find((i) => i.code === "blank-row-in-data")
+
+    expect(issue?.location?.ref).toBe("2:2")
+  })
+})
+
+describe("a11y.audit — text boxes", () => {
+  const anchor = { from: { row: 1, col: 1 } }
+
+  it("warns about a text box with no alt text", () => {
+    const textBoxes: SheetTextBox[] = [
+      { text: "Q3 target", anchor },
+      { text: "blank alt", anchor, altText: "   " },
+    ]
+    const wb = workbook(sheet({ rows: [["a"]], a11y: { headerRow: 0 }, textBoxes }))
+
+    const issues = audit(wb, { skipContrast: true }).filter((i) => i.code === "missing-alt-text")
+
+    expect(issues).toHaveLength(2)
+    // A text box is advisory (warning); a missing image alt text is an error.
+    expect(issues[0]!.type).toBe("warning")
+    expect(issues[0]!.location).toEqual({ sheet: "Sheet1", ref: "B2", textBox: 0 })
+    expect(issues[1]!.location?.textBox).toBe(1)
+  })
+
+  it("stays quiet when every text box has alt text", () => {
+    const textBoxes: SheetTextBox[] = [{ text: "Q3 target", anchor, altText: "Q3 target callout" }]
+    const wb = workbook(sheet({ rows: [["a"]], a11y: { headerRow: 0 }, textBoxes }))
+
+    expect(audit(wb, { skipContrast: true }).filter((i) => i.code === "missing-alt-text")).toEqual(
+      [],
+    )
+  })
+})
+
+describe("a11y.audit — contrast sampling", () => {
+  function lowContrastSheet(count: number): Sheet {
+    const cells = new Map<string, Cell>()
+    for (let i = 0; i < count; i++) cells.set(`${i},0`, styled("text", "FFCCCCCC", "FFFFFFFF"))
+    return sheet({ rows: [["text"]], a11y: { headerRow: 0 }, cells })
+  }
+
+  it("stops inspecting once contrastSampleLimit cells have been walked", () => {
+    const wb = workbook(lowContrastSheet(5))
+
+    const limited = audit(wb, { contrastSampleLimit: 2 }).filter((i) => i.code === "low-contrast")
+    const full = audit(wb).filter((i) => i.code === "low-contrast")
+
+    expect(limited).toHaveLength(2)
+    expect(full).toHaveLength(5)
+  })
+
+  it("ignores cells with no user-visible text", () => {
+    const cells = new Map<string, Cell>([
+      ["0,0", styled("", "FFCCCCCC", "FFFFFFFF")],
+      ["1,0", styled(null, "FFCCCCCC", "FFFFFFFF")],
+    ])
+    const wb = workbook(sheet({ rows: [[""]], a11y: { headerRow: 0 }, cells }))
+
+    expect(audit(wb).filter((i) => i.code === "low-contrast")).toEqual([])
+  })
+
+  // Gradient fills have no single background colour to measure against, and
+  // an unfilled cell inherits the (unknown) theme background.
+  it("skips cells without a resolvable pattern background", () => {
+    const cells = new Map<string, Cell>([
+      ["0,0", { value: "x", type: "string", style: { font: { color: { rgb: "FFCCCCCC" } } } }],
+      [
+        "1,0",
+        {
+          value: "y",
+          type: "string",
+          style: {
+            font: { color: { rgb: "FFCCCCCC" } },
+            fill: { type: "gradient", stops: [{ position: 0, color: { rgb: "FFFFFFFF" } }] },
+          },
+        },
+      ],
+    ])
+    const wb = workbook(sheet({ rows: [["x"]], a11y: { headerRow: 0 }, cells }))
+
+    expect(audit(wb).filter((i) => i.code === "low-contrast")).toEqual([])
+  })
+
+  // Theme-driven fonts have no `rgb`, and indexed/named colours are not
+  // hex — neither can be measured, so the check backs off silently.
+  it("skips cells whose font or fill colour cannot be resolved to a hex triple", () => {
+    const cells = new Map<string, Cell>([
+      ["0,0", styled("no font colour", undefined, "FFFFFFFF")],
+      ["1,0", styled("no fill colour", "FFCCCCCC", undefined)],
+      ["2,0", styled("not hex", "theme:accent1", "FFFFFFFF")],
+    ])
+    const wb = workbook(sheet({ rows: [["x"]], a11y: { headerRow: 0 }, cells }))
+
+    expect(audit(wb).filter((i) => i.code === "low-contrast")).toEqual([])
+  })
+
+  // ODS and hand-authored XLSX write plain 6-digit RRGGBB where Excel
+  // writes 8-digit AARRGGBB; both have to measure the same.
+  it("accepts 6-digit RRGGBB as well as 8-digit AARRGGBB", () => {
+    const cells = new Map<string, Cell>([["0,0", styled("text", "CCCCCC", "FFFFFF")]])
+    const wb = workbook(sheet({ rows: [["text"]], a11y: { headerRow: 0 }, cells }))
+
+    const issue = audit(wb).find((i) => i.code === "low-contrast")
+
+    expect(issue?.location?.ref).toBe("A1")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// defter — format detection
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("read() — malformed ZIP envelopes", () => {
+  it("rejects a file that is only a ZIP signature", async () => {
+    const data = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0, 0, 0, 0])
+
+    await expect(read(data)).rejects.toThrow(UnsupportedFormatError)
+    await expect(read(data)).rejects.toThrow(/ZIP too short/)
+  })
+
+  it("rejects a local file header whose name runs past the end of the file", async () => {
+    const data = new Uint8Array(34)
+    data.set([0x50, 0x4b, 0x03, 0x04], 0)
+    data[26] = 200 // filename length far beyond the 34 bytes we have
+    data[27] = 0
+
+    await expect(read(data)).rejects.toThrow(/ZIP truncated/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// defter — writeObjects
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("writeObjects()", () => {
+  // Columns come from the first object's keys; later objects that are
+  // missing one of them get a blank rather than an `undefined` cell.
+  it("writes a blank for keys absent from a later object", async () => {
+    const output = await writeObjects([
+      { Name: "Alice", Age: 30 },
+      { Name: "Bob" } as Record<string, CellValue>,
+    ])
+
+    const rows = (await readXlsx(output)).sheets[0]!.rows
+    expect(rows[2]).toEqual(["Bob", null])
+  })
+
+  it("wraps the rows in a native table sized to the data", async () => {
+    const output = await writeObjects(
+      [
+        { Region: "EMEA", Revenue: 10 },
+        { Region: "APAC", Revenue: 20 },
+      ],
+      { table: { name: "Sales", style: "TableStyleMedium2", showRowStripes: false } },
+    )
+
+    const table = (await readXlsx(output)).sheets[0]!.tables![0]!
+    // 2 data rows + header, two columns → A1:B3.
+    expect(table.range).toBe("A1:B3")
+    expect(table.columns.map((c) => c.name)).toEqual(["Region", "Revenue"])
+    expect(table.columns.every((c) => c.totalFunction === undefined)).toBe(true)
+  })
+
+  // A totals row occupies one extra row beyond the data, and only the
+  // columns named in `totals` get a function.
+  it("extends the table range by one row and tags columns when totals are requested", async () => {
+    const output = await writeObjects(
+      [
+        { Region: "EMEA", Revenue: 10 },
+        { Region: "APAC", Revenue: 20 },
+      ],
+      {
+        table: {
+          name: "Sales",
+          showTotalRow: true,
+          showAutoFilter: false,
+          totals: { Revenue: "sum" },
+        },
+      },
+    )
+
+    const xml = await extractXml(output, "xl/tables/table1.xml")
+    expect(xml).toContain('ref="A1:B4"')
+    expect(xml).toContain('totalsRowCount="1"')
+    expect(xml).toContain('totalsRowFunction="sum"')
+  })
+
+  // `colToLetterSimple` has to roll over past Z for wide object shapes.
+  it("computes the table range past column Z", async () => {
+    const wide: Record<string, CellValue> = {}
+    for (let i = 0; i < 28; i++) wide[`c${i}`] = i
+    const output = await writeObjects([wide], { table: { name: "Wide" } })
+
+    expect((await readXlsx(output)).sheets[0]!.tables![0]!.range).toBe("A1:AB2")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// builder
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("WorkbookBuilder", () => {
+  // The override Map is created lazily on the first cell() call; the
+  // second call has to reuse it rather than replace it.
+  it("accumulates repeated cell() overrides into one map", async () => {
+    const data = await WorkbookBuilder.create()
+      .addSheet("Sales")
+      .row(["Widget", 100])
+      .cell(0, 0, { style: { font: { bold: true } } })
+      .cell(0, 1, { formula: "1+1" })
+      .build()
+
+    const sheetXml = await extractXml(data, "xl/worksheets/sheet1.xml")
+    const styles = await extractXml(data, "xl/styles.xml")
+
+    expect(sheetXml).toContain("<f>1+1</f>")
+    expect(styles).toContain("<b/>")
+    // A1 carries a non-default style index, so both overrides survived.
+    expect(sheetXml).toMatch(/<c r="A1"[^>]*\ss="[1-9]/)
+  })
+
+  // `hidden()` / `veryHidden()` default to true so the common call is
+  // argument-free; passing false is the explicit un-hide.
+  it("defaults hidden() and veryHidden() to true", async () => {
+    const data = await WorkbookBuilder.create()
+      .addSheet("Visible")
+      .row(["a"])
+      .done()
+      .addSheet("Hidden")
+      .row(["b"])
+      .hidden()
+      .done()
+      .addSheet("Gone")
+      .row(["c"])
+      .veryHidden()
+      .build()
+
+    const xml = await extractXml(data, "xl/workbook.xml")
+    expect(xml).toContain('state="hidden"')
+    expect(xml).toContain('state="veryHidden"')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// cell-utils / sheet-utils / image
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("letterToCol", () => {
+  // The inverse of `colToLetter` only consumes the letter prefix, so an
+  // A1-style reference resolves to its column and stops at the digits.
+  it("stops at the first non-letter character", () => {
+    expect(letterToCol("A1")).toBe(0)
+    expect(letterToCol("AB12")).toBe(27)
+    expect(letterToCol("A:A")).toBe(0)
+  })
+
+  it("returns -1 for an empty string", () => {
+    expect(letterToCol("")).toBe(-1)
+  })
+})
+
+describe("sheetToArrays", () => {
+  // Header cells are stringified and trimmed; a blank leading column reads
+  // back as "" rather than "null".
+  it("renders blank header cells as empty strings", () => {
+    const result = sheetToArrays(
+      sheet({
+        rows: [
+          [null, "  Name  ", 2025],
+          [1, "Alice", 30],
+        ],
+      }),
+    )
+
+    expect(result.headers).toEqual(["", "Name", "2025"])
+    expect(result.data).toEqual([[1, "Alice", 30]])
+  })
+})
+
+describe("imageFromBase64", () => {
+  const anchor = { from: { row: 0, col: 0 } }
+  // 1×1 transparent GIF — the smallest real image that survives a writer.
+  const gif = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+
+  it("accepts a bare base64 payload", () => {
+    const image = imageFromBase64(gif, "gif", anchor)
+
+    expect(image.type).toBe("gif")
+    expect(image.data[0]).toBe(0x47) // "G" of GIF89a
+    expect(image.data).toHaveLength(42)
+  })
+
+  it("strips a data URI prefix before decoding", () => {
+    const bare = imageFromBase64(gif, "gif", anchor)
+    const uri = imageFromBase64(`data:image/gif;base64,${gif}`, "gif", anchor)
+
+    expect(uri.data).toEqual(bare.data)
+  })
+})

--- a/test/coverage-json-branches.test.ts
+++ b/test/coverage-json-branches.test.ts
@@ -1,0 +1,521 @@
+import { describe, expect, it } from "vitest"
+import { collectHeaders, flattenValue } from "../src/json/flatten"
+import { parseJson, parseNdjson, parseValue } from "../src/json/reader"
+import { workbookToJson, writeJson, writeNdjson } from "../src/json/writer"
+import { streamNdjsonRows } from "../src/json/stream"
+import { toJson } from "../src/export/json"
+import { toHtml } from "../src/export/html"
+import type { Cell, CellValue, Sheet, Workbook } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const enc = new TextEncoder()
+
+/** A one-chunk-per-string ReadableStream, so chunk boundaries are explicit. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(enc.encode(chunk))
+      controller.close()
+    },
+  })
+}
+
+async function drain<T>(iter: AsyncGenerator<T, void, undefined>): Promise<T[]> {
+  const out: T[] = []
+  for await (const row of iter) out.push(row)
+  return out
+}
+
+function sheet(rows: CellValue[][], extra?: Partial<Sheet>): Sheet {
+  return { name: "Sheet1", rows, ...extra }
+}
+
+/** A sheet whose cells carry styles, for the HTML exporter. */
+function styledSheet(rows: CellValue[][], styles: Record<string, Partial<Cell>>): Sheet {
+  const cells = new Map<string, Cell>()
+  for (const [key, cell] of Object.entries(styles)) {
+    cells.set(key, cell as Cell)
+  }
+  return { name: "Sheet1", rows, cells }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// json/flatten — the documented flattening rules
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("flattenValue — scalars and absent values", () => {
+  it("drops a top-level null instead of inventing a column for it", async () => {
+    // There is no key to hang the value on, so the row is empty rather than
+    // carrying a "" column.
+    expect({ ...flattenValue(null) }).toEqual({})
+    expect({ ...flattenValue(undefined) }).toEqual({})
+  })
+
+  it("keeps a null property as a null cell", () => {
+    expect({ ...flattenValue({ name: "Ada", nickname: null }) }).toEqual({
+      name: "Ada",
+      nickname: null,
+    })
+  })
+
+  it("normalizes undefined properties to null", () => {
+    // JSON.parse never produces undefined, but `parseValue` accepts objects
+    // built in JS, where a missing-but-present key is common.
+    expect({ ...flattenValue({ a: undefined }) }).toEqual({ a: null })
+  })
+
+  it("preserves a Date rather than stringifying it", () => {
+    const d = new Date("2024-03-01T00:00:00Z")
+    expect(flattenValue({ when: d }).when).toBe(d)
+  })
+
+  it("stringifies values JSON cannot carry", () => {
+    // bigint and functions reach the writer from hand-built JS objects.
+    const out = flattenValue({ big: 10n as unknown as CellValue })
+    expect(out.big).toBe("10")
+  })
+})
+
+describe("flattenValue — arrays", () => {
+  it("renders an empty array as an empty cell", () => {
+    expect(flattenValue({ tags: [] }).tags).toBe("")
+  })
+
+  it("joins an all-primitive array with arrayJoin", () => {
+    const out = flattenValue({ tags: ["a", 1, true, null] })
+    expect(out.tags).toBe("a, 1, true, ")
+  })
+
+  it("honours a custom arrayJoin", () => {
+    expect(flattenValue({ tags: [1, 2, 3] }, { arrayJoin: " | " }).tags).toBe("1 | 2 | 3")
+  })
+
+  it("falls back to JSON for an array of objects", () => {
+    // A tabular row has no room for a nested table, so the array is kept
+    // verbatim rather than being lossily flattened.
+    const out = flattenValue({ items: [{ id: 1 }, { id: 2 }] })
+    expect(out.items).toBe(`[{"id":1},{"id":2}]`)
+  })
+
+  it("falls back to JSON for a mixed array", () => {
+    expect(flattenValue({ mixed: [1, { a: 2 }] }).mixed).toBe(`[1,{"a":2}]`)
+  })
+})
+
+describe("flattenValue — nested objects", () => {
+  it("joins nested keys with dots", () => {
+    const out = flattenValue({ user: { name: "Ada", address: { city: "London" } } })
+    expect({ ...out }).toEqual({ "user.name": "Ada", "user.address.city": "London" })
+  })
+
+  it("renders an empty nested object as an empty cell", () => {
+    expect(flattenValue({ meta: {} }).meta).toBe("")
+  })
+
+  it("produces no columns at all for an empty top-level object", () => {
+    expect({ ...flattenValue({}) }).toEqual({})
+  })
+
+  it("serializes nested objects as JSON when flatten is off", () => {
+    const out = flattenValue({ id: 1, user: { name: "Ada" } }, { flatten: false })
+    expect({ ...out }).toEqual({ id: 1, user: `{"name":"Ada"}` })
+  })
+
+  it("stops descending at maxDepth and keeps the remainder as JSON", () => {
+    // Guards against a deeply nested (or cyclic-looking) document producing
+    // thousands of columns.
+    const value = { a: { b: { c: { d: 1 } } } }
+    expect({ ...flattenValue(value, { maxDepth: 2 }) }).toEqual({ "a.b": `{"c":{"d":1}}` })
+  })
+
+  it("does not prefix a dot when the outer key is the empty string", () => {
+    // `{"": {...}}` is legal JSON and appears in API payloads keyed by a
+    // possibly-blank identifier.
+    expect({ ...flattenValue({ "": { a: 1 } }) }).toEqual({ a: 1 })
+  })
+
+  it("stores __proto__ as an ordinary column", () => {
+    // The output object has a null prototype precisely so this key cannot
+    // hit the prototype setter and vanish.
+    const out = flattenValue(JSON.parse(`{"__proto__": 1, "id": 2}`))
+    expect(Object.keys(out)).toEqual(["__proto__", "id"])
+    expect(out["__proto__"]).toBe(1)
+  })
+})
+
+describe("collectHeaders", () => {
+  it("unions keys across rows in first-seen order", () => {
+    const headers = collectHeaders([
+      { b: 1, a: 2 },
+      { c: 3, a: 4 },
+    ])
+    expect(headers).toEqual(["b", "a", "c"])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// json/reader
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseJson — row extraction", () => {
+  it("treats an empty rowsAt path as 'the whole document'", () => {
+    const result = parseJson(`[{"a":1}]`, { rowsAt: "" })
+    expect(result.data).toEqual([{ a: 1 }])
+  })
+
+  it("wraps a single object found at rowsAt as one row", () => {
+    const result = parseJson(`{"result":{"id":7,"name":"x"}}`, { rowsAt: "result" })
+    expect(result.data).toEqual([{ id: 7, name: "x" }])
+  })
+
+  it("rejects a rowsAt path that resolves to a primitive", () => {
+    expect(() => parseJson(`{"count":3}`, { rowsAt: "count" })).toThrow(/not an object or array/)
+  })
+
+  it("rejects a rowsAt path that resolves to nothing", () => {
+    expect(() => parseJson(`{"a":1}`, { rowsAt: "missing.deep" })).toThrow(/No data found/)
+  })
+
+  it("turns a null array element into an empty row", () => {
+    // A sparse API response (`[{...}, null, {...}]`) must not shift the rows
+    // that follow it.
+    const result = parseJson(`[{"a":1},null,{"a":3}]`)
+    expect(result.data).toEqual([{ a: 1 }, { a: null }, { a: 3 }])
+  })
+
+  it("wraps primitive and array elements in a 'value' column", () => {
+    const result = parseJson(`[1,"two",[3,4]]`)
+    expect(result.headers).toEqual(["value"])
+    expect(result.data).toEqual([{ value: 1 }, { value: "two" }, { value: "3, 4" }])
+  })
+
+  it("returns nothing for whitespace-only input", () => {
+    expect(parseJson("   \n  ")).toEqual({ data: [], headers: [] })
+  })
+
+  it("accepts UTF-8 bytes as well as a string", () => {
+    expect(parseJson(enc.encode(`[{"a":1}]`)).data).toEqual([{ a: 1 }])
+  })
+
+  it("rejects a top-level null", () => {
+    expect(() => parseValue(null)).toThrow(/must be an object or an array of objects/)
+  })
+
+  it("rejects a top-level primitive", () => {
+    expect(() => parseValue(42)).toThrow(/must be an object or an array of objects/)
+  })
+})
+
+describe("parseNdjson", () => {
+  it("returns nothing for whitespace-only input", () => {
+    expect(parseNdjson("\n \n")).toEqual({ data: [], headers: [] })
+  })
+
+  it("hands malformed lines to onError and keeps going", () => {
+    const seen: Array<[string, number]> = []
+    const result = parseNdjson(`{"a":1}\nnot json\n{"a":3}\n`, {
+      onError: (line, lineNumber) => seen.push([line, lineNumber]),
+    })
+    expect(seen).toEqual([["not json", 2]])
+    expect(result.data).toEqual([{ a: 1 }, { a: 3 }])
+  })
+
+  it("throws with the offending line number when no onError is given", () => {
+    expect(() => parseNdjson(`{"a":1}\noops\n`)).toThrow(/line 2/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// json/stream
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("streamNdjsonRows", () => {
+  it("skips blank lines between records", () => {
+    // Producers that flush per-record often emit a stray newline.
+    return drain(streamNdjsonRows(streamOf(`{"a":1}\n`, `\n`, `  \n`, `{"a":2}\n`))).then(
+      (rows) => {
+        expect(rows).toEqual([{ a: 1 }, { a: 2 }])
+      },
+    )
+  })
+
+  it("flattens a trailing record that has no terminating newline", async () => {
+    // The last line of a file frequently lacks its "\n"; it must take the
+    // same flattening path as every other line.
+    const rows = await drain(
+      streamNdjsonRows(
+        streamOf(`{"id":1,"user":{"name":"Ada"}}\n`, `{"id":2,"user":{"name":"G"}}`),
+        {
+          flattenRows: true,
+        },
+      ),
+    )
+    expect(rows.map((r) => ({ ...r }))).toEqual([
+      { id: 1, "user.name": "Ada" },
+      { id: 2, "user.name": "G" },
+    ])
+  })
+
+  it("yields a trailing array record untouched even with flattenRows on", async () => {
+    // Flattening only applies to objects; an array line is passed through.
+    const rows = await drain(streamNdjsonRows(streamOf(`[1,2]`), { flattenRows: true }))
+    expect(rows).toEqual([[1, 2]])
+  })
+
+  it("reports a malformed trailing line through onError", async () => {
+    const seen: number[] = []
+    const rows = await drain(
+      streamNdjsonRows(streamOf(`{"a":1}\n`, `{oops`), {
+        onError: (_line, lineNumber) => seen.push(lineNumber),
+      }),
+    )
+    expect(seen).toEqual([2])
+    expect(rows).toEqual([{ a: 1 }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// json/writer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("writeJson / writeNdjson", () => {
+  it("pretty-prints with a custom indent", () => {
+    expect(writeJson([{ a: 1 }], { pretty: true, indent: "\t" })).toBe('[\n\t{\n\t\t"a": 1\n\t}\n]')
+  })
+
+  it("emits nothing at all for an empty NDJSON set", () => {
+    // Not "\n" — an empty file is a valid empty NDJSON document.
+    expect(writeNdjson([])).toBe("")
+  })
+})
+
+describe("workbookToJson", () => {
+  const wb: Workbook = {
+    sheets: [
+      {
+        name: "First",
+        rows: [
+          ["a", "b"],
+          [1, 2],
+        ],
+      },
+      { name: "Second", rows: [["x"], [9]] },
+    ],
+  }
+
+  it("selects a sheet by name", () => {
+    expect(JSON.parse(workbookToJson(wb, { sheet: "Second" }))).toEqual([{ x: 9 }])
+  })
+
+  it("selects a sheet by index", () => {
+    expect(JSON.parse(workbookToJson(wb, { sheet: 1 }))).toEqual([{ x: 9 }])
+  })
+
+  it("names the missing sheet in the error", () => {
+    expect(() => workbookToJson(wb, { sheet: "Nope" })).toThrow(`Sheet "Nope" not found`)
+    expect(() => workbookToJson(wb, { sheet: 5 })).toThrow("Sheet index 5 out of range")
+  })
+
+  it("keys multi-sheet output by sheet name, and pretty-prints it on request", () => {
+    const out = workbookToJson(wb, { pretty: true })
+    expect(out).toContain('"First"')
+    expect(out).toContain("\n  ")
+    expect(JSON.parse(out)).toEqual({ First: [{ a: 1, b: 2 }], Second: [{ x: 9 }] })
+  })
+
+  it("returns an empty array when the header row is past the end of the sheet", () => {
+    const single: Workbook = { sheets: [{ name: "One", rows: [["a"], [1]] }] }
+    expect(workbookToJson(single, { headerRow: 5 })).toBe("[]")
+  })
+
+  it("uses an empty key for a blank header cell and pads short rows with null", () => {
+    const single: Workbook = {
+      sheets: [{ name: "One", rows: [["a", null, " c "], [1]] }],
+    }
+    expect(JSON.parse(workbookToJson(single))).toEqual([{ a: 1, "": null, c: null }])
+  })
+
+  it("normalizes an in-row null to null rather than dropping the key", () => {
+    const single: Workbook = {
+      sheets: [
+        {
+          name: "One",
+          rows: [
+            ["a", "b"],
+            [1, null],
+          ],
+        },
+      ],
+    }
+    expect(JSON.parse(workbookToJson(single))).toEqual([{ a: 1, b: null }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// export/json — toJson formats
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("toJson — empty and header-less sheets", () => {
+  it("returns the shape matching the requested format for an empty sheet", () => {
+    expect(toJson(sheet([]))).toBe("[]")
+    expect(toJson(sheet([]), { format: "arrays" })).toBe(`{"headers":[],"data":[]}`)
+    expect(toJson(sheet([]), { format: "columns" })).toBe("{}")
+  })
+
+  it("returns the same empty shapes when headerRow points past the last row", () => {
+    // `headerRow: 3` on a two-row sheet is a caller mistake, not a crash.
+    const s = sheet([["a"], [1]])
+    expect(toJson(s, { headerRow: 3 })).toBe("[]")
+    expect(toJson(s, { headerRow: 3, format: "arrays" })).toBe(`{"headers":[],"data":[]}`)
+    expect(toJson(s, { headerRow: 3, format: "columns" })).toBe("{}")
+  })
+})
+
+describe("toJson — formats", () => {
+  const s = sheet([
+    ["Name", null, " Price "],
+    ["Widget", "x", 9.99],
+    ["Gadget", null, null],
+    ["Sprocket"],
+  ])
+
+  it("pads short rows with null in objects format", () => {
+    expect(JSON.parse(toJson(s))).toEqual([
+      { Name: "Widget", "": "x", Price: 9.99 },
+      { Name: "Gadget", "": null, Price: null },
+      { Name: "Sprocket", "": null, Price: null },
+    ])
+  })
+
+  it("pads short rows with null in arrays format", () => {
+    expect(JSON.parse(toJson(s, { format: "arrays" }))).toEqual({
+      headers: ["Name", "", "Price"],
+      data: [
+        ["Widget", "x", 9.99],
+        ["Gadget", null, null],
+        ["Sprocket", null, null],
+      ],
+    })
+  })
+
+  it("pads short rows with null in columns format", () => {
+    expect(JSON.parse(toJson(s, { format: "columns" }))).toEqual({
+      Name: ["Widget", "Gadget", "Sprocket"],
+      "": ["x", null, null],
+      Price: [9.99, null, null],
+    })
+  })
+
+  it("serializes Date cells as ISO strings in every format", () => {
+    // JSON has no date type; the exporter pins the representation instead of
+    // leaving it to the ambient locale.
+    const withDate = sheet([["When"], [new Date("2024-03-01T12:00:00Z")]])
+    expect(JSON.parse(toJson(withDate))).toEqual([{ When: "2024-03-01T12:00:00.000Z" }])
+    expect(JSON.parse(toJson(withDate, { format: "arrays" })).data).toEqual([
+      ["2024-03-01T12:00:00.000Z"],
+    ])
+    expect(JSON.parse(toJson(withDate, { format: "columns" })).When).toEqual([
+      "2024-03-01T12:00:00.000Z",
+    ])
+  })
+
+  it("emits null for an unparseable Date instead of throwing", () => {
+    // `JSON.stringify` calls Date.prototype.toJSON, which returns null for
+    // an invalid Date — so this never reaches `toISOString()` and never
+    // throws the RangeError #364 fixed in the HTML and ODS writers.
+    expect(toJson(sheet([["When"], [new Date("nope")]]))).toBe(`[{"When":null}]`)
+  })
+
+  it("indents by two spaces when pretty is set", () => {
+    expect(toJson(sheet([["a"], [1]]), { pretty: true })).toContain('\n    "a": 1')
+  })
+
+  it("honours headerRow to skip a title row", () => {
+    const titled = sheet([["Q1 report"], ["Name", "Qty"], ["Widget", 2]])
+    expect(JSON.parse(toJson(titled, { headerRow: 1 }))).toEqual([{ Name: "Widget", Qty: 2 }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// export/html — style translation
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("toHtml — inline styles", () => {
+  function cssFor(style: Cell["style"]): string {
+    const html = toHtml(styledSheet([["v"]], { "0,0": { value: "v", style } }), { styles: true })
+    return html.match(/style="([^"]*)"/)?.[1] ?? ""
+  }
+
+  it("combines underline and strikethrough into one text-decoration", () => {
+    // Two separate `text-decoration` declarations would have the second win,
+    // silently dropping the underline.
+    expect(cssFor({ font: { underline: true, strikethrough: true } })).toBe(
+      "text-decoration:underline line-through",
+    )
+  })
+
+  it("emits strikethrough on its own when there is no underline", () => {
+    expect(cssFor({ font: { strikethrough: true } })).toBe("text-decoration:line-through")
+  })
+
+  it("maps alignment, wrapping and font metadata", () => {
+    const css = cssFor({
+      font: { size: 12, name: "Inter" },
+      alignment: { horizontal: "center", vertical: "center", wrapText: true },
+    })
+    expect(css).toBe(
+      "font-size:12pt;font-family:Inter;text-align:center;vertical-align:center;white-space:pre-wrap",
+    )
+  })
+
+  it("omits text-align for the 'general' horizontal alignment", () => {
+    // "general" means "let the browser decide", which is the default anyway.
+    expect(cssFor({ alignment: { horizontal: "general" } })).toBe("")
+  })
+
+  it("emits no colour for a theme or indexed Color the reader left unresolved", () => {
+    // XLSX theme colours arrive as `{ theme, tint }` with no rgb; CSS has
+    // nothing to say about them, so the declaration is skipped entirely
+    // rather than emitting `color:#undefined`.
+    expect(
+      cssFor({
+        font: { bold: true, color: { theme: 1 } },
+        fill: { type: "pattern", pattern: "solid", fgColor: { indexed: 64 } },
+      }),
+    ).toBe("font-weight:bold")
+  })
+
+  it("maps each Excel border style onto its CSS width and pattern", () => {
+    expect(cssFor({ border: { top: { style: "dashed" } } })).toBe("border-top:1px dashed #000000")
+    expect(cssFor({ border: { right: { style: "dotted" } } })).toBe(
+      "border-right:1px dotted #000000",
+    )
+    // `double` changes the pattern but not the width — Excel's "double"
+    // is a hairline pair, not a thick rule.
+    expect(cssFor({ border: { bottom: { style: "double" } } })).toBe(
+      "border-bottom:1px double #000000",
+    )
+    expect(cssFor({ border: { left: { style: "mediumDashed", color: { rgb: "FF0000" } } } })).toBe(
+      "border-left:2px dashed #FF0000",
+    )
+    expect(cssFor({ border: { top: { style: "thick" } } })).toBe("border-top:3px solid #000000")
+  })
+})
+
+describe("toHtml — merged header cells", () => {
+  it("skips the cells a header-row merge covers", () => {
+    // A "2024" heading spanning two columns must produce one <th>, not one
+    // <th> plus an empty duplicate.
+    const s = sheet(
+      [
+        ["2024", null],
+        [1, 2],
+      ],
+      { merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }] },
+    )
+    const html = toHtml(s, { hasHeaderRow: true })
+    expect(html.match(/<th\s/g)!.length).toBe(1)
+    expect(html).toContain(`<th scope="col" colspan="2">2024</th>`)
+  })
+})

--- a/test/coverage-number-format.test.ts
+++ b/test/coverage-number-format.test.ts
@@ -1,0 +1,762 @@
+import { describe, expect, it } from "vitest"
+import { formatValue } from "../src/_format"
+import {
+  dateToSerial,
+  formatDate,
+  isDateFormat,
+  parseDate,
+  serialToDate,
+  serialToTime,
+  timeToSerial,
+} from "../src/_date"
+import { bufferReadableStream, readInputToUint8Array } from "../src/_input"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** A fixed instant with a non-trivial time part: Fri 5 Mar 2021, 14:07:09.250 UTC. */
+const MOMENT = new Date(Date.UTC(2021, 2, 5, 14, 7, 9, 250))
+
+/** Serial for {@link MOMENT} in the 1900 system. */
+const MOMENT_SERIAL = dateToSerial(MOMENT)
+
+/** Build a byte stream that yields the given chunks, one `read()` at a time. */
+function streamOf(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk)
+      controller.close()
+    },
+  })
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// formatValue — value kinds the format engine has to normalize first
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — input coercion", () => {
+  // A `Date` reaching the General branch has no format to follow, so the
+  // engine falls back to the unambiguous ISO rendering rather than the
+  // host locale's `toString()`.
+  it("renders a Date under General as an ISO 8601 timestamp", () => {
+    expect(formatValue(new Date(Date.UTC(2021, 0, 15)), "General")).toBe("2021-01-15T00:00:00.000Z")
+  })
+
+  // Cells read from a workbook carry Date objects; applying a numeric
+  // format to one must go through the serial conversion, not String().
+  it("converts a Date to its serial before applying a numeric format", () => {
+    expect(formatValue(new Date(Date.UTC(2021, 0, 15)), "0.00")).toBe("44211.00")
+  })
+
+  // The 1904 workbook flag shifts the epoch by 1462 days.
+  it("honours the 1904 date system when serializing a Date", () => {
+    const jan15 = new Date(Date.UTC(2021, 0, 15))
+    expect(formatValue(jan15, "0", { is1904: true })).toBe("42749")
+    expect(formatValue(jan15, "0")).toBe("44211")
+  })
+
+  // Anything that is neither string, number, boolean nor Date has no
+  // meaningful numeric form — the engine stringifies it instead of
+  // producing NaN.
+  it("stringifies values that are not numbers, strings, booleans or Dates", () => {
+    expect(formatValue(10n, "0.00")).toBe("10")
+    expect(formatValue({ toString: () => "obj" }, "0.00")).toBe("obj")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Section selection — positive; negative; zero; text
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — section selection", () => {
+  // The Excel accounting-style format: the third section renders zero and
+  // the second renders the magnitude of negatives (sign supplied by the
+  // parentheses, not by the number).
+  const ACCOUNTING = '$#,##0.00;[Red]($#,##0.00);"-"'
+
+  it("uses the first section for positive values", () => {
+    expect(formatValue(1234.5, ACCOUNTING)).toBe("$1,234.50")
+  })
+
+  it("uses the second section — on the absolute value — for negatives", () => {
+    expect(formatValue(-1234.5, ACCOUNTING)).toBe("($1,234.50)")
+  })
+
+  it("uses the third section for exactly zero", () => {
+    expect(formatValue(0, ACCOUNTING)).toBe("-")
+  })
+
+  // An empty section suppresses the value entirely — that is how Excel's
+  // "hide positives"/"hide negatives" formats work.
+  it("renders nothing when the matching section is empty", () => {
+    expect(formatValue(0, '#,##0.00;;"zero"')).toBe("zero")
+    expect(formatValue(-5, "0.0;;")).toBe("")
+  })
+
+  // Sections are split on *unquoted* semicolons only; a semicolon that is
+  // escaped or quoted belongs to the literal text.
+  it("does not split on a backslash-escaped semicolon", () => {
+    expect(formatValue(5, "0.00\\;x")).toBe("5.00;x")
+  })
+
+  it("does not split on a quoted semicolon", () => {
+    expect(formatValue(5, '0.00";"')).toBe("5.00;")
+  })
+
+  // A format ending in a lone backslash has nothing to escape — the
+  // scanner must stop rather than read past the end of the string.
+  it("tolerates a trailing backslash with nothing to escape", () => {
+    expect(formatValue(5, "0.00\\")).toBe("5.00")
+  })
+
+  // Strings take the fourth section when one exists, and are passed
+  // through untouched when the format has fewer sections.
+  it("routes strings through the fourth (text) section", () => {
+    expect(formatValue("hi", '0.00;-0.00;"z";"["@"]"')).toBe("[hi]")
+  })
+
+  it("returns a string unchanged when the format has no text section", () => {
+    expect(formatValue("hi", "0.00")).toBe("hi")
+  })
+
+  // Backslash escapes inside a text section are literal characters, and a
+  // section with no @ placeholder discards its literals entirely.
+  it("expands backslash escapes around the @ placeholder", () => {
+    expect(formatValue("hi", "\\@@\\!")).toBe("hihi!")
+  })
+
+  it("tolerates a text section ending in a bare backslash", () => {
+    expect(formatValue("hi", "@\\")).toBe("hi")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Conditional sections — [>100], [<=0], …
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — conditions", () => {
+  it("applies the first section when its condition matches", () => {
+    expect(formatValue(150, '[>100]"big";[<=100]"small"')).toBe("big")
+  })
+
+  it("falls through to the second section when the condition fails", () => {
+    expect(formatValue(50, '[>100]"big";"small"')).toBe("small")
+  })
+
+  // A single conditional section always applies: Excel has no other
+  // section to fall back to, so the condition only strips itself.
+  it("strips a condition from a lone section regardless of the outcome", () => {
+    expect(formatValue(5, "[>0]0.00")).toBe("5.00")
+    expect(formatValue(5, "[<0]0.00")).toBe("5.00")
+  })
+
+  it.each([
+    [">", '[>5]"gt";"le"', "le"],
+    ["<", '[<5]"lt";"ge"', "ge"],
+    [">=", '[>=5]"ge";"lt"', "ge"],
+    ["<=", '[<=5]"le";"gt"', "le"],
+    ["=", '[=5]"eq";"ne"', "eq"],
+    ["<>", '[<>5]"ne";"eq"', "eq"],
+  ])("evaluates the %s comparison operator", (_op, fmt, expected) => {
+    expect(formatValue(5, fmt)).toBe(expected)
+  })
+
+  // `==` and `!=` are not Excel syntax, but the condition scanner accepts
+  // any run of comparison characters, so they behave as their Excel
+  // spellings rather than silently matching everything.
+  it("treats == and != as aliases of = and <>", () => {
+    expect(formatValue(5, '[==5]"eq";"ne"')).toBe("eq")
+    expect(formatValue(5, '[!=5]"ne";"eq"')).toBe("eq")
+  })
+
+  // An unrecognised operator must not throw or drop the value — it
+  // degrades to "always true" so the first section still renders.
+  it("treats an unrecognised operator as always matching", () => {
+    expect(formatValue(5, '[!5]"first";"second"')).toBe("first")
+  })
+
+  // Conditions compare against the numeric value, so a Date cell is
+  // compared on its serial.
+  it("compares a Date against the condition using its serial number", () => {
+    const jan15 = new Date(Date.UTC(2021, 0, 15)) // serial 44211
+    expect(formatValue(jan15, '[>44000]"future";"past"')).toBe("future")
+    expect(formatValue(jan15, '[>50000]"future";"past"')).toBe("past")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Integer / decimal placeholders
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — digit placeholders", () => {
+  // `0` demands a digit, `#` does not — so an all-# format renders zero
+  // as an empty cell, which is the classic "hide zeros" trick.
+  it("renders zero as empty under an all-# format", () => {
+    expect(formatValue(0, "#")).toBe("")
+  })
+
+  // …but the decimal point of "#.##" survives, exactly as Excel shows it.
+  it("keeps the decimal point of #.## when the value is zero", () => {
+    expect(formatValue(0, "#.##")).toBe(".")
+  })
+
+  it("pads with leading zeros up to the count of 0 placeholders", () => {
+    expect(formatValue(123, "000000")).toBe("000123")
+  })
+
+  // A format with no `0` at all still has to group correctly.
+  it("groups a format built only from # placeholders", () => {
+    expect(formatValue(1234, "#,###")).toBe("1,234")
+  })
+
+  // `#` after the decimal point suppresses insignificant trailing digits;
+  // `0` keeps them.
+  it("suppresses trailing zeros behind a # decimal placeholder", () => {
+    expect(formatValue(5, "0.0#")).toBe("5.0")
+    expect(formatValue(1.05, "0.0#")).toBe("1.05")
+    expect(formatValue(1.5, "0.00#")).toBe("1.50")
+  })
+
+  it("adds group separators to a bare negative number", () => {
+    expect(formatValue(-1234.5, "#,##0")).toBe("-1,235")
+  })
+
+  // A format made only of literal text has no placeholders at all; the
+  // engine returns the literals and drops the number.
+  it("returns only the literal text when the section has no placeholders", () => {
+    expect(formatValue(42, '"N/A"')).toBe("N/A")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Literals, currency, colours and locale prefixes
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — literals and bracketed directives", () => {
+  it("keeps a backslash-escaped currency prefix", () => {
+    expect(formatValue(42, "\\$0.00")).toBe("$42.00")
+  })
+
+  it("keeps quoted text before and after the number", () => {
+    expect(formatValue(42, '"USD "0.00')).toBe("USD 42.00")
+    expect(formatValue(42, '0.00" units"')).toBe("42.00 units")
+    expect(formatValue(1234.5, '#,##0.00 "TL"')).toBe("1,234.50 TL")
+  })
+
+  it("keeps a backslash-escaped suffix character", () => {
+    expect(formatValue(42, "0.00\\!")).toBe("42.00!")
+  })
+
+  // Colour directives, locale/currency prefixes and `_x` alignment
+  // padding are display hints — they must not leak into the text.
+  it.each([
+    ["[Red]#,##0.00", "a named colour"],
+    ["[Color 3]#,##0.00", "an indexed colour"],
+    ["[$$-409]#,##0.00", "a locale-qualified currency prefix"],
+    ["_(#,##0.00_)", "alignment padding"],
+  ])("strips %s", (fmt) => {
+    expect(formatValue(1234.5, fmt)).toBe("1,234.50")
+  })
+
+  // Excel's built-in accounting format (numFmtId 39/40) wraps negatives
+  // in parentheses and pads positives to match.
+  it("renders the built-in accounting format's parenthesised negative", () => {
+    expect(formatValue(-1234.5, "#,##0.00_);(#,##0.00)")).toBe("(1,234.50)")
+    expect(formatValue(1234.5, "#,##0.00_);(#,##0.00)")).toBe("1,234.50")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Percentages, scaling and scientific notation
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — percentage", () => {
+  it("multiplies by 100 and appends the sign", () => {
+    expect(formatValue(0.1234, "0.00%")).toBe("12.34%")
+    expect(formatValue(0.1234, "0%")).toBe("12%")
+  })
+})
+
+describe("formatValue — thousands scaling", () => {
+  // Two trailing commas divide by a million — the "in millions" format
+  // used on financial summaries.
+  it("divides by a million for a double trailing comma", () => {
+    expect(formatValue(123456789, '#,##0.00,," M"')).toBe("123.46 M")
+    expect(formatValue(1500, '0.0,,"M"')).toBe("0.0M")
+  })
+})
+
+describe("formatValue — scientific notation", () => {
+  it("renders the mantissa with the declared decimals and a signed exponent", () => {
+    expect(formatValue(12345.6789, "0.000E+00")).toBe("1.235E+04")
+    expect(formatValue(12345678, "0.0E+00")).toBe("1.2E+07")
+    expect(formatValue(1, "0.0E+00")).toBe("1.0E+00")
+  })
+
+  it("renders a negative exponent for values below one", () => {
+    expect(formatValue(0.000123, "0.0E+00")).toBe("1.2E-04")
+    expect(formatValue(0.00012, "0.00E-00")).toBe("1.20E-04")
+  })
+
+  // `E-00` only shows the sign when the exponent is negative, unlike `E+00`.
+  it("hides the + sign when the format asks for E-", () => {
+    expect(formatValue(12345.6789, "0.00E-00")).toBe("1.23E04")
+  })
+
+  it("preserves the case of the exponent marker", () => {
+    expect(formatValue(12345.6789, "0.00e+00")).toBe("1.23e+04")
+  })
+
+  // A mantissa with no decimal point renders the exponent alone.
+  it("renders a mantissa with no decimals", () => {
+    expect(formatValue(12345.6789, "0E+00")).toBe("1E+04")
+  })
+
+  // A prefix in front of the mantissa defeats the strict pattern match,
+  // so the engine falls back to deriving the decimals from the mantissa.
+  it("falls back to mantissa-derived decimals when the pattern is unusual", () => {
+    expect(formatValue(12345.6789, "$0.00E+00")).toBe("1.23E+04")
+    expect(formatValue(12345.6789, "0.00E00")).toBe("1.23E04")
+  })
+
+  // …and to two decimals when the fallback cannot find a mantissa either.
+  it("defaults to two decimals when the fallback finds no mantissa", () => {
+    expect(formatValue(12345.6789, "$0E+00")).toBe("1.23E+04")
+  })
+
+  it("keeps the exponent marker case and sign rules on the fallback path", () => {
+    expect(formatValue(12345.6789, "$0.00e+00")).toBe("1.23e+04")
+    expect(formatValue(0.00012, "$0.00E+00")).toBe("1.20E-04")
+    expect(formatValue(0.00012, "$0.00E00")).toBe("1.20E-04")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Fractions
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — fractions", () => {
+  // Built-in numFmtId 12 ("# ?/?") searches for the best denominator with
+  // a single digit; numFmtId 13 ("# ??/??") allows two.
+  it("finds the closest single-digit denominator", () => {
+    expect(formatValue(0.5, "# ?/?")).toBe("1/2")
+  })
+
+  it("keeps the whole part beside a two-digit fraction", () => {
+    expect(formatValue(2.25, "# ??/??")).toBe("2  1/ 4")
+  })
+
+  // With no fractional remainder Excel shows the integer alone.
+  it("shows only the integer when the value is whole", () => {
+    expect(formatValue(3, "# ?/?")).toBe("3")
+  })
+
+  // Zero has no integer to show either, so the fraction area is blanked.
+  it("pads zero out to the width of the fraction area", () => {
+    expect(formatValue(0, "# ?/?")).toBe("0      ")
+  })
+
+  it("carries the minus sign of a negative mixed number", () => {
+    expect(formatValue(-2.5, "# ?/?")).toBe("-2 1/2")
+  })
+
+  // Three `?` in the denominator widen the search to 999.
+  it("widens the denominator search as the format grows", () => {
+    expect(formatValue(0.125, "# ?/???")).toBe("1/  8")
+  })
+
+  // `?` is an integer placeholder too, so a whole number still renders
+  // without a fraction under "? ?/?".
+  it("shows a whole number under a ?-only integer placeholder", () => {
+    expect(formatValue(3, "? ?/?")).toBe("3")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Known deviations from Excel — see the report accompanying this file
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatValue — Excel parity gaps", () => {
+  // BUG: src/_format.ts:541 decides whether to prepend "-" from
+  // `value < 0`, but `formatValue` already replaced the value with its
+  // absolute value when it picked the negative section (line 108), so
+  // `isNegative` is always false there. The explicit "-" written in the
+  // format is swallowed into `core` by `extractLiterals` (line 598 puts
+  // "-" in the placeholder set) and `formatIntegerPart` never emits it,
+  // so the sign disappears entirely.
+  // Excel renders -42 as "-42.00" under "0.00;-0.00".
+  it.skip("keeps the explicit minus sign of a negative section", () => {
+    expect(formatValue(-42, "0.00;-0.00")).toBe("-42.00")
+    expect(formatValue(-1234.5, "#,##0.00;-#,##0.00")).toBe("-1,234.50")
+  })
+
+  // BUG: src/_format.ts:485-493. A single trailing comma is Excel's
+  // "scale by 1000" directive, but `useThousandSep` is true for any
+  // format containing `[#0?],` — which a trailing comma also satisfies —
+  // and the scaling block is gated on `!useThousandSep`, so it never
+  // runs. Excel renders 1234567 as "1,235" under "#,##0," and as "1235"
+  // under "0,".
+  it.skip("divides by a thousand for a single trailing comma", () => {
+    expect(formatValue(1234567, "#,##0,")).toBe("1,235")
+    expect(formatValue(1234567, "0,")).toBe("1235")
+  })
+
+  // BUG: src/_format.ts:485. When the scaling *does* apply (",,") the
+  // same flag turns group separators off, so the scaled result loses its
+  // commas. Excel renders 1234567890 as "1,235" under "#,##0,,".
+  it.skip("keeps group separators on a scaled-down value", () => {
+    expect(formatValue(1234567890, "#,##0,,")).toBe("1,235")
+  })
+
+  // BUG: src/_format.ts:404. `isFractionFormat` requires the denominator
+  // to be made of `?`, `#` or `0`, so Excel's fixed-denominator fraction
+  // formats ("As halves" = `# ?/2`, "As eighths" = `# ?/8`, "As
+  // sixteenths" = `# ??/16`) are not recognised as fractions at all and
+  // fall through to plain number formatting: 3.5 renders as "4/2".
+  // `formatFraction`'s own `fixedDenom` branch (lines 429-443) is
+  // therefore dead code — it can never be reached.
+  it.skip("honours a fixed denominator written in the format", () => {
+    expect(formatValue(3.5, "# ?/2")).toBe("3 1/2")
+    expect(formatValue(3.5, "# ?/8")).toBe("3 4/8")
+  })
+
+  // BUG: src/_format.ts:447. For -0.5 the integer part is `-0`, and both
+  // `intPart !== 0` and `intPart < 0` are false for negative zero, so no
+  // sign is emitted. Excel renders -0.5 as "-1/2" under "# ?/?".
+  it.skip("keeps the sign of a negative value smaller than one", () => {
+    expect(formatValue(-0.5, "# ?/?")).toBe("-1/2")
+  })
+
+  // BUG: src/_format.ts:446. `hasIntPart` only looks for `#` and `0`, so
+  // a `?` integer placeholder is not recognised and the whole part is
+  // dropped from a mixed number. Excel renders 2.5 as "2 1/2" under
+  // "? ?/?".
+  it.skip("keeps the whole part in front of a ?-placeholder fraction", () => {
+    expect(formatValue(2.5, "? ?/?")).toBe("2 1/2")
+  })
+
+  // BUG: src/_format.ts:695-702. The `?` decimal placeholder is meant to
+  // render insignificant digits as spaces so decimal points line up, but
+  // `decStr` is produced by `toFixed(decimalPlaces)` and therefore always
+  // has exactly as many digits as the format has placeholders — the
+  // `else result += " "` arm can never run and `?` behaves like `0`.
+  // Excel renders 0.5 as "0.5  " under "0.???".
+  it.skip("pads insignificant decimals with spaces for a ? placeholder", () => {
+    expect(formatValue(0.5, "0.???")).toBe("0.5  ")
+  })
+
+  // BUG: src/_format.ts:598. Literal characters that sit *between* digit
+  // placeholders (rather than before or after the number) are folded into
+  // `core` and then dropped, because `formatIntegerPart` only understands
+  // `0` and `#`. This breaks Excel's fixed-width identifier formats.
+  it.skip("keeps separators written between digit groups", () => {
+    expect(formatValue(123456789, "000-00-0000")).toBe("123-45-6789")
+    expect(formatValue(5551234567, "(000) 000-0000")).toBe("(555) 123-4567")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// isDateFormat — telling dates from numbers
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("isDateFormat", () => {
+  it("returns false for an empty format", () => {
+    expect(isDateFormat("")).toBe(false)
+  })
+
+  // Built-in numeric IDs from ECMA-376 §18.8.30 arrive as strings from
+  // the styles part.
+  it.each([
+    ["14", true], // m/d/yyyy
+    ["45", true], // mm:ss
+    ["0", false], // integer
+    ["9", false], // 0%
+  ])("classifies the built-in format id %s", (id, expected) => {
+    expect(isDateFormat(id)).toBe(expected)
+  })
+
+  it.each([
+    ["General", false],
+    ["@", false],
+    ["yyyy", true],
+    ["d/m", true],
+    ["hh:mm", true],
+    ["mmm", true],
+    ["mmmm", true],
+    ["AM/PM", true],
+    ["a/p", true],
+    ["[h]", true],
+    ["[s]", true],
+  ])("classifies the format string %s", (fmt, expected) => {
+    expect(isDateFormat(fmt)).toBe(expected)
+  })
+
+  // A lone "m"/"mm" is genuinely ambiguous (month or minute) and Excel
+  // only reads it as a date when a d/y/h/s token is present, so the
+  // reader treats it as a number.
+  it("does not treat a lone m or mm as a date", () => {
+    expect(isDateFormat("m")).toBe(false)
+    expect(isDateFormat("mm")).toBe(false)
+  })
+
+  // Literal text must not be mistaken for time tokens: the "s" of
+  // "shares" and an escaped "\s" would both otherwise look like seconds.
+  it("ignores letters that live inside quoted or escaped literals", () => {
+    expect(isDateFormat('0.00 "shares"')).toBe(false)
+    expect(isDateFormat('#,##0" units"')).toBe(false)
+    expect(isDateFormat("0.0 \\s")).toBe(false)
+  })
+
+  // Unquoted trailing words are common in hand-written formats. "hrs"
+  // contains both an h and an s but neither stands alone as a token, so
+  // the format is still a number.
+  it("does not treat a word containing h or s as a time token", () => {
+    expect(isDateFormat("0.0 hrs")).toBe(false)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// formatDate — token rendering
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formatDate — tokens", () => {
+  it("renders single-letter day, month and second tokens unpadded", () => {
+    expect(formatDate(MOMENT, "m")).toBe("3")
+    expect(formatDate(MOMENT, "d")).toBe("5")
+    expect(formatDate(MOMENT, "s")).toBe("9")
+  })
+
+  it("renders day and month names", () => {
+    expect(formatDate(MOMENT, "dddd")).toBe("Friday")
+    expect(formatDate(MOMENT, "ddd")).toBe("Fri")
+    expect(formatDate(MOMENT, "mmm d, yyyy")).toBe("Mar 5, 2021")
+    expect(formatDate(MOMENT, "yy")).toBe("21")
+  })
+
+  // Fractional-second tokens read the millisecond field, truncated to the
+  // number of zeros written.
+  it("renders fractional seconds at the requested precision", () => {
+    expect(formatDate(MOMENT, "yyyy-mm-dd hh:mm:ss.000")).toBe("2021-03-05 14:07:09.250")
+    expect(formatDate(MOMENT, "h:mm:ss.00")).toBe("14:07:09.25")
+    expect(formatDate(MOMENT, "mm:ss.0")).toBe("07:09.2")
+  })
+
+  // A "." that is not followed by a zero is an ordinary separator — this
+  // is what makes the German "d.m.yyyy" date work.
+  it("treats a dot that is not a fractional-second token as a separator", () => {
+    expect(formatDate(MOMENT, "d.m.yyyy")).toBe("5.3.2021")
+    expect(formatDate(MOMENT, "hh:mm:ss.")).toBe("14:07:09.")
+  })
+
+  it("switches to a 12-hour clock when AM/PM is present", () => {
+    expect(formatDate(MOMENT, "h:mm:ss.0 AM/PM")).toBe("2:07:09.2 PM")
+    expect(formatDate(MOMENT, "h:mm A/P")).toBe("2:07 P")
+  })
+
+  it("stays on the 24-hour clock without an AM/PM token", () => {
+    expect(formatDate(MOMENT, "hh:mm:ss")).toBe("14:07:09")
+  })
+
+  // Elapsed-time brackets accumulate past their usual range and are
+  // computed from the serial, not from the Date's clock fields.
+  it("accumulates elapsed time from the serial number", () => {
+    expect(formatDate(MOMENT, "[h]:mm:ss", 1.5)).toBe("36:07:09")
+    expect(formatDate(MOMENT, "[mm]:ss", 1.5)).toBe("2160:09")
+    expect(formatDate(MOMENT, "[ss]", 1.5)).toBe("129600")
+  })
+
+  // Without a serial (and for negative serials) elapsed totals clamp to 0
+  // rather than rendering NaN.
+  it("clamps elapsed totals to zero when no serial is supplied", () => {
+    expect(formatDate(MOMENT, "[h]:mm")).toBe("0:07")
+    expect(formatDate(MOMENT, "[h]:mm", -3)).toBe("0:07")
+  })
+
+  it("emits quoted and backslash-escaped text literally", () => {
+    expect(formatDate(MOMENT, '"Year "yyyy')).toBe("Year 2021")
+    expect(formatDate(MOMENT, "\\Qyyyy")).toBe("Q2021")
+  })
+
+  // Colour and locale directives are display hints; the tokenizer drops
+  // them so they cannot end up in the rendered text.
+  it("drops colour and locale directives", () => {
+    expect(formatDate(MOMENT, "[Red]hh:mm")).toBe("14:07")
+    expect(formatDate(MOMENT, "[$-409]d mmmm yyyy")).toBe("5 March 2021")
+  })
+
+  // "mm" is minutes after an hour token and a month everywhere else.
+  it("disambiguates mm between month and minute by its neighbours", () => {
+    expect(formatDate(MOMENT, "mm/dd")).toBe("03/05")
+    expect(formatDate(MOMENT, "hh:mm")).toBe("14:07")
+    expect(formatDate(MOMENT, "mm:ss")).toBe("07:09")
+  })
+
+  it("passes unknown letters through as literal text", () => {
+    expect(formatDate(MOMENT, "nn")).toBe("nn")
+  })
+
+  // A truncated file can leave a bracket directive unterminated; the
+  // tokenizer must fall back to treating it as literal text instead of
+  // consuming the rest of the format.
+  it("treats an unterminated bracket directive as literal text", () => {
+    expect(formatDate(MOMENT, "[$-409")).toBe("[$-409")
+    expect(formatDate(MOMENT, "[h")).toBe("[14")
+  })
+
+  it("tolerates a format ending in a bare backslash", () => {
+    expect(formatDate(MOMENT, "yyyy\\")).toBe("2021")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Serial ↔ Date conversion
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("serial conversion", () => {
+  // Serial 60 is the phantom "29 Feb 1900" the 1900 system inherited from
+  // Lotus 1-2-3; it has no real timestamp, so it maps to 28 Feb.
+  it("maps the Lotus phantom serial 60 onto 28 Feb 1900", () => {
+    expect(serialToDate(60).toISOString()).toBe("1900-02-28T00:00:00.000Z")
+  })
+
+  it("maps serial 0 to the Excel 'Jan 0, 1900' placeholder", () => {
+    expect(serialToDate(0).toISOString()).toBe("1899-12-31T00:00:00.000Z")
+  })
+
+  it("skips the phantom day for serials above 60", () => {
+    expect(serialToDate(61).toISOString()).toBe("1900-03-01T00:00:00.000Z")
+  })
+
+  it("uses 1 Jan 1904 as day zero in the 1904 system", () => {
+    expect(serialToDate(0, true).toISOString()).toBe("1904-01-01T00:00:00.000Z")
+  })
+
+  it("round-trips a moment through the serial and back", () => {
+    expect(serialToDate(MOMENT_SERIAL).getTime()).toBe(MOMENT.getTime())
+  })
+
+  it("round-trips through the 1904 system too", () => {
+    const s = dateToSerial(MOMENT, true)
+    expect(serialToDate(s, true).getTime()).toBe(MOMENT.getTime())
+  })
+
+  it("splits a serial fraction into clock components", () => {
+    expect(serialToTime(0.5)).toEqual({ hours: 12, minutes: 0, seconds: 0, milliseconds: 0 })
+    expect(serialToTime(-1.75).hours).toBe(18)
+  })
+
+  it("builds a serial fraction from clock components", () => {
+    expect(timeToSerial(12, 0)).toBe(0.5)
+    expect(timeToSerial(0, 0, 0, 86_400_000 / 2)).toBe(0.5)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseDate
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseDate", () => {
+  it("returns null for blank or unparseable input", () => {
+    expect(parseDate("")).toBeNull()
+    expect(parseDate("   ")).toBeNull()
+    expect(parseDate("not a date")).toBeNull()
+  })
+
+  it("applies an ISO 8601 UTC offset", () => {
+    expect(parseDate("2021-01-15T14:30:00+05:00")?.toISOString()).toBe("2021-01-15T09:30:00.000Z")
+    expect(parseDate("2021-01-15T14:30:00-05:00")?.toISOString()).toBe("2021-01-15T19:30:00.000Z")
+  })
+
+  // RFC 3339 allows the offset without its colon; Excel exports written
+  // by non-Microsoft tools use that spelling.
+  it("accepts an offset written without a colon", () => {
+    expect(parseDate("2021-01-15T14:30:00-0530")?.toISOString()).toBe("2021-01-15T20:00:00.000Z")
+  })
+
+  it("pads a short fractional-second field to milliseconds", () => {
+    expect(parseDate("2021-01-15T14:30:00.5Z")?.toISOString()).toBe("2021-01-15T14:30:00.500Z")
+  })
+
+  it("parses the US, EU and dashed day-first spellings", () => {
+    expect(parseDate("1/15/2021")?.toISOString()).toBe("2021-01-15T00:00:00.000Z")
+    expect(parseDate("15.01.2021")?.toISOString()).toBe("2021-01-15T00:00:00.000Z")
+    expect(parseDate("15-01-2021")?.toISOString()).toBe("2021-01-15T00:00:00.000Z")
+  })
+
+  // Out-of-range components are rejected rather than silently rolled over
+  // by the Date constructor.
+  it("rejects out-of-range month and day components", () => {
+    expect(parseDate("13/45/2021")).toBeNull()
+    expect(parseDate("45.13.2021")).toBeNull()
+    expect(parseDate("31-13-2021")).toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ReadInput normalization
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readInputToUint8Array", () => {
+  it("returns a Uint8Array untouched", async () => {
+    const bytes = new Uint8Array([1, 2, 3])
+    expect(await readInputToUint8Array(bytes)).toBe(bytes)
+  })
+
+  it("wraps an ArrayBuffer without copying its contents", async () => {
+    const buf = new Uint8Array([4, 5, 6]).buffer
+    expect(Array.from(await readInputToUint8Array(buf))).toEqual([4, 5, 6])
+  })
+
+  it("rejects input shapes that are neither bytes nor a stream", async () => {
+    await expect(readInputToUint8Array("nope" as never)).rejects.toThrow(/Unsupported input type/)
+  })
+})
+
+describe("bufferReadableStream", () => {
+  // A closed-without-data stream is what an empty file yields; it has to
+  // produce an empty buffer rather than throwing on the concat path.
+  it("returns an empty buffer for a stream that yields nothing", async () => {
+    expect((await bufferReadableStream(streamOf())).length).toBe(0)
+  })
+
+  it("returns the single chunk as-is when the stream yields one", async () => {
+    const only = new Uint8Array([7, 8])
+    expect(await bufferReadableStream(streamOf(only))).toBe(only)
+  })
+
+  // Some stream sources (and polyfills) hand back `{ done: false,
+  // value: undefined }` for an empty read; that must not append an
+  // undefined chunk.
+  it("ignores a read that yields no value", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(undefined as unknown as Uint8Array)
+        controller.enqueue(new Uint8Array([1]))
+        controller.close()
+      },
+    })
+    expect(Array.from(await bufferReadableStream(stream))).toEqual([1])
+  })
+
+  it("concatenates multiple chunks in order", async () => {
+    const merged = await bufferReadableStream(
+      streamOf(new Uint8Array([1, 2]), new Uint8Array([3]), new Uint8Array([4, 5])),
+    )
+    expect(Array.from(merged)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it("aborts once the running total passes the cap", async () => {
+    await expect(
+      bufferReadableStream(streamOf(new Uint8Array(10), new Uint8Array(10)), 15),
+    ).rejects.toThrow(/exceeds the maximum of 15 bytes/)
+  })
+
+  // A caller passing 0, a negative number or Infinity has not asked for
+  // "no limit" — the documented default applies instead.
+  it.each([0, -1, Number.POSITIVE_INFINITY, Number.NaN])(
+    "falls back to the default cap for a nonsensical limit (%s)",
+    async (cap) => {
+      const bytes = await bufferReadableStream(streamOf(new Uint8Array([9])), cap)
+      expect(Array.from(bytes)).toEqual([9])
+    },
+  )
+})

--- a/test/coverage-ods-branches.test.ts
+++ b/test/coverage-ods-branches.test.ts
@@ -1,0 +1,1349 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { ZipReader } from "../src/zip/reader"
+import { parseXml } from "../src/xml/parser"
+import { readOds } from "../src/ods/reader"
+import { writeOds } from "../src/ods/writer"
+import { streamOdsRows } from "../src/ods/stream"
+import { readOdsObjects, writeOdsObjects } from "../src/ods/objects"
+import { ParseError, ZipError } from "../src/errors"
+import type { Cell, PatternFill, StreamRow, Workbook, WriteSheet } from "../src/_types"
+
+const enc = new TextEncoder()
+const dec = new TextDecoder("utf-8")
+
+// ── Building ODF fragments ──────────────────────────────────────────
+//
+// Every ODF namespace a real content.xml declares on its root element.
+// Declaring them all keeps the fragments below valid documents rather
+// than XML the parser only tolerates by accident.
+
+const NS = [
+  `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"`,
+  `xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"`,
+  `xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"`,
+  `xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"`,
+  `xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0"`,
+  `xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"`,
+  `xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"`,
+  `xmlns:dc="http://purl.org/dc/elements/1.1/"`,
+  `xmlns:xlink="http://www.w3.org/1999/xlink"`,
+  `xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0"`,
+].join(" ")
+
+/** A complete `content.xml` around a `<office:spreadsheet>` body. */
+function contentXml(body: string, automaticStyles = ""): string {
+  const styles = automaticStyles
+    ? `<office:automatic-styles>${automaticStyles}</office:automatic-styles>`
+    : ""
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<office:document-content ${NS} office:version="1.3">` +
+    styles +
+    `<office:body><office:spreadsheet>${body}</office:spreadsheet></office:body>` +
+    `</office:document-content>`
+  )
+}
+
+/** A complete `meta.xml` around the `<office:meta>` children. */
+function metaXml(inner: string): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<office:document-meta ${NS} office:version="1.3">` +
+    `<office:meta>${inner}</office:meta>` +
+    `</office:document-meta>`
+  )
+}
+
+interface OdsParts {
+  /** Full content.xml. Omit to leave the entry out of the archive. */
+  content?: string
+  meta?: string
+  /** Defaults to the spreadsheet media type. */
+  mimetype?: string | null
+}
+
+async function odsFile(parts: OdsParts): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  if (parts.mimetype !== null) {
+    zip.add(
+      "mimetype",
+      enc.encode(parts.mimetype ?? "application/vnd.oasis.opendocument.spreadsheet"),
+      { compress: false },
+    )
+  }
+  if (parts.content !== undefined) zip.add("content.xml", enc.encode(parts.content))
+  if (parts.meta !== undefined) zip.add("meta.xml", enc.encode(parts.meta))
+  return await zip.build()
+}
+
+/** One table containing exactly the given `<table:table-row>` markup. */
+function table(rowsXml: string, name = "S"): string {
+  return `<table:table table:name="${name}">${rowsXml}</table:table>`
+}
+
+async function readBody(body: string, automaticStyles = ""): Promise<Workbook> {
+  return await readOds(await odsFile({ content: contentXml(body, automaticStyles) }), {
+    readStyles: automaticStyles !== "",
+  })
+}
+
+/**
+ * Reconstruct the Excel-style `numFmt` the reader derives from a
+ * `<number:*-style>` data style, by pointing a cell style at it and
+ * reading the resulting `CellStyle`.
+ */
+async function numFmtFor(dataStyleXml: string, dataStyleName: string): Promise<string | undefined> {
+  const styles =
+    dataStyleXml +
+    `<style:style style:name="ce1" style:family="table-cell" style:data-style-name="${dataStyleName}"/>`
+  const body = table(
+    `<table:table-row><table:table-cell table:style-name="ce1" office:value-type="float" office:value="1"><text:p>1</text:p></table:table-cell></table:table-row>`,
+  )
+  const wb = await readBody(body, styles)
+  return wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt
+}
+
+async function collectStream(data: Uint8Array): Promise<StreamRow[]> {
+  const out: StreamRow[] = []
+  for await (const row of streamOdsRows(data)) out.push(row)
+  return out
+}
+
+// ── Reading back what writeOds produced ─────────────────────────────
+
+async function contentOf(data: Uint8Array, path = "content.xml"): Promise<string> {
+  const zip = new ZipReader(data)
+  return dec.decode(await zip.extract(path))
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — data styles (number formats)
+// ═══════════════════════════════════════════════════════════════════════
+//
+// LibreOffice stores a cell's number format as a `<number:*-style>`
+// element referenced through `style:data-style-name`. The reader
+// re-serializes that element tree back into an Excel format code, which
+// is the only representation `CellStyle.numFmt` can carry.
+
+describe("ODS reader — number data styles", () => {
+  it("rebuilds a grouped two-decimal code from number:number attributes", async () => {
+    const code = await numFmtFor(
+      `<number:number-style style:name="N100"><number:number number:decimal-places="2" number:grouping="true" number:min-integer-digits="1"/></number:number-style>`,
+      "N100",
+    )
+    expect(code).toBe("#,##0.00")
+  })
+
+  it("treats a missing number:decimal-places as zero decimals", async () => {
+    // ODF makes the attribute optional; omitting it means an integer format.
+    const code = await numFmtFor(
+      `<number:number-style style:name="N100"><number:number number:min-integer-digits="1"/></number:number-style>`,
+      "N100",
+    )
+    expect(code).toBe("0")
+  })
+
+  it("falls back to zero decimals when decimal-places is not a number", async () => {
+    const code = await numFmtFor(
+      `<number:number-style style:name="N100"><number:number number:decimal-places="lots"/></number:number-style>`,
+      "N100",
+    )
+    expect(code).toBe("0")
+  })
+
+  it("caps an absurd decimal-places so the format code cannot be a memory bomb", async () => {
+    // A hand-crafted file can ask for a billion decimals; the reader clamps
+    // the repeat the same way it clamps text:c. See #363.
+    const code = await numFmtFor(
+      `<number:number-style style:name="N100"><number:number number:decimal-places="900000000"/></number:number-style>`,
+      "N100",
+    )
+    expect(code!.length).toBe("0.".length + 100_000)
+  })
+
+  it("appends the percent sign when the style has no literal % child", async () => {
+    // Some producers rely on the element name alone to mean "percent".
+    const code = await numFmtFor(
+      `<number:percentage-style style:name="N101"><number:number number:decimal-places="0"/></number:percentage-style>`,
+      "N101",
+    )
+    expect(code).toBe("0%")
+  })
+
+  it("keeps a single-character separator bare rather than quoting it", async () => {
+    const code = await numFmtFor(
+      `<number:percentage-style style:name="N101"><number:number number:decimal-places="1"/><number:text>%</number:text></number:percentage-style>`,
+      "N101",
+    )
+    expect(code).toBe("0.0%")
+  })
+
+  it("quotes a multi-character literal from number:text", async () => {
+    const code = await numFmtFor(
+      `<number:number-style style:name="N100"><number:number number:decimal-places="0"/><number:text> kg</number:text></number:number-style>`,
+      "N100",
+    )
+    expect(code).toBe(`0" kg"`)
+  })
+
+  it("places a leading currency symbol before the number", async () => {
+    const code = await numFmtFor(
+      `<number:currency-style style:name="N102"><number:currency-symbol>$</number:currency-symbol><number:number number:decimal-places="2" number:grouping="true"/></number:currency-style>`,
+      "N102",
+    )
+    expect(code).toBe(`"$"#,##0.00`)
+  })
+
+  it("keeps a trailing currency symbol after the number", async () => {
+    // European layouts write "1 234,50 €" — the symbol element comes last.
+    const code = await numFmtFor(
+      `<number:currency-style style:name="N102"><number:number number:decimal-places="2" number:grouping="true"/><number:text> </number:text><number:currency-symbol>€</number:currency-symbol></number:currency-style>`,
+      "N102",
+    )
+    expect(code).toBe(`#,##0.00 "€"`)
+  })
+})
+
+describe("ODS reader — date and time data styles", () => {
+  it("maps number:style=long onto the two-letter date tokens", async () => {
+    const code = await numFmtFor(
+      `<number:date-style style:name="N103">` +
+        `<number:year number:style="long"/><number:text>-</number:text>` +
+        `<number:month number:style="long"/><number:text>-</number:text>` +
+        `<number:day number:style="long"/>` +
+        `</number:date-style>`,
+      "N103",
+    )
+    expect(code).toBe("yyyy-mm-dd")
+  })
+
+  it("maps the short forms onto single-letter tokens", async () => {
+    const code = await numFmtFor(
+      `<number:date-style style:name="N103">` +
+        `<number:day/><number:text>.</number:text>` +
+        `<number:month/><number:text>.</number:text>` +
+        `<number:year/>` +
+        `</number:date-style>`,
+      "N103",
+    )
+    expect(code).toBe("d.m.yy")
+  })
+
+  it("turns number:textual months into mmm / mmmm", async () => {
+    const long = await numFmtFor(
+      `<number:date-style style:name="N103"><number:month number:textual="true" number:style="long"/></number:date-style>`,
+      "N103",
+    )
+    const short = await numFmtFor(
+      `<number:date-style style:name="N103"><number:month number:textual="true"/></number:date-style>`,
+      "N103",
+    )
+    expect([long, short]).toEqual(["mmmm", "mmm"])
+  })
+
+  it("turns number:day-of-week into ddd / dddd", async () => {
+    const long = await numFmtFor(
+      `<number:date-style style:name="N103"><number:day-of-week number:style="long"/></number:date-style>`,
+      "N103",
+    )
+    const short = await numFmtFor(
+      `<number:date-style style:name="N103"><number:day-of-week/></number:date-style>`,
+      "N103",
+    )
+    expect([long, short]).toEqual(["dddd", "ddd"])
+  })
+
+  it("rebuilds a 12-hour clock with the AM/PM marker", async () => {
+    const code = await numFmtFor(
+      `<number:time-style style:name="N104">` +
+        `<number:hours/><number:text>:</number:text>` +
+        `<number:minutes number:style="long"/><number:text>:</number:text>` +
+        `<number:seconds number:style="long"/><number:text> </number:text>` +
+        `<number:am-pm/>` +
+        `</number:time-style>`,
+      "N104",
+    )
+    expect(code).toBe("h:mm:ss AM/PM")
+  })
+
+  it("brackets the hour token when truncate-on-overflow is false", async () => {
+    // `number:truncate-on-overflow="false"` is ODF's way of saying "elapsed
+    // time" — Excel spells the same thing `[hh]:mm`.
+    const code = await numFmtFor(
+      `<number:time-style style:name="N104" number:truncate-on-overflow="false">` +
+        `<number:hours number:style="long"/><number:text>:</number:text>` +
+        `<number:minutes number:style="long"/>` +
+        `</number:time-style>`,
+      "N104",
+    )
+    expect(code).toBe("[hh]:mm")
+  })
+
+  it("leaves a clock-style time unbracketed when truncate-on-overflow is true", async () => {
+    const code = await numFmtFor(
+      `<number:time-style style:name="N104" number:truncate-on-overflow="true">` +
+        `<number:hours number:style="long"/><number:text>:</number:text>` +
+        `<number:minutes number:style="long"/>` +
+        `</number:time-style>`,
+      "N104",
+    )
+    expect(code).toBe("hh:mm")
+  })
+
+  it("ignores data-style children it has no Excel token for", async () => {
+    // ODF also defines number:era, number:quarter, number:week-of-year …;
+    // none has a format-code equivalent, so they are dropped rather than
+    // guessed at.
+    const code = await numFmtFor(
+      `<number:date-style style:name="N103">` +
+        `<number:era number:style="long"/><number:quarter/>` +
+        `<number:year number:style="long"/>` +
+        `</number:date-style>`,
+      "N103",
+    )
+    expect(code).toBe("yyyy")
+  })
+
+  it("ignores a data style that carries no style:name", async () => {
+    // Nameless styles cannot be referenced, so there is nothing to resolve.
+    const styles =
+      `<number:number-style><number:number number:decimal-places="3"/></number:number-style>` +
+      `<style:style style:name="ce1" style:family="table-cell" style:data-style-name="N100"/>`
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell table:style-name="ce1" office:value-type="float" office:value="1"/></table:table-row>`,
+      ),
+      styles,
+    )
+    expect(wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt).toBeUndefined()
+  })
+
+  it("tolerates whitespace between the automatic-style elements", async () => {
+    // Pretty-printed ODF (hand-edited files, some non-LibreOffice writers)
+    // puts text nodes between every element.
+    const styles = `
+      <number:number-style style:name="N100">
+        <number:number number:decimal-places="1"/>
+      </number:number-style>
+      <style:style style:name="ce1" style:family="table-cell" style:data-style-name="N100"/>
+    `
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell table:style-name="ce1" office:value-type="float" office:value="1"/></table:table-row>`,
+      ),
+      styles,
+    )
+    expect(wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt).toBe("0.0")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — cell styles
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — automatic cell styles", () => {
+  const cellRow = `<table:table-row><table:table-cell table:style-name="ce1" office:value-type="string"><text:p>x</text:p></table:table-cell></table:table-row>`
+
+  it("only reads styles from the table-cell family", async () => {
+    // content.xml also holds column, row and table styles under the same
+    // parent; a `co1` column style must not become a cell style.
+    const styles = `<style:style style:name="ce1" style:family="table-column"><style:text-properties fo:font-weight="bold"/></style:style>`
+    const wb = await readBody(table(cellRow), styles)
+    expect(wb.sheets[0]!.cells).toBeUndefined()
+  })
+
+  it("skips a style element with no style:name", async () => {
+    const styles = `<style:style style:family="table-cell"><style:text-properties fo:font-weight="bold"/></style:style>`
+    const wb = await readBody(table(cellRow), styles)
+    expect(wb.sheets[0]!.cells).toBeUndefined()
+  })
+
+  it("accepts colours written without the leading # as well as with it", async () => {
+    // ODF requires `#rrggbb`, but files in the wild omit the hash; the
+    // reader normalizes both to the bare uppercase hex an XLSX Color wants.
+    const styles =
+      `<style:style style:name="ce1" style:family="table-cell">` +
+      `<style:text-properties fo:color="ff0000" fo:font-size="10.5pt"/>` +
+      `<style:table-cell-properties fo:background-color="00ff00"/>` +
+      `</style:style>`
+    const wb = await readBody(table(cellRow), styles)
+    const style = wb.sheets[0]!.cells?.get("0,0")?.style
+    expect(style?.font?.color?.rgb).toBe("FF0000")
+    expect(style?.font?.size).toBe(10.5)
+    expect((style!.fill as PatternFill).fgColor?.rgb).toBe("00FF00")
+  })
+
+  it("ignores a font size it cannot parse", async () => {
+    const styles =
+      `<style:style style:name="ce1" style:family="table-cell">` +
+      `<style:text-properties fo:font-size="medium" fo:font-weight="bold"/>` +
+      `</style:style>`
+    const wb = await readBody(table(cellRow), styles)
+    const font = wb.sheets[0]!.cells?.get("0,0")?.style?.font
+    expect(font).toEqual({ bold: true })
+  })
+
+  it("drops a transparent background instead of emitting a white fill", async () => {
+    const styles =
+      `<style:style style:name="ce1" style:family="table-cell">` +
+      `<style:text-properties fo:font-style="italic"/>` +
+      `<style:table-cell-properties fo:background-color="transparent"/>` +
+      `</style:style>`
+    const wb = await readBody(table(cellRow), styles)
+    const style = wb.sheets[0]!.cells?.get("0,0")?.style
+    expect(style?.font?.italic).toBe(true)
+    expect(style?.fill).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — office:value-type variants
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — value types", () => {
+  async function firstCell(cellXml: string): Promise<unknown> {
+    // The trailing text cell anchors the row — a cell that reads as null
+    // would otherwise be trimmed off the end before the row is built.
+    const wb = await readBody(
+      table(
+        `<table:table-row>${cellXml}` +
+          `<table:table-cell office:value-type="string"><text:p>end</text:p></table:table-cell>` +
+          `</table:table-row>`,
+      ),
+    )
+    return wb.sheets[0]!.rows[0]?.[0]
+  }
+
+  it("returns an ISO 8601 duration for office:value-type=time", async () => {
+    // ODF stores times as durations (`PT12H30M`); there is no Date that can
+    // represent "12:30 of no particular day", so the string is preserved.
+    expect(
+      await firstCell(
+        `<table:table-cell office:value-type="time" office:time-value="PT12H30M00S"><text:p>12:30:00</text:p></table:table-cell>`,
+      ),
+    ).toBe("PT12H30M00S")
+  })
+
+  it("yields null for a time cell with no office:time-value", async () => {
+    expect(
+      await firstCell(`<table:table-cell office:value-type="time"><text:p/></table:table-cell>`),
+    ).toBeNull()
+  })
+
+  it("reads both boolean literals and rejects anything else", async () => {
+    expect(
+      await firstCell(
+        `<table:table-cell office:value-type="boolean" office:boolean-value="true"/>`,
+      ),
+    ).toBe(true)
+    expect(
+      await firstCell(
+        `<table:table-cell office:value-type="boolean" office:boolean-value="false"/>`,
+      ),
+    ).toBe(false)
+    expect(
+      await firstCell(`<table:table-cell office:value-type="boolean" office:boolean-value="1"/>`),
+    ).toBeNull()
+  })
+
+  it("yields null for an unparseable office:date-value", async () => {
+    expect(
+      await firstCell(
+        `<table:table-cell office:value-type="date" office:date-value="not-a-date"/>`,
+      ),
+    ).toBeNull()
+    expect(await firstCell(`<table:table-cell office:value-type="date"/>`)).toBeNull()
+  })
+
+  it("falls back to office:string-value when the cell has no text:p", async () => {
+    expect(
+      await firstCell(
+        `<table:table-cell office:value-type="string" office:string-value="from attribute"/>`,
+      ),
+    ).toBe("from attribute")
+  })
+
+  it("returns an empty string for a string cell with neither text nor attribute", async () => {
+    // Distinguishable from an untyped empty cell, which reads as null.
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string"/><table:table-cell office:value-type="float" office:value="1"/></table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.rows[0]).toEqual(["", 1])
+  })
+
+  it("yields null for a float cell with no office:value", async () => {
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="float"/><table:table-cell office:value-type="string"><text:p>end</text:p></table:table-cell></table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.rows[0]).toEqual([null, "end"])
+  })
+
+  it("honours calcext:value-type when office:value-type is absent", async () => {
+    // LibreOffice writes the calcext mirror for error/boolean cells.
+    expect(
+      await firstCell(
+        `<table:table-cell calcext:value-type="boolean" office:boolean-value="true"/>`,
+      ),
+    ).toBe(true)
+  })
+
+  it("reads an untyped cell as its plain text", async () => {
+    expect(await firstCell(`<table:table-cell><text:p>bare</text:p></table:table-cell>`)).toBe(
+      "bare",
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — text content and hyperlinks
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — hyperlinks", () => {
+  it("finds a link nested inside a text:span", async () => {
+    // LibreOffice wraps a formatted link in a span, so the anchor is not a
+    // direct child of the paragraph.
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string">` +
+          `<text:p>see <text:span text:style-name="T1"><text:a xlink:href="https://example.com/">the docs</text:a></text:span></text:p>` +
+          `</table:table-cell></table:table-row>`,
+      ),
+    )
+    const cell = wb.sheets[0]!.cells?.get("0,0")
+    expect(cell?.hyperlink).toEqual({ target: "https://example.com/", display: "the docs" })
+    expect(cell?.value).toBe("see the docs")
+  })
+
+  it("ignores a text:a with no xlink:href and keeps looking", async () => {
+    // An anchor without a target is a bookmark, not a hyperlink.
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string">` +
+          `<text:p><text:a office:name="bookmark">anchor</text:a><text:a xlink:href="https://real.example/">real</text:a></text:p>` +
+          `</table:table-cell></table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.cells?.get("0,0")?.hyperlink?.target).toBe("https://real.example/")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — formulas
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — formula namespace prefixes", () => {
+  async function formulaOf(attr: string): Promise<string | undefined> {
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell table:formula="${attr}" office:value-type="float" office:value="3"><text:p>3</text:p></table:table-cell></table:table-row>`,
+      ),
+    )
+    return wb.sheets[0]!.cells?.get("0,0")?.formula
+  }
+
+  it("strips the legacy oooc: prefix OpenOffice.org 1.x wrote", async () => {
+    expect(await formulaOf("oooc:=SUM([.A1:.A10])")).toBe("SUM(A1:A10)")
+  })
+
+  it("strips a bare = prefix", async () => {
+    // Gnumeric and several exporters omit the namespace prefix entirely.
+    expect(await formulaOf("=SUM([.A1])")).toBe("SUM(A1)")
+  })
+
+  it("leaves an unprefixed formula untouched", async () => {
+    expect(await formulaOf("SUM([.A1])")).toBe("SUM(A1)")
+  })
+
+  it("keeps a formula on a cell whose style name is not a cell style", async () => {
+    // `table:style-name` may point at a column or row style that
+    // parseStyles never collected; the formula must survive anyway.
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell table:style-name="co1" table:formula="of:=1" office:value-type="float" office:value="1"><text:p>1</text:p></table:table-cell></table:table-row>`,
+      ),
+      `<style:style style:name="co1" style:family="table-column"/>`,
+    )
+    const cell = wb.sheets[0]!.cells?.get("0,0")
+    expect(cell?.formula).toBe("1")
+    expect(cell?.style).toBeUndefined()
+  })
+
+  it("marks a formula cell as type formula", async () => {
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell table:formula="of:=1+1" office:value-type="float" office:value="2"><text:p>2</text:p></table:table-cell></table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.cells?.get("0,0")?.type).toBe("formula")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — table structure
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — repeated cells, covered cells and merges", () => {
+  it("expands table:number-columns-repeated in place", async () => {
+    const wb = await readBody(
+      table(
+        `<table:table-row>` +
+          `<table:table-cell office:value-type="float" office:value="7" table:number-columns-repeated="3"><text:p>7</text:p></table:table-cell>` +
+          `<table:table-cell office:value-type="string"><text:p>tail</text:p></table:table-cell>` +
+          `</table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.rows[0]).toEqual([7, 7, 7, "tail"])
+  })
+
+  it("clamps a column repeat that would run past Excel's last column", async () => {
+    // A non-trailing repeat is expanded, so an unbounded count is an
+    // allocation of 2^31 slots from a few bytes of XML. See #363.
+    const wb = await readBody(
+      table(
+        `<table:table-row>` +
+          `<table:table-cell office:value-type="float" office:value="1" table:number-columns-repeated="99999999"><text:p>1</text:p></table:table-cell>` +
+          `<table:table-cell office:value-type="string"><text:p>tail</text:p></table:table-cell>` +
+          `</table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.rows[0]!.length).toBe(16_384 + 1)
+  })
+
+  it("fills covered cells of a merge with nulls", async () => {
+    const wb = await readBody(
+      table(
+        `<table:table-row>` +
+          `<table:table-cell table:number-columns-spanned="2" table:number-rows-spanned="1" office:value-type="string"><text:p>wide</text:p></table:table-cell>` +
+          `<table:covered-table-cell/>` +
+          `<table:table-cell office:value-type="string"><text:p>after</text:p></table:table-cell>` +
+          `</table:table-row>`,
+      ),
+    )
+    const sheet = wb.sheets[0]!
+    expect(sheet.rows[0]).toEqual(["wide", null, "after"])
+    expect(sheet.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }])
+  })
+
+  it("expands a repeated covered cell run", async () => {
+    const wb = await readBody(
+      table(
+        `<table:table-row>` +
+          `<table:table-cell table:number-columns-spanned="3" office:value-type="string"><text:p>wide</text:p></table:table-cell>` +
+          `<table:covered-table-cell table:number-columns-repeated="2"/>` +
+          `<table:table-cell office:value-type="string"><text:p>after</text:p></table:table-cell>` +
+          `</table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.rows[0]).toEqual(["wide", null, null, "after"])
+  })
+
+  it("repeats a row that carries a merge without cloning the merge range", async () => {
+    // Repeated rows containing merges are unusual; the reader duplicates the
+    // row data but records the merge once, from the first occurrence.
+    const wb = await readBody(
+      table(
+        `<table:table-row table:number-rows-repeated="2">` +
+          `<table:table-cell table:number-columns-spanned="2" office:value-type="string"><text:p>m</text:p></table:table-cell>` +
+          `<table:covered-table-cell/>` +
+          `<table:table-cell office:value-type="string"><text:p>z</text:p></table:table-cell>` +
+          `</table:table-row>`,
+      ),
+    )
+    const sheet = wb.sheets[0]!
+    expect(sheet.rows.length).toBe(2)
+    expect(sheet.rows[1]).toEqual(["m", null, "z"])
+    expect(sheet.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }])
+  })
+
+  it("advances the row counter across empty repeated rows", async () => {
+    // LibreOffice pads the tail of a sheet with a single empty row repeated
+    // a million times; those must not become a million row arrays, but the
+    // rows after them must still land at the right index.
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>` +
+          `<table:table-row table:number-rows-repeated="5"><table:table-cell/></table:table-row>` +
+          `<table:table-row><table:table-cell table:formula="of:=1" office:value-type="float" office:value="1"><text:p>1</text:p></table:table-cell></table:table-row>`,
+      ),
+    )
+    const sheet = wb.sheets[0]!
+    expect(sheet.rows.length).toBe(2)
+    expect([...sheet.cells!.keys()]).toEqual(["6,0"])
+  })
+})
+
+describe("ODS reader — cell metadata types", () => {
+  const styles = `<style:style style:name="ce1" style:family="table-cell"><style:text-properties fo:font-weight="bold"/></style:style>`
+
+  async function typeOf(cellXml: string): Promise<string | undefined> {
+    const wb = await readBody(table(`<table:table-row>${cellXml}</table:table-row>`), styles)
+    return wb.sheets[0]!.cells?.get("0,0")?.type
+  }
+
+  it("tags a styled boolean cell as boolean", async () => {
+    expect(
+      await typeOf(
+        `<table:table-cell table:style-name="ce1" office:value-type="boolean" office:boolean-value="true"/>`,
+      ),
+    ).toBe("boolean")
+  })
+
+  it("tags a styled date cell as date", async () => {
+    expect(
+      await typeOf(
+        `<table:table-cell table:style-name="ce1" office:value-type="date" office:date-value="2024-03-01"/>`,
+      ),
+    ).toBe("date")
+  })
+
+  it("tags a styled valueless cell as empty", async () => {
+    // A style-only cell is kept — the trailing-null trim skips entries that
+    // carry a style name.
+    expect(await typeOf(`<table:table-cell table:style-name="ce1"/>`)).toBe("empty")
+  })
+
+  it("tags a styled number cell as number", async () => {
+    expect(
+      await typeOf(
+        `<table:table-cell table:style-name="ce1" office:value-type="float" office:value="2.5"/>`,
+      ),
+    ).toBe("number")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — sheet selection
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — the sheets filter", () => {
+  const threeTables =
+    table(
+      `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>`,
+      "Alpha",
+    ) +
+    table(
+      `<table:table-row><table:table-cell office:value-type="string"><text:p>b</text:p></table:table-cell></table:table-row>`,
+      "Beta",
+    ) +
+    table(
+      `<table:table-row><table:table-cell office:value-type="string"><text:p>c</text:p></table:table-cell></table:table-row>`,
+      "Gamma",
+    )
+
+  async function names(sheets: Array<number | string>): Promise<string[]> {
+    const wb = await readOds(await odsFile({ content: contentXml(threeTables) }), { sheets })
+    return wb.sheets.map((s) => s.name)
+  }
+
+  it("treats an empty filter array as 'every sheet'", async () => {
+    expect(await names([])).toEqual(["Alpha", "Beta", "Gamma"])
+  })
+
+  it("keeps genuinely empty sheets when the filter array is empty", async () => {
+    const content = contentXml(threeTables + table("", "Blank"))
+    const wb = await readOds(await odsFile({ content }), { sheets: [] })
+    expect(wb.sheets.map((s) => s.name)).toEqual(["Alpha", "Beta", "Gamma", "Blank"])
+  })
+
+  it("selects by sheet name", async () => {
+    expect(await names(["Beta"])).toEqual(["Beta"])
+  })
+
+  it("selects by 0-based index", async () => {
+    expect(await names([2])).toEqual(["Gamma"])
+  })
+
+  it("ignores a filter entry that is neither a name nor an index", async () => {
+    // JS callers can pass anything; an unrecognised spec matches nothing
+    // rather than throwing or matching everything.
+    expect(await names([null as unknown as string, "Alpha"])).toEqual(["Alpha"])
+  })
+
+  it("keeps a selected sheet that genuinely has no rows", async () => {
+    // The skipped sheets are represented by empty placeholders, so the final
+    // pass has to tell "empty because skipped" from "empty in the file".
+    const content = contentXml(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>`,
+        "Alpha",
+      ) + table("", "Empty"),
+    )
+    const byName = await readOds(await odsFile({ content }), { sheets: ["Empty"] })
+    expect(byName.sheets.map((s) => s.name)).toEqual(["Empty"])
+
+    const byPredicate = await readOds(await odsFile({ content }), {
+      sheets: (info) => info.name === "Empty",
+    })
+    expect(byPredicate.sheets.map((s) => s.name)).toEqual(["Empty"])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — document structure and failure modes
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — malformed documents", () => {
+  it("returns no sheets when content.xml has no office:body", async () => {
+    const content =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<office:document-content ${NS}><office:scripts/></office:document-content>`
+    const wb = await readOds(await odsFile({ content }))
+    expect(wb.sheets).toEqual([])
+  })
+
+  it("returns no sheets when the body holds a text document instead of a spreadsheet", async () => {
+    // An .odt renamed to .ods gets this far: valid ZIP, ODF mimetype prefix,
+    // a body — but no <office:spreadsheet>.
+    const content =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<office:document-content ${NS}><office:body><office:text/></office:body></office:document-content>`
+    const wb = await readOds(
+      await odsFile({ content, mimetype: "application/vnd.oasis.opendocument.text" }),
+    )
+    expect(wb.sheets).toEqual([])
+  })
+
+  it("names an unnamed table by its position", async () => {
+    const content = contentXml(
+      `<table:table><table:table-row><table:table-cell office:value-type="string"><text:p>x</text:p></table:table-cell></table:table-row></table:table>`,
+    )
+    const wb = await readOds(await odsFile({ content }))
+    expect(wb.sheets[0]!.name).toBe("Sheet1")
+  })
+
+  it("rejects a ZIP whose mimetype is not an OpenDocument type", async () => {
+    const data = await odsFile({ content: contentXml(""), mimetype: "application/zip" })
+    await expect(readOds(data)).rejects.toThrow(/Invalid ODS mimetype/)
+  })
+
+  it("rejects an OpenDocument package with no content.xml", async () => {
+    const data = await odsFile({})
+    await expect(readOds(data)).rejects.toThrow(ParseError)
+    await expect(readOds(data)).rejects.toThrow(/missing content\.xml/)
+  })
+
+  it("rejects a file that is not a ZIP archive at all", async () => {
+    // A CSV renamed to .ods — the ZIP layer owns this failure, so the error
+    // stays a ZipError instead of being re-wrapped as a ParseError.
+    await expect(readOds(enc.encode("Name,Age\nAda,36\n"))).rejects.toThrow(ZipError)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS reader — meta.xml
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS reader — document properties from meta.xml", () => {
+  it("maps every meta element the reader understands", async () => {
+    const meta = metaXml(`
+      <dc:title>Quarterly</dc:title>
+      <dc:subject>Revenue</dc:subject>
+      <meta:initial-creator>Ada Lovelace</meta:initial-creator>
+      <dc:description>Numbers for Q1</dc:description>
+      <meta:keyword>finance</meta:keyword>
+      <meta:creation-date>2024-01-02T03:04:05</meta:creation-date>
+      <dc:date>2024-05-06T07:08:09</dc:date>
+    `)
+    const wb = await readOds(await odsFile({ content: contentXml(""), meta }))
+    const props = wb.properties!
+    expect(props.title).toBe("Quarterly")
+    expect(props.subject).toBe("Revenue")
+    expect(props.creator).toBe("Ada Lovelace")
+    expect(props.description).toBe("Numbers for Q1")
+    expect(props.keywords).toBe("finance")
+    expect(props.created?.getFullYear()).toBe(2024)
+    expect(props.modified?.getMonth()).toBe(4)
+  })
+
+  it("ignores empty elements rather than writing empty-string properties", async () => {
+    // LibreOffice emits the full set of meta elements even when the user
+    // never filled them in.
+    const meta = metaXml(
+      `<dc:title></dc:title><dc:subject></dc:subject><meta:initial-creator></meta:initial-creator>` +
+        `<dc:description></dc:description><meta:keyword></meta:keyword>` +
+        `<meta:creation-date></meta:creation-date><dc:date></dc:date>` +
+        `<meta:editing-cycles>3</meta:editing-cycles>`,
+    )
+    const wb = await readOds(await odsFile({ content: contentXml(""), meta }))
+    expect(wb.properties).toBeUndefined()
+  })
+
+  it("ignores dates it cannot parse", async () => {
+    const meta = metaXml(
+      `<meta:creation-date>whenever</meta:creation-date><dc:date>soon</dc:date><dc:title>Kept</dc:title>`,
+    )
+    const wb = await readOds(await odsFile({ content: contentXml(""), meta }))
+    expect(wb.properties).toEqual({ title: "Kept" })
+  })
+
+  it("ignores a meta.xml with no office:meta element", async () => {
+    const meta = `<?xml version="1.0" encoding="UTF-8"?><office:document-meta ${NS}></office:document-meta>`
+    const wb = await readOds(await odsFile({ content: contentXml(""), meta }))
+    expect(wb.properties).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// streamOdsRows
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("streamOdsRows — cell shapes", () => {
+  it("emits nulls for covered cells, including repeated runs", async () => {
+    const data = await odsFile({
+      content: contentXml(
+        table(
+          `<table:table-row>` +
+            `<table:table-cell table:number-columns-spanned="3" office:value-type="string"><text:p>wide</text:p></table:table-cell>` +
+            `<table:covered-table-cell table:number-columns-repeated="2"/>` +
+            `<table:table-cell office:value-type="string"><text:p>after</text:p></table:table-cell>` +
+            `</table:table-row>`,
+        ),
+      ),
+    })
+    const rows = await collectStream(data)
+    expect(rows[0]!.values).toEqual(["wide", null, null, "after"])
+  })
+
+  it("expands a bare text:s as a single space", async () => {
+    // `<text:s/>` without text:c means exactly one space per ODF §6.1.3.
+    const data = await odsFile({
+      content: contentXml(
+        table(
+          `<table:table-row><table:table-cell office:value-type="string"><text:p>a<text:s/>b</text:p></table:table-cell></table:table-row>`,
+        ),
+      ),
+    })
+    expect((await collectStream(data))[0]!.values[0]).toBe("a b")
+  })
+
+  it("treats a non-numeric or zero text:c as one space", async () => {
+    const data = await odsFile({
+      content: contentXml(
+        table(
+          `<table:table-row><table:table-cell office:value-type="string"><text:p>a<text:s text:c="many"/>b<text:s text:c="0"/>c</text:p></table:table-cell></table:table-row>`,
+        ),
+      ),
+    })
+    expect((await collectStream(data))[0]!.values[0]).toBe("a b c")
+  })
+
+  it("resolves date, boolean and empty-string cells the way the batch reader does", async () => {
+    const body = table(
+      `<table:table-row>` +
+        `<table:table-cell office:value-type="date" office:date-value="2024-03-01"/>` +
+        `<table:table-cell office:value-type="date" office:date-value="nope"/>` +
+        `<table:table-cell office:value-type="date"/>` +
+        `<table:table-cell office:value-type="boolean" office:boolean-value="false"/>` +
+        `<table:table-cell office:value-type="boolean" office:boolean-value="maybe"/>` +
+        `<table:table-cell office:value-type="float"/>` +
+        `<table:table-cell office:value-type="string"/>` +
+        `<table:table-cell><text:p>untyped</text:p></table:table-cell>` +
+        `</table:table-row>`,
+    )
+    const data = await odsFile({ content: contentXml(body) })
+    const values = (await collectStream(data))[0]!.values
+    expect(values[0]).toBeInstanceOf(Date)
+    expect(values.slice(1)).toEqual([null, null, false, null, null, "", "untyped"])
+
+    // …and identically through readOds.
+    const wb = await readOds(data)
+    expect(wb.sheets[0]!.rows[0]!.slice(1)).toEqual(values.slice(1))
+  })
+
+  // ── Known defect ─────────────────────────────────────────────────
+  it.skip("does not fold a cell annotation into the cell value (BUG)", async () => {
+    // src/ods/stream.ts:131 sets `inP` for *any* <text:p> seen while inside
+    // a <table:table-cell>, including the paragraphs of the
+    // <office:annotation> LibreOffice writes as the cell's first child for
+    // a comment. The batch reader takes only direct <text:p> children
+    // (src/ods/reader.ts:283), so the two disagree:
+    //   readOds        → "value"
+    //   streamOdsRows  → "a notevalue"
+    // Any ODS with cell comments streams back with the comment text glued
+    // to the front of the cell's own text.
+    const body = table(
+      `<table:table-row><table:table-cell office:value-type="string">` +
+        `<office:annotation><dc:creator>Ada</dc:creator><text:p>a note</text:p></office:annotation>` +
+        `<text:p>value</text:p>` +
+        `</table:table-cell></table:table-row>`,
+    )
+    const data = await odsFile({ content: contentXml(body) })
+    const streamed = (await collectStream(data))[0]!.values
+    const batched = (await readOds(data)).sheets[0]!.rows[0]
+    expect(batched).toEqual(["value"])
+    expect(streamed).toEqual(batched)
+  })
+
+  it("skips empty repeated rows but keeps the row index in step", async () => {
+    const body = table(
+      `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>` +
+        `<table:table-row table:number-rows-repeated="4"><table:table-cell/></table:table-row>` +
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>b</text:p></table:table-cell></table:table-row>`,
+    )
+    const rows = await collectStream(await odsFile({ content: contentXml(body) }))
+    expect(rows.map((r) => [r.index, r.values[0]])).toEqual([
+      [0, "a"],
+      [5, "b"],
+    ])
+  })
+})
+
+describe("streamOdsRows — options and failure modes", () => {
+  const twoSheets = contentXml(
+    table(
+      `<table:table-row><table:table-cell office:value-type="string"><text:p>a1</text:p></table:table-cell></table:table-row>` +
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>a2</text:p></table:table-cell></table:table-row>`,
+      "Alpha",
+    ) +
+      table(
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>b1</text:p></table:table-cell></table:table-row>`,
+        "Beta",
+      ),
+  )
+
+  it("streams every sheet when the filter names sheets it cannot resolve", async () => {
+    // The SAX pass never sees table names, so a name-only filter degrades to
+    // "stream everything" rather than silently yielding nothing.
+    const data = await odsFile({ content: twoSheets })
+    const rows: StreamRow[] = []
+    for await (const row of streamOdsRows(data, { sheets: ["Beta"] })) rows.push(row)
+    expect(rows.length).toBe(3)
+  })
+
+  it("restricts streaming to the requested sheet index", async () => {
+    const data = await odsFile({ content: twoSheets })
+    const rows: StreamRow[] = []
+    for await (const row of streamOdsRows(data, { sheets: [1] })) rows.push(row)
+    expect(rows.map((r) => r.values[0])).toEqual(["b1"])
+  })
+
+  it("stops after maxRows", async () => {
+    const data = await odsFile({ content: twoSheets })
+    const rows: StreamRow[] = []
+    for await (const row of streamOdsRows(data, { maxRows: 2 })) rows.push(row)
+    expect(rows.map((r) => r.values[0])).toEqual(["a1", "a2"])
+  })
+
+  it("yields nothing for a text document's content.xml", async () => {
+    // An .odt renamed to .ods clears the mimetype check (both start with
+    // `application/vnd.oasis.opendocument`) and reaches the SAX pass. Its
+    // body holds paragraphs and a text table built from the very same
+    // table:/text: elements a spreadsheet uses — none of which may be
+    // mistaken for sheet rows.
+    const content =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<office:document-content ${NS}><office:body><office:text>` +
+      `<text:p>a paragraph<text:s text:c="2"/><text:tab/><text:line-break/>more</text:p>` +
+      `<table:table table:name="T1"><table:table-row>` +
+      `<table:table-cell office:value-type="string"><text:p>in a text table</text:p></table:table-cell>` +
+      `<table:covered-table-cell/>` +
+      `</table:table-row></table:table>` +
+      `</office:text></office:body></office:document-content>`
+    const data = await odsFile({
+      content,
+      mimetype: "application/vnd.oasis.opendocument.text",
+    })
+    expect(await collectStream(data)).toEqual([])
+    expect((await readOds(data)).sheets).toEqual([])
+  })
+
+  it("rejects a package with no mimetype entry", async () => {
+    const zip = new ZipWriter()
+    zip.add("content.xml", enc.encode(contentXml("")))
+    const data = await zip.build()
+    await expect(collectStream(data)).rejects.toThrow(/missing 'mimetype'/)
+  })
+
+  it("rejects a package with no content.xml", async () => {
+    await expect(collectStream(await odsFile({}))).rejects.toThrow(/missing content\.xml/)
+  })
+
+  it("rejects input that is not a ZIP archive", async () => {
+    await expect(collectStream(enc.encode("just some bytes"))).rejects.toThrow(ZipError)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS writer — number-format translation
+// ═══════════════════════════════════════════════════════════════════════
+//
+// Writing a numFmt and reading it back with `readStyles` exercises both
+// halves of the Excel ⇄ ODF format-code translation in one pass.
+
+describe("ODS writer — date format code round-trips", () => {
+  async function roundTrip(numFmt: string): Promise<string | undefined> {
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: 1, style: { numFmt } })
+    const data = await writeOds({
+      sheets: [{ name: "S", rows: [[1]], cells }],
+    })
+    const wb = await readOds(data, { readStyles: true })
+    return wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt
+  }
+
+  it.each([
+    ["yy-m-d", "yy-m-d"],
+    ["dd.mm.yyyy", "dd.mm.yyyy"],
+    ["mmm-yy", "mmm-yy"],
+    ["dddd, mmmm d, yyyy", "dddd, mmmm d, yyyy"],
+    ["ddd d mmm", "ddd d mmm"],
+    ["h:m:s AM/PM", "h:m:s AM/PM"],
+    ["hh:mm:ss", "hh:mm:ss"],
+  ])("preserves %s", async (input, expected) => {
+    expect(await roundTrip(input)).toBe(expected)
+  })
+
+  it("keeps a quoted literal in a date code", async () => {
+    expect(await roundTrip(`yyyy" (fiscal)"`)).toBe(`yyyy" (fiscal)"`)
+  })
+
+  it("normalizes a backslash-escaped separator to the bare character", async () => {
+    // Excel's `\-` and a literal `-` mean the same thing in ODF, which has
+    // only <number:text>.
+    expect(await roundTrip(`yyyy\\-mm`)).toBe("yyyy-mm")
+  })
+
+  it("drops formats it cannot translate rather than emitting an empty style", async () => {
+    // "General" and "@" have no ODF data-style equivalent; the cell style
+    // would carry nothing else, so no <style:style> is emitted at all.
+    expect(await roundTrip("General")).toBeUndefined()
+    expect(await roundTrip("@")).toBeUndefined()
+  })
+
+  it("shares one data style between two different cell styles", async () => {
+    // The cell-style cache is keyed on the whole style, so bold+0.000 and
+    // italic+0.000 are two <style:style> elements — but they must point at
+    // the same <number:number-style>.
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: 1, style: { numFmt: "0.000", font: { bold: true } } })
+    cells.set("0,1", { value: 2, style: { numFmt: "0.000", font: { italic: true } } })
+    const xml = await contentOf(await writeOds({ sheets: [{ name: "S", rows: [[1, 2]], cells }] }))
+    expect(xml.match(/<number:number-style/g)!.length).toBe(1)
+    expect(xml.match(/<style:style/g)!.length).toBe(2)
+  })
+
+  it("emits nothing for a style object with no properties at all", async () => {
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: 1, style: {} })
+    const xml = await contentOf(await writeOds({ sheets: [{ name: "S", rows: [[1]], cells }] }))
+    expect(xml).not.toContain("<style:style")
+    expect(xml).not.toContain("table:style-name")
+  })
+
+  it("reads a bracketed currency symbol out of an Excel locale tag", async () => {
+    // Excel writes `[$€-2]#,##0` for a Euro format.
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: 1, style: { numFmt: "[$€-2]#,##0" } })
+    const data = await writeOds({ sheets: [{ name: "S", rows: [[1]], cells }] })
+    expect(await contentOf(data)).toContain("<number:currency-symbol>€</number:currency-symbol>")
+    const wb = await readOds(data, { readStyles: true })
+    expect(wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt).toBe(`"€"#,##0`)
+  })
+
+  it("marks bracketed minute and second durations as non-truncating", async () => {
+    // `[m]:ss` is elapsed minutes. ODF expresses that with
+    // number:truncate-on-overflow="false" on the time style; the bracket
+    // itself has no ODF spelling, so this is checked on the written XML.
+    const codes = ["[m]:ss", "[ss]", "[h]:mm", "[mm]:[s]"]
+    const cells = new Map<string, Partial<Cell>>()
+    codes.forEach((numFmt, i) => cells.set(`${i},0`, { value: i, style: { numFmt } }))
+    const xml = await contentOf(
+      await writeOds({ sheets: [{ name: "S", rows: codes.map((_, i) => [i]), cells }] }),
+    )
+    expect(xml.match(/number:truncate-on-overflow="false"/g)!.length).toBe(codes.length)
+    expect(xml).toContain(`<number:minutes/>`)
+    expect(xml).toContain(`<number:minutes number:style="long"/>`)
+    expect(xml).toContain(`<number:seconds/>`)
+    expect(xml).toContain(`<number:seconds number:style="long"/>`)
+    expect(xml).toContain(`<number:hours/>`)
+  })
+
+  it("puts a trailing currency symbol after the number element", async () => {
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: 1, style: { numFmt: `#,##0.00 "€"` } })
+    const data = await writeOds({ sheets: [{ name: "S", rows: [[1]], cells }] })
+    const doc = parseXml(await contentOf(data))
+    const autoStyles = doc.children.find(
+      (c): c is Exclude<typeof c, string> =>
+        typeof c !== "string" && (c.local || c.tag) === "automatic-styles",
+    )!
+    const currency = autoStyles.children.find(
+      (c): c is Exclude<typeof c, string> =>
+        typeof c !== "string" && (c.local || c.tag) === "currency-style",
+    )!
+    const kinds = currency.children
+      .filter((c): c is Exclude<typeof c, string> => typeof c !== "string")
+      .map((c) => c.local || c.tag)
+    expect(kinds[kinds.length - 1]).toBe("currency-symbol")
+  })
+
+  // ── Known defect ─────────────────────────────────────────────────
+  it.skip("treats [$-409] as a locale tag, not a currency symbol (BUG)", async () => {
+    // src/ods/writer.ts:120 — detectCurrencySymbol() falls through to a bare
+    // /[$€£¥₺₽₹]/ scan of the whole code. Excel's locale prefix `[$-409]`
+    // (and `[$-F800]`, used by the built-in long-date format) contains a "$",
+    // so a *date* code is classified as currency: the writer emits
+    // <number:currency-style> with a "$" symbol and drops every date token.
+    // Input:    numFmt "[$-409]mmm-yy"
+    // Expected: a <number:date-style> round-tripping to "mmm-yy"
+    // Actual:   a <number:currency-style> round-tripping to `"$"0`
+    // The guard at writer.ts:115 already recognises that `[$-409]` has an
+    // empty symbol group; the fallback at :120 undoes that decision.
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: 1, style: { numFmt: "[$-409]mmm-yy" } })
+    const data = await writeOds({ sheets: [{ name: "S", rows: [[1]], cells }] })
+    const wb = await readOds(data, { readStyles: true })
+    expect(wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt).toBe("mmm-yy")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS writer — object data and sparse rows
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ODS writer — columns + data", () => {
+  it("omits the header row when no column declares a header", async () => {
+    const sheet: WriteSheet = {
+      name: "S",
+      columns: [{ key: "a" }, { key: "b" }],
+      data: [{ a: 1, b: 2 }],
+    }
+    const wb = await readOds(await writeOds({ sheets: [sheet] }))
+    expect(wb.sheets[0]!.rows).toEqual([[1, 2]])
+  })
+
+  it("uses the header as the lookup key when no key is given", async () => {
+    const sheet: WriteSheet = {
+      name: "S",
+      columns: [{ header: "Name" }, { header: "Age" }],
+      data: [{ Name: "Ada", Age: 36 }],
+    }
+    const wb = await readOds(await writeOds({ sheets: [sheet] }))
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["Name", "Age"],
+      ["Ada", 36],
+    ])
+  })
+
+  it("writes null for a key the object does not have", async () => {
+    const sheet: WriteSheet = {
+      name: "S",
+      columns: [
+        { key: "a", header: "A" },
+        { key: "missing", header: "M" },
+      ],
+      data: [{ a: 1 }],
+    }
+    const wb = await readOds(await writeOds({ sheets: [sheet] }))
+    expect(wb.sheets[0]!.rows[1]).toEqual([1])
+  })
+
+  it("falls back to an empty header for a column with neither key nor header", async () => {
+    // A column declared only for its width still occupies a position.
+    const sheet: WriteSheet = {
+      name: "S",
+      columns: [{ header: "A", key: "a" }, { key: "b" }, { width: 10 }],
+      data: [{ a: 1, b: 2 }],
+    }
+    const wb = await readOds(await writeOds({ sheets: [sheet] }))
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["A", "b", ""],
+      [1, 2],
+    ])
+  })
+
+  it("writes an empty sheet when neither rows nor data are given", async () => {
+    const wb = await readOds(await writeOds({ sheets: [{ name: "S" }] }))
+    expect(wb.sheets[0]!.rows).toEqual([])
+  })
+
+  // ── Known defect ─────────────────────────────────────────────────
+  it.skip("writes a cells override that sits on a trailing empty cell (BUG)", async () => {
+    // src/ods/writer.ts:629-642 computes `lastMeaningful` from the row's own
+    // values and then extends it only for merge starts and covered cells —
+    // never for `sheet.cells`. Any override whose column is at or past the
+    // row's last non-null value is therefore never emitted: the row stops
+    // short of it. The same holds for an override below the last row, since
+    // writeContentXml iterates `rows` (src/ods/writer.ts:736) and sizes the
+    // table from `rows` + `merges` only (src/ods/writer.ts:762-772).
+    // The XLSX writer grows the grid for exactly this case
+    // (src/xlsx/worksheet-writer.ts:679-692), so one WriteSheet produces two
+    // different documents depending on the output format.
+    // Input:    rows [[1, null, null]], cells { "0,2": { formula: "NOW()" } }
+    // Expected: <table:table-cell table:formula="of:=NOW()"> in column C
+    // Actual:   the row ends after column A; the override is dropped
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,2", { value: null, formula: "NOW()" })
+    cells.set("2,0", { value: "z" })
+    const wb = await readOds(
+      await writeOds({ sheets: [{ name: "S", rows: [[1, null, null]], cells }] }),
+    )
+    expect(wb.sheets[0]!.cells?.get("0,2")?.formula).toBe("NOW()")
+    expect(wb.sheets[0]!.rows[2]).toEqual(["z"])
+  })
+
+  it("writes a self-closing cell for a null override with nothing else on it", async () => {
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { value: null })
+    const data = await writeOds({ sheets: [{ name: "S", rows: [[null, "b"]], cells }] })
+    expect(await contentOf(data)).toContain("<table:table-cell/>")
+    expect((await readOds(data)).sheets[0]!.rows[0]).toEqual([null, "b"])
+  })
+
+  it("keeps an empty cell that carries a formula", async () => {
+    // The empty-run collapse must not swallow a cell that has an override.
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,1", { formula: "SUM(A1:A1)" })
+    const data = await writeOds({ sheets: [{ name: "S", rows: [[1, null, 3]], cells }] })
+    const xml = await contentOf(data)
+    expect(xml).toContain(`table:formula="of:=SUM([.A1:.A1])"`)
+    const wb = await readOds(data)
+    expect(wb.sheets[0]!.cells?.get("0,1")?.formula).toBe("SUM(A1:A1)")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ODS object shorthand
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readOdsObjects / writeOdsObjects", () => {
+  it("writes only the data rows when writeHeaders is false", async () => {
+    const data = await writeOdsObjects([{ a: 1, b: 2 }], { writeHeaders: false })
+    const wb = await readOds(data as Uint8Array)
+    expect(wb.sheets[0]!.rows).toEqual([[1, 2]])
+  })
+
+  it("uses an explicit header order and fills absent keys with null", async () => {
+    const data = await writeOdsObjects([{ b: 2 }], { headers: ["a", "b"], sheetName: "Data" })
+    const wb = await readOds(data as Uint8Array)
+    expect(wb.sheets[0]!.name).toBe("Data")
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["a", "b"],
+      [null, 2],
+    ])
+  })
+
+  it("writes a header-only sheet for an empty data array", async () => {
+    const data = await writeOdsObjects([])
+    const wb = await readOds(data as Uint8Array)
+    expect(wb.sheets[0]!.rows).toEqual([])
+  })
+
+  it("round-trips through readOdsObjects", async () => {
+    const data = await writeOdsObjects([
+      { Name: "Ada", Age: 36 },
+      { Name: "Grace", Age: 45 },
+    ])
+    const result = await readOdsObjects(data as Uint8Array)
+    expect(result.headers).toEqual(["Name", "Age"])
+    expect(result.data).toEqual([
+      { Name: "Ada", Age: 36 },
+      { Name: "Grace", Age: 45 },
+    ])
+  })
+})

--- a/test/coverage-roundtrip-pivot.test.ts
+++ b/test/coverage-roundtrip-pivot.test.ts
@@ -1,0 +1,883 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { resolvePivotSource, writePivotTable } from "../src/xlsx/pivot-writer"
+import { cloneChart } from "../src/xlsx/chart-clone"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import { EncryptedFileError } from "../src/errors"
+import type { Chart, SheetChart, WritePivotTable, WriteSheet } from "../src/_types"
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder("utf-8")
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function part(buf: Uint8Array, path: string): Promise<string> {
+  return decoder.decode(await new ZipReader(buf).extract(path))
+}
+
+function entries(buf: Uint8Array): string[] {
+  return new ZipReader(buf).entries()
+}
+
+/**
+ * Re-package a workbook with extra ZIP entries, the way a real producer
+ * (Excel, WPS) ships parts hucre never authors itself — chart style
+ * sidecars, slicers, external links. Nothing else about the file changes.
+ */
+async function withParts(
+  buf: Uint8Array,
+  extra: Record<string, string | Uint8Array>,
+): Promise<Uint8Array> {
+  const all = await new ZipReader(buf).extractAll()
+  for (const [path, body] of Object.entries(extra)) {
+    all.set(path, typeof body === "string" ? encoder.encode(body) : body)
+  }
+  const out = new ZipWriter()
+  for (const [path, data] of all) out.add(path, data, { compress: false })
+  return out.build()
+}
+
+const SALES: WriteSheet = {
+  name: "Data",
+  rows: [
+    ["Region", "Product", "Quarter", "Revenue"],
+    ["EU", "Widget", "Q1", 100],
+    ["US", "Widget", "Q1", 200],
+    ["EU", "Gadget", "Q2", 50],
+    ["US", "Gadget", "Q2", 75],
+  ],
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// pivot-writer — axis placement
+//
+// Phase 1 of #159 emits a structurally valid pivot Excel finishes on
+// refresh. The page (filter) axis and multi-field axes were the parts
+// nothing exercised, so a broken `<pageFields>` block would have shipped.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("pivot page fields", () => {
+  it("emits <pageFields> and an axisPage pivotField for a filter field", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        SALES,
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "ByRegion",
+              sourceSheet: "Data",
+              pages: ["Quarter"],
+              rows: ["Region"],
+              values: [{ field: "Revenue" }],
+            },
+          ],
+        },
+      ],
+    })
+    const xml = await part(buf, "xl/pivotTables/pivotTable1.xml")
+
+    expect(xml).toContain('<pageFields count="1">')
+    expect(xml).toContain('<pageField fld="2" hier="-1"/>')
+    expect(xml).toContain('axis="axisPage"')
+  })
+
+  it("keeps each axis in declaration order when several fields share it", () => {
+    // The axis lists are sorted by `axisOrder`; with one field per axis
+    // the comparator never runs, so the ordering contract was untested.
+    const pivot: WritePivotTable = {
+      name: "Wide",
+      rows: ["Product", "Region"],
+      columns: ["Year", "Quarter"],
+      pages: ["Channel", "Currency"],
+      values: [{ field: "Revenue" }],
+    }
+    const source = resolvePivotSource(pivot, "Data", [
+      ["Region", "Product", "Quarter", "Year", "Channel", "Currency", "Revenue"],
+      ["EU", "Widget", "Q1", "2024", "Web", "EUR", 100],
+      ["US", "Gadget", "Q2", "2025", "Retail", "USD", 200],
+    ])
+    const { pivotTableXml } = writePivotTable(pivot, source, 0)
+
+    // Product (index 1) is declared before Region (index 0) on the row axis.
+    expect(pivotTableXml).toContain('<rowFields count="2"><field x="1"/><field x="0"/></rowFields>')
+    expect(pivotTableXml).toContain('<colFields count="2"><field x="3"/><field x="2"/></colFields>')
+    expect(pivotTableXml).toContain(
+      '<pageFields count="2"><pageField fld="4" hier="-1"/><pageField fld="5" hier="-1"/></pageFields>',
+    )
+  })
+
+  it("marks a source column that is on no axis as hidden", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        SALES,
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "Sparse",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [{ field: "Revenue" }],
+            },
+          ],
+        },
+      ],
+    })
+    const xml = await part(buf, "xl/pivotTables/pivotTable1.xml")
+
+    // Product and Quarter are cached but unplaced.
+    expect(xml).toContain('<pivotField showAll="0"/>')
+  })
+})
+
+describe("pivot data fields", () => {
+  it("declares a numFmtId for a value field that asked for a number format", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        SALES,
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "Money",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [{ field: "Revenue", numberFormat: "#,##0.00" }],
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(await part(buf, "xl/pivotTables/pivotTable1.xml")).toContain('numFmtId="0"')
+  })
+
+  it("labels every aggregation Excel supports", () => {
+    const fns = [
+      ["product", "Product of Revenue"],
+      ["countNums", "Count Nums of Revenue"],
+      ["stdDev", "StdDev of Revenue"],
+      ["stdDevp", "StdDevp of Revenue"],
+      ["var", "Var of Revenue"],
+      ["varp", "Varp of Revenue"],
+    ] as const
+
+    for (const [fn, label] of fns) {
+      const pivot: WritePivotTable = {
+        name: "P",
+        rows: ["Region"],
+        values: [{ field: "Revenue", function: fn }],
+      }
+      const source = resolvePivotSource(pivot, "Data", SALES.rows!)
+      const { pivotTableXml } = writePivotTable(pivot, source, 0)
+      expect(pivotTableXml).toContain(`name="${label}"`)
+      expect(pivotTableXml).toContain(`subtotal="${fn}"`)
+    }
+  })
+
+  it("streams a text field placed on the data axis as inline strings", async () => {
+    // `Count of Region` puts a string field on the data axis, where no
+    // shared-items table is built — the records fall back to `<s v="…"/>`.
+    const buf = await writeXlsx({
+      sheets: [
+        SALES,
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "Counts",
+              sourceSheet: "Data",
+              rows: ["Product"],
+              values: [{ field: "Region", function: "count" }],
+            },
+          ],
+        },
+      ],
+    })
+    const records = await part(buf, "xl/pivotCache/pivotCacheRecords1.xml")
+
+    expect(records).toContain('<s v="EU"/>')
+    expect(records).toContain('<s v="US"/>')
+  })
+})
+
+describe("pivot cache fields", () => {
+  it("names an unlabelled source column ColumnN", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["Column2"],
+      values: [{ field: "Revenue" }],
+    }
+    const source = resolvePivotSource(pivot, "Data", [
+      ["Region", null, "Revenue"],
+      ["EU", "x", 100],
+      ["US", "y", 200],
+    ])
+
+    expect(source.fieldNames).toEqual(["Region", "Column2", "Revenue"])
+  })
+
+  it("accepts a pivot with no row axis at all", () => {
+    // Columns-only pivots are legal; `rows` being absent must not throw
+    // while collecting the field names to validate.
+    const pivot: WritePivotTable = {
+      name: "P",
+      columns: ["Region"],
+      values: [{ field: "Revenue" }],
+    }
+    const source = resolvePivotSource(pivot, "Data", SALES.rows!)
+    const { pivotTableXml } = writePivotTable(pivot, source, 0)
+
+    expect(pivotTableXml).toContain("<colFields")
+    expect(pivotTableXml).not.toContain("<rowFields")
+  })
+
+  it("registers the blank of a string axis field as an empty shared item", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    }
+    const source = resolvePivotSource(pivot, "Data", [
+      ["Region", "Revenue"],
+      ["EU", 100],
+      [null, 200],
+    ])
+    const { cacheDefinitionXml, cacheRecordsXml } = writePivotTable(pivot, source, 0)
+
+    expect(cacheDefinitionXml).toContain('<s v=""/>')
+    // The record side still writes `<m/>` for the blank — the empty
+    // shared item exists so Excel can show a "(blank)" row label.
+    expect(cacheRecordsXml).toContain("<m/>")
+  })
+
+  it("reports containsInteger=0 for a column with fractional values", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    }
+    const source = resolvePivotSource(pivot, "Data", [
+      ["Region", "Revenue"],
+      ["EU", 10.5],
+      ["US", 20.25],
+    ])
+    const { cacheDefinitionXml } = writePivotTable(pivot, source, 0)
+
+    expect(cacheDefinitionXml).toContain('containsInteger="0"')
+    expect(cacheDefinitionXml).toContain('minValue="10.5"')
+  })
+})
+
+describe("pivot input validation", () => {
+  it("rejects a targetCell that is not an A1 reference", () => {
+    const pivot: WritePivotTable = {
+      name: "P",
+      targetCell: "top-left",
+      rows: ["Region"],
+      values: [{ field: "Revenue" }],
+    }
+    const source = resolvePivotSource(pivot, "Data", SALES.rows!)
+
+    expect(() => writePivotTable(pivot, source, 0)).toThrow(/A1-style reference/)
+  })
+
+  it("rejects a source sheet whose header row is empty", () => {
+    // No header cells means no fields, so there is no range to describe.
+    expect(() => resolvePivotSource({ name: "P", values: [] }, "Data", [[], [1]])).toThrow(
+      /at least one column and row/,
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// roundtrip — openXlsx
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("openXlsx on an encrypted workbook", () => {
+  it("refuses to open a password-protected file without the password", async () => {
+    const enc = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]] }],
+      encryption: { password: "pw", spinCount: 64 },
+    })
+
+    await expect(openXlsx(enc)).rejects.toBeInstanceOf(EncryptedFileError)
+  })
+
+  it("decrypts up front so the preserved raw entries are plaintext parts", async () => {
+    const enc = await writeXlsx({
+      sheets: [{ name: "S", rows: [["kept"]] }],
+      encryption: { password: "pw", spinCount: 64 },
+    })
+    const wb = await openXlsx(enc, { password: "pw" })
+    const saved = await saveXlsx(wb)
+
+    expect(entries(saved)).toContain("xl/worksheets/sheet1.xml")
+    expect(wb.sheets[0].rows[0]).toEqual(["kept"])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// roundtrip — tables
+//
+// Tables are regenerated (not preserved), so open → save has to rebuild
+// the table part, its relationship, and its range.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("openXlsx → saveXlsx keeps Excel tables", () => {
+  const withTable: WriteSheet = {
+    name: "S",
+    rows: [
+      ["Name", "Price"],
+      ["Bolt", 2],
+      ["Nut", 1],
+    ],
+    tables: [
+      {
+        name: "Inventory",
+        range: "A1:B3",
+        columns: [{ name: "Name" }, { name: "Price" }],
+      },
+    ],
+  }
+
+  it("re-emits the table part and the sheet relationship that points at it", async () => {
+    const saved = await saveXlsx(await openXlsx(await writeXlsx({ sheets: [withTable] })))
+
+    expect(await part(saved, "xl/tables/table1.xml")).toContain('ref="A1:B3"')
+    expect(await part(saved, "xl/worksheets/_rels/sheet1.xml.rels")).toContain(
+      "../tables/table1.xml",
+    )
+    expect(await part(saved, "[Content_Types].xml")).toContain("/xl/tables/table1.xml")
+  })
+
+  it("numbers tables across sheets from a single global counter", async () => {
+    const second: WriteSheet = { ...withTable, name: "S2" }
+    second.tables = [{ name: "Second", range: "A1:B3", columns: [{ name: "Name" }] }]
+    const saved = await saveXlsx(await openXlsx(await writeXlsx({ sheets: [withTable, second] })))
+
+    expect(entries(saved)).toContain("xl/tables/table2.xml")
+  })
+
+  it("recomputes a range for a table added to an opened workbook", async () => {
+    const wb = await openXlsx(await writeXlsx({ sheets: [{ name: "S", rows: [["A"], [1], [2]] }] }))
+    wb.sheets[0].tables = [
+      { name: "Added", showTotalRow: true, columns: [{ name: "A" }, { name: "B" }] },
+    ]
+    const saved = await saveXlsx(wb)
+
+    // 3 sheet rows + 1 totals row.
+    expect(await part(saved, "xl/tables/table1.xml")).toContain('ref="A1:B4"')
+  })
+
+  it("never computes an empty range for a table on an empty sheet", async () => {
+    const wb = await openXlsx(await writeXlsx({ sheets: [{ name: "S", rows: [] }] }))
+    wb.sheets[0].tables = [{ name: "Added", columns: [{ name: "A" }] }]
+    const saved = await saveXlsx(wb)
+
+    expect(await part(saved, "xl/tables/table1.xml")).toContain('ref="A1:A1"')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// roundtrip — print settings
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("openXlsx → saveXlsx rebuilds print defined names", () => {
+  it("re-declares Print_Area and Print_Titles from the sheet page setup", async () => {
+    const wb = await openXlsx(
+      await writeXlsx({
+        sheets: [
+          {
+            name: "Report",
+            rows: [
+              ["a", "b"],
+              [1, 2],
+            ],
+          },
+        ],
+      }),
+    )
+    wb.sheets[0].pageSetup = {
+      printArea: "$A$1:$B$2",
+      printTitlesRow: "$1:$1",
+      printTitlesColumn: "$A:$A",
+    }
+    const xml = await part(await saveXlsx(wb), "xl/workbook.xml")
+
+    expect(xml).toContain("_xlnm.Print_Area")
+    expect(xml).toContain("Report!$A$1:$B$2")
+    expect(xml).toContain("_xlnm.Print_Titles")
+    expect(xml).toContain("Report!$1:$1,Report!$A:$A")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// roundtrip — parts hucre does not model
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("openXlsx → saveXlsx re-declares foreign workbook parts", () => {
+  it("keeps two external links and gives each its own workbook relationship", async () => {
+    const link = (n: number) =>
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <externalBook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" r:id="rId1">
+    <sheetNames><sheetName val="Sheet${n}"/></sheetNames>
+  </externalBook>
+</externalLink>`
+    const base = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] })
+    const buf = await withParts(base, {
+      "xl/externalLinks/externalLink1.xml": link(1),
+      "xl/externalLinks/externalLink2.xml": link(2),
+    })
+    const saved = await saveXlsx(await openXlsx(buf))
+    const rels = await part(saved, "xl/_rels/workbook.xml.rels")
+
+    expect(rels).toContain("externalLinks/externalLink1.xml")
+    expect(rels).toContain("externalLinks/externalLink2.xml")
+    expect(await part(saved, "[Content_Types].xml")).toContain(
+      "/xl/externalLinks/externalLink2.xml",
+    )
+  })
+
+  it("keeps two slicers and two timelines wired to their caches", async () => {
+    const slicers = (n: number) =>
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicers xmlns="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">
+  <slicer name="S${n}" cache="Slicer_S${n}" caption="S${n}"/>
+</slicers>`
+    const slicerCache = (n: number) =>
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<slicerCacheDefinition xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" name="Slicer_S${n}" sourceName="S${n}"/>`
+    const timelines = (n: number) =>
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelines xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main">
+  <timeline name="T${n}" cache="NativeTimeline_T${n}" caption="T${n}" level="months"/>
+</timelines>`
+    const timelineCache = (n: number) =>
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<timelineCacheDefinition xmlns="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main" name="NativeTimeline_T${n}" sourceName="T${n}"/>`
+
+    const base = await writeXlsx({
+      sheets: [
+        { name: "Data", rows: [["a"]] },
+        { name: "Filters", rows: [["b"]] },
+      ],
+    })
+    const buf = await withParts(base, {
+      "xl/slicers/slicer1.xml": slicers(1),
+      "xl/slicers/slicer2.xml": slicers(2),
+      "xl/slicerCaches/slicerCache1.xml": slicerCache(1),
+      "xl/slicerCaches/slicerCache2.xml": slicerCache(2),
+      "xl/timelines/timeline1.xml": timelines(1),
+      "xl/timelines/timeline2.xml": timelines(2),
+      "xl/timelineCaches/timelineCache1.xml": timelineCache(1),
+      "xl/timelineCaches/timelineCache2.xml": timelineCache(2),
+      "xl/worksheets/_rels/sheet2.xml.rels": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.microsoft.com/office/2007/relationships/slicer" Target="../slicers/slicer1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.microsoft.com/office/2007/relationships/slicer" Target="../slicers/slicer2.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2011/relationships/timeline" Target="../timelines/timeline1.xml"/>
+  <Relationship Id="rId4" Type="http://schemas.microsoft.com/office/2011/relationships/timeline" Target="../timelines/timeline2.xml"/>
+</Relationships>`,
+    })
+    const saved = await saveXlsx(await openXlsx(buf))
+
+    const wbRels = await part(saved, "xl/_rels/workbook.xml.rels")
+    expect(wbRels).toContain("slicerCaches/slicerCache2.xml")
+    expect(wbRels).toContain("timelineCaches/timelineCache2.xml")
+
+    const sheetRels = await part(saved, "xl/worksheets/_rels/sheet2.xml.rels")
+    expect(sheetRels).toContain("../slicers/slicer2.xml")
+    expect(sheetRels).toContain("../timelines/timeline2.xml")
+  })
+
+  it("keeps two pivot caches and their pivot tables", async () => {
+    const pivotSheet: WriteSheet = {
+      name: "Pivots",
+      pivotTables: [
+        {
+          name: "First",
+          sourceSheet: "Data",
+          rows: ["Region"],
+          values: [{ field: "Revenue" }],
+        },
+        {
+          name: "Second",
+          sourceSheet: "Data",
+          targetCell: "A20",
+          rows: ["Product"],
+          values: [{ field: "Revenue", function: "average" }],
+        },
+      ],
+    }
+    const saved = await saveXlsx(await openXlsx(await writeXlsx({ sheets: [SALES, pivotSheet] })))
+    const names = entries(saved)
+
+    expect(names).toContain("xl/pivotCache/pivotCacheDefinition2.xml")
+    expect(names).toContain("xl/pivotCache/pivotCacheRecords2.xml")
+    expect(names).toContain("xl/pivotTables/pivotTable2.xml")
+
+    const sheetRels = await part(saved, "xl/worksheets/_rels/sheet2.xml.rels")
+    expect(sheetRels).toContain("../pivotTables/pivotTable1.xml")
+    expect(sheetRels).toContain("../pivotTables/pivotTable2.xml")
+  })
+
+  it("resolves cell-image media paths written as package-absolute or ../ targets", async () => {
+    // WPS writes `media/imageN.png` relative to `xl/cellimages.xml`, but
+    // the same registry is also seen with package-absolute targets
+    // (`/xl/media/...`) and with `../` segments, which land at the
+    // package root. Both forms have to be resolved, because a path that
+    // resolves under `xl/media/` would otherwise be swept away with the
+    // drawing images the writer regenerates.
+    const base = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] })
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    const buf = await withParts(base, {
+      "xl/cellimages.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<etc:cellImages xmlns:etc="http://www.wps.cn/officeDocument/2017/etCustomData"/>`,
+      "xl/_rels/cellimages.xml.rels": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="/xl/media/image90.png"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image91.png"/>
+</Relationships>`,
+      "xl/media/image90.png": png,
+      "media/image91.png": png,
+    })
+    const saved = await saveXlsx(await openXlsx(buf))
+    const names = entries(saved)
+
+    // Without the absolute-target branch this one is filtered out as a
+    // regenerated drawing image.
+    expect(names).toContain("xl/media/image90.png")
+    expect(names).toContain("media/image91.png")
+    expect(names).toContain("xl/_rels/cellimages.xml.rels")
+  })
+})
+
+describe("openXlsx → saveXlsx drops parts the workbook no longer needs", () => {
+  it("leaves behind the worksheet of a sheet that was removed", async () => {
+    const wb = await openXlsx(
+      await writeXlsx({
+        sheets: [
+          { name: "Keep", rows: [["a"]] },
+          { name: "Drop", rows: [["b"]] },
+        ],
+      }),
+    )
+    wb.sheets.splice(1, 1)
+    const saved = await saveXlsx(wb)
+
+    // sheet2.xml survives in the raw entries but is filtered by the
+    // "xl/worksheets/" regenerated prefix, so it must not be re-added.
+    expect(entries(saved)).not.toContain("xl/worksheets/sheet2.xml")
+    expect(await part(saved, "xl/workbook.xml")).not.toContain('name="Drop"')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// roundtrip — chart preservation
+//
+// hucre's drawing writer cannot re-emit a chart graphicFrame, so a
+// chart-bearing drawing is preserved byte-for-byte and re-anchored into
+// the regenerated worksheet body.
+// ═══════════════════════════════════════════════════════════════════════
+
+function chartOn(row: number, title: string): SheetChart {
+  return {
+    type: "column",
+    title,
+    series: [{ name: "Revenue", values: "D2:D5", categories: "A2:A5" }],
+    anchor: { from: { row, col: 0 }, to: { row: row + 12, col: 6 } },
+  }
+}
+
+describe("chart parts survive the roundtrip", () => {
+  it("declares preserved chart style and colour sidecars in [Content_Types].xml", async () => {
+    // `style1.xml` / `colors1.xml` only come from Excel — hucre never
+    // writes them — so they exercise the preserved-sidecar declaration.
+    const base = await writeXlsx({
+      sheets: [{ ...SALES, charts: [chartOn(7, "First"), chartOn(24, "Second")] }],
+    })
+    const sidecar = (tag: string) =>
+      `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<${tag} xmlns="http://schemas.microsoft.com/office/drawing/2012/chartStyle" id="201"/>`
+    const buf = await withParts(base, {
+      "xl/charts/style1.xml": sidecar("cs:chartStyle"),
+      "xl/charts/style2.xml": sidecar("cs:chartStyle"),
+      "xl/charts/colors1.xml": sidecar("cs:colorStyle"),
+      "xl/charts/colors2.xml": sidecar("cs:colorStyle"),
+    })
+    const saved = await saveXlsx(await openXlsx(buf))
+    const ct = await part(saved, "[Content_Types].xml")
+
+    expect(ct).toContain("/xl/charts/style2.xml")
+    expect(ct).toContain("/xl/charts/colors2.xml")
+    expect(entries(saved)).toContain("xl/charts/chart2.xml")
+  })
+
+  it("re-anchors the preserved drawing into the regenerated worksheet body", async () => {
+    const base = await writeXlsx({ sheets: [{ ...SALES, charts: [chartOn(7, "Sales")] }] })
+    const saved = await saveXlsx(await openXlsx(base))
+    const ws = await part(saved, "xl/worksheets/sheet1.xml")
+
+    expect(ws).toContain("<drawing r:id=")
+    expect(await part(saved, "xl/worksheets/_rels/sheet1.xml.rels")).toContain(
+      "../drawings/drawing1.xml",
+    )
+  })
+
+  it("inserts the re-anchored <drawing> before <tableParts>", async () => {
+    // CT_Worksheet fixes the child order: `drawing` precedes `tableParts`.
+    // Appending at the end of the body would make Excel reject the sheet.
+    const sheet: WriteSheet = {
+      ...SALES,
+      charts: [chartOn(7, "Sales")],
+      tables: [
+        {
+          name: "T",
+          range: "A1:D5",
+          columns: [
+            { name: "Region" },
+            { name: "Product" },
+            { name: "Quarter" },
+            { name: "Revenue" },
+          ],
+        },
+      ],
+    }
+    const saved = await saveXlsx(await openXlsx(await writeXlsx({ sheets: [sheet] })))
+    const ws = await part(saved, "xl/worksheets/sheet1.xml")
+
+    expect(ws.indexOf("<drawing ")).toBeGreaterThan(-1)
+    expect(ws.indexOf("<drawing ")).toBeLessThan(ws.indexOf("<tableParts"))
+  })
+
+  it("does not preserve a drawing that holds no chart", async () => {
+    // Sheet 2 keeps a hucre-managed image (its drawing is regenerated);
+    // sheet 3's image is removed before saving, so its original drawing
+    // is neither regenerated nor chart-bearing and is simply dropped.
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    const base = await writeXlsx({
+      sheets: [
+        { ...SALES, charts: [chartOn(7, "Sales")] },
+        {
+          name: "Pics",
+          rows: [["b"]],
+          images: [{ data: png, type: "png", anchor: { from: { row: 0, col: 2 } } }],
+        },
+        {
+          name: "WasPics",
+          rows: [["c"]],
+          images: [{ data: png, type: "png", anchor: { from: { row: 0, col: 2 } } }],
+        },
+      ],
+    })
+    const wb = await openXlsx(base)
+    wb.sheets[2].images = []
+    const saved = await saveXlsx(wb)
+    const names = entries(saved)
+
+    expect(names).toContain("xl/drawings/drawing1.xml") // chart drawing, preserved
+    expect(names).toContain("xl/drawings/drawing2.xml") // image drawing, regenerated
+    expect(names).not.toContain("xl/drawings/drawing3.xml")
+  })
+
+  it("finds the chart drawing past unrelated and unnumbered drawing relationships", async () => {
+    // Sheet rels list hyperlinks first, and some producers ship an
+    // unnumbered `drawing.xml`. Neither may stop the scan that maps the
+    // sheet onto its chart-bearing drawing.
+    const sheet: WriteSheet = {
+      ...SALES,
+      charts: [chartOn(7, "Sales")],
+      cells: new Map([["0,0", { value: "Region", hyperlink: { target: "https://example.com" } }]]),
+    }
+    const base = await writeXlsx({ sheets: [sheet] })
+    const relsPath = "xl/worksheets/_rels/sheet1.xml.rels"
+    const original = await part(base, relsPath)
+    const buf = await withParts(base, {
+      "xl/drawings/drawing.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"/>`,
+      // The unnumbered drawing is listed first, so the scan has to skip
+      // past it rather than stop at the first drawing relationship.
+      [relsPath]: original.replace(
+        "<Relationship ",
+        `<Relationship Id="rId90" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing.xml"/><Relationship `,
+      ),
+    })
+    const saved = await saveXlsx(await openXlsx(buf))
+
+    expect(await part(saved, "xl/worksheets/sheet1.xml")).toContain("<drawing r:id=")
+    expect(entries(saved)).toContain("xl/drawings/drawing1.xml")
+  })
+
+  it("ignores a drawing that merely mentions :chartSpace in an attribute", async () => {
+    // The detector matches the `chart` local name only — `:chartSpace`
+    // and `:chartstyle` must not make an ordinary drawing look
+    // chart-bearing, or the roundtrip preserves an orphan part.
+    const base = await writeXlsx({ sheets: [{ ...SALES, charts: [chartOn(7, "Sales")] }] })
+    const buf = await withParts(base, {
+      "xl/drawings/drawing7.xml": `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
+          xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">
+  <xdr:oneCellAnchor>
+    <xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2" name="Legacy" descr="exported from c:chartSpace, see c:chartstyle"/></xdr:nvPicPr></xdr:pic>
+  </xdr:oneCellAnchor>
+</xdr:wsDr>`,
+    })
+    const saved = await saveXlsx(await openXlsx(buf))
+
+    expect(entries(saved)).not.toContain("xl/drawings/drawing7.xml")
+  })
+})
+
+describe("model charts added to an opened workbook", () => {
+  it("skips a sheet that already owns a hucre-managed image drawing", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    const wb = await openXlsx(
+      await writeXlsx({
+        sheets: [
+          {
+            ...SALES,
+            images: [{ data: png, type: "png", anchor: { from: { row: 0, col: 6 } } }],
+          },
+        ],
+      }),
+    )
+    // @ts-expect-error Sheet.charts is the read model; the roundtrip
+    // bridge accepts write-model entries here (issue #136).
+    wb.sheets[0].charts = [chartOn(7, "Too late")]
+    const saved = await saveXlsx(wb)
+
+    // The image drawing is rebuilt; adding a chart to it is out of scope,
+    // so no chart part appears.
+    expect(entries(saved).some((n) => n.startsWith("xl/charts/"))).toBe(false)
+  })
+
+  it("skips a sheet whose original drawing hucre is no longer rebuilding", async () => {
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    const wb = await openXlsx(
+      await writeXlsx({
+        sheets: [
+          {
+            ...SALES,
+            images: [{ data: png, type: "png", anchor: { from: { row: 0, col: 6 } } }],
+          },
+        ],
+      }),
+    )
+    wb.sheets[0].images = []
+    // @ts-expect-error see above — write-model chart on a read-model sheet.
+    wb.sheets[0].charts = [chartOn(7, "Still too late")]
+    const saved = await saveXlsx(wb)
+
+    expect(entries(saved).some((n) => n.startsWith("xl/charts/"))).toBe(false)
+  })
+
+  it("drops charts the write model cannot express instead of failing the save", async () => {
+    const wb = await openXlsx(await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] }))
+    const radar: Chart = {
+      kinds: ["radar"],
+      seriesCount: 1,
+      series: [{ kind: "radar", index: 0, name: "R", valuesRef: "S!$A$1:$A$2" }],
+    }
+    wb.sheets[0].charts = [radar]
+    const saved = await saveXlsx(wb)
+
+    expect(entries(saved).some((n) => n.startsWith("xl/charts/"))).toBe(false)
+    expect(await part(saved, "xl/worksheets/sheet1.xml")).not.toContain("<drawing ")
+  })
+
+  it("anchors a chart that arrives without one at the top-left cell", async () => {
+    const wb = await openXlsx(await writeXlsx({ sheets: [{ ...SALES }] }))
+    // A write-model chart with no anchor — the shape JSON or a template
+    // helper hands over. Sheet.charts is the read model; the roundtrip
+    // bridge accepts write-model entries here (issue #136).
+    const unanchored = {
+      type: "column",
+      title: "Unanchored",
+      series: [{ name: "Revenue", values: "D2:D5", categories: "A2:A5" }],
+    }
+    wb.sheets[0].charts = [unanchored as unknown as Chart]
+    const saved = await saveXlsx(wb)
+    const drawing = await part(saved, "xl/drawings/drawing1.xml")
+
+    expect(drawing).toContain("<xdr:col>0</xdr:col>")
+    expect(drawing).toContain("<xdr:row>0</xdr:row>")
+  })
+
+  it("ignores a non-object entry in a sheet's charts array", async () => {
+    // `charts` can arrive from JSON with holes in it.
+    const wb = await openXlsx(await writeXlsx({ sheets: [{ ...SALES }] }))
+    // @ts-expect-error deliberately malformed input, as JSON would deliver it.
+    wb.sheets[0].charts = [null, chartOn(7, "Real")]
+    const saved = await saveXlsx(wb)
+
+    expect(entries(saved)).toContain("xl/charts/chart1.xml")
+    expect(await part(saved, "xl/charts/chart1.xml")).toContain("Real")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// chart-clone — line cap / compound overrides
+//
+// `<a:ln cap= cmpd=>` is the last pair of stroke knobs; the clone
+// resolvers are shared with the colour / width / dash ones but each
+// target lives on a different OOXML host.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cloneChart border cap and compound", () => {
+  const source: Chart = {
+    kinds: ["bar"],
+    seriesCount: 1,
+    title: "Template",
+    series: [
+      {
+        kind: "bar",
+        index: 0,
+        name: "Revenue",
+        valuesRef: "Sheet1!$B$2:$B$5",
+        categoriesRef: "Sheet1!$A$2:$A$5",
+      },
+    ],
+  }
+
+  it("applies cap and compound overrides to the legend, plot area and title borders", () => {
+    const clone = cloneChart(source, {
+      anchor: { from: { row: 0, col: 0 } },
+      title: "Clone",
+      legendBorderCap: "rnd",
+      legendBorderCompound: "dbl",
+      plotAreaBorderCap: "sq",
+      plotAreaBorderCompound: "thickThin",
+      titleBorderCap: "rnd",
+      titleBorderCompound: "tri",
+      // "flat" is the OOXML default cap and collapses to absence.
+      plotAreaBorderDash: "dash",
+    })
+
+    expect(clone.legendBorderCap).toBe("rnd")
+    expect(clone.legendBorderCompound).toBe("dbl")
+    expect(clone.plotAreaBorderCap).toBe("sq")
+    expect(clone.plotAreaBorderCompound).toBe("thickThin")
+    expect(clone.titleBorderCap).toBe("rnd")
+    expect(clone.titleBorderCompound).toBe("tri")
+  })
+
+  it("drops a series 3-D shape when the clone is coerced off the bar family", () => {
+    // `<c:shape>` only exists on bar3D series; carrying it onto a line
+    // clone would leak metadata the writer must ignore anyway.
+    const bar3d: Chart = {
+      ...source,
+      kinds: ["bar3D"],
+      series: [{ ...source.series![0], kind: "bar3D", shape3D: "cylinder" }],
+    }
+
+    const anchor = { from: { row: 0, col: 0 } }
+    expect(cloneChart(bar3d, { anchor }).series?.[0].shape3D).toBe("cylinder")
+    expect(cloneChart(bar3d, { anchor, type: "line" }).series?.[0].shape3D).toBeUndefined()
+  })
+})

--- a/test/coverage-sheet-ops.test.ts
+++ b/test/coverage-sheet-ops.test.ts
@@ -1,0 +1,875 @@
+import { describe, expect, it } from "vitest"
+import type {
+  Cell,
+  CellStyle,
+  CellValue,
+  ConditionalRule,
+  Sheet,
+  SheetImage,
+  Workbook,
+} from "../src/_types"
+import {
+  cloneSheet,
+  copyRange,
+  deleteColumns,
+  deleteRows,
+  insertColumns,
+  insertRows,
+  moveRows,
+  replaceCells,
+  sortRows,
+} from "../src/sheet-ops"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function sheet(overrides: Partial<Sheet> = {}): Sheet {
+  return { name: "Sheet1", rows: [], ...overrides }
+}
+
+/** A 1×1 PNG-ish blob — the row/column ops never look inside it. */
+function img(from: { row: number; col: number }, to?: { row: number; col: number }): SheetImage {
+  return { data: new Uint8Array([1, 2, 3]), type: "png", anchor: { from, to } }
+}
+
+function rule(range: string): ConditionalRule {
+  return { type: "cellIs", operator: "greaterThan", formula: "0", priority: 1, range }
+}
+
+/** Grid of `rows`×`cols` labelled cells, so shifts are visible in assertions. */
+function grid(rows: number, cols: number): (string | null)[][] {
+  return Array.from({ length: rows }, (_, r) =>
+    Array.from({ length: cols }, (_, c) => `r${r}c${c}`),
+  )
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Range rewriting — single-cell references
+// ═══════════════════════════════════════════════════════════════════════
+
+// Excel writes one-cell data validations and conditional rules with a bare
+// `sqref="B3"` (no colon). The rewriter has to treat that as a degenerate
+// range rather than dropping the end coordinate.
+describe("range rewriting with colon-less references", () => {
+  it("shifts a single-cell validation range and normalises it to start:end", () => {
+    const s = sheet({
+      rows: grid(4, 2),
+      dataValidations: [{ type: "list", range: "B3", values: ["x"] }],
+      conditionalRules: [rule("A2")],
+      tables: [{ name: "T", range: "A1", columns: [{ name: "a" }] }],
+    })
+
+    insertRows(s, 0, 2)
+
+    expect(s.dataValidations![0].range).toBe("B5:B5")
+    expect(s.conditionalRules![0].range).toBe("A4:A4")
+    expect(s.tables![0].range).toBe("A3:A3")
+  })
+
+  it("shifts a single-cell reference on column insert too", () => {
+    const s = sheet({
+      rows: grid(2, 4),
+      dataValidations: [{ type: "list", range: "C1", values: ["x"] }],
+      conditionalRules: [rule("D2")],
+      tables: [{ name: "T", range: "C2", columns: [{ name: "a" }] }],
+    })
+
+    insertColumns(s, 0, 1)
+
+    expect(s.dataValidations![0].range).toBe("D1:D1")
+    expect(s.conditionalRules![0].range).toBe("E2:E2")
+    expect(s.tables![0].range).toBe("D2:D2")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// insertRows
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("insertRows", () => {
+  // A sheet read from XLSX can declare more `<col>` entries than any row
+  // actually populates (styled-but-empty trailing columns). The inserted
+  // blank rows must be as wide as the widest of the two, or the new rows
+  // come out narrower than the sheet.
+  it("sizes new blank rows from the column defs when they are wider than any row", () => {
+    const s = sheet({
+      rows: [["a", "b"]],
+      columns: [{ width: 10 }, { width: 10 }, { width: 10 }, { width: 10 }],
+    })
+
+    insertRows(s, 0, 1)
+
+    expect(s.rows[0]).toEqual([null, null, null, null])
+  })
+
+  it("rewrites conditional rules and table ranges that sit below the insertion", () => {
+    const s = sheet({
+      rows: grid(5, 2),
+      conditionalRules: [rule("A3:B5")],
+      tables: [{ name: "T", range: "A3:B5", columns: [{ name: "a" }, { name: "b" }] }],
+    })
+
+    insertRows(s, 1, 2)
+
+    expect(s.conditionalRules![0].range).toBe("A5:B7")
+    expect(s.tables![0].range).toBe("A5:B7")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// deleteRows
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("deleteRows", () => {
+  // A merge that starts above the cut and ends inside it survives, but its
+  // bottom edge has to land on the last surviving row.
+  it("clamps the bottom edge of a merge that ends inside the deleted range", () => {
+    const s = sheet({
+      rows: grid(6, 2),
+      merges: [{ startRow: 1, startCol: 0, endRow: 3, endCol: 1 }],
+    })
+
+    deleteRows(s, 2, 3)
+
+    expect(s.merges).toEqual([{ startRow: 1, startCol: 0, endRow: 1, endCol: 1 }])
+  })
+
+  it("drops images anchored inside the cut and lifts the ones below it", () => {
+    const s = sheet({
+      rows: grid(8, 2),
+      images: [
+        img({ row: 0, col: 0 }), // above the cut — untouched
+        img({ row: 3, col: 0 }), // inside the cut — dropped
+        img({ row: 6, col: 0 }, { row: 7, col: 1 }), // below — from and to lift
+        img({ row: 1, col: 0 }, { row: 4, col: 1 }), // spans the cut — only `from` kept
+      ],
+    })
+
+    deleteRows(s, 2, 3)
+
+    expect(s.images!.map((i) => i.anchor.from.row)).toEqual([0, 3, 1])
+    expect(s.images![1].anchor.to).toEqual({ row: 4, col: 1 })
+    // `to` inside the deleted range is left alone — it is not >= deleteEnd.
+    expect(s.images![2].anchor.to).toEqual({ row: 4, col: 1 })
+  })
+
+  it("drops tables fully inside the cut and lifts the ones below it", () => {
+    const s = sheet({
+      rows: grid(10, 2),
+      tables: [
+        { name: "Inside", range: "A3:B4", columns: [{ name: "a" }] },
+        { name: "Below", range: "A7:B9", columns: [{ name: "a" }] },
+        { name: "NoRange", columns: [{ name: "a" }] },
+      ],
+    })
+
+    deleteRows(s, 2, 3)
+
+    expect(s.tables!.map((t) => t.name)).toEqual(["Below", "NoRange"])
+    expect(s.tables![0].range).toBe("A4:B6")
+    expect(s.tables![1].range).toBeUndefined()
+  })
+
+  // The two halves of `shiftDeletedRangeRows`: a range whose top is inside
+  // the cut collapses onto the first surviving row; a range whose bottom is
+  // inside the cut collapses onto the last surviving row above it.
+  it("clamps ranges that straddle the deleted rows", () => {
+    const s = sheet({
+      rows: grid(10, 2),
+      dataValidations: [{ type: "list", range: "A4:B8", values: ["x"] }],
+      conditionalRules: [rule("A1:B4")],
+      autoFilter: { range: "A2:B6" },
+    })
+
+    deleteRows(s, 3, 3) // cut rows 4..6 (1-based)
+
+    // Top was row 4 (inside) → clamps to the cut position; bottom row 8 lifts by 3.
+    expect(s.dataValidations![0].range).toBe("A4:B5")
+    // Bottom was row 4 (inside) → clamps to row 3, the last surviving row above.
+    expect(s.conditionalRules![0].range).toBe("A1:B3")
+    expect(s.autoFilter!.range).toBe("A2:B3")
+  })
+
+  it("keeps an auto filter that only partially overlaps the cut", () => {
+    const s = sheet({ rows: grid(6, 2), autoFilter: { range: "A1:B6" } })
+
+    deleteRows(s, 1, 2)
+
+    expect(s.autoFilter!.range).toBe("A1:B4")
+  })
+
+  it("drops conditional rules that live entirely in the deleted rows", () => {
+    const s = sheet({
+      rows: grid(8, 2),
+      conditionalRules: [
+        { ...rule("A3:B4"), priority: 1 }, // fully inside → dropped
+        { ...rule("A6:B8"), priority: 2 }, // below → lifts
+      ],
+    })
+
+    deleteRows(s, 2, 3)
+
+    expect(s.conditionalRules!.map((r) => r.range)).toEqual(["A3:B5"])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// insert/delete columns
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("insertColumns / deleteColumns", () => {
+  it("are no-ops for a non-positive count", () => {
+    const s = sheet({ rows: grid(2, 2) })
+    const before = JSON.stringify(s.rows)
+
+    insertColumns(s, 0, 0)
+    deleteColumns(s, 0, -1)
+
+    expect(JSON.stringify(s.rows)).toBe(before)
+  })
+
+  it("shifts conditional rules and table ranges right on insert", () => {
+    const s = sheet({
+      rows: grid(2, 4),
+      conditionalRules: [rule("C1:D2")],
+      tables: [{ name: "T", range: "C1:D2", columns: [{ name: "a" }, { name: "b" }] }],
+    })
+
+    insertColumns(s, 1, 2)
+
+    expect(s.conditionalRules![0].range).toBe("E1:F2")
+    expect(s.tables![0].range).toBe("E1:F2")
+  })
+
+  it("clamps merges that straddle the deleted columns", () => {
+    const s = sheet({
+      rows: grid(3, 8),
+      merges: [
+        { startRow: 0, startCol: 2, endRow: 0, endCol: 6 }, // starts inside, ends after
+        { startRow: 1, startCol: 0, endRow: 1, endCol: 3 }, // starts before, ends inside
+        { startRow: 2, startCol: 0, endRow: 2, endCol: 6 }, // spans the whole cut
+      ],
+    })
+
+    deleteColumns(s, 2, 3) // cut columns C..E
+
+    expect(s.merges).toEqual([
+      { startRow: 0, startCol: 2, endRow: 0, endCol: 3 },
+      { startRow: 1, startCol: 0, endRow: 1, endCol: 1 },
+      { startRow: 2, startCol: 0, endRow: 2, endCol: 3 },
+    ])
+  })
+
+  it("drops conditional rules fully inside the cut and clamps the rest", () => {
+    const s = sheet({
+      rows: grid(2, 8),
+      conditionalRules: [
+        { ...rule("C1:D2"), priority: 1 }, // fully inside → dropped
+        { ...rule("A1:D2"), priority: 2 }, // right edge inside → clamps
+        { ...rule("C1:H2"), priority: 3 }, // left edge inside → clamps
+      ],
+    })
+
+    deleteColumns(s, 2, 3)
+
+    expect(s.conditionalRules!.map((r) => r.range)).toEqual(["A1:B2", "C1:E2"])
+  })
+
+  it("keeps an auto filter that only partially overlaps the deleted columns", () => {
+    const s = sheet({ rows: grid(2, 6), autoFilter: { range: "A1:F2" } })
+
+    deleteColumns(s, 1, 2)
+
+    expect(s.autoFilter!.range).toBe("A1:D2")
+  })
+
+  it("drops images anchored inside the cut and pulls the ones to its right", () => {
+    const s = sheet({
+      rows: grid(2, 8),
+      images: [
+        img({ row: 0, col: 0 }),
+        img({ row: 0, col: 3 }), // inside → dropped
+        img({ row: 0, col: 6 }, { row: 1, col: 7 }), // right of cut → both shift
+        img({ row: 0, col: 1 }, { row: 1, col: 4 }), // straddles → `to` stays
+      ],
+    })
+
+    deleteColumns(s, 2, 3)
+
+    expect(s.images!.map((i) => i.anchor.from.col)).toEqual([0, 3, 1])
+    expect(s.images![1].anchor.to).toEqual({ row: 1, col: 4 })
+    expect(s.images![2].anchor.to).toEqual({ row: 1, col: 4 })
+  })
+
+  it("drops tables fully inside the cut and clamps the rest", () => {
+    const s = sheet({
+      rows: grid(2, 8),
+      tables: [
+        { name: "Inside", range: "C1:D2", columns: [{ name: "a" }] },
+        { name: "Right", range: "F1:H2", columns: [{ name: "a" }] },
+        { name: "NoRange", columns: [{ name: "a" }] },
+      ],
+    })
+
+    deleteColumns(s, 2, 3)
+
+    expect(s.tables!.map((t) => t.name)).toEqual(["Right", "NoRange"])
+    expect(s.tables![0].range).toBe("C1:E2")
+    expect(s.tables![1].range).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// moveRows
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("moveRows", () => {
+  it("carries row definitions along with the rows they describe", () => {
+    const s = sheet({
+      rows: grid(4, 1),
+      rowDefs: new Map([
+        [0, { height: 10 }],
+        [1, { height: 20 }],
+        [3, { height: 40 }],
+      ]),
+    })
+
+    moveRows(s, 0, 1, 3) // row 0 moves to the end
+
+    expect(s.rows.map((r) => r[0])).toEqual(["r1c0", "r2c0", "r0c0", "r3c0"])
+    expect(s.rowDefs!.get(2)).toEqual({ height: 10 }) // the moved row's def
+    expect(s.rowDefs!.get(0)).toEqual({ height: 20 })
+    expect(s.rowDefs!.get(3)).toEqual({ height: 40 })
+  })
+
+  // An empty override Map is indistinguishable from "no overrides", and the
+  // writers branch on `sheet.cells` being present at all — so the move
+  // clears it rather than leaving an empty Map behind.
+  it("drops empty cell and rowDef maps instead of keeping them empty", () => {
+    const s = sheet({ rows: grid(3, 1), cells: new Map(), rowDefs: new Map() })
+
+    moveRows(s, 0, 1, 2)
+
+    expect(s.cells).toBeUndefined()
+    expect(s.rowDefs).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// cloneSheet — deep-copy coverage of the style/cell trees
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cloneSheet", () => {
+  it("deep-copies a gradient fill without sharing the stop array", () => {
+    const style: CellStyle = {
+      fill: {
+        type: "gradient",
+        degree: 90,
+        stops: [
+          { position: 0, color: { rgb: "FFFF0000" } },
+          { position: 1, color: { rgb: "FF0000FF" } },
+        ],
+      },
+    }
+    const s = sheet({
+      rows: [["x"]],
+      cells: new Map([["0,0", { value: "x", type: "string", style }]]),
+    })
+
+    const c = cloneSheet(s, "Copy")
+    const clonedFill = c.cells!.get("0,0")!.style!.fill!
+    if (clonedFill.type !== "gradient") throw new Error("expected a gradient fill")
+
+    expect(clonedFill.degree).toBe(90)
+    expect(clonedFill.stops).toHaveLength(2)
+    clonedFill.stops[0].color.rgb = "FF00FF00"
+    const originalFill = s.cells!.get("0,0")!.style!.fill!
+    if (originalFill.type !== "gradient") throw new Error("expected a gradient fill")
+    expect(originalFill.stops[0].color.rgb).toBe("FFFF0000")
+  })
+
+  it("keeps a pattern fill with no explicit colours as colourless", () => {
+    const style: CellStyle = { fill: { type: "pattern", pattern: "gray125" } }
+    const s = sheet({
+      rows: [["x"]],
+      cells: new Map([["0,0", { value: "x", type: "string", style }]]),
+    })
+
+    const clonedFill = cloneSheet(s, "Copy").cells!.get("0,0")!.style!.fill!
+    if (clonedFill.type !== "pattern") throw new Error("expected a pattern fill")
+
+    expect(clonedFill.fgColor).toBeUndefined()
+    expect(clonedFill.bgColor).toBeUndefined()
+  })
+
+  // The overwhelmingly common solid fill in the wild sets only fgColor;
+  // bgColor is meaningful for the striped patterns.
+  it("deep-copies a pattern fill's foreground and background independently", () => {
+    const both: CellStyle = {
+      fill: {
+        type: "pattern",
+        pattern: "lightGrid",
+        fgColor: { rgb: "FF000000" },
+        bgColor: { rgb: "FFFFFFFF" },
+      },
+    }
+    const fgOnly: CellStyle = {
+      fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFFFF00" } },
+    }
+    const s = sheet({
+      rows: [["x", "y"]],
+      cells: new Map<string, Cell>([
+        ["0,0", { value: "x", type: "string", style: both }],
+        ["0,1", { value: "y", type: "string", style: fgOnly }],
+      ]),
+    })
+
+    const c = cloneSheet(s, "Copy")
+    const a = c.cells!.get("0,0")!.style!.fill!
+    const b = c.cells!.get("0,1")!.style!.fill!
+    if (a.type !== "pattern" || b.type !== "pattern") throw new Error("expected pattern fills")
+
+    expect(b.bgColor).toBeUndefined()
+    a.bgColor!.rgb = "FF123456"
+    const originalA = s.cells!.get("0,0")!.style!.fill!
+    if (originalA.type !== "pattern") throw new Error("expected a pattern fill")
+    expect(originalA.bgColor!.rgb).toBe("FFFFFFFF")
+  })
+
+  it("deep-copies every border side, with and without a colour", () => {
+    const style: CellStyle = {
+      border: {
+        top: { style: "thin", color: { rgb: "FF111111" } },
+        right: { style: "thin" },
+        bottom: { style: "medium", color: { rgb: "FF222222" } },
+        left: { style: "dashed" },
+        diagonal: { style: "thick", color: { rgb: "FF333333" } },
+        diagonalUp: true,
+      },
+      alignment: { horizontal: "center" },
+      numFmt: "0.00",
+      protection: { locked: false },
+    }
+    const s = sheet({
+      rows: [["x"]],
+      cells: new Map([["0,0", { value: "x", type: "string", style }]]),
+    })
+
+    const c = cloneSheet(s, "Copy")
+    const border = c.cells!.get("0,0")!.style!.border!
+
+    expect(border.top!.color).toEqual({ rgb: "FF111111" })
+    expect(border.right!.color).toBeUndefined()
+    expect(border.left!.color).toBeUndefined()
+    expect(border.diagonal!.color).toEqual({ rgb: "FF333333" })
+    expect(border.diagonalUp).toBe(true)
+
+    border.bottom!.color!.rgb = "FFFFFFFF"
+    expect(s.cells!.get("0,0")!.style!.border!.bottom!.color!.rgb).toBe("FF222222")
+  })
+
+  // Partial borders are the norm — a header underline is a bottom edge and
+  // nothing else. Every side has to survive being absent, and every side
+  // has to survive carrying no explicit colour.
+  it("preserves partial borders and colourless sides", () => {
+    const mixed: CellStyle = {
+      border: {
+        top: { style: "thin" }, // present, no colour
+        right: { style: "thin", color: { rgb: "FF111111" } },
+        left: { style: "thin", color: { rgb: "FF222222" } },
+        diagonal: { style: "thin" }, // present, no colour
+        // no bottom at all
+      },
+    }
+    const underlineOnly: CellStyle = { border: { bottom: { style: "medium" } } }
+    const s = sheet({
+      rows: [["x", "y"]],
+      cells: new Map<string, Cell>([
+        ["0,0", { value: "x", type: "string", style: mixed }],
+        ["0,1", { value: "y", type: "string", style: underlineOnly }],
+      ]),
+    })
+
+    const c = cloneSheet(s, "Copy")
+    const a = c.cells!.get("0,0")!.style!.border!
+    const b = c.cells!.get("0,1")!.style!.border!
+
+    expect(a.top!.color).toBeUndefined()
+    expect(a.diagonal!.color).toBeUndefined()
+    expect(a.bottom).toBeUndefined()
+    expect(a.right!.color).toEqual({ rgb: "FF111111" })
+    expect(a.left!.color).toEqual({ rgb: "FF222222" })
+
+    expect(b.top).toBeUndefined()
+    expect(b.right).toBeUndefined()
+    expect(b.left).toBeUndefined()
+    expect(b.diagonal).toBeUndefined()
+    expect(b.bottom).toEqual({ style: "medium", color: undefined })
+  })
+
+  it("deep-copies formulas, cached results and rich text runs", () => {
+    const cell: Cell = {
+      value: 3,
+      type: "number",
+      formula: "SUM(A1:A2)",
+      formulaResult: 3,
+      richText: [
+        { text: "red", font: { bold: true, color: { rgb: "FFFF0000" } } },
+        { text: " bold", font: { bold: true } }, // a font with no colour
+        { text: " plain" }, // a run with no font at all
+      ],
+    }
+    const s = sheet({ rows: [[3]], cells: new Map([["0,0", cell]]) })
+
+    const cloned = cloneSheet(s, "Copy").cells!.get("0,0")!
+
+    expect(cloned.formula).toBe("SUM(A1:A2)")
+    expect(cloned.formulaResult).toBe(3)
+    expect(cloned.richText![1].font!.color).toBeUndefined()
+    expect(cloned.richText![2].font).toBeUndefined()
+    cloned.richText![0].font!.color!.rgb = "FF00FF00"
+    expect(s.cells!.get("0,0")!.richText![0].font!.color!.rgb).toBe("FFFF0000")
+  })
+
+  it("deep-copies a comment's rich text runs", () => {
+    const cell: Cell = {
+      value: "x",
+      type: "string",
+      comment: {
+        text: "note",
+        author: "QA",
+        richText: [{ text: "red", font: { color: { rgb: "FFFF0000" } } }, { text: "plain" }],
+      },
+    }
+    const s = sheet({ rows: [["x"]], cells: new Map([["0,0", cell]]) })
+
+    const cloned = cloneSheet(s, "Copy").cells!.get("0,0")!
+
+    expect(cloned.comment!.richText![1].font).toBeUndefined()
+    cloned.comment!.richText![0].font!.color!.rgb = "FF00FF00"
+    expect(s.cells!.get("0,0")!.comment!.richText![0].font!.color!.rgb).toBe("FFFF0000")
+  })
+
+  it("deep-copies a column-level style", () => {
+    const s = sheet({
+      rows: [["x"]],
+      columns: [
+        { width: 12, style: { font: { bold: true, color: { rgb: "FF010203" } } } },
+        { width: 8 },
+      ],
+    })
+
+    const c = cloneSheet(s, "Copy")
+
+    expect(c.columns![1].style).toBeUndefined()
+    c.columns![0].style!.font!.color!.rgb = "FFFFFFFF"
+    expect(s.columns![0].style!.font!.color!.rgb).toBe("FF010203")
+  })
+
+  it("deep-copies data bar, icon set and multi-formula conditional rules", () => {
+    const s = sheet({
+      rows: [[1]],
+      conditionalRules: [
+        {
+          type: "dataBar",
+          priority: 1,
+          range: "A1:A5",
+          dataBar: { cfvo: [{ type: "min" }, { type: "max" }], color: "FF638EC6" },
+        },
+        {
+          type: "iconSet",
+          priority: 2,
+          range: "A1:A5",
+          iconSet: {
+            iconSet: "3TrafficLights1",
+            cfvo: [
+              { type: "percent", value: "0" },
+              { type: "percent", value: "67" },
+            ],
+            reverse: true,
+          },
+        },
+        { type: "cellIs", operator: "between", priority: 3, range: "A1:A5", formula: ["1", "5"] },
+      ],
+    })
+
+    const c = cloneSheet(s, "Copy")
+
+    c.conditionalRules![0].dataBar!.cfvo[0].type = "num"
+    c.conditionalRules![1].iconSet!.cfvo[0].value = "99"
+    ;(c.conditionalRules![2].formula as string[])[0] = "42"
+
+    expect(s.conditionalRules![0].dataBar!.cfvo[0].type).toBe("min")
+    expect(s.conditionalRules![1].iconSet!.cfvo[0].value).toBe("0")
+    expect((s.conditionalRules![2].formula as string[])[0]).toBe("1")
+  })
+
+  it("copies the sheet-level odds and ends: anchors, margins, tab colour and visibility", () => {
+    const s = sheet({
+      rows: [["x"]],
+      images: [img({ row: 0, col: 0 }, { row: 2, col: 2 }), img({ row: 3, col: 0 })],
+      pageSetup: { orientation: "landscape", margins: { left: 1, right: 1, top: 1, bottom: 1 } },
+      view: { tabColor: { rgb: "FF00B050" }, showGridLines: false },
+      hidden: true,
+      veryHidden: false,
+    })
+
+    const c = cloneSheet(s, "Copy")
+
+    expect(c.images![0].anchor.to).toEqual({ row: 2, col: 2 })
+    expect(c.images![1].anchor.to).toBeUndefined()
+    c.images![0].anchor.to!.row = 9
+    expect(s.images![0].anchor.to!.row).toBe(2)
+
+    c.pageSetup!.margins!.left = 5
+    expect(s.pageSetup!.margins!.left).toBe(1)
+
+    c.view!.tabColor!.rgb = "FFFFFFFF"
+    expect(s.view!.tabColor!.rgb).toBe("FF00B050")
+
+    expect(c.hidden).toBe(true)
+    expect(c.veryHidden).toBe(false)
+  })
+
+  it("leaves margins and tab colour undefined when the source has none", () => {
+    const s = sheet({
+      rows: [["x"]],
+      pageSetup: { orientation: "portrait" },
+      view: { showGridLines: false },
+    })
+
+    const c = cloneSheet(s, "Copy")
+
+    expect(c.pageSetup!.margins).toBeUndefined()
+    expect(c.view!.tabColor).toBeUndefined()
+    expect(c.view!.showGridLines).toBe(false)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// copyRange
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("copyRange", () => {
+  it("reads out-of-bounds source cells as null and clears stale target overrides", () => {
+    const s = sheet({
+      rows: [["a"], ["b"]],
+      // The target already carries an override that the (empty) source must clear.
+      cells: new Map<string, Cell>([
+        ["0,0", { value: "a", type: "string", style: { font: { bold: true } } }],
+        ["5,1", { value: "stale", type: "string" }],
+      ]),
+    })
+
+    // Source B1:B2 is past the end of every row; target starts at row 5.
+    copyRange(s, { startRow: 0, startCol: 1, endRow: 1, endCol: 1 }, { startRow: 5, startCol: 1 })
+
+    expect(s.rows[5][1]).toBeNull()
+    expect(s.rows[6][1]).toBeNull()
+    expect(s.cells!.has("5,1")).toBe(false)
+    expect(s.cells!.get("0,0")!.style!.font!.bold).toBe(true)
+  })
+
+  it("reads rows past the end of the sheet as null", () => {
+    const s = sheet({ rows: [["a", "b"]] })
+
+    // Row 3 does not exist at read time — it must land as null, not throw.
+    copyRange(s, { startRow: 3, startCol: 0, endRow: 3, endCol: 1 }, { startRow: 0, startCol: 0 })
+
+    expect(s.rows[0]).toEqual([null, null])
+  })
+
+  it("does not duplicate a merge that the target range already has", () => {
+    const s = sheet({
+      rows: grid(6, 4),
+      merges: [
+        { startRow: 0, startCol: 0, endRow: 0, endCol: 1 }, // the source merge
+        { startRow: 3, startCol: 2, endRow: 3, endCol: 3 }, // same top row, other columns
+        { startRow: 3, startCol: 0, endRow: 4, endCol: 1 }, // same corner, taller
+      ],
+    })
+
+    const src = { startRow: 0, startCol: 0, endRow: 1, endCol: 1 }
+    copyRange(s, src, { startRow: 3, startCol: 0 })
+    const afterFirst = s.merges!.length
+    copyRange(s, src, { startRow: 3, startCol: 0 })
+
+    expect(afterFirst).toBe(4)
+    expect(s.merges).toHaveLength(4) // second copy adds nothing
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// replaceCells
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("replaceCells", () => {
+  // A row built by index assignment (`row[3] = x`) has holes; the scan reads
+  // a hole as null so `replaceCells(sheet, null, …)` fills it like any other
+  // blank instead of comparing against `undefined`.
+  it("reads holes inside a row as null", () => {
+    const sparse: (string | null)[] = ["keep"]
+    sparse[3] = "target"
+    const s = sheet({ rows: [sparse] })
+
+    expect(replaceCells(s, null, "filled")).toBe(2)
+    expect(s.rows[0]).toEqual(["keep", "filled", "filled", "target"])
+  })
+
+  // `String.replace` only makes sense for a string replacement; a non-string
+  // one replaces the whole cell so the type is not silently stringified.
+  it("swaps the whole cell when a RegExp find is paired with a non-string replacement", () => {
+    const s = sheet({
+      rows: [
+        ["N/A", "12"],
+        ["N/A", "ok"],
+      ],
+    })
+
+    expect(replaceCells(s, /^N\/A$/, 0)).toBe(2)
+    expect(s.rows[0][0]).toBe(0)
+    expect(s.rows[1][0]).toBe(0)
+    expect(s.rows[0][1]).toBe("12")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// sortRows
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sortRows", () => {
+  it("treats a row shorter than the sort column as blank and sorts it last", () => {
+    const s = sheet({ rows: [[1], [], [3], [2]] })
+
+    sortRows(s, 0)
+
+    expect(s.rows.map((r) => r[0] ?? null)).toEqual([1, 2, 3, null])
+  })
+
+  it('reverses the order for "desc"', () => {
+    const s = sheet({ rows: [[1], [3], [2]] })
+
+    sortRows(s, 0, "desc")
+
+    expect(s.rows.map((r) => r[0])).toEqual([3, 2, 1])
+  })
+
+  // BUG (see report): `sortRows` documents "nulls last" without qualifying
+  // the order, and Excel always sinks blank cells to the bottom regardless
+  // of sort direction. `compareCellValues` returns +1 for a null `a`, and
+  // "desc" negates the whole comparison, so blanks float to the top.
+  // src/sheet-ops.ts:1270 (and the mirror at 1297).
+  it.skip("keeps blanks last when sorting descending, as Excel does", () => {
+    const s = sheet({ rows: [[1], [], [3], [2]] })
+
+    sortRows(s, 0, "desc")
+
+    expect(s.rows.map((r) => r[0] ?? null)).toEqual([3, 2, 1, null])
+  })
+
+  it("remaps the cell override map when sorting descending", () => {
+    const s = sheet({
+      rows: [["b"], ["c"], ["a"], []],
+      cells: new Map<string, Cell>([
+        ["0,0", { value: "b", type: "string" }],
+        ["1,0", { value: "c", type: "string" }],
+        ["2,0", { value: "a", type: "string" }],
+        // A key for a row that does not exist — left exactly as it is.
+        ["99,0", { value: "orphan", type: "string" }],
+      ]),
+    })
+
+    sortRows(s, 0, "desc")
+
+    // The short row carries no value, so it sorts as a blank (see the
+    // skipped test above for where that lands under "desc").
+    expect(s.rows.map((r) => r[0] ?? null)).toEqual([null, "c", "b", "a"])
+    expect(s.cells!.get("1,0")!.value).toBe("c")
+    expect(s.cells!.get("2,0")!.value).toBe("b")
+    expect(s.cells!.get("3,0")!.value).toBe("a")
+    expect(s.cells!.get("99,0")!.value).toBe("orphan")
+  })
+
+  it("sorts FALSE before TRUE", () => {
+    const s = sheet({ rows: [[true], [false], [true], [false]] })
+
+    sortRows(s, 0)
+
+    expect(s.rows.map((r) => r[0])).toEqual([false, false, true, true])
+  })
+
+  // Sheets whose rows were assembled column-by-column can be ragged and
+  // hole-ridden; the sort has to read those positions as blanks on both
+  // sides of the comparison rather than throwing.
+  it("handles ragged and hole-ridden rows while remapping overrides", () => {
+    const withHole: CellValue[] = ["x"]
+    withHole[2] = "y" // index 1 is a hole
+    const s = sheet({
+      rows: [withHole, ["b"], [], ["a"], []],
+      cells: new Map<string, Cell>([["0,0", { value: "x", type: "string" }]]),
+    })
+
+    sortRows(s, 1)
+
+    expect(s.rows[0]![1]).toBeUndefined()
+    expect(s.rows.map((r) => r[0] ?? null)).toEqual(["x", "b", null, "a", null])
+    expect(s.cells!.get("0,0")!.value).toBe("x")
+  })
+
+  it("orders dates chronologically, ahead of strings and booleans", () => {
+    const s = sheet({
+      rows: [
+        ["zeta"],
+        [new Date(Date.UTC(2020, 0, 2))],
+        [true],
+        [new Date(Date.UTC(2019, 5, 1))],
+        [false],
+        [7],
+      ],
+    })
+
+    sortRows(s, 0)
+
+    const values = s.rows.map((r) => r[0])
+    expect(values[0]).toBe(7)
+    expect((values[1] as Date).getUTCFullYear()).toBe(2019)
+    expect((values[2] as Date).getUTCFullYear()).toBe(2020)
+    expect(values[3]).toBe("zeta")
+    expect(values[4]).toBe(false)
+    expect(values[5]).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// A workbook-shaped smoke test
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("row/column ops on a workbook sheet", () => {
+  it("keeps merges, validations, images and tables consistent through insert + delete", () => {
+    const wb: Workbook = {
+      sheets: [
+        sheet({
+          rows: grid(6, 4),
+          merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 3 }],
+          dataValidations: [{ type: "list", range: "A2:A6", values: ["x", "y"] }],
+          autoFilter: { range: "A1:D6" },
+          images: [img({ row: 4, col: 2 }, { row: 5, col: 3 })],
+          tables: [{ name: "T", range: "A1:D6", columns: [{ name: "a" }] }],
+        }),
+      ],
+    }
+    const s = wb.sheets[0]
+
+    insertRows(s, 1, 2)
+    expect(s.dataValidations![0].range).toBe("A4:A8")
+    expect(s.autoFilter!.range).toBe("A1:D8")
+    expect(s.images![0].anchor.from.row).toBe(6)
+    expect(s.tables![0].range).toBe("A1:D8")
+
+    deleteRows(s, 1, 2)
+    expect(s.dataValidations![0].range).toBe("A2:A6")
+    expect(s.autoFilter!.range).toBe("A1:D6")
+    expect(s.images![0].anchor.from.row).toBe(4)
+    expect(s.tables![0].range).toBe("A1:D6")
+    expect(s.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 3 }])
+  })
+})

--- a/test/coverage-xlsx-parts.test.ts
+++ b/test/coverage-xlsx-parts.test.ts
@@ -1,0 +1,902 @@
+import { describe, expect, it } from "vitest"
+import type { CellValue } from "../src/_types"
+import { calculateColumnWidth, measureValueWidth } from "../src/xlsx/auto-width"
+import { calculateRowHeight } from "../src/xlsx/auto-size"
+import {
+  parseAppProperties,
+  parseCoreProperties,
+  parseCustomProperties,
+} from "../src/xlsx/doc-props-reader"
+import { parseExternalLink } from "../src/xlsx/external-link-reader"
+import {
+  parseSlicerCache,
+  parseSlicers,
+  parseTimelineCache,
+  parseTimelines,
+} from "../src/xlsx/slicer-reader"
+import { parseComments } from "../src/xlsx/comments-reader"
+import { parsePersons, parseThreadedComments } from "../src/xlsx/threaded-comments-reader"
+import { parseCsv, parseCsvObjects } from "../src/csv/reader"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+
+const NS_MAIN = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+const NS_REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+/** Wrap external-link body XML in the element Excel actually writes. */
+function externalLinkXml(body: string): string {
+  return `${XML_DECL}<externalLink xmlns="${NS_MAIN}" xmlns:r="${NS_REL}">${body}</externalLink>`
+}
+
+/** A single-relationship `_rels/externalLink1.xml.rels` part. */
+function externalLinkRels(target: string, targetMode?: string): string {
+  const mode = targetMode === undefined ? "" : ` TargetMode="${targetMode}"`
+  return `${XML_DECL}<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="${NS_REL}/externalLinkPath" Target="${target}"${mode}/></Relationships>`
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// auto-width — measuring what a cell will actually display
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("measureValueWidth — double-width scripts", () => {
+  // Every CJK block the width table knows about, one character each.
+  // A workbook with Japanese, Korean and fullwidth Latin headers hits all
+  // of these; each must count as two character units.
+  it.each([
+    ["CJK Unified Ideographs", "\u6F22"],
+    ["CJK Extension A", "\u3400"],
+    ["CJK Extension B", "\u{20000}"],
+    ["CJK Compatibility Ideographs", "\uF900"],
+    ["Hangul Syllables", "\uAC00"],
+    ["Katakana", "\u30AB"],
+    ["Hiragana", "\u3072"],
+    ["CJK Symbols and Punctuation", "\u3002"],
+    ["Fullwidth Forms", "\uFF21"],
+    ["Halfwidth/Fullwidth currency signs", "\uFFE0"],
+  ])("counts %s as two units", (_name, char) => {
+    expect(measureValueWidth(char)).toBe(2)
+  })
+
+  // A code point just outside every block stays single-width, which is
+  // what keeps Latin and Cyrillic columns from being over-widened.
+  it("counts a non-CJK character as one unit", () => {
+    expect(measureValueWidth("\u2FFF")).toBe(1)
+    expect(measureValueWidth("\uFFEF")).toBe(1)
+  })
+})
+
+describe("measureValueWidth — number formats", () => {
+  // Negative values pick the second section, and its parentheses/minus
+  // do not change the digit count the column has to hold.
+  it("measures a negative value through the negative section", () => {
+    expect(measureValueWidth(-1234.5, "#,##0.00;(#,##0.00)")).toBe(8)
+  })
+
+  // With no negative section the minus sign is rendered by the default
+  // path and does widen the column.
+  it("includes the minus sign when the format has no negative section", () => {
+    expect(measureValueWidth(-1234.5, "#,##0.00")).toBe(9)
+  })
+
+  it("measures zero through the third section", () => {
+    expect(measureValueWidth(0, '#,##0.00;(#,##0.00);"-"')).toBe(1)
+  })
+
+  // Decimal counting stops at the first character that is not a digit
+  // placeholder, so trailing literal text does not inflate the precision.
+  it("stops counting decimals at the first non-placeholder", () => {
+    // "#,##0.0 TL" → one decimal, so "1,234.5" (7) plus the 3 literal
+    // characters of " TL".
+    expect(measureValueWidth(1234.5, '#,##0.0" TL"')).toBe(10)
+  })
+
+  it("treats a format without a decimal point as zero decimals", () => {
+    expect(measureValueWidth(1234.5, "#,##0")).toBe(5)
+  })
+
+  // Literal characters that widen the cell: quoted text, escaped
+  // characters and the common currency symbols.
+  it.each([
+    ['$#,##0.00" USD"', 13],
+    ["\\$#,##0.00", 9],
+    ["\u20AC#,##0.00", 9],
+    ["\u00A3#,##0.00", 9],
+    ["\u00A5#,##0.00", 9],
+  ])("adds the literal characters of %s to the measured width", (fmt, expected) => {
+    expect(measureValueWidth(1234.5, fmt)).toBe(expected)
+  })
+
+  // Percentages are measured after the ×100, including grouping.
+  it("measures a grouped percentage after scaling", () => {
+    // 12.3456 → "1,234.6%"
+    expect(measureValueWidth(12.3456, "#,##0.0%")).toBe(8)
+  })
+
+  // Colour and locale directives are stripped before measuring.
+  it("ignores bracketed directives", () => {
+    expect(measureValueWidth(1234.5, "[Red][$-409]#,##0.00")).toBe(8)
+  })
+})
+
+describe("calculateColumnWidth", () => {
+  // Excel snaps auto-fit widths to half-character increments and clamps
+  // to the 255-character maximum.
+  it("snaps to the next half character", () => {
+    // 9 chars × 1.1 = 9.9, + 2 padding = 11.9 → 12
+    expect(calculateColumnWidth(["123456789"], { minWidth: 0 })).toBe(12)
+  })
+
+  it("widens bold columns by the bold multiplier", () => {
+    const plain = calculateColumnWidth(["123456789"], { minWidth: 0 })
+    const bold = calculateColumnWidth(["123456789"], { minWidth: 0, font: { bold: true } })
+    expect(bold).toBeGreaterThan(plain)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// auto-size — row heights
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("calculateRowHeight", () => {
+  it("returns the Calibri 11pt default for a single line", () => {
+    expect(calculateRowHeight(["hello"])).toBe(15)
+  })
+
+  // Line height scales with the font, rounded up to Excel's quarter-point
+  // granularity.
+  it("scales the line height with the font size", () => {
+    expect(calculateRowHeight(["hello"], { fontSize: 22 })).toBe(30)
+    expect(calculateRowHeight(["hello"], { fontSize: 10 })).toBe(13.75)
+  })
+
+  // A sparse row hands `undefined` to the calculator even though it is
+  // outside the CellValue union; both it and null are skipped.
+  it("ignores empty and absent cells", () => {
+    const sparse = [null, undefined, ""] as unknown as CellValue[]
+    expect(calculateRowHeight(sparse)).toBe(15)
+  })
+
+  // Without wrapText only explicit newlines add height.
+  it("counts explicit newlines when wrapping is off", () => {
+    expect(calculateRowHeight(["a\nb\nc"])).toBe(45)
+  })
+
+  // With wrapText the text is divided by the column width.
+  it("wraps text against the matching column width", () => {
+    expect(calculateRowHeight(["abcdefghij"], { wrapText: true, columnWidths: [4] })).toBe(45)
+  })
+
+  // A column with no measured width falls back to Excel's 8.43 default,
+  // including for cells past the end of the columnWidths array.
+  it("falls back to the default column width when none is given", () => {
+    expect(calculateRowHeight(["x".repeat(30)], { wrapText: true })).toBe(60)
+    expect(calculateRowHeight(["a", "x".repeat(30)], { wrapText: true, columnWidths: [10] })).toBe(
+      60,
+    )
+  })
+
+  // A zero or negative width would divide by zero; the wrap maths clamps
+  // it to one character.
+  it("clamps a zero column width to one character", () => {
+    expect(calculateRowHeight(["abc"], { wrapText: true, columnWidths: [0] })).toBe(45)
+  })
+
+  // A blank paragraph between two lines is still a line.
+  it("counts a blank line between paragraphs", () => {
+    expect(calculateRowHeight(["a\n\nb"], { wrapText: true, columnWidths: [10] })).toBe(45)
+  })
+
+  // CJK text occupies two units per character when deciding where it
+  // wraps, so a five-character Japanese label needs more lines than a
+  // five-character Latin one.
+  it("wraps double-width text at half the character count", () => {
+    expect(
+      calculateRowHeight(["\u6F22\u5B57\u6F22\u5B57\u6F22"], {
+        wrapText: true,
+        columnWidths: [4],
+      }),
+    ).toBe(45)
+    expect(calculateRowHeight(["abcde"], { wrapText: true, columnWidths: [4] })).toBe(30)
+  })
+
+  // The wrap calculation has its own copy of the double-width table; a
+  // label mixing every CJK block must be measured at two units each.
+  it.each([
+    ["CJK Unified Ideographs", "\u6F22"],
+    ["CJK Extension A", "\u3400"],
+    ["CJK Extension B", "\u{20000}"],
+    ["CJK Compatibility Ideographs", "\uF900"],
+    ["Hangul Syllables", "\uAC00"],
+    ["Katakana", "\u30AB"],
+    ["Hiragana", "\u3072"],
+    ["CJK Symbols and Punctuation", "\u3002"],
+    ["Fullwidth Forms", "\uFF21"],
+    ["Halfwidth/Fullwidth currency signs", "\uFFE0"],
+  ])("wraps %s at two units per character", (_name, char) => {
+    // Two double-width characters fill a 2-unit column across 2 lines,
+    // where two single-width characters would fit on one.
+    expect(calculateRowHeight([char + char], { wrapText: true, columnWidths: [2] })).toBe(30)
+    expect(calculateRowHeight(["ab"], { wrapText: true, columnWidths: [2] })).toBe(15)
+  })
+
+  it("takes the tallest cell in the row", () => {
+    expect(calculateRowHeight(["a", "b\nc\nd", "e"])).toBe(45)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// docProps — core.xml, custom.xml, app.xml
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseCoreProperties", () => {
+  // Empty elements are what Excel writes for properties the user cleared;
+  // they must not turn into empty-string properties.
+  it("skips elements with no text", () => {
+    const xml = `${XML_DECL}<cp:coreProperties xmlns:cp="x" xmlns:dc="y" xmlns:dcterms="z"><dc:title></dc:title><dc:subject/><dc:creator/><cp:keywords/><dc:description/><cp:lastModifiedBy/><cp:category/><dcterms:created/><dcterms:modified/></cp:coreProperties>`
+    expect(parseCoreProperties(xml)).toEqual({})
+  })
+
+  // A date Excel cannot round-trip (or a third-party tool's garbage) is
+  // dropped rather than surfacing an Invalid Date.
+  it("drops a created/modified stamp that is not a valid date", () => {
+    const xml = `${XML_DECL}<cp:coreProperties xmlns:cp="x" xmlns:dcterms="z"><dcterms:created>not-a-date</dcterms:created><dcterms:modified>whenever</dcterms:modified></cp:coreProperties>`
+    const props = parseCoreProperties(xml)
+    expect(props.created).toBeUndefined()
+    expect(props.modified).toBeUndefined()
+  })
+
+  it("ignores unknown child elements", () => {
+    const xml = `${XML_DECL}<cp:coreProperties xmlns:cp="x" xmlns:dc="y"><cp:contentStatus>Draft</cp:contentStatus><dc:title>T</dc:title></cp:coreProperties>`
+    expect(parseCoreProperties(xml)).toEqual({ title: "T" })
+  })
+})
+
+describe("parseCustomProperties", () => {
+  // A real docProps/custom.xml: one property per supported variant type
+  // from the docPropsVTypes schema (ECMA-376 Part 4, §7.4).
+  const CUSTOM_XML = `${XML_DECL}
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"
+            xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2" name="Department"><vt:lpwstr>Finance</vt:lpwstr></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="3" name="Revision"><vt:i4>7</vt:i4></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="4" name="Rows"><vt:i8>9007199254740</vt:i8></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="5" name="Retries"><vt:int>3</vt:int></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="6" name="Ratio"><vt:r8>1.5</vt:r8></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="7" name="Total"><vt:decimal>12.75</vt:decimal></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="8" name="Approved"><vt:bool>true</vt:bool></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="9" name="Archived"><vt:bool>1</vt:bool></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="10" name="Draft"><vt:bool>0</vt:bool></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="11" name="Deadline"><vt:filetime>2026-01-15T10:00:00Z</vt:filetime></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="12" name="Signed"><vt:date>2026-02-01T00:00:00Z</vt:date></property>
+  <property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="13" name="Empty"><vt:lpwstr/></property>
+</Properties>`
+
+  it("reads every supported variant type", () => {
+    expect(parseCustomProperties(CUSTOM_XML)).toEqual({
+      Department: "Finance",
+      Revision: 7,
+      Rows: 9007199254740,
+      Retries: 3,
+      Ratio: 1.5,
+      Total: 12.75,
+      Approved: true,
+      Archived: true,
+      Draft: false,
+      Deadline: new Date("2026-01-15T10:00:00Z"),
+      Signed: new Date("2026-02-01T00:00:00Z"),
+      Empty: "",
+    })
+  })
+
+  // Properties without a name have nothing to key on; elements that are
+  // not <property> at all (schema extensions) are skipped.
+  it("skips unnamed properties and foreign elements", () => {
+    const xml = `${XML_DECL}<Properties xmlns="c" xmlns:vt="v"><property pid="2"><vt:lpwstr>x</vt:lpwstr></property><ext/><property pid="3" name="Kept"><vt:lpwstr>y</vt:lpwstr></property></Properties>`
+    expect(parseCustomProperties(xml)).toEqual({ Kept: "y" })
+  })
+
+  // Numeric and date variants with unusable text are dropped rather than
+  // stored as NaN or Invalid Date.
+  it("drops numeric and date variants that cannot be parsed", () => {
+    const xml = `${XML_DECL}<Properties xmlns="c" xmlns:vt="v">
+      <property pid="2" name="NoNumber"><vt:i4/></property>
+      <property pid="3" name="NoFloat"><vt:r8/></property>
+      <property pid="4" name="NoDate"><vt:filetime/></property>
+      <property pid="5" name="BadDate"><vt:filetime>whenever</vt:filetime></property>
+      <property pid="6" name="Unsupported"><vt:cy>1.0000</vt:cy></property>
+    </Properties>`
+    expect(parseCustomProperties(xml)).toEqual({})
+  })
+
+  // Only the first variant child counts — a malformed property carrying
+  // two values must not have the second overwrite the first.
+  // Pretty-printed custom.xml puts the variant element on its own line,
+  // so the whitespace text nodes around it must be skipped.
+  it("skips the whitespace of a pretty-printed property", () => {
+    const xml = `${XML_DECL}<Properties xmlns="c" xmlns:vt="v">
+  <property pid="2" name="Department">
+    <vt:lpwstr>Finance</vt:lpwstr>
+  </property>
+</Properties>`
+    expect(parseCustomProperties(xml)).toEqual({ Department: "Finance" })
+  })
+
+  it("takes only the first value element of a property", () => {
+    const xml = `${XML_DECL}<Properties xmlns="c" xmlns:vt="v"><property pid="2" name="P"><vt:lpwstr>first</vt:lpwstr><vt:lpwstr>second</vt:lpwstr></property></Properties>`
+    expect(parseCustomProperties(xml)).toEqual({ P: "first" })
+  })
+})
+
+describe("parseAppProperties", () => {
+  // app.xml always carries Application/DocSecurity/TitlesOfParts; only
+  // Company and Manager map onto workbook properties.
+  it("returns nothing when neither Company nor Manager is present", () => {
+    const xml = `${XML_DECL}<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"><Application>Microsoft Excel</Application><DocSecurity>0</DocSecurity></Properties>`
+    expect(parseAppProperties(xml)).toEqual({})
+  })
+
+  it("ignores Company and Manager elements that are empty", () => {
+    const xml = `${XML_DECL}<Properties xmlns="e"><Company/><Manager></Manager></Properties>`
+    expect(parseAppProperties(xml)).toEqual({})
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// externalLink1.xml — linked workbooks and their cached values
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseExternalLink", () => {
+  const FULL = externalLinkXml(`
+    <externalBook r:id="rId1">
+      <sheetNames><sheetName val="Sheet1"/><sheetName val="Budget"/><sheetName/></sheetNames>
+      <definedNames>
+        <definedName name="Rate" refersTo="'[1]Sheet1'!$A$1" sheetId="0"/>
+        <definedName name="Bare"/>
+        <definedName refersTo="'[1]Sheet1'!$B$1"/>
+        <definedName name="BadSheet" sheetId="zero"/>
+      </definedNames>
+      <sheetDataSet>
+        <sheetData sheetId="0">
+          <row r="1">
+            <cell r="A1"><v>42</v></cell>
+            <cell r="B1" t="str"><v>Hello</v></cell>
+            <cell r="C1" t="b"><v>1</v></cell>
+            <cell r="D1" t="e"><v>#REF!</v></cell>
+            <cell r="E1" t="s"><v>3</v></cell>
+          </row>
+          <row r="2">
+            <cell r="A2"><v>not-a-number</v></cell>
+            <cell r="B2" t="b"><v>true</v></cell>
+            <cell r="C2" t="b"><v>0</v></cell>
+            <cell r="D2"/>
+          </row>
+        </sheetData>
+        <sheetData sheetId="notanumber"><row r="1"><cell r="A1"><v>1</v></cell></row></sheetData>
+        <sheetData><row r="1"><cell r="A1"><v>1</v></cell></row></sheetData>
+      </sheetDataSet>
+    </externalBook>`)
+
+  it("resolves the linked workbook path through the rels part", () => {
+    const link = parseExternalLink(FULL, externalLinkRels("C:\\Budgets\\2026.xlsx", "External"))
+    expect(link.target).toBe("C:\\Budgets\\2026.xlsx")
+    expect(link.targetMode).toBe("External")
+  })
+
+  // A link with no rels part (or one whose r:id does not resolve) still
+  // parses — only the target is unknown.
+  it("leaves the target empty when no rels part is supplied", () => {
+    const link = parseExternalLink(FULL)
+    expect(link.target).toBe("")
+    expect(link.targetMode).toBeUndefined()
+    expect(link.sheetNames).toEqual(["Sheet1", "Budget", ""])
+  })
+
+  it("leaves the target empty when the relationship id does not resolve", () => {
+    const link = parseExternalLink(FULL, externalLinkRels("other.xlsx", "External"))
+    const missing = parseExternalLink(
+      externalLinkXml('<externalBook r:id="rIdMissing"><sheetNames/></externalBook>'),
+      externalLinkRels("other.xlsx", "External"),
+    )
+    expect(link.target).toBe("other.xlsx")
+    expect(missing.target).toBe("")
+  })
+
+  // The strict-transitional variants of the schema use an unprefixed
+  // `id`, so the reader accepts both spellings.
+  it("accepts an unprefixed relationship id", () => {
+    const xml = externalLinkXml('<externalBook id="rId1"><sheetNames/></externalBook>')
+    expect(parseExternalLink(xml, externalLinkRels("book.xlsx")).target).toBe("book.xlsx")
+  })
+
+  // An externalBook with no r:id at all cannot be resolved, even when a
+  // rels part is present — the reader never guesses at the sole entry.
+  it("skips resolution when the externalBook carries no relationship id", () => {
+    const xml = externalLinkXml("<externalBook><sheetNames/></externalBook>")
+    expect(parseExternalLink(xml, externalLinkRels("book.xlsx")).target).toBe("")
+  })
+
+  // TargetMode is only reported for the two values the schema defines.
+  it.each([
+    ["External", "External"],
+    ["Internal", "Internal"],
+  ])("reports the %s target mode", (mode, expected) => {
+    const xml = externalLinkXml('<externalBook r:id="rId1"><sheetNames/></externalBook>')
+    expect(parseExternalLink(xml, externalLinkRels("b.xlsx", mode)).targetMode).toBe(expected)
+  })
+
+  it("omits an unrecognised or absent target mode", () => {
+    const xml = externalLinkXml('<externalBook r:id="rId1"><sheetNames/></externalBook>')
+    expect(parseExternalLink(xml, externalLinkRels("b.xlsx")).targetMode).toBeUndefined()
+    expect(parseExternalLink(xml, externalLinkRels("b.xlsx", "Odd")).targetMode).toBeUndefined()
+  })
+
+  // Cached values keep the type the external workbook recorded; `s`
+  // (shared-string index) stays numeric because the string table lives in
+  // the *other* workbook.
+  it("coerces cached cell values by their recorded type", () => {
+    const link = parseExternalLink(FULL)
+    expect(link.sheetData[0].cells).toEqual([
+      { ref: "A1", type: "n", value: 42 },
+      { ref: "B1", type: "str", value: "Hello" },
+      { ref: "C1", type: "b", value: true },
+      { ref: "D1", type: "e", value: "#REF!" },
+      { ref: "E1", type: "s", value: 3 },
+      { ref: "A2", type: "n", value: 0 },
+      { ref: "B2", type: "b", value: true },
+      { ref: "C2", type: "b", value: false },
+      { ref: "D2", type: "n", value: 0 },
+    ])
+  })
+
+  it("falls back to sheetId 0 when the attribute is missing or unparseable", () => {
+    const link = parseExternalLink(FULL)
+    expect(link.sheetData.map((s) => s.sheetId)).toEqual([0, 0, 0])
+  })
+
+  // Defined names need a name; the sheetId is optional and is dropped
+  // when it is not a number.
+  it("keeps only named defined names and numeric sheet ids", () => {
+    const link = parseExternalLink(FULL)
+    expect(link.definedNames).toEqual([
+      { name: "Rate", refersTo: "'[1]Sheet1'!$A$1", sheetId: 0 },
+      { name: "Bare" },
+      { name: "BadSheet" },
+    ])
+  })
+
+  // A link file that carries no externalBook (or an unexpected root)
+  // degrades to an empty link rather than throwing.
+  it("returns empty collections when the externalBook is missing", () => {
+    const link = parseExternalLink(externalLinkXml("<extLst/>"))
+    expect(link).toEqual({ target: "", sheetNames: [], sheetData: [] })
+  })
+
+  it("returns empty collections when the sections are absent", () => {
+    const link = parseExternalLink(externalLinkXml("<externalBook/>"))
+    expect(link.sheetNames).toEqual([])
+    expect(link.sheetData).toEqual([])
+    expect(link.definedNames).toBeUndefined()
+  })
+
+  // Unexpected element names inside each section are ignored so a file
+  // carrying extension elements still parses.
+  it("ignores foreign elements inside each section", () => {
+    const link = parseExternalLink(
+      externalLinkXml(`<externalBook r:id="rId1">
+        <sheetNames><ext/><sheetName val="S"/></sheetNames>
+        <sheetDataSet><ext/><sheetData sheetId="1"><ext/><row r="1"><ext/><cell r="A1"><v>1</v></cell><cell><v>2</v></cell></row></sheetData></sheetDataSet>
+        <definedNames><ext/><definedName name="N"/></definedNames>
+      </externalBook>`),
+    )
+    expect(link.sheetNames).toEqual(["S"])
+    expect(link.sheetData).toEqual([{ sheetId: 1, cells: [{ ref: "A1", type: "n", value: 1 }] }])
+    expect(link.definedNames).toEqual([{ name: "N" }])
+  })
+
+  // An unknown `t` value falls back to the numeric default rather than
+  // producing a cell with a type the ExternalCellType union forbids.
+  it("falls back to the numeric type for an unrecognised cell type", () => {
+    const link = parseExternalLink(
+      externalLinkXml(
+        '<externalBook><sheetDataSet><sheetData sheetId="0"><row r="1"><cell r="A1" t="inlineStr"><v>7</v></cell></row></sheetData></sheetDataSet></externalBook>',
+      ),
+    )
+    expect(link.sheetData[0].cells).toEqual([{ ref: "A1", type: "n", value: 7 }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Slicers and timelines
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSlicers", () => {
+  it("reads every optional slicer attribute", () => {
+    const xml = `${XML_DECL}<slicers xmlns="x14"><slicer name="Region" cache="Slicer_Region" caption="Region" columnCount="2" style="SlicerStyleLight1" sortOrder="descending" rowHeight="234950"/></slicers>`
+    expect(parseSlicers(xml)).toEqual([
+      {
+        name: "Region",
+        cache: "Slicer_Region",
+        caption: "Region",
+        columnCount: 2,
+        style: "SlicerStyleLight1",
+        sortOrder: "descending",
+        rowHeight: 234950,
+      },
+    ])
+  })
+
+  // name and cache are the only required attributes; a slicer missing
+  // either cannot be tied back to its cache, so it is skipped.
+  it("skips slicers without a name or cache and foreign elements", () => {
+    const xml = `${XML_DECL}<slicers xmlns="x14"><extLst/><slicer cache="c"/><slicer name="n"/><slicer name="ok" cache="c"/></slicers>`
+    expect(parseSlicers(xml)).toEqual([{ name: "ok", cache: "c" }])
+  })
+
+  // Non-numeric counts are dropped rather than stored as NaN.
+  it("drops unparseable numeric attributes", () => {
+    const xml = `${XML_DECL}<slicers xmlns="x14"><slicer name="n" cache="c" columnCount="many" rowHeight="tall"/></slicers>`
+    expect(parseSlicers(xml)).toEqual([{ name: "n", cache: "c" }])
+  })
+})
+
+describe("parseSlicerCache", () => {
+  it("reads the pivot tables a cache drives", () => {
+    const xml = `${XML_DECL}<slicerCacheDefinition xmlns="x14" name="Slicer_Region" sourceName="Region"><pivotTables><pivotTable tabId="1" name="PivotTable1"/><pivotTable name="NoTab"/><pivotTable tabId="2"/><ext/></pivotTables></slicerCacheDefinition>`
+    expect(parseSlicerCache(xml)).toEqual({
+      name: "Slicer_Region",
+      sourceName: "Region",
+      pivotTables: [{ tabId: 1, name: "PivotTable1" }],
+    })
+  })
+
+  // Table slicers (Excel 2013+) record their source in an x15 extension
+  // rather than in <pivotTables>.
+  it("reads a table slicer's source from the x15 extension", () => {
+    const xml = `${XML_DECL}<slicerCacheDefinition xmlns="x14" xmlns:x15="x15" name="Slicer_Name"><extLst><ext uri="{2F2917AC}"><x15:tableSlicerCache tableId="1" column="3"/></ext></extLst></slicerCacheDefinition>`
+    expect(parseSlicerCache(xml)).toEqual({
+      name: "Slicer_Name",
+      tableSource: { name: "1", column: "3" },
+    })
+  })
+
+  it("prefers an explicit table name over the table id", () => {
+    const xml = `${XML_DECL}<slicerCacheDefinition xmlns="x14" xmlns:x15="x15" name="S"><extLst><ext><x15:tableSlicerCache name="Table1" tableId="1"/></ext></extLst></slicerCacheDefinition>`
+    expect(parseSlicerCache(xml)?.tableSource).toEqual({ name: "Table1" })
+  })
+
+  it("ignores extensions that carry no table slicer cache", () => {
+    const xml = `${XML_DECL}<slicerCacheDefinition xmlns="x14" xmlns:x15="x15" name="S"><extLst><notExt/><ext uri="{other}"><x15:somethingElse/></ext><ext><x15:tableSlicerCache/></ext></extLst></slicerCacheDefinition>`
+    expect(parseSlicerCache(xml)?.tableSource).toBeUndefined()
+  })
+
+  // A cache without a name cannot be referenced by a slicer.
+  it("returns undefined for a cache with no name or no definition", () => {
+    expect(parseSlicerCache(`${XML_DECL}<slicerCacheDefinition xmlns="x14"/>`)).toBeUndefined()
+    expect(parseSlicerCache(`${XML_DECL}<somethingElse/>`)).toBeUndefined()
+  })
+
+  // Excel wraps the definition in a container element in some files, so
+  // the reader looks one level down as well.
+  it("finds the definition nested inside a wrapper element", () => {
+    const xml = `${XML_DECL}<wrapper><slicerCacheDefinition name="S"/></wrapper>`
+    expect(parseSlicerCache(xml)).toEqual({ name: "S" })
+  })
+})
+
+describe("parseTimelines", () => {
+  it("reads the boolean display flags", () => {
+    const xml = `${XML_DECL}<timelines xmlns="x15"><timeline name="OrderDate" cache="NativeTimeline_OrderDate" caption="Order Date" style="TimeSlicerStyleLight1" level="2" showHeader="1" showSelectionLabel="0" showTimeLevel="true" showHorizontalScrollbar="false"/></timelines>`
+    expect(parseTimelines(xml)).toEqual([
+      {
+        name: "OrderDate",
+        cache: "NativeTimeline_OrderDate",
+        caption: "Order Date",
+        style: "TimeSlicerStyleLight1",
+        level: "2",
+        showHeader: true,
+        showSelectionLabel: false,
+        showTimeLevel: true,
+        showHorizontalScrollbar: false,
+      },
+    ])
+  })
+
+  it("skips timelines without a name or cache and foreign elements", () => {
+    const xml = `${XML_DECL}<timelines xmlns="x15"><extLst/><timeline cache="c"/><timeline name="n"/><timeline name="ok" cache="c"/></timelines>`
+    expect(parseTimelines(xml)).toEqual([{ name: "ok", cache: "c" }])
+  })
+})
+
+describe("parseTimelineCache", () => {
+  it("reads the cache name, source and pivot tables", () => {
+    const xml = `${XML_DECL}<timelineCacheDefinition xmlns="x15" name="NativeTimeline_OrderDate" sourceName="OrderDate"><pivotTables><pivotTable tabId="1" name="PivotTable1"/></pivotTables></timelineCacheDefinition>`
+    expect(parseTimelineCache(xml)).toEqual({
+      name: "NativeTimeline_OrderDate",
+      sourceName: "OrderDate",
+      pivotTables: [{ tabId: 1, name: "PivotTable1" }],
+    })
+  })
+
+  it("returns undefined without a definition or a name", () => {
+    expect(parseTimelineCache(`${XML_DECL}<somethingElse/>`)).toBeUndefined()
+    expect(parseTimelineCache(`${XML_DECL}<timelineCacheDefinition xmlns="x15"/>`)).toBeUndefined()
+  })
+
+  it("finds the definition nested inside a wrapper element", () => {
+    const xml = `${XML_DECL}<wrapper><timelineCacheDefinition name="T"/></wrapper>`
+    expect(parseTimelineCache(xml)).toEqual({ name: "T" })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// commentsN.xml — the classic (VML-anchored) comment system
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseComments", () => {
+  // Excel splits comment text into runs so the author name can be bold;
+  // the reader concatenates every <t> in the <text> element.
+  it("concatenates the text runs of a comment", () => {
+    const xml = `${XML_DECL}<comments xmlns="${NS_MAIN}"><authors><author>Ada Lovelace</author></authors><commentList><comment ref="A1" authorId="0"><text><r><rPr><b/></rPr><t>Ada Lovelace:</t></r><r><t xml:space="preserve"> check this</t></r></text></comment></commentList></comments>`
+    expect(parseComments(xml).get("A1")).toEqual({
+      author: "Ada Lovelace",
+      text: "Ada Lovelace: check this",
+    })
+  })
+
+  // Some writers emit the whole spreadsheetml package with an `x:` prefix.
+  it("handles prefixed element names", () => {
+    const xml = `${XML_DECL}<x:comments xmlns:x="${NS_MAIN}"><x:authors><x:author>Grace</x:author></x:authors><x:commentList><x:comment ref="B2" authorId="0"><x:text><x:t>Hi</x:t></x:text></x:comment></x:commentList></x:comments>`
+    expect(parseComments(xml).get("B2")).toEqual({ author: "Grace", text: "Hi" })
+  })
+
+  // An authorId that is out of range, absent, or points at an empty
+  // author entry leaves the comment unattributed rather than crashing.
+  it("leaves a comment unattributed when the author cannot be resolved", () => {
+    const xml = `${XML_DECL}<comments xmlns="${NS_MAIN}"><authors><author>Ada</author><author></author></authors><commentList><comment ref="A1" authorId="9"><text><t>out of range</t></text></comment><comment ref="A2"><text><t>no id</t></text></comment><comment ref="A3" authorId="1"><text><t>blank author</t></text></comment></commentList></comments>`
+    const comments = parseComments(xml)
+    expect(comments.get("A1")).toEqual({ text: "out of range" })
+    expect(comments.get("A2")).toEqual({ text: "no id" })
+    expect(comments.get("A3")).toEqual({ text: "blank author" })
+  })
+
+  // A comment with no ref has no cell to attach to.
+  it("skips a comment with no cell reference", () => {
+    const xml = `${XML_DECL}<comments xmlns="${NS_MAIN}"><authors><author>Ada</author></authors><commentList><comment authorId="0"><text><t>orphan</t></text></comment></commentList></comments>`
+    expect(parseComments(xml).size).toBe(0)
+  })
+
+  // Every piece of state is scoped to its container: an <author>,
+  // <comment>, <text>, <r> or <t> that appears outside the element it
+  // belongs to (a malformed file, or an element of the same name from
+  // another schema) must be ignored rather than polluting the result.
+  it("ignores comment-shaped elements outside their container", () => {
+    const xml = `${XML_DECL}<comments xmlns="${NS_MAIN}"><author>stray author</author><comment ref="Z9"><text><t>stray comment</t></text></comment><r><t>stray run</t></r><t>stray</t><authors><author>Ada</author></authors><commentList><comment ref="A1" authorId="0"><text><t>real</t></text></comment></commentList></comments>`
+    const comments = parseComments(xml)
+    expect(comments.size).toBe(1)
+    expect(comments.get("A1")).toEqual({ author: "Ada", text: "real" })
+  })
+
+  it("returns an empty map for a file with no comments", () => {
+    const xml = `${XML_DECL}<comments xmlns="${NS_MAIN}"><authors/><commentList/></comments>`
+    expect(parseComments(xml).size).toBe(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Threaded comments (Excel 365) — persons + threads
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parsePersons", () => {
+  it("reads the optional identity attributes", () => {
+    const xml = `${XML_DECL}<personList xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments"><person displayName="Ada Lovelace" id="{6EE7...}" userId="ada@example.com" providerId="AD"/></personList>`
+    expect(parsePersons(xml)).toEqual([
+      {
+        id: "{6EE7...}",
+        displayName: "Ada Lovelace",
+        userId: "ada@example.com",
+        providerId: "AD",
+      },
+    ])
+  })
+
+  // A person without an id cannot be referenced by a comment; a person
+  // without a displayName is not a person entry at all.
+  it("skips entries missing an id or display name, and foreign elements", () => {
+    const xml = `${XML_DECL}<personList xmlns="tc"><ext/><person displayName="No Id"/><person id="{1}"/><person id="{2}" displayName=""/></personList>`
+    expect(parsePersons(xml)).toEqual([{ id: "{2}", displayName: "" }])
+  })
+})
+
+describe("parseThreadedComments", () => {
+  const THREAD = `${XML_DECL}
+<ThreadedComments xmlns="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments">
+  <ext/>
+  <threadedComment ref="A1" dT="2026-01-15T10:00:00.00" personId="{P1}" id="{C1}" done="1">
+    <text>Can you check @Ada Lovelace ?</text>
+    <mentions>
+      <ext/>
+      <mention mentionpersonId="{P2}" mentionId="{M1}" startIndex="13" length="12"/>
+      <mention mentionId="{M2}" startIndex="0" length="1"/>
+      <mention mentionpersonId="{P3}" startIndex="0" length="1"/>
+      <mention mentionpersonId="{P4}" mentionId="{M3}"/>
+      <mention mentionpersonId="{P5}" mentionId="{M4}" startIndex="first" length="lots"/>
+    </mentions>
+  </threadedComment>
+  <threadedComment personId="{P2}" id="{C2}" parentId="{C1}" done="true"><text>Checked</text></threadedComment>
+  <threadedComment personId="{P2}" id="{C3}"/>
+  <threadedComment id="{C4}"><text>no person</text></threadedComment>
+  <threadedComment personId="{P2}"><text>no id</text></threadedComment>
+</ThreadedComments>`
+
+  it("reads a thread with its mentions", () => {
+    expect(parseThreadedComments(THREAD)[0]).toEqual({
+      id: "{C1}",
+      personId: "{P1}",
+      ref: "A1",
+      date: "2026-01-15T10:00:00.00",
+      done: true,
+      text: "Can you check @Ada Lovelace ?",
+      // A mention needs both ids; its offsets default to 0 when they are
+      // absent or unparseable.
+      mentions: [
+        { mentionPersonId: "{P2}", mentionId: "{M1}", startIndex: 13, length: 12 },
+        { mentionPersonId: "{P4}", mentionId: "{M3}", startIndex: 0, length: 0 },
+        { mentionPersonId: "{P5}", mentionId: "{M4}", startIndex: 0, length: 0 },
+      ],
+    })
+  })
+
+  // A reply carries parentId and no ref; `done` accepts both spellings
+  // Excel writes.
+  it("reads a reply and accepts done written as 'true'", () => {
+    expect(parseThreadedComments(THREAD)[1]).toEqual({
+      id: "{C2}",
+      personId: "{P2}",
+      parentId: "{C1}",
+      done: true,
+      text: "Checked",
+    })
+  })
+
+  // A comment element with no <text> child yields an empty body rather
+  // than undefined.
+  it("yields empty text when the text element is missing", () => {
+    expect(parseThreadedComments(THREAD)[2]).toEqual({ id: "{C3}", personId: "{P2}", text: "" })
+  })
+
+  // id and personId are both required to place a comment in a thread.
+  it("skips comments missing an id or a person id", () => {
+    expect(parseThreadedComments(THREAD)).toHaveLength(3)
+  })
+
+  it("omits mentions entirely when none survive validation", () => {
+    const xml = `${XML_DECL}<ThreadedComments xmlns="tc"><threadedComment id="{C}" personId="{P}"><text>x</text><mentions><mention/></mentions></threadedComment></ThreadedComments>`
+    expect(parseThreadedComments(xml)[0].mentions).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// CSV reader — option interactions the other suites do not reach
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseCsv — skipLines", () => {
+  // Files exported from reporting tools often carry a title block above
+  // the header; skipLines must count a CRLF pair as one line, not two.
+  it("counts a CRLF pair as a single line", () => {
+    expect(parseCsv("title\r\nsub\r\na,b\r\n1,2", { skipLines: 2 })).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ])
+  })
+
+  it("counts a bare CR as a line", () => {
+    expect(parseCsv("title\rsub\ra,b", { skipLines: 2 })).toEqual([["a", "b"]])
+  })
+
+  it("returns nothing when every line is skipped", () => {
+    expect(parseCsv("a,b\nc,d", { skipLines: 10 })).toEqual([])
+  })
+})
+
+describe("parseCsv — transformValue", () => {
+  // With `header: true` the callback receives the header cell's text as
+  // the column name so a caller can switch on the column.
+  it("passes the header text as the column name", () => {
+    const seen: string[] = []
+    parseCsv("name,age\nAda,36", {
+      header: true,
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["name", "age", "name", "age"])
+  })
+
+  // Without headers the column index stands in for the name.
+  it("passes the column index when there is no header row", () => {
+    const seen: string[] = []
+    parseCsv("Ada,36", {
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["0", "1"])
+  })
+
+  // A ragged row reaching past the header falls back to the index.
+  it("falls back to the column index past the end of the header row", () => {
+    const seen: string[] = []
+    parseCsv("name\nAda,36", {
+      header: true,
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["name", "name", "1"])
+  })
+})
+
+describe("parseCsvObjects", () => {
+  // The options argument is optional even though the type suggests a
+  // `header: true` flag — the first row is always the header here.
+  it("works with no options at all", () => {
+    expect(parseCsvObjects("name,age\nAda,36")).toEqual({
+      headers: ["name", "age"],
+      data: [{ name: "Ada", age: "36" }],
+    })
+  })
+})
+
+describe("parseCsv — delimiter detection", () => {
+  // Two candidates appearing equally often on every line tie; the first
+  // candidate in the probe order (comma) wins, so a file mixing commas
+  // and semicolons is still read as comma-separated.
+  it("keeps the earlier candidate when two delimiters tie", () => {
+    expect(parseCsv("a,b;c\n1,2;3")).toEqual([
+      ["a", "b;c"],
+      ["1", "2;3"],
+    ])
+  })
+})
+
+describe("parseCsv — type inference", () => {
+  // A field shaped like an ISO date but naming a day that does not exist
+  // stays a string rather than becoming an Invalid Date.
+  it("leaves an impossible ISO-shaped date as text", () => {
+    expect(parseCsv("2021-13-45,2021-01-15", { typeInference: true })).toEqual([
+      ["2021-13-45", new Date("2021-01-15")],
+    ])
+  })
+
+  // A lone sign is not a number; neither is a value that overflows to
+  // Infinity.
+  it("leaves non-numeric sign characters and overflows as text", () => {
+    expect(parseCsv("-,+,1e999,1e308", { typeInference: true })).toEqual([
+      ["-", "+", "1e999", 1e308],
+    ])
+  })
+
+  it("leaves an all-whitespace field as text", () => {
+    expect(parseCsv('" ",1', { typeInference: true })).toEqual([[" ", 1]])
+  })
+
+  // Thousands separators are stripped only when they group three digits.
+  it("parses grouped numbers but not arbitrary comma text", () => {
+    expect(parseCsv('"1,234.56";"1,23"', { typeInference: true, delimiter: ";" })).toEqual([
+      [1234.56, "1,23"],
+    ])
+  })
+})
+
+describe("parseCsv — comments", () => {
+  // A quoted leading # is data, not a comment — this is what keeps a
+  // column of hashtags intact.
+  it("keeps a quoted field that starts with the comment character", () => {
+    expect(parseCsv('#skip me\n"#hashtag",1', { comment: "#" })).toEqual([["#hashtag", "1"]])
+  })
+})

--- a/test/coverage-xlsx-reader.test.ts
+++ b/test/coverage-xlsx-reader.test.ts
@@ -1,0 +1,1167 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ParseError } from "../src/errors"
+import { REL_CELL_IMAGES } from "../src/xlsx/cell-images-reader"
+
+// ── Package assembly helpers ─────────────────────────────────────────
+
+const enc = new TextEncoder()
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const XDR = 'xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"'
+const A = 'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"'
+const REL_BASE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+/** A one-pixel PNG stand-in — the reader only ever copies these bytes. */
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+interface RelSpec {
+  id: string
+  /** Short OOXML type name, or a full URI for vendor namespaces. */
+  type: string
+  target: string
+  mode?: string
+}
+
+function relsXml(entries: RelSpec[]): string {
+  const items = entries
+    .map((e) => {
+      const type = e.type.includes("://") ? e.type : `${REL_BASE}/${e.type}`
+      const mode = e.mode ? ` TargetMode="${e.mode}"` : ""
+      return `<Relationship Id="${e.id}" Type="${type}" Target="${e.target}"${mode}/>`
+    })
+    .join("")
+  return (
+    `<?xml version="1.0"?><Relationships ` +
+    `xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${items}</Relationships>`
+  )
+}
+
+// The reader only validates that this part parses; the per-part overrides
+// are irrelevant to every branch under test, so one constant serves all.
+const CONTENT_TYPES =
+  `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+  `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+  `<Default Extension="xml" ContentType="application/xml"/></Types>`
+
+const workbookXml = (body: string): string =>
+  `<?xml version="1.0"?><workbook ${NS} ${R}>${body}</workbook>`
+
+const worksheetXml = (body: string): string =>
+  `<?xml version="1.0"?><worksheet ${NS} ${R}>${body}</worksheet>`
+
+const ONE_CELL = `<sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>hi</t></is></c></row></sheetData>`
+
+type Parts = Record<string, string | Uint8Array>
+
+/** The five parts every valid single-sheet workbook needs. */
+function defaultParts(): Parts {
+  return {
+    "[Content_Types].xml": CONTENT_TYPES,
+    "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "xl/workbook.xml" }]),
+    "xl/workbook.xml": workbookXml(
+      `<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>`,
+    ),
+    "xl/_rels/workbook.xml.rels": relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+    ]),
+    "xl/worksheets/sheet1.xml": worksheetXml(ONE_CELL),
+  }
+}
+
+async function build(parts: Parts): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  for (const [path, content] of Object.entries(parts)) {
+    zip.add(path, typeof content === "string" ? enc.encode(content) : content)
+  }
+  return zip.build()
+}
+
+/** Read a package made of the default parts plus `extra` (which may replace them). */
+async function read(extra: Parts = {}, options?: Parameters<typeof readXlsx>[1]) {
+  return readXlsx(await build({ ...defaultParts(), ...extra }), options)
+}
+
+/** Read a package built only from the parts given. */
+async function readExact(parts: Parts, options?: Parameters<typeof readXlsx>[1]) {
+  return readXlsx(await build(parts), options)
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Package layout
+//
+// Nothing in OPC requires the workbook to live under `xl/`. Relationship
+// targets may be package-absolute (`/workbook.xml`), and a producer that
+// puts everything at the root exercises every "no directory prefix"
+// branch in the path helpers at once.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("packages that do not use the xl/ layout", () => {
+  it("reads a workbook addressed by an absolute target at the package root", async () => {
+    const wb = await readExact({
+      "[Content_Types].xml": CONTENT_TYPES,
+      "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "/workbook.xml" }]),
+      "workbook.xml": workbookXml(`<sheets><sheet name="Root" sheetId="1" r:id="rId1"/></sheets>`),
+      "_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "sheet1.xml" },
+        { id: "rId2", type: "externalLink", target: "link1.xml" },
+      ]),
+      // NB: no `_rels/sheet1.xml.rels` here — see the skipped test at the
+      // bottom of this file for why a root-level part cannot find its own
+      // relationships today.
+      "sheet1.xml": worksheetXml(ONE_CELL),
+      "theme/theme1.xml":
+        `<?xml version="1.0"?><a:theme ${A}><a:themeElements><a:clrScheme name="x">` +
+        `<a:dk1><a:srgbClr val="000000"/></a:dk1><a:lt1><a:srgbClr val="FFFFFF"/></a:lt1>` +
+        `</a:clrScheme></a:themeElements></a:theme>`,
+      "link1.xml":
+        `<?xml version="1.0"?><externalLink ${NS} ${R}><externalBook r:id="rId1">` +
+        `<sheetNames><sheetName val="Budget"/></sheetNames></externalBook></externalLink>`,
+      "_rels/link1.xml.rels": relsXml([
+        { id: "rId1", type: "externalLinkPath", target: "C:/other.xlsx", mode: "External" },
+      ]),
+    })
+
+    expect(wb.sheets[0].name).toBe("Root")
+    expect(wb.sheets[0].rows[0][0]).toBe("hi")
+    expect(wb.themeColors).toBeDefined()
+    expect(wb.externalLinks![0].sheetNames).toEqual(["Budget"])
+  })
+
+  it("resolves a relative target that walks up out of its own directory", async () => {
+    // `xl/_rels/workbook.xml.rels` pointing at `../sheets/sheet1.xml` —
+    // legal OPC and produced by a few non-Excel writers.
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "../sheets/./sheet1.xml" },
+      ]),
+      "sheets/sheet1.xml": worksheetXml(ONE_CELL),
+    })
+    expect(wb.sheets[0].rows[0][0]).toBe("hi")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Structural failures
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("invalid packages", () => {
+  it("rejects a package whose root rels name no officeDocument", async () => {
+    const parts = defaultParts()
+    parts["_rels/.rels"] = relsXml([
+      { id: "rId1", type: "extended-properties", target: "docProps/app.xml" },
+    ])
+    await expect(readExact(parts)).rejects.toThrow(/cannot find workbook relationship/)
+  })
+
+  it("rejects a package whose workbook part is missing", async () => {
+    const parts = defaultParts()
+    delete parts["xl/workbook.xml"]
+    await expect(readExact(parts)).rejects.toThrow(/missing workbook at xl\/workbook\.xml/)
+  })
+
+  it("rejects a sheet whose worksheet part is missing", async () => {
+    const parts = defaultParts()
+    delete parts["xl/worksheets/sheet1.xml"]
+    await expect(readExact(parts)).rejects.toThrow(ParseError)
+  })
+
+  it("rejects a sheet whose rId has no worksheet relationship", async () => {
+    await expect(
+      read({
+        "xl/workbook.xml": workbookXml(
+          `<sheets><sheet name="Sheet1" sheetId="1" r:id="rId404"/></sheets>`,
+        ),
+      }),
+    ).rejects.toThrow(/missing worksheet file for sheet "Sheet1"/)
+  })
+
+  it("reads a workbook with no workbook.xml.rels at all", async () => {
+    // Without the rels part there are no sheet targets, so no sheets —
+    // but the file still opens rather than throwing.
+    const parts = defaultParts()
+    delete parts["xl/_rels/workbook.xml.rels"]
+    parts["xl/workbook.xml"] = workbookXml(`<sheets/>`)
+    const wb = await readExact(parts)
+    expect(wb.sheets).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// workbook.xml
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sheet declarations", () => {
+  it("marks hidden and veryHidden sheets", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<sheets>` +
+          `<sheet name="V" sheetId="1" r:id="rId1"/>` +
+          `<sheet name="H" sheetId="2" r:id="rId1" state="hidden"/>` +
+          `<sheet name="VH" sheetId="3" r:id="rId1" state="veryHidden"/>` +
+          `<sheet name="Odd" sheetId="4" r:id="rId1" state="somethingElse"/>` +
+          `</sheets>`,
+      ),
+    })
+    expect(wb.sheets.map((s) => [s.hidden, s.veryHidden])).toEqual([
+      [undefined, undefined],
+      [true, undefined],
+      [undefined, true],
+      [undefined, undefined],
+    ])
+  })
+
+  it("skips sheet entries with no name or no relationship id", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<sheets><sheet sheetId="1" r:id="rId1"/><sheet name="NoRel" sheetId="2"/>` +
+          `<sheet name="Good" r:id="rId1"/><notASheet name="X" r:id="rId1"/></sheets>`,
+      ),
+    })
+    expect(wb.sheets.map((s) => s.name)).toEqual(["Good"])
+  })
+
+  it("finds the relationship id under any namespace prefix", async () => {
+    // The `r` prefix is conventional, not required — the attribute is
+    // identified by its namespace, which we approximate by shape.
+    const wb = await read({
+      "xl/workbook.xml":
+        `<?xml version="1.0"?><workbook ${NS} ` +
+        `xmlns:rel="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+        `<sheets><sheet name="Prefixed" sheetId="1" rel:id="rId1"/></sheets></workbook>`,
+    })
+    expect(wb.sheets[0].name).toBe("Prefixed")
+  })
+})
+
+describe("date system", () => {
+  const wb1904 = workbookXml(
+    `<workbookPr date1904="true"/><sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`,
+  )
+
+  it("auto-detects the 1904 epoch from workbookPr", async () => {
+    expect((await read({ "xl/workbook.xml": wb1904 })).dateSystem).toBe("1904")
+    expect((await read({ "xl/workbook.xml": wb1904 }, { dateSystem: "auto" })).dateSystem).toBe(
+      "1904",
+    )
+  })
+
+  it("lets an explicit dateSystem option override the file", async () => {
+    // Legacy Mac files sometimes carry the flag when the serials are in
+    // fact 1900-based, so the option has to win.
+    expect((await read({ "xl/workbook.xml": wb1904 }, { dateSystem: "1900" })).dateSystem).toBe(
+      "1900",
+    )
+    expect((await read({}, { dateSystem: "1904" })).dateSystem).toBe("1904")
+  })
+})
+
+describe("workbook protection", () => {
+  it("reads the structure and window locks", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<workbookProtection lockStructure="true" lockWindows="1"/>` +
+          `<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`,
+      ),
+    })
+    expect(wb.workbookProtection).toEqual({ lockStructure: true, lockWindows: true })
+  })
+
+  it("omits the block when nothing is actually locked", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<workbookProtection workbookPassword="CC1A"/>` +
+          `<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`,
+      ),
+    })
+    expect(wb.workbookProtection).toBeUndefined()
+  })
+})
+
+describe("defined names", () => {
+  it("scopes a name to its sheet and keeps its comment", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>` +
+          `<definedNames>` +
+          `<definedName name="Global">S!$A$1</definedName>` +
+          `<definedName name="Local" localSheetId="0" comment="notes">S!$B$1</definedName>` +
+          `<definedName name="Dangling" localSheetId="9">S!$C$1</definedName>` +
+          `<definedName name="Empty"></definedName>` +
+          `<definedName localSheetId="0">S!$D$1</definedName>` +
+          `</definedNames>`,
+      ),
+    })
+    expect(wb.namedRanges).toEqual([
+      { name: "Global", range: "S!$A$1" },
+      { name: "Local", range: "S!$B$1", scope: "S", comment: "notes" },
+      // A localSheetId past the end of the sheet list resolves to no
+      // scope rather than crashing on the array lookup.
+      { name: "Dangling", range: "S!$C$1" },
+    ])
+  })
+})
+
+describe("sheets read option", () => {
+  const threeSheets = {
+    "xl/workbook.xml": workbookXml(
+      `<sheets><sheet name="A" sheetId="1" r:id="rId1"/>` +
+        `<sheet name="B" sheetId="2" r:id="rId1" state="hidden"/>` +
+        `<sheet name="C" sheetId="3" r:id="rId1" state="veryHidden"/></sheets>`,
+    ),
+  }
+
+  it("treats an empty array as no filter at all", async () => {
+    const wb = await read(threeSheets, { sheets: [] })
+    expect(wb.sheets.map((s) => s.name)).toEqual(["A", "B", "C"])
+  })
+
+  it("ignores indices and names that match nothing", async () => {
+    const wb = await read(threeSheets, { sheets: [2, 99, "B", "Nope", -1] })
+    expect(wb.sheets.map((s) => s.name)).toEqual(["C", "B"])
+  })
+
+  it("passes hidden state to a predicate filter", async () => {
+    const seen: Array<[string, number, boolean | undefined, boolean | undefined]> = []
+    const wb = await read(threeSheets, {
+      sheets: (info, i) => {
+        seen.push([info.name, i, info.hidden, info.veryHidden])
+        return !info.hidden && !info.veryHidden
+      },
+    })
+    expect(seen).toEqual([
+      ["A", 0, false, false],
+      ["B", 1, true, false],
+      ["C", 2, false, true],
+    ])
+    expect(wb.sheets.map((s) => s.name)).toEqual(["A"])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Optional workbook-level parts
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("relationships that point at parts which are not in the package", () => {
+  it("skips every dangling workbook-level relationship without failing", async () => {
+    // Files edited by third-party tools routinely keep relationships to
+    // parts that were dropped. None of these should abort the read.
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        { id: "rId2", type: "sharedStrings", target: "sharedStrings.xml" },
+        { id: "rId3", type: "styles", target: "styles.xml" },
+        { id: "rId4", type: "person", target: "persons/person.xml" },
+        { id: "rId5", type: "externalLink", target: "externalLinks/externalLink1.xml" },
+        { id: "rIdX", type: "externalLink", target: "externalLinks/externalLink2.xml" },
+        { id: "rId6", type: "slicerCache", target: "slicerCaches/slicerCache1.xml" },
+        { id: "rId7", type: "slicerCache", target: "slicerCaches/legacy.xml" },
+        { id: "rId8", type: "timelineCache", target: "timelineCaches/timelineCache1.xml" },
+        {
+          id: "rId9",
+          type: "pivotCacheDefinition",
+          target: "pivotCache/pivotCacheDefinition1.xml",
+        },
+        { id: "rId10", type: REL_CELL_IMAGES, target: "cellimages.xml" },
+      ]),
+      "xl/workbook.xml": workbookXml(
+        `<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>` +
+          `<pivotCaches><pivotCache cacheId="0" r:id="rId9"/>` +
+          `<pivotCache cacheId="1" r:id="rIdMissing"/>` +
+          `<pivotCache r:id="rId9"/></pivotCaches>`,
+      ),
+    })
+    expect(wb.sheets).toHaveLength(1)
+    expect(wb.externalLinks).toBeUndefined()
+    expect(wb.pivotCaches).toBeUndefined()
+    expect(wb.slicerCaches).toBeUndefined()
+    expect(wb.timelineCaches).toBeUndefined()
+    expect(wb.cellImages).toBeUndefined()
+    expect(wb.persons).toBeUndefined()
+  })
+
+  it("skips a worksheet-level relationship whose part is missing", async () => {
+    const wb = await read({
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "drawing", target: "../drawings/drawing1.xml" },
+        { id: "rId2", type: "comments", target: "../comments1.xml" },
+        { id: "rId3", type: "threadedComment", target: "../threadedComments/tc1.xml" },
+        { id: "rId4", type: "table", target: "../tables/table1.xml" },
+        { id: "rId5", type: "image", target: "../media/bg.png" },
+        { id: "rId6", type: "pivotTable", target: "../pivotTables/pivotTable1.xml" },
+        { id: "rId7", type: "slicer", target: "../slicers/slicer1.xml" },
+        { id: "rId8", type: "timeline", target: "../timelines/timeline1.xml" },
+      ]),
+    })
+    const sheet = wb.sheets[0]
+    expect(sheet.images).toBeUndefined()
+    expect(sheet.tables).toBeUndefined()
+    expect(sheet.backgroundImage).toBeUndefined()
+    expect(sheet.pivotTables).toBeUndefined()
+    expect(sheet.slicers).toBeUndefined()
+    expect(sheet.timelines).toBeUndefined()
+    expect(sheet.threadedComments).toBeUndefined()
+  })
+})
+
+describe("shared strings, styles and background image", () => {
+  it("resolves shared strings and a sheet background", async () => {
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        { id: "rId2", type: "sharedStrings", target: "sharedStrings.xml" },
+      ]),
+      "xl/sharedStrings.xml": `<?xml version="1.0"?><sst ${NS} count="1" uniqueCount="1"><si><t>Shared</t></si></sst>`,
+      "xl/worksheets/sheet1.xml": worksheetXml(
+        `<sheetData><row r="1"><c r="A1" t="s"><v>0</v></c></row></sheetData>`,
+      ),
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "image", target: "../media/bg.png" },
+      ]),
+      "xl/media/bg.png": PNG,
+    })
+    expect(wb.sheets[0].rows[0][0]).toBe("Shared")
+    expect(wb.sheets[0].backgroundImage).toEqual(PNG)
+  })
+})
+
+describe("document properties", () => {
+  it("attaches custom properties even with no core or app part", async () => {
+    const wb = await read({
+      "docProps/custom.xml":
+        `<?xml version="1.0"?><Properties ` +
+        `xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" ` +
+        `xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">` +
+        `<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2" name="Dept">` +
+        `<vt:lpwstr>Finance</vt:lpwstr></property></Properties>`,
+    })
+    expect(wb.properties).toEqual({ custom: { Dept: "Finance" } })
+  })
+
+  it("ignores empty docProps parts", async () => {
+    const wb = await read({
+      "docProps/core.xml":
+        `<?xml version="1.0"?><cp:coreProperties ` +
+        `xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"/>`,
+      "docProps/app.xml":
+        `<?xml version="1.0"?><Properties ` +
+        `xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"/>`,
+      "docProps/custom.xml":
+        `<?xml version="1.0"?><Properties ` +
+        `xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"/>`,
+    })
+    expect(wb.properties).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Comments
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("legacy comments", () => {
+  it("creates a cell for a comment anchored on an empty cell", async () => {
+    // Comments outlive their content: deleting the text leaves the note
+    // attached to a cell that no longer appears in <sheetData>.
+    const wb = await read({
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "comments", target: "../comments1.xml" },
+      ]),
+      "xl/comments1.xml":
+        `<?xml version="1.0"?><comments ${NS}><authors><author>Ana</author></authors>` +
+        `<commentList>` +
+        `<comment ref="A1" authorId="0"><text><t>on data</t></text></comment>` +
+        `<comment ref="D9" authorId="0"><text><t>orphan</t></text></comment>` +
+        `</commentList></comments>`,
+    })
+    const cells = wb.sheets[0].cells!
+    expect(cells.get("0,0")!.comment!.text).toBe("on data")
+    const orphan = cells.get("8,3")!
+    expect(orphan.value).toBeNull()
+    expect(orphan.comment!.text).toBe("orphan")
+  })
+
+  it("ignores a comments part that lists no comments", async () => {
+    const wb = await read({
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "comments", target: "../comments1.xml" },
+      ]),
+      "xl/comments1.xml": `<?xml version="1.0"?><comments ${NS}><commentList/></comments>`,
+    })
+    expect(wb.sheets[0].cells).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Tables
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("table parts", () => {
+  const withTable = (tableXml: string): Parts => ({
+    "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+      { id: "rId1", type: "table", target: "../tables/table1.xml" },
+    ]),
+    "xl/tables/table1.xml": tableXml,
+  })
+
+  it("drops a table part with no name", async () => {
+    const wb = await read(
+      withTable(
+        `<?xml version="1.0"?><table ${NS} id="1" ref="A1:B2"><tableColumns count="0"/></table>`,
+      ),
+    )
+    expect(wb.sheets[0].tables).toBeUndefined()
+  })
+
+  it("reads columns, totals and style flags", async () => {
+    const wb = await read(
+      withTable(
+        `<?xml version="1.0"?><table ${NS} id="1" name="Sales" displayName="Sales_2024" ` +
+          `ref="A1:C4" totalsRowCount="1">` +
+          `<autoFilter ref="A1:C3"/>` +
+          `<tableColumns count="3">` +
+          `<tableColumn id="1" name="Item"/>` +
+          `<tableColumn id="2" name="Qty" totalsRowFunction="sum"/>` +
+          `<tableColumn id="3" name="Note" totalsRowLabel="Total">` +
+          `<totalsRowFormula>SUBTOTAL(109,Sales[Qty])</totalsRowFormula>` +
+          `<calculatedColumnFormula>1</calculatedColumnFormula></tableColumn>` +
+          `</tableColumns>` +
+          `<tableStyleInfo name="TableStyleMedium2" showRowStripes="1" showColumnStripes="0"/>` +
+          `</table>`,
+      ),
+    )
+    expect(wb.sheets[0].tables![0]).toEqual({
+      name: "Sales",
+      displayName: "Sales_2024",
+      range: "A1:C4",
+      style: "TableStyleMedium2",
+      showRowStripes: true,
+      showColumnStripes: false,
+      showAutoFilter: true,
+      showTotalRow: true,
+      columns: [
+        { name: "Item" },
+        { name: "Qty", totalFunction: "sum" },
+        { name: "Note", totalLabel: "Total", totalFormula: "SUBTOTAL(109,Sales[Qty])" },
+      ],
+    })
+  })
+
+  it("omits displayName when it merely repeats the name, and ref when absent", async () => {
+    const wb = await read(
+      withTable(
+        `<?xml version="1.0"?><table ${NS} id="1" name="T" displayName="T" totalsRowCount="0">` +
+          `<tableColumns count="1"><tableColumn id="1" name="A">` +
+          `<totalsRowFormula></totalsRowFormula></tableColumn></tableColumns></table>`,
+      ),
+    )
+    const table = wb.sheets[0].tables![0]
+    expect(table.displayName).toBeUndefined()
+    expect(table.range).toBeUndefined()
+    expect(table.style).toBeUndefined()
+    expect(table.showTotalRow).toBeUndefined()
+    expect(table.columns[0]).toEqual({ name: "A" })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Drawings: images, textboxes, charts
+// ═══════════════════════════════════════════════════════════════════════
+
+/** Wire a drawing part (plus its rels) onto sheet1. */
+function withDrawing(drawing: string, drawingRels: RelSpec[], extra: Parts = {}): Parts {
+  return {
+    "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+      { id: "rId1", type: "drawing", target: "../drawings/drawing1.xml" },
+    ]),
+    "xl/drawings/drawing1.xml": `<?xml version="1.0"?><xdr:wsDr ${XDR} ${A} ${R}>${drawing}</xdr:wsDr>`,
+    "xl/drawings/_rels/drawing1.xml.rels": relsXml(drawingRels),
+    ...extra,
+  }
+}
+
+const pic = (embed: string, meta = ""): string =>
+  `<xdr:pic><xdr:nvPicPr><xdr:cNvPr id="1" name="p"${meta}/><xdr:cNvPicPr/></xdr:nvPicPr>` +
+  `<xdr:blipFill><a:blip ${embed}/></xdr:blipFill></xdr:pic>`
+
+const fromTo = (fc: number, fr: number, tc: number, tr: number): string =>
+  `<xdr:from><xdr:col>${fc}</xdr:col><xdr:row>${fr}</xdr:row></xdr:from>` +
+  `<xdr:to><xdr:col>${tc}</xdr:col><xdr:row>${tr}</xdr:row></xdr:to>`
+
+describe("drawing images", () => {
+  it("reads a oneCellAnchor image with its extent and accessibility metadata", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:oneCellAnchor>` +
+          `<xdr:from><xdr:col>2</xdr:col><xdr:row>3</xdr:row></xdr:from>` +
+          `<xdr:ext cx="952500" cy="476250"/>` +
+          pic(`r:embed="rId1"`, ` descr="A logo" title="Logo"`) +
+          `</xdr:oneCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.png" }],
+        { "xl/media/image1.png": PNG },
+      ),
+    )
+    expect(wb.sheets[0].images![0]).toEqual({
+      data: PNG,
+      type: "png",
+      anchor: { from: { row: 3, col: 2 } },
+      width: 100,
+      height: 50,
+      altText: "A logo",
+      title: "Logo",
+    })
+  })
+
+  it("omits width and height when the extent is zero or unparseable", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from>` +
+          `<xdr:ext cx="0" cy="not-a-number"/>` +
+          pic(`r:embed="rId1"`) +
+          `</xdr:oneCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.png" }],
+        { "xl/media/image1.png": PNG },
+      ),
+    )
+    const img = wb.sheets[0].images![0]
+    expect(img.width).toBeUndefined()
+    expect(img.height).toBeUndefined()
+  })
+
+  it("falls back to png for a media file with an unknown extension", async () => {
+    // Some producers store `image1.bin` or drop the extension entirely.
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${pic(`r:embed="rId1"`)}</xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.bin" }],
+        { "xl/media/image1.bin": PNG },
+      ),
+    )
+    expect(wb.sheets[0].images![0].type).toBe("png")
+  })
+
+  it("finds the embed id under a non-standard namespace prefix", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}` +
+          pic(`rel:embed="rId1" xmlns:rel="${REL_BASE}"`) +
+          `</xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.jpeg" }],
+        { "xl/media/image1.jpeg": PNG },
+      ),
+    )
+    expect(wb.sheets[0].images![0].type).toBe("jpeg")
+  })
+
+  it("drops an anchor whose embed id resolves to no relationship", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${pic(`r:embed="rId404"`)}</xdr:twoCellAnchor>` +
+          `<xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from>` +
+          `${pic(`r:embed="rId404"`)}</xdr:oneCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.png" }],
+        { "xl/media/image1.png": PNG },
+      ),
+    )
+    expect(wb.sheets[0].images).toBeUndefined()
+  })
+
+  it("drops an anchor with no picture at all", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}<xdr:clientData/></xdr:twoCellAnchor>` +
+          `<xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from>` +
+          `<xdr:clientData/></xdr:oneCellAnchor>`,
+        [],
+      ),
+    )
+    expect(wb.sheets[0].images).toBeUndefined()
+  })
+
+  it("drops an image whose media file is missing from the package", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${pic(`r:embed="rId1"`)}</xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/gone.png" }],
+      ),
+    )
+    expect(wb.sheets[0].images).toBeUndefined()
+  })
+
+  it("ignores a drawing relationship whose part is not in the package", async () => {
+    const wb = await read({
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "drawing", target: "../drawings/drawing1.xml" },
+      ]),
+    })
+    expect(wb.sheets[0].images).toBeUndefined()
+  })
+
+  it("reads a drawing that has no rels file of its own", async () => {
+    // No rels means no resolvable embeds, so the anchors yield nothing.
+    const parts = withDrawing(
+      `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${pic(`r:embed="rId1"`)}</xdr:twoCellAnchor>`,
+      [],
+    )
+    delete parts["xl/drawings/_rels/drawing1.xml.rels"]
+    const wb = await read(parts)
+    expect(wb.sheets[0].images).toBeUndefined()
+  })
+})
+
+describe("drawing textboxes", () => {
+  const txBody = (runs: string): string => `<xdr:txBody><a:bodyPr/><a:p>${runs}</a:p></xdr:txBody>`
+
+  it("reads text, run styling and shape colours", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(1, 1, 4, 6)}<xdr:sp>` +
+          `<xdr:nvSpPr><xdr:cNvPr id="2" name="tb" descr="Note" title="A note"/>` +
+          `<xdr:cNvSpPr txBox="true"/></xdr:nvSpPr>` +
+          `<xdr:spPr><a:solidFill><a:srgbClr val="FFFF00"/></a:solidFill>` +
+          `<a:ln><a:solidFill><a:srgbClr val="000080"/></a:solidFill></a:ln></xdr:spPr>` +
+          txBody(
+            `<a:r><a:rPr sz="1400" b="true"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill>` +
+              `</a:rPr><a:t>Hello</a:t></a:r>`,
+          ) +
+          `</xdr:sp></xdr:twoCellAnchor>`,
+        [],
+      ),
+    )
+    expect(wb.sheets[0].textBoxes![0]).toEqual({
+      text: "Hello",
+      anchor: { from: { row: 1, col: 1 }, to: { row: 6, col: 4 } },
+      altText: "Note",
+      title: "A note",
+      style: {
+        fontSize: 14,
+        bold: true,
+        color: "FF0000",
+        fillColor: "FFFF00",
+        borderColor: "000080",
+      },
+    })
+  })
+
+  it("drops a textbox shape that holds no text", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}<xdr:sp>` +
+          `<xdr:nvSpPr><xdr:cNvPr id="2" name="tb"/><xdr:cNvSpPr txBox="1"/></xdr:nvSpPr>` +
+          `<xdr:txBody><a:bodyPr/><a:p/></xdr:txBody></xdr:sp></xdr:twoCellAnchor>`,
+        [],
+      ),
+    )
+    expect(wb.sheets[0].textBoxes).toBeUndefined()
+  })
+
+  it("ignores a shape that is not marked as a textbox", async () => {
+    // A plain autoshape (`txBox` absent) is not a textbox, so neither
+    // the textbox nor the image path claims it.
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}<xdr:sp>` +
+          `<xdr:nvSpPr><xdr:cNvPr id="2" name="s"/><xdr:cNvSpPr/></xdr:nvSpPr>` +
+          txBody(`<a:r><a:t>x</a:t></a:r>`) +
+          `</xdr:sp></xdr:twoCellAnchor>`,
+        [],
+      ),
+    )
+    expect(wb.sheets[0].textBoxes).toBeUndefined()
+  })
+
+  it("joins multiple paragraphs with newlines and keeps the first run's style", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 2, 2)}<xdr:sp>` +
+          `<xdr:nvSpPr><xdr:cNvPr id="2" name="tb"/><xdr:cNvSpPr txBox="1"/></xdr:nvSpPr>` +
+          `<xdr:spPr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill>` +
+          `<a:ln><a:noFill/></a:ln></xdr:spPr>` +
+          `<xdr:txBody><a:bodyPr/>` +
+          `<a:p><a:r><a:rPr sz="1200"/><a:t>one</a:t></a:r></a:p>` +
+          `<a:p><a:r><a:rPr sz="9999"/><a:t>two</a:t></a:r></a:p>` +
+          `<a:endParaRPr/></xdr:txBody></xdr:sp></xdr:twoCellAnchor>`,
+        [],
+      ),
+    )
+    const tb = wb.sheets[0].textBoxes![0]
+    expect(tb.text).toBe("one\ntwo")
+    // A theme fill has no srgbClr to read, so no fillColor is surfaced.
+    expect(tb.style).toEqual({ fontSize: 12 })
+  })
+})
+
+describe("drawing charts", () => {
+  const chartFrame = (rid: string): string =>
+    `<xdr:graphicFrame><a:graphic><a:graphicData ` +
+    `uri="http://schemas.openxmlformats.org/drawingml/2006/chart">` +
+    `<c:chart xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" ` +
+    `r:id="${rid}"/></a:graphicData></a:graphic></xdr:graphicFrame>`
+
+  const barChart =
+    `<?xml version="1.0"?><c:chartSpace ` +
+    `xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" ${A}><c:chart><c:plotArea>` +
+    `<c:barChart><c:ser><c:tx><c:strRef><c:f>Sheet1!$B$1</c:f></c:strRef></c:tx>` +
+    `<c:val><c:numRef><c:f>Sheet1!$B$2:$B$4</c:f></c:numRef></c:val></c:ser></c:barChart>` +
+    `</c:plotArea></c:chart></c:chartSpace>`
+
+  it("pins a twoCellAnchor chart to its cell range", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 7, 15)}${chartFrame("rId1")}</xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "chart", target: "../charts/chart1.xml" }],
+        { "xl/charts/chart1.xml": barChart },
+      ),
+    )
+    expect(wb.sheets[0].charts![0].anchor).toEqual({
+      from: { row: 0, col: 0 },
+      to: { row: 15, col: 7 },
+    })
+  })
+
+  it("reads a oneCellAnchor chart with a from-only anchor", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:oneCellAnchor><xdr:from><xdr:col>3</xdr:col><xdr:row>2</xdr:row></xdr:from>` +
+          `<xdr:ext cx="1" cy="1"/>${chartFrame("rId1")}</xdr:oneCellAnchor>`,
+        [{ id: "rId1", type: "chart", target: "../charts/chart1.xml" }],
+        { "xl/charts/chart1.xml": barChart },
+      ),
+    )
+    expect(wb.sheets[0].charts![0].anchor).toEqual({ from: { row: 2, col: 3 } })
+  })
+
+  it("leaves an absoluteAnchor chart unanchored rather than inventing A1", async () => {
+    // absoluteAnchor positions in EMU, so there is no cell to report.
+    const wb = await read(
+      withDrawing(
+        `<xdr:absoluteAnchor><xdr:pos x="0" y="0"/><xdr:ext cx="1" cy="1"/>` +
+          `${chartFrame("rId1")}</xdr:absoluteAnchor>`,
+        [{ id: "rId1", type: "chart", target: "../charts/chart1.xml" }],
+        { "xl/charts/chart1.xml": barChart },
+      ),
+    )
+    expect(wb.sheets[0].charts![0].anchor).toBeUndefined()
+  })
+
+  it("reports no anchor for a twoCellAnchor missing its <from>", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor><xdr:to><xdr:col>3</xdr:col><xdr:row>3</xdr:row></xdr:to>` +
+          `${chartFrame("rId1")}</xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "chart", target: "../charts/chart1.xml" }],
+        { "xl/charts/chart1.xml": barChart },
+      ),
+    )
+    expect(wb.sheets[0].charts![0].anchor).toBeUndefined()
+  })
+
+  it("skips a chart whose part is missing or unparseable", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${chartFrame("rId1")}</xdr:twoCellAnchor>` +
+          `<xdr:twoCellAnchor>${fromTo(2, 2, 3, 3)}${chartFrame("rId2")}</xdr:twoCellAnchor>` +
+          `<xdr:twoCellAnchor>${fromTo(4, 4, 5, 5)}${chartFrame("rId404")}</xdr:twoCellAnchor>`,
+        [
+          { id: "rId1", type: "chart", target: "../charts/gone.xml" },
+          { id: "rId2", type: "chart", target: "../charts/chart2.xml" },
+        ],
+        { "xl/charts/chart2.xml": `<?xml version="1.0"?><notAChart/>` },
+      ),
+    )
+    expect(wb.sheets[0].charts).toBeUndefined()
+  })
+
+  it("keeps only the first reference to a chart part shared by two anchors", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${chartFrame("rId1")}</xdr:twoCellAnchor>` +
+          `<xdr:twoCellAnchor>${fromTo(5, 5, 6, 6)}${chartFrame("rId1")}</xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "chart", target: "../charts/chart1.xml" }],
+        { "xl/charts/chart1.xml": barChart },
+      ),
+    )
+    expect(wb.sheets[0].charts).toHaveLength(1)
+    expect(wb.sheets[0].charts![0].anchor!.from).toEqual({ row: 0, col: 0 })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// WPS cell-embedded images (xl/cellimages.xml)
+//
+// The part backing `=_xlfn.DISPIMG("id", 1)`. Its rels file mixes image
+// entries with whatever else the producer attached, so the media walk
+// has to be selective.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cell images", () => {
+  const cellImage = (name: string, embed: string, descr = ""): string =>
+    `<etc:cellImage><xdr:pic><xdr:nvPicPr>` +
+    `<xdr:cNvPr id="1" name="${name}"${descr ? ` descr="${descr}"` : ""}/><xdr:cNvPicPr/>` +
+    `</xdr:nvPicPr><xdr:blipFill><a:blip r:embed="${embed}"/></xdr:blipFill></xdr:pic></etc:cellImage>`
+
+  it("resolves each DISPIMG entry to its media bytes", async () => {
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        { id: "rId2", type: REL_CELL_IMAGES, target: "cellimages.xml" },
+      ]),
+      "xl/cellimages.xml":
+        `<?xml version="1.0"?><etc:cellImages ` +
+        `xmlns:etc="http://www.wps.cn/officeDocument/2017/etCustomData" ${XDR} ${A} ${R}>` +
+        cellImage("ID_OK", "rId1", "A photo") +
+        // Points at a rel whose media file is not in the package.
+        cellImage("ID_GONE", "rId2") +
+        // Points at a rel whose extension is not a known image type.
+        cellImage("ID_ODD", "rId3") +
+        // Points at a rel that is not an image relationship at all.
+        cellImage("ID_NOTIMAGE", "rId4") +
+        `</etc:cellImages>`,
+      "xl/_rels/cellimages.xml.rels": relsXml([
+        { id: "rId1", type: "image", target: "media/ci1.png" },
+        { id: "rId2", type: "image", target: "media/missing.png" },
+        { id: "rId3", type: "image", target: "media/thing.dat" },
+        { id: "rId4", type: "hyperlink", target: "https://example.com" },
+      ]),
+      "xl/media/ci1.png": PNG,
+      "xl/media/thing.dat": PNG,
+    })
+    expect(wb.cellImages).toEqual([{ id: "ID_OK", data: PNG, type: "png", description: "A photo" }])
+  })
+
+  it("omits the workbook field when no entry resolves", async () => {
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        { id: "rId2", type: REL_CELL_IMAGES, target: "cellimages.xml" },
+      ]),
+      // No sibling rels file, so no embed id can be resolved to media.
+      "xl/cellimages.xml":
+        `<?xml version="1.0"?><etc:cellImages ` +
+        `xmlns:etc="http://www.wps.cn/officeDocument/2017/etCustomData" ${XDR} ${A} ${R}>` +
+        cellImage("ID_A", "rId1") +
+        `</etc:cellImages>`,
+    })
+    expect(wb.cellImages).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Pivot caches and pivot tables
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("pivot wiring", () => {
+  const CACHE_DEF =
+    `<?xml version="1.0"?><pivotCacheDefinition ${NS} ${R} recordCount="3">` +
+    `<cacheSource type="worksheet"><worksheetSource ref="A1:B4" sheet="Sheet1"/></cacheSource>` +
+    `<cacheFields count="2"><cacheField name="Region"/><cacheField name="Amount"/></cacheFields>` +
+    `</pivotCacheDefinition>`
+
+  const PIVOT_TABLE =
+    `<?xml version="1.0"?><pivotTableDefinition ${NS} name="PivotTable1" cacheId="5">` +
+    `<location ref="A3:B6" firstHeaderRow="1" firstDataRow="2" firstDataCol="1"/>` +
+    `<pivotFields count="2"><pivotField axis="axisRow"/><pivotField dataField="1"/></pivotFields>` +
+    `</pivotTableDefinition>`
+
+  it("joins a pivot table to its cache through the two rels files", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>` +
+          // The first ref is dangling on purpose: the pivot-table lookup
+          // walks every ref and must skip the ones with no relationship.
+          `<pivotCaches><pivotCache cacheId="0" r:id="rIdGone"/>` +
+          `<pivotCache cacheId="5" r:id="rId9"/></pivotCaches>`,
+      ),
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        {
+          id: "rId9",
+          type: "pivotCacheDefinition",
+          target: "pivotCache/pivotCacheDefinition1.xml",
+        },
+      ]),
+      "xl/pivotCache/pivotCacheDefinition1.xml": CACHE_DEF,
+      "xl/pivotCache/_rels/pivotCacheDefinition1.xml.rels": relsXml([
+        { id: "rId1", type: "pivotCacheRecords", target: "pivotCacheRecords1.xml" },
+      ]),
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "pivotTable", target: "../pivotTables/pivotTable1.xml" },
+      ]),
+      "xl/pivotTables/pivotTable1.xml": PIVOT_TABLE,
+      "xl/pivotTables/_rels/pivotTable1.xml.rels": relsXml([
+        {
+          id: "rId1",
+          type: "pivotCacheDefinition",
+          target: "../pivotCache/pivotCacheDefinition1.xml",
+        },
+      ]),
+    })
+
+    expect(wb.pivotCaches).toHaveLength(1)
+    expect(wb.pivotCaches![0]).toMatchObject({ cacheId: 5, hasRecords: true, sourceRef: "A1:B4" })
+    const pivot = wb.sheets[0].pivotTables![0]
+    expect(pivot.cacheId).toBe(5)
+    // The cache's real field names replace parsePivotTable's placeholders.
+    expect(pivot.fields.map((f) => f.name)).toEqual(["Region", "Amount"])
+  })
+
+  it("skips cache and table parts whose XML is not what the relationship claims", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>` +
+          `<pivotCaches><pivotCache cacheId="1" r:id="rId9"/></pivotCaches>`,
+      ),
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        {
+          id: "rId9",
+          type: "pivotCacheDefinition",
+          target: "pivotCache/pivotCacheDefinition1.xml",
+        },
+      ]),
+      "xl/pivotCache/pivotCacheDefinition1.xml": `<?xml version="1.0"?><somethingElse/>`,
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "pivotTable", target: "../pivotTables/pivotTable1.xml" },
+      ]),
+      "xl/pivotTables/pivotTable1.xml": `<?xml version="1.0"?><notAPivot/>`,
+    })
+    expect(wb.pivotCaches).toBeUndefined()
+    expect(wb.sheets[0].pivotTables).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Whitespace tolerance
+//
+// Excel writes these parts with no whitespace between elements, but
+// pretty-printed packages are common from other producers and from
+// anyone who has opened the XML in an editor.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("pretty-printed parts", () => {
+  it("ignores indentation between defined names and table columns", async () => {
+    const wb = await read({
+      "xl/workbook.xml": workbookXml(
+        `\n  <sheets>\n    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>\n  </sheets>\n` +
+          `  <definedNames>\n    <definedName name="Q1">Sheet1!$A$1</definedName>\n  </definedNames>\n`,
+      ),
+      "xl/worksheets/_rels/sheet1.xml.rels": relsXml([
+        { id: "rId1", type: "table", target: "../tables/table1.xml" },
+      ]),
+      "xl/tables/table1.xml":
+        `<?xml version="1.0"?>\n<table ${NS} id="1" name="T" ref="A1:A2">\n` +
+        `  <tableColumns count="1">\n    <tableColumn id="1" name="A">\n` +
+        `      <totalsRowFormula>SUM(T[A])</totalsRowFormula>\n    </tableColumn>\n` +
+        `  </tableColumns>\n</table>`,
+    })
+    expect(wb.namedRanges).toEqual([{ name: "Q1", range: "Sheet1!$A$1" }])
+    expect(wb.sheets[0].tables![0].columns[0].totalFormula).toBe("SUM(T[A])")
+  })
+
+  it("ignores indentation inside a drawing textbox", async () => {
+    const wb = await read(
+      withDrawing(
+        `\n  <xdr:twoCellAnchor>\n    ${fromTo(0, 0, 2, 2)}\n    <xdr:sp>\n` +
+          `      <xdr:nvSpPr><xdr:cNvPr id="2" name="tb"/><xdr:cNvSpPr txBox="1"/></xdr:nvSpPr>\n` +
+          `      <xdr:txBody>\n        <a:bodyPr/>\n        <a:p>\n` +
+          `          <a:r><a:t>spaced</a:t></a:r>\n        </a:p>\n      </xdr:txBody>\n` +
+          `    </xdr:sp>\n  </xdr:twoCellAnchor>\n`,
+        [],
+      ),
+    )
+    expect(wb.sheets[0].textBoxes![0].text).toBe("spaced")
+  })
+})
+
+describe("more relationship shapes", () => {
+  it("resolves a package-absolute worksheet target", async () => {
+    // `Target="/xl/worksheets/sheet1.xml"` is legal OPC and bypasses
+    // the base-directory join entirely.
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "/xl/worksheets/sheet1.xml" },
+      ]),
+    })
+    expect(wb.sheets[0].rows[0][0]).toBe("hi")
+  })
+
+  it("reads an external link that has no sibling rels file", async () => {
+    // Without the rels there is no path to the linked workbook, but the
+    // cached sheet names and values are still usable.
+    const wb = await read({
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+        { id: "rIdNoDigits", type: "externalLink", target: "externalLinks/externalLink1.xml" },
+      ]),
+      "xl/externalLinks/externalLink1.xml":
+        `<?xml version="1.0"?><externalLink ${NS} ${R}><externalBook r:id="rId1">` +
+        `<sheetNames><sheetName val="Prices"/></sheetNames></externalBook></externalLink>`,
+    })
+    expect(wb.externalLinks![0]).toMatchObject({ target: "", sheetNames: ["Prices"] })
+  })
+
+  // BUG (reported, not worked around): a part stored at the package root
+  // never finds its own `_rels` file. `reader.ts:369` computes
+  //     wsFileName = wsPath.slice(dirname(wsPath).length + 1)
+  // and `reader.ts:747` does the same for drawings. With no directory
+  // prefix `dirname()` returns "", so the `+ 1` eats the first character
+  // of the file name: the reader looks for `_rels/heet1.xml.rels`
+  // instead of `_rels/sheet1.xml.rels`. The sibling helper `relsPathFor()`
+  // (reader.ts:686) special-cases the no-slash form correctly, so the two
+  // code paths disagree. Consequence: for a root-level worksheet, all of
+  // hyperlinks, comments, tables, drawings, pivot tables and the sheet
+  // background silently vanish. Verified directly: the same package with
+  // the rels part deliberately misnamed `_rels/heet1.xml.rels` DOES
+  // resolve the hyperlink, while the correctly named one does not.
+  it.skip("reads a drawing stored at the package root", async () => {
+    const wb = await readExact({
+      "[Content_Types].xml": CONTENT_TYPES,
+      "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "workbook.xml" }]),
+      "workbook.xml": workbookXml(`<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`),
+      "_rels/workbook.xml.rels": relsXml([{ id: "rId1", type: "worksheet", target: "sheet1.xml" }]),
+      "sheet1.xml": worksheetXml(ONE_CELL),
+      "_rels/sheet1.xml.rels": relsXml([{ id: "rId1", type: "drawing", target: "drawing1.xml" }]),
+      "drawing1.xml":
+        `<?xml version="1.0"?><xdr:wsDr ${XDR} ${A} ${R}>` +
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}${pic(`r:embed="rId1"`)}</xdr:twoCellAnchor>` +
+        `</xdr:wsDr>`,
+      "_rels/drawing1.xml.rels": relsXml([{ id: "rId1", type: "image", target: "media/i.gif" }]),
+      "media/i.gif": PNG,
+    })
+    expect(wb.sheets[0].images![0].type).toBe("gif")
+  })
+
+  it("falls back to png for a oneCellAnchor with an unknown media extension", async () => {
+    const wb = await read(
+      withDrawing(
+        `<xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from>` +
+          `<xdr:ext cx="9525" cy="9525"/>${pic(`r:embed="rId1"`)}</xdr:oneCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.tiff" }],
+        { "xl/media/image1.tiff": PNG },
+      ),
+    )
+    expect(wb.sheets[0].images![0]).toMatchObject({ type: "png", width: 1, height: 1 })
+  })
+
+  it("reads a picture whose shape metadata is absent", async () => {
+    // `nvPicPr` / `cNvPr` are required by the schema but turn up missing
+    // in files assembled by templating engines; alt text is simply
+    // unavailable then.
+    const wb = await read(
+      withDrawing(
+        `<xdr:twoCellAnchor>${fromTo(0, 0, 1, 1)}<xdr:pic>` +
+          `<xdr:blipFill><a:blip r:embed="rId1"/></xdr:blipFill></xdr:pic></xdr:twoCellAnchor>` +
+          `<xdr:twoCellAnchor>${fromTo(2, 2, 3, 3)}<xdr:pic>` +
+          `<xdr:nvPicPr><xdr:cNvPicPr/></xdr:nvPicPr>` +
+          `<xdr:blipFill><a:blip r:embed="rId1"/></xdr:blipFill></xdr:pic></xdr:twoCellAnchor>`,
+        [{ id: "rId1", type: "image", target: "../media/image1.svg" }],
+        { "xl/media/image1.svg": PNG },
+      ),
+    )
+    const images = wb.sheets[0].images!
+    expect(images).toHaveLength(2)
+    expect(images[0].altText).toBeUndefined()
+    expect(images[1].title).toBeUndefined()
+    expect(images[0].type).toBe("svg")
+  })
+})

--- a/test/coverage-xlsx-stream-reader.test.ts
+++ b/test/coverage-xlsx-stream-reader.test.ts
@@ -1,0 +1,637 @@
+import { describe, expect, it } from "vitest"
+import { ZipWriter } from "../src/zip/writer"
+import { streamXlsxRows } from "../src/xlsx/stream-reader"
+import type { StreamRow } from "../src/xlsx/stream-reader"
+import { ParseError, ZipError } from "../src/errors"
+import type { CellValue, ReadOptions } from "../src/_types"
+
+// ── Package assembly helpers ─────────────────────────────────────────
+
+const enc = new TextEncoder()
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+const REL_BASE = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+function relsXml(entries: Array<{ id: string; type: string; target: string }>): string {
+  const items = entries
+    .map((e) => `<Relationship Id="${e.id}" Type="${REL_BASE}/${e.type}" Target="${e.target}"/>`)
+    .join("")
+  return (
+    `<?xml version="1.0"?><Relationships ` +
+    `xmlns="http://schemas.openxmlformats.org/package/2006/relationships">${items}</Relationships>`
+  )
+}
+
+const CONTENT_TYPES =
+  `<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">` +
+  `<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>` +
+  `<Default Extension="xml" ContentType="application/xml"/></Types>`
+
+const workbookXml = (body: string): string =>
+  `<?xml version="1.0"?><workbook ${NS} ${R}>${body}</workbook>`
+
+const worksheetXml = (body: string): string =>
+  `<?xml version="1.0"?><worksheet ${NS} ${R}><sheetData>${body}</sheetData></worksheet>`
+
+type Parts = Record<string, string | Uint8Array>
+
+/**
+ * Build a ZIP from an ordered part list. Order matters here: the true
+ * streaming path walks entries in archive order and can only resolve the
+ * target worksheet from metadata it has already passed.
+ */
+async function build(parts: Parts): Promise<Uint8Array> {
+  const zip = new ZipWriter()
+  for (const [path, content] of Object.entries(parts)) {
+    zip.add(path, typeof content === "string" ? enc.encode(content) : content)
+  }
+  return zip.build()
+}
+
+function defaultParts(sheetBody: string): Parts {
+  return {
+    "[Content_Types].xml": CONTENT_TYPES,
+    "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "xl/workbook.xml" }]),
+    "xl/workbook.xml": workbookXml(
+      `<sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>`,
+    ),
+    "xl/_rels/workbook.xml.rels": relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+    ]),
+    "xl/worksheets/sheet1.xml": worksheetXml(sheetBody),
+  }
+}
+
+function toStream(data: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(data)
+      controller.close()
+    },
+  })
+}
+
+async function collect(
+  gen: AsyncGenerator<StreamRow, void, undefined>,
+): Promise<Array<CellValue[]>> {
+  const out: Array<CellValue[]> = []
+  for await (const row of gen) out.push(row.values)
+  return out
+}
+
+/** Stream the default package's rows from a buffer. */
+async function rowsOf(sheetBody: string, options?: ReadOptions & { sheet?: number | string }) {
+  return collect(streamXlsxRows(await build(defaultParts(sheetBody)), options))
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Cell value resolution
+//
+// The streaming reader resolves values without building Cell objects, so
+// it has its own copy of the type switch. It must agree with the batch
+// reader on every `t` the spec defines (§18.18.11, ST_CellType).
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cell types", () => {
+  it("resolves every ST_CellType the same way the batch reader does", async () => {
+    const rows = await rowsOf(
+      `<row r="1">` +
+        `<c r="A1" t="str"><f>UPPER(B9)</f><v>line1_x000A_line2</v></c>` +
+        `<c r="B1" t="b"><v>1</v></c>` +
+        `<c r="C1" t="b"><v>TRUE</v></c>` +
+        `<c r="D1" t="b"><v>0</v></c>` +
+        `<c r="E1" t="e"><v>#REF!</v></c>` +
+        `<c r="F1" t="n"><v>12.5</v></c>` +
+        `<c r="G1"><v>7</v></c>` +
+        `</row>`,
+    )
+    expect(rows[0]).toEqual(["line1\nline2", true, true, false, "#REF!", 12.5, 7])
+  })
+
+  it("returns null for an out-of-range shared string index", async () => {
+    // No sharedStrings part at all, so every `t="s"` index is out of
+    // range — the raw index must not leak through as text.
+    const rows = await rowsOf(`<row r="1"><c r="A1" t="s"><v>3</v></c></row>`)
+    expect(rows[0]).toEqual([null])
+  })
+
+  it("keeps unparseable numeric text as a string and empty text as null", async () => {
+    const rows = await rowsOf(
+      `<row r="1"><c r="A1"><v>N/A</v></c><c r="B1"><v></v></c><c r="C1"/></row>`,
+    )
+    expect(rows[0]).toEqual(["N/A", null, null])
+  })
+
+  it("joins the runs of an inline rich-text string", async () => {
+    const rows = await rowsOf(
+      `<row r="1">` +
+        `<c r="A1" t="inlineStr"><is><r><rPr><b/></rPr><t>Bo</t></r><r><t>ld</t></r></is></c>` +
+        `<c r="B1" t="inlineStr"><is><t>plain_x000A_text</t></is></c>` +
+        `</row>`,
+    )
+    expect(rows[0]).toEqual(["Bold", "plain\ntext"])
+  })
+
+  it("resolves shared strings declared in sharedStrings.xml", async () => {
+    const parts = defaultParts(
+      `<row r="1"><c r="A1" t="s"><v>1</v></c><c r="B1" t="s"><v>0</v></c></row>`,
+    )
+    parts["xl/_rels/workbook.xml.rels"] = relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+      { id: "rId2", type: "sharedStrings", target: "sharedStrings.xml" },
+    ])
+    parts["xl/sharedStrings.xml"] =
+      `<?xml version="1.0"?><sst ${NS} count="2" uniqueCount="2">` +
+      `<si><t>zero</t></si><si><t>one</t></si></sst>`
+    expect(await collect(streamXlsxRows(await build(parts)))).toEqual([["one", "zero"]])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Row and column positioning
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("implicit positioning", () => {
+  it("numbers rows and cells by document order when r is absent", async () => {
+    const rows = await collect(
+      streamXlsxRows(
+        await build(
+          defaultParts(
+            `<row><c><v>1</v></c><c><v>2</v></c></row>` +
+              `<row><c r="C2"><v>3</v></c><c><v>4</v></c></row>`,
+          ),
+        ),
+      ),
+    )
+    expect(rows).toEqual([
+      [1, 2],
+      [null, null, 3, 4],
+    ])
+  })
+
+  it("places cells written out of column order at their stated column", async () => {
+    // Nothing requires `<c>` elements to be sorted; the row width comes
+    // from the largest column seen, not the last one.
+    const rows = await rowsOf(`<row r="1"><c r="C1"><v>3</v></c><c r="A1"><v>1</v></c></row>`)
+    expect(rows).toEqual([[1, null, 3]])
+  })
+
+  it("yields an empty value array for a row with no cells", async () => {
+    const rows = await rowsOf(`<row r="1"/><row r="2"><c r="A2"><v>1</v></c></row>`)
+    expect(rows).toEqual([[], [1]])
+  })
+
+  it("reads a worksheet written with a namespace prefix on every tag", async () => {
+    // Files from some Java toolchains prefix the main namespace
+    // (`<x:sheetData>`) instead of defaulting it.
+    const parts = defaultParts("")
+    parts["xl/worksheets/sheet1.xml"] =
+      `<?xml version="1.0"?><x:worksheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main">` +
+      `<x:sheetData><x:row r="1"><x:c r="A1" t="inlineStr"><x:is><x:t>pre</x:t></x:is></x:c>` +
+      `<x:c r="B1"><x:v>2</x:v></x:c></x:row></x:sheetData></x:worksheet>`
+    expect(await collect(streamXlsxRows(await build(parts)))).toEqual([["pre", 2]])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// range and maxRows
+// ═══════════════════════════════════════════════════════════════════════
+
+const GRID = Array.from(
+  { length: 6 },
+  (_, r) =>
+    `<row r="${r + 1}">` +
+    Array.from(
+      { length: 4 },
+      (_, c) => `<c r="${String.fromCharCode(65 + c)}${r + 1}"><v>${r * 10 + c}</v></c>`,
+    ).join("") +
+    `</row>`,
+).join("")
+
+describe("range read option", () => {
+  it("masks columns outside the window and keeps values at their own index", async () => {
+    const rows = await rowsOf(GRID, { range: "B2:C4" })
+    expect(rows).toEqual([
+      [null, 11, 12, null],
+      [null, 21, 22, null],
+      [null, 31, 32, null],
+    ])
+  })
+
+  it("stops reading once a row past the end of the range is seen", async () => {
+    // Worksheet rows are written in ascending order, so the first row
+    // past the window means no further row can qualify.
+    const rows = await rowsOf(GRID, { range: "A1:B2" })
+    expect(rows).toHaveLength(2)
+  })
+
+  it("pads the row out to the end column even when the sheet is narrower", async () => {
+    const rows = await rowsOf(`<row r="1"><c r="A1"><v>1</v></c></row>`, { range: "A1:D1" })
+    expect(rows[0]).toEqual([1, null, null, null])
+  })
+
+  it("accepts a single-cell range", async () => {
+    const rows = await rowsOf(GRID, { range: "C3" })
+    expect(rows).toEqual([[null, null, 22, null]])
+  })
+
+  it("normalises a reversed range", async () => {
+    // `C3:A1` describes the same rectangle as `A1:C3`.
+    const rows = await rowsOf(GRID, { range: "C3:A1" })
+    expect(rows).toEqual([
+      [0, 1, 2, null],
+      [10, 11, 12, null],
+      [20, 21, 22, null],
+    ])
+  })
+
+  it("rejects a reference with more than two endpoints", async () => {
+    await expect(
+      collect(streamXlsxRows(await build(defaultParts(GRID)), { range: "A1:B2:C3" })),
+    ).rejects.toThrow(ParseError)
+  })
+})
+
+describe("maxRows read option", () => {
+  it("stops after the requested number of rows", async () => {
+    expect(await rowsOf(GRID, { maxRows: 2 })).toHaveLength(2)
+  })
+
+  it("treats zero and negative caps as unlimited", async () => {
+    expect(await rowsOf(GRID, { maxRows: 0 })).toHaveLength(6)
+    expect(await rowsOf(GRID, { maxRows: -5 })).toHaveLength(6)
+  })
+
+  it("counts only rows that survive the range filter", async () => {
+    const rows = await rowsOf(GRID, { range: "A3:D6", maxRows: 2 })
+    expect(rows).toHaveLength(2)
+    expect(rows[0][0]).toBe(20)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Sheet selection
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sheet selection", () => {
+  const twoSheets = (): Parts => {
+    const parts = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+    parts["xl/workbook.xml"] = workbookXml(
+      `<sheets><sheet name="First" sheetId="1" r:id="rId1"/>` +
+        `<sheet name="Second" sheetId="2" r:id="rId2"/></sheets>`,
+    )
+    parts["xl/_rels/workbook.xml.rels"] = relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+      { id: "rId2", type: "worksheet", target: "worksheets/sheet2.xml" },
+    ])
+    parts["xl/worksheets/sheet2.xml"] = worksheetXml(`<row r="1"><c r="A1"><v>2</v></c></row>`)
+    return parts
+  }
+
+  it("selects by index and by name", async () => {
+    const parts = twoSheets()
+    expect(await collect(streamXlsxRows(await build(parts), { sheet: 1 }))).toEqual([[2]])
+    expect(await collect(streamXlsxRows(await build(parts), { sheet: "Second" }))).toEqual([[2]])
+  })
+
+  it("yields nothing for an index past the end of the sheet list", async () => {
+    expect(await collect(streamXlsxRows(await build(twoSheets()), { sheet: 9 }))).toEqual([])
+    expect(await collect(streamXlsxRows(await build(twoSheets()), { sheet: -1 }))).toEqual([])
+  })
+
+  it("yields nothing when the workbook declares no sheets at all", async () => {
+    const parts = defaultParts("")
+    parts["xl/workbook.xml"] = workbookXml(`<sheets/>`)
+    expect(await collect(streamXlsxRows(await build(parts)))).toEqual([])
+  })
+
+  it("finds the relationship id under any namespace prefix", async () => {
+    const parts = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+    parts["xl/workbook.xml"] =
+      `<?xml version="1.0"?><workbook ${NS} xmlns:rel="${REL_BASE}">` +
+      `<sheets><sheet name="S" sheetId="1" rel:id="rId1"/><sheet name="NoId" sheetId="2"/>` +
+      `</sheets></workbook>`
+    expect(await collect(streamXlsxRows(await build(parts)))).toEqual([[1]])
+  })
+
+  it("ignores entries in <sheets> that are not usable sheet declarations", async () => {
+    // A sheet with no name, a non-sheet child, and a sheet with no
+    // sheetId all appear in files stitched together by other tools.
+    const parts = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+    parts["xl/workbook.xml"] = workbookXml(
+      `<sheets><sheet sheetId="1" r:id="rId1"/><sheetGroup name="x"/>` +
+        `<sheet name="Real" r:id="rId1"/></sheets>`,
+    )
+    expect(await collect(streamXlsxRows(await build(parts)))).toEqual([[1]])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Date system
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("date system", () => {
+  const dated = (workbookPr: string): Parts => {
+    const parts = defaultParts(`<row r="1"><c r="A1" s="1"><v>40000</v></c></row>`)
+    parts["xl/workbook.xml"] = workbookXml(
+      `${workbookPr}<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`,
+    )
+    parts["xl/_rels/workbook.xml.rels"] = relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+      { id: "rId2", type: "styles", target: "styles.xml" },
+    ])
+    parts["xl/styles.xml"] =
+      `<?xml version="1.0"?><styleSheet ${NS}>` +
+      `<fonts count="1"><font/></fonts><fills count="1"><fill/></fills>` +
+      `<borders count="1"><border/></borders>` +
+      `<cellXfs count="2"><xf numFmtId="0"/><xf numFmtId="14" applyNumberFormat="1"/></cellXfs>` +
+      `</styleSheet>`
+    return parts
+  }
+
+  const serialOf = async (parts: Parts, options?: ReadOptions): Promise<Date> => {
+    const rows = await collect(streamXlsxRows(await build(parts), options))
+    return rows[0][0] as Date
+  }
+
+  it("auto-detects the 1904 epoch from workbookPr", async () => {
+    const auto = await serialOf(dated(`<workbookPr date1904="true"/>`))
+    const explicit = await serialOf(dated(`<workbookPr date1904="1"/>`), { dateSystem: "auto" })
+    expect(auto).toBeInstanceOf(Date)
+    expect(auto.getTime()).toBe(explicit.getTime())
+  })
+
+  it("lets an explicit dateSystem option override the file's flag", async () => {
+    const forced1900 = await serialOf(dated(`<workbookPr date1904="1"/>`), {
+      dateSystem: "1900",
+    })
+    const forced1904 = await serialOf(dated(``), { dateSystem: "1904" })
+    expect(forced1904.getTime()).toBeGreaterThan(forced1900.getTime())
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Package layout and structural failures
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("package layout", () => {
+  it("reads a workbook addressed by an absolute target at the package root", async () => {
+    const parts: Parts = {
+      "[Content_Types].xml": CONTENT_TYPES,
+      "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "/workbook.xml" }]),
+      "workbook.xml": workbookXml(`<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`),
+      "_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "../sheets/./sheet1.xml" },
+      ]),
+      "sheets/sheet1.xml": worksheetXml(`<row r="1"><c r="A1"><v>42</v></c></row>`),
+    }
+    expect(await collect(streamXlsxRows(await build(parts)))).toEqual([[42]])
+  })
+
+  it("streams the same root-layout package straight from a stream", async () => {
+    // The stream resolver has its own copy of the path helpers, so the
+    // root layout has to be exercised on that side too.
+    const parts: Parts = {
+      "[Content_Types].xml": CONTENT_TYPES,
+      "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "/workbook.xml" }]),
+      "workbook.xml": workbookXml(`<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`),
+      "_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "/xl/worksheets/sheet1.xml" },
+      ]),
+      "xl/worksheets/sheet1.xml": worksheetXml(`<row r="1"><c r="A1"><v>42</v></c></row>`),
+    }
+    expect(await collect(streamXlsxRows(toStream(await build(parts))))).toEqual([[42]])
+  })
+})
+
+describe("invalid packages", () => {
+  const withoutPart = async (path: string): Promise<Uint8Array> => {
+    const parts = defaultParts("")
+    delete parts[path]
+    return build(parts)
+  }
+
+  it("rejects input that is not a ZIP archive at all", async () => {
+    const notAZip = enc.encode("This is a CSV,not,an,xlsx\n")
+    await expect(collect(streamXlsxRows(notAZip))).rejects.toThrow(ZipError)
+  })
+
+  it("rejects a package with no [Content_Types].xml", async () => {
+    await expect(collect(streamXlsxRows(await withoutPart("[Content_Types].xml")))).rejects.toThrow(
+      /missing \[Content_Types\]\.xml/,
+    )
+  })
+
+  it("rejects a package with no root relationships", async () => {
+    await expect(collect(streamXlsxRows(await withoutPart("_rels/.rels")))).rejects.toThrow(
+      /missing _rels\/\.rels/,
+    )
+  })
+
+  it("rejects root rels that name no officeDocument", async () => {
+    const parts = defaultParts("")
+    parts["_rels/.rels"] = relsXml([
+      { id: "rId1", type: "extended-properties", target: "docProps/app.xml" },
+    ])
+    await expect(collect(streamXlsxRows(await build(parts)))).rejects.toThrow(
+      /cannot find workbook relationship/,
+    )
+  })
+
+  it("rejects a package whose workbook part is missing", async () => {
+    await expect(collect(streamXlsxRows(await withoutPart("xl/workbook.xml")))).rejects.toThrow(
+      /missing workbook at xl\/workbook\.xml/,
+    )
+  })
+
+  it("rejects a sheet whose worksheet part is missing", async () => {
+    await expect(
+      collect(streamXlsxRows(await withoutPart("xl/worksheets/sheet1.xml"))),
+    ).rejects.toThrow(/missing worksheet file for sheet "Sheet1"/)
+  })
+
+  it("rejects a sheet with no worksheet relationship to resolve", async () => {
+    // Dropping workbook.xml.rels leaves the declared sheet unreachable.
+    await expect(
+      collect(streamXlsxRows(await withoutPart("xl/_rels/workbook.xml.rels"))),
+    ).rejects.toThrow(ParseError)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// True streaming path (ReadableStream input)
+//
+// `prepareStreaming` walks ZIP local headers in archive order. It can
+// only stream the worksheet if every part it needs was already passed,
+// so several realistic archive layouts must fall back to buffering —
+// silently, and with identical results.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ReadableStream input", () => {
+  it("streams the target worksheet when metadata comes first", async () => {
+    const rows = await collect(streamXlsxRows(toStream(await build(defaultParts(GRID)))))
+    expect(rows).toHaveLength(6)
+    expect(rows[5]).toEqual([50, 51, 52, 53])
+  })
+
+  it("applies range and maxRows while streaming", async () => {
+    expect(
+      await collect(
+        streamXlsxRows(toStream(await build(defaultParts(GRID))), {
+          range: "B2:C3",
+        }),
+      ),
+    ).toEqual([
+      [null, 11, 12, null],
+      [null, 21, 22, null],
+    ])
+    expect(
+      await collect(streamXlsxRows(toStream(await build(defaultParts(GRID))), { maxRows: 3 })),
+    ).toHaveLength(3)
+  })
+
+  it("skips non-target worksheets it passes on the way", async () => {
+    const parts = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+    parts["xl/workbook.xml"] = workbookXml(
+      `<sheets><sheet name="First" sheetId="1" r:id="rId1"/>` +
+        `<sheet name="Second" sheetId="2" r:id="rId2"/></sheets>`,
+    )
+    parts["xl/_rels/workbook.xml.rels"] = relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+      { id: "rId2", type: "worksheet", target: "worksheets/sheet2.xml" },
+    ])
+    parts["xl/worksheets/sheet2.xml"] = worksheetXml(`<row r="1"><c r="A1"><v>2</v></c></row>`)
+    expect(await collect(streamXlsxRows(toStream(await build(parts)), { sheet: 1 }))).toEqual([[2]])
+  })
+
+  it("falls back to buffering when the worksheet precedes the workbook metadata", async () => {
+    // Some writers emit sheets first. The resolver has nothing to match
+    // against at that point, so it buffers and re-reads by index.
+    const src = defaultParts(`<row r="1"><c r="A1"><v>9</v></c></row>`)
+    const reordered: Parts = { "xl/worksheets/sheet1.xml": src["xl/worksheets/sheet1.xml"] }
+    for (const [k, v] of Object.entries(src)) {
+      if (k !== "xl/worksheets/sheet1.xml") reordered[k] = v
+    }
+    expect(await collect(streamXlsxRows(toStream(await build(reordered))))).toEqual([[9]])
+  })
+
+  it("falls back when sharedStrings.xml is stored after the worksheet", async () => {
+    // String cells cannot be resolved without the table, so streaming
+    // must not start until it has been seen.
+    const parts = defaultParts(`<row r="1"><c r="A1" t="s"><v>0</v></c></row>`)
+    parts["xl/_rels/workbook.xml.rels"] = relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+      { id: "rId2", type: "sharedStrings", target: "sharedStrings.xml" },
+    ])
+    // Added last, so it lands after xl/worksheets/sheet1.xml.
+    parts["xl/sharedStrings.xml"] =
+      `<?xml version="1.0"?><sst ${NS} count="1" uniqueCount="1"><si><t>late</t></si></sst>`
+    expect(await collect(streamXlsxRows(toStream(await build(parts))))).toEqual([["late"]])
+  })
+
+  it("falls back when styles.xml is stored after the worksheet", async () => {
+    const parts = defaultParts(`<row r="1"><c r="A1"><v>5</v></c></row>`)
+    parts["xl/_rels/workbook.xml.rels"] = relsXml([
+      { id: "rId1", type: "worksheet", target: "worksheets/sheet1.xml" },
+      { id: "rId2", type: "styles", target: "styles.xml" },
+    ])
+    parts["xl/styles.xml"] =
+      `<?xml version="1.0"?><styleSheet ${NS}><cellXfs count="1"><xf numFmtId="0"/></cellXfs></styleSheet>`
+    expect(await collect(streamXlsxRows(toStream(await build(parts))))).toEqual([[5]])
+  })
+
+  it("falls back when the worksheet is not stored under xl/worksheets/", async () => {
+    // The stream resolver only recognises the canonical worksheet path;
+    // anything else is resolved by the random-access reader.
+    const parts: Parts = {
+      "[Content_Types].xml": CONTENT_TYPES,
+      "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "xl/workbook.xml" }]),
+      "xl/workbook.xml": workbookXml(`<sheets><sheet name="S" sheetId="1" r:id="rId1"/></sheets>`),
+      "xl/_rels/workbook.xml.rels": relsXml([
+        { id: "rId1", type: "worksheet", target: "sheets/sheet1.xml" },
+      ]),
+      "xl/sheets/sheet1.xml": worksheetXml(`<row r="1"><c r="A1"><v>3</v></c></row>`),
+    }
+    expect(await collect(streamXlsxRows(toStream(await build(parts))))).toEqual([[3]])
+  })
+
+  it("falls back and then yields nothing when the named sheet does not exist", async () => {
+    const data = await build(defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`))
+    expect(await collect(streamXlsxRows(toStream(data), { sheet: "Nope" }))).toEqual([])
+  })
+
+  it("falls back when the entries cannot be streamed from their local headers", async () => {
+    // Bit 3 of the general-purpose flag says the sizes live in a trailing
+    // data descriptor, so the local header alone cannot bound the entry.
+    // The central directory is untouched, so the buffered reader copes.
+    const data = await build(defaultParts(`<row r="1"><c r="A1"><v>8</v></c></row>`))
+    const patched = withDataDescriptorFlag(data)
+    expect(await collect(streamXlsxRows(toStream(patched)))).toEqual([[8]])
+  })
+
+  it("hands a broken package back to the buffered path for its error", async () => {
+    // The stream resolver bails out silently on anything it cannot
+    // resolve; the diagnosis is the buffered reader's job, so the same
+    // messages must come out either way.
+    const cases: Array<[string, RegExp]> = [
+      ["_rels/.rels", /missing _rels\/\.rels/],
+      ["xl/workbook.xml", /missing workbook at xl\/workbook\.xml/],
+      ["xl/_rels/workbook.xml.rels", /missing worksheet file/],
+    ]
+    for (const [drop, message] of cases) {
+      const parts = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+      delete parts[drop]
+      await expect(collect(streamXlsxRows(toStream(await build(parts))))).rejects.toThrow(message)
+    }
+
+    const noOfficeDoc = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+    noOfficeDoc["_rels/.rels"] = relsXml([
+      { id: "rId1", type: "extended-properties", target: "docProps/app.xml" },
+    ])
+    await expect(collect(streamXlsxRows(toStream(await build(noOfficeDoc))))).rejects.toThrow(
+      /cannot find workbook relationship/,
+    )
+
+    const danglingSheet = defaultParts(`<row r="1"><c r="A1"><v>1</v></c></row>`)
+    danglingSheet["xl/workbook.xml"] = workbookXml(
+      `<sheets><sheet name="Sheet1" sheetId="1" r:id="rId404"/></sheets>`,
+    )
+    await expect(collect(streamXlsxRows(toStream(await build(danglingSheet))))).rejects.toThrow(
+      /missing worksheet file for sheet "Sheet1"/,
+    )
+  })
+
+  it("propagates a row-handler failure instead of hanging on the stream", async () => {
+    // The bound check in the row builder throws from inside the SAX
+    // handler. A rejected parse used to be swallowed here, so the read
+    // looked short-but-successful. See #363.
+    const parts = defaultParts(`<row r="1"><c r="AAAAAA1"><v>1</v></c></row>`)
+    await expect(collect(streamXlsxRows(toStream(await build(parts))))).rejects.toThrow(
+      /outside the supported sheet bounds/,
+    )
+  })
+
+  it("releases the stream when the consumer abandons the generator early", async () => {
+    const gen = streamXlsxRows(toStream(await build(defaultParts(GRID))))
+    const first = await gen.next()
+    expect(first.value!.values).toEqual([0, 1, 2, 3])
+    await gen.return()
+    // A second pull after return() must simply report completion.
+    expect(await gen.next()).toEqual({ done: true, value: undefined })
+  })
+})
+
+/**
+ * Set the "sizes follow in a data descriptor" flag on every *local*
+ * header, leaving the central directory intact. Marks the archive
+ * un-streamable without making it unreadable.
+ */
+function withDataDescriptorFlag(zip: Uint8Array): Uint8Array {
+  const out = zip.slice()
+  for (let i = 0; i + 3 < out.length; i++) {
+    if (out[i] === 0x50 && out[i + 1] === 0x4b && out[i + 2] === 0x03 && out[i + 3] === 0x04) {
+      out[i + 6] |= 0x08
+    }
+  }
+  return out
+}

--- a/test/coverage-xlsx-worksheet.test.ts
+++ b/test/coverage-xlsx-worksheet.test.ts
@@ -1,0 +1,917 @@
+import { describe, expect, it } from "vitest"
+import { parseWorksheet } from "../src/xlsx/worksheet"
+import type { WorksheetContext } from "../src/xlsx/worksheet"
+import { parseStyles } from "../src/xlsx/styles"
+import type { SharedString } from "../src/xlsx/shared-strings"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const NS = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+const R = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+
+function ctx(over: Partial<WorksheetContext> = {}): WorksheetContext {
+  return { sharedStrings: [], styles: null, readStyles: false, dateSystem: "1900", ...over }
+}
+
+/** Wrap a worksheet body in the `<worksheet>` root Excel writes. */
+function sheet(body: string, over?: Partial<WorksheetContext>) {
+  const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet ${NS} ${R}>${body}</worksheet>`
+  return parseWorksheet(xml, "Sheet1", ctx(over))
+}
+
+/** Wrap rows in `<sheetData>`. */
+function data(rowsXml: string, over?: Partial<WorksheetContext>) {
+  return sheet(`<sheetData>${rowsXml}</sheetData>`, over)
+}
+
+const ss = (texts: string[]): SharedString[] => texts.map((text) => ({ text }))
+
+// ═══════════════════════════════════════════════════════════════════════
+// Cell references
+//
+// `parseCellRef` accepts more spellings than Excel itself writes, because
+// the reader is fed by every generator on the internet, not just Excel.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cell reference spellings", () => {
+  it("accepts lower-case column letters", () => {
+    // Excel always upper-cases the column part, but hand-rolled writers
+    // and some XSLT pipelines emit `<c r="b2">`. The reader treats a-z
+    // as the same column alphabet rather than dropping the cell.
+    const s = data(`<row r="2"><c r="b2" t="inlineStr"><is><t>lower</t></is></c></row>`)
+    expect(s.rows[1][1]).toBe("lower")
+  })
+
+  it("accepts a mixed-case multi-letter column", () => {
+    const s = data(`<row r="1"><c r="aA1" t="inlineStr"><is><t>x</t></is></c></row>`)
+    // aA == 26 + 1 - 1 == 26 (0-based)
+    expect(s.rows[0][26]).toBe("x")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Implicit positioning
+//
+// The `r` attribute on `<row>` and `<c>` is optional in the schema.
+// Files that omit it rely purely on document order.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("rows and cells without an r attribute", () => {
+  it("numbers rows sequentially when <row> has no r", () => {
+    const s = data(
+      `<row><c t="inlineStr"><is><t>a</t></is></c></row>` +
+        `<row><c t="inlineStr"><is><t>b</t></is></c></row>`,
+    )
+    expect(s.rows).toEqual([["a"], ["b"]])
+  })
+
+  it("numbers cells left to right within a row", () => {
+    const s = data(`<row r="1"><c><v>1</v></c><c><v>2</v></c><c><v>3</v></c></row>`)
+    expect(s.rows[0]).toEqual([1, 2, 3])
+  })
+
+  it("resumes implicit numbering after an explicitly placed cell", () => {
+    // A mixed file: the first cell pins the column, the next continues
+    // from there rather than restarting at A.
+    const s = data(`<row r="1"><c r="C1"><v>1</v></c><c><v>2</v></c></row>`)
+    expect(s.rows[0]).toEqual([null, null, 1, 2])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// <cols>
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("column definitions", () => {
+  it("drops a <col> with no min/max instead of guessing a span", () => {
+    // `min`/`max` are required; without them there is no range to apply
+    // the width to, so the element carries no information.
+    const s = sheet(`<cols><col width="12"/></cols><sheetData/>`)
+    expect(s.columns).toBeUndefined()
+  })
+
+  it("drops a <col> whose max is not a number", () => {
+    const s = sheet(`<cols><col min="1" max="nonsense" width="12"/></cols><sheetData/>`)
+    expect(s.columns).toBeUndefined()
+  })
+
+  it("records hidden and outline levels for width-less columns", () => {
+    // Grouping columns produces `<col>` entries with no width at all.
+    const s = sheet(
+      `<cols><col min="2" max="3" hidden="1" outlineLevel="2" collapsed="true"/></cols><sheetData/>`,
+    )
+    expect(s.columns![1]).toEqual({ hidden: true, outlineLevel: 2, collapsed: true })
+    expect(s.columns![2]).toEqual({ hidden: true, outlineLevel: 2, collapsed: true })
+    expect(s.columns![0]).toEqual({})
+  })
+
+  it("ignores outlineLevel 0, which means no grouping", () => {
+    const s = sheet(`<cols><col min="1" max="1" outlineLevel="0" width="9"/></cols><sheetData/>`)
+    expect(s.columns![0]).toEqual({ width: 9 })
+  })
+
+  it("ignores <col> outside a <cols> wrapper", () => {
+    const s = sheet(`<col min="1" max="4" width="30"/><sheetData/>`)
+    expect(s.columns).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Row properties
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("row definitions", () => {
+  it("accepts the boolean spelling Excel uses for row flags", () => {
+    // OOXML booleans are `1`/`0` or `true`/`false`; both spellings occur
+    // in real files depending on the producer.
+    const s = data(
+      `<row r="1" ht="30" customHeight="true" hidden="true" collapsed="true" outlineLevel="1">` +
+        `<c r="A1"><v>1</v></c></row>`,
+    )
+    expect(s.rowDefs!.get(0)).toEqual({
+      height: 30,
+      hidden: true,
+      outlineLevel: 1,
+      collapsed: true,
+    })
+  })
+
+  it("ignores ht when customHeight is not set", () => {
+    // Excel writes the computed height on every row; only `customHeight`
+    // marks it as user-chosen and worth round-tripping.
+    const s = data(`<row r="1" ht="15"><c r="A1"><v>1</v></c></row>`)
+    expect(s.rowDefs).toBeUndefined()
+  })
+
+  it("ignores outlineLevel 0", () => {
+    const s = data(`<row r="1" outlineLevel="0"><c r="A1"><v>1</v></c></row>`)
+    expect(s.rowDefs).toBeUndefined()
+  })
+
+  it("drops row flags on a row that carries no row number", () => {
+    // Row properties are keyed by row index; with no `r` there is
+    // nothing to key them to, so the flags are dropped even though the
+    // row's cells are still read.
+    const s = data(
+      `<row hidden="1" collapsed="1" outlineLevel="2" ht="40" customHeight="1">` +
+        `<c><v>1</v></c></row>`,
+    )
+    expect(s.rows).toEqual([[1]])
+    expect(s.rowDefs).toBeUndefined()
+  })
+
+  it("stops parsing rows once maxRows is reached", () => {
+    const s = data(
+      `<row r="1"><c r="A1"><v>1</v></c></row>` +
+        `<row r="2"><c r="A2"><v>2</v></c></row>` +
+        `<row r="3"><c r="A3"><v>3</v></c></row>`,
+      { maxRows: 2 },
+    )
+    expect(s.rows).toEqual([[1], [2]])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Cell types
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cell types", () => {
+  it('reads t="str" without a formula as a plain string', () => {
+    // `str` means "the value is text"; Excel only emits it for formula
+    // results, but LibreOffice writes it for literal text too.
+    const s = data(`<row r="1"><c r="A1" t="str"><v>plain_x000A_text</v></c></row>`)
+    expect(s.rows[0][0]).toBe("plain\ntext")
+    expect(s.cells).toBeUndefined()
+  })
+
+  it('reads t="str" with a formula as a formula cell', () => {
+    const s = data(`<row r="1"><c r="A1" t="str"><f>UPPER(B1)</f><v>HI</v></c></row>`)
+    const cell = s.cells!.get("0,0")!
+    expect(cell.type).toBe("formula")
+    expect(cell.formula).toBe("UPPER(B1)")
+  })
+
+  it('reads t="e" error values', () => {
+    const s = data(`<row r="1"><c r="A1" t="e"><v>#DIV/0!</v></c></row>`)
+    expect(s.rows[0][0]).toBe("#DIV/0!")
+    expect(s.cells!.get("0,0")!.type).toBe("error")
+  })
+
+  it('accepts both boolean spellings for t="b"', () => {
+    const s = data(
+      `<row r="1"><c r="A1" t="b"><v>1</v></c><c r="B1" t="b"><v>0</v></c>` +
+        `<c r="C1" t="b"><v>TRUE</v></c></row>`,
+    )
+    expect(s.rows[0]).toEqual([true, false, true])
+  })
+
+  it("returns null for a shared-string index past the end of the table", () => {
+    // A truncated or mismatched sharedStrings.xml would otherwise leak
+    // the raw index into the data as a string.
+    const s = data(`<row r="1"><c r="A1" t="s"><v>7</v></c></row>`, { sharedStrings: ss(["only"]) })
+    expect(s.rows[0][0]).toBeNull()
+  })
+
+  it("keeps non-numeric text in an untyped cell as a string", () => {
+    // `<v>` under the default numeric type should be a number; when it
+    // isn't, the text is preserved rather than turned into NaN.
+    const s = data(`<row r="1"><c r="A1"><v>N/A</v></c></row>`)
+    expect(s.rows[0][0]).toBe("N/A")
+  })
+
+  it("treats an untyped cell with no value as empty", () => {
+    const s = data(`<row r="1"><c r="A1"/><c r="B1"><v>2</v></c></row>`)
+    expect(s.rows[0]).toEqual([null, 2])
+  })
+
+  it("reads a shared string carrying rich-text runs as a richText cell", () => {
+    const rich: SharedString[] = [
+      { text: "ab", richText: [{ text: "a", font: { bold: true } }, { text: "b" }] },
+    ]
+    const s = data(`<row r="1"><c r="A1" t="s"><v>0</v></c></row>`, { sharedStrings: rich })
+    const cell = s.cells!.get("0,0")!
+    expect(cell.type).toBe("richText")
+    expect(cell.richText).toHaveLength(2)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Inline strings and their rich-text runs
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("inline strings", () => {
+  it("concatenates rich-text runs into the cell value", () => {
+    const s = data(
+      `<row r="1"><c r="A1" t="inlineStr"><is>` +
+        `<r><rPr><b/></rPr><t>Bold</t></r><r><t> tail</t></r>` +
+        `</is></c></row>`,
+    )
+    expect(s.rows[0][0]).toBe("Bold tail")
+    const cell = s.cells!.get("0,0")!
+    expect(cell.type).toBe("richText")
+    expect(cell.richText![0].font).toEqual({ bold: true })
+    expect(cell.richText![1].font).toBeUndefined()
+  })
+
+  it("maps every rPr child Excel can write onto the run font", () => {
+    // One run carrying the full DrawingML-free font vocabulary from
+    // §18.4.7 (CT_RPrElt), so each property has a parse path.
+    const s = data(
+      `<row r="1"><c r="A1" t="inlineStr"><is><r><rPr>` +
+        `<b/><i/><u val="double"/><strike/><sz val="14"/><rFont val="Arial"/>` +
+        `<color rgb="FFFF0000"/><vertAlign val="superscript"/>` +
+        `<family val="2"/><charset val="204"/><scheme val="minor"/>` +
+        `</rPr><t>styled</t></r></is></c></row>`,
+    )
+    expect(s.cells!.get("0,0")!.richText![0].font).toEqual({
+      bold: true,
+      italic: true,
+      underline: "double",
+      strikethrough: true,
+      size: 14,
+      name: "Arial",
+      color: { rgb: "FF0000" },
+      vertAlign: "superscript",
+      family: 2,
+      charset: 204,
+      scheme: "minor",
+    })
+  })
+
+  it('honours val="0" as the off state for toggle properties', () => {
+    // `<b/>` and `<b val="0"/>` are opposites — the bare element means on.
+    const s = data(
+      `<row r="1"><c r="A1" t="inlineStr"><is><r><rPr>` +
+        `<b val="0"/><i val="false"/><strike val="0"/><u/>` +
+        // Six-digit RGB: no alpha prefix to strip, unlike Excel's ARGB.
+        `<color rgb="00FF00" theme="4" tint="-0.25" indexed="9"/>` +
+        `</rPr><t>off</t></r></is></c></row>`,
+    )
+    expect(s.cells!.get("0,0")!.richText![0].font).toEqual({
+      bold: false,
+      italic: false,
+      strikethrough: false,
+      underline: true,
+      color: { rgb: "00FF00", theme: 4, tint: -0.25, indexed: 9 },
+    })
+  })
+
+  it("ignores unknown rPr children and out-of-range enum values", () => {
+    const s = data(
+      `<row r="1"><c r="A1" t="inlineStr"><is><r><rPr>` +
+        `<condense/><sz/><rFont/><vertAlign val="sideways"/>` +
+        `<family/><charset/><scheme val="bogus"/>` +
+        `</rPr><t>t</t></r></is></c></row>`,
+    )
+    expect(s.cells!.get("0,0")!.richText![0].font).toEqual({})
+  })
+
+  it("decodes OOXML escapes in a plain inline string", () => {
+    const s = data(`<row r="1"><c r="A1" t="inlineStr"><is><t>a_x000A_b</t></is></c></row>`)
+    expect(s.rows[0][0]).toBe("a\nb")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Merges, hyperlinks
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("merged cells", () => {
+  it("accepts a degenerate single-cell merge ref", () => {
+    // `<mergeCell ref="B2"/>` (no colon) is malformed but appears in
+    // files produced by report generators; treat start == end.
+    const s = sheet(`<sheetData/><mergeCells count="1"><mergeCell ref="B2"/></mergeCells>`)
+    expect(s.merges).toEqual([{ startRow: 1, startCol: 1, endRow: 1, endCol: 1 }])
+  })
+
+  it("ignores a mergeCell with no ref", () => {
+    const s = sheet(`<sheetData/><mergeCells count="1"><mergeCell/></mergeCells>`)
+    expect(s.merges).toBeUndefined()
+  })
+})
+
+describe("hyperlinks", () => {
+  it("creates a cell for a link that points at an empty area of the sheet", () => {
+    // Excel keeps hyperlinks after the text is deleted, so the target
+    // row may not exist in <sheetData> at all.
+    const s = sheet(
+      `<sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>` +
+        `<hyperlinks><hyperlink ref="C10" r:id="rId1" tooltip="tip" display="shown"/></hyperlinks>`,
+      { worksheetRels: [{ id: "rId1", type: "hyperlink", target: "https://example.com" }] },
+    )
+    const cell = s.cells!.get("9,2")!
+    expect(cell.value).toBeNull()
+    expect(cell.hyperlink).toEqual({
+      target: "https://example.com",
+      tooltip: "tip",
+      display: "shown",
+    })
+  })
+
+  it("leaves the target empty when the rId resolves to nothing", () => {
+    // A dangling r:id — the .rels file lost the entry. Better an empty
+    // target than a thrown read.
+    const s = sheet(
+      `<sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>` +
+        `<hyperlinks><hyperlink ref="A1" r:id="rId99"/></hyperlinks>`,
+      { worksheetRels: [] },
+    )
+    expect(s.cells!.get("0,0")!.hyperlink).toEqual({ target: "" })
+  })
+
+  it("uses the location for an internal link", () => {
+    const s = sheet(
+      `<sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData>` +
+        `<hyperlinks><hyperlink ref="A1" location="Sheet2!A1"/></hyperlinks>`,
+    )
+    expect(s.cells!.get("0,0")!.hyperlink).toEqual({
+      target: "Sheet2!A1",
+      location: "Sheet2!A1",
+    })
+  })
+
+  it("ignores a hyperlink with no ref", () => {
+    const s = sheet(`<sheetData/><hyperlinks><hyperlink r:id="rId1"/></hyperlinks>`)
+    expect(s.cells).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Range filter
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("range read option", () => {
+  it("keeps only cells inside the window", () => {
+    const s = data(
+      `<row r="1"><c r="A1"><v>1</v></c><c r="B1"><v>2</v></c></row>` +
+        `<row r="2"><c r="A2"><v>3</v></c><c r="B2"><v>4</v></c></row>`,
+      { range: "B2:B2" },
+    )
+    expect(s.rows[1][1]).toBe(4)
+    // Rows are still padded to the sheet's bounding box, so the skipped
+    // cells read back as null rather than disappearing.
+    expect(s.rows[0]).toEqual([null, null])
+  })
+
+  it("accepts a single-cell range with no colon", () => {
+    const s = data(`<row r="1"><c r="A1"><v>1</v></c><c r="B1"><v>2</v></c></row>`, {
+      range: "A1",
+    })
+    expect(s.rows[0]).toEqual([1])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Sheet view, panes, protection
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sheet view", () => {
+  it("reads a six-digit tab colour verbatim", () => {
+    // Excel writes ARGB (8 chars); the alpha prefix is stripped. A
+    // six-char value has no alpha to strip.
+    const s = sheet(`<sheetPr><tabColor rgb="FF0000" theme="2" tint="0.4" indexed="7"/></sheetPr>`)
+    expect(s.view!.tabColor).toEqual({ rgb: "FF0000", theme: 2, tint: 0.4, indexed: 7 })
+  })
+
+  it("ignores a tabColor outside <sheetPr>", () => {
+    const s = sheet(`<tabColor rgb="FFFF0000"/><sheetData/>`)
+    expect(s.view).toBeUndefined()
+  })
+
+  it("accepts the false/0 spellings for view toggles", () => {
+    const s = sheet(
+      `<sheetViews><sheetView showGridLines="false" showRowColHeaders="false" ` +
+        `zoomScale="150" rightToLeft="true"/></sheetViews><sheetData/>`,
+    )
+    expect(s.view).toEqual({
+      showGridLines: false,
+      showRowColHeaders: false,
+      zoomScale: 150,
+      rightToLeft: true,
+    })
+  })
+
+  it("ignores a non-numeric zoomScale", () => {
+    const s = sheet(`<sheetViews><sheetView zoomScale="big"/></sheetViews><sheetData/>`)
+    expect(s.view).toBeUndefined()
+  })
+})
+
+describe("panes", () => {
+  it("reads a split pane", () => {
+    const s = sheet(
+      `<sheetViews><sheetView><pane xSplit="1200" ySplit="600" state="split"/></sheetView>` +
+        `</sheetViews><sheetData/>`,
+    )
+    expect(s.splitPane).toEqual({ xSplit: 1200, ySplit: 600 })
+    expect(s.freezePane).toBeUndefined()
+  })
+
+  it("reads frozenSplit as a freeze", () => {
+    const s = sheet(
+      `<sheetViews><sheetView><pane xSplit="2" state="frozenSplit"/></sheetView>` +
+        `</sheetViews><sheetData/>`,
+    )
+    expect(s.freezePane).toEqual({ columns: 2 })
+  })
+
+  it("ignores a pane that splits nothing", () => {
+    const s = sheet(
+      `<sheetViews><sheetView><pane xSplit="0" ySplit="0" state="split"/></sheetView>` +
+        `</sheetViews><sheetData/>`,
+    )
+    expect(s.splitPane).toBeUndefined()
+  })
+
+  it("ignores a pane with no state (a plain scroll position)", () => {
+    const s = sheet(
+      `<sheetViews><sheetView><pane topLeftCell="B2"/></sheetView></sheetViews><sheetData/>`,
+    )
+    expect(s.freezePane).toBeUndefined()
+    expect(s.splitPane).toBeUndefined()
+  })
+})
+
+describe("sheet protection", () => {
+  it("accepts the true/false spellings", () => {
+    const s = sheet(
+      `<sheetData/><sheetProtection sheet="true" objects="true" scenarios="true" ` +
+        `formatCells="false" sort="1"/>`,
+    )
+    expect(s.protection).toEqual({
+      sheet: true,
+      objects: true,
+      scenarios: true,
+      formatCells: true,
+      sort: false,
+    })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Auto filter
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("auto filter", () => {
+  it("ignores an autoFilter with no ref", () => {
+    const s = sheet(`<sheetData/><autoFilter/>`)
+    expect(s.autoFilter).toBeUndefined()
+  })
+
+  it("drops a filterColumn that lists no values", () => {
+    // A `<filterColumn>` holding only `<customFilters>` or `<top10>` has
+    // no plain value list for us to surface yet.
+    const s = sheet(
+      `<sheetData/><autoFilter ref="A1:B9"><filterColumn colId="0"><top10 val="5"/>` +
+        `</filterColumn></autoFilter>`,
+    )
+    expect(s.autoFilter).toEqual({ range: "A1:B9" })
+  })
+
+  it("collects the value list of a filterColumn", () => {
+    const s = sheet(
+      `<sheetData/><autoFilter ref="A1:B9"><filterColumn colId="1"><filters>` +
+        `<filter val="x"/><filter val="y"/></filters></filterColumn></autoFilter>`,
+    )
+    expect(s.autoFilter!.columns).toEqual([{ colIndex: 1, filters: ["x", "y"] }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Data validation
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("data validation", () => {
+  it("drops a validation whose type is not in the schema enum", () => {
+    const s = sheet(
+      `<sheetData/><dataValidations count="1">` +
+        `<dataValidation type="madeUp" sqref="A1"><formula1>1</formula1></dataValidation>` +
+        `</dataValidations>`,
+    )
+    expect(s.dataValidations).toBeUndefined()
+  })
+
+  it("drops a validation with no sqref to apply it to", () => {
+    const s = sheet(
+      `<sheetData/><dataValidations count="1">` +
+        `<dataValidation type="whole"><formula1>1</formula1></dataValidation></dataValidations>`,
+    )
+    expect(s.dataValidations).toBeUndefined()
+  })
+
+  it("splits a quoted inline list into values", () => {
+    const s = sheet(
+      `<sheetData/><dataValidations count="1">` +
+        `<dataValidation type="list" sqref="A1:A5" allowBlank="true" showInputMessage="true" ` +
+        `showErrorMessage="true" errorStyle="warning" promptTitle="Pick" prompt="One of these" ` +
+        `errorTitle="Nope" error="Not in list">` +
+        `<formula1>"red,green,blue"</formula1></dataValidation></dataValidations>`,
+    )
+    expect(s.dataValidations![0]).toEqual({
+      type: "list",
+      range: "A1:A5",
+      allowBlank: true,
+      showInputMessage: true,
+      showErrorMessage: true,
+      errorStyle: "warning",
+      inputTitle: "Pick",
+      inputMessage: "One of these",
+      errorTitle: "Nope",
+      errorMessage: "Not in list",
+      values: ["red", "green", "blue"],
+    })
+  })
+
+  it("keeps an unquoted list formula as a reference", () => {
+    const s = sheet(
+      `<sheetData/><dataValidations count="1">` +
+        `<dataValidation type="list" sqref="A1"><formula1>Sheet2!$A$1:$A$9</formula1>` +
+        `</dataValidation></dataValidations>`,
+    )
+    expect(s.dataValidations![0].formula1).toBe("Sheet2!$A$1:$A$9")
+    expect(s.dataValidations![0].values).toBeUndefined()
+  })
+
+  it("reads both formulas of a between rule and ignores an unknown operator", () => {
+    const s = sheet(
+      `<sheetData/><dataValidations count="1">` +
+        `<dataValidation type="decimal" operator="somethingElse" sqref="B1">` +
+        `<formula1>0</formula1><formula2>100</formula2></dataValidation></dataValidations>`,
+    )
+    expect(s.dataValidations![0].operator).toBeUndefined()
+    expect(s.dataValidations![0].formula1).toBe("0")
+    expect(s.dataValidations![0].formula2).toBe("100")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Conditional formatting
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("conditional formatting", () => {
+  it("drops a rule whose block has no sqref", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting><cfRule type="expression" priority="1">` +
+        `<formula>TRUE</formula></cfRule></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules).toBeUndefined()
+  })
+
+  it("drops a rule of an unknown type", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="notARule" priority="1"/></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules).toBeUndefined()
+  })
+
+  it("defaults priority to 1 when the attribute is absent", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="containsBlanks"/></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules![0].priority).toBe(1)
+  })
+
+  it("keeps both formulas of a two-formula rule as an array", () => {
+    // `cellIs` with operator `between` carries two `<formula>` children.
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="cellIs" operator="between" priority="3" stopIfTrue="true">` +
+        `<formula>1</formula><formula>10</formula></cfRule></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules![0]).toMatchObject({
+      operator: "between",
+      priority: 3,
+      stopIfTrue: true,
+      formula: ["1", "10"],
+    })
+  })
+
+  it("keeps the text attribute of a containsText rule", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="containsText" operator="containsText" text="err" priority="1">` +
+        `<formula>NOT(ISERROR(SEARCH("err",A1)))</formula></cfRule></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules![0].text).toBe("err")
+    expect(s.conditionalRules![0].formula).toBe('NOT(ISERROR(SEARCH("err",A1)))')
+  })
+
+  it("defaults a cfvo with no type to min and a colour with no rgb to empty", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="colorScale" priority="1"><colorScale>` +
+        `<cfvo/><cfvo type="max"/><color/><color theme="4"/>` +
+        `</colorScale></cfRule></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules![0].colorScale).toEqual({
+      cfvo: [
+        { type: "min", value: undefined },
+        { type: "max", value: undefined },
+      ],
+      colors: ["", ""],
+    })
+  })
+
+  it("reads a data bar, defaulting its cfvo type and colour", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="dataBar" priority="1"><dataBar>` +
+        `<cfvo/><cfvo type="max"/><color/></dataBar></cfRule></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules![0].dataBar).toEqual({
+      cfvo: [
+        { type: "min", value: undefined },
+        { type: "max", value: undefined },
+      ],
+      color: "",
+    })
+  })
+
+  it("falls back to 3TrafficLights1 when the icon set is unnamed", () => {
+    const s = sheet(
+      `<sheetData/><conditionalFormatting sqref="A1:A9">` +
+        `<cfRule type="iconSet" priority="1"><iconSet reverse="true" showValue="false">` +
+        `<cfvo/><cfvo type="percent" val="33"/><cfvo type="percent" val="67"/>` +
+        `</iconSet></cfRule></conditionalFormatting>`,
+    )
+    expect(s.conditionalRules![0].iconSet).toEqual({
+      iconSet: "3TrafficLights1",
+      reverse: true,
+      showValue: false,
+      cfvo: [
+        { type: "min", value: undefined },
+        { type: "percent", value: "33" },
+        { type: "percent", value: "67" },
+      ],
+    })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Print settings
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("page setup", () => {
+  it("ignores a paper size hucre has no name for", () => {
+    // The reverse map only covers the sizes the writer can emit; an
+    // unmapped number is dropped rather than surfaced as a raw code.
+    const s = sheet(`<sheetData/><pageSetup paperSize="256" orientation="sideways" scale="80"/>`)
+    expect(s.pageSetup).toEqual({ scale: 80 })
+  })
+
+  it("turns on fitToPage when only fitToHeight is present", () => {
+    // Either half of the fit-to pair implies the fitToPage mode; the
+    // missing half stays unset rather than defaulting to 1.
+    const s = sheet(`<sheetData/><pageSetup fitToHeight="2"/>`)
+    expect(s.pageSetup).toEqual({ fitToPage: true, fitToHeight: 2 })
+  })
+
+  it("still accepts centering flags written on pageSetup", () => {
+    const s = sheet(
+      `<sheetData/><pageSetup horizontalCentered="true" verticalCentered="1" paperSize="9"/>`,
+    )
+    expect(s.pageSetup).toEqual({
+      paperSize: "a4",
+      horizontalCentered: true,
+      verticalCentered: true,
+    })
+  })
+
+  it("merges printOptions written before pageSetup", () => {
+    const s = sheet(
+      `<sheetData/><printOptions gridLines="true" headings="1" horizontalCentered="1" ` +
+        `verticalCentered="true"/><pageSetup orientation="landscape"/>`,
+    )
+    expect(s.pageSetup).toEqual({
+      showGridLines: true,
+      showRowColHeaders: true,
+      horizontalCentered: true,
+      verticalCentered: true,
+      orientation: "landscape",
+    })
+  })
+
+  it("attaches margins even with no pageSetup element", () => {
+    const s = sheet(
+      `<sheetData/><pageMargins left="0.5" right="0.5" top="1" bottom="1" ` +
+        `header="0.3" footer="0.3"/>`,
+    )
+    expect(s.pageSetup).toEqual({
+      margins: { left: 0.5, right: 0.5, top: 1, bottom: 1, header: 0.3, footer: 0.3 },
+    })
+  })
+})
+
+describe("headers, footers and page breaks", () => {
+  it("reads every header/footer slot", () => {
+    const s = sheet(
+      `<sheetData/><headerFooter differentOddEven="true" differentFirst="1">` +
+        `<oddHeader>&amp;Codd h</oddHeader><oddFooter>odd f</oddFooter>` +
+        `<evenHeader>even h</evenHeader><evenFooter>even f</evenFooter>` +
+        `<firstHeader>first h</firstHeader><firstFooter>first f</firstFooter></headerFooter>`,
+    )
+    expect(s.headerFooter).toEqual({
+      differentOddEven: true,
+      differentFirst: true,
+      oddHeader: "&Codd h",
+      oddFooter: "odd f",
+      evenHeader: "even h",
+      evenFooter: "even f",
+      firstHeader: "first h",
+      firstFooter: "first f",
+    })
+  })
+
+  it("sorts page breaks and converts them to 0-based indices", () => {
+    const s = sheet(
+      `<sheetData/><rowBreaks count="2"><brk id="20" max="16383" man="1"/>` +
+        `<brk id="10"/><brk/></rowBreaks>` +
+        `<colBreaks count="1"><brk id="4"/></colBreaks>`,
+    )
+    expect(s.rowBreaks).toEqual([9, 19])
+    expect(s.colBreaks).toEqual([3])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Sparklines
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sparklines", () => {
+  it("reads a column sparkline group with markers and a six-digit colour", () => {
+    const s = sheet(
+      `<sheetData/><extLst><ext><x14:sparklineGroups ` +
+        `xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">` +
+        `<x14:sparklineGroup type="column" markers="true">` +
+        `<x14:colorSeries rgb="336699"/>` +
+        `<x14:sparklines><x14:sparkline>` +
+        `<xm:f>Sheet1!B1:E1</xm:f><xm:sqref>A1</xm:sqref>` +
+        `</x14:sparkline></x14:sparklines></x14:sparklineGroup></x14:sparklineGroups></ext></extLst>`,
+    )
+    expect(s.sparklines).toEqual([
+      { location: "A1", dataRange: "Sheet1!B1:E1", type: "column", color: "336699", markers: true },
+    ])
+  })
+
+  it("drops a sparkline that names no cell to draw in", () => {
+    const s = sheet(
+      `<sheetData/><extLst><ext><x14:sparklineGroups ` +
+        `xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main">` +
+        `<x14:sparklineGroup><x14:colorSeries/><x14:sparklines><x14:sparkline>` +
+        `<xm:f>Sheet1!B1:E1</xm:f></x14:sparkline></x14:sparklines>` +
+        `</x14:sparklineGroup></x14:sparklineGroups></ext></extLst>`,
+    )
+    expect(s.sparklines).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Formulas and styles
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("formulas", () => {
+  it("marks the slave cells of a shared formula", () => {
+    // The master carries the text plus `ref`; the slaves carry only `si`,
+    // so their formula text is empty but the link must survive.
+    const s = data(
+      `<row r="1"><c r="A1"><f t="shared" ref="A1:A3" si="0">B1*2</f><v>2</v></c></row>` +
+        `<row r="2"><c r="A2"><f t="shared" si="0"/><v>4</v></c></row>`,
+    )
+    expect(s.cells!.get("0,0")).toMatchObject({
+      formula: "B1*2",
+      formulaType: "shared",
+      formulaSharedIndex: 0,
+      formulaRef: "A1:A3",
+      formulaResult: 2,
+    })
+    expect(s.cells!.get("1,0")).toMatchObject({
+      formula: "",
+      formulaType: "shared",
+      formulaSharedIndex: 0,
+    })
+  })
+
+  it("flags a dynamic array formula", () => {
+    const s = data(
+      `<row r="1"><c r="A1"><f t="array" ref="A1:A3" cm="1">SEQUENCE(3)</f>` + `<v>1</v></c></row>`,
+    )
+    expect(s.cells!.get("0,0")).toMatchObject({
+      formulaType: "array",
+      formulaRef: "A1:A3",
+      formulaDynamic: true,
+    })
+  })
+})
+
+describe("styles", () => {
+  const stylesXml =
+    `<?xml version="1.0"?><styleSheet ${NS}>` +
+    `<numFmts count="1"><numFmt numFmtId="164" formatCode="yyyy-mm-dd"/></numFmts>` +
+    `<fonts count="1"><font><sz val="11"/></font></fonts>` +
+    `<fills count="1"><fill><patternFill patternType="none"/></fill></fills>` +
+    `<borders count="1"><border/></borders>` +
+    `<cellXfs count="2"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/>` +
+    `<xf numFmtId="164" fontId="0" fillId="0" borderId="0" applyNumberFormat="1"/></cellXfs>` +
+    `</styleSheet>`
+
+  it("turns a serial into a Date when the cell's format is a date format", () => {
+    const s = data(`<row r="1"><c r="A1" s="1"><v>45000</v></c></row>`, {
+      styles: parseStyles(stylesXml),
+    })
+    expect(s.rows[0][0]).toBeInstanceOf(Date)
+  })
+
+  it("uses the 1904 epoch when the workbook asks for it", () => {
+    const y1900 = data(`<row r="1"><c r="A1" s="1"><v>45000</v></c></row>`, {
+      styles: parseStyles(stylesXml),
+    }).rows[0][0] as Date
+    const y1904 = data(`<row r="1"><c r="A1" s="1"><v>45000</v></c></row>`, {
+      styles: parseStyles(stylesXml),
+      dateSystem: "1904",
+    }).rows[0][0] as Date
+    expect(y1904.getTime()).toBeGreaterThan(y1900.getTime())
+  })
+
+  it("emits no Cell object for a styled cell unless readStyles is on", () => {
+    const withoutStyles = data(`<row r="1"><c r="A1" s="1"><v>1</v></c></row>`, {
+      styles: parseStyles(stylesXml),
+    })
+    expect(withoutStyles.cells).toBeUndefined()
+
+    const withStyles = data(`<row r="1"><c r="A1" s="1"><v>1</v></c></row>`, {
+      styles: parseStyles(stylesXml),
+      readStyles: true,
+    })
+    expect(withStyles.cells!.get("0,0")!.style).toBeDefined()
+  })
+
+  it("skips style resolution for a cell with no s attribute", () => {
+    const s = data(`<row r="1"><c r="A1"><v>1</v></c></row>`, {
+      styles: parseStyles(stylesXml),
+      readStyles: true,
+    })
+    expect(s.cells).toBeUndefined()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Empty sheets
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("empty worksheets", () => {
+  it("returns no rows for a sheet with an empty sheetData", () => {
+    const s = data("")
+    expect(s.rows).toEqual([])
+    expect(s.cells).toBeUndefined()
+    expect(s.merges).toBeUndefined()
+  })
+
+  it("ignores <c> and <v> outside a row", () => {
+    // Guards the SAX state machine: stray elements must not open cell
+    // state and corrupt the next real row.
+    const s = sheet(`<c r="A1"><v>9</v></c><sheetData/>`)
+    expect(s.rows).toEqual([])
+  })
+})

--- a/test/coverage-xlsx-writer.test.ts
+++ b/test/coverage-xlsx-writer.test.ts
@@ -1,0 +1,1185 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { XlsxStreamWriter, writeXlsxStream } from "../src/xlsx/stream-writer"
+import { writeTable } from "../src/xlsx/table-writer"
+import { writeContentTypes } from "../src/xlsx/content-types-writer"
+import { writeCustomProperties } from "../src/xlsx/doc-props-writer"
+import { writeXml } from "../src/xml/data-writer"
+import { deserializeWorkbook, serializeWorkbook } from "../src/worker"
+import { ZipReader } from "../src/zip/reader"
+import type {
+  Cell,
+  CellStyle,
+  ConditionalRule,
+  RowDef,
+  Sheet,
+  Workbook,
+  WriteOptions,
+  WriteSheet,
+} from "../src/_types"
+
+const decoder = new TextDecoder("utf-8")
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function part(buf: Uint8Array, path: string): Promise<string> {
+  return decoder.decode(await new ZipReader(buf).extract(path))
+}
+
+/** Write one sheet and hand back its `xl/worksheets/sheet1.xml`. */
+async function sheetXml(sheet: WriteSheet, options?: Omit<WriteOptions, "sheets">) {
+  const buf = await writeXlsx({ sheets: [sheet], ...options })
+  return part(buf, "xl/worksheets/sheet1.xml")
+}
+
+/** Write one sheet and hand back its `xl/styles.xml`. */
+async function stylesXml(sheet: WriteSheet) {
+  const buf = await writeXlsx({ sheets: [sheet] })
+  return part(buf, "xl/styles.xml")
+}
+
+const cellMap = (entries: Array<[string, Partial<Cell>]>): Map<string, Partial<Cell>> =>
+  new Map(entries)
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// worksheet-writer — row emission
+//
+// A `<row>` can exist for two independent reasons: it holds cells, or it
+// holds row-level properties (height / hidden / outline). The second one
+// only ever appears in files that came from Excel, so the write path for
+// it went unverified.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("worksheet rows without cells", () => {
+  it("emits a self-closing <row> for a row that carries only row properties", async () => {
+    // Row 3 is an empty spacer inside the data range, given a custom
+    // height. Excel writes `<row r="3" ht="40" customHeight="1"/>`;
+    // dropping it would lose the height the user set.
+    const rowDefs = new Map<number, RowDef>([[2, { height: 40 }]])
+    const xml = await sheetXml({ name: "S", rows: [["a"], ["b"], [], ["d"]], rowDefs })
+
+    expect(xml).toContain('<row r="3" ht="40" customHeight="1"/>')
+  })
+
+  it("carries hidden, outlineLevel and collapsed onto a property-only row", async () => {
+    const rowDefs = new Map<number, RowDef>([
+      [1, { hidden: true }],
+      [2, { outlineLevel: 2 }],
+      [3, { collapsed: true }],
+    ])
+    const xml = await sheetXml({ name: "S", rows: [["a"], [], [], [], ["e"]], rowDefs })
+
+    expect(xml).toContain('<row r="2" hidden="1"/>')
+    expect(xml).toContain('<row r="3" outlineLevel="2"/>')
+    expect(xml).toContain('<row r="4" collapsed="1"/>')
+  })
+
+  it("skips the placeholder cells a far-right cell override pads a row with", async () => {
+    // Setting F1 on a sheet with no `rows` grows the row with nulls at
+    // A1..E1. Those placeholders must not become `<c/>` elements.
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([["0,5", { value: "far right" }]]),
+    })
+
+    expect(xml).toContain('<c r="F1"')
+    expect(xml).not.toContain('r="A1"')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// worksheet-writer — cell serialization
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("styled cells of every value shape", () => {
+  const styled: CellStyle = { font: { bold: true } }
+
+  it("keeps the style index on a rich-text cell", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([
+        [
+          "0,0",
+          {
+            style: styled,
+            richText: [{ text: "bold-ish " }, { text: "run", font: { italic: true } }],
+          },
+        ],
+      ]),
+    })
+
+    expect(xml).toMatch(/<c r="A1" t="inlineStr" s="\d+">/)
+  })
+
+  it("keeps the style index on an error cell", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([["0,0", { value: "#DIV/0!", style: styled }]]),
+    })
+
+    expect(xml).toMatch(/<c r="A1" t="e" s="\d+"><v>#DIV\/0!<\/v><\/c>/)
+  })
+
+  it("keeps the style index on an inline string when stringMode is inline", async () => {
+    const xml = await sheetXml(
+      { name: "S", cells: cellMap([["0,0", { value: "hello", style: styled }]]) },
+      { stringMode: "inline" },
+    )
+
+    expect(xml).toMatch(/<c r="A1" t="inlineStr" s="\d+"><is><t>hello<\/t><\/is><\/c>/)
+  })
+
+  it("keeps the style on a cell whose number is not finite", async () => {
+    // NaN / Infinity have no OOXML representation, but the formatting the
+    // user applied to the cell still has to survive.
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: Number.POSITIVE_INFINITY, style: styled }],
+        ["1,0", { value: Number.NaN }],
+      ]),
+    })
+
+    expect(xml).toMatch(/<c r="A1" s="\d+"\/>/)
+    // Unstyled, so there is nothing left to write at all.
+    expect(xml).not.toContain('r="A2"')
+  })
+
+  it("drops a value the cell model cannot represent", async () => {
+    // Objects reach here from untyped JSON input. There is no `t=` for
+    // them, so the cell is skipped rather than written as "[object Object]".
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: { nested: true } as never }],
+        ["0,1", { value: "kept" }],
+      ]),
+    })
+
+    expect(xml).not.toContain('r="A1"')
+    expect(xml).toContain('<c r="B1" t="s"')
+  })
+
+  it('writes a boolean cached formula result as t="b"', async () => {
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { formula: "ISBLANK(B1)", formulaResult: true }],
+        ["1,0", { formula: "ISBLANK(B2)", formulaResult: false }],
+      ]),
+    })
+
+    expect(xml).toContain('<c r="A1" t="b"><f>ISBLANK(B1)</f><v>1</v></c>')
+    expect(xml).toContain('<c r="A2" t="b"><f>ISBLANK(B2)</f><v>0</v></c>')
+  })
+
+  it("leaves an explicit number format on a date cell alone", async () => {
+    // Dates only get the yyyy-mm-dd default when the style says nothing;
+    // a caller-supplied format must not be overwritten.
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          cells: cellMap([
+            ["0,0", { value: new Date(Date.UTC(2024, 0, 15)), style: { numFmt: "mmm yyyy" } }],
+          ]),
+        },
+      ],
+    })
+    const styles = await part(buf, "xl/styles.xml")
+
+    expect(styles).toContain('formatCode="mmm yyyy"')
+    expect(styles).not.toContain('formatCode="yyyy-mm-dd"')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// worksheet-writer — sheet-level blocks
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sheet-level OOXML blocks", () => {
+  it("emits a dimension for a sheet that has columns but no rows", async () => {
+    // A column-definitions-only sheet is what a template looks like before
+    // any data is appended; `<dimension>` must still cover the columns.
+    const xml = await sheetXml({
+      name: "S",
+      rows: [],
+      columns: [{ key: "a", width: 20 }, { key: "b" }, { key: "c" }],
+    })
+
+    expect(xml).toContain('<dimension ref="A1:C1"/>')
+  })
+
+  it("writes summaryBelow / summaryRight as 0 when outlines summarise above and left", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      rows: [["a"]],
+      outlineProperties: { summaryBelow: false, summaryRight: false },
+    })
+
+    expect(xml).toContain('<outlinePr summaryBelow="0" summaryRight="0"/>')
+  })
+
+  it("writes summaryBelow / summaryRight as 1 for Excel's default outline placement", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      rows: [["a"]],
+      outlineProperties: { summaryBelow: true, summaryRight: true },
+    })
+
+    expect(xml).toContain('<outlinePr summaryBelow="1" summaryRight="1"/>')
+  })
+
+  it("passes an 8-character ARGB tab colour through without a second alpha prefix", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      rows: [["a"]],
+      view: { tabColor: { rgb: "80FF0000" } },
+    })
+
+    expect(xml).toContain('<tabColor rgb="80FF0000"/>')
+  })
+
+  it("emits a self-closing <dataValidation> when the rule carries no formula", async () => {
+    // `custom` without a formula is degenerate but legal — Excel keeps the
+    // prompt text and drops the constraint.
+    const xml = await sheetXml({
+      name: "S",
+      rows: [["a"]],
+      dataValidations: [
+        {
+          type: "custom",
+          range: "A1:A10",
+          showInputMessage: true,
+          inputTitle: "Heads up",
+          inputMessage: "Anything goes",
+        },
+      ],
+    })
+
+    expect(xml).toContain('<dataValidation type="custom" sqref="A1:A10"')
+    expect(xml).toContain('prompt="Anything goes"/>')
+  })
+
+  it("omits <headerFooter> entirely when only the flags are set", async () => {
+    // `differentOddEven` with no odd/even strings describes nothing; an
+    // empty `<headerFooter differentOddEven="1"/>` would just be noise.
+    const xml = await sheetXml({
+      name: "S",
+      rows: [["a"]],
+      headerFooter: { differentOddEven: true, differentFirst: true },
+    })
+
+    expect(xml).not.toContain("headerFooter")
+  })
+
+  it("serializes theme, tint and indexed colours on a tab colour", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      rows: [["a"]],
+      view: { tabColor: { theme: 4, tint: -0.25, indexed: 12 } },
+    })
+
+    expect(xml).toContain('<tabColor theme="4" tint="-0.25" indexed="12"/>')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// worksheet-writer — rich text run properties
+//
+// `<rPr>` accepts the same font children as `<font>` in styles.xml. The
+// less common ones (vertAlign / family / charset / scheme) only appear on
+// text pasted out of Word or a non-Latin locale.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("rich text run properties", () => {
+  it("writes vertAlign, family, charset and scheme into <rPr>", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([
+        [
+          "0,0",
+          {
+            richText: [
+              { text: "E=mc" },
+              {
+                text: "2",
+                font: {
+                  vertAlign: "superscript",
+                  family: 2,
+                  charset: 204,
+                  scheme: "minor",
+                  color: { indexed: 10 },
+                },
+              },
+            ],
+          },
+        ],
+      ]),
+    })
+
+    expect(xml).toContain('<vertAlign val="superscript"/>')
+    expect(xml).toContain('<family val="2"/>')
+    expect(xml).toContain('<charset val="204"/>')
+    expect(xml).toContain('<scheme val="minor"/>')
+    expect(xml).toContain('<color indexed="10"/>')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// worksheet-writer — conditional formatting and sparklines
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("conditional formatting rule bodies", () => {
+  it("emits one <formula> per entry when the rule carries a formula pair", async () => {
+    // `between` needs two operands, which the API accepts as an array.
+    const rule: ConditionalRule = {
+      type: "cellIs",
+      range: "A1:A10",
+      operator: "between",
+      priority: 1,
+      formula: ["10", "20"],
+      style: { fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } } },
+    }
+    const xml = await sheetXml({ name: "S", rows: [[5]], conditionalRules: [rule] })
+
+    expect(xml).toContain("<formula>10</formula><formula>20</formula>")
+  })
+
+  it("writes the cfvo values of a data bar", async () => {
+    const rule: ConditionalRule = {
+      type: "dataBar",
+      range: "A1:A10",
+      priority: 1,
+      dataBar: {
+        cfvo: [
+          { type: "num", value: "0" },
+          { type: "num", value: "100" },
+        ],
+        color: "638EC6",
+      },
+    }
+    const xml = await sheetXml({ name: "S", rows: [[5]], conditionalRules: [rule] })
+
+    expect(xml).toContain('<cfvo type="num" val="0"/>')
+    expect(xml).toContain('<cfvo type="num" val="100"/>')
+    expect(xml).toContain('<color rgb="638EC6"/>')
+  })
+
+  it("honours reverse and showValue:false on an icon set", async () => {
+    const rule: ConditionalRule = {
+      type: "iconSet",
+      range: "A1:A10",
+      priority: 1,
+      iconSet: {
+        iconSet: "3TrafficLights1",
+        reverse: true,
+        showValue: false,
+        cfvo: [
+          { type: "percent", value: "0" },
+          { type: "percent", value: "33" },
+          { type: "percent", value: "67" },
+        ],
+      },
+    }
+    const xml = await sheetXml({ name: "S", rows: [[5]], conditionalRules: [rule] })
+
+    expect(xml).toContain('reverse="true"')
+    expect(xml).toContain('showValue="false"')
+  })
+})
+
+describe("sparkline colours", () => {
+  it("passes an 8-character ARGB colour through untouched", async () => {
+    // 6-char colours get an FF alpha prefix; a value that already carries
+    // alpha must not be prefixed twice.
+    const xml = await sheetXml({
+      name: "S",
+      rows: [[1, 2, 3]],
+      sparklines: [{ location: "D1", dataRange: "Sheet1!A1:C1", color: "80FF0000" }],
+    })
+
+    expect(xml).toContain('<x14:colorSeries rgb="80FF0000"/>')
+    expect(xml).not.toContain("FF80FF0000")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// worksheet-writer — object data (`data` + `columns`)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("object rows resolved through column keys", () => {
+  it("applies a column numFmt to every cell in the column", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          columns: [
+            { key: "name", header: "Name" },
+            { key: "amount", header: "Amount", numFmt: "#,##0.00" },
+          ],
+          data: [{ name: "Widget", amount: 12.5 }],
+        },
+      ],
+    })
+
+    expect(await part(buf, "xl/styles.xml")).toContain('formatCode="#,##0.00"')
+  })
+
+  it("leaves a column's own style numFmt in place instead of overriding it", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          columns: [{ key: "amount", header: "Amount", numFmt: "0.00", style: { numFmt: "0%" } }],
+          data: [{ amount: 0.5 }],
+        },
+      ],
+    })
+    const styles = await part(buf, "xl/styles.xml")
+
+    expect(styles).toContain('formatCode="0%"')
+    expect(styles).not.toContain('formatCode="0.00"')
+  })
+
+  it("falls back to the column key, then to nothing, for a missing header", async () => {
+    // `columns` is often written key-only; the header row still has to be
+    // emitted (one column here declares neither, and contributes nothing).
+    const xml = await sheetXml({
+      name: "S",
+      columns: [{ key: "a", header: "A" }, { key: "b" }, {}],
+      data: [{ a: 1, b: 2 }],
+    })
+
+    expect(xml).toContain('<row r="1">')
+    // A and the key-named column are shared strings 0 and 1.
+    expect(xml).toContain('<c r="B1" t="s"><v>1</v></c>')
+    expect(xml).not.toContain('r="C1"')
+  })
+
+  it("writes an empty cell for a key the object does not have", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      columns: [
+        { key: "a", header: "A" },
+        { key: "missing", header: "B" },
+      ],
+      data: [{ a: 1 }],
+    })
+
+    // Row 2 has A2 only; the missing key contributes no `<c>`.
+    expect(xml).toContain('<row r="2"><c r="A2"><v>1</v></c></row>')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// styles-writer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("styles.xml colour and alignment coverage", () => {
+  it("writes theme, tint and indexed on a font colour", async () => {
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: "x", style: { font: { color: { theme: 1, tint: 0.5 } } } }],
+      ]),
+    })
+
+    expect(xml).toContain('theme="1"')
+    expect(xml).toContain('tint="0.5"')
+  })
+
+  it("distinguishes two fonts that differ only by indexed colour", async () => {
+    // The dedup key has to include every colour field or the second cell
+    // silently inherits the first cell's colour.
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: "a", style: { font: { color: { indexed: 10 } } } }],
+        ["0,1", { value: "b", style: { font: { color: { indexed: 12 } } } }],
+      ]),
+    })
+
+    expect(xml).toContain('<color indexed="10"/>')
+    expect(xml).toContain('<color indexed="12"/>')
+  })
+
+  it("writes the full alignment attribute set", async () => {
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        [
+          "0,0",
+          {
+            value: "x",
+            style: {
+              alignment: {
+                shrinkToFit: true,
+                textRotation: 45,
+                indent: 2,
+                readingOrder: "rtl",
+              },
+            },
+          },
+        ],
+      ]),
+    })
+
+    expect(xml).toContain('shrinkToFit="true"')
+    expect(xml).toContain('textRotation="45"')
+    expect(xml).toContain('indent="2"')
+    expect(xml).toContain('readingOrder="2"')
+  })
+
+  it("keeps two alignments distinct when only the reading order differs", async () => {
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: "a", style: { alignment: { readingOrder: "ltr" } } }],
+        ["0,1", { value: "b", style: { alignment: { readingOrder: "context" } } }],
+      ]),
+    })
+
+    expect(xml).toContain('readingOrder="1"')
+    expect(xml).toContain('readingOrder="0"')
+  })
+
+  it("writes protection hidden=0 when the formula is explicitly not hidden", async () => {
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: "x", style: { protection: { locked: true, hidden: false } } }],
+      ]),
+    })
+
+    expect(xml).toContain('<protection locked="1" hidden="0"/>')
+  })
+
+  it("reuses one border definition across two different cell formats", async () => {
+    // Same border, different fonts: the xf cache misses but the border
+    // cache must hit, or styles.xml grows a duplicate `<border>`.
+    const thin = { style: "thin" as const, color: { rgb: "FF000000" } }
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: "a", style: { border: { top: thin }, font: { bold: true } } }],
+        ["0,1", { value: "b", style: { border: { top: thin }, font: { italic: true } } }],
+      ]),
+    })
+
+    expect(xml).toContain('<borders count="2">')
+  })
+
+  it("gives a gradient fill without an explicit degree a stable key", async () => {
+    const xml = await stylesXml({
+      name: "S",
+      cells: cellMap([
+        [
+          "0,0",
+          {
+            value: "a",
+            style: {
+              fill: {
+                type: "gradient",
+                stops: [
+                  { position: 0, color: { rgb: "FFFFFF" } },
+                  { position: 1, color: { rgb: "000000" } },
+                ],
+              },
+            },
+          },
+        ],
+      ]),
+    })
+
+    expect(xml).toContain("<gradientFill")
+  })
+})
+
+describe("dxf (conditional formatting) styles", () => {
+  it("serializes numFmt, border and alignment inside a <dxf>", async () => {
+    const style: CellStyle = {
+      numFmt: "0.00%",
+      border: { bottom: { style: "double", color: { rgb: "FFFF0000" } } },
+      alignment: { horizontal: "center" },
+      fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } },
+    }
+    const xml = await stylesXml({
+      name: "S",
+      rows: [[1]],
+      conditionalRules: [
+        { type: "cellIs", range: "A1", operator: "greaterThan", formula: "0", priority: 1, style },
+      ],
+    })
+
+    const dxf = xml.slice(xml.indexOf("<dxfs"))
+    expect(dxf).toContain('formatCode="0.00%"')
+    expect(dxf).toContain("<border")
+    expect(dxf).toContain('<alignment horizontal="center"/>')
+  })
+
+  it("emits a single <dxf> when two rules share one style", async () => {
+    const style: CellStyle = { font: { bold: true } }
+    const xml = await stylesXml({
+      name: "S",
+      rows: [[1]],
+      conditionalRules: [
+        { type: "cellIs", range: "A1", operator: "greaterThan", formula: "0", priority: 1, style },
+        {
+          type: "cellIs",
+          range: "A2",
+          operator: "lessThan",
+          formula: "0",
+          priority: 2,
+          style: { ...style },
+        },
+      ],
+    })
+
+    expect(xml).toContain('<dxfs count="1">')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// stream-writer (incremental XlsxStreamWriter + streaming writeXlsxStream)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("XlsxStreamWriter cell serialization", () => {
+  const styledColumns = [{ key: "a", style: { font: { bold: true } } }]
+
+  it("skips a row whose every cell is empty", async () => {
+    const w = new XlsxStreamWriter({ name: "S" })
+    w.addRow(["kept"])
+    w.addRow([null, null])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('<row r="1">')
+    expect(xml).not.toContain('<row r="2"')
+  })
+
+  it("keeps a styled empty cell and a styled non-finite number", async () => {
+    const w = new XlsxStreamWriter({ name: "S", columns: styledColumns })
+    w.addRow([null])
+    w.addRow([Number.POSITIVE_INFINITY])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toMatch(/<row r="1"><c r="A1" s="\d+"\/><\/row>/)
+    expect(xml).toMatch(/<row r="2"><c r="A2" s="\d+"\/><\/row>/)
+  })
+
+  it("keeps the style index on shared-string and boolean cells", async () => {
+    const w = new XlsxStreamWriter({ name: "S", columns: styledColumns })
+    w.addRow(["text"])
+    w.addRow([true])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toMatch(/<c r="A1" t="s" s="\d+">/)
+    expect(xml).toMatch(/<c r="A2" t="b" s="\d+">/)
+  })
+
+  it("drops a value that is not a cell value at all", async () => {
+    const w = new XlsxStreamWriter({ name: "S" })
+    w.addRow([{ nested: true } as never, "kept"])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).not.toContain('r="A1"')
+    expect(xml).toContain('<c r="B1"')
+  })
+
+  it("writes null for a column with no key, and for a key the object lacks", async () => {
+    const w = new XlsxStreamWriter({
+      name: "S",
+      columns: [{ key: "a", header: "A" }, { header: "Spacer" }, { key: "missing", header: "M" }],
+    })
+    w.addObject({ a: 1 })
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('<row r="2"><c r="A2"><v>1</v></c></row>')
+  })
+
+  it("takes the header row from the column keys when a header is missing", async () => {
+    const w = new XlsxStreamWriter({
+      name: "S",
+      columns: [{ key: "a", header: "A" }, { key: "b" }, {}],
+    })
+    w.addRow([1, 2, 3])
+    const buf = await w.finish()
+    const shared = await part(buf, "xl/sharedStrings.xml")
+
+    // Header cells: the declared header, then the bare key. The third
+    // column declares neither and contributes no cell.
+    expect(shared).toContain("<t>A</t>")
+    expect(shared).toContain("<t>b</t>")
+  })
+
+  it("merges a column numFmt into a column style that has none", async () => {
+    const w = new XlsxStreamWriter({
+      name: "S",
+      columns: [{ key: "amount", numFmt: "#,##0.00", style: { font: { bold: true } } }],
+    })
+    w.addRow([12.5])
+    const styles = await part(await w.finish(), "xl/styles.xml")
+
+    expect(styles).toContain('formatCode="#,##0.00"')
+    expect(styles).toContain("<b/>")
+  })
+
+  it("leaves a column's own date format on a Date value", async () => {
+    const w = new XlsxStreamWriter({
+      name: "S",
+      columns: [{ key: "when", style: { numFmt: "mmm yyyy" } }],
+    })
+    w.addRow([new Date(Date.UTC(2024, 0, 15))])
+    const styles = await part(await w.finish(), "xl/styles.xml")
+
+    expect(styles).toContain('formatCode="mmm yyyy"')
+    expect(styles).not.toContain('formatCode="yyyy-mm-dd"')
+  })
+
+  it("truncates a rolled-over sheet name back to 31 characters", async () => {
+    // "_2" pushes a legal 30-character base over Excel's limit. See #364.
+    const base = "Quarterly Revenue By Region Co" // 30 chars
+    const w = new XlsxStreamWriter({ name: base, maxRowsPerSheet: 2 })
+    w.addRow(["h"])
+    w.addRow([1])
+    w.addRow([2])
+    const wb = await part(await w.finish(), "xl/workbook.xml")
+
+    expect(wb).toContain(`name="${base}"`)
+    // The base is shortened, not the suffix — the sheet number survives.
+    expect(wb).toContain('name="Quarterly Revenue By Region C_2"')
+  })
+
+  it("refuses addObject when no columns were declared", () => {
+    const w = new XlsxStreamWriter({ name: "S" })
+    expect(() => w.addObject({ a: 1 })).toThrow(/columns with key accessors/)
+  })
+})
+
+describe("XlsxStreamWriter freeze panes and column properties", () => {
+  it("freezes rows only, leaving the active pane at bottom-left", async () => {
+    const w = new XlsxStreamWriter({ name: "S", freezePane: { rows: 1 } })
+    w.addRow(["h"])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('ySplit="1"')
+    expect(xml).not.toContain("xSplit")
+    expect(xml).toContain('activePane="bottomLeft"')
+  })
+
+  it("freezes columns only, putting the active pane at top-right", async () => {
+    const w = new XlsxStreamWriter({ name: "S", freezePane: { columns: 2 } })
+    w.addRow(["h"])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('xSplit="2"')
+    expect(xml).toContain('activePane="topRight"')
+  })
+
+  it("freezes both axes at once", async () => {
+    const w = new XlsxStreamWriter({ name: "S", freezePane: { rows: 1, columns: 1 } })
+    w.addRow(["h"])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('activePane="bottomRight"')
+    expect(xml).toContain('topLeftCell="B2"')
+  })
+
+  it("writes hidden and outlineLevel on <col>", async () => {
+    const w = new XlsxStreamWriter({
+      name: "S",
+      columns: [
+        { key: "a", hidden: true },
+        { key: "b", outlineLevel: 2 },
+      ],
+    })
+    w.addRow([1, 2])
+    const xml = await part(await w.finish(), "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('<col min="1" max="1" hidden="true"/>')
+    expect(xml).toContain('<col min="2" max="2" outlineLevel="2"/>')
+  })
+})
+
+describe("writeXlsxStream", () => {
+  it("emits a worksheet larger than one chunk in several pieces", async () => {
+    // The chunker flushes at 64 KB; a few thousand wide-ish rows crosses it
+    // repeatedly, which is the only way the mid-sheet flush path runs.
+    const rows: Array<Array<string | number>> = []
+    for (let i = 0; i < 4000; i++) {
+      rows.push([`row-${i}`, i, `payload-${i}-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`])
+    }
+    const buf = await drain(writeXlsxStream(rows, { name: "Big" }))
+    const xml = await part(buf, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain("row-0")
+    expect(xml).toContain("row-3999")
+    expect(xml.endsWith("</sheetData></worksheet>")).toBe(true)
+  })
+
+  it("emits the sheet opening in its own chunk when the prelude is huge", async () => {
+    // 1200 sized columns push the `<cols>` block past the 64 KB flush
+    // threshold before the first row is ever serialized.
+    const columns = Array.from({ length: 1200 }, (_, i) => ({
+      key: `c${i}`,
+      width: 12.5,
+      hidden: true,
+      outlineLevel: 1,
+    }))
+    const buf = await drain(writeXlsxStream([[1, 2, 3]], { name: "Wide", columns }))
+    const xml = await part(buf, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain('<col min="1200" max="1200"')
+    expect(xml).toContain("<sheetData>")
+  })
+
+  it("flushes a header row that alone crosses the chunk threshold", async () => {
+    // Wide reports (a column per day, say) can carry a header row larger
+    // than the 64 KB flush window all by itself.
+    const columns = Array.from({ length: 300 }, (_, i) => ({
+      key: `c${i}`,
+      header: `Header ${i} `.padEnd(300, "-"),
+    }))
+    const buf = await drain(writeXlsxStream([[1]], { name: "Wide", columns }))
+    const xml = await part(buf, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain("Header 0 ")
+    expect(xml).toContain("Header 299 ")
+    expect(xml.endsWith("</sheetData></worksheet>")).toBe(true)
+  })
+
+  it("fails the stream when object rows arrive without column definitions", async () => {
+    const stream = writeXlsxStream([{ a: 1 }], { name: "S" })
+    await expect(drain(stream)).rejects.toThrow(/columns with key accessors/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// writer.ts — pivot source collection and table range computation
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("pivot source rows from object data", () => {
+  it("names pivot fields from the header, then the key, and blanks the rest", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "Data",
+          columns: [
+            { key: "region", header: "Region" },
+            { key: "notes" },
+            { header: "Spacer" },
+            {},
+            { key: "revenue", header: "Revenue" },
+          ],
+          data: [
+            { region: "EU", revenue: 100 },
+            { region: "US", revenue: 200 },
+          ],
+        },
+        {
+          name: "Pivot",
+          pivotTables: [
+            {
+              name: "P",
+              sourceSheet: "Data",
+              rows: ["Region"],
+              values: [{ field: "Revenue" }],
+            },
+          ],
+        },
+      ],
+    })
+    const cache = await part(buf, "xl/pivotCache/pivotCacheDefinition1.xml")
+    const records = await part(buf, "xl/pivotCache/pivotCacheRecords1.xml")
+
+    expect(cache).toContain('<cacheField name="notes"')
+    expect(cache).toContain('<cacheField name=""')
+    // The key-less columns contribute a blank `<m/>` in every record.
+    expect(records).toContain("<m/>")
+  })
+
+  it("rejects a pivot whose source sheet holds no row-shaped data", async () => {
+    await expect(
+      writeXlsx({
+        sheets: [
+          { name: "Data", columns: [{ key: "a", header: "A" }] },
+          {
+            name: "Pivot",
+            pivotTables: [{ name: "P", sourceSheet: "Data", values: [{ field: "A" }] }],
+          },
+        ],
+      }),
+    ).rejects.toThrow(/at least a header row plus one data row/)
+  })
+})
+
+describe("auto-computed table ranges", () => {
+  it("counts the header row when the sheet is object data", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          columns: [
+            { key: "a", header: "A" },
+            { key: "b", header: "B" },
+          ],
+          data: [
+            { a: 1, b: 2 },
+            { a: 3, b: 4 },
+          ],
+          tables: [{ name: "T", columns: [{ name: "A" }, { name: "B" }] }],
+        },
+      ],
+    })
+
+    // 2 data rows + 1 header row.
+    expect(await part(buf, "xl/tables/table1.xml")).toContain('ref="A1:B3"')
+  })
+
+  it("adds a row for the totals row", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [
+            ["A", "B"],
+            [1, 2],
+          ],
+          tables: [
+            {
+              name: "T",
+              showTotalRow: true,
+              columns: [{ name: "A" }, { name: "B", totalFunction: "sum" }],
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(await part(buf, "xl/tables/table1.xml")).toContain('ref="A1:B3"')
+  })
+
+  it("counts only the data rows when the columns declare no headers", async () => {
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          columns: [{ key: "a" }, { key: "b" }],
+          data: [
+            { a: 1, b: 2 },
+            { a: 3, b: 4 },
+          ],
+          tables: [{ name: "T", columns: [{ name: "A" }, { name: "B" }] }],
+        },
+      ],
+    })
+
+    expect(await part(buf, "xl/tables/table1.xml")).toContain('ref="A1:B2"')
+  })
+
+  it("never computes an empty range for a table on a sheet with no data", async () => {
+    const buf = await writeXlsx({
+      sheets: [{ name: "S", tables: [{ name: "T", columns: [{ name: "A" }, { name: "B" }] }] }],
+    })
+
+    expect(await part(buf, "xl/tables/table1.xml")).toContain('ref="A1:B1"')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// table-writer — degenerate ranges
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("writeTable range handling", () => {
+  it("writes an empty ref when the definition carries no range", () => {
+    const { tableXml } = writeTable({ name: "T", columns: [{ name: "A" }] }, 1, 1)
+    expect(tableXml).toContain('ref=""')
+  })
+
+  it("leaves a single-cell range alone when trimming the totals row", () => {
+    const { tableXml } = writeTable(
+      { name: "T", range: "A1", showTotalRow: true, columns: [{ name: "A" }] },
+      1,
+      1,
+    )
+    expect(tableXml).toContain('<autoFilter ref="A1"/>')
+  })
+
+  it("refuses to trim a totals row off a single-row table", () => {
+    // "A1:B1" minus one row would be "A1:B0", which Excel rejects.
+    const { tableXml } = writeTable(
+      { name: "T", range: "A1:B1", showTotalRow: true, columns: [{ name: "A" }, { name: "B" }] },
+      1,
+      1,
+    )
+    expect(tableXml).toContain('<autoFilter ref="A1:B1"/>')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// content-types-writer / doc-props-writer
+// ═══════════════════════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════════════════════
+// drawing-writer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("chart graphic frame metadata", () => {
+  it("puts frameTitle on the drawing shape, next to the alt text", async () => {
+    // Screen readers announce `title`; `descr` carries the long
+    // description. Both live on the drawing, not on the chart part.
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [
+            ["Q", "Rev"],
+            ["Q1", 100],
+          ],
+          charts: [
+            {
+              type: "column",
+              frameTitle: "Revenue chart",
+              altText: "Column chart of revenue by quarter",
+              series: [{ name: "Rev", values: "B2:B2", categories: "A2:A2" }],
+              anchor: { from: { row: 3, col: 0 } },
+            },
+          ],
+        },
+      ],
+    })
+    const drawing = await part(buf, "xl/drawings/drawing1.xml")
+
+    expect(drawing).toContain('title="Revenue chart"')
+    expect(drawing).toContain('descr="Column chart of revenue by quarter"')
+  })
+})
+
+describe("writeContentTypes defaults", () => {
+  it("omits the sharedStrings override when the flag is left out", () => {
+    const xml = writeContentTypes({ sheetCount: 1, hasSharedStrings: false })
+    expect(xml).toContain("/xl/worksheets/sheet1.xml")
+    expect(xml).not.toContain("sharedStrings")
+  })
+
+  it("still accepts the positional (sheetCount, hasSharedStrings) signature", () => {
+    // The older call shape is still in use inside the streaming writers.
+    expect(writeContentTypes(2)).not.toContain("sharedStrings")
+    expect(writeContentTypes(2, true)).toContain("/xl/sharedStrings.xml")
+    expect(writeContentTypes(2)).toContain("/xl/worksheets/sheet2.xml")
+  })
+})
+
+describe("writeCustomProperties", () => {
+  it("returns null when the custom bag is present but empty", () => {
+    expect(writeCustomProperties({ custom: {} })).toBeNull()
+  })
+
+  it("returns null when every custom value is of an unsupported type", () => {
+    // Values arriving from JSON can be null or objects; those have no
+    // `vt:` element, so the part must not be emitted at all.
+    expect(writeCustomProperties({ custom: { junk: null as never } })).toBeNull()
+  })
+
+  it("skips the unsupported entries but keeps the rest", () => {
+    const xml = writeCustomProperties({ custom: { junk: null as never, ok: "yes" } })
+    expect(xml).toContain("<vt:lpwstr>yes</vt:lpwstr>")
+    expect(xml).not.toContain("junk")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// xml/data-writer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("writeXml mixed content and holes", () => {
+  it("skips a key whose value is undefined", () => {
+    const out = writeXml([{ sku: "P1", note: undefined as never }])
+    expect(out).toContain("<sku>P1</sku>")
+    expect(out).not.toContain("note")
+  })
+
+  it("writes the #text key as the element's own text", () => {
+    const out = writeXml([{ "@id": 7, "#text": "plain body" }], { rowTag: "item" })
+    expect(out).toContain('<item id="7">plain body</item>')
+  })
+
+  it("keeps the text alongside child elements in mixed content", () => {
+    const out = writeXml([{ "#text": "leading", child: "value" }], { rowTag: "item", pretty: true })
+    expect(out).toContain("<child>value</child>")
+    expect(out).toContain("leading")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// worker.ts — structured-clone-safe workbook transfer
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("worker serialization round trip", () => {
+  it("carries rich text, image metadata, conditional rules, a11y and external links", () => {
+    const cells = new Map<string, Cell>([
+      [
+        "0,0",
+        {
+          value: "styled",
+          type: "richText",
+          richText: [{ text: "bold", font: { bold: true } }],
+        },
+      ],
+    ])
+    const sheet: Sheet = {
+      name: "S",
+      rows: [["styled"]],
+      cells,
+      conditionalRules: [
+        { type: "cellIs", range: "A1", operator: "greaterThan", formula: "0", priority: 1 },
+      ],
+      a11y: { summary: "Revenue by region", headerRow: 0 },
+      images: [
+        {
+          data: new Uint8Array([1, 2, 3]),
+          type: "png",
+          anchor: { from: { row: 0, col: 0 } },
+          altText: "logo",
+          title: "Logo",
+        },
+      ],
+    }
+    const wb: Workbook = {
+      sheets: [sheet],
+      externalLinks: [{ target: "../other.xlsx", sheetNames: ["Sheet1"], sheetData: [] }],
+    }
+
+    const round = deserializeWorkbook(serializeWorkbook(wb))
+
+    expect(round.sheets[0].cells?.get("0,0")?.richText).toEqual([
+      { text: "bold", font: { bold: true } },
+    ])
+    expect(round.sheets[0].images?.[0].altText).toBe("logo")
+    expect(round.sheets[0].images?.[0].title).toBe("Logo")
+    expect(round.sheets[0].conditionalRules).toHaveLength(1)
+    expect(round.sheets[0].a11y).toEqual({ summary: "Revenue by region", headerRow: 0 })
+    expect(round.externalLinks).toEqual([
+      { target: "../other.xlsx", sheetNames: ["Sheet1"], sheetData: [] },
+    ])
+  })
+})

--- a/test/coverage-xml-parser.test.ts
+++ b/test/coverage-xml-parser.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "vitest"
+import { parseSax, parseSaxStream, parseXml, SAX_TEXT_FLUSH_CHARS } from "../src/xml/parser"
+import type { SaxHandlers } from "../src/xml/parser"
+import { readXml } from "../src/xml/data-reader"
+import { XmlError, ParseError } from "../src/errors"
+
+const enc = new TextEncoder()
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Feed the streaming parser a fixed sequence of chunks, one per pull. */
+function chunkStream(chunks: (string | Uint8Array)[]): ReadableStream<Uint8Array> {
+  const bytes = chunks.map((c) => (typeof c === "string" ? enc.encode(c) : c))
+  let i = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i >= bytes.length) {
+        controller.close()
+        return
+      }
+      controller.enqueue(bytes[i++])
+    },
+  })
+}
+
+/** Record every SAX event the streaming parser emits for `chunks`. */
+async function streamEvents(chunks: (string | Uint8Array)[]): Promise<{
+  open: Array<[string, Record<string, string>]>
+  close: string[]
+  text: string[]
+  cdata: string[]
+}> {
+  const out = {
+    open: [] as Array<[string, Record<string, string>]>,
+    close: [] as string[],
+    text: [] as string[],
+    cdata: [] as string[],
+  }
+  const handlers: SaxHandlers = {
+    onOpenTag: (tag, attrs) => out.open.push([tag, attrs]),
+    onCloseTag: (tag) => out.close.push(tag),
+    onText: (text) => out.text.push(text),
+    onCData: (text) => out.cdata.push(text),
+  }
+  await parseSaxStream(chunkStream(chunks), handlers)
+  return out
+}
+
+/** Collect only the attribute map of the first element in `xml`. */
+function attrsOf(xml: string): Record<string, string> {
+  let found: Record<string, string> = {}
+  let first = true
+  parseSax(xml, {
+    onOpenTag(_tag, attrs) {
+      if (first) {
+        found = attrs
+        first = false
+      }
+    },
+  })
+  return found
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Attribute parsing — the lenient paths
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSax — attribute syntax the spec does not bless", () => {
+  it("stops at an attribute list that begins with '='", () => {
+    // Nothing readable as a name: bail out rather than loop forever.
+    expect(attrsOf(`<c ="orphan"/>`)).toEqual({})
+  })
+
+  it("records a valueless attribute as an empty string", () => {
+    // HTML-style boolean attributes turn up in hand-edited OOXML parts.
+    expect(attrsOf(`<c hidden/>`)).toEqual({ hidden: "" })
+  })
+
+  it("records a valueless attribute that is followed by a real one", () => {
+    expect(attrsOf(`<c hidden r="A1"/>`)).toEqual({ hidden: "", r: "A1" })
+  })
+
+  it("ignores a trailing '=' with no value behind it", () => {
+    expect(attrsOf(`<c r=/>`)).toEqual({})
+  })
+
+  it("accepts an unquoted attribute value", () => {
+    expect(attrsOf(`<c r=A1/>`)).toEqual({ r: "A1" })
+  })
+
+  it("terminates an unquoted value at the next space", () => {
+    expect(attrsOf(`<c r=A1 t=s/>`)).toEqual({ r: "A1", t: "s" })
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseSax — truncated markup
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSax — truncated markup", () => {
+  it("reports a document that ends on a bare '<'", () => {
+    expect(() => parseSax("<a></a><", {})).toThrow(XmlError)
+    expect(() => parseSax("<a></a><", {})).toThrow(/Unterminated opening tag/)
+  })
+
+  it("reports a declaration that never closes", () => {
+    expect(() => parseSax(`<!DOCTYPE workbook`, {})).toThrow(/Unterminated declaration/)
+  })
+
+  it("reports a closing tag with no matching open tag", () => {
+    expect(() => parseXml(`</row>`)).toThrow(/Unexpected closing tag: no matching open tag/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseSaxStream — constructs split across chunk boundaries
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSaxStream — chunk boundaries", () => {
+  it("strips a BOM that arrives in the first chunk", async () => {
+    const bom = new Uint8Array([0xef, 0xbb, 0xbf])
+    const events = await streamEvents([bom, `<root><a>1</a></root>`])
+    expect(events.open.map((o) => o[0])).toEqual(["root", "a"])
+  })
+
+  it("holds back a lone '<' at the end of a chunk", async () => {
+    const events = await streamEvents([`<root><`, `a r="1"/></root>`])
+    expect(events.open).toEqual([
+      ["root", {}],
+      ["a", { r: "1" }],
+    ])
+  })
+
+  it("rejoins a comment split across chunks", async () => {
+    const events = await streamEvents([`<root><!-- part one`, ` part two --><a/></root>`])
+    expect(events.open.map((o) => o[0])).toEqual(["root", "a"])
+    expect(events.text).toEqual([])
+  })
+
+  it("rejoins a CDATA section split across chunks", async () => {
+    const events = await streamEvents([`<root><![CDATA[first`, `second]]></root>`])
+    expect(events.cdata).toEqual(["firstsecond"])
+  })
+
+  it("holds back a partial '<!' marker too short to classify", async () => {
+    // Fewer than 9 characters remain, so it could still become <![CDATA[.
+    const events = await streamEvents([`<root><![C`, `DATA[body]]></root>`])
+    expect(events.cdata).toEqual(["body"])
+  })
+
+  it("rejoins a DOCTYPE declaration split across chunks", async () => {
+    const events = await streamEvents([`<!DOCTYPE workbook SYSTEM`, ` "wb.dtd"><root/>`])
+    expect(events.open.map((o) => o[0])).toEqual(["root"])
+  })
+
+  it("rejoins a processing instruction split across chunks", async () => {
+    const events = await streamEvents([`<?xml version="1.0"`, ` encoding="UTF-8"?><root/>`])
+    expect(events.open.map((o) => o[0])).toEqual(["root"])
+  })
+
+  it("rejoins a closing tag split across chunks", async () => {
+    const events = await streamEvents([`<root><a>x</a`, `></root>`])
+    expect(events.close).toEqual(["a", "root"])
+  })
+
+  it("rejoins an opening tag split inside an attribute value", async () => {
+    const events = await streamEvents([`<root><c r="A`, `1" t="s"/></root>`])
+    expect(events.open[1]).toEqual(["c", { r: "A1", t: "s" }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseSaxStream — truncated tail
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSaxStream — a source that stops mid-construct", () => {
+  // The streaming parser has no error contract for a truncated document —
+  // it drops the unfinished construct and returns normally, leaving the
+  // caller (e.g. the XLSX row reader) to notice the missing close tags.
+
+  it("drops an unterminated comment", async () => {
+    const events = await streamEvents([`<root><a/><!-- cut off here`])
+    expect(events.open.map((o) => o[0])).toEqual(["root", "a"])
+  })
+
+  it("drops an unterminated CDATA section", async () => {
+    const events = await streamEvents([`<root><a/><![CDATA[cut off here`])
+    expect(events.cdata).toEqual([])
+  })
+
+  it("drops an unterminated declaration", async () => {
+    const events = await streamEvents([`<root><a/><!DOCTYPE cut off here`])
+    expect(events.open.map((o) => o[0])).toEqual(["root", "a"])
+  })
+
+  it("drops a '<!' marker that never became anything", async () => {
+    const events = await streamEvents([`<root><a/><!X`])
+    expect(events.open.map((o) => o[0])).toEqual(["root", "a"])
+  })
+
+  it("drops an unterminated processing instruction", async () => {
+    const events = await streamEvents([`<root><a/><?php echo`])
+    expect(events.open.map((o) => o[0])).toEqual(["root", "a"])
+  })
+
+  it("drops an unterminated closing tag", async () => {
+    const events = await streamEvents([`<root><a/></roo`])
+    expect(events.close).toEqual(["a"])
+  })
+
+  it("drops an unterminated opening tag", async () => {
+    const events = await streamEvents([`<root><c r="A1`])
+    expect(events.open.map((o) => o[0])).toEqual(["root"])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseSaxStream — very long text runs
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parseSaxStream — text runs past the flush threshold", () => {
+  // A text run carried across every chunk is re-copied each time, which is
+  // quadratic. Past SAX_TEXT_FLUSH_CHARS the parser emits what it safely
+  // can and keeps only the tail — so handlers must accumulate, not assign.
+  const LONG = "x".repeat(SAX_TEXT_FLUSH_CHARS + 40000)
+
+  it("splits one long run into several onText calls", async () => {
+    const events = await streamEvents([`<r>${LONG}`, `tail</r>`])
+    expect(events.text.length).toBeGreaterThan(1)
+    expect(events.text.join("")).toBe(`${LONG}tail`)
+  })
+
+  it("never cuts inside an entity reference", async () => {
+    // The chunk ends mid-"&amp;": splitting there would emit a literal
+    // "&am" and then "p;" instead of a single "&".
+    const events = await streamEvents([`<r>${LONG}&am`, `p;tail</r>`])
+    expect(events.text.join("")).toBe(`${LONG}&tail`)
+  })
+
+  it("keeps an astral character whole across the split", async () => {
+    const events = await streamEvents([`<r>${LONG}\u{1F600}`, `tail</r>`])
+    expect(events.text.join("")).toBe(`${LONG}\u{1F600}tail`)
+  })
+
+  it("does not split a run that is merely long, not enormous", async () => {
+    const short = "y".repeat(1000)
+    const events = await streamEvents([`<r>${short}`, `tail</r>`])
+    expect(events.text).toEqual([`${short}tail`])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// readXml — row detection and options
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readXml — row tag selection", () => {
+  it("returns nothing when the caller pins an empty row tag", () => {
+    const result = readXml(`<feed><item><a>1</a></item></feed>`, { rowTag: "" })
+    expect(result).toEqual({ data: [], headers: [], rowTag: "" })
+  })
+
+  it("prefers a later tag that repeats more often than the first", () => {
+    // Feeds often open with a single <header> element before the records.
+    const xml = `<feed><header>meta</header><item><a>1</a></item><item><a>2</a></item></feed>`
+    const result = readXml(xml)
+    expect(result.rowTag).toBe("item")
+    expect(result.data).toEqual([{ a: "1" }, { a: "2" }])
+  })
+
+  it("throws when the document has a root but no child elements", () => {
+    expect(() => readXml(`<feed>text only</feed>`)).toThrow(ParseError)
+  })
+
+  it("ignores CDATA that sits outside any row", () => {
+    const xml = `<feed><![CDATA[ignore me]]><item><a>1</a></item><item><a>2</a></item></feed>`
+    expect(readXml(xml).data).toEqual([{ a: "1" }, { a: "2" }])
+  })
+
+  it("stores a text-only row under the text key", () => {
+    const result = readXml(`<feed><sku>A-1</sku><sku>A-2</sku></feed>`)
+    expect(result.headers).toEqual(["#text"])
+    expect(result.data).toEqual([{ "#text": "A-1" }, { "#text": "A-2" }])
+  })
+
+  it("fills missing columns with null after transformHeader renames them", () => {
+    // Rows in a real feed are heterogeneous; the renamed header still has to
+    // exist on every row.
+    const xml = `<feed><item><a>1</a></item><item><b>2</b></item></feed>`
+    const result = readXml(xml, { transformHeader: (h) => h.toUpperCase() })
+    expect(result.headers).toEqual(["A", "B"])
+    expect(result.data).toEqual([
+      { A: "1", B: null },
+      { A: null, B: "2" },
+    ])
+  })
+})
+
+describe("readXml — mixed content", () => {
+  it("captures text that sits alongside child elements", () => {
+    const xml = `<feed><item>leading note<a>1</a></item></feed>`
+    expect(readXml(xml).data).toEqual([{ a: "1", "#text": "leading note" }])
+  })
+
+  it("captures mixed text inside a nested element under its dot path", () => {
+    const xml = `<feed><item><desc>note<b>bold</b></desc></item></feed>`
+    expect(readXml(xml).data).toEqual([{ "desc.b": "bold", "desc.#text": "note" }])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// readXml — flatten: false
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("readXml — flatten:false serialisation", () => {
+  it("keeps top-level child names and stringifies their subtrees", () => {
+    const xml = `<feed><item><specs><spec>1</spec><spec>2</spec><spec>3</spec></specs></item></feed>`
+    const result = readXml(xml, { flatten: false })
+    expect(JSON.parse(String(result.data[0].specs))).toEqual({ spec: ["1", "2", "3"] })
+  })
+
+  it("nests repeated grandchildren as arrays", () => {
+    const xml = `<feed><item><specs><group><spec>1</spec><spec>2</spec><spec>3</spec></group></specs></item></feed>`
+    const result = readXml(xml, { flatten: false })
+    expect(JSON.parse(String(result.data[0].specs))).toEqual({ group: { spec: ["1", "2", "3"] } })
+  })
+
+  it("keeps an attribute-carrying leaf as an object with its text", () => {
+    const xml = `<feed><item><price currency="EUR">10.50</price></item></feed>`
+    const result = readXml(xml, { flatten: false })
+    expect(JSON.parse(String(result.data[0].price))).toEqual({
+      "@currency": "EUR",
+      "#text": "10.50",
+    })
+  })
+
+  it("keeps an empty attribute-carrying leaf as attributes alone", () => {
+    const xml = `<feed><item><price currency="EUR"/></item></feed>`
+    const result = readXml(xml, { flatten: false })
+    expect(JSON.parse(String(result.data[0].price))).toEqual({ "@currency": "EUR" })
+  })
+
+  it("wraps a nested element that carries attributes in an object", () => {
+    const xml = `<feed><item><specs><spec code="w">10</spec></specs></item></feed>`
+    const result = readXml(xml, { flatten: false })
+    expect(JSON.parse(String(result.data[0].specs))).toEqual({
+      spec: { "@code": "w", "#text": "10" },
+    })
+  })
+
+  it("emits null for an empty top-level child", () => {
+    const xml = `<feed><item><a/><b>1</b></item></feed>`
+    expect(readXml(xml, { flatten: false }).data[0]).toEqual({ a: null, b: "1" })
+  })
+
+  it("captures mixed text on the row root", () => {
+    const xml = `<feed><item>loose text<a>1</a></item></feed>`
+    expect(readXml(xml, { flatten: false }).data[0]).toEqual({ a: "1", "#text": "loose text" })
+  })
+
+  it("strips namespace prefixes from the stringified child names", () => {
+    const xml = `<feed xmlns:g="urn:g"><item><g:specs><g:spec>1</g:spec></g:specs></item></feed>`
+    const result = readXml(xml, { flatten: false, stripNamespaces: true })
+    expect(Object.keys(result.data[0])).toEqual(["specs"])
+  })
+})

--- a/test/coverage-zip-branches.test.ts
+++ b/test/coverage-zip-branches.test.ts
@@ -1,0 +1,892 @@
+import { describe, expect, it } from "vitest"
+import { ZipReader } from "../src/zip/reader"
+import { ZipStreamReader } from "../src/zip/stream-reader"
+import { ZipWriter } from "../src/zip/writer"
+import { crc32, deflate, inflate } from "../src/zip/deflate"
+import { ParseError, ZipError } from "../src/errors"
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+const SIG_LOCAL = 0x04034b50
+const SIG_CENTRAL = 0x02014b50
+const SIG_EOCD = 0x06054b50
+const SIG_DESCRIPTOR = 0x08074b50
+const SENTINEL = 0xffffffff
+
+// ── Archive builder ──────────────────────────────────────────────────
+// Deliberately lets each field be set independently of the bytes it is
+// supposed to describe: nearly every branch below is a reader defence
+// against a header that disagrees with reality (truncation, a lying
+// producer, a ZIP64 escape without the matching extra field).
+
+interface EntrySpec {
+  name: string
+  /** Bytes stored in the archive body — already compressed when `method` is 8. */
+  body: Uint8Array
+  method?: number
+  /** General-purpose bit flags; 0x08 marks a trailing data descriptor. */
+  flags?: number
+  crc?: number
+  /** Sizes recorded in the central directory (default: the real ones). */
+  centralSizes?: { compressed: number; uncompressed: number }
+  /** Sizes recorded in the local file header (default: the real ones). */
+  localSizes?: { compressed: number; uncompressed: number }
+  /** Local header offset recorded in the central directory. */
+  centralOffset?: number
+  /** Classic 16-byte data descriptor appended after the body. */
+  descriptor?: { crc: number; compressed: number; uncompressed: number }
+  /** Raw extra-field bytes appended to the central-directory record. */
+  centralExtra?: Uint8Array
+}
+
+function viewOf(buf: Uint8Array): DataView {
+  return new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
+}
+
+function buildZip(specs: EntrySpec[]): Uint8Array {
+  const parts: Uint8Array[] = []
+  const offsets: number[] = []
+  let offset = 0
+
+  for (const s of specs) {
+    const nameBytes = enc.encode(s.name)
+    const crc = s.crc ?? ((s.method ?? 0) === 0 ? crc32(s.body) : 0)
+    const local = new Uint8Array(30 + nameBytes.length + s.body.length + (s.descriptor ? 16 : 0))
+    const dv = viewOf(local)
+    dv.setUint32(0, SIG_LOCAL, true)
+    dv.setUint16(4, 20, true)
+    dv.setUint16(6, s.flags ?? 0, true)
+    dv.setUint16(8, s.method ?? 0, true)
+    dv.setUint16(12, 0x0021, true)
+    dv.setUint32(14, crc, true)
+    dv.setUint32(18, s.localSizes ? s.localSizes.compressed : s.body.length, true)
+    dv.setUint32(22, s.localSizes ? s.localSizes.uncompressed : s.body.length, true)
+    dv.setUint16(26, nameBytes.length, true)
+    local.set(nameBytes, 30)
+    local.set(s.body, 30 + nameBytes.length)
+    if (s.descriptor) {
+      const at = 30 + nameBytes.length + s.body.length
+      dv.setUint32(at, SIG_DESCRIPTOR, true)
+      dv.setUint32(at + 4, s.descriptor.crc, true)
+      dv.setUint32(at + 8, s.descriptor.compressed, true)
+      dv.setUint32(at + 12, s.descriptor.uncompressed, true)
+    }
+    offsets.push(offset)
+    offset += local.length
+    parts.push(local)
+  }
+
+  const centralDirOffset = offset
+  specs.forEach((s, i) => {
+    const nameBytes = enc.encode(s.name)
+    const extra = s.centralExtra ?? new Uint8Array(0)
+    const crc = s.crc ?? ((s.method ?? 0) === 0 ? crc32(s.body) : 0)
+    const central = new Uint8Array(46 + nameBytes.length + extra.length)
+    const dv = viewOf(central)
+    dv.setUint32(0, SIG_CENTRAL, true)
+    dv.setUint16(4, 20, true)
+    dv.setUint16(6, 20, true)
+    dv.setUint16(8, s.flags ?? 0, true)
+    dv.setUint16(10, s.method ?? 0, true)
+    dv.setUint16(14, 0x0021, true)
+    dv.setUint32(16, crc, true)
+    dv.setUint32(20, s.centralSizes ? s.centralSizes.compressed : s.body.length, true)
+    dv.setUint32(24, s.centralSizes ? s.centralSizes.uncompressed : s.body.length, true)
+    dv.setUint16(28, nameBytes.length, true)
+    dv.setUint16(30, extra.length, true)
+    dv.setUint32(42, s.centralOffset ?? offsets[i], true)
+    central.set(nameBytes, 46)
+    central.set(extra, 46 + nameBytes.length)
+    offset += central.length
+    parts.push(central)
+  })
+
+  const eocd = new Uint8Array(22)
+  const ev = viewOf(eocd)
+  ev.setUint32(0, SIG_EOCD, true)
+  ev.setUint16(8, specs.length, true)
+  ev.setUint16(10, specs.length, true)
+  ev.setUint32(12, offset - centralDirOffset, true)
+  ev.setUint32(16, centralDirOffset, true)
+  parts.push(eocd)
+
+  const total = parts.reduce((n, p) => n + p.length, 0)
+  const out = new Uint8Array(total)
+  let pos = 0
+  for (const p of parts) {
+    out.set(p, pos)
+    pos += p.length
+  }
+  return out
+}
+
+/** A ZIP64 extended-information extra field with an explicitly chosen size header. */
+function zip64Extra(values: bigint[], opts?: { declaredSize?: number }): Uint8Array {
+  const out = new Uint8Array(4 + values.length * 8)
+  const dv = viewOf(out)
+  dv.setUint16(0, 0x0001, true)
+  dv.setUint16(2, opts?.declaredSize ?? values.length * 8, true)
+  values.forEach((v, i) => dv.setBigUint64(4 + i * 8, v, true))
+  return out
+}
+
+/** An extra field the reader must skip over: 0x5455 "extended timestamp". */
+function timestampExtra(): Uint8Array {
+  const out = new Uint8Array(4 + 5)
+  const dv = viewOf(out)
+  dv.setUint16(0, 0x5455, true)
+  dv.setUint16(2, 5, true)
+  return out
+}
+
+function findEocd(buf: Uint8Array): number {
+  const view = viewOf(buf)
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (view.getUint32(i, true) === SIG_EOCD) return i
+  }
+  throw new Error("EOCD not found")
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0)
+  const out = new Uint8Array(total)
+  let pos = 0
+  for (const c of chunks) {
+    out.set(c, pos)
+    pos += c.length
+  }
+  return out
+}
+
+/** Emit bytes as a ReadableStream in fixed-size chunks. */
+function chunked(data: Uint8Array, chunkSize: number): ReadableStream<Uint8Array> {
+  let offset = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= data.length) {
+        controller.close()
+        return
+      }
+      const end = Math.min(offset + chunkSize, data.length)
+      controller.enqueue(data.subarray(offset, end))
+      offset = end
+    },
+  })
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZipReader — central directory integrity
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipReader — central directory integrity", () => {
+  it("rejects a directory that claims more entries than the file holds", () => {
+    // Truncated downloads keep a plausible EOCD but lose trailing records;
+    // walking off the end must be a ZipError, not a raw RangeError.
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    viewOf(buf).setUint16(findEocd(buf) + 10, 2, true)
+
+    expect(() => new ZipReader(buf)).toThrow(ZipError)
+    expect(() => new ZipReader(buf)).toThrow(/Central Directory entry extends beyond file/)
+  })
+
+  it("rejects a central-directory record with a corrupted signature", () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    const eocd = findEocd(buf)
+    const centralOffset = viewOf(buf).getUint32(eocd + 16, true)
+    viewOf(buf).setUint32(centralOffset, 0xdeadbeef, true)
+
+    expect(() => new ZipReader(buf)).toThrow(/Invalid Central Directory signature/)
+  })
+
+  it("skips directory entries when extracting everything", async () => {
+    // Zip tools record folders as zero-length entries whose name ends in
+    // "/". They are structure, not content, and must not appear as files.
+    const buf = buildZip([
+      { name: "docs/", body: new Uint8Array(0) },
+      { name: "docs/a.txt", body: enc.encode("inside") },
+    ])
+    const all = await new ZipReader(buf).extractAll()
+
+    expect([...all.keys()]).toEqual(["docs/a.txt"])
+    expect(dec.decode(all.get("docs/a.txt")!)).toBe("inside")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZipReader — ZIP64 escapes in the central directory
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipReader — ZIP64 extra field", () => {
+  /** Central record with every 32-bit field escaped to the sentinel. */
+  function escapedEntry(extra: Uint8Array): EntrySpec {
+    return {
+      name: "a.txt",
+      body: enc.encode("payload"),
+      centralSizes: { compressed: SENTINEL, uncompressed: SENTINEL },
+      centralOffset: SENTINEL,
+      centralExtra: extra,
+    }
+  }
+
+  it("walks past unrelated extra fields to find the ZIP64 record", () => {
+    // Info-ZIP writes an "extended timestamp" (0x5455) field ahead of the
+    // ZIP64 one; the reader has to skip header ids it does not know.
+    const payload = enc.encode("payload")
+    const extra = new Uint8Array(timestampExtra().length + 28)
+    extra.set(timestampExtra(), 0)
+    extra.set(
+      zip64Extra([BigInt(payload.length), BigInt(payload.length), 0n]),
+      timestampExtra().length,
+    )
+
+    const zip = new ZipReader(buildZip([escapedEntry(extra)]))
+    expect(zip.entries()).toEqual(["a.txt"])
+  })
+
+  it("rejects a ZIP64 extra field that stops mid-record", () => {
+    // Three fields are escaped but only one 64-bit value is present.
+    const buf = buildZip([escapedEntry(zip64Extra([0n]))])
+    expect(() => new ZipReader(buf)).toThrow(/Truncated ZIP64 extra field for entry: a\.txt/)
+  })
+
+  it("rejects a ZIP64 extra field whose declared size runs past the file", () => {
+    // The header claims 24 bytes of ZIP64 data but the extra field length
+    // stops at the header, so the third value would be read out of the EOCD
+    // and beyond the end of the archive.
+    const extra = zip64Extra([], { declaredSize: 24 })
+    expect(() => new ZipReader(buildZip([escapedEntry(extra)]))).toThrow(/extends beyond file/)
+  })
+
+  it("refuses a ZIP64 size larger than JavaScript can index", () => {
+    // 2^60 bytes is a valid ZIP64 value and an unusable JS array index —
+    // surfacing it as a ZipError beats silently truncating to a float.
+    const extra = zip64Extra([1n << 60n, 7n, 0n])
+    expect(() => new ZipReader(buildZip([escapedEntry(extra)]))).toThrow(
+      /exceeds the addressable range/,
+    )
+  })
+
+  it("rejects a ZIP64 locator pointing past the end of the file", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"), { compress: false })
+    const buf = await zip.build()
+    const grown = new Uint8Array(buf.length + 42)
+    grown.set(buf.subarray(0, buf.length - 22), 0)
+
+    // Locator immediately before the EOCD, pointing at a record that would
+    // start 10 bytes from the end (a ZIP64 EOCD needs 56).
+    const dv = viewOf(grown)
+    const locator = grown.length - 42
+    dv.setUint32(locator, 0x07064b50, true)
+    dv.setBigUint64(locator + 8, BigInt(grown.length - 10), true)
+    grown.set(buf.subarray(buf.length - 22), grown.length - 22)
+    dv.setUint16(grown.length - 22 + 8, 0xffff, true)
+    dv.setUint16(grown.length - 22 + 10, 0xffff, true)
+
+    expect(() => new ZipReader(grown)).toThrow(
+      /ZIP64 End of Central Directory record extends beyond file/,
+    )
+  })
+
+  it("rejects a ZIP64 EOCD record with the wrong signature", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"), { compress: false })
+    const buf = await zip.build()
+    const grown = new Uint8Array(buf.length + 98)
+    grown.set(buf.subarray(0, buf.length - 22), 0)
+
+    const dv = viewOf(grown)
+    const record = buf.length - 22
+    dv.setUint32(record, 0x06064b50 ^ 0xff, true) // corrupted record signature
+    const locator = record + 56
+    dv.setUint32(locator, 0x07064b50, true)
+    dv.setBigUint64(locator + 8, BigInt(record), true)
+    grown.set(buf.subarray(buf.length - 22), locator + 20)
+    dv.setUint16(locator + 20 + 8, 0xffff, true)
+    dv.setUint16(locator + 20 + 10, 0xffff, true)
+
+    expect(() => new ZipReader(grown)).toThrow(/Invalid ZIP64 End of Central Directory signature/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZipReader — local headers and entry bodies
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipReader — local header and body validation", () => {
+  it("rejects an entry whose local header offset lands past the end", async () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    viewOf(buf).setUint32(findEocd(buf) - 46 - 5 + 42, buf.length - 10, true)
+
+    const zip = new ZipReader(buf)
+    await expect(zip.extract("a.txt")).rejects.toThrow(/Local file header extends beyond file/)
+  })
+
+  it("rejects an entry whose local header signature is wrong", async () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    viewOf(buf).setUint32(0, 0x504b0304, true) // byte-swapped signature
+
+    const zip = new ZipReader(buf)
+    await expect(zip.extract("a.txt")).rejects.toThrow(/Invalid local file header signature/)
+  })
+
+  it("rejects a compressed size that runs past the end of the archive", async () => {
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: enc.encode("hello"),
+        centralSizes: { compressed: 4096, uncompressed: 4096 },
+      },
+    ])
+    const zip = new ZipReader(buf)
+    await expect(zip.extract("a.txt")).rejects.toThrow(
+      /Compressed data extends beyond file for entry: a\.txt/,
+    )
+  })
+
+  it("rejects a compression method it cannot decode", async () => {
+    // Method 12 is BZIP2 — legal in the spec, unsupported here.
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello"), method: 12, crc: 0 }])
+    const zip = new ZipReader(buf)
+    await expect(zip.extract("a.txt")).rejects.toThrow(
+      /Unsupported compression method 12 for entry: a\.txt/,
+    )
+  })
+
+  it("returns nothing for a DEFLATE entry declared empty on both sides", async () => {
+    // Excel writes zero-length parts as method 8 with both sizes 0 and no
+    // deflate stream at all; inflating that would throw.
+    const buf = buildZip([
+      {
+        name: "empty.xml",
+        body: new Uint8Array(0),
+        method: 8,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+      },
+    ])
+    expect(await new ZipReader(buf).extract("empty.xml")).toHaveLength(0)
+  })
+
+  it("reports a CRC-32 mismatch rather than handing back corrupt bytes", async () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello"), crc: 0x12345678 }])
+    await expect(new ZipReader(buf).extract("a.txt")).rejects.toThrow(/CRC-32 mismatch for a\.txt/)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZipReader — data descriptors (general-purpose flag bit 3)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipReader — data descriptor entries", () => {
+  const payload = enc.encode("streamed content")
+  const payloadCrc = crc32(payload)
+
+  it("falls back to the local header when the directory sizes are zero", () => {
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: payloadCrc,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+      },
+    ])
+    return expect(new ZipReader(buf).extract("a.txt").then(dec.decode.bind(dec))).resolves.toBe(
+      "streamed content",
+    )
+  })
+
+  it("scans for the data descriptor when neither header carries a size", async () => {
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+        localSizes: { compressed: 0, uncompressed: 0 },
+        descriptor: { crc: payloadCrc, compressed: payload.length, uncompressed: payload.length },
+      },
+    ])
+    expect(dec.decode(await new ZipReader(buf).extract("a.txt"))).toBe("streamed content")
+  })
+
+  it("ignores a ZIP64 sentinel in the local header instead of reading 4 GiB", async () => {
+    // A ZIP64 streaming producer writes 0xFFFFFFFF in the local size fields
+    // and the real value in the local extra field. Taking the sentinel
+    // literally would index far past the archive.
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+        localSizes: { compressed: SENTINEL, uncompressed: SENTINEL },
+        descriptor: { crc: payloadCrc, compressed: payload.length, uncompressed: payload.length },
+      },
+    ])
+    expect(dec.decode(await new ZipReader(buf).extract("a.txt"))).toBe("streamed content")
+  })
+
+  it("yields an empty entry when no descriptor can be located", async () => {
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+        localSizes: { compressed: 0, uncompressed: 0 },
+      },
+    ])
+    expect(await new ZipReader(buf).extract("a.txt")).toHaveLength(0)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZipReader — extractStream
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipReader — extractStream", () => {
+  it("throws for an entry that is not in the archive", () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    expect(() => new ZipReader(buf).extractStream("missing.txt")).toThrow(
+      /Entry not found: missing\.txt/,
+    )
+  })
+
+  it("streams a stored entry verbatim", async () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("stored bytes") }])
+    const out = await collect(new ZipReader(buf).extractStream("a.txt"))
+    expect(dec.decode(out)).toBe("stored bytes")
+  })
+
+  it("streams a DEFLATE entry that declares no uncompressed size", async () => {
+    // Without a declared size the stream is bounded only by the absolute
+    // decompression cap.
+    const body = deflate(enc.encode("compressed payload ".repeat(20)))
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body,
+        method: 8,
+        crc: 0,
+        centralSizes: { compressed: body.length, uncompressed: 0 },
+      },
+    ])
+    const out = await collect(new ZipReader(buf).extractStream("a.txt"))
+    expect(dec.decode(out)).toBe("compressed payload ".repeat(20))
+  })
+
+  it("streams nothing for a DEFLATE entry declared empty", async () => {
+    const buf = buildZip([
+      {
+        name: "empty.xml",
+        body: new Uint8Array(0),
+        method: 8,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+      },
+    ])
+    expect(await collect(new ZipReader(buf).extractStream("empty.xml"))).toHaveLength(0)
+  })
+
+  it("recovers the size from the local header for a data-descriptor entry", async () => {
+    const payload = enc.encode("descriptor streamed")
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: crc32(payload),
+        centralSizes: { compressed: 0, uncompressed: 0 },
+      },
+    ])
+    const out = await collect(new ZipReader(buf).extractStream("a.txt"))
+    expect(dec.decode(out)).toBe("descriptor streamed")
+  })
+
+  it("scans for the data descriptor when neither header carries a size", async () => {
+    const payload = enc.encode("descriptor streamed")
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+        localSizes: { compressed: 0, uncompressed: 0 },
+        descriptor: {
+          crc: crc32(payload),
+          compressed: payload.length,
+          uncompressed: payload.length,
+        },
+      },
+    ])
+    const out = await collect(new ZipReader(buf).extractStream("a.txt"))
+    expect(dec.decode(out)).toBe("descriptor streamed")
+  })
+
+  it("rejects a local header that extends past the end of the archive", () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    viewOf(buf).setUint32(findEocd(buf) - 46 - 5 + 42, buf.length - 10, true)
+    expect(() => new ZipReader(buf).extractStream("a.txt")).toThrow(
+      /Local file header extends beyond file/,
+    )
+  })
+
+  it("rejects a wrong local header signature", () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello") }])
+    viewOf(buf).setUint32(0, 0x504b0304, true)
+    expect(() => new ZipReader(buf).extractStream("a.txt")).toThrow(
+      /Invalid local file header signature/,
+    )
+  })
+
+  it("rejects a compressed size that runs past the end of the archive", () => {
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: enc.encode("hello"),
+        centralSizes: { compressed: 4096, uncompressed: 5 },
+      },
+    ])
+    expect(() => new ZipReader(buf).extractStream("a.txt")).toThrow(
+      /Compressed data extends beyond file for entry: a\.txt/,
+    )
+  })
+
+  it("rejects a compression method it cannot decode", () => {
+    const buf = buildZip([{ name: "a.txt", body: enc.encode("hello"), method: 12, crc: 0 }])
+    expect(() => new ZipReader(buf).extractStream("a.txt")).toThrow(
+      /Unsupported compression method 12 for entry: a\.txt/,
+    )
+  })
+
+  // BUG (reported): src/zip/reader.ts:490 adopts the local compressed size
+  // without the ZIP64-sentinel guard that its buffered twin applies at
+  // src/zip/reader.ts:408. The same entry therefore extracts fine through
+  // `extract()` (see "ignores a ZIP64 sentinel in the local header…" above)
+  // but throws "Compressed data extends beyond file" through
+  // `extractStream()`, because 0xFFFFFFFF is taken as a real length.
+  it.skip("ignores a ZIP64 sentinel in the local header when streaming", async () => {
+    const payload = enc.encode("streamed content")
+    const buf = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: 0,
+        centralSizes: { compressed: 0, uncompressed: 0 },
+        localSizes: { compressed: SENTINEL, uncompressed: SENTINEL },
+        descriptor: {
+          crc: crc32(payload),
+          compressed: payload.length,
+          uncompressed: payload.length,
+        },
+      },
+    ])
+    const out = await collect(new ZipReader(buf).extractStream("a.txt"))
+    expect(dec.decode(out)).toBe("streamed content")
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Pure-TypeScript inflate/deflate
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("inflate — malformed streams", () => {
+  it("rejects a reserved DEFLATE block type", () => {
+    // BFINAL=1, BTYPE=11 (reserved) packed into one byte.
+    expect(() => inflate(new Uint8Array([0b111]))).toThrow(/Invalid DEFLATE block type: 3/)
+  })
+
+  it("rejects a stream that ends before the block header", () => {
+    expect(() => inflate(new Uint8Array(0))).toThrow(/Unexpected end of DEFLATE data/)
+  })
+
+  it("rejects a stored block whose payload is truncated", () => {
+    // BFINAL=1 BTYPE=00, LEN=8, NLEN, then only 2 of the 8 bytes.
+    const data = new Uint8Array([0x01, 0x08, 0x00, 0xf7, 0xff, 0x41, 0x42])
+    expect(() => inflate(data)).toThrow(/Unexpected end of DEFLATE data/)
+  })
+
+  it("refuses to expand past the caller's byte ceiling", () => {
+    const compressed = deflate(new Uint8Array(4096))
+    expect(() => inflate(compressed, 64)).toThrow(ZipError)
+    expect(() => inflate(compressed, 64)).toThrow(/possible zip bomb/)
+  })
+})
+
+describe("deflate — output buffer growth", () => {
+  it("round-trips incompressible data larger than its initial buffer", () => {
+    // Fixed-Huffman literals cost ~9 bits/byte, so random input of this size
+    // overflows the `length + 512` output buffer and forces a re-allocation.
+    let seed = 0x2545f491
+    const data = new Uint8Array(16384).map(() => {
+      seed = (seed * 1664525 + 1013904223) >>> 0
+      return (seed >>> 24) & 0xff
+    })
+    expect([...inflate(deflate(data))]).toEqual([...data])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZipStreamReader — local-header streaming
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ZipStreamReader — entry sequencing", () => {
+  async function zipBytes(): Promise<Uint8Array> {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("first entry"), { compress: false })
+    zip.add("b.txt", enc.encode("second entry ".repeat(40)))
+    return zip.build()
+  }
+
+  it("refuses to advance while the previous body is unread", async () => {
+    const reader = new ZipStreamReader(chunked(await zipBytes(), 64))
+    await reader.nextEntry()
+    await expect(reader.nextEntry()).rejects.toThrow(/previous entry body not consumed/)
+    await reader.close()
+  })
+
+  it("refuses to read the same body twice", async () => {
+    const reader = new ZipStreamReader(chunked(await zipBytes(), 64))
+    const entry = (await reader.nextEntry())!
+    await reader.readEntryBytes(entry)
+    await expect(reader.readEntryBytes(entry)).rejects.toThrow(/entry body already consumed/)
+    expect(() => reader.entryStream(entry)).toThrow(/entry body already consumed/)
+    await reader.close()
+  })
+
+  it("skipEntry is a no-op once the body has been consumed", async () => {
+    const reader = new ZipStreamReader(chunked(await zipBytes(), 64))
+    const entry = (await reader.nextEntry())!
+    await reader.readEntryBytes(entry)
+    await expect(reader.skipEntry()).resolves.toBeUndefined()
+    await reader.close()
+  })
+
+  it("reassembles headers split across single-byte chunks", async () => {
+    // Every field of the local header lands on a chunk boundary here, which
+    // is the whole point of the leftover buffer.
+    const reader = new ZipStreamReader(chunked(await zipBytes(), 1))
+    const a = (await reader.nextEntry())!
+    expect(a.name).toBe("a.txt")
+    expect(dec.decode(await reader.readEntryBytes(a))).toBe("first entry")
+    const b = (await reader.nextEntry())!
+    expect(dec.decode(await reader.readEntryBytes(b))).toBe("second entry ".repeat(40))
+    expect(await reader.nextEntry()).toBeNull()
+    await reader.close()
+  })
+
+  it("returns null when the source ends exactly at an entry boundary", async () => {
+    // A ZIP truncated right after the last entry body has no central
+    // directory left to signal the end — running out of bytes must do it.
+    const full = await zipBytes()
+    const view = viewOf(full)
+    let centralStart = 0
+    for (let i = 0; i < full.length - 4; i++) {
+      if (view.getUint32(i, true) === SIG_CENTRAL) {
+        centralStart = i
+        break
+      }
+    }
+    const reader = new ZipStreamReader(chunked(full.subarray(0, centralStart), 64))
+    for (;;) {
+      const entry = await reader.nextEntry()
+      if (!entry) break
+      await reader.skipEntry()
+    }
+    await reader.close()
+  })
+
+  it("reads and streams an entry with an empty body", async () => {
+    const zip = new ZipWriter()
+    zip.add("empty.txt", new Uint8Array(0))
+    const bytes = await zip.build()
+
+    const buffered = new ZipStreamReader(chunked(bytes, 16))
+    const entry = (await buffered.nextEntry())!
+    expect(entry.compressedSize).toBe(0)
+    expect(await buffered.readEntryBytes(entry)).toHaveLength(0)
+    await buffered.close()
+
+    const streamed = new ZipStreamReader(chunked(bytes, 16))
+    const entry2 = (await streamed.nextEntry())!
+    expect(await collect(streamed.entryStream(entry2))).toHaveLength(0)
+    await streamed.close()
+  })
+
+  it("marks an entry with an extra field and a data descriptor unstreamable", async () => {
+    // Streaming writers set flag bit 3 and defer the sizes; the local header
+    // alone is then not enough to find the body's end.
+    const payload = enc.encode("streamed")
+    const bytes = buildZip([
+      {
+        name: "a.txt",
+        body: payload,
+        flags: 0x08,
+        crc: 0,
+        localSizes: { compressed: 0, uncompressed: 0 },
+        descriptor: {
+          crc: crc32(payload),
+          compressed: payload.length,
+          uncompressed: payload.length,
+        },
+      },
+    ])
+    const reader = new ZipStreamReader(chunked(bytes, 8))
+    const entry = (await reader.nextEntry())!
+    expect(entry.streamable).toBe(false)
+    await reader.close()
+  })
+
+  it("streams a stored entry without decompressing it", async () => {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("raw bytes"), { compress: false })
+    const reader = new ZipStreamReader(chunked(await zip.build(), 4))
+    const entry = (await reader.nextEntry())!
+    expect(entry.compressionMethod).toBe(0)
+    expect(dec.decode(await collect(reader.entryStream(entry)))).toBe("raw bytes")
+    await reader.close()
+  })
+})
+
+describe("ZipStreamReader — truncated sources", () => {
+  async function truncatedAfter(bytes: number): Promise<Uint8Array> {
+    const zip = new ZipWriter()
+    zip.add("some/long/path/name.txt", enc.encode("body bytes here"), { compress: false })
+    return (await zip.build()).subarray(0, bytes)
+  }
+
+  it("reports a local file header cut short", async () => {
+    const reader = new ZipStreamReader(chunked(await truncatedAfter(12), 4))
+    await expect(reader.nextEntry()).rejects.toThrow(/truncated local file header/)
+    await reader.close()
+  })
+
+  it("reports an entry name cut short", async () => {
+    const reader = new ZipStreamReader(chunked(await truncatedAfter(36), 4))
+    await expect(reader.nextEntry()).rejects.toThrow(/truncated entry name/)
+    await reader.close()
+  })
+
+  it("reports an extra field cut short", async () => {
+    // Rewrite the header to declare a 16-byte extra field, then cut the file
+    // where the name ends.
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("body"), { compress: false })
+    const full = await zip.build()
+    viewOf(full).setUint16(28, 16, true)
+    const reader = new ZipStreamReader(chunked(full.subarray(0, 35), 4))
+    await expect(reader.nextEntry()).rejects.toThrow(/truncated extra field/)
+    await reader.close()
+  })
+
+  it("reports a body cut short while skipping", async () => {
+    const reader = new ZipStreamReader(chunked(await truncatedAfter(60), 8))
+    const entry = (await reader.nextEntry())!
+    await expect(reader.skipEntry()).rejects.toThrow(/truncated entry body/)
+    await reader.close()
+    expect(entry.name).toBe("some/long/path/name.txt")
+  })
+
+  it("reports a body cut short while buffering", async () => {
+    const reader = new ZipStreamReader(chunked(await truncatedAfter(60), 8))
+    const entry = (await reader.nextEntry())!
+    await expect(reader.readEntryBytes(entry)).rejects.toThrow(/truncated entry body/)
+    await reader.close()
+  })
+
+  it("errors the entry stream when the body is cut short", async () => {
+    const reader = new ZipStreamReader(chunked(await truncatedAfter(60), 8))
+    const entry = (await reader.nextEntry())!
+    await expect(collect(reader.entryStream(entry))).rejects.toThrow(/truncated entry body/)
+    await reader.close()
+  })
+})
+
+describe("ZipStreamReader — drainToBuffer", () => {
+  async function zipBytes(): Promise<Uint8Array> {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode("hello"), { compress: false })
+    zip.add("b.txt", enc.encode("world"), { compress: false })
+    return zip.build()
+  }
+
+  it("reconstructs the whole archive after inspecting the first header", async () => {
+    const bytes = await zipBytes()
+    const reader = new ZipStreamReader(chunked(bytes, 7))
+    await reader.nextEntry()
+    const drained = await reader.drainToBuffer()
+
+    expect([...drained]).toEqual([...bytes])
+    expect(new ZipReader(drained).entries()).toEqual(["a.txt", "b.txt"])
+  })
+
+  it("falls back to the default ceiling for a non-positive limit", async () => {
+    const bytes = await zipBytes()
+    const reader = new ZipStreamReader(chunked(bytes, 7))
+    await reader.nextEntry()
+    expect((await reader.drainToBuffer(0)).length).toBe(bytes.length)
+  })
+
+  it("refuses to buffer more than the ceiling allows", async () => {
+    const reader = new ZipStreamReader(chunked(await zipBytes(), 7))
+    await reader.nextEntry()
+    await expect(reader.drainToBuffer(8)).rejects.toBeInstanceOf(ParseError)
+    await reader.close()
+  })
+
+  it("refuses to fall back once streaming has started", async () => {
+    const reader = new ZipStreamReader(chunked(await zipBytes(), 7))
+    const entry = (await reader.nextEntry())!
+    await collect(reader.entryStream(entry))
+    await expect(reader.drainToBuffer()).rejects.toThrow(/cannot fall back after streaming started/)
+    await reader.close()
+  })
+})
+
+describe("ZipStreamReader — DEFLATE bodies", () => {
+  async function deflatedZip(text: string): Promise<Uint8Array> {
+    const zip = new ZipWriter()
+    zip.add("a.txt", enc.encode(text))
+    return zip.build()
+  }
+
+  it("inflates a buffered body whose header declares no uncompressed size", async () => {
+    const text = "repeated payload ".repeat(60)
+    const bytes = await deflatedZip(text)
+    // Zero out the local header's uncompressed size, as a streaming writer
+    // that defers sizes would.
+    viewOf(bytes).setUint32(22, 0, true)
+
+    const reader = new ZipStreamReader(chunked(bytes, 64))
+    const entry = (await reader.nextEntry())!
+    expect(entry.compressionMethod).toBe(8)
+    expect(dec.decode(await reader.readEntryBytes(entry))).toBe(text)
+    await reader.close()
+  })
+
+  it("streams a body whose header declares no uncompressed size", async () => {
+    const text = "repeated payload ".repeat(60)
+    const bytes = await deflatedZip(text)
+    viewOf(bytes).setUint32(22, 0, true)
+
+    const reader = new ZipStreamReader(chunked(bytes, 64))
+    const entry = (await reader.nextEntry())!
+    expect(dec.decode(await collect(reader.entryStream(entry)))).toBe(text)
+    await reader.close()
+  })
+})


### PR DESCRIPTION
Definition-of-done item 6 from #352: *branch coverage above 90%, no module below 80%*. Tests only — no `src/` change.

| | before | after |
| --- | ---: | ---: |
| Statements | 92.47% | **99.07%** |
| Branches | **85.53%** | **97.24%** |
| Functions | 95.21% | 98.75% |
| Lines | 94.54% | 99.27% |

**Modules under 80% branches: 27 → 0.** The lowest are now `image.ts` 83.3% (a browser `atob` fallback), `xlsx/hyperlink.ts` 87.5%, `crypto/cfb.ts` 88.4%.

16 new suites, ~1,180 tests. Full suite **9,260 passing, 15 skipped**.

## Eight bugs, 15 skipped tests

The skips are deliberate: each marks a defect with a test that documents it. **I re-verified the highest-impact ones independently** before writing this.

**1. A malformed `.xls` hangs the process forever.** `BlockStream.skip()` loops `while (left > 0)`; once blocks run out, `remainingInBlock()` returns 0, so `take` is 0 and `left` never decreases. `readSstString` feeds it two untrusted values — `cRun * 4` (u16) and `cbExt` (**u32**). `readXls`'s try/catch cannot stop a live lock. This is the same class as #355 and #368, in a reader those never reached. Its test stays skipped because un-skipping hangs the suite.

**2. `_format.ts` — seven number-format defects.** Verified directly against Excel's behaviour:

| input | format | hucre | Excel |
| --- | --- | --- | --- |
| `-42` | `0.00;-0.00` | `"42.00"` | `-42.00` |
| `1234567` | `#,##0,` | `"1,234,567"` | `1,235` |
| `123456789` | `000-00-0000` | `"123456789"` | `123-45-6789` |
| `5551234567` | `(000) 000-0000` | `"(5551234567"` | `(555) 123-4567` |
| `2.5` | `? ?/?` | `"1/2"` | `2 1/2` |
| `-0.5` | `# ?/?` | `"1/2"` | `-1/2` |

The first one **silently drops the minus sign** — the negative section replaces the value with its absolute value, so the literal `-` is folded into the core pattern and never emitted. The SSN and phone rows are Excel's built-in Special formats.

**3. Excel locale tags read as currency symbols in the ODS writer.** `detectCurrencySymbol` correctly rejects `[$-409]`, then a fallback scans the *whole* code for `[$€£¥₺₽₹]` and finds the `$` inside the locale tag. Verified end to end: Excel's built-in **long date** `[$-F800]dddd, mmmm dd, yyyy` emits

```xml
<number:currency-style><number:currency-symbol>$</number:currency-symbol>
  <number:number number:decimal-places="0"/></number:currency-style>
```

Every date token gone. This fires on ordinary XLSX→ODS conversion.

**4. Root-level parts never find their `_rels`.** `wsPath.slice(dirname(wsPath).length + 1)` eats the first character when `dirname` returns `""`: `sheet1.xml` looks for `_rels/heet1.xml.rels`. The sibling helper `relsPathFor()` handles the no-slash case correctly, so this is an oversight. For a root-level worksheet, hyperlinks, comments, tables, drawings, pivots, slicers and the background image all silently vanish.

**5. `sortRows(…, "desc")` floats blanks to the top.** Verified: `[[1],[],[3],[2]]` → asc `[[1],[2],[3],[]]` (correct), desc `[[],[3],[2],[1]]`. The desc path negates the *whole* comparison instead of only the value comparison. The method's own JSDoc says "nulls last" unconditionally, and Excel always sinks blanks.

**6. ODS streaming folds annotations into cell values.** `case "p"` matches `<text:p>` inside `<office:annotation>`; the batch reader takes only direct children. A cell with annotation "a note" and text "value" reads as `"value"` batch, `"a notevalue"` streaming — breaking the parity contract `test/ods-stream-parity.test.ts` exists to enforce.

**7. ODS drops `sheet.cells` overrides on trailing empty cells.** `rows: [[1, null, null]]` with `cells {"0,2": {formula: "NOW()"}}` never reaches `content.xml`. The XLSX writer grows the grid for exactly this case, so one `WriteSheet` yields different documents per format.

**8. `extractStream()` is missing the ZIP64-sentinel guard its buffered twin has.** For a data-descriptor entry with local sizes `0xFFFFFFFF` — what a ZIP64 streaming producer writes — `extract()` succeeds and `extractStream()` throws.

Each is filed as its own issue; the skipped tests un-skip with the fixes.

## What was deliberately left uncovered

An honest 97% beats a padded 99%. The recurring one is the `child.local || child.tag` fallback in ~40 places: `splitTagName` always sets a non-empty `local` for a non-empty tag, so the `|| tag` arm is dead.

Others: guards already implied by their only caller; dead arms after an earlier normalisation; a `TextDecoder` BOM guard that can never fire because the decoder strips it first; a `never` exhaustiveness guard; a scheduler race not deterministically forceable. The two `DecompressionStream` fallbacks are memoised at first use and would need a global stubbed before module load — not worth the fragility.

One stub was accepted: `csv/fetch.ts`'s `!response.ok` branch, because no URL scheme Node's fetch accepts yields a non-2xx `Response` without a live peer. It clears the last sub-80% module and pins the documented error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
