### PR TITLE
fix(csv): give the write options a way back in

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -139,8 +139,11 @@ Each of these was exported or declared and had no effect. v1 would have frozen t
 | `WORKER_SAFE_FUNCTIONS`                       | 40 entries against ~125 exports; every export is worker-safe |
 | `ReadOptions.headerRow`, `ReadOptions.schema` | honoured by no reader                                        |
 | `CsvReadOptions.lineSeparator`, `.encoding`   | never read (`CsvWriteOptions.lineSeparator` is fine)         |
+| `CsvReadOptions.schema`                       | zero references under `src/csv/` — no CSV reader validated   |
 | `isoDates` on the JSON writers                | see below                                                    |
 | `WriteSheet.threadedComments`                 | typed and accepted; no writer ever produced the part         |
+
+`CsvReadOptions.schema` never validated anything: `parseCsv` returned every row exactly as parsed whatever you passed. Validate the parsed rows with `validateWithSchema`, which is what the option looked like it was doing.
 
 `isoDates` is worth explaining because it _looked_ like it worked. `JSON.stringify` calls `Date.prototype.toJSON` **before** consulting the replacer, so a replacer testing `value instanceof Date` is never reached — `isoDates: false` produced byte-identical output. Dates still serialize as ISO strings, exactly as before.
 
@@ -176,5 +179,9 @@ Very large legitimate files may now hit a limit that used to be absent. Every on
 - **Format entry points export their own types**, so `import type { WriteSheet } from "hucre/xlsx"` works without a second import from the root.
 - **`streamOdsRows` takes options and a `ReadableStream`.** It previously accepted neither.
 - **`writeCsvStream` exists** — constant-memory CSV writing, the counterpart to `writeXlsxStream`.
+- **A CSV write option now has a way back in.** `escapeFormulae: true` prefixed `= + - @ | \t \r \n \0` values with `'` and nothing removed it, so a round trip through hucre turned `-5` into `'-5` permanently. `parseCsv` and `streamCsvRows` take `unescapeFormulae: true`, which drops that `'` — and only where the writer would have added one, so `'quoted'` is left alone. `nullValue` and a custom `dateFormat` remain one-way by decision; both are documented as such on the option.
+- **The streaming CSV writers escape formulae too.** `escapeFormulae` was honoured by `writeCsv` alone — `CsvStreamWriter` and `writeCsvStream` ignored it silently, which for an injection escape meant the protection you asked for was simply absent. If you passed it to either, their output changes.
+- **`parseCsv` honours `skipHeaderRow`.** It was implemented in `streamCsvRows` and ignored here, so the same option on the same options type behaved two ways. `parseCsv(input, { header: true, skipHeaderRow: true })` now drops the header row, and `maxRows` counts data rows in both readers.
+- **`CsvWriteOptions.comment` quotes values that would read as comments.** A value starting with `#`, written bare, is deleted by a reader configured with `comment: "#"` — the whole row, silently. Pass the same character to the writer and those values are quoted instead. Off by default; the output is unchanged unless you set it.
 - **ZIP64 archives are readable**, and writable via `zip64: true`.
 - **`hucre/ooxml` exists.** The low-level OOXML part parsers — `parseChart`, `parsePivotTable`, `parseSlicers`, `parseThemeColors` and friends — have a home of their own, explicitly outside the v1 stability commitment. They are still exported from the root, marked deprecated, so nothing breaks.

--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,18 @@ return new Response(writeCsvStream(dbCursor, { headers: ["id", "name"] }), {
 detectDelimiter(csvString) // "," or ";" or "\t" or "|"
 ```
 
+Round-tripping through hucre: `escapeFormulae` (which prefixes `= + - @ |`
+values with `'` so a spreadsheet cannot execute them) is reversed by
+`unescapeFormulae` on the read side, and `comment` on the write side quotes
+values that a reader configured with the same character would otherwise
+delete as comment lines. `nullValue` and a custom `dateFormat` are one-way
+— nothing on the read side restores a `null` or parses a non-ISO date.
+
+```ts
+const csv = writeCsv([["-5"]], { escapeFormulae: true }) // "'-5"
+parseCsv(csv, { unescapeFormulae: true, typeInference: true }) // [[-5]]
+```
+
 `writeCsvStream` is to `CsvStreamWriter` what `writeXlsxStream` is to
 `XlsxStreamWriter`: the class formats each row on arrival but retains
 every line until `finish()` returns one string, while the function

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1456,12 +1456,28 @@ export interface OutlineProperties {
 
 // ── CSV Options ────────────────────────────────────────────────────
 
+/**
+ * Options shared by `parseCsv`, `parseCsvObjects` and `streamCsvRows` —
+ * every one of them means the same thing in all three.
+ *
+ * `schema` used to live here and was honoured by no CSV reader at all; it
+ * was removed before v1 rather than frozen. Validate with
+ * `validateWithSchema` on the parsed rows, which does implement it.
+ */
 export interface CsvReadOptions {
   /** Field delimiter. Default: auto-detect */
   delimiter?: string
   /** Quote character. Default: " */
   quote?: string
-  /** Escape character. Default: " (RFC 4180 doubled quotes) */
+  /**
+   * Escape character. Default: " (RFC 4180 doubled quotes)
+   *
+   * Read-only on purpose: set it to read a foreign dialect (a backslash
+   * escape, say), but the writers always emit RFC 4180 doubled quotes.
+   * Writing a backslash dialect losslessly would need the escape character
+   * itself escaped, which this parser does not decode — a half-implemented
+   * `escape` on the write side would corrupt a value ending in one.
+   */
   escape?: string
   /** Whether first row is header. Default: false */
   header?: boolean
@@ -1471,8 +1487,6 @@ export interface CsvReadOptions {
   typeInference?: boolean
   /** Keep strings with leading zeros (e.g. "0123") as strings instead of converting to numbers. Default: true */
   preserveLeadingZeros?: boolean
-  /** Schema for validation */
-  schema?: SchemaDefinition
   /** Skip empty rows. Default: false */
   skipEmptyRows?: boolean
   /** Comment character (lines starting with this are skipped) */
@@ -1498,6 +1512,18 @@ export interface CsvReadOptions {
    * Default: false
    */
   skipHeaderRow?: boolean
+  /**
+   * Undo {@link CsvWriteOptions.escapeFormulae}: drop the leading `'` from
+   * values that start with one of the characters the writer escapes for
+   * (`= + - @ | \t \r \n \0`). Runs before type inference, so `'-5` reads
+   * back as the number -5. Default: false
+   *
+   * Set it only for input produced with `escapeFormulae: true` — a source
+   * value that genuinely began `'-5` is written unescaped, and this cannot
+   * tell the two apart. Values whose apostrophe is followed by anything
+   * else (`'quoted'`, `'tis`) are never touched.
+   */
+  unescapeFormulae?: boolean
 }
 
 export interface CsvWriteOptions {
@@ -1513,12 +1539,44 @@ export interface CsvWriteOptions {
   headers?: string[] | boolean
   /** Prepend UTF-8 BOM (for Excel compatibility). Default: false */
   bom?: boolean
-  /** Date format string. Default: ISO 8601 */
+  /**
+   * Date format string. Default: ISO 8601
+   *
+   * **One-way.** The readers recognize ISO 8601 and nothing else, so a
+   * `Date` written with the default round-trips as a `Date` under
+   * `typeInference`, while any custom format comes back a string — a
+   * reader cannot tell `03/04/2024` in one convention from the other.
+   * Use a custom format for output people read, not for output hucre
+   * reads back.
+   */
   dateFormat?: string
-  /** Null/undefined representation. Default: "" */
+  /**
+   * Null/undefined representation. Default: ""
+   *
+   * **One-way.** CSV has no null, so nothing on the read side turns the
+   * token back into `null` — `nullValue: "NULL"` reads as the string
+   * `"NULL"`, and the default reads as `""`. That is true of the default
+   * too, which is why there is no inverse option: restoring `null` for
+   * `""` would have to guess for every empty field in the file.
+   */
   nullValue?: string
-  /** Escape formula injection by prefixing cells starting with =, +, -, @, \t, \r with a single quote. Default: false */
+  /**
+   * Escape formula injection by prefixing cells starting with =, +, -, @, \t, \r with a single quote. Default: false
+   *
+   * Reverse it on the way back in with
+   * {@link CsvReadOptions.unescapeFormulae}; without that, the `'` is
+   * part of the value and every round trip keeps it (#408).
+   */
   escapeFormulae?: boolean
+  /**
+   * Comment character used by the reader this output is written for.
+   * Values starting with it are quoted, so the reader keeps them as data
+   * instead of discarding the line. Default: unset — a value starting with
+   * `#` is written bare, and a reader with `comment: "#"` drops the row.
+   *
+   * No effect under `quoteStyle: "none"`, which cannot quote anything.
+   */
+  comment?: string
   /** Column keys to include (for writeCsvObjects). When provided, only these columns are output in this order. */
   columns?: string[]
 }

--- a/src/csv/formula.ts
+++ b/src/csv/formula.ts
@@ -1,0 +1,64 @@
+// Formula-injection escaping, shared by every CSV writer and reader.
+//
+// It lives in its own module because the escape and its inverse have to
+// agree on one list of trigger characters: the reader strips a leading
+// apostrophe only where the writer would have added one (#408). Two copies
+// of the list would drift, and a drifted list corrupts data in exactly the
+// cases the escape exists to protect.
+
+// Characters that trigger formula interpretation in Excel/Sheets/LibreOffice
+// Covers: formulas (=), unary operators (+, -), at-sign (@), whitespace injection (\t, \r, \n), null byte (\0)
+const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r", "\n", "\0", "|"]
+
+// DDE and dangerous function patterns (case-insensitive)
+const DANGEROUS_PATTERNS = [
+  /^=cmd\b/i,
+  /^=HYPERLINK\s*\(/i,
+  /^=IMPORTXML\s*\(/i,
+  /^=IMPORTDATA\s*\(/i,
+  /^=IMPORTFEED\s*\(/i,
+  /^=IMPORTHTML\s*\(/i,
+  /^=IMPORTRANGE\s*\(/i,
+  /^=IMAGE\s*\(/i,
+]
+
+/**
+ * Prefix a string value with a single quote if it starts with a formula-triggering character
+ * or matches a dangerous function/DDE pattern.
+ */
+export function escapeFormula(value: string): string {
+  if (value.length === 0) return value
+
+  // Check prefix characters
+  if (FORMULA_PREFIXES.includes(value[0]!)) {
+    return "'" + value
+  }
+
+  // Check dangerous patterns (DDE, data exfiltration via HYPERLINK, etc.)
+  for (const pattern of DANGEROUS_PATTERNS) {
+    if (pattern.test(value)) {
+      return "'" + value
+    }
+  }
+
+  return value
+}
+
+/**
+ * Undo {@link escapeFormula}: drop a leading apostrophe when the character
+ * behind it is one the writer escapes for.
+ *
+ * The narrow test is the point. Stripping every leading apostrophe would
+ * eat one from `'quoted'` and from any value a human typed that way; this
+ * only touches shapes the writer can actually produce. Every dangerous
+ * pattern starts with `=`, which is in {@link FORMULA_PREFIXES}, so the
+ * prefix check covers those too.
+ *
+ * One ambiguity survives and cannot be removed: a source value that itself
+ * began `'-5` is written unescaped (the apostrophe is not a trigger), and
+ * un-escaping then reads it as `-5`. Documented on `unescapeFormulae`.
+ */
+export function unescapeFormula(value: string): string {
+  if (value.length < 2 || value[0] !== "'") return value
+  return FORMULA_PREFIXES.includes(value[1]!) ? value.slice(1) : value
+}

--- a/src/csv/reader.ts
+++ b/src/csv/reader.ts
@@ -1,5 +1,6 @@
 import type { CellValue, CsvReadOptions } from "../_types"
 import { rowsToObjects } from "../_objects"
+import { unescapeFormula } from "./formula"
 
 // ── Public API ───────────────────────────────────────────────────────
 
@@ -126,6 +127,26 @@ export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][]
     )
   }
 
+  // Undo the writer's formula escape before anything else looks at the
+  // values, so type inference and header names see what was written rather
+  // than `'` + the value (#408).
+  if (opts.unescapeFormulae) {
+    filtered = filtered.map((row) =>
+      row.map((v) => (typeof v === "string" ? unescapeFormula(v) : v)),
+    )
+  }
+
+  // `header: true` only marks the first row — it still comes back, and only
+  // names columns for transformValue. `skipHeaderRow` is the opt-in that
+  // consumes it, honoured by streamCsvRows and, until #408, ignored here.
+  // The row is captured before it goes, because transformValue names its
+  // columns from it either way, and it drops before maxRows so that limit
+  // counts data rows in both readers.
+  const headerRow = opts.header && filtered.length > 0 ? filtered[0]! : null
+  if (opts.header && opts.skipHeaderRow && filtered.length > 0) {
+    filtered = filtered.slice(1)
+  }
+
   // Limit to maxRows data rows
   if (opts.maxRows !== undefined && opts.maxRows >= 0 && filtered.length > opts.maxRows) {
     filtered = filtered.slice(0, opts.maxRows)
@@ -140,9 +161,8 @@ export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][]
   // transformValue callback — applied after type inference
   const transformValue = options?.transformValue
   if (transformValue) {
-    // When we don't have headers we pass column index as the header name
-    // Detect headers from first row if header option is set
-    const headerRow = options?.header && filtered.length > 0 ? filtered[0]! : null
+    // When we don't have headers we pass column index as the header name;
+    // `headerRow` above is the first row when `header` is set.
     filtered = filtered.map((row, rowIdx) =>
       row.map((val, colIdx) => {
         const header = headerRow ? String(headerRow[colIdx] ?? colIdx) : String(colIdx)
@@ -388,6 +408,8 @@ function normalizeReadOptions(options?: CsvReadOptions) {
     skipEmptyRows: options?.skipEmptyRows ?? false,
     comment: options?.comment,
     header: options?.header ?? false,
+    skipHeaderRow: options?.skipHeaderRow ?? false,
+    unescapeFormulae: options?.unescapeFormulae ?? false,
     maxRows: options?.maxRows,
   }
 }

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -13,6 +13,7 @@
 
 import type { CellValue, CsvReadOptions, CsvWriteOptions } from "../_types"
 import { stripBom, detectDelimiter } from "./reader"
+import { escapeFormula, unescapeFormula } from "./formula"
 
 const TEXT_ENCODER = /* @__PURE__ */ new TextEncoder()
 
@@ -87,6 +88,7 @@ export function* streamCsvRows(
   const commentChar = options?.comment
   const isHeaderMode = options?.header ?? false
   const skipHeaderRow = options?.skipHeaderRow ?? false
+  const unescapeFormulae = options?.unescapeFormulae ?? false
   // Align inferType default with parseCsv (defaults to true).
   const preserveLeadingZeros = options?.preserveLeadingZeros !== false
   const maxRows = options?.maxRows
@@ -220,12 +222,16 @@ export function* streamCsvRows(
       continue
     }
 
+    // Undo the writer's formula escape first, so type inference and header
+    // names both see the value that was written, not `'` + the value.
+    const fields = unescapeFormulae ? row.map(unescapeFormula) : row
+
     // Capture the header row. Like parseCsv, `header: true` only marks it —
     // the row is still yielded, and is used to name columns for
     // transformValue. `skipHeaderRow` is the opt-in that consumes it.
     const isHeaderRowNow = isFirstRow && isHeaderMode
     if (isHeaderRowNow) {
-      headerRow = row
+      headerRow = fields
     }
     isFirstRow = false
 
@@ -240,8 +246,8 @@ export function* streamCsvRows(
 
     // Apply type inference if requested
     let outRow: CellValue[] = doTypeInference
-      ? row.map((v) => inferType(v, preserveLeadingZeros))
-      : row
+      ? fields.map((v) => inferType(v, preserveLeadingZeros))
+      : fields
 
     // transformValue — after type inference, matching parseCsv's ordering.
     if (transformValue) {
@@ -277,6 +283,8 @@ class CsvRowFormatter {
   private quoteStyle: "all" | "required" | "none"
   private dateFormat: string | undefined
   private nullValue: string
+  private escapeFormulae: boolean
+  private comment: string | undefined
 
   constructor(options?: CsvWriteOptions) {
     this.delimiter = options?.delimiter ?? ","
@@ -286,6 +294,12 @@ class CsvRowFormatter {
     this.bom = options?.bom ?? false
     this.dateFormat = options?.dateFormat
     this.nullValue = options?.nullValue ?? ""
+    // Both of these were honoured by writeCsv alone until #408, so the
+    // same options produced different bytes depending on which writer you
+    // reached for — and one of the two was the injection escape.
+    this.escapeFormulae = options?.escapeFormulae ?? false
+    // "" would make startsWith() true for every value, so treat it as unset.
+    this.comment = options?.comment || undefined
   }
 
   /** Format one row of values into a delimited line. */
@@ -318,7 +332,8 @@ class CsvRowFormatter {
       return this.quoteField(this.formatDate(value))
     }
 
-    return this.quoteField(String(value))
+    const str = String(value)
+    return this.quoteField(this.escapeFormulae ? escapeFormula(str) : str)
   }
 
   private quoteField(value: string): string {
@@ -331,7 +346,10 @@ class CsvRowFormatter {
       value.includes(this.delimiter) ||
       value.includes(this.quote) ||
       value.includes("\n") ||
-      value.includes("\r")
+      value.includes("\r") ||
+      // A leading comment character is quoted so a reader configured with
+      // `comment` keeps the row rather than dropping the line (#408).
+      (this.comment !== undefined && value.startsWith(this.comment))
 
     if (!needsQuoting) {
       return value

--- a/src/csv/writer.ts
+++ b/src/csv/writer.ts
@@ -1,4 +1,5 @@
 import type { CellValue, CsvWriteOptions } from "../_types"
+import { escapeFormula } from "./formula"
 
 // ── BOM constant ─────────────────────────────────────────────────────
 
@@ -37,7 +38,7 @@ export function formatCsvValue(value: CellValue, options?: CsvWriteOptions): str
   if (opts.escapeFormulae) {
     str = escapeFormula(str)
   }
-  return quoteField(str, opts.delimiter, opts.quote, opts.quoteStyle)
+  return quoteField(str, opts)
 }
 
 /**
@@ -55,11 +56,7 @@ export function writeCsv(rows: CellValue[][], options?: CsvWriteOptions): string
   // Headers row
   if (opts.headers) {
     if (Array.isArray(opts.headers)) {
-      parts.push(
-        opts.headers
-          .map((h) => quoteField(h, opts.delimiter, opts.quote, opts.quoteStyle))
-          .join(opts.delimiter),
-      )
+      parts.push(opts.headers.map((h) => quoteField(h, opts)).join(opts.delimiter))
       if (rows.length > 0) {
         parts.push(opts.lineSeparator)
       }
@@ -142,6 +139,7 @@ interface NormalizedWriteOptions {
   dateFormat: string | undefined
   nullValue: string
   escapeFormulae: boolean
+  comment: string | undefined
 }
 
 function normalizeWriteOptions(options?: CsvWriteOptions): NormalizedWriteOptions {
@@ -155,45 +153,9 @@ function normalizeWriteOptions(options?: CsvWriteOptions): NormalizedWriteOption
     dateFormat: options?.dateFormat,
     nullValue: options?.nullValue ?? "",
     escapeFormulae: options?.escapeFormulae ?? false,
+    // "" would make startsWith() true for every value, so treat it as unset.
+    comment: options?.comment || undefined,
   }
-}
-
-// Characters that trigger formula interpretation in Excel/Sheets/LibreOffice
-// Covers: formulas (=), unary operators (+, -), at-sign (@), whitespace injection (\t, \r, \n), null byte (\0)
-const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r", "\n", "\0", "|"]
-
-// DDE and dangerous function patterns (case-insensitive)
-const DANGEROUS_PATTERNS = [
-  /^=cmd\b/i,
-  /^=HYPERLINK\s*\(/i,
-  /^=IMPORTXML\s*\(/i,
-  /^=IMPORTDATA\s*\(/i,
-  /^=IMPORTFEED\s*\(/i,
-  /^=IMPORTHTML\s*\(/i,
-  /^=IMPORTRANGE\s*\(/i,
-  /^=IMAGE\s*\(/i,
-]
-
-/**
- * Prefix a string value with a single quote if it starts with a formula-triggering character
- * or matches a dangerous function/DDE pattern.
- */
-function escapeFormula(value: string): string {
-  if (value.length === 0) return value
-
-  // Check prefix characters
-  if (FORMULA_PREFIXES.includes(value[0]!)) {
-    return "'" + value
-  }
-
-  // Check dangerous patterns (DDE, data exfiltration via HYPERLINK, etc.)
-  for (const pattern of DANGEROUS_PATTERNS) {
-    if (pattern.test(value)) {
-      return "'" + value
-    }
-  }
-
-  return value
 }
 
 function formatAndQuote(value: CellValue, opts: NormalizedWriteOptions): string {
@@ -207,50 +169,51 @@ function formatAndQuote(value: CellValue, opts: NormalizedWriteOptions): string 
 
   if (typeof value === "boolean") {
     const raw = value ? "true" : "false"
-    return quoteField(raw, opts.delimiter, opts.quote, opts.quoteStyle)
+    return quoteField(raw, opts)
   }
 
   if (typeof value === "number") {
     const raw = formatNumber(value)
-    return quoteField(raw, opts.delimiter, opts.quote, opts.quoteStyle)
+    return quoteField(raw, opts)
   }
 
   if (value instanceof Date) {
     const raw = formatDate(value, opts.dateFormat)
-    return quoteField(raw, opts.delimiter, opts.quote, opts.quoteStyle)
+    return quoteField(raw, opts)
   }
 
   let str = String(value)
   if (opts.escapeFormulae) {
     str = escapeFormula(str)
   }
-  return quoteField(str, opts.delimiter, opts.quote, opts.quoteStyle)
+  return quoteField(str, opts)
 }
 
-function quoteField(
-  value: string,
-  delimiter: string,
-  quote: string,
-  quoteStyle: "all" | "required" | "none",
-): string {
-  if (quoteStyle === "none") {
+function quoteField(value: string, opts: NormalizedWriteOptions): string {
+  if (opts.quoteStyle === "none") {
     return value
   }
 
   const needsQuoting =
-    quoteStyle === "all" ||
-    value.includes(delimiter) ||
-    value.includes(quote) ||
+    opts.quoteStyle === "all" ||
+    value.includes(opts.delimiter) ||
+    value.includes(opts.quote) ||
     value.includes("\n") ||
-    value.includes("\r")
+    value.includes("\r") ||
+    // A leading comment character is quoted so a reader configured with
+    // `comment` keeps the row instead of dropping the whole line (#408).
+    // The reader only skips *unquoted* leading comment chars, so quoting
+    // is a complete fix — and it is applied wherever the value sits, since
+    // a caller may reorder or concatenate what we hand back.
+    (opts.comment !== undefined && value.startsWith(opts.comment))
 
   if (!needsQuoting) {
     return value
   }
 
   // Escape quote characters by doubling them
-  const escaped = value.replaceAll(quote, quote + quote)
-  return quote + escaped + quote
+  const escaped = value.replaceAll(opts.quote, opts.quote + opts.quote)
+  return opts.quote + escaped + opts.quote
 }
 
 function formatNumber(n: number): string {

--- a/test/csv-roundtrip-options.test.ts
+++ b/test/csv-roundtrip-options.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest"
+import { parseCsv } from "../src/csv/reader"
+import { writeCsv } from "../src/csv/writer"
+import { CsvStreamWriter, streamCsvRows, writeCsvStream } from "../src/csv/stream"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #408 — write options that transform values on the way out need a way
+// back in. Everything here is a writeCsv → parseCsv round trip: what goes
+// in must come out, or the one-way-ness must be a documented decision.
+// ═══════════════════════════════════════════════════════════════════════
+
+const collect = async (stream: ReadableStream<Uint8Array>): Promise<string> => {
+  const decoder = new TextDecoder()
+  const reader = stream.getReader()
+  let out = ""
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out += decoder.decode(value, { stream: true })
+  }
+  return out + decoder.decode()
+}
+
+// ── skipHeaderRow ────────────────────────────────────────────────────
+
+describe("parseCsv — skipHeaderRow", () => {
+  const SIMPLE = "name,qty\r\nfoo,1\r\nbar,2\r\n"
+
+  it("consumes the header row when asked", () => {
+    expect(parseCsv(SIMPLE, { header: true, skipHeaderRow: true })).toEqual([
+      ["foo", "1"],
+      ["bar", "2"],
+    ])
+  })
+
+  it("keeps the header row by default", () => {
+    expect(parseCsv(SIMPLE, { header: true })[0]).toEqual(["name", "qty"])
+  })
+
+  it("is inert without header: true", () => {
+    expect(parseCsv(SIMPLE, { skipHeaderRow: true })).toEqual(parseCsv(SIMPLE))
+  })
+
+  it("still names transformValue columns from the consumed header", () => {
+    const seen: string[] = []
+    parseCsv(SIMPLE, {
+      header: true,
+      skipHeaderRow: true,
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["name", "qty", "name", "qty"])
+  })
+
+  it("counts maxRows against emitted rows only", () => {
+    expect(parseCsv(SIMPLE, { header: true, skipHeaderRow: true, maxRows: 1 })).toEqual([
+      ["foo", "1"],
+    ])
+  })
+
+  it("agrees with streamCsvRows", () => {
+    const options = { header: true, skipHeaderRow: true }
+    expect(parseCsv(SIMPLE, options)).toEqual(Array.from(streamCsvRows(SIMPLE, options)))
+  })
+})
+
+// ── escapeFormulae / unescapeFormulae ────────────────────────────────
+
+describe("escapeFormulae round trip", () => {
+  const TRIGGERS = ["=SUM(A1)", "+1", "-5", "@handle", "|pipe", "\ttab", "\rcr", "\nlf", "\0nul"]
+
+  it("returns the original values with unescapeFormulae", () => {
+    const rows: CellValue[][] = [TRIGGERS]
+    const written = writeCsv(rows, { escapeFormulae: true })
+    expect(parseCsv(written, { unescapeFormulae: true })).toEqual(rows)
+  })
+
+  it("still corrupts without it — the option is opt-in", () => {
+    const written = writeCsv([["-5"]], { escapeFormulae: true })
+    expect(written).toBe("'-5")
+    expect(parseCsv(written)).toEqual([["'-5"]])
+  })
+
+  it("strips only what the writer would have added", () => {
+    // A value that genuinely starts with an apostrophe is never escaped
+    // (the writer only fires on formula triggers), so it must survive.
+    expect(parseCsv("'foo", { unescapeFormulae: true })).toEqual([["'foo"]])
+    expect(parseCsv("'", { unescapeFormulae: true })).toEqual([["'"]])
+  })
+
+  it("runs before type inference, so an escaped number comes back a number", () => {
+    const written = writeCsv([["-5"]], { escapeFormulae: true })
+    expect(parseCsv(written, { unescapeFormulae: true, typeInference: true })).toEqual([[-5]])
+  })
+
+  it("un-escapes header names too", () => {
+    const written = writeCsv([["-h"], ["v"]], { escapeFormulae: true })
+    const seen: string[] = []
+    parseCsv(written, {
+      header: true,
+      unescapeFormulae: true,
+      transformValue: (v, header) => {
+        seen.push(header)
+        return v
+      },
+    })
+    expect(seen).toEqual(["-h", "-h"])
+  })
+
+  it("works the same in streamCsvRows", () => {
+    const written = writeCsv([TRIGGERS], { escapeFormulae: true })
+    const options = { unescapeFormulae: true }
+    expect(Array.from(streamCsvRows(written, options))).toEqual(parseCsv(written, options))
+  })
+})
+
+describe("escapeFormulae in the streaming writers", () => {
+  it("CsvStreamWriter escapes like writeCsv", () => {
+    const writer = new CsvStreamWriter({ escapeFormulae: true })
+    writer.addRow(["=SUM(A1)", "-5"])
+    expect(writer.finish()).toBe(writeCsv([["=SUM(A1)", "-5"]], { escapeFormulae: true }))
+  })
+
+  it("writeCsvStream escapes like writeCsv", async () => {
+    const out = await collect(writeCsvStream([["=SUM(A1)", "-5"]], { escapeFormulae: true }))
+    expect(out).toBe(writeCsv([["=SUM(A1)", "-5"]], { escapeFormulae: true }))
+  })
+})
+
+// ── comment character ────────────────────────────────────────────────
+
+describe("comment character on write", () => {
+  it("quotes a value that would otherwise be read as a comment", () => {
+    const rows = [
+      ["#1", "a"],
+      ["b", "c"],
+    ]
+    const written = writeCsv(rows, { comment: "#" })
+    expect(written).toBe('"#1",a\r\nb,c')
+    expect(parseCsv(written, { comment: "#" })).toEqual(rows)
+  })
+
+  it("deletes the row without the option — hence the option", () => {
+    const written = writeCsv([["#1", "a"]])
+    expect(parseCsv(written, { comment: "#" })).toEqual([])
+  })
+
+  it("quotes header cells too", () => {
+    const written = writeCsv([["v"]], { headers: ["#h"], comment: "#" })
+    expect(parseCsv(written, { comment: "#" })).toEqual([["#h"], ["v"]])
+  })
+
+  it("leaves values that do not start with the comment character alone", () => {
+    expect(writeCsv([["a#b", "c"]], { comment: "#" })).toBe("a#b,c")
+  })
+
+  it("is honoured by the streaming writers", async () => {
+    const writer = new CsvStreamWriter({ comment: "#" })
+    writer.addRow(["#1", "a"])
+    expect(writer.finish()).toBe('"#1",a')
+    const out = await collect(writeCsvStream([["#1", "a"]], { comment: "#" }))
+    expect(out).toBe('"#1",a')
+  })
+})
+
+// ── Documented one-way options ───────────────────────────────────────
+
+describe("write options documented as one-way", () => {
+  // These have no inverse by decision, not by oversight (#408). The tests
+  // pin the documented behaviour so that adding an inverse later is a
+  // deliberate change to a stated contract rather than a silent one.
+
+  it("nullValue does not survive the round trip", () => {
+    expect(parseCsv(writeCsv([[null, "a"]], { nullValue: "NULL" }))).toEqual([["NULL", "a"]])
+    // Even the default is one-way: CSV has no null, so it reads back as "".
+    expect(parseCsv(writeCsv([[null, "a"]]))).toEqual([["", "a"]])
+  })
+
+  it("a custom dateFormat does not survive, while the ISO default does", () => {
+    const date = new Date(Date.UTC(2024, 0, 15, 12, 0, 0))
+    const custom = writeCsv([[date]], { dateFormat: "DD/MM/YYYY" })
+    expect(parseCsv(custom, { typeInference: true })).toEqual([["15/01/2024"]])
+    expect(parseCsv(writeCsv([[date]]), { typeInference: true })).toEqual([[date]])
+  })
+})

--- a/test/csv-stream-read-parity.test.ts
+++ b/test/csv-stream-read-parity.test.ts
@@ -11,6 +11,8 @@ function stream(input: string, options?: CsvReadOptions): CellValue[][] {
 
 const SIMPLE = "name,qty\r\nfoo,1\r\nbar,2\r\n"
 const QUOTED = 'a,"b,c"\r\n"x""y",z\r\n'
+// As writeCsv({ escapeFormulae: true }) emits it.
+const ESCAPED = "'-5,'=SUM(A1)\r\n'@x,plain\r\n"
 const MESSY = [
   "# leading comment",
   "name;qty;when",
@@ -30,6 +32,7 @@ describe("streamCsvRows / parseCsv parity", () => {
     ["simple", SIMPLE],
     ["quoted", QUOTED],
     ["messy", MESSY],
+    ["escaped", ESCAPED],
   ]
 
   const optionCases: Array<[string, CsvReadOptions]> = [
@@ -47,6 +50,13 @@ describe("streamCsvRows / parseCsv parity", () => {
     ["comment", { comment: "#" }],
     ["delimiter ;", { delimiter: ";" }],
     ["skipBom off", { skipBom: false }],
+    // Both were on CsvReadOptions but implemented in one reader only —
+    // skipHeaderRow in streamCsvRows, and neither honoured unescapeFormulae
+    // before it existed (#408).
+    ["header + skipHeaderRow", { header: true, skipHeaderRow: true }],
+    ["header + skipHeaderRow + maxRows 1", { header: true, skipHeaderRow: true, maxRows: 1 }],
+    ["unescapeFormulae", { unescapeFormulae: true }],
+    ["unescapeFormulae + typeInference", { unescapeFormulae: true, typeInference: true }],
   ]
 
   for (const [inputLabel, input] of inputs) {
@@ -160,6 +170,14 @@ describe("streamCsvRows — onRow", () => {
 })
 
 describe("streamCsvRows — skipHeaderRow", () => {
+  it("drops the header row in parseCsv too", () => {
+    // It was honoured here and ignored there — one option, two behaviours,
+    // which is the divergence this whole file exists to prevent (#408).
+    expect(parseCsv(SIMPLE, { header: true, skipHeaderRow: true })).toEqual(
+      stream(SIMPLE, { header: true, skipHeaderRow: true }),
+    )
+  })
+
   it("drops the header row when asked", () => {
     expect(stream(SIMPLE, { header: true, skipHeaderRow: true })).toEqual([
       ["foo", "1"],

--- a/test/migration-guide.test.ts
+++ b/test/migration-guide.test.ts
@@ -14,12 +14,14 @@ import {
   toHtml,
   toMarkdown,
   validateWithSchema,
+  writeCsv,
   writeCsvStream,
   writeXlsx,
   writeXlsxStream,
 } from "../src/index"
 import { readXlsx } from "../src/xlsx/reader"
 import { parseCsv } from "../src/csv/reader"
+import type { CsvReadOptions } from "../src/_types"
 import { MAX_INPUT_BYTES } from "../src/limits"
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -124,8 +126,9 @@ describe("streamCsvRows matches parseCsv", () => {
     ])
   })
 
-  it("drops it only when asked, via skipHeaderRow", () => {
+  it("drops it only when asked, via skipHeaderRow — in both readers", () => {
     expect([...streamCsvRows(source, { header: true, skipHeaderRow: true })]).toEqual([["1", "2"]])
+    expect(parseCsv(source, { header: true, skipHeaderRow: true })).toEqual([["1", "2"]])
   })
 
   it("actually runs onRow and transformValue, which used to be ignored", () => {
@@ -290,6 +293,19 @@ describe("removed API that never did anything", () => {
     expect(workbook.sheets[0].threadedComments).toBeUndefined()
   })
 
+  it("no longer accepts CsvReadOptions.schema", () => {
+    // A removed *type member* leaves no runtime trace, so the claim is a
+    // compile-time one: if `schema` came back, the @ts-expect-error below
+    // would itself be the error. The row of data proves what the option
+    // never did — parseCsv returned it unvalidated.
+    const options: CsvReadOptions = {
+      header: true,
+      // @ts-expect-error — removed in v1; no CSV reader ever validated with it
+      schema: { a: { type: "number", required: true } },
+    }
+    expect(parseCsv("a\r\nnot-a-number", options)).toEqual([["a"], ["not-a-number"]])
+  })
+
   it("keeps RoundtripWorkbook's internals off the object", async () => {
     const buf = await writeXlsx({ sheets: [{ name: "S", rows: [["a"]] }] })
     const workbook = await openXlsx(buf)
@@ -332,6 +348,25 @@ describe("reading untrusted files", () => {
 describe("also worth knowing", () => {
   it("exports writeCsvStream, the counterpart to writeXlsxStream", () => {
     expect(typeof writeCsvStream).toBe("function")
+  })
+
+  it("gives escapeFormulae a way back in, and only where it applies", () => {
+    const written = writeCsv([["-5", "'quoted'"]], { escapeFormulae: true })
+    expect(written).toBe("'-5,'quoted'")
+    expect(parseCsv(written, { unescapeFormulae: true })).toEqual([["-5", "'quoted'"]])
+  })
+
+  it("escapes formulae in the streaming CSV writers too", async () => {
+    const escaped = writeCsv([["=SUM(A1)"]], { escapeFormulae: true })
+    const streamed = await bytes(writeCsvStream([["=SUM(A1)"]], { escapeFormulae: true }))
+    expect(new TextDecoder().decode(streamed)).toBe(escaped)
+  })
+
+  it("quotes values a comment-configured reader would delete", () => {
+    const written = writeCsv([["#1", "a"]], { comment: "#" })
+    expect(parseCsv(written, { comment: "#" })).toEqual([["#1", "a"]])
+    // …and without the option, the guide's warning holds.
+    expect(parseCsv(writeCsv([["#1", "a"]]), { comment: "#" })).toEqual([])
   })
 
   it("has a hucre/ooxml entry point that still re-exports from the root", async () => {


### PR DESCRIPTION
Closes #408.

`writeCsv` had options that transform values on the way out with nothing on the way back in, so a `writeCsv` → `parseCsv` round trip through hucre did not return what went in. Reproduced against unfixed code first:

```
parseCsv  header+skipHeaderRow : [["name","age"],["alice","30"]]
stream    header+skipHeaderRow : [["alice","30"]]

parseCsv with schema requiring number: [["a"],["not-a-number"]]   // no validation

written : "'-5,'=SUM(A1),'@x,'+1,'|pipe,'\ttab"
read    : [["'-5","'=SUM(A1)","'@x","'+1","'|pipe","'\ttab"]]

written : "#1,a\r\nb,c"  read with comment:"#" : [["b","c"]]      // row deleted
```

## The decision for each option

The issue asked for one of *implement the inverse*, *document as one-way*, or *remove*, per option, with reasons. They are:

| Option | Decision | Why |
| --- | --- | --- |
| `skipHeaderRow` | **implement** in `parseCsv` | one option name, one options type, two behaviours. Drops before the `maxRows` slice and after the header is captured, so both readers now agree exactly |
| `schema` (read) | **remove** | zero references under `src/csv/`; v1 would have frozen it permanently |
| `escapeFormulae` | **implement the inverse** — new `CsvReadOptions.unescapeFormulae` | it is a security default users are *told* to enable, and it fires on ordinary data (`-5`, `-Wall`, `+phone`), so "do not round-trip it" is unactionable advice. Strips `'` only where the writer would have added one, so `'quoted'` survives; runs before type inference so `'-5` becomes the number `-5` |
| `nullValue` | **document as one-way** | CSV has no null. An inverse would fix the custom token and leave the hole, since the default is lossy too, and making `""` mean null guesses for every empty field |
| custom `dateFormat` | **document as one-way** | the reader knows ISO only and cannot disambiguate `03/04/2024`. The ISO default does round-trip to an equal `Date` |
| `comment` on write | **implement** — new `CsvWriteOptions.comment` | a value starting with `#` was written bare and then *deleted* by a reader configured with `comment: "#"`. Quoting it is a complete fix, because the reader only strips unquoted comment lines. Off by default |

Escape and un-escape share one trigger list in a new `src/csv/formula.ts`, because two copies would drift and a drifted list corrupts data in exactly the cases the escape exists to prevent.

## One bug the issue did not mention

`CsvStreamWriter` / `writeCsvStream` **ignored `escapeFormulae` entirely** — `"=SUM(A1),-5"` where `writeCsv` gives `"'=SUM(A1),'-5"`. The formula-injection escape was silently absent from the streaming writers, which is the worse half to be missing it from. Both writers now share one formatter.

## Where the issue was wrong

Both corrections are mine to own:

1. **`CsvWriteOptions.escape` is not "accepted and ignored" — it is not on the type at all.** `writeCsv(rows, { escape: "\\" })` is a compile error. Nothing to remove. It was also left unimplemented deliberately: lossless backslash writing needs the escape character itself escaped, which the parser does not decode, so a value ending in `\` would be written `"a\"` and read as an unterminated field — a *new* round-trip corruption inside a commit about removing them.
2. **The `dateFormat` reproduction in the issue overstates the ISO case.** Both lines print identically only because `JSON.stringify` renders a `Date` and a string the same way. The ISO default is sound end to end; only the custom format loses the type.

## Left out deliberately

`quoteStyle: "none"` producing unparseable output — inherent to the mode, and `comment` quoting is documented as a no-op under it. No `parseTsv`/`readTsv` — a separate feature, not a round-trip-option decision.

## Tests

New `test/csv-roundtrip-options.test.ts` (21 tests, **12 failing** against unfixed source). Parity and migration additions: **13 failing** against unfixed source, verified by stashing. **No existing test changed** — none encoded the defects, so nothing was weakened. MIGRATION.md gained the `schema` removal plus four behaviour-change entries, and `test/migration-guide.test.ts` covers each.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,441 tests, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
