### PR TITLE
fix(cli): make the CLI testable, and fix what that exposed

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -11,7 +11,12 @@ export default defineBuildConfig({
       // the shipped file. Transforming it here as well would emit a second
       // dist/cli.mjs carrying bare `citty` / `consola` imports — which is
       // exactly how the published binary ended up broken. See #357.
-      filter: (filePath) => !filePath.endsWith("cli.ts"),
+      //
+      // `src/cli/` is excluded for the same reason: the bin is a two-line
+      // wrapper around ./cli/commands (#399), and transforming that module
+      // would put the unresolvable bare imports back in dist under a new
+      // name. The bundle entry inlines it into dist/cli.mjs instead.
+      filter: (filePath) => !/(?:^|[/\\])cli(?:\.ts$|[/\\])/.test(filePath),
     },
     {
       // The library keeps zero runtime dependencies, so the CLI's own deps

--- a/package.json
+++ b/package.json
@@ -77,11 +77,12 @@
     "lint:fix": "oxlint . --fix && oxfmt .",
     "fmt": "oxfmt .",
     "test": "pnpm lint && pnpm typecheck && vitest run",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.cli.json",
     "release": "pnpm test && pnpm build && bumpp --commit --tag --push --all",
     "prepack": "pnpm build"
   },
   "devDependencies": {
+    "@types/node": "^26.1.2",
     "@vitest/coverage-v8": "^4.1.10",
     "bumpp": "^12.1.1",
     "citty": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -34,16 +37,16 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
 
   web:
     devDependencies:
       nitro:
         specifier: latest
-        version: 3.0.260610-beta(jiti@2.7.0)(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0))
+        version: 3.0.260610-beta(jiti@2.7.0)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
       vite:
         specifier: latest
-        version: 8.2.0(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
 
 packages:
 
@@ -455,6 +458,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -1231,6 +1237,9 @@ packages:
   unconfig@7.5.0:
     resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -1651,6 +1660,10 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -1723,7 +1736,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -1734,13 +1747,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.0(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2029,7 +2042,7 @@ snapshots:
 
   nf3@0.3.23: {}
 
-  nitro@3.0.260610-beta(jiti@2.7.0)(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0)):
+  nitro@3.0.260610-beta(jiti@2.7.0)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
@@ -2047,7 +2060,7 @@ snapshots:
       unstorage: 2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       jiti: 2.7.0
-      vite: 8.2.0(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -2293,6 +2306,8 @@ snapshots:
       quansync: 1.0.0
       unconfig-core: 7.5.0
 
+  undici-types@8.3.0: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -2304,7 +2319,7 @@ snapshots:
 
   verkit@0.3.1: {}
 
-  vite@8.2.0(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -2312,14 +2327,15 @@ snapshots:
       rolldown: 1.2.1
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@vitest/coverage-v8@4.1.10)(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.0(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2336,9 +2352,10 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.0(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 26.1.2
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,343 +1,46 @@
 #!/usr/bin/env node
 
-// ── CLI Tool ────────────────────────────────────────────────────────
+// ── CLI entry point ─────────────────────────────────────────────────
 // hucre convert input.xlsx output.csv
 // hucre convert input.csv output.xlsx
 // hucre convert input.xlsx output.ods
 // hucre inspect file.xlsx
 // hucre inspect file.xlsx --sheet 0
 // hucre validate data.xlsx --schema schema.json
+//
+// Only the bin lives here. The commands are in ./cli/commands so a test
+// can import and run them without this file's side effect of parsing
+// argv and taking over the process — which is why the CLI used to be the
+// one module in the tree at 0% coverage. See #399.
 // ─────────────────────────────────────────────────────────────────────
 
-import { defineCommand, runMain } from "citty"
+import { runMain } from "citty"
 import { consola } from "consola"
-import { readFileSync, writeFileSync } from "node:fs"
-import { createRequire } from "node:module"
-import { extname } from "node:path"
-import { readXlsx } from "./xlsx/reader"
-import { writeXlsx } from "./xlsx/writer"
-import { readOds } from "./ods/reader"
-import { writeOds } from "./ods/writer"
-import { parseCsv } from "./csv/reader"
-import { writeCsv } from "./csv/writer"
-import { validateWithSchema } from "./_schema"
-import type { Workbook, CellValue, WriteOptions, SchemaDefinition } from "./_types"
+import {
+  CliError,
+  convertCommand,
+  inspectCommand,
+  mainCommand,
+  validateCommand,
+} from "./cli/commands"
 
-// ── Helpers ─────────────────────────────────────────────────────────
-
-type Format = "xlsx" | "ods" | "csv"
-
-function detectFormatFromExtension(filePath: string): Format {
-  const ext = extname(filePath).toLowerCase()
-  switch (ext) {
-    case ".xlsx":
-      return "xlsx"
-    case ".ods":
-      return "ods"
-    case ".csv":
-    case ".tsv":
-      return "csv"
-    default:
-      consola.error(`Unsupported file extension: ${ext}`)
-      process.exit(1)
-  }
-}
-
-async function readFile(filePath: string): Promise<Workbook> {
-  const format = detectFormatFromExtension(filePath)
-  const data = readFileSync(filePath)
-  const input = new Uint8Array(data)
-
-  switch (format) {
-    case "xlsx":
-      return readXlsx(input)
-    case "ods":
-      return readOds(input)
-    case "csv": {
-      const text = new TextDecoder("utf-8").decode(input)
-      const rows = parseCsv(text)
-      return {
-        sheets: [{ name: "Sheet1", rows }],
-      }
-    }
-  }
-}
-
-function formatCellValue(value: CellValue): string {
-  if (value === null || value === undefined) return ""
-  if (value instanceof Date) return value.toISOString()
-  return String(value)
-}
-
-// ── Convert Command ─────────────────────────────────────────────────
-
-const convertCommand = defineCommand({
-  meta: {
-    name: "convert",
-    description: "Convert between spreadsheet formats",
-  },
-  args: {
-    input: {
-      type: "positional",
-      description: "Input file path",
-      required: true,
-    },
-    output: {
-      type: "positional",
-      description: "Output file path",
-      required: true,
-    },
-  },
-  async run({ args }) {
-    const inputPath = args.input as string
-    const outputPath = args.output as string
-    const outputFormat = detectFormatFromExtension(outputPath)
-
-    consola.start(`Reading ${inputPath}...`)
-    const workbook = await readFile(inputPath)
-    consola.success(`Read ${workbook.sheets.length} sheet(s)`)
-
-    consola.start(`Writing ${outputPath}...`)
-
-    if (outputFormat === "csv") {
-      // CSV: use first sheet only
-      const sheet = workbook.sheets[0]
-      if (!sheet) {
-        consola.error("No sheets found in input file")
-        process.exit(1)
-      }
-      const headers = sheet.rows[0]?.map((v) => formatCellValue(v))
-      const dataRows = sheet.rows.slice(headers ? 1 : 0)
-      const csv = writeCsv(dataRows, {
-        headers: headers ?? undefined,
-      })
-      writeFileSync(outputPath, csv, "utf-8")
-    } else {
-      // XLSX or ODS
-      const writeOptions: WriteOptions = {
-        sheets: workbook.sheets.map((sheet) => ({
-          name: sheet.name,
-          rows: sheet.rows,
-        })),
-        properties: workbook.properties,
-      }
-
-      let output: Uint8Array
-      if (outputFormat === "ods") {
-        output = await writeOds(writeOptions)
-      } else {
-        output = await writeXlsx(writeOptions)
-      }
-
-      writeFileSync(outputPath, output)
-    }
-
-    consola.success(`Written to ${outputPath}`)
-  },
-})
-
-// ── Inspect Command ─────────────────────────────────────────────────
-
-const inspectCommand = defineCommand({
-  meta: {
-    name: "inspect",
-    description: "Inspect a spreadsheet file",
-  },
-  args: {
-    file: {
-      type: "positional",
-      description: "File to inspect",
-      required: true,
-    },
-    sheet: {
-      type: "string",
-      description: "Sheet index to show detailed data (0-based)",
-    },
-  },
-  async run({ args }) {
-    const filePath = args.file as string
-
-    consola.start(`Inspecting ${filePath}...`)
-    const workbook = await readFile(filePath)
-
-    consola.info(`Sheets: ${workbook.sheets.length}`)
-
-    for (let i = 0; i < workbook.sheets.length; i++) {
-      const sheet = workbook.sheets[i]!
-      const rowCount = sheet.rows.length
-      const colCount = sheet.rows.reduce((max, row) => Math.max(max, row.length), 0)
-
-      // Count cell types
-      const typeCounts: Record<string, number> = {}
-      for (const row of sheet.rows) {
-        for (const cell of row) {
-          let type: string
-          if (cell === null || cell === undefined) type = "empty"
-          else if (typeof cell === "string") type = "string"
-          else if (typeof cell === "number") type = "number"
-          else if (typeof cell === "boolean") type = "boolean"
-          else if (cell instanceof Date) type = "date"
-          else type = "unknown"
-
-          typeCounts[type] = (typeCounts[type] ?? 0) + 1
-        }
-      }
-
-      const typeStr = Object.entries(typeCounts)
-        .map(([t, c]) => `${t}: ${c}`)
-        .join(", ")
-
-      consola.log(`  [${i}] "${sheet.name}" - ${rowCount} rows x ${colCount} cols (${typeStr})`)
-    }
-
-    if (workbook.properties) {
-      const props = workbook.properties
-      if (props.title) consola.log(`  Title: ${props.title}`)
-      if (props.creator) consola.log(`  Creator: ${props.creator}`)
-      if (props.created) consola.log(`  Created: ${props.created.toISOString()}`)
-    }
-
-    // Show detailed sheet data if --sheet is specified
-    if (args.sheet !== undefined) {
-      const sheetIdx = Number(args.sheet)
-      if (Number.isNaN(sheetIdx) || sheetIdx < 0 || sheetIdx >= workbook.sheets.length) {
-        consola.error(
-          `Invalid sheet index: ${args.sheet}. Valid range: 0-${workbook.sheets.length - 1}`,
-        )
-        process.exit(1)
-      }
-
-      const sheet = workbook.sheets[sheetIdx]!
-      consola.info(`\nSheet "${sheet.name}" (first 10 rows):`)
-
-      const previewRows = sheet.rows.slice(0, 10)
-      if (previewRows.length === 0) {
-        consola.log("  (empty sheet)")
-      } else {
-        // Build column widths for formatting
-        const maxCols = previewRows.reduce((max, row) => Math.max(max, row.length), 0)
-        const colWidths: number[] = Array.from({ length: maxCols }, () => 0)
-
-        const formatted = previewRows.map((row) =>
-          Array.from({ length: maxCols }, (_, j) => {
-            const val = j < row.length ? formatCellValue(row[j]!) : ""
-            const str = val.length > 40 ? `${val.substring(0, 37)}...` : val
-            if (str.length > colWidths[j]!) colWidths[j] = str.length
-            return str
-          }),
-        )
-
-        for (let i = 0; i < formatted.length; i++) {
-          const row = formatted[i]!
-          const line = row.map((val, j) => val.padEnd(colWidths[j]! + 2)).join("")
-          consola.log(`  ${String(i).padStart(3)}| ${line}`)
-        }
-
-        if (sheet.rows.length > 10) {
-          consola.log(`  ... and ${sheet.rows.length - 10} more rows`)
-        }
-      }
-    }
-  },
-})
-
-// ── Validate Command ────────────────────────────────────────────────
-
-const validateCommand = defineCommand({
-  meta: {
-    name: "validate",
-    description: "Validate a spreadsheet against a JSON schema",
-  },
-  args: {
-    file: {
-      type: "positional",
-      description: "Spreadsheet file to validate",
-      required: true,
-    },
-    schema: {
-      type: "string",
-      description: "Path to JSON schema file",
-      required: true,
-    },
-    sheet: {
-      type: "string",
-      description: "Sheet index to validate (0-based, default: 0)",
-      default: "0",
-    },
-  },
-  async run({ args }) {
-    const filePath = args.file as string
-    const schemaPath = args.schema as string
-    const sheetIdx = Number(args.sheet ?? "0")
-
-    if (Number.isNaN(sheetIdx)) {
-      consola.error(`Invalid sheet index: ${args.sheet}`)
-      process.exit(1)
-    }
-
-    consola.start(`Validating ${filePath} with schema ${schemaPath}...`)
-
-    // Read schema
-    const schemaJson = readFileSync(schemaPath, "utf-8")
-    let schema: SchemaDefinition
+// The commands throw CliError rather than calling process.exit, so they
+// stay testable. Translating that back into an exit code is this file's
+// job: citty's runMain would otherwise print a raw stack trace for it,
+// and a CliError's message is already written for a user to read.
+for (const sub of [convertCommand, inspectCommand, validateCommand]) {
+  const command = sub as { run?: (ctx: never) => unknown }
+  const run = command.run
+  if (!run) continue
+  command.run = async (ctx: never) => {
     try {
-      schema = JSON.parse(schemaJson) as SchemaDefinition
-    } catch {
-      consola.error("Invalid JSON schema file")
+      return await run(ctx)
+    } catch (error) {
+      if (!(error instanceof CliError)) throw error
+      consola.error(error.message)
       process.exit(1)
     }
-
-    // Read spreadsheet
-    const workbook = await readFile(filePath)
-
-    if (sheetIdx < 0 || sheetIdx >= workbook.sheets.length) {
-      consola.error(`Invalid sheet index: ${sheetIdx}. File has ${workbook.sheets.length} sheet(s)`)
-      process.exit(1)
-    }
-
-    const sheet = workbook.sheets[sheetIdx]!
-    // headerRow is 0-based since v1 — the first row (#365).
-    const result = validateWithSchema(sheet.rows, schema, { headerRow: 0 })
-
-    if (result.errors.length === 0) {
-      consola.success(`Valid! ${result.data.length} row(s) passed validation.`)
-    } else {
-      consola.error(`Found ${result.errors.length} error(s) in ${result.data.length} row(s):`)
-      for (const err of result.errors.slice(0, 20)) {
-        consola.log(`  Row ${err.row}, Column "${err.column}": ${err.message}`)
-      }
-      if (result.errors.length > 20) {
-        consola.log(`  ... and ${result.errors.length - 20} more errors`)
-      }
-      process.exit(1)
-    }
-  },
-})
-
-// ── Main Command ────────────────────────────────────────────────────
-
-const pkgVersion: string = (() => {
-  try {
-    const require = createRequire(import.meta.url)
-    const pkg = require("../package.json") as { version?: string }
-    return pkg.version ?? "0.0.0"
-  } catch {
-    return "0.0.0"
   }
-})()
+}
 
-const main = defineCommand({
-  meta: {
-    name: "hucre",
-    version: pkgVersion,
-    description:
-      "Spreadsheet Swiss Army knife. Convert, inspect, and validate XLSX, CSV, and ODS files.",
-  },
-  subCommands: {
-    convert: convertCommand,
-    inspect: inspectCommand,
-    validate: validateCommand,
-  },
-})
-
-runMain(main)
+runMain(mainCommand)

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,0 +1,369 @@
+// ── CLI commands ────────────────────────────────────────────────────
+// The command definitions live here rather than beside `runMain` so a
+// test can import and run them. `src/cli.ts` is the bin: it does nothing
+// but hand `mainCommand` to citty. Before the split the whole CLI sat in
+// one module ending in a bare `runMain(main)`, which meant importing it
+// *ran* it — reading process.argv and possibly calling process.exit. That
+// is why it was the only module in the tree at 0% coverage. See #399.
+// ─────────────────────────────────────────────────────────────────────
+
+import { defineCommand } from "citty"
+import { consola } from "consola"
+import { readFileSync, writeFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { extname } from "node:path"
+import { readXlsx } from "../xlsx/reader"
+import { writeXlsx } from "../xlsx/writer"
+import { readOds } from "../ods/reader"
+import { writeOds } from "../ods/writer"
+import { parseCsv } from "../csv/reader"
+import { writeCsv } from "../csv/writer"
+import { validateWithSchema } from "../_schema"
+import type { Workbook, CellValue, WriteOptions, SchemaDefinition } from "../_types"
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+/**
+ * A CLI failure with a message already fit for a user.
+ *
+ * The commands throw this instead of calling `process.exit(1)` directly.
+ * citty's `runMain` catches it, prints it and exits non-zero, so the
+ * behaviour at the terminal is unchanged — but a test can now assert on
+ * the failure instead of watching the test runner die.
+ */
+export class CliError extends Error {
+  override readonly name = "CliError"
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+export type Format = "xlsx" | "ods" | "csv"
+
+/** Text formats carry their separator in the extension, not the format. */
+const DELIMITERS: Record<string, string> = { ".csv": ",", ".tsv": "\t" }
+
+export function detectFormatFromExtension(filePath: string): Format {
+  const ext = extname(filePath).toLowerCase()
+  switch (ext) {
+    case ".xlsx":
+      return "xlsx"
+    case ".ods":
+      return "ods"
+    case ".csv":
+    case ".tsv":
+      return "csv"
+    default:
+      throw new CliError(
+        `Unsupported file extension: ${ext || "(none)"}. Supported: .xlsx, .ods, .csv, .tsv`,
+      )
+  }
+}
+
+/**
+ * `.tsv` is tab-separated. Naming the file `.tsv` and filling it with
+ * commas — which is what this used to do, because both extensions mapped
+ * to the format "csv" and the writer took its default delimiter — makes a
+ * file that lies about itself. The read side never had the bug: parseCsv
+ * sniffs the delimiter from the content.
+ */
+export function delimiterForExtension(filePath: string): string {
+  return DELIMITERS[extname(filePath).toLowerCase()] ?? ","
+}
+
+export async function readFile(filePath: string): Promise<Workbook> {
+  const format = detectFormatFromExtension(filePath)
+  const data = readFileSync(filePath)
+  const input = new Uint8Array(data)
+
+  switch (format) {
+    case "xlsx":
+      return readXlsx(input)
+    case "ods":
+      return readOds(input)
+    case "csv": {
+      const text = new TextDecoder("utf-8").decode(input)
+      const rows = parseCsv(text, { delimiter: delimiterForExtension(filePath) })
+      return {
+        sheets: [{ name: "Sheet1", rows }],
+      }
+    }
+  }
+}
+
+export function formatCellValue(value: CellValue): string {
+  if (value === null || value === undefined) return ""
+  if (value instanceof Date) return value.toISOString()
+  return String(value)
+}
+
+// ── Convert Command ─────────────────────────────────────────────────
+
+export const convertCommand = defineCommand({
+  meta: {
+    name: "convert",
+    description:
+      "Convert between spreadsheet formats (cell values only — styles, " +
+      "merges, formulas, charts and images are not carried over)",
+  },
+  args: {
+    input: {
+      type: "positional",
+      description: "Input file path",
+      required: true,
+    },
+    output: {
+      type: "positional",
+      description: "Output file path",
+      required: true,
+    },
+  },
+  async run({ args }) {
+    const inputPath = args.input as string
+    const outputPath = args.output as string
+    const outputFormat = detectFormatFromExtension(outputPath)
+
+    consola.start(`Reading ${inputPath}...`)
+    const workbook = await readFile(inputPath)
+    consola.success(`Read ${workbook.sheets.length} sheet(s)`)
+
+    consola.start(`Writing ${outputPath}...`)
+
+    if (outputFormat === "csv") {
+      // CSV: use first sheet only
+      const sheet = workbook.sheets[0]
+      if (!sheet) {
+        throw new CliError("No sheets found in input file")
+      }
+      // Every row goes through writeCsv, including the first. It used to
+      // be pulled out as `headers` and stringified separately, so a Date
+      // in row 0 came out ISO while the same Date in row 1 came out in
+      // writeCsv's format — one column, two formats, decided by which
+      // row the value happened to land in.
+      const csv = writeCsv(sheet.rows, { delimiter: delimiterForExtension(outputPath) })
+      writeFileSync(outputPath, csv, "utf-8")
+    } else {
+      // XLSX or ODS
+      const writeOptions: WriteOptions = {
+        sheets: workbook.sheets.map((sheet) => ({
+          name: sheet.name,
+          rows: sheet.rows,
+        })),
+        properties: workbook.properties,
+      }
+
+      let output: Uint8Array
+      if (outputFormat === "ods") {
+        output = await writeOds(writeOptions)
+      } else {
+        output = await writeXlsx(writeOptions)
+      }
+
+      writeFileSync(outputPath, output)
+    }
+
+    consola.success(`Written to ${outputPath}`)
+  },
+})
+
+// ── Inspect Command ─────────────────────────────────────────────────
+
+export const inspectCommand = defineCommand({
+  meta: {
+    name: "inspect",
+    description: "Inspect a spreadsheet file",
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "File to inspect",
+      required: true,
+    },
+    sheet: {
+      type: "string",
+      description: "Sheet index to show detailed data (0-based)",
+    },
+  },
+  async run({ args }) {
+    const filePath = args.file as string
+
+    consola.start(`Inspecting ${filePath}...`)
+    const workbook = await readFile(filePath)
+
+    consola.info(`Sheets: ${workbook.sheets.length}`)
+
+    for (let i = 0; i < workbook.sheets.length; i++) {
+      const sheet = workbook.sheets[i]!
+      const rowCount = sheet.rows.length
+      const colCount = sheet.rows.reduce((max, row) => Math.max(max, row.length), 0)
+
+      // Count cell types
+      const typeCounts: Record<string, number> = {}
+      for (const row of sheet.rows) {
+        for (const cell of row) {
+          let type: string
+          if (cell === null || cell === undefined) type = "empty"
+          else if (typeof cell === "string") type = "string"
+          else if (typeof cell === "number") type = "number"
+          else if (typeof cell === "boolean") type = "boolean"
+          else if (cell instanceof Date) type = "date"
+          else type = "unknown"
+
+          typeCounts[type] = (typeCounts[type] ?? 0) + 1
+        }
+      }
+
+      const typeStr = Object.entries(typeCounts)
+        .map(([t, c]) => `${t}: ${c}`)
+        .join(", ")
+
+      consola.log(`  [${i}] "${sheet.name}" - ${rowCount} rows x ${colCount} cols (${typeStr})`)
+    }
+
+    if (workbook.properties) {
+      const props = workbook.properties
+      if (props.title) consola.log(`  Title: ${props.title}`)
+      if (props.creator) consola.log(`  Creator: ${props.creator}`)
+      if (props.created) consola.log(`  Created: ${props.created.toISOString()}`)
+    }
+
+    // Show detailed sheet data if --sheet is specified
+    if (args.sheet !== undefined) {
+      const sheetIdx = Number(args.sheet)
+      if (!Number.isInteger(sheetIdx) || sheetIdx < 0 || sheetIdx >= workbook.sheets.length) {
+        throw new CliError(
+          `Invalid sheet index: ${args.sheet}. Valid range: 0-${workbook.sheets.length - 1}`,
+        )
+      }
+
+      const sheet = workbook.sheets[sheetIdx]!
+      consola.info(`\nSheet "${sheet.name}" (first 10 rows):`)
+
+      const previewRows = sheet.rows.slice(0, 10)
+      if (previewRows.length === 0) {
+        consola.log("  (empty sheet)")
+      } else {
+        // Build column widths for formatting
+        const maxCols = previewRows.reduce((max, row) => Math.max(max, row.length), 0)
+        const colWidths: number[] = Array.from({ length: maxCols }, () => 0)
+
+        const formatted = previewRows.map((row) =>
+          Array.from({ length: maxCols }, (_, j) => {
+            const val = j < row.length ? formatCellValue(row[j]!) : ""
+            const str = val.length > 40 ? `${val.substring(0, 37)}...` : val
+            if (str.length > colWidths[j]!) colWidths[j] = str.length
+            return str
+          }),
+        )
+
+        for (let i = 0; i < formatted.length; i++) {
+          const row = formatted[i]!
+          const line = row.map((val, j) => val.padEnd(colWidths[j]! + 2)).join("")
+          consola.log(`  ${String(i).padStart(3)}| ${line}`)
+        }
+
+        if (sheet.rows.length > 10) {
+          consola.log(`  ... and ${sheet.rows.length - 10} more rows`)
+        }
+      }
+    }
+  },
+})
+
+// ── Validate Command ────────────────────────────────────────────────
+
+export const validateCommand = defineCommand({
+  meta: {
+    name: "validate",
+    description: "Validate a spreadsheet against a JSON schema",
+  },
+  args: {
+    file: {
+      type: "positional",
+      description: "Spreadsheet file to validate",
+      required: true,
+    },
+    schema: {
+      type: "string",
+      description: "Path to JSON schema file",
+      required: true,
+    },
+    sheet: {
+      type: "string",
+      description: "Sheet index to validate (0-based, default: 0)",
+      default: "0",
+    },
+  },
+  async run({ args }) {
+    const filePath = args.file as string
+    const schemaPath = args.schema as string
+    const sheetIdx = Number(args.sheet ?? "0")
+
+    if (!Number.isInteger(sheetIdx)) {
+      throw new CliError(`Invalid sheet index: ${args.sheet}`)
+    }
+
+    consola.start(`Validating ${filePath} with schema ${schemaPath}...`)
+
+    // Read schema
+    const schemaJson = readFileSync(schemaPath, "utf-8")
+    let schema: SchemaDefinition
+    try {
+      schema = JSON.parse(schemaJson) as SchemaDefinition
+    } catch {
+      throw new CliError(`Invalid JSON schema file: ${schemaPath}`)
+    }
+
+    // Read spreadsheet
+    const workbook = await readFile(filePath)
+
+    if (sheetIdx < 0 || sheetIdx >= workbook.sheets.length) {
+      throw new CliError(
+        `Invalid sheet index: ${sheetIdx}. File has ${workbook.sheets.length} sheet(s)`,
+      )
+    }
+
+    const sheet = workbook.sheets[sheetIdx]!
+    // headerRow is 0-based since v1 — the first row (#365).
+    const result = validateWithSchema(sheet.rows, schema, { headerRow: 0 })
+
+    if (result.errors.length === 0) {
+      consola.success(`Valid! ${result.data.length} row(s) passed validation.`)
+      return
+    }
+
+    consola.error(`Found ${result.errors.length} error(s) in ${result.data.length} row(s):`)
+    for (const err of result.errors.slice(0, 20)) {
+      consola.log(`  Row ${err.row}, Column "${err.column}": ${err.message}`)
+    }
+    if (result.errors.length > 20) {
+      consola.log(`  ... and ${result.errors.length - 20} more errors`)
+    }
+    throw new CliError(`Validation failed with ${result.errors.length} error(s)`)
+  },
+})
+
+// ── Main Command ────────────────────────────────────────────────────
+
+export const pkgVersion: string = (() => {
+  try {
+    const require = createRequire(import.meta.url)
+    const pkg = require("../../package.json") as { version?: string }
+    return pkg.version ?? "0.0.0"
+  } catch {
+    return "0.0.0"
+  }
+})()
+
+export const mainCommand = defineCommand({
+  meta: {
+    name: "hucre",
+    version: pkgVersion,
+    description:
+      "Spreadsheet Swiss Army knife. Convert, inspect, and validate XLSX, CSV, and ODS files.",
+  },
+  subCommands: {
+    convert: convertCommand,
+    inspect: inspectCommand,
+    validate: validateCommand,
+  },
+})

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,403 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { consola } from "consola"
+import {
+  CliError,
+  convertCommand,
+  delimiterForExtension,
+  detectFormatFromExtension,
+  formatCellValue,
+  inspectCommand,
+  mainCommand,
+  pkgVersion,
+  readFile,
+  validateCommand,
+} from "../src/cli/commands"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeOds } from "../src/ods/writer"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #399 — the CLI was the only module in the tree at 0% coverage, because
+// src/cli.ts ended in a bare runMain(): importing it ran it. The commands
+// now live in src/cli/commands.ts and are importable, so this suite runs
+// them the way citty does — cmd.run({ args }) — with no child process.
+// ═══════════════════════════════════════════════════════════════════════
+
+let dir: string
+let logs: string[]
+
+/** Run a command's handler the way citty would, with defaults applied. */
+function run(cmd: any, args: Record<string, unknown>): Promise<void> {
+  const defaults: Record<string, unknown> = {}
+  for (const [name, spec] of Object.entries(cmd.args as Record<string, any>)) {
+    if (spec.default !== undefined) defaults[name] = spec.default
+  }
+  return cmd.run({ args: { ...defaults, ...args }, cmd, rawArgs: [] })
+}
+
+const path = (name: string) => join(dir, name)
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "hucre-cli-"))
+  logs = []
+  // consola writes to stdout; capture instead of spraying the test output.
+  for (const level of ["start", "success", "info", "log", "error"] as const) {
+    vi.spyOn(consola, level).mockImplementation(((...a: unknown[]) => {
+      logs.push(a.map(String).join(" "))
+    }) as never)
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  rmSync(dir, { recursive: true, force: true })
+})
+
+async function makeXlsx(name: string, rows: unknown[][], sheet = "Sheet1"): Promise<string> {
+  const p = path(name)
+  writeFileSync(p, await writeXlsx({ sheets: [{ name: sheet, rows: rows as never }] }))
+  return p
+}
+
+// ── Format detection ────────────────────────────────────────────────
+
+describe("detectFormatFromExtension", () => {
+  it("maps the extensions it supports", () => {
+    expect(detectFormatFromExtension("a.xlsx")).toBe("xlsx")
+    expect(detectFormatFromExtension("a.ODS")).toBe("ods")
+    expect(detectFormatFromExtension("a.csv")).toBe("csv")
+    expect(detectFormatFromExtension("a.tsv")).toBe("csv")
+  })
+
+  it("rejects anything else, naming what is supported", () => {
+    expect(() => detectFormatFromExtension("a.numbers")).toThrow(CliError)
+    expect(() => detectFormatFromExtension("a.numbers")).toThrow(/\.xlsx, \.ods, \.csv, \.tsv/)
+  })
+
+  it("says so when there is no extension at all", () => {
+    expect(() => detectFormatFromExtension("README")).toThrow(/\(none\)/)
+  })
+})
+
+// ── The .tsv delimiter bug ──────────────────────────────────────────
+
+describe("tab-separated files", () => {
+  it("writes .tsv with tabs, not commas", async () => {
+    // Both extensions map to the format "csv", and the writer then took
+    // its default delimiter — so `convert x.xlsx out.tsv` produced a
+    // comma-separated file whose name said otherwise.
+    const input = await makeXlsx("in.xlsx", [
+      ["h1", "h2"],
+      ["b", 2],
+    ])
+    await run(convertCommand, { input, output: path("out.tsv") })
+
+    const text = readFileSync(path("out.tsv"), "utf-8")
+    expect(text).toContain("h1\th2")
+    expect(text).not.toContain("h1,h2")
+  })
+
+  it("still writes .csv with commas", async () => {
+    const input = await makeXlsx("in.xlsx", [["h1", "h2"]])
+    await run(convertCommand, { input, output: path("out.csv") })
+    expect(readFileSync(path("out.csv"), "utf-8")).toContain("h1,h2")
+  })
+
+  it("round-trips a tab-separated file without changing its separator", async () => {
+    writeFileSync(path("in.tsv"), "a\tb\nc\td", "utf-8")
+    await run(convertCommand, { input: path("in.tsv"), output: path("out.tsv") })
+    const text = readFileSync(path("out.tsv"), "utf-8")
+    expect(text).toContain("a\tb")
+    expect(text).toContain("c\td")
+  })
+
+  it("reads a comma file named .tsv by its extension, not its content", () => {
+    // Deliberate: the extension is the declaration. parseCsv's sniffing
+    // is a fallback for input of unknown provenance, not a licence to
+    // ignore what the caller named the file.
+    expect(delimiterForExtension("x.tsv")).toBe("\t")
+    expect(delimiterForExtension("x.csv")).toBe(",")
+    expect(delimiterForExtension("x.xlsx")).toBe(",")
+  })
+})
+
+// ── convert ─────────────────────────────────────────────────────────
+
+describe("convert", () => {
+  it("formats the first row like every other row", async () => {
+    // Row 0 used to be pulled out as `headers` and stringified through
+    // formatCellValue, while rows 1..n went through writeCsv — so the
+    // same Date rendered two different ways depending on its row.
+    const d = new Date(Date.UTC(2024, 0, 15))
+    const input = await makeXlsx("in.xlsx", [[d], [d]])
+    await run(convertCommand, { input, output: path("out.csv") })
+
+    const [first, second] = readFileSync(path("out.csv"), "utf-8").trim().split(/\r?\n/)
+    expect(first).toBe(second)
+  })
+
+  it("converts xlsx to ods", async () => {
+    const input = await makeXlsx("in.xlsx", [["a", 1]], "Data")
+    await run(convertCommand, { input, output: path("out.ods") })
+    const back = await readFile(path("out.ods"))
+    expect(back.sheets[0].name).toBe("Data")
+    expect(back.sheets[0].rows[0]).toEqual(["a", 1])
+  })
+
+  it("converts ods to xlsx", async () => {
+    writeFileSync(path("in.ods"), await writeOds({ sheets: [{ name: "S", rows: [["x", 2]] }] }))
+    await run(convertCommand, { input: path("in.ods"), output: path("out.xlsx") })
+    const back = await readXlsx(readFileSync(path("out.xlsx")))
+    expect(back.sheets[0].rows[0]).toEqual(["x", 2])
+  })
+
+  it("converts csv to xlsx", async () => {
+    writeFileSync(path("in.csv"), "a,b\n1,2", "utf-8")
+    await run(convertCommand, { input: path("in.csv"), output: path("out.xlsx") })
+    const back = await readXlsx(readFileSync(path("out.xlsx")))
+    expect(back.sheets[0].rows).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ])
+  })
+
+  it("takes the first sheet only when the target is csv", async () => {
+    const p = path("multi.xlsx")
+    writeFileSync(
+      p,
+      await writeXlsx({
+        sheets: [
+          { name: "One", rows: [["first"]] },
+          { name: "Two", rows: [["second"]] },
+        ],
+      }),
+    )
+    await run(convertCommand, { input: p, output: path("out.csv") })
+    const text = readFileSync(path("out.csv"), "utf-8")
+    expect(text).toContain("first")
+    expect(text).not.toContain("second")
+  })
+
+  it("rejects an output extension it cannot write", async () => {
+    const input = await makeXlsx("in.xlsx", [["a"]])
+    await expect(run(convertCommand, { input, output: path("out.pdf") })).rejects.toThrow(CliError)
+  })
+
+  it("says in --help that it carries values only", () => {
+    expect(convertCommand.meta).toMatchObject({
+      description: expect.stringContaining("cell values only"),
+    })
+  })
+})
+
+// ── inspect ─────────────────────────────────────────────────────────
+
+describe("inspect", () => {
+  it("reports sheets, dimensions and a cell-type breakdown", async () => {
+    const input = await makeXlsx(
+      "in.xlsx",
+      [
+        ["a", 1, true],
+        [new Date(0), null],
+      ],
+      "Mixed",
+    )
+    await run(inspectCommand, { file: input })
+
+    const out = logs.join("\n")
+    expect(out).toContain("Sheets: 1")
+    expect(out).toContain('"Mixed"')
+    expect(out).toContain("2 rows x 3 cols")
+    expect(out).toMatch(/string: \d/)
+    expect(out).toMatch(/number: \d/)
+    expect(out).toMatch(/boolean: \d/)
+  })
+
+  it("prints document properties when the file carries them", async () => {
+    const p = path("props.xlsx")
+    writeFileSync(
+      p,
+      await writeXlsx({
+        sheets: [{ name: "S", rows: [["a"]] }],
+        properties: { title: "Quarterly", creator: "Ada", created: new Date(Date.UTC(2020, 0, 1)) },
+      }),
+    )
+    await run(inspectCommand, { file: p })
+
+    const out = logs.join("\n")
+    expect(out).toContain("Title: Quarterly")
+    expect(out).toContain("Creator: Ada")
+    expect(out).toContain("2020-01-01")
+  })
+
+  it("previews a sheet with --sheet", async () => {
+    const input = await makeXlsx("in.xlsx", [["header"], ["value"]])
+    await run(inspectCommand, { file: input, sheet: "0" })
+    expect(logs.join("\n")).toContain("header")
+  })
+
+  it("truncates a long cell in the preview", async () => {
+    const input = await makeXlsx("in.xlsx", [["x".repeat(100)]])
+    await run(inspectCommand, { file: input, sheet: "0" })
+    expect(logs.join("\n")).toContain("...")
+  })
+
+  it("caps the preview at ten rows and says how many were left out", async () => {
+    const rows = Array.from({ length: 25 }, (_, i) => [`r${i}`])
+    const input = await makeXlsx("in.xlsx", rows)
+    await run(inspectCommand, { file: input, sheet: "0" })
+
+    const out = logs.join("\n")
+    expect(out).toContain("and 15 more rows")
+    expect(out).not.toContain("r10")
+  })
+
+  it("handles an empty sheet", async () => {
+    writeFileSync(path("empty.csv"), "", "utf-8")
+    await run(inspectCommand, { file: path("empty.csv"), sheet: "0" })
+    expect(logs.join("\n")).toContain("(empty sheet)")
+  })
+
+  const badIndexes = ["9", "-1", "abc", "1.5"]
+  for (const bad of badIndexes) {
+    it(`rejects --sheet ${bad}`, async () => {
+      const input = await makeXlsx("in.xlsx", [["a"]])
+      await expect(run(inspectCommand, { file: input, sheet: bad })).rejects.toThrow(
+        /Invalid sheet index/,
+      )
+    })
+  }
+})
+
+// ── validate ────────────────────────────────────────────────────────
+
+describe("validate", () => {
+  const schema = {
+    name: { type: "string", required: true },
+    age: { type: "number" },
+  }
+
+  async function withSchema(rows: unknown[][]): Promise<{ file: string; schema: string }> {
+    const file = await makeXlsx("data.xlsx", rows)
+    const schemaPath = path("schema.json")
+    writeFileSync(schemaPath, JSON.stringify(schema), "utf-8")
+    return { file, schema: schemaPath }
+  }
+
+  it("passes a conforming sheet", async () => {
+    const paths = await withSchema([
+      ["name", "age"],
+      ["Ada", 36],
+    ])
+    await run(validateCommand, paths)
+    expect(logs.join("\n")).toContain("1 row(s) passed")
+  })
+
+  it("fails, lists the errors, and throws", async () => {
+    const paths = await withSchema([
+      ["name", "age"],
+      [null, "not a number"],
+    ])
+    await expect(run(validateCommand, paths)).rejects.toThrow(/Validation failed/)
+    expect(logs.join("\n")).toMatch(/Row \d+, Column/)
+  })
+
+  it("caps the listed errors at twenty", async () => {
+    const rows: unknown[][] = [["name", "age"]]
+    for (let i = 0; i < 30; i++) rows.push([null, 1])
+    const paths = await withSchema(rows)
+
+    await expect(run(validateCommand, paths)).rejects.toThrow(CliError)
+    expect(logs.join("\n")).toContain("and 10 more errors")
+  })
+
+  it("rejects a schema file that is not JSON", async () => {
+    const file = await makeXlsx("data.xlsx", [["name"], ["Ada"]])
+    const schemaPath = path("broken.json")
+    writeFileSync(schemaPath, "{ not json", "utf-8")
+    await expect(run(validateCommand, { file, schema: schemaPath })).rejects.toThrow(
+      /Invalid JSON schema/,
+    )
+  })
+
+  it("rejects a sheet index the file does not have", async () => {
+    const paths = await withSchema([["name"], ["Ada"]])
+    await expect(run(validateCommand, { ...paths, sheet: "3" })).rejects.toThrow(
+      /File has 1 sheet\(s\)/,
+    )
+  })
+
+  it("rejects a sheet index that is not a number", async () => {
+    const paths = await withSchema([["name"], ["Ada"]])
+    await expect(run(validateCommand, { ...paths, sheet: "x" })).rejects.toThrow(
+      /Invalid sheet index/,
+    )
+  })
+
+  it("defaults to the first sheet", async () => {
+    const paths = await withSchema([["name"], ["Ada"]])
+    await run(validateCommand, paths)
+    expect(logs.join("\n")).toContain("passed validation")
+  })
+})
+
+// ── Wiring ──────────────────────────────────────────────────────────
+
+describe("the command tree", () => {
+  it("exposes all three subcommands", () => {
+    expect(Object.keys(mainCommand.subCommands as object).sort()).toEqual([
+      "convert",
+      "inspect",
+      "validate",
+    ])
+  })
+
+  it("reports the package version, not the 0.0.0 fallback", () => {
+    // The fallback exists so the CLI still runs if package.json cannot be
+    // resolved; reaching it in a normal install means the bundle's
+    // relative path to package.json is wrong, which is #357's failure.
+    expect(pkgVersion).toMatch(/^\d+\.\d+\.\d+/)
+    expect(pkgVersion).not.toBe("0.0.0")
+  })
+})
+
+describe("the node-builtin boundary", () => {
+  it("is crossed by the CLI and nothing else in src/", async () => {
+    // The library is platform-neutral: Web APIs only, so it runs the same
+    // in a browser, a worker and Deno. tsconfig.json enforces that by
+    // declaring no ambient types, which makes `process` and `Buffer` type
+    // errors — but an `import ... from "node:fs"` would still resolve at
+    // run time in Node, so check the imports directly too.
+    const { readdirSync, readFileSync: read } = await import("node:fs")
+    const { join: j } = await import("node:path")
+
+    const offenders: string[] = []
+    const walk = (rel: string): void => {
+      for (const entry of readdirSync(j("src", rel), { withFileTypes: true })) {
+        const child = rel ? `${rel}/${entry.name}` : entry.name
+        if (entry.isDirectory()) {
+          walk(child)
+        } else if (entry.name.endsWith(".ts")) {
+          if (/from\s+["']node:/.test(read(j("src", child), "utf-8"))) offenders.push(child)
+        }
+      }
+    }
+    walk("")
+
+    expect(offenders.sort()).toEqual(["cli/commands.ts"])
+  })
+})
+
+describe("formatCellValue", () => {
+  it("renders each cell type", () => {
+    expect(formatCellValue(null)).toBe("")
+    expect(formatCellValue(undefined as never)).toBe("")
+    expect(formatCellValue(new Date(0))).toBe("1970-01-01T00:00:00.000Z")
+    expect(formatCellValue(42)).toBe("42")
+    expect(formatCellValue(true)).toBe("true")
+    expect(formatCellValue("x")).toBe("x")
+  })
+})

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,16 @@
+{
+  // The CLI, and only the CLI, gets node's ambient types.
+  //
+  // It used to be excluded from typechecking altogether — `src/cli.ts`
+  // sat in tsconfig.json's `exclude` list, so the one part of hucre that
+  // ships as an executable was the one part `tsc` never looked at. That
+  // is how #357 (a published binary that could not start) got through.
+  // Splitting it into its own project restores the check without letting
+  // `process` and `Buffer` leak into the platform-neutral library.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/cli.ts", "src/cli", "test/cli.test.ts"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,15 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
-    "noEmit": true
+    "noEmit": true,
+    // No ambient types, deliberately. The library is platform-neutral —
+    // Web APIs only, no `node:` imports — and leaving `process`, `Buffer`
+    // and friends undeclared is what keeps it that way: reaching for one
+    // is a type error here rather than something that quietly works on
+    // the machine it was written on. The CLI is the one part allowed node
+    // builtins, and it is checked by tsconfig.cli.json instead. See #399.
+    "types": []
   },
   "include": ["src", "test"],
-  "exclude": ["src/cli.ts"]
+  "exclude": ["src/cli.ts", "src/cli", "test/cli.test.ts"]
 }


### PR DESCRIPTION

src/cli.ts ended in a bare runMain(), so importing the module ran the
CLI: it read process.argv and could call process.exit. That is why it was
the only module in the tree at 0% coverage, and it is not a coverage
problem — it is why nobody could test the one part of hucre that users
invoke directly.

The commands move to src/cli/commands.ts and are exported. src/cli.ts is
now the bin and nothing else. Commands throw CliError instead of calling
process.exit; the bin translates that to a clean message and exit 1,
since citty's runMain would otherwise print a raw stack trace.

Three defects the tests found immediately:

.tsv was written comma-separated. Both .csv and .tsv mapped to the
format "csv" and the writer then took its default delimiter, so
`hucre convert in.xlsx out.tsv` produced a comma-separated file whose
name said otherwise. The read side never had the bug — parseCsv sniffs
the delimiter — which made it worse: `convert data.tsv out.tsv` silently
turned tabs into commas. Both directions now go by the extension.

Row 0 was formatted by a different code path from every other row.
convert pulled the first row out as `headers` and stringified it through
formatCellValue, while rows 1..n went to writeCsv untouched. A Date in
row 0 came out ISO; the same Date in row 1 came out in writeCsv's format.
Every row now goes through writeCsv.

The CLI was never typechecked. src/cli.ts sat in tsconfig.json's
`exclude` list, so the one part of hucre that ships as an executable was
the one part tsc never looked at — which is how #357 (a published binary
that could not start) got through. It now has its own project,
tsconfig.cli.json, and the check caught a real type error on the first
run.

The base tsconfig keeps `types: []` rather than adding @types/node
globally. The library is platform-neutral — Web APIs only — and having
`process` and `Buffer` undeclared is what keeps it that way. A test walks
src/ and asserts that src/cli/commands.ts is the only file importing a
node: builtin, so the boundary holds even where types would not catch it.

Also: convert's --help now says it carries cell values only. Styles,
merges, formulas, charts and images are dropped, which may be the right
scope for a CLI but should be stated rather than discovered.

35 tests covering all three subcommands, the format detection, and every
error exit.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 146 files, 9,320 tests. `node scripts/verify-package.mjs` passes against the rebuilt tarball, and the built `dist/cli.mjs` was smoke-tested by hand for the tab output and the exit codes.

Closes #399.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD