### PR TITLE
test: stop the default-spin-count crypto test failing under load

### DIFF
--- a/test/encryption.test.ts
+++ b/test/encryption.test.ts
@@ -55,7 +55,14 @@ describe("agile crypto primitive", () => {
     await expect(decryptAgile(enc, "wrong")).rejects.toBeInstanceOf(DecryptionError)
   })
 
-  it("interoperates at Excel's default spin count", { timeout: 30000 }, async () => {
+  // 100,000 spins on each side is 200,000 SHA-512 iterations, and the
+  // budget has to cover the worst case rather than the quiet one: vitest
+  // runs files in parallel, so this shares a machine with the rest of the
+  // suite. 30s was enough in isolation and not under load, so it failed
+  // intermittently — on a test whose subject is not speed. Keeping the
+  // real default matters: this is the only assertion that Excel's own
+  // spin count works end to end.
+  it("interoperates at Excel's default spin count", { timeout: 180_000 }, async () => {
     const payload = new TextEncoder().encode("z".repeat(9000))
     const enc = await encryptAgile(payload, "pw") // default 100000
     expect([...(await decryptAgile(enc, "pw"))]).toEqual([...payload])


### PR DESCRIPTION
`test/encryption.test.ts > interoperates at Excel's default spin count` encrypts and decrypts at Excel's real default of 100,000 spins — 200,000 SHA-512 iterations — inside a 30 second budget.

That was enough in isolation and not enough under full-suite load, where vitest runs files in parallel and this test shares a machine with everything else. So it failed intermittently, on a test whose subject is not speed.

I saw it three times today across different branches and misattributed it twice before finding it, which is the real cost: an intermittent failure that is not about the thing under test makes every genuine failure beside it suspect. Two agents working in parallel independently reported "one flaky test, does not reproduce" — that is exactly the signal that gets ignored until it hides something real.

The budget is raised rather than the work reduced. The spin count is the point of the test: it is the only assertion that Excel's own default works end to end, so lowering it to fit the clock would leave nothing checking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD