### PR TITLE
fix: keep interior empty ODS rows, and fix improper/zero-rounding fractions

### DIFF
--- a/src/_format.ts
+++ b/src/_format.ts
@@ -410,23 +410,24 @@ function isFractionFormat(fmt: string): boolean {
 }
 
 function formatFraction(value: number, fmt: string): string {
-  const intPart = Math.trunc(value)
-  let frac = Math.abs(value - intPart)
-
-  if (frac === 0) {
-    // Show integer only for whole numbers
-    const showInt = fmt.includes("#") || /^[0?]/.test(fmt.trim())
-    if (showInt && intPart !== 0) {
-      return String(intPart)
-    }
-    return String(intPart) + "      " // padded like Excel
-  }
-
   // Determine denominator precision from format
   const fracMatch = fmt.match(FRACTION_PARTS)
   if (!fracMatch) {
     return String(value)
   }
+
+  // A whole part is only rendered when the format has a placeholder in front
+  // of the fraction — "?" counts just as much as "#" and "0" ("? ?/?" is a
+  // mixed number, "??/??" is improper.)
+  const wholeFmt = fmt.slice(0, fracMatch.index)
+  const hasIntPart = /[#0?]/.test(wholeFmt)
+
+  const intPart = Math.trunc(value)
+  // With no whole-part placeholder there is nowhere to put the integer, so
+  // Excel folds it into the numerator: 2.5 under "??/??" is "5/2", not
+  // "1/2". Formatting the remainder alone would drop the whole part
+  // silently — a different number, not a different presentation. See #397.
+  const target = hasIntPart ? Math.abs(value - intPart) : Math.abs(value)
 
   const denomLen = fracMatch[2].length
 
@@ -436,22 +437,34 @@ function formatFraction(value: number, fmt: string): string {
   let bestNum: number
   let bestDen: number
 
-  if (fixedDenom > 0) {
+  if (target === 0) {
+    bestNum = 0
+    bestDen = fixedDenom > 0 ? fixedDenom : 1
+  } else if (fixedDenom > 0) {
     bestDen = fixedDenom
-    bestNum = Math.round(frac * fixedDenom)
+    bestNum = Math.round(target * fixedDenom)
   } else {
     // Find best fraction with denominator up to 10^denomLen
     const maxDen = Math.pow(10, denomLen) - 1
-    const result = findBestFraction(frac, maxDen)
+    const result = findBestFraction(target, maxDen)
     bestNum = result.num
     bestDen = result.den
   }
 
-  // Build the formatted string. A whole part is only rendered when the
-  // format has a placeholder in front of the fraction — "?" counts just as
-  // much as "#" and "0" ("? ?/?" is a mixed number, "??/??" is improper.)
-  const wholeFmt = fmt.slice(0, fracMatch.index)
-  const hasIntPart = /[#0?]/.test(wholeFmt)
+  // Nothing left for the fraction area: either the value is whole, or the
+  // remainder rounded away against a denominator the format fixed (0.1 over
+  // halves). Excel prints the whole part rather than a zero numerator —
+  // "3 0/2" is not something it ever renders. See #397.
+  if (bestNum === 0) {
+    // Show integer only for whole numbers
+    const showInt = fmt.includes("#") || /^[0?]/.test(fmt.trim())
+    if (showInt && intPart !== 0) {
+      return String(intPart)
+    }
+    return String(intPart) + "      " // padded like Excel
+  }
+
+  // Build the formatted string.
   // The sign has to come from the value: Math.trunc(-0.5) is -0, which is
   // neither `!== 0` nor `< 0`, so the sign would be lost for -1 < value < 0.
   const sign = value < 0 ? "-" : ""

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -458,6 +458,7 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
     const tableRows = findChildren(table, "table-row")
 
     let currentRow = 0
+    let pendingEmptyRows = 0
 
     for (const tableRow of tableRows) {
       const rowRepeat = Number(tableRow.attrs["table:number-rows-repeated"] ?? "1")
@@ -589,12 +590,40 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
         }
       }
 
-      // Cap row repeats for empty rows to avoid memory issues
-      // (LibreOffice may emit large row repeats for trailing empty rows).
-      // For non-empty rows, a hostile file can set a huge number-rows-repeated
-      // on a one-cell row to force millions of allocations — clamp to Excel's
-      // row limit.
-      const effectiveRowRepeat = rowData.length > 0 ? Math.min(rowRepeat, MAX_ROW_INDEX + 1) : 0
+      if (rowData.length === 0) {
+        // An empty row is held back rather than pushed. Whether it is data
+        // depends on what comes after it: an interior one carries position
+        // and has to survive, while the run LibreOffice pads the end of a
+        // sheet with — one row repeated a million times — is not. Deciding
+        // that here would need lookahead; deferring costs nothing and keeps
+        // the trailing run from ever being allocated. See #394.
+        // A malformed repeat parses to NaN, and the populated path drops
+        // such a row outright (Math.min(NaN, …) is NaN, so its loop never
+        // runs) — keep NaN out of the accumulator rather than letting it
+        // poison every later flush.
+        if (rowRepeat > 0) pendingEmptyRows += rowRepeat
+        // The row counter still advances: merges and `cells` are keyed off
+        // it, so it has to track the file's own row numbering either way.
+        currentRow += rowRepeat
+        continue
+      }
+
+      // A populated row makes every held-back empty row an interior one, so
+      // flush them at the positions the file gave them. They carry no cells,
+      // which puts them outside the MAX_TOTAL_CELLS guard below — bound them
+      // by the sheet's row limit instead, or a file of nothing but huge
+      // repeated empty rows would allocate without limit.
+      if (pendingEmptyRows > 0) {
+        const flush = Math.min(pendingEmptyRows, MAX_ROW_INDEX + 1 - rows.length)
+        for (let r = 0; r < flush; r++) {
+          rows.push([])
+        }
+        pendingEmptyRows = 0
+      }
+
+      // A hostile file can set a huge number-rows-repeated on a one-cell row
+      // to force millions of allocations — clamp to Excel's row limit.
+      const effectiveRowRepeat = Math.min(rowRepeat, MAX_ROW_INDEX + 1)
 
       // Each repeat attribute is capped on its own, but the aggregate is
       // not: one row of 16,384 cells repeated 1,048,576 times is 1.7e10
@@ -612,14 +641,11 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
         }
         currentRow++
       }
-
-      if (effectiveRowRepeat === 0) {
-        // Still advance row counter for empty repeated rows
-        currentRow += rowRepeat
-      }
     }
 
-    // Trim trailing empty rows
+    // Trim trailing empty rows. The walk above no longer pushes any (a run
+    // of empty rows is only flushed once a populated row follows it), so
+    // this is a backstop rather than the mechanism.
     while (rows.length > 0 && rows[rows.length - 1].length === 0) {
       rows.pop()
     }

--- a/test/coverage-number-format.test.ts
+++ b/test/coverage-number-format.test.ts
@@ -417,6 +417,43 @@ describe("formatValue — Excel parity", () => {
     expect(formatValue(2.5, "? ?/?")).toBe("2 1/2")
   })
 
+  // ── #397 ──────────────────────────────────────────────────────────
+  //
+  // With no placeholder at all ahead of the slash there is nowhere to put
+  // the whole part, so Excel folds it into the numerator: the fraction is
+  // improper. Formatting the remainder alone dropped it — 2.5 read back as
+  // one half.
+  it("folds the whole part into the numerator when the format has no integer slot", () => {
+    expect(formatValue(2.5, "??/??")).toBe(" 5/ 2")
+    expect(formatValue(2.5, "??/2")).toBe(" 5/2")
+  })
+
+  it("keeps the sign of an improper fraction", () => {
+    expect(formatValue(-2.5, "??/??")).toBe("- 5/ 2")
+  })
+
+  // A whole number under an improper format still has to render as a
+  // fraction — "??/??" has no other place to show it.
+  it("gives a whole number a denominator of one under an improper format", () => {
+    expect(formatValue(3, "??/??")).toBe(" 3/ 1")
+  })
+
+  // A denominator the format fixes can round the remainder away: 0.1 over
+  // halves is 0. Excel renders the whole part rather than a zero numerator
+  // — it never shows "3 0/2". The whole-number path is shared, so 3.1 and
+  // 3 print alike under "# ?/2".
+  it("drops the fraction area when the remainder rounds to a zero numerator", () => {
+    expect(formatValue(3.1, "# ?/2")).toBe("3")
+    expect(formatValue(3.1, "# ?/2")).toBe(formatValue(3, "# ?/2"))
+    expect(formatValue(-3.1, "# ?/2")).toBe("-3")
+  })
+
+  // The remainder only rounds away against a coarse denominator; a search
+  // that can reach the value still renders a fraction.
+  it("still renders a fraction when the denominator can represent the remainder", () => {
+    expect(formatValue(3.1, "# ??/??")).toBe("3  1/10")
+  })
+
   // "?" renders insignificant decimals as spaces so decimal points line up
   // down a column, where "0" would render them as zeros.
   it("pads insignificant decimals with spaces for a ? placeholder", () => {

--- a/test/coverage-ods-branches.test.ts
+++ b/test/coverage-ods-branches.test.ts
@@ -660,10 +660,11 @@ describe("ODS reader — repeated cells, covered cells and merges", () => {
     expect(sheet.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }])
   })
 
-  it("advances the row counter across empty repeated rows", async () => {
-    // LibreOffice pads the tail of a sheet with a single empty row repeated
-    // a million times; those must not become a million row arrays, but the
-    // rows after them must still land at the right index.
+  it("keeps empty repeated rows that sit between populated ones", async () => {
+    // An empty row with a populated row after it is interior: it carries
+    // position, so it has to occupy its own index. The `cells` key and the
+    // array index are the same coordinate, and they used to disagree —
+    // the key said 6 while the row landed at 1. See #394.
     const wb = await readBody(
       table(
         `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>` +
@@ -672,8 +673,64 @@ describe("ODS reader — repeated cells, covered cells and merges", () => {
       ),
     )
     const sheet = wb.sheets[0]!
-    expect(sheet.rows.length).toBe(2)
+    expect(sheet.rows.length).toBe(7)
+    expect(sheet.rows.slice(1, 6)).toEqual([[], [], [], [], []])
+    expect(sheet.rows[6]).toEqual([1])
     expect([...sheet.cells!.keys()]).toEqual(["6,0"])
+  })
+
+  it("drops a trailing run of empty repeated rows instead of materializing it", async () => {
+    // LibreOffice pads the tail of a sheet with a single empty row repeated
+    // a million times. Nothing follows it, so it is padding rather than
+    // position — it must not become a million row arrays.
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>` +
+          `<table:table-row table:number-rows-repeated="1048570"><table:table-cell/></table:table-row>`,
+      ),
+    )
+    expect(wb.sheets[0]!.rows).toEqual([["a"]])
+  })
+
+  it("keeps a blank separator row between two populated ones", async () => {
+    // The shape every ODS with a title block or a gap between sections has.
+    // Collapsing it shifted every row below by one, so merge ranges and
+    // `cells` keys stopped lining up with the file. See #394.
+    const body = table(
+      `<table:table-row><table:table-cell office:value-type="string"><text:p>a</text:p></table:table-cell></table:table-row>` +
+        `<table:table-row/>` +
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>b</text:p></table:table-cell></table:table-row>`,
+    )
+    const wb = await readBody(body)
+    expect(wb.sheets[0]!.rows).toEqual([["a"], [], ["b"]])
+
+    // The streaming reader never emitted the empty row, but it carries the
+    // row number on each `StreamRow` rather than in the array position, so
+    // it always agreed with the file. Now the two readers agree with it too.
+    const data = await odsFile({ content: contentXml(body) })
+    const streamed = await collectStream(data)
+    expect(streamed.map((r) => [r.index, r.values])).toEqual([
+      [0, ["a"]],
+      [2, ["b"]],
+    ])
+  })
+
+  it("keeps a merge anchored below a blank separator row on its own row", async () => {
+    const wb = await readBody(
+      table(
+        `<table:table-row><table:table-cell office:value-type="string"><text:p>title</text:p></table:table-cell></table:table-row>` +
+          `<table:table-row/>` +
+          `<table:table-row>` +
+          `<table:table-cell table:number-columns-spanned="2" office:value-type="string"><text:p>wide</text:p></table:table-cell>` +
+          `<table:covered-table-cell/>` +
+          `</table:table-row>`,
+      ),
+    )
+    const sheet = wb.sheets[0]!
+    // The covered cell is a trailing null, so it trims off the row itself;
+    // the merge it belongs to is what has to keep the row number.
+    expect(sheet.rows).toEqual([["title"], [], ["wide"]])
+    expect(sheet.merges).toEqual([{ startRow: 2, startCol: 0, endRow: 2, endCol: 1 }])
   })
 })
 
@@ -1262,38 +1319,29 @@ describe("ODS writer — columns + data", () => {
     expect(wb.sheets[0]!.rows).toEqual([])
   })
 
-  // ── Known defect ─────────────────────────────────────────────────
   it("writes a cells override that sits on a trailing empty cell", async () => {
-    // src/ods/writer.ts:629-642 computes `lastMeaningful` from the row's own
-    // values and then extends it only for merge starts and covered cells —
-    // never for `sheet.cells`. Any override whose column is at or past the
-    // row's last non-null value is therefore never emitted: the row stops
-    // short of it. The same holds for an override below the last row, since
-    // writeContentXml iterates `rows` (src/ods/writer.ts:736) and sizes the
-    // table from `rows` + `merges` only (src/ods/writer.ts:762-772).
-    // The XLSX writer grows the grid for exactly this case
-    // (src/xlsx/worksheet-writer.ts:679-692), so one WriteSheet produces two
-    // different documents depending on the output format.
-    // Input:    rows [[1, null, null]], cells { "0,2": { formula: "NOW()" } }
-    // Expected: <table:table-cell table:formula="of:=NOW()"> in column C
-    // Actual:   the row ends after column A; the override is dropped
+    // src/ods/writer.ts computes `lastMeaningful` from the row's own values;
+    // it now extends the row for `sheet.cells` too, and grows the table past
+    // the last `rows` entry for an override below it. Without that, an
+    // override at or past a row's last non-null value was simply dropped —
+    // and the XLSX writer grows the grid for exactly this case, so one
+    // WriteSheet produced two different documents per output format.
     const cells = new Map<string, Partial<Cell>>()
     cells.set("0,2", { value: null, formula: "NOW()" })
     cells.set("2,0", { value: "z" })
     const data = await writeOds({ sheets: [{ name: "S", rows: [[1, null, null]], cells }] })
 
-    // The column-wise override round-trips.
-    const wb = await readOds(data)
-    expect(wb.sheets[0]!.cells?.get("0,2")?.formula).toBe("NOW()")
-
-    // The row-wise one is asserted on the emitted XML rather than the
-    // round-trip, because the reader collapses an *interior* empty row
-    // instead of preserving its position — a separate defect, filed
-    // separately. The writer's half is what this fix is about.
     const xml = new TextDecoder().decode(await new ZipReader(data).extract("content.xml"))
     const emittedRows = xml.match(/<table:table-row[\s\S]*?(?:<\/table:table-row>|\/>)/g) ?? []
     expect(emittedRows).toHaveLength(3)
     expect(emittedRows[2]).toContain("<text:p>z</text:p>")
+
+    // Both overrides round-trip. The row-wise one used to be asserted on the
+    // emitted XML alone, because the reader collapsed the interior empty row
+    // between them and "z" read back at index 1. See #394.
+    const wb = await readOds(data)
+    expect(wb.sheets[0]!.cells?.get("0,2")?.formula).toBe("NOW()")
+    expect(wb.sheets[0]!.rows).toEqual([[1, null, null], [], ["z"]])
   })
 
   it("writes a self-closing cell for a null override with nothing else on it", async () => {

--- a/test/ods.test.ts
+++ b/test/ods.test.ts
@@ -781,15 +781,14 @@ describe("ODS Reader", () => {
     })
 
     const workbook = await readOds(written)
-    expect(workbook.sheets[0].rows.length).toBe(2) // middle empty row trimmed from end? no, row 3 exists
-    // Actually: row 0 has data, row 1 is empty (trimmed because all null), row 2 has data
-    // The reader trims trailing null cells and skips fully-empty rows...
-    // But with the new reader, fully empty rows between data rows are still skipped
-    // Row 0: ["A1", null x 8, "J1"] -> ["A1", null, null, null, null, null, null, null, null, "J1"]
-    // Row 1: all null -> skipped
-    // Row 2: ["A3"] -> ["A3"]
+    // Row 0: ["A1", null x 8, "J1"] -> trailing nulls trimmed, "J1" keeps col 9
+    // Row 1: all null -> [], an interior empty row keeps its position (#394)
+    // Row 2: ["A3"] -> ["A3"], still at index 2
+    expect(workbook.sheets[0].rows.length).toBe(3)
     expect(workbook.sheets[0].rows[0][0]).toBe("A1")
     expect(workbook.sheets[0].rows[0][9]).toBe("J1")
+    expect(workbook.sheets[0].rows[1]).toEqual([])
+    expect(workbook.sheets[0].rows[2][0]).toBe("A3")
   })
 
   it("reads cells with number-columns-repeated correctly", async () => {


### PR DESCRIPTION
Closes #394. Closes #397.

## #394 — ODS reader collapsed interior empty rows

`parseContentXml` computed `effectiveRowRepeat = rowData.length > 0 ? … : 0`, so a row with no cell values pushed nothing while `currentRow` advanced. Trailing padding and an interior gap were treated identically, and every row after a blank one shifted up:

```
before: [["a"], ["b"]]        "b" at index 1
after:  [["a"], [], ["b"]]    "b" at index 2
```

The fix defers rather than trims. Empty rows go into a `pendingEmptyRows` counter and are flushed as `[]` at their real positions the moment a populated row proves them interior; a trailing run is never flushed. That deferral is the point — the issue's "always push, then trim at the end" sketch would materialize LibreOffice's ~1,048,576-row tail padding on every real ODS file before throwing it away.

Empty rows carry no cells, so they sit outside the `MAX_TOTAL_CELLS` guard; the flush is bounded by `MAX_ROW_INDEX + 1` instead. An interior `number-rows-repeated="1048570"` reads as 1,048,572 rows in ~115 ms; the same repeat in trailing position still reads as 1 row.

**The streaming reader did not share the defect.** `src/ods/stream.ts` also skips empty rows, but a `StreamRow` carries its position in `index` rather than in an array slot, and it already did `currentRowIndex += rowRepeat` — it reported populated rows at the file's own indices all along. So the batch fix brings the two into agreement rather than the reverse; there is now a parity assertion saying so.

## #397 — improper and zero-rounding fractions

`formatFraction` always fed the *remainder* to the denominator search and computed `hasIntPart` afterwards, purely for presentation.

**Improper fractions.** `hasIntPart` is now computed first and decides what gets formatted: with no whole-part placeholder there is nowhere to put the integer, so the whole value goes to the numerator.

| | before | after |
| --- | --- | --- |
| `2.5` as `??/??` | `1/2` | `5/2` |
| `-2.5` as `??/??` | `-1/2` | `-5/2` |
| `3` as `??/??` | `3` | `3/1` |

Formatting the remainder alone was not a presentation difference — it printed a different number.

**Zero-rounding.** The whole-number branch moved below the numerator computation so `bestNum === 0` shares it: `3.1` as `# ?/2` was `3 0/2`, now `3`. Excel never renders a zero numerator.

(Actual strings are space-padded to the `?` widths, per the existing convention `formatValue(2.25, "# ??/??") === "2  1/ 4"`; the issue quotes them trimmed.)

**One deliberate deviation.** The issue quotes Excel as `"3    "` — whole number with a blanked fraction area. hucre returns bare `"3"` for an *exact* whole under the same format, asserted in `coverage-number-format.test.ts` with the comment "Excel shows the integer alone". 3 and 3.1 have to render identically under one format, so the rounds-to-zero case was routed through the existing whole-number path rather than making 3.1 pad while 3.0 does not. Making both pad is the more Excel-faithful outcome but rewrites an assertion outside this issue's scope — filed separately.

## Existing tests changed (3, all of which encoded the collapse)

- `ods.test.ts` "handles large sheet with sparse data efficiently" — expected 2 rows for populated/empty/populated, its own comment reading "fully empty rows between data rows are still skipped". Now 3, with `rows[1] === []`.
- `coverage-ods-branches.test.ts` "advances the row counter across empty repeated rows" — expected `rows.length === 2` while asserting a `cells` key of `"6,0"`: the two coordinates the defect put out of step. Split into an interior case (7 rows, key still `"6,0"`) and a new trailing-padding case.
- `coverage-ods-branches.test.ts` "writes a cells override that sits on a trailing empty cell" — strengthened to assert the round-trip alongside the XML. Its "known defect" header was stale; #389 fixed the writer half.

New tests: blank separator row plus stream parity, a merge anchored below a blank row, trailing-padding drop, and five fraction cases in the #388 Excel-parity block.

## Found along the way, not fixed here

- `isFractionFormat` requires **two** placeholders before the slash (`/[#0?]\s*[?#0]+\//`), so single-placeholder formats are not recognized at all and fall through to `formatNumber`: `formatValue(2.5, "?/?")` returns `" /3"` for a legal Excel format, and `"0/2"` is affected the same way. Left alone — it widens a regex #396 just reworked, and neither issue mentions it.
- A malformed `table:number-rows-repeated` parses to `NaN`. The populated path drops such a row silently (`Math.min(NaN, …)` is `NaN`, so its loop never runs); left as-is, but guarded with `if (rowRepeat > 0)` so it cannot poison the new empty-row accumulator.

Verified: `pnpm lint`, `pnpm typecheck`, `pnpm test` — 145 files, 9,293 tests, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
