### PR TITLE
fix: six defects found by the coverage pass — closes #389 #390 #391 #392

### DIFF
--- a/src/ods/stream.ts
+++ b/src/ods/stream.ts
@@ -62,6 +62,7 @@ function* parseContentRows(xml: string): Generator<StreamRow, void, undefined> {
   let inRow = false
   let inCell = false
   let inP = false
+  let inAnnotation = false
 
   let sheetIndex = -1
   let currentRowIndex = -1
@@ -128,8 +129,16 @@ function* parseContentRows(xml: string): Generator<StreamRow, void, undefined> {
             }
           }
           break
+        case "annotation":
+          // A cell comment carries its own <text:p>. The batch reader
+          // takes only direct children of the cell, so folding the
+          // annotation into the value made the two readers disagree —
+          // the divergence test/ods-stream-parity.test.ts exists to
+          // catch. See #393.
+          inAnnotation = true
+          break
         case "p":
-          if (inCell) inP = true
+          if (inCell && !inAnnotation) inP = true
           break
         // Text content special elements — mirror collectText() in reader.ts so
         // the streaming and batch readers return the same string for a cell.
@@ -162,6 +171,9 @@ function* parseContentRows(xml: string): Generator<StreamRow, void, undefined> {
       const local = tag.includes(":") ? tag.slice(tag.indexOf(":") + 1) : tag
 
       switch (local) {
+        case "annotation":
+          inAnnotation = false
+          break
         case "p":
           inP = false
           break

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -116,11 +116,14 @@ function detectCurrencySymbol(code: string): string | undefined {
   // "$" or "€" etc. as a quoted literal
   const quoted = code.match(/"([^"]+)"/)
   if (quoted && /[$€£¥₺₽₹]/.test(quoted[1])) return quoted[1]
-  // Bare $ at the start
-  if (code.startsWith("$") || /[$€£¥₺₽₹]/.test(code)) {
-    const m = code.match(/[$€£¥₺₽₹]/)
-    if (m) return m[0]
-  }
+  // Bare $ or another symbol, outside any bracketed section. Excel's
+  // built-in date and time formats carry a locale tag like [$-F800], and
+  // scanning the whole code found the `$` inside it — so the long-date
+  // format became a currency style and every date token was lost. See
+  // #390.
+  const outsideBrackets = code.replace(/\[[^\]]*\]/g, "")
+  const bare = outsideBrackets.match(/[$€£¥₺₽₹]/)
+  if (bare) return bare[0]
   return undefined
 }
 
@@ -291,7 +294,16 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
 
   // Take only the first section (before `;`); negative/zero sections are
   // ODS' `<style:map>` territory and outside this writer's scope.
-  const firstSection = trimmed.split(";")[0]
+  //
+  // Excel's built-in date and time codes carry a locale prefix —
+  // `[$-409]mmm-yy`, `[$-F800]dddd, mmmm dd, yyyy`. It is a hint about
+  // which locale's month and day names to use, not content, and ODF
+  // expresses that through the style's language attributes rather than
+  // inline. Left in place it was serialized character by character as
+  // <number:text>, so the code round-tripped as `"["$"-"4""0""9""]"mmm-yy`.
+  // A currency symbol written as `[$€-407]` keeps its symbol, because
+  // detectCurrencySymbol reads that form before we get here. See #390.
+  const firstSection = trimmed.split(";")[0]!.replace(/\[\$-[^\]]*\]/g, "")
 
   if (isPercentageFormat(firstSection)) {
     const decimals = decimalsFromCode(firstSection)
@@ -633,10 +645,15 @@ function rowToOds(
   ) {
     lastMeaningful--
   }
-  // Also consider merge starts and covered cells beyond data
+  // Also consider merge starts, covered cells, and per-cell overrides
+  // beyond the last data value. An override carries a formula, a style or
+  // a comment that the row array cannot express, so stopping at the last
+  // non-null value dropped it silently — and the XLSX writer grows its
+  // grid for exactly this case, so one WriteSheet produced different
+  // documents per format. See #393.
   for (let c = lastMeaningful + 1; c <= effectiveMax; c++) {
     const key = `${rowIndex},${c}`
-    if (mergeMap.starts.has(key) || mergeMap.covered.has(key)) {
+    if (mergeMap.starts.has(key) || mergeMap.covered.has(key) || sheet.cells?.has(key)) {
       lastMeaningful = c
     }
   }
@@ -665,10 +682,15 @@ function rowToOds(
       continue
     }
 
-    const cell = i < row.length ? row[i] : null
-
-    // Get cell override for formulas, hyperlinks, styles
+    // Get cell override for values, formulas, hyperlinks, styles
     const cellOverride = sheet.cells?.get(key)
+
+    // The override's value wins, matching resolveRows in the XLSX writer.
+    // Reading only from `row` meant an override past the row's last value
+    // serialized as an empty cell even once the grid had been grown to
+    // reach it. See #393.
+    const cell =
+      cellOverride?.value !== undefined ? cellOverride.value : i < row.length ? row[i] : null
 
     // Build cell context
     const ctx: CellContext = {}
@@ -753,6 +775,24 @@ function writeContentXml(options: WriteOptions): string {
       for (const item of sheet.data) {
         const row = keys.map((k) => (k in item ? unwrapCellValue(item[k]) : null))
         rows.push(row)
+      }
+    }
+
+    // Grow the grid to reach any per-cell override that sits past the
+    // last row. The row loop below iterates `rows`, so an override at a
+    // higher row index was never visited — the row-wise half of the same
+    // defect as the trailing-column case in serializeRow. See #393.
+    if (sheet.cells && sheet.cells.size > 0) {
+      let maxOverrideRow = -1
+      for (const key of sheet.cells.keys()) {
+        const comma = key.indexOf(",")
+        if (comma === -1) continue
+        const r = Number(key.slice(0, comma))
+        if (Number.isInteger(r) && r > maxOverrideRow) maxOverrideRow = r
+      }
+      if (maxOverrideRow >= rows.length) {
+        if (rows === sheet.rows) rows = [...rows]
+        while (rows.length <= maxOverrideRow) rows.push([])
       }
     }
 

--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -1266,8 +1266,7 @@ export function sortRows(sheet: Sheet, colIndex: number, order?: "asc" | "desc")
     tagged.sort((a, b) => {
       const va = colIndex < a.row.length ? (a.row[colIndex] ?? null) : null
       const vb = colIndex < b.row.length ? (b.row[colIndex] ?? null) : null
-      const cmp = compareCellValues(va, vb)
-      return desc ? -cmp : cmp
+      return compareCellValues(va, vb, desc)
     })
 
     const oldToNew = new Map<number, number>()
@@ -1293,8 +1292,7 @@ export function sortRows(sheet: Sheet, colIndex: number, order?: "asc" | "desc")
   sheet.rows.sort((a, b) => {
     const va = colIndex < a.length ? (a[colIndex] ?? null) : null
     const vb = colIndex < b.length ? (b[colIndex] ?? null) : null
-    const cmp = compareCellValues(va, vb)
-    return desc ? -cmp : cmp
+    return compareCellValues(va, vb, desc)
   })
 }
 
@@ -1310,12 +1308,24 @@ function syncCellOverride(sheet: Sheet, row: number, col: number, value: CellVal
 }
 
 /** Compare two cell values for sorting: nulls last, numbers < strings < booleans. */
-function compareCellValues(a: CellValue, b: CellValue): number {
-  // Nulls last
+/**
+ * Compare two cell values for {@link sortRows}.
+ *
+ * `desc` is applied to the *value* comparison only. Negating the whole
+ * result flipped the null rule with it, so descending floated blanks to
+ * the top — against this function's own contract and against Excel,
+ * which sinks blanks in both directions. See #392.
+ */
+function compareCellValues(a: CellValue, b: CellValue, desc = false): number {
+  // Nulls last, regardless of direction
   if (a === null && b === null) return 0
   if (a === null) return 1
   if (b === null) return -1
 
+  return desc ? -compareNonNull(a, b) : compareNonNull(a, b)
+}
+
+function compareNonNull(a: CellValue, b: CellValue): number {
   const ta = typeRank(a)
   const tb = typeRank(b)
   if (ta !== tb) return ta - tb

--- a/src/xls/biff.ts
+++ b/src/xls/biff.ts
@@ -4,6 +4,8 @@
 // data (each record body is ≤ 8224 bytes; longer data overflows into
 // CONTINUE records). See [MS-XLS].
 
+import { ParseError } from "../errors"
+
 export interface BiffRecord {
   /** Record id (sid). */
   id: number
@@ -169,6 +171,16 @@ class BlockStream {
     while (left > 0) {
       this.ensure()
       const take = Math.min(left, this.remainingInBlock())
+      // Once the blocks are exhausted, remainingInBlock() returns 0 and
+      // `left` would never decrease — a live lock no try/catch can
+      // interrupt. The callers feed this untrusted lengths (`cRun * 4`
+      // from a u16, `cbExt` from a u32), so a file claiming more
+      // trailer bytes than it carries used to hang the process. See #389.
+      if (take === 0) {
+        throw new ParseError(
+          `Invalid XLS: string record claims ${n} trailing bytes but the stream ends after ${n - left}`,
+        )
+      }
       this.pos += take
       left -= take
     }

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -364,10 +364,13 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       throw new ParseError(`Invalid XLSX: missing worksheet file for sheet "${info.name}"`)
     }
 
-    // Check for worksheet-level relationships (hyperlinks, etc.)
+    // Check for worksheet-level relationships (hyperlinks, etc.).
+    // relsPathFor handles a root-level part; the hand-rolled slice here
+    // ate the first character when dirname returned "", so sheet1.xml
+    // looked for _rels/heet1.xml.rels and every relationship-reached
+    // feature silently vanished. See #391.
     const wsDir = dirname(wsPath)
-    const wsFileName = wsPath.slice(wsDir.length + 1)
-    const wsRelsPath = wsDir ? `${wsDir}/_rels/${wsFileName}.rels` : `_rels/${wsFileName}.rels`
+    const wsRelsPath = relsPathFor(wsPath)
     let worksheetRels: Relationship[] | undefined
     if (zip.has(wsRelsPath)) {
       const wsRelsXml = decodeUtf8(await zip.extract(wsRelsPath))
@@ -742,12 +745,11 @@ async function extractSheetDrawing(
 
   const drawingXml = decodeUtf8(await zip.extract(drawingPath))
 
-  // Parse drawing relationships
+  // Parse drawing relationships. Same fix as the worksheet path — the
+  // hand-rolled slice dropped the first character for a root-level
+  // drawing. See #391.
   const drawDir = dirname(drawingPath)
-  const drawFileName = drawingPath.slice(drawDir.length + 1)
-  const drawRelsPath = drawDir
-    ? `${drawDir}/_rels/${drawFileName}.rels`
-    : `_rels/${drawFileName}.rels`
+  const drawRelsPath = relsPathFor(drawingPath)
 
   const imageRelMap = new Map<string, string>()
   // Chart relationships are resolved by the same .rels file. We collect

--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -486,8 +486,13 @@ export class ZipReader {
     let { compressedSize } = entry
 
     if (entry.hasDataDescriptor && compressedSize === 0) {
+      // Same sentinel guard as extractEntry: 0xFFFFFFFF means the real
+      // size lives in the ZIP64 extra field, so taking it literally
+      // reads 4 GiB past the entry. A ZIP64 streaming producer writes
+      // exactly this, and without the check extract() succeeded while
+      // extractStream() threw. See #393.
       const localCompressedSize = this.view.getUint32(pos + 18, true)
-      if (localCompressedSize > 0) {
+      if (localCompressedSize > 0 && localCompressedSize !== ZIP64_SENTINEL) {
         compressedSize = localCompressedSize
       }
       if (compressedSize === 0) {

--- a/test/coverage-binary-formats.test.ts
+++ b/test/coverage-binary-formats.test.ts
@@ -402,20 +402,25 @@ describe("parseSst — rich, phonetic, wide and continued strings", () => {
 
   // BUG (reported): BlockStream.skip in src/xls/biff.ts:166-175 spins
   // forever once every block is exhausted — `ensure()` cannot advance past
-  // the last block, `remainingInBlock()` then returns 0 (biff.ts:131), and
-  // `left` never decreases. readSstString reaches it with an untrusted cRun
-  // (biff.ts:222) or cbExt (biff.ts:223), so an .xls whose rich-run count
-  // overruns the record hangs the process. Un-skipping this test hangs the
-  // suite; the wrapping try/catch in readXls cannot help with a live lock.
-  it.skip("does not hang on a rich-run count that overruns the record", async () => {
-    const rich = [...u16(1), 0x08, ...u16(0xffff), ...chars("A")]
-    const sst = record(SID.SST, [...u32(1), ...u32(1), ...rich])
-    const data = xlsFile({
-      globals: [...xf(0), ...sst],
-      sheets: [{ name: "S", records: [...bof(0x0010), ...eof()] }],
-    })
-    await expect(readXls(data)).rejects.toThrow()
-  })
+  // the last block, `remainingInBlock()` then returned 0 and `left` never
+  // decreased. readSstString reaches skip() with an untrusted cRun (a u16)
+  // or cbExt (a u32), so an .xls claiming more trailer bytes than it
+  // carries used to hang the process — a live lock readXls's try/catch
+  // could not interrupt. Fixed in #389; the timeout keeps a regression a
+  // failure rather than a hung CI job.
+  it(
+    "does not hang on a rich-run count that overruns the record",
+    { timeout: 15_000 },
+    async () => {
+      const rich = [...u16(1), 0x08, ...u16(0xffff), ...chars("A")]
+      const sst = record(SID.SST, [...u32(1), ...u32(1), ...rich])
+      const data = xlsFile({
+        globals: [...xf(0), ...sst],
+        sheets: [{ name: "S", records: [...bof(0x0010), ...eof()] }],
+      })
+      await expect(readXls(data)).rejects.toThrow()
+    },
+  )
 })
 
 // ═══════════════════════════════════════════════════════════════════════

--- a/test/coverage-ods-branches.test.ts
+++ b/test/coverage-ods-branches.test.ts
@@ -956,7 +956,7 @@ describe("streamOdsRows — cell shapes", () => {
   })
 
   // ── Known defect ─────────────────────────────────────────────────
-  it.skip("does not fold a cell annotation into the cell value (BUG)", async () => {
+  it("does not fold a cell annotation into the cell value", async () => {
     // src/ods/stream.ts:131 sets `inP` for *any* <text:p> seen while inside
     // a <table:table-cell>, including the paragraphs of the
     // <office:annotation> LibreOffice writes as the cell's first child for
@@ -1183,7 +1183,7 @@ describe("ODS writer — date format code round-trips", () => {
   })
 
   // ── Known defect ─────────────────────────────────────────────────
-  it.skip("treats [$-409] as a locale tag, not a currency symbol (BUG)", async () => {
+  it("treats [$-409] as a locale tag, not a currency symbol", async () => {
     // src/ods/writer.ts:120 — detectCurrencySymbol() falls through to a bare
     // /[$€£¥₺₽₹]/ scan of the whole code. Excel's locale prefix `[$-409]`
     // (and `[$-F800]`, used by the built-in long-date format) contains a "$",
@@ -1263,7 +1263,7 @@ describe("ODS writer — columns + data", () => {
   })
 
   // ── Known defect ─────────────────────────────────────────────────
-  it.skip("writes a cells override that sits on a trailing empty cell (BUG)", async () => {
+  it("writes a cells override that sits on a trailing empty cell", async () => {
     // src/ods/writer.ts:629-642 computes `lastMeaningful` from the row's own
     // values and then extends it only for merge starts and covered cells —
     // never for `sheet.cells`. Any override whose column is at or past the
@@ -1280,11 +1280,20 @@ describe("ODS writer — columns + data", () => {
     const cells = new Map<string, Partial<Cell>>()
     cells.set("0,2", { value: null, formula: "NOW()" })
     cells.set("2,0", { value: "z" })
-    const wb = await readOds(
-      await writeOds({ sheets: [{ name: "S", rows: [[1, null, null]], cells }] }),
-    )
+    const data = await writeOds({ sheets: [{ name: "S", rows: [[1, null, null]], cells }] })
+
+    // The column-wise override round-trips.
+    const wb = await readOds(data)
     expect(wb.sheets[0]!.cells?.get("0,2")?.formula).toBe("NOW()")
-    expect(wb.sheets[0]!.rows[2]).toEqual(["z"])
+
+    // The row-wise one is asserted on the emitted XML rather than the
+    // round-trip, because the reader collapses an *interior* empty row
+    // instead of preserving its position — a separate defect, filed
+    // separately. The writer's half is what this fix is about.
+    const xml = new TextDecoder().decode(await new ZipReader(data).extract("content.xml"))
+    const emittedRows = xml.match(/<table:table-row[\s\S]*?(?:<\/table:table-row>|\/>)/g) ?? []
+    expect(emittedRows).toHaveLength(3)
+    expect(emittedRows[2]).toContain("<text:p>z</text:p>")
   })
 
   it("writes a self-closing cell for a null override with nothing else on it", async () => {

--- a/test/coverage-sheet-ops.test.ts
+++ b/test/coverage-sheet-ops.test.ts
@@ -758,7 +758,7 @@ describe("sortRows", () => {
   // of sort direction. `compareCellValues` returns +1 for a null `a`, and
   // "desc" negates the whole comparison, so blanks float to the top.
   // src/sheet-ops.ts:1270 (and the mirror at 1297).
-  it.skip("keeps blanks last when sorting descending, as Excel does", () => {
+  it("keeps blanks last when sorting descending, as Excel does", () => {
     const s = sheet({ rows: [[1], [], [3], [2]] })
 
     sortRows(s, 0, "desc")
@@ -780,12 +780,13 @@ describe("sortRows", () => {
 
     sortRows(s, 0, "desc")
 
-    // The short row carries no value, so it sorts as a blank (see the
-    // skipped test above for where that lands under "desc").
-    expect(s.rows.map((r) => r[0] ?? null)).toEqual([null, "c", "b", "a"])
-    expect(s.cells!.get("1,0")!.value).toBe("c")
-    expect(s.cells!.get("2,0")!.value).toBe("b")
-    expect(s.cells!.get("3,0")!.value).toBe("a")
+    // The short row carries no value, so it sorts as a blank — and blanks
+    // sink in both directions now (#392). This test previously asserted
+    // the pre-fix order, with the blank floating to the top.
+    expect(s.rows.map((r) => r[0] ?? null)).toEqual(["c", "b", "a", null])
+    expect(s.cells!.get("0,0")!.value).toBe("c")
+    expect(s.cells!.get("1,0")!.value).toBe("b")
+    expect(s.cells!.get("2,0")!.value).toBe("a")
     expect(s.cells!.get("99,0")!.value).toBe("orphan")
   })
 

--- a/test/coverage-xlsx-reader.test.ts
+++ b/test/coverage-xlsx-reader.test.ts
@@ -1113,7 +1113,7 @@ describe("more relationship shapes", () => {
   // background silently vanish. Verified directly: the same package with
   // the rels part deliberately misnamed `_rels/heet1.xml.rels` DOES
   // resolve the hyperlink, while the correctly named one does not.
-  it.skip("reads a drawing stored at the package root", async () => {
+  it("reads a drawing stored at the package root", async () => {
     const wb = await readExact({
       "[Content_Types].xml": CONTENT_TYPES,
       "_rels/.rels": relsXml([{ id: "rId1", type: "officeDocument", target: "workbook.xml" }]),

--- a/test/coverage-zip-branches.test.ts
+++ b/test/coverage-zip-branches.test.ts
@@ -579,7 +579,7 @@ describe("ZipReader — extractStream", () => {
   // `extract()` (see "ignores a ZIP64 sentinel in the local header…" above)
   // but throws "Compressed data extends beyond file" through
   // `extractStream()`, because 0xFFFFFFFF is taken as a real length.
-  it.skip("ignores a ZIP64 sentinel in the local header when streaming", async () => {
+  it("ignores a ZIP64 sentinel in the local header when streaming", async () => {
     const payload = enc.encode("streamed content")
     const buf = buildZip([
       {


### PR DESCRIPTION
Closes #389, #390, #391, #392, and most of #393. Part of #352.

Each was reproduced before fixing, and each un-skips the test that documented it.

## #389 — a malformed `.xls` hung the process forever

`BlockStream.skip()` loops `while (left > 0)`, but once the blocks are exhausted `remainingInBlock()` returns `0`, so `take` is `0` and `left` never decreases. `readSstString` reaches it with two untrusted lengths — `cRun * 4` from a u16 and `cbExt` from a **u32**.

`readXls` wraps parsing in a try/catch, which cannot interrupt a live lock. Same class as #355 and #368, in a reader those never reached.

`skip()` now throws `ParseError` naming how far it got. The test that previously hung the whole suite runs, with a timeout so a regression fails rather than hangs CI.

## #390 — Excel locale tags read as currency symbols

`detectCurrencySymbol` rejects the bracketed `[$-409]` form correctly, then a fallback scanned the **whole** code for a currency character and found the `$` inside the locale tag. Excel's built-in long date `[$-F800]dddd, mmmm dd, yyyy` became a currency style with every date token gone — on ordinary XLSX→ODS conversion.

Fixing the classification surfaced a **second half**: the locale prefix was then serialized character by character as `<number:text>`, so the code round-tripped as `"["$"-"4""0""9""]"mmm-yy`. ODF expresses locale through the style's language attributes rather than inline, so the prefix is stripped. A currency written as `[$€-407]` keeps its symbol, because the bracketed branch reads that form first.

Worth noting because the first fix looked complete and was not.

## #391 — root-level parts never found their `_rels`

`wsPath.slice(dirname(wsPath).length + 1)` eats the first character when `dirname` returns `""`: `sheet1.xml` looked for `_rels/heet1.xml.rels`. Everything reached through relationships silently vanished — hyperlinks, comments, tables, drawings, images, charts, pivots, slicers, background image.

Both sites now use `relsPathFor()`, which already handled the no-slash case. Two of three call sites were already correct, which is what made this an oversight rather than a decision.

## #392 — `sortRows` descending floated blanks to the top

The desc path negated the **whole** comparison, flipping the null rule with it. Direction now applies to the value comparison only, so nulls stay last in both directions — matching the method's own JSDoc and Excel.

One companion test in the same file asserted the pre-fix order (its comment even pointed at the skipped test) and is updated.

## #393 — three smaller ones

- **ODS streaming folded cell annotations into values.** `case "p"` matched `<text:p>` inside `<office:annotation>`; the batch reader takes only direct children. A cell with a comment read as `"a notevalue"` streaming and `"value"` batch — breaking the parity contract `ods-stream-parity.test.ts` exists to enforce.
- **`extractStream()` was missing the ZIP64 sentinel guard** its buffered twin has. A data-descriptor entry with `0xFFFFFFFF` local sizes — what a ZIP64 streaming producer writes — succeeded buffered and threw streaming.
- **ODS dropped `sheet.cells` overrides past a row's last value.** This turned out to have **three** causes, two of them in the writer and fixed here: the row width now accounts for overrides, and the grid grows to reach an override below the last row. The override's value also wins over the row array, matching `resolveRows` in the XLSX writer — reading only from `row` meant an override serialized as an empty cell even once it was reachable.

The third cause is in the **reader**: an *interior* empty row is collapsed rather than kept, so a row-wise override lands at the wrong index on read. The emitted XML is correct now and the test asserts that directly; the reader half is #394.

## Verification

Full suite **9,267 passing / 8 skipped** (the remaining skips are the number-format defects in #388, being fixed separately). Lint, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
