### PR TITLE
fix: guard column indices before they become cell references

### DIFF
--- a/src/_validate.ts
+++ b/src/_validate.ts
@@ -8,12 +8,31 @@
 // no half-written output.
 
 import { InvalidArgumentError } from "./errors"
+import { MAX_COL_INDEX } from "./limits"
 
 /**
  * Excel's hard limit on a sheet name. Enforced by Excel's UI, by the
  * XLSX format, and by LibreOffice for ODS.
  */
 export const MAX_SHEET_NAME_LENGTH = 31
+
+/**
+ * Excel's limit on the text in one cell, and on a formula's length.
+ *
+ * Neither is enforced, and that is deliberate. Both are *application*
+ * limits, not format limits: ECMA-376 imposes no such cap, the file
+ * stays valid OOXML, and LibreOffice, pandas and hucre's own reader all
+ * handle longer values. Excel truncates the display rather than refusing
+ * the file. Throwing here would make hucre stricter than the format it
+ * writes, and would break using it as a general interchange engine.
+ *
+ * Sheet names are different, and are enforced: an illegal one makes the
+ * whole workbook unreadable rather than one cell lossy. See #364.
+ *
+ * Exported so a caller targeting Excel specifically can check.
+ */
+export const MAX_CELL_TEXT_LENGTH = 32_767
+export const MAX_FORMULA_LENGTH = 8_192
 
 /**
  * Characters Excel forbids in a sheet name. They collide with range
@@ -95,5 +114,22 @@ export function validateSheetNames(sheets: ReadonlyArray<{ name: string }>): voi
       )
     }
     seen.set(key, i)
+  }
+}
+
+/**
+ * Guard a 0-based column index before it becomes an `r=` attribute.
+ *
+ * `colToLetter` is pure arithmetic and produced nonsense for anything
+ * outside the grid — `-1` gave `"@"`, `NaN` gave a NUL character, `1.5`
+ * silently truncated, and `16384` gave `"XFE"`, one past Excel's last
+ * column. Each produced a cell reference no reader can parse, from a
+ * file that otherwise looked fine. See #364.
+ */
+export function validateColumnIndex(col: number): void {
+  if (!Number.isInteger(col) || col < 0 || col > MAX_COL_INDEX) {
+    throw new InvalidArgumentError(
+      `Column index ${col} is not a valid 0-based column ` + `(Excel allows 0..${MAX_COL_INDEX})`,
+    )
   }
 }

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -25,6 +25,7 @@ import { isHyperlinkValue } from "./hyperlink"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 import { calculateColumnWidth } from "./auto-width"
 import { hashSheetPassword } from "./password"
+import { validateColumnIndex } from "../_validate"
 
 // ── Hyperlink Relationship ────────────────────────────────────────
 
@@ -63,6 +64,10 @@ const NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationship
 
 /** Convert a 0-based column index to an Excel column letter (A, B, ... Z, AA, AB, ...) */
 export function colToLetter(col: number): string {
+  // Pure arithmetic on an unchecked number produced references no reader
+  // can parse — "@" for -1, a NUL character for NaN, "XFE" one past the
+  // last column. See #364.
+  validateColumnIndex(col)
   let result = ""
   let c = col
   do {

--- a/test/column-index-validation.test.ts
+++ b/test/column-index-validation.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import { cellRef, colToLetter, rangeRef } from "../src/xlsx/worksheet-writer"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { InvalidArgumentError } from "../src/errors"
+import { MAX_CELL_TEXT_LENGTH } from "../src/_validate"
+import { MAX_COL_INDEX } from "../src/limits"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #364 — colToLetter is pure arithmetic on an unchecked number, so an
+// out-of-range or non-integer column produced a cell reference no reader
+// can parse, inside a file that otherwise looked fine.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("colToLetter bounds", () => {
+  it("still converts every legal column", () => {
+    expect(colToLetter(0)).toBe("A")
+    expect(colToLetter(25)).toBe("Z")
+    expect(colToLetter(26)).toBe("AA")
+    expect(colToLetter(MAX_COL_INDEX)).toBe("XFD")
+  })
+
+  const bad: Array<[string, number, string]> = [
+    ["negative", -1, 'used to give "@"'],
+    ["NaN", Number.NaN, "used to give a NUL character, illegal in XML"],
+    ["fractional", 1.5, 'used to truncate silently to "B"'],
+    ["past the last column", MAX_COL_INDEX + 1, 'used to give "XFE"'],
+    ["absurdly large", 1_000_000, 'used to give "BDWGO"'],
+  ]
+
+  for (const [label, col, why] of bad) {
+    it(`rejects a ${label} column — ${why}`, () => {
+      expect(() => colToLetter(col)).toThrow(InvalidArgumentError)
+    })
+  }
+
+  it("names the offending value", () => {
+    expect(() => colToLetter(-1)).toThrow(/Column index -1/)
+  })
+
+  it("guards the helpers built on it", () => {
+    expect(() => cellRef(0, -1)).toThrow(InvalidArgumentError)
+    expect(() => rangeRef(0, 0, 0, MAX_COL_INDEX + 1)).toThrow(InvalidArgumentError)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// The length limits are deliberately NOT enforced. Pinned so the choice
+// stays a decision rather than an omission someone "fixes" later.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("cell text beyond Excel's limit", () => {
+  it("is written rather than rejected", async () => {
+    // Excel's 32,767-character cap is an *application* limit, not a
+    // format one: ECMA-376 imposes no such cap, the file stays valid
+    // OOXML, and LibreOffice, pandas and hucre's own reader handle it.
+    // Excel truncates the display rather than refusing the file, so
+    // throwing here would make hucre stricter than the format it writes.
+    const big = "A".repeat(MAX_CELL_TEXT_LENGTH + 1000)
+    const workbook = await readXlsx(await writeXlsx({ sheets: [{ name: "S", rows: [[big]] }] }))
+    expect(workbook.sheets[0].rows[0][0]).toBe(big)
+  })
+
+  it("exports the limit so a caller targeting Excel can check", () => {
+    expect(MAX_CELL_TEXT_LENGTH).toBe(32_767)
+  })
+})


### PR DESCRIPTION
Closes #364.

## The bug

`colToLetter` is pure arithmetic on an unchecked number, so anything outside the grid produced a cell reference no reader can parse — inside a file that otherwise looked fine:

| call | before | why it matters |
| --- | --- | --- |
| `colToLetter(-1)` | `"@"` | not a column letter at all |
| `colToLetter(NaN)` | a NUL character | illegal in an XML attribute; the file will not open |
| `colToLetter(1.5)` | `"B"` | silently truncated — wrong column, no warning |
| `colToLetter(16384)` | `"XFE"` | one past Excel's last column |
| `colToLetter(1e6)` | `"BDWGO"` | far outside the grid |

It now throws `InvalidArgumentError` naming the value. `cellRef` and `rangeRef` are built on it, so they are covered too. No existing test changed — nothing was relying on a malformed reference.

## The part of #364 I am deliberately *not* doing

#364 also asked for caps on cell text (32,767 chars) and formula length (8,192). I implemented both, and then took them back out.

Adding the text cap broke an existing test that writes and reads a 100 KB cell (from #135). Investigating instead of adjusting the test was the right call: **Excel's limit is an application limit, not a format limit.** ECMA-376 imposes no such cap, the file stays valid OOXML, and LibreOffice, pandas and hucre's own reader all handle longer values — Excel truncates the *display* rather than refusing the file. Throwing would have made hucre stricter than the format it writes and broken its use as a general interchange engine.

That is the distinction from sheet names, which *are* enforced: an illegal sheet name makes the whole workbook unreadable, not one cell lossy. The rule this settles on:

> Reject what makes the file invalid. Do not reject what merely makes one consumer unhappy.

The constants stay exported and documented, so a caller specifically targeting Excel can check them, and a test pins the non-enforcement so it reads as a decision rather than an omission someone "fixes" later.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` — 145 files, 9,285 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
