### PR TITLE
fix: remove the dead WriteSheet.threadedComments field, and the README lines that contradicted the code

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,18 +8,18 @@ If a change here breaks something and the reason isn't clear, please open an iss
 
 ## At a glance
 
-| Change                                                                                               | Affects you if…                                                          |
-| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| [`writeXlsxStream` argument order](#writexlsxstream-takes-rows-first)                                | you call `writeXlsxStream`                                               |
-| [`headerRow` is 0-based everywhere](#headerrow-means-one-thing-now)                                  | you pass `headerRow` to `validateWithSchema`                             |
-| [`hasHeaderRow` on the exporters](#hasheaderrow-on-tohtml-and-tomarkdown)                            | you pass `headerRow` to `toHtml` / `toMarkdown`                          |
-| [`streamCsvRows` header handling](#streamcsvrows-matches-parsecsv)                                   | you call `streamCsvRows({ header: true })`                               |
-| [`readObjects` / `sheetToObjects` return shape](#readobjects-and-sheettoobjects-return-data-headers) | you call either                                                          |
-| [`HucreError`](#deftererror-is-now-hucreerror)                                                       | nothing — the old name still works                                       |
-| [`readNdjsonStream`](#readndjsonstream-is-now-streamndjsonrows)                                      | nothing — the old name still works                                       |
-| [Sheet names are validated](#sheet-names-are-validated-on-write)                                     | you write sheet names with `: * ? / \ [ ]`, over 31 chars, or duplicates |
-| [Removed dead API](#removed-api-that-never-did-anything)                                             | you reference `ReadResult`, `WORKER_SAFE_FUNCTIONS`, `isoDates`, …       |
-| [Files that were silently corrupt](#files-that-were-silently-wrong)                                  | you round-trip workbooks, or print them                                  |
+| Change                                                                                               | Affects you if…                                                                                   |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [`writeXlsxStream` argument order](#writexlsxstream-takes-rows-first)                                | you call `writeXlsxStream`                                                                        |
+| [`headerRow` is 0-based everywhere](#headerrow-means-one-thing-now)                                  | you pass `headerRow` to `validateWithSchema`                                                      |
+| [`hasHeaderRow` on the exporters](#hasheaderrow-on-tohtml-and-tomarkdown)                            | you pass `headerRow` to `toHtml` / `toMarkdown`                                                   |
+| [`streamCsvRows` header handling](#streamcsvrows-matches-parsecsv)                                   | you call `streamCsvRows({ header: true })`                                                        |
+| [`readObjects` / `sheetToObjects` return shape](#readobjects-and-sheettoobjects-return-data-headers) | you call either                                                                                   |
+| [`HucreError`](#deftererror-is-now-hucreerror)                                                       | nothing — the old name still works                                                                |
+| [`readNdjsonStream`](#readndjsonstream-is-now-streamndjsonrows)                                      | nothing — the old name still works                                                                |
+| [Sheet names are validated](#sheet-names-are-validated-on-write)                                     | you write sheet names with `: * ? / \ [ ]`, over 31 chars, or duplicates                          |
+| [Removed dead API](#removed-api-that-never-did-anything)                                             | you reference `ReadResult`, `WORKER_SAFE_FUNCTIONS`, `isoDates`, `WriteSheet.threadedComments`, … |
+| [Files that were silently corrupt](#files-that-were-silently-wrong)                                  | you round-trip workbooks, or print them                                                           |
 
 ---
 
@@ -140,6 +140,7 @@ Each of these was exported or declared and had no effect. v1 would have frozen t
 | `ReadOptions.headerRow`, `ReadOptions.schema` | honoured by no reader                                        |
 | `CsvReadOptions.lineSeparator`, `.encoding`   | never read (`CsvWriteOptions.lineSeparator` is fine)         |
 | `isoDates` on the JSON writers                | see below                                                    |
+| `WriteSheet.threadedComments`                 | typed and accepted; no writer ever produced the part         |
 
 `isoDates` is worth explaining because it _looked_ like it worked. `JSON.stringify` calls `Date.prototype.toJSON` **before** consulting the replacer, so a replacer testing `value instanceof Date` is never reached — `isoDates: false` produced byte-identical output. Dates still serialize as ISO strings, exactly as before.
 

--- a/README.md
+++ b/README.md
@@ -555,6 +555,24 @@ workbook.sheets[0].rows[0][0] = "Updated!"
 const output = await saveXlsx(workbook) // Charts, VBA, themes preserved
 ```
 
+Preservation is a property of **this** path. `openXlsx`/`saveXlsx` copies
+every part it does not regenerate byte-for-byte, so anything hucre does
+not model survives. `readXlsx`/`writeXlsx` is the authoring path: it
+rebuilds the workbook from the model, and only what `WriteSheet` and
+`WriteOptions` describe comes out the other side. Reading an `.xlsm` with
+`readXlsx` and writing it back leaves no `xl/vbaProject.bin` — use
+`openXlsx`/`saveXlsx` to edit a macro-enabled workbook.
+
+To attach a macro project to a workbook you are authoring, pass the
+binary to `writeXlsx` — the output becomes macro-enabled:
+
+```ts
+await writeXlsx({
+  sheets: [{ name: "Sheet1", rows }],
+  vbaProject: await readFile("vbaProject.bin"), // output is .xlsm
+})
+```
+
 ### External Workbook References
 
 `[N]Sheet!Ref` references to other workbooks are read into a typed
@@ -1670,10 +1688,9 @@ See the [issue tracker](https://github.com/productdevbook/hucre/issues) for the 
 - Conditional formatting: `timePeriod` rules, and the `rank` / `percent` / `bottom` / `aboveAverage` / `equalAverage` / `stdDev` knobs on `top10` and `aboveAverage`
 - Auto-filter criteria beyond value lists (custom, dynamic, colour, icon filters)
 - Pre-computed pivot value cells (the writer emits the structure; Excel computes on open)
-- Threaded comments (Excel 365+) — synthesize from a fresh write (read + roundtrip already supported)
+- Threaded comments (Excel 365+) — synthesize from a fresh write (read + roundtrip already supported). `WriteSheet` has no `threadedComments` field; it is not silently accepted
 - Slicers & timeline filters — synthesize from a fresh write (read + roundtrip already supported)
 - WPS DISPIMG cell-embedded images — synthesize from a fresh write (read + roundtrip already supported)
-- VBA/macro injection
 - XLS / XLSB writing (both formats are read-only today)
 
 ## Alternatives

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1428,8 +1428,13 @@ export interface WriteSheet {
    * share the worksheet's drawing part with images and text boxes.
    */
   charts?: SheetChart[]
-  /** Excel 365 threaded comments for this sheet. */
-  threadedComments?: ThreadedComment[]
+  // No `threadedComments` here, deliberately. Authoring Excel 365 threaded
+  // comments is a roadmap item, not a shipped feature: it needs a
+  // `xl/threadedComments/` part, a workbook-wide `xl/persons/person.xml`,
+  // and the legacy `<comment>` fallback Excel expects alongside them. The
+  // field used to sit here typed and accepted, and was silently discarded
+  // — see #404. `Sheet.threadedComments` is real: they are read, and
+  // preserved through `openXlsx` → `saveXlsx`.
   /**
    * Pivot tables anchored on this sheet. The source data is read from
    * either the same sheet or a sibling sheet identified by

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -261,6 +261,11 @@ export async function saveXlsx(
     sparklines: sheet.sparklines,
     textBoxes: sheet.textBoxes,
     backgroundImage: sheet.backgroundImage,
+    // `threadedComments`, `pivotTables`, `charts` and `a11y` are absent on
+    // purpose: the writer cannot author them, so they survive this path by
+    // raw-part preservation instead. `WriteSheet` no longer declares a
+    // `threadedComments` field at all, which is what stops someone adding
+    // a line here and assuming it does something — see #404.
   }))
 
   // Create shared collectors

--- a/test/migration-guide.test.ts
+++ b/test/migration-guide.test.ts
@@ -274,6 +274,22 @@ describe("removed API that never did anything", () => {
     })
   }
 
+  it("no longer accepts WriteSheet.threadedComments", async () => {
+    // Typed and accepted, written by nothing — see #404. Removing it is
+    // the only option that tells the caller anything.
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          threadedComments: [{ id: "{c1}", ref: "A1", personId: "{p1}", text: "hi" }],
+        } as never,
+      ],
+    })
+    const workbook = await openXlsx(buf)
+    expect(workbook.sheets[0].threadedComments).toBeUndefined()
+  })
+
   it("keeps RoundtripWorkbook's internals off the object", async () => {
     const buf = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] })
     const workbook = await openXlsx(buf)

--- a/test/threaded-comments-write.test.ts
+++ b/test/threaded-comments-write.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #404 — `WriteSheet.threadedComments` was a shipped, typed field that
+// nothing wrote. A caller could pass a full thread and get a workbook
+// with no `xl/threadedComments/` part and no error. The field is gone;
+// these tests keep it gone, and keep the two README lines that
+// contradicted the code honest.
+// ═══════════════════════════════════════════════════════════════════════
+
+const readme = (): string => readFileSync(new URL("../README.md", import.meta.url), "utf-8")
+
+describe("WriteSheet has no threadedComments field", () => {
+  it("does not accept one — the type is the guard", () => {
+    const sheet: import("../src/_types").WriteSheet = {
+      name: "S",
+      rows: [["a"]],
+      // @ts-expect-error — removed in #404. If this ever compiles again,
+      // the field is back, and the writer had better write it this time.
+      threadedComments: [{ id: "{c1}", ref: "A1", personId: "{p1}", text: "hi" }],
+    }
+    expect(sheet.name).toBe("S")
+  })
+
+  it("would have produced no part even if it were passed", async () => {
+    // The reason the field had to go rather than stay as a no-op: the
+    // output looks entirely successful.
+    const buf = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          threadedComments: [{ id: "{c1}", ref: "A1", personId: "{p1}", text: "hi" }],
+        } as never,
+      ],
+    })
+    const parts = new ZipReader(buf).entries()
+    expect(parts.some((p) => p.includes("threadedComment"))).toBe(false)
+    expect(parts.some((p) => p.includes("person"))).toBe(false)
+  })
+})
+
+describe("Sheet.threadedComments is real", () => {
+  it("stays on the read model", async () => {
+    // Removing the write field must not touch the read one — they are
+    // read, and preserved through openXlsx → saveXlsx.
+    const buf = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] })
+    const workbook = await readXlsx(buf)
+    expect(workbook.sheets[0]).not.toHaveProperty("threadedComments")
+    // The property is optional, so absence here is correct; the round-trip
+    // suite in threaded-comments.test.ts covers a file that has them.
+  })
+})
+
+describe("the README no longer contradicts the code", () => {
+  it("does not list VBA injection as unimplemented, because it works", async () => {
+    const text = readme()
+    expect(text).not.toContain("- VBA/macro injection")
+
+    // …and it works, which is why the roadmap entry had to go.
+    const buf = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]] }],
+      vbaProject: new Uint8Array([1, 2, 3]),
+    })
+    expect(new ZipReader(buf).entries()).toContain("xl/vbaProject.bin")
+  })
+
+  it("scopes 'VBA preserved' to the round-trip path", () => {
+    // The claim beside the saveXlsx sample is true of that path only;
+    // readXlsx → writeXlsx drops the macro project with no warning.
+    expect(readme()).toContain("Preservation is a property of **this** path")
+  })
+
+  it("says threaded comments are not silently accepted", () => {
+    expect(readme()).toMatch(/`WriteSheet` has no `threadedComments` field/)
+  })
+})

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,7 +1,8 @@
 {
-  // The CLI, and only the CLI, gets node's ambient types.
+  // The files allowed node's ambient types. The CLI is the main occupant,
+  // hence the name, plus the handful of tests that read from disk.
   //
-  // It used to be excluded from typechecking altogether — `src/cli.ts`
+  // The CLI used to be excluded from typechecking altogether — `src/cli.ts`
   // sat in tsconfig.json's `exclude` list, so the one part of hucre that
   // ships as an executable was the one part `tsc` never looked at. That
   // is how #357 (a published binary that could not start) got through.
@@ -11,6 +12,6 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["src/cli.ts", "src/cli", "test/cli.test.ts"],
+  "include": ["src/cli.ts", "src/cli", "test/cli.test.ts", "test/threaded-comments-write.test.ts"],
   "exclude": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,5 @@
     "types": []
   },
   "include": ["src", "test"],
-  "exclude": ["src/cli.ts", "src/cli", "test/cli.test.ts"]
+  "exclude": ["src/cli.ts", "src/cli", "test/cli.test.ts", "test/threaded-comments-write.test.ts"]
 }


### PR DESCRIPTION
It was typed, shipped, documented by its own JSDoc, and written by
nothing. Pass a full thread to writeXlsx and the output has no
xl/threadedComments/ part, no xl/persons/person.xml, and no error —
verified. That is the worst category for a v1 freeze: not "unimplemented"
but "accepted and silently discarded", with no way for a caller to find
out.

Removing rather than implementing. Authoring threaded comments needs the
threadedComments part, a workbook-wide persons part, and the legacy
<comment> fallback Excel expects alongside them; the roadmap already
lists it as future work, and this project has shipped one workbook Excel
refused to open by adding a part without its plumbing (#367). Sheet
.threadedComments is untouched — they are read, and preserved through
openXlsx -> saveXlsx.

The roundtrip Sheet -> WriteSheet map gains a comment saying which fields
are absent on purpose, since that map is exactly where someone would add
a line and assume it did something.

Two README lines contradicted the code, in opposite directions:

  - "VBA/macro injection" was listed as not implemented, while
    WriteOptions.vbaProject ships and works. Roadmap entry removed, and
    the feature documented with an example, since nothing described it.
  - Threaded-comment authoring was listed as a roadmap item while the
    field shipped. The entry now says WriteSheet has no such field.

Also scoped "Charts, VBA, themes preserved". That claim sits beside the
saveXlsx sample and is true of the round-trip path only: openXlsx/saveXlsx
copies unregenerated parts byte-for-byte, while readXlsx/writeXlsx rebuilds
from the model and drops xl/vbaProject.bin with no warning. Someone
reading that line before choosing an API would have picked the wrong one.

The type removal is pinned with @ts-expect-error, so the field coming
back is a compile error rather than a quiet regression, and the README
claims are pinned by reading the file.

**Breaking**: `WriteSheet.threadedComments` is removed. It never did anything, so no working code depends on it — but it was a public field, so it is recorded here rather than dropped quietly.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,369 tests.

Closes #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD