### PR TITLE
fix: XLSB honours the file's 1904 flag and reads merges; the CLI can open .xls and .xlsb

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,8 +514,9 @@ const same = await read(bytes) // auto-detected (XLSX vs XLSB vs ODS)
 ```
 
 Decodes shared strings, RK / floating-point numbers, inline strings,
-booleans, error codes, cached formula values, and dates (via the binary
-style table). Read-only; password-protected `.xlsb` also decrypts with
+booleans, error codes, cached formula values, merged cells, and dates (via
+the binary style table, honouring the workbook's own 1900/1904 date
+system). Read-only; password-protected `.xlsb` also decrypts with
 `{ password }`.
 
 ### XLS (Legacy Excel 97-2003) — read
@@ -533,6 +534,13 @@ const same = await read(bytes) // auto-detected
 Decodes the shared-string table (with CONTINUE spanning), RK / MULRK /
 number / boolean / error cells, labels, cached formula values, dates, and
 merged cells. Read-only.
+
+Both legacy readers surface sheet names, cell values, and merges — and
+nothing else. Formulas arrive as their **cached value**, never as formula
+text; styles, column widths, row heights, sheet visibility, named ranges
+and workbook properties are not read. Converting `.xls` / `.xlsb` to
+`.xlsx` through hucre is therefore a values-and-sheet-names conversion,
+not a faithful copy.
 
 ### ODS (OpenDocument)
 
@@ -1026,10 +1034,17 @@ const xlsx = await writeObjects(products, { sheetName: "Products" })
 ```bash
 npx hucre convert input.xlsx output.csv
 npx hucre convert input.csv output.xlsx
+npx hucre convert legacy.xls output.xlsx # .xls / .xlsb read as input
 npx hucre inspect file.xlsx
 npx hucre inspect file.xlsx --sheet 0
 npx hucre validate data.xlsx --schema schema.json
 ```
+
+Input: `.xlsx`, `.ods`, `.csv`, `.tsv`, `.xls`, `.xlsb`. Output: the first
+four — `.xls` and `.xlsb` are read-only formats, and naming one as the
+output says so. `convert` carries cell values and sheet names only; from a
+legacy binary input that is all there is (see the notes on each format
+above).
 
 ### Sheet Operations
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -14,6 +14,8 @@ import { createRequire } from "node:module"
 import { extname } from "node:path"
 import { readXlsx } from "../xlsx/reader"
 import { writeXlsx } from "../xlsx/writer"
+import { readXlsb } from "../xlsx/xlsb/reader"
+import { readXls } from "../xls/reader"
 import { readOds } from "../ods/reader"
 import { writeOds } from "../ods/writer"
 import { parseCsv } from "../csv/reader"
@@ -37,10 +39,17 @@ export class CliError extends Error {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-export type Format = "xlsx" | "ods" | "csv"
+export type Format = "xlsx" | "ods" | "csv" | "xls" | "xlsb"
+
+/** The formats hucre can write; `.xls` and `.xlsb` are read-only. */
+export type WritableFormat = Exclude<Format, "xls" | "xlsb">
 
 /** Text formats carry their separator in the extension, not the format. */
 const DELIMITERS: Record<string, string> = { ".csv": ",", ".tsv": "\t" }
+
+const READ_ONLY_FORMATS = new Set<Format>(["xls", "xlsb"])
+
+const SUPPORTED = ".xlsx, .ods, .csv, .tsv (read-only: .xls, .xlsb)"
 
 export function detectFormatFromExtension(filePath: string): Format {
   const ext = extname(filePath).toLowerCase()
@@ -52,11 +61,36 @@ export function detectFormatFromExtension(filePath: string): Format {
     case ".csv":
     case ".tsv":
       return "csv"
+    // The legacy binary readers ship in the library, so the CLI can open
+    // these too — `hucre convert legacy.xls out.xlsx` is the whole reason
+    // a read-only reader is useful at the terminal. Input only; see
+    // detectOutputFormat.
+    case ".xls":
+      return "xls"
+    case ".xlsb":
+      return "xlsb"
     default:
-      throw new CliError(
-        `Unsupported file extension: ${ext || "(none)"}. Supported: .xlsx, .ods, .csv, .tsv`,
-      )
+      throw new CliError(`Unsupported file extension: ${ext || "(none)"}. Supported: ${SUPPORTED}`)
   }
+}
+
+/**
+ * Detect the format of a file we are about to *write*.
+ *
+ * `.xls` and `.xlsb` are readable but not writable, and "unsupported
+ * extension" would be a lie about a file the CLI just opened happily —
+ * so name the actual reason.
+ */
+export function detectOutputFormat(filePath: string): WritableFormat {
+  const format = detectFormatFromExtension(filePath)
+  if (READ_ONLY_FORMATS.has(format)) {
+    throw new CliError(
+      `Cannot write .${format}: it is a read-only format in hucre — ` +
+        "readable as input, but there is no writer for it. " +
+        "Write .xlsx, .ods, .csv or .tsv instead.",
+    )
+  }
+  return format as WritableFormat
 }
 
 /**
@@ -78,6 +112,10 @@ export async function readFile(filePath: string): Promise<Workbook> {
   switch (format) {
     case "xlsx":
       return readXlsx(input)
+    case "xlsb":
+      return readXlsb(input)
+    case "xls":
+      return readXls(input)
     case "ods":
       return readOds(input)
     case "csv": {
@@ -120,7 +158,7 @@ export const convertCommand = defineCommand({
   async run({ args }) {
     const inputPath = args.input as string
     const outputPath = args.output as string
-    const outputFormat = detectFormatFromExtension(outputPath)
+    const outputFormat = detectOutputFormat(outputPath)
 
     consola.start(`Reading ${inputPath}...`)
     const workbook = await readFile(inputPath)
@@ -359,7 +397,8 @@ export const mainCommand = defineCommand({
     name: "hucre",
     version: pkgVersion,
     description:
-      "Spreadsheet Swiss Army knife. Convert, inspect, and validate XLSX, CSV, and ODS files.",
+      "Spreadsheet Swiss Army knife. Convert, inspect, and validate XLSX, CSV, " +
+      "and ODS files; reads legacy .xls and .xlsb as input.",
   },
   subCommands: {
     convert: convertCommand,

--- a/src/xls/biff.ts
+++ b/src/xls/biff.ts
@@ -30,6 +30,13 @@ export const SID = {
   MULRK: 0x00bd,
   MULBLANK: 0x00be,
   LABELSST: 0x00fd,
+  // RSTRING is a BIFF5/BIFF7 record (rich-text cell: rw, col, ixfe, a
+  // codepage byte string, then a run count and its runs). BIFF8 dropped it:
+  // rich text moved into the SST, so those cells arrive as LABELSST and
+  // readSstString already skips the runs and yields the plain text. The
+  // reader rejects anything that is not BIFF8 (see the version gate in
+  // reader.ts), so this sid cannot reach a cell handler — listed for
+  // recognition only, deliberately not parsed. See #411.
   RSTRING: 0x00d6,
   SST: 0x00fc,
   XF: 0x00e0,

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -5,7 +5,7 @@
 // of XML. We reuse the ZIP layer + the XML rels parser, and decode the
 // `.bin` parts with the record reader. Read-only (MS-XLSB).
 
-import type { CellValue, ReadOptions, Sheet, Workbook } from "../../_types"
+import type { CellValue, MergeRange, ReadOptions, Sheet, Workbook } from "../../_types"
 import { EncryptedFileError, ParseError, ZipError } from "../../errors"
 import { isOle2Container, readInputToUint8Array } from "../../_input"
 import { decryptAgile } from "../crypto/agile"
@@ -32,7 +32,9 @@ const BrtFmlaError = 11
 const BrtSSTItem = 19
 const BrtFmt = 44
 const BrtXF = 47
+const BrtWbProp = 153
 const BrtBundleSh = 156
+const BrtMergeCell = 176
 const BrtBeginCellXFs = 617
 const BrtEndCellXFs = 618
 
@@ -104,8 +106,6 @@ export async function readXlsb(
     throw new ParseError("Failed to open XLSB: not a valid ZIP archive", undefined, { cause: err })
   }
 
-  const date1904 = options?.dateSystem === "1904"
-
   // Locate the workbook part via the root relationships (fallback to the
   // conventional path).
   let workbookPath = "xl/workbook.bin"
@@ -123,7 +123,7 @@ export async function readXlsb(
   // hostile .bin can make the Cursor/DataView throw a raw RangeError. Wrap the
   // parse so malformed input surfaces as the library's ParseError.
   try {
-    return await parseXlsbParts(zip, workbookPath, workbookDir, date1904)
+    return await parseXlsbParts(zip, workbookPath, workbookDir, options?.dateSystem)
   } catch (err) {
     if (err instanceof ParseError || err instanceof EncryptedFileError || err instanceof ZipError) {
       throw err
@@ -138,10 +138,15 @@ async function parseXlsbParts(
   zip: ZipReader,
   workbookPath: string,
   workbookDir: string,
-  date1904: boolean,
+  dateSystem: ReadOptions["dateSystem"],
 ): Promise<Workbook> {
-  // Sheets (name + relId) from the workbook .bin.
-  const sheetEntries = parseWorkbookBin(await zip.extract(workbookPath))
+  // Sheets (name + relId) and the workbook's own date system from the .bin.
+  const { sheets: sheetEntries, file1904 } = parseWorkbookBin(await zip.extract(workbookPath))
+
+  // The file's flag wins unless the caller pinned a system, exactly as the
+  // XLSX and XLS readers do — a Mac-authored 1904 workbook read with the
+  // documented default ("auto") was otherwise 1462 days out on every date.
+  const date1904 = !dateSystem || dateSystem === "auto" ? file1904 : dateSystem === "1904"
 
   // Workbook relationships (XML) → relId → part path.
   const wbRelsPath = workbookDir
@@ -173,8 +178,15 @@ async function parseXlsbParts(
       sheets.push({ name: entry.name, rows: [] })
       continue
     }
-    const rows = parseWorksheetBin(await zip.extract(path), sharedStrings, dateXf, date1904)
-    sheets.push({ name: entry.name, rows })
+    const { rows, merges } = parseWorksheetBin(
+      await zip.extract(path),
+      sharedStrings,
+      dateXf,
+      date1904,
+    )
+    const sheet: Sheet = { name: entry.name, rows }
+    if (merges.length > 0) sheet.merges = merges
+    sheets.push(sheet)
   }
 
   return { sheets }
@@ -187,18 +199,26 @@ interface SheetEntry {
   relId: string
 }
 
-function parseWorkbookBin(bin: Uint8Array): SheetEntry[] {
+function parseWorkbookBin(bin: Uint8Array): { sheets: SheetEntry[]; file1904: boolean } {
   const out: SheetEntry[] = []
+  let file1904 = false
   for (const rec of iterateRecords(bin)) {
-    if (rec.id !== BrtBundleSh) continue
-    const c = new Cursor(rec.data)
-    c.u32() // hsState
-    c.u32() // iTabID
-    const relId = c.nullableWideString()
-    const name = c.wideString()
-    out.push({ name, relId })
+    if (rec.id === BrtWbProp) {
+      // BrtWbProp (record 153, MS-XLSB §2.4): a 32-bit flag word, then
+      // dwThemeVersion, then strName. Bit 0 of the flag word is f1904 —
+      // the 1904 date system, XLSB's equivalent of workbookPr/@date1904 in
+      // XLSX and the DATEMODE record in BIFF8. No record means 1900.
+      file1904 = (new Cursor(rec.data).u32() & 0x01) !== 0
+    } else if (rec.id === BrtBundleSh) {
+      const c = new Cursor(rec.data)
+      c.u32() // hsState
+      c.u32() // iTabID
+      const relId = c.nullableWideString()
+      const name = c.wideString()
+      out.push({ name, relId })
+    }
   }
-  return out
+  return { sheets: out, file1904 }
 }
 
 // ── sharedStrings.bin ────────────────────────────────────────────────
@@ -249,8 +269,9 @@ function parseWorksheetBin(
   sst: string[],
   dateXf: boolean[],
   date1904: boolean,
-): CellValue[][] {
+): { rows: CellValue[][]; merges: MergeRange[] } {
   const rows: CellValue[][] = []
+  const merges: MergeRange[] = []
   let row = 0
 
   const setCell = (col: number, value: CellValue): void => {
@@ -333,10 +354,24 @@ function parseWorksheetBin(
         setCell(col, sst[idx] ?? "")
         break
       }
+      case BrtMergeCell: {
+        // BrtMergeCell (record 176, MS-XLSB §2.4) carries one UncheckedRfX
+        // (§2.5): rwFirst, rwLast, colFirst, colLast as four u32s — one
+        // record per merged range, unlike BIFF8's MERGECELLS, which packs
+        // a count and the whole list into a single record.
+        const c = new Cursor(rec.data)
+        merges.push({
+          startRow: c.u32(),
+          endRow: c.u32(),
+          startCol: c.u32(),
+          endCol: c.u32(),
+        })
+        break
+      }
       default:
         break
     }
   }
 
-  return rows
+  return { rows, merges }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -8,6 +8,7 @@ import {
   convertCommand,
   delimiterForExtension,
   detectFormatFromExtension,
+  detectOutputFormat,
   formatCellValue,
   inspectCommand,
   mainCommand,
@@ -18,6 +19,8 @@ import {
 import { writeXlsx } from "../src/xlsx/writer"
 import { readXlsx } from "../src/xlsx/reader"
 import { writeOds } from "../src/ods/writer"
+import { writeCfb } from "../src/xlsx/crypto/cfb"
+import { ZipWriter } from "../src/zip/writer"
 
 // ═══════════════════════════════════════════════════════════════════════
 // #399 — the CLI was the only module in the tree at 0% coverage, because
@@ -62,6 +65,102 @@ async function makeXlsx(name: string, rows: unknown[][], sheet = "Sheet1"): Prom
   return p
 }
 
+// ── Legacy read-only fixtures (#411) ────────────────────────────────
+// There is no .xls or .xlsb writer to build these with, so both are
+// assembled by hand — the smallest file each reader accepts — to exercise
+// `convert legacy.xls out.xlsx`, which used to fail on the extension
+// alone.
+
+const u16 = (n: number): number[] => [n & 0xff, (n >> 8) & 0xff]
+const u32 = (n: number): number[] => [
+  n & 0xff,
+  (n >> 8) & 0xff,
+  (n >> 16) & 0xff,
+  (n >>> 24) & 0xff,
+]
+const chars = (s: string): number[] => [...s].map((c) => c.charCodeAt(0))
+
+/** A one-sheet BIFF8 .xls holding a single LABEL cell. */
+function makeXls(name: string, text: string): string {
+  const biff = (sid: number, data: number[]): number[] => [
+    ...u16(sid),
+    ...u16(data.length),
+    ...data,
+  ]
+  const bof = (dt: number): number[] =>
+    biff(0x0809, [...u16(0x0600), ...u16(dt), ...u16(0), ...u16(0), ...u32(0), ...u32(0)])
+  const eof = (): number[] => biff(0x000a, [])
+  const sheet = [
+    ...bof(0x0010),
+    ...biff(0x0204, [...u16(0), ...u16(0), ...u16(0), ...u16(text.length), 0, ...chars(text)]),
+    ...eof(),
+  ]
+  // BOUNDSHEET carries the sheet substream's byte offset, so the globals
+  // are laid out twice: once to measure, once for real.
+  const globals = (sheetPos: number): number[] => [
+    ...bof(0x0005),
+    ...biff(0x0085, [...u32(sheetPos), 0, 0, "Legacy".length, 0, ...chars("Legacy")]),
+    ...eof(),
+  ]
+  const stream = new Uint8Array([...globals(globals(0).length), ...sheet])
+  const p = path(name)
+  writeFileSync(p, writeCfb([{ name: "Workbook", data: stream }]))
+  return p
+}
+
+/** A one-sheet .xlsb holding a single inline-string cell. */
+async function makeXlsb(name: string, text: string): Promise<string> {
+  const varint = (n: number): number[] => {
+    const out: number[] = []
+    let s = n
+    do {
+      let b = s & 0x7f
+      s >>>= 7
+      if (s) b |= 0x80
+      out.push(b)
+    } while (s)
+    return out
+  }
+  const rec = (id: number, body: number[]): number[] => [
+    ...(id < 0x80 ? [id] : [(id & 0x7f) | 0x80, (id >> 7) & 0x7f]),
+    ...varint(body.length),
+    ...body,
+  ]
+  /** XLWideString: u32 char count + UTF-16LE units. */
+  const wstr = (s: string): number[] => [
+    ...u32(s.length),
+    ...[...s].flatMap((c) => u16(c.charCodeAt(0))),
+  ]
+
+  const ws = [
+    ...rec(0, u32(0)), // BrtRowHdr
+    ...rec(6, [...u32(0), ...u32(0), ...wstr(text)]), // BrtCellSt
+  ]
+  const wb = rec(156, [...u32(0), ...u32(0), ...wstr("rId1"), ...wstr("Legacy")]) // BrtBundleSh
+  const ns = "http://schemas.openxmlformats.org/package/2006/relationships"
+  const rel = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  const enc = new TextEncoder()
+  const zw = new ZipWriter()
+  zw.add(
+    "_rels/.rels",
+    enc.encode(
+      `<Relationships xmlns="${ns}"><Relationship Id="r" Type="${rel}/officeDocument" Target="xl/workbook.bin"/></Relationships>`,
+    ),
+  )
+  zw.add("xl/workbook.bin", new Uint8Array(wb))
+  zw.add(
+    "xl/_rels/workbook.bin.rels",
+    enc.encode(
+      `<Relationships xmlns="${ns}"><Relationship Id="rId1" Type="${rel}/worksheet" Target="worksheets/sheet1.bin"/></Relationships>`,
+    ),
+  )
+  zw.add("xl/worksheets/sheet1.bin", new Uint8Array(ws))
+
+  const p = path(name)
+  writeFileSync(p, await zw.build())
+  return p
+}
+
 // ── Format detection ────────────────────────────────────────────────
 
 describe("detectFormatFromExtension", () => {
@@ -72,14 +171,39 @@ describe("detectFormatFromExtension", () => {
     expect(detectFormatFromExtension("a.tsv")).toBe("csv")
   })
 
+  it("maps the read-only legacy extensions too", () => {
+    expect(detectFormatFromExtension("a.xls")).toBe("xls")
+    expect(detectFormatFromExtension("a.XLSB")).toBe("xlsb")
+  })
+
   it("rejects anything else, naming what is supported", () => {
+    // The supported list now distinguishes the two directions, so the
+    // message says which formats are input-only rather than leaving a
+    // user to infer it from a failure two commands later.
     expect(() => detectFormatFromExtension("a.numbers")).toThrow(CliError)
     expect(() => detectFormatFromExtension("a.numbers")).toThrow(/\.xlsx, \.ods, \.csv, \.tsv/)
+    expect(() => detectFormatFromExtension("a.numbers")).toThrow(/read-only: \.xls, \.xlsb/)
   })
 
   it("says so when there is no extension at all", () => {
     expect(() => detectFormatFromExtension("README")).toThrow(/\(none\)/)
   })
+})
+
+describe("detectOutputFormat", () => {
+  it("accepts every writable format", () => {
+    expect(detectOutputFormat("a.xlsx")).toBe("xlsx")
+    expect(detectOutputFormat("a.ods")).toBe("ods")
+    expect(detectOutputFormat("a.tsv")).toBe("csv")
+  })
+
+  for (const ext of [".xls", ".xlsb"]) {
+    it(`refuses to write ${ext}, and says it is read-only rather than unsupported`, () => {
+      expect(() => detectOutputFormat(`out${ext}`)).toThrow(CliError)
+      expect(() => detectOutputFormat(`out${ext}`)).toThrow(/read-only format/)
+      expect(() => detectOutputFormat(`out${ext}`)).not.toThrow(/Unsupported file extension/)
+    })
+  }
 })
 
 // ── The .tsv delimiter bug ──────────────────────────────────────────
@@ -186,6 +310,34 @@ describe("convert", () => {
     await expect(run(convertCommand, { input, output: path("out.pdf") })).rejects.toThrow(CliError)
   })
 
+  // ── Legacy input formats (#411) ───────────────────────────────────
+  // The readers shipped, but the CLI's extension switch did not know
+  // about them, so the most obvious use of a read-only format —
+  // rescuing an archive into .xlsx — failed before a byte was read.
+
+  it("converts a legacy .xls to xlsx", async () => {
+    const input = makeXls("legacy.xls", "from-xls")
+    await run(convertCommand, { input, output: path("out.xlsx") })
+    const back = await readXlsx(readFileSync(path("out.xlsx")))
+    expect(back.sheets[0].name).toBe("Legacy")
+    expect(back.sheets[0].rows[0]).toEqual(["from-xls"])
+  })
+
+  it("converts an .xlsb to csv", async () => {
+    const input = await makeXlsb("legacy.xlsb", "from-xlsb")
+    await run(convertCommand, { input, output: path("out.csv") })
+    expect(readFileSync(path("out.csv"), "utf-8")).toContain("from-xlsb")
+  })
+
+  it("refuses .xls and .xlsb as an output target", async () => {
+    const input = await makeXlsx("in.xlsx", [["a"]])
+    for (const out of ["out.xls", "out.xlsb"]) {
+      await expect(run(convertCommand, { input, output: path(out) })).rejects.toThrow(
+        /read-only format/,
+      )
+    }
+  })
+
   it("says in --help that it carries values only", () => {
     expect(convertCommand.meta).toMatchObject({
       description: expect.stringContaining("cell values only"),
@@ -214,6 +366,13 @@ describe("inspect", () => {
     expect(out).toMatch(/string: \d/)
     expect(out).toMatch(/number: \d/)
     expect(out).toMatch(/boolean: \d/)
+  })
+
+  it("inspects a legacy .xls", async () => {
+    await run(inspectCommand, { file: makeXls("legacy.xls", "cell"), sheet: "0" })
+    const out = logs.join("\n")
+    expect(out).toContain('"Legacy"')
+    expect(out).toContain("cell")
   })
 
   it("prints document properties when the file carries them", async () => {

--- a/test/xlsb.test.ts
+++ b/test/xlsb.test.ts
@@ -72,14 +72,23 @@ const BrtRowHdr = 0,
   BrtCellIsst = 7,
   BrtSSTItem = 19,
   BrtXF = 47,
+  BrtWbProp = 153,
   BrtBundleSh = 156,
+  BrtMergeCell = 176,
   BrtBeginCellXFs = 617,
   BrtEndCellXFs = 618
 
 const REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 const NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 
-async function buildXlsb(): Promise<Uint8Array> {
+/**
+ * BrtWbProp (record 153): 32-bit flag word (bit 0 = f1904), then
+ * dwThemeVersion, then strName — here the "absent" nullable string.
+ */
+const wbProp = (date1904: boolean): Uint8Array =>
+  rec(BrtWbProp, concat([u32(date1904 ? 1 : 0), u32(0), nwstr(null)]))
+
+async function buildXlsb(opts: { date1904?: boolean } = {}): Promise<Uint8Array> {
   // Shared strings: 0:"Name" 1:"Score" 2:"Ada"
   const sst = concat([
     rec(BrtSSTItem, concat([[0], wstr("Name")])),
@@ -107,8 +116,13 @@ async function buildXlsb(): Promise<Uint8Array> {
     rec(BrtCellSt, concat([cellPrefix(0, 0), wstr("Hi")])),
     rec(BrtCellBool, concat([cellPrefix(1, 0), [1]])),
     rec(BrtCellError, concat([cellPrefix(2, 0), [0x07]])),
+    // BrtMergeCell: one UncheckedRfX — rwFirst, rwLast, colFirst, colLast.
+    rec(BrtMergeCell, concat([u32(0), u32(0), u32(0), u32(1)])),
   ])
-  const wb = rec(BrtBundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")]))
+  const wb = concat([
+    ...(opts.date1904 === undefined ? [] : [wbProp(opts.date1904)]),
+    rec(BrtBundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("Sheet1")])),
+  ])
   const rels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="rIdWb" Type="${REL}/officeDocument" Target="xl/workbook.bin"/></Relationships>`
   const wbRels =
     `<?xml version="1.0"?><Relationships xmlns="${NS}">` +
@@ -144,6 +158,30 @@ describe("XLSB reader", () => {
     expect(rows[2][2]).toBe("#DIV/0!")
   })
 
+  it("reads merged ranges from BrtMergeCell", async () => {
+    // XLS has read merges since it landed; XLSB ignored record 176
+    // entirely, so a converted workbook lost its merge layout. See #411.
+    const wb = await readXlsb(await buildXlsb())
+    expect(wb.sheets[0].merges).toEqual([{ startRow: 0, endRow: 0, startCol: 0, endCol: 1 }])
+  })
+
+  it("leaves merges undefined when the sheet has none", async () => {
+    const ws = concat([
+      rec(BrtRowHdr, u32(0)),
+      rec(BrtCellSt, concat([cellPrefix(0, 0), wstr("x")])),
+    ])
+    const wb = rec(BrtBundleSh, concat([u32(0), u32(0), nwstr("rId1"), wstr("S")]))
+    const rels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="r" Type="${REL}/officeDocument" Target="xl/workbook.bin"/></Relationships>`
+    const wbRels = `<?xml version="1.0"?><Relationships xmlns="${NS}"><Relationship Id="rId1" Type="${REL}/worksheet" Target="worksheets/sheet1.bin"/></Relationships>`
+    const zw = new ZipWriter()
+    zw.add("_rels/.rels", enc.encode(rels))
+    zw.add("xl/workbook.bin", wb)
+    zw.add("xl/_rels/workbook.bin.rels", enc.encode(wbRels))
+    zw.add("xl/worksheets/sheet1.bin", ws)
+    const out = await readXlsb(await zw.build())
+    expect(out.sheets[0].merges).toBeUndefined()
+  })
+
   it("is auto-detected by read()", async () => {
     const wb = await read(await buildXlsb())
     expect(wb.sheets[0].rows[1][1]).toBe(95)
@@ -167,6 +205,47 @@ describe("XLSB reader", () => {
     zw.add("xl/worksheets/sheet1.bin", ws)
     const out = await readXlsb(await zw.build())
     expect(out.sheets[0].rows[0][0]).toBeCloseTo(12.34, 5)
+  })
+
+  // ── Date system (#411) ────────────────────────────────────────────
+  // Serial 45000 with the builtin date format: 1900 → 2023-03-15,
+  // 1904 → 2027-03-16. The two systems are 1462 days apart, so reading a
+  // Mac-authored workbook with the wrong one is silent and always wrong.
+  const serial45000 = (wb: { sheets: Array<{ rows: unknown[][] }> }): string =>
+    (wb.sheets[0].rows[1][3] as Date).toISOString()
+
+  describe("date system", () => {
+    it("honours the 1904 flag in BrtWbProp by default", async () => {
+      const wb = await readXlsb(await buildXlsb({ date1904: true }))
+      expect(serial45000(wb)).toBe("2027-03-16T00:00:00.000Z")
+    })
+
+    it("uses 1900 when BrtWbProp says so", async () => {
+      const wb = await readXlsb(await buildXlsb({ date1904: false }))
+      expect(serial45000(wb)).toBe("2023-03-15T00:00:00.000Z")
+    })
+
+    it("uses 1900 when the workbook has no BrtWbProp at all", async () => {
+      const wb = await readXlsb(await buildXlsb())
+      expect(serial45000(wb)).toBe("2023-03-15T00:00:00.000Z")
+    })
+
+    it("detects the file's system under an explicit dateSystem: auto", async () => {
+      const wb = await readXlsb(await buildXlsb({ date1904: true }), { dateSystem: "auto" })
+      expect(serial45000(wb)).toBe("2027-03-16T00:00:00.000Z")
+    })
+
+    it("lets the caller pin a system that contradicts the file", async () => {
+      const pinned1900 = await readXlsb(await buildXlsb({ date1904: true }), {
+        dateSystem: "1900",
+      })
+      expect(serial45000(pinned1900)).toBe("2023-03-15T00:00:00.000Z")
+
+      const pinned1904 = await readXlsb(await buildXlsb({ date1904: false }), {
+        dateSystem: "1904",
+      })
+      expect(serial45000(pinned1904)).toBe("2027-03-16T00:00:00.000Z")
+    })
   })
 
   it("surfaces a malformed workbook.bin as ParseError, not a raw RangeError", async () => {


### PR DESCRIPTION
Closes #411.

## The bug, reproduced first

A hand-assembled XLSB with `BrtWbProp` bit 0 set and a serial-45000 cell under builtin format 14, read before touching any source:

```
default (README says dateSystem "auto"): 2023-03-15T00:00:00.000Z
forced 1904:                             2027-03-16T00:00:00.000Z
delta days: 1462
merges: undefined
```

`src/xlsx/xlsb/reader.ts` had `const date1904 = options?.dateSystem === "1904"` — no `BrtWbProp` parse, no `"auto"` branch — while both sibling readers auto-detect and README.md:129 advertises `"auto"` as the default. So a Mac-authored workbook read with default options had **every date 1462 days out, silently**, in the one direction the documentation promised was handled.

After the fix the same script prints `2027-03-16` by default, and `[{"startRow":0,"endRow":1,"startCol":0,"endCol":2}]` for merges.

## What changed

- **XLSB date system.** `parseWorkbookBin` now also parses `BrtWbProp` (record 153, bit 0 of the flag word = `f1904`) and returns it with the sheet entries. The file's flag wins unless the caller pinned one — the same precedence as `xls/reader.ts` and `xlsx/reader.ts`, deliberately not a third scheme.
- **XLSB merges.** `BrtMergeCell` (record 176, one `UncheckedRfX`) was handled nowhere, while the XLS reader has read merges all along. `merges` is set on the sheet only when non-empty, matching XLS.
- **The CLI can open `.xls` and `.xlsb`.** `hucre convert legacy.xls out.xlsx` — the single most obvious use of a read-only reader — used to fail with "Unsupported file extension" while the reader sat right there. Input only: output detection is split into `detectOutputFormat`, which rejects them with *"it is a read-only format in hucre — readable as input, but there is no writer for it"*. "Unsupported" would have been a lie about a file the CLI had just opened happily.
- **README.** The XLSB section no longer omits merges and the date system, both legacy sections now state the read scope (values, sheet names, merges; formulas as cached values only; no styles, widths, visibility or named ranges), and the CLI section lists input versus output formats.

## Where the issue was wrong

**The RSTRING claim was mine and it was wrong.** RSTRING (0x00d6) is a BIFF5/BIFF7 record; BIFF8 moved rich text into the SST, so those cells arrive as `LABELSST` and `readSstString` already skips the formatting runs and yields plain text — verified with a BIFF8 SST entry carrying `grbit 0x08` and two runs, which reads back as `[["Rich"]]`. Rich-text cells do not vanish; they degrade to plain text, which is what the issue asked for. And the reader hard-rejects any BIFF version but 0x0600, so the sid cannot reach a cell handler in a file it accepts at all.

Left unimplemented, with the bare constant in `src/xls/biff.ts` replaced by a comment giving the record layout, the reason, and a pointer to the version gate — so the next person does not re-derive this.

## Tests

`test/xlsb.test.ts`: merges read and absent, plus a date-system block covering the file flag honoured by default and under explicit `"auto"`, 1900 when the record says so or is missing, and the caller's pin winning in both directions. `test/cli.test.ts`: legacy extension mapping, `detectOutputFormat` acceptance and rejection, `.xls → .xlsx` and `.xlsb → .csv` end to end, both refused as output, and `inspect` on a `.xls`. Fixtures are byte-assembled in the test files, following the existing convention.

Verified by stashing each source file: 3 XLSB tests and 9 CLI tests fail against the unfixed code.

One existing test changed — `"rejects anything else, naming what is supported"` gained an assertion for the read-only list. It was pinning the old supported-formats string, not asserting a defect, so it was extended rather than replaced.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,385 tests, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
