### PR TITLE
fix(ods): valid cross-sheet formulas, rich text that survives, and dates that do not drift

### DIFF
--- a/src/cell-utils.ts
+++ b/src/cell-utils.ts
@@ -20,25 +20,75 @@ export { colToLetter, cellRef, rangeRef } from "./xlsx/worksheet-writer"
  */
 const A1_REF_TOKEN = /(?<![A-Za-z0-9_$])(\$?[A-Z]{1,3}\$?\d+)(?![A-Za-z0-9_(])/g
 
-/** Like {@link A1_REF_TOKEN} but also captures an optional `:ref2` range tail. */
-const A1_RANGE_TOKEN =
-  /(?<![A-Za-z0-9_$])(\$?[A-Z]{1,3}\$?\d+)(?::(\$?[A-Z]{1,3}\$?\d+))?(?![A-Za-z0-9_(])/g
+/**
+ * The sheet a reference is qualified with, written either Excel's way
+ * (`Sheet2!A1`, `'My Sheet'!A1`) or with the dot separator OpenFormula and
+ * LibreOffice's UI use (`Sheet2.A1`). A name needing quotes is quoted the
+ * same way in both dialects — single quotes, an embedded quote doubled —
+ * so the quoted form passes through untouched.
+ */
+const SHEET_QUALIFIER = "(?:\\$?(?:'(?:[^']|'')*'|[A-Za-z_][A-Za-z0-9_]*)[.!])?"
+
+/** The reference itself, as matched inside {@link A1_RANGE_TOKEN}. */
+const A1_REF = "\\$?[A-Z]{1,3}\\$?\\d+"
+
+/**
+ * Like {@link A1_REF_TOKEN} but also captures the sheet qualifier of each
+ * reference and an optional `:ref2` range tail. The qualifier has to be part
+ * of the match, not something the caller finds afterwards: a consumer that
+ * only ever sees `A1` cannot tell `Sheet2!A1` from `A1`, and the ODS writer
+ * used to prove it by emitting `Sheet2.[.A1]` — brackets around the cell but
+ * not the sheet, which is not a reference ODF recognises. The lookbehind
+ * also rejects a preceding `.`/`!` so that a qualifier this pattern failed
+ * to parse can never be left outside the match.
+ */
+const A1_RANGE_TOKEN = new RegExp(
+  `(?<![A-Za-z0-9_$.!])(${SHEET_QUALIFIER})(${A1_REF})(?::(${SHEET_QUALIFIER})(${A1_REF}))?(?![A-Za-z0-9_(])`,
+  "g",
+)
+
+/** One A1 reference or range matched by {@link replaceA1Ranges}. */
+export interface A1RangeMatch {
+  /** Sheet qualifier of the first ref, separator stripped — `undefined` when the ref is local. */
+  sheet1?: string
+  ref1: string
+  /** Sheet qualifier of the second ref; only a 3-D range such as `Sheet1!A1:Sheet3!B2` has one. */
+  sheet2?: string
+  /** Present only for a range. */
+  ref2?: string
+}
+
+/** Strip the `.`/`!` separator and the `$` of an absolute sheet locator. */
+function normalizeQualifier(raw: string): string | undefined {
+  if (!raw) return undefined
+  const name = raw.slice(0, -1)
+  return name.startsWith("$") ? name.slice(1) : name
+}
 
 /**
  * Run a replacer over the A1 cell references / ranges in an Excel formula,
  * skipping quoted string literals, function names, and embedded
  * identifiers (same safety rules as {@link replaceA1Refs}). `replacer`
- * receives the first ref and, for a range, the second; it returns the
- * full replacement for the matched span.
+ * receives the reference's parts and returns the full replacement for the
+ * matched span, sheet qualifier included.
  */
 export function replaceA1Ranges(
   formula: string,
-  replacer: (ref1: string, ref2?: string) => string,
+  replacer: (match: A1RangeMatch) => string,
 ): string {
   const parts = formula.split(/("(?:[^"]|"")*")/)
   for (let i = 0; i < parts.length; i++) {
     if (i % 2 === 1) continue
-    parts[i] = parts[i].replace(A1_RANGE_TOKEN, (_m, r1: string, r2?: string) => replacer(r1, r2))
+    parts[i] = parts[i].replace(
+      A1_RANGE_TOKEN,
+      (_m, q1: string, r1: string, q2?: string, r2?: string) =>
+        replacer({
+          sheet1: normalizeQualifier(q1),
+          ref1: r1,
+          sheet2: q2 ? normalizeQualifier(q2) : undefined,
+          ref2: r2,
+        }),
+    )
   }
   return parts.join("")
 }

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -141,6 +141,8 @@ function parseStyles(doc: XmlElement): Map<string, OdsStyleDef> {
  */
 function parseDataStyles(autoStyles: XmlElement): Map<string, string> {
   const out = new Map<string, string>()
+  /** style name → the sections it maps to, by `<style:map>` condition */
+  const mapped = new Map<string, Array<{ condition: string; target: string }>>()
 
   for (const child of autoStyles.children) {
     if (typeof child === "string") continue
@@ -161,7 +163,41 @@ function parseDataStyles(autoStyles: XmlElement): Map<string, string> {
       const truncate = child.attrs["number:truncate-on-overflow"]
       code = serializeDataStyleChildren(child, "time", truncate === "false")
     }
-    if (code) out.set(name, code)
+    if (!code) continue
+    out.set(name, code)
+
+    const maps = findChildren(child, "map")
+    if (maps.length > 0) {
+      mapped.set(
+        name,
+        maps.map((m) => ({
+          condition: m.attrs["style:condition"] ?? "",
+          target: m.attrs["style:apply-style-name"] ?? "",
+        })),
+      )
+    }
+  }
+
+  // Reassemble Excel's `positive;negative;zero` from the styles a
+  // `<style:map>` chains together. The style a cell points at holds the
+  // negative section, and the maps name the styles for the other two — the
+  // inverse of what getOrCreateDataStyleName writes, and of what
+  // LibreOffice writes.
+  for (const [name, maps] of mapped) {
+    let positive: string | undefined
+    let zero: string | undefined
+    for (const { condition, target } of maps) {
+      const code = out.get(target)
+      if (!code) continue
+      if (condition.includes(">")) positive = code
+      else if (condition.includes("=")) zero = code
+    }
+    // Without a section for the values the main style does not cover, the
+    // maps describe something this reader cannot express — keep the main
+    // style's own code rather than inventing sections around it.
+    if (!positive) continue
+    const negative = out.get(name)!
+    out.set(name, zero ? `${positive};${negative};${zero}` : `${positive};${negative}`)
   }
 
   return out
@@ -329,6 +365,34 @@ function collectText(el: XmlElement): string {
 
 // ── Formula Parsing ─────────────────────────────────────────────────
 
+/** A cell, whole-column or whole-row address, as it appears after the dot. */
+const ODS_ADDRESS = /^\$?(?:[A-Za-z]{1,3}(?:\$?\d+)?|\d+)$/
+
+/**
+ * Convert one side of an OpenFormula reference — everything between the
+ * brackets, or between the brackets and the `:` — to its Excel spelling.
+ * Returns `undefined` when the text is not an address, which is the signal
+ * to leave the reference alone rather than mangle it.
+ */
+function odsAddressToExcel(part: string): string | undefined {
+  // The separator is the *last* dot: a sheet name may contain one
+  // (`['Q1.2024'.A1]`), an address never does.
+  const dot = part.lastIndexOf(".")
+  if (dot < 0) return undefined
+  const address = part.slice(dot + 1)
+  if (!ODS_ADDRESS.test(address)) return undefined
+
+  let sheet = part.slice(0, dot)
+  // An external reference (`['budget.ods'#$Sheet1.A1]`) has no Excel
+  // spelling this reader can produce — leave the whole thing verbatim.
+  if (sheet.includes("#")) return undefined
+  // `$Sheet1` marks the sheet absolute; Excel has no notation for that, and
+  // a cross-sheet reference never shifts on copy anyway.
+  if (sheet.startsWith("$")) sheet = sheet.slice(1)
+
+  return sheet ? `${sheet}!${address}` : address
+}
+
 /**
  * Convert an ODS formula to Excel-style formula.
  * ODS: "of:=SUM([.A1:.A10])" → "SUM(A1:A10)"
@@ -340,13 +404,56 @@ function odsFormulaToExcel(formula: string): string {
   else if (f.startsWith("oooc:=")) f = f.slice(6)
   else if (f.startsWith("=")) f = f.slice(1)
 
-  // Convert [.A1:.B2] → A1:B2 and [.A1] → A1
-  f = f.replace(/\[\.([^\]:.]+)(?::\.([^\]]+))?\]/g, (_match, ref1: string, ref2?: string) => {
-    if (ref2) return `${ref1}:${ref2}`
-    return ref1
-  })
+  // Convert [.A1:.B2] → A1:B2, [.A1] → A1, and the cross-sheet forms
+  // LibreOffice writes — [$Sheet2.A1] / [Sheet2.A1] → Sheet2!A1,
+  // [$Sheet2.A1:.B2] → Sheet2!A1:B2. Matching on a literal `[.` (as this
+  // did) decoded only the local forms and left every cross-sheet reference
+  // in the file as raw ODF text. See #405.
+  //
+  // Split on string literals first, as the writer does, so a bracketed
+  // token inside one is left as the text it is.
+  const parts = f.split(/("(?:[^"]|"")*")/)
+  for (let i = 0; i < parts.length; i++) {
+    if (i % 2 === 1) continue
+    parts[i] = parts[i]!.replace(/\[([^\]]*)\]/g, (match, body: string) => {
+      // A sheet name cannot contain `:`, so this only ever splits a range.
+      const halves = body.split(":")
+      if (halves.length > 2) return match
+      const first = odsAddressToExcel(halves[0]!)
+      if (first === undefined) return match
+      if (halves.length === 1) return first
+      const second = odsAddressToExcel(halves[1]!)
+      if (second === undefined) return match
+      return `${first}:${second}`
+    })
+  }
 
-  return f
+  return parts.join("")
+}
+
+// ── Date Parsing ────────────────────────────────────────────────────
+
+/**
+ * Parse an ODF date (`xsd:date` / `xsd:dateTime`), whose zone designator is
+ * optional.
+ *
+ * `new Date(text)` cannot be used directly: ECMAScript reads an unqualified
+ * date-*time* as local but a date-*only* string as UTC. The writer builds
+ * `office:date-value` out of UTC components, so the reader used to shift
+ * every value by the machine's offset — and because the shifted value was
+ * written back out the same way, the error accumulated with each save.
+ * Silent on a UTC machine, one day off after four round trips in Tokyo.
+ * See #415.
+ *
+ * An explicit offset (`...+02:00`, `...Z`) is what the file says and is
+ * honoured; only an unqualified time is taken to mean UTC.
+ */
+export function parseOdsDateTime(text: string): Date | undefined {
+  const trimmed = text.trim()
+  const timeAt = trimmed.indexOf("T")
+  const zoned = timeAt >= 0 && /(?:Z|[+-]\d{2}:?\d{2})$/.test(trimmed.slice(timeAt + 1))
+  const date = new Date(timeAt >= 0 && !zoned ? `${trimmed}Z` : trimmed)
+  return Number.isNaN(date.getTime()) ? undefined : date
 }
 
 // ── Cell Value Parsing ──────────────────────────────────────────────
@@ -382,10 +489,7 @@ function parseCellValue(cell: XmlElement): CellValue {
 
     case "date": {
       const dateVal = cell.attrs["office:date-value"]
-      if (dateVal) {
-        const d = new Date(dateVal)
-        if (!Number.isNaN(d.getTime())) return d
-      }
+      if (dateVal) return parseOdsDateTime(dateVal) ?? null
       return null
     }
 
@@ -718,14 +822,16 @@ function parseMetaXml(xml: string): Partial<WorkbookProperties> {
         break
       case "creation-date":
         if (text) {
-          const d = new Date(text)
-          if (!Number.isNaN(d.getTime())) props.created = d
+          // LibreOffice writes these without a zone designator, so they
+          // need the same UTC reading as office:date-value. See #415.
+          const d = parseOdsDateTime(text)
+          if (d) props.created = d
         }
         break
       case "date":
         if (text) {
-          const d = new Date(text)
-          if (!Number.isNaN(d.getTime())) props.modified = d
+          const d = parseOdsDateTime(text)
+          if (d) props.modified = d
         }
         break
     }

--- a/src/ods/stream.ts
+++ b/src/ods/stream.ts
@@ -6,6 +6,7 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseSax } from "../xml/parser"
+import { parseOdsDateTime } from "./reader"
 import { MAX_COL_INDEX, MAX_REPEAT_COUNT, MAX_ROW_INDEX } from "../limits"
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -252,10 +253,9 @@ function resolveCellValue(
       if (boolValue === "false") return false
       return null
     case "date":
-      if (dateValue) {
-        const d = new Date(dateValue)
-        if (!Number.isNaN(d.getTime())) return d
-      }
+      // Same UTC reading as readOds — a streamed row must not disagree with
+      // the same file read whole. See #415.
+      if (dateValue) return parseOdsDateTime(dateValue) ?? null
       return null
     case "string":
       return text || ""

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -9,7 +9,9 @@ import type {
   WriteSheet,
   Cell,
   CellStyle,
+  FontStyle,
   MergeRange,
+  RichTextRun,
 } from "../_types"
 import { ZipWriter } from "../zip/writer"
 import { validateSheetNames } from "../_validate"
@@ -281,9 +283,80 @@ function buildDateChildren(code: string): string[] {
 }
 
 /**
- * Convert an Excel-style `numFmt` code into an ODS data-style definition.
- * Returns `undefined` for codes the writer cannot translate — those are
- * silently dropped rather than emitting an invalid style.
+ * Split an Excel format code into its `positive;negative;zero;text`
+ * sections. A `;` inside a quoted literal or a bracketed tag is part of the
+ * section, not a separator.
+ */
+function splitFormatSections(code: string): string[] {
+  const sections: string[] = []
+  let current = ""
+  let quoted = false
+  let bracketed = false
+
+  for (let i = 0; i < code.length; i++) {
+    const ch = code[i]!
+    if (ch === "\\" && i + 1 < code.length) {
+      current += ch + code[++i]
+      continue
+    }
+    if (quoted) {
+      current += ch
+      if (ch === '"') quoted = false
+      continue
+    }
+    if (ch === '"') quoted = true
+    else if (ch === "[") bracketed = true
+    else if (ch === "]") bracketed = false
+    else if (ch === ";" && !bracketed) {
+      sections.push(current)
+      current = ""
+      continue
+    }
+    current += ch
+  }
+  sections.push(current)
+  return sections
+}
+
+/** Strip Excel's non-printing directives from a run of literal text. */
+function unquoteLiteral(text: string): string {
+  return (
+    text
+      // `_x` reserves the width of `x`; `*x` repeats `x` to fill the cell —
+      // both are spacing hints with no ODF equivalent and no text of their own.
+      .replace(/[_*]./g, "")
+      .replace(/\\(.)/g, "$1")
+      .replace(/"/g, "")
+  )
+}
+
+/**
+ * The literal text around the `#`/`0` core of a numeric section — the `-`
+ * of `-#,##0.00`, the parentheses of `(#,##0.00)`, a trailing unit. Without
+ * it a negative section renders unsigned, which matters because ODF reaches
+ * that section through a `<style:map>` rather than by negating.
+ */
+function numberLiterals(code: string): { prefix: string; suffix: string } {
+  const first = code.search(/[#0?]/)
+  if (first < 0) return { prefix: unquoteLiteral(code), suffix: "" }
+  let last = first
+  for (let i = code.length - 1; i > first; i--) {
+    if (/[#0?]/.test(code[i]!)) {
+      last = i
+      break
+    }
+  }
+  return {
+    prefix: unquoteLiteral(code.slice(0, first)),
+    suffix: unquoteLiteral(code.slice(last + 1)),
+  }
+}
+
+/**
+ * Convert one section of an Excel-style `numFmt` code into an ODS
+ * data-style definition. Returns `undefined` for sections the writer cannot
+ * translate — those are silently dropped rather than emitting an invalid
+ * style.
  */
 function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   if (!code) return undefined
@@ -292,9 +365,6 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   // "General" or "@" (text) — no data style needed
   if (trimmed === "General" || trimmed === "@" || trimmed === "") return undefined
 
-  // Take only the first section (before `;`); negative/zero sections are
-  // ODS' `<style:map>` territory and outside this writer's scope.
-  //
   // Excel's built-in date and time codes carry a locale prefix —
   // `[$-409]mmm-yy`, `[$-F800]dddd, mmmm dd, yyyy`. It is a hint about
   // which locale's month and day names to use, not content, and ODF
@@ -303,11 +373,17 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   // <number:text>, so the code round-tripped as `"["$"-"4""0""9""]"mmm-yy`.
   // A currency symbol written as `[$€-407]` keeps its symbol, because
   // detectCurrencySymbol reads that form before we get here. See #390.
-  const firstSection = trimmed.split(";")[0]!.replace(/\[\$-[^\]]*\]/g, "")
+  //
+  // A colour tag (`[Red]`) is dropped for the same reason — and dropping it
+  // is what keeps `[White]0.00` from being mistaken for a time format by
+  // the bare `h` in "White".
+  const section = trimmed
+    .replace(/\[\$-[^\]]*\]/g, "")
+    .replace(/\[(?:black|blue|cyan|green|magenta|red|white|yellow|color\s*\d+)\]/gi, "")
 
-  if (isPercentageFormat(firstSection)) {
-    const decimals = decimalsFromCode(firstSection)
-    const grouping = hasGrouping(firstSection)
+  if (isPercentageFormat(section)) {
+    const decimals = decimalsFromCode(section)
+    const grouping = hasGrouping(section)
     const children = [
       buildNumberChild(decimals, grouping),
       xmlElement("number:text", undefined, "%"),
@@ -315,26 +391,26 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
     return { kind: "percentage", children }
   }
 
-  const currency = detectCurrencySymbol(firstSection)
+  const currency = detectCurrencySymbol(section)
   if (currency) {
-    const decimals = decimalsFromCode(firstSection)
-    const grouping = hasGrouping(firstSection)
+    const decimals = decimalsFromCode(section)
+    const grouping = hasGrouping(section)
     const symbol = xmlElement("number:currency-symbol", undefined, xmlEscape(currency))
     const number = buildNumberChild(decimals, grouping)
     // Detect symbol position: leading vs trailing
-    const beforeNum = /^[^0#]*(\$|\[\$|"[$€£¥₺₽₹])/.test(firstSection)
+    const beforeNum = /^[^0#]*(\$|\[\$|"[$€£¥₺₽₹])/.test(section)
     const children = beforeNum ? [symbol, number] : [number, symbol]
     return { kind: "currency", children, attrs: { "number:automatic-order": "true" } }
   }
 
-  const time = isTimeFormat(firstSection)
-  const date = isDateFormat(firstSection)
+  const time = isTimeFormat(section)
+  const date = isDateFormat(section)
   // Bracketed-hour durations like `[HH]:MM` are pure time; check time first.
-  const isElapsed = /\[[hHmMsS]+\]/.test(firstSection)
+  const isElapsed = /\[[hHmMsS]+\]/.test(section)
   if (isElapsed || (time && !date)) {
     const def: OdsNumFmtDef = {
       kind: "time",
-      children: buildDateChildren(firstSection),
+      children: buildDateChildren(section),
     }
     // `[H]`, `[M]`, `[S]` request a duration presentation that doesn't wrap
     // at 24h — ODS marks this with `number:truncate-on-overflow="false"`.
@@ -342,13 +418,22 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
     return def
   }
   if (date) {
-    return { kind: "date", children: buildDateChildren(firstSection) }
+    return { kind: "date", children: buildDateChildren(section) }
   }
 
   // Plain number
-  const decimals = decimalsFromCode(firstSection)
-  const grouping = hasGrouping(firstSection)
-  return { kind: "number", children: [buildNumberChild(decimals, grouping)] }
+  const { prefix, suffix } = numberLiterals(section)
+  const children: string[] = []
+  if (prefix) children.push(xmlElement("number:text", undefined, xmlEscape(prefix)))
+  // A section with no `#`/`0` at all is pure literal text — Excel's third
+  // section is often `"-"` for zero — and gets no <number:number> child.
+  if (/[#0?]/.test(section)) {
+    children.push(buildNumberChild(decimalsFromCode(section), hasGrouping(section)))
+  } else if (children.length === 0) {
+    return undefined
+  }
+  if (suffix) children.push(xmlElement("number:text", undefined, xmlEscape(suffix)))
+  return { kind: "number", children }
 }
 
 // ── Style Generation ────────────────────────────────────────────────
@@ -367,23 +452,25 @@ function styleKey(style: CellStyle): string {
   return parts.join("|")
 }
 
+/**
+ * The `<style:text-properties>` attributes a font maps onto. Shared by cell
+ * styles and by the `text`-family styles rich-text runs reference, so a run
+ * and a whole-cell font of the same description serialize identically.
+ */
+function fontTextProps(font: FontStyle | undefined): Record<string, string> {
+  const props: Record<string, string> = {}
+  if (!font) return props
+  if (font.bold) props["fo:font-weight"] = "bold"
+  if (font.italic) props["fo:font-style"] = "italic"
+  if (font.size) props["fo:font-size"] = `${font.size}pt`
+  if (font.color?.rgb) props["fo:color"] = `#${font.color.rgb}`
+  return props
+}
+
 /** Generate a <style:style> element for a cell style */
 function generateStyleElement(name: string, style: CellStyle, dataStyleName?: string): string {
-  const textProps: Record<string, string> = {}
+  const textProps = fontTextProps(style.font)
   const cellProps: Record<string, string> = {}
-
-  if (style.font?.bold) {
-    textProps["fo:font-weight"] = "bold"
-  }
-  if (style.font?.italic) {
-    textProps["fo:font-style"] = "italic"
-  }
-  if (style.font?.size) {
-    textProps["fo:font-size"] = `${style.font.size}pt`
-  }
-  if (style.font?.color?.rgb) {
-    textProps["fo:color"] = `#${style.font.color.rgb}`
-  }
 
   if (style.fill?.type === "pattern" && style.fill.fgColor?.rgb) {
     cellProps["fo:background-color"] = `#${style.fill.fgColor.rgb}`
@@ -418,6 +505,12 @@ interface StyleCollector {
   dataStyleElements: Map<string, string>
   /** Counter for generating unique data-style names */
   dataStyleCounter: number
+  /** Map from font key → text-style name (e.g. "T1"), for rich-text runs */
+  textStyleMap: Map<string, string>
+  /** Map from text-style name → XML element string */
+  textStyleElements: Map<string, string>
+  /** Counter for generating unique text-style names */
+  textStyleCounter: number
 }
 
 function createStyleCollector(): StyleCollector {
@@ -428,24 +521,101 @@ function createStyleCollector(): StyleCollector {
     dataStyleMap: new Map(),
     dataStyleElements: new Map(),
     dataStyleCounter: 100,
+    textStyleMap: new Map(),
+    textStyleElements: new Map(),
+    textStyleCounter: 1,
   }
+}
+
+/**
+ * A `text`-family style for one rich-text run. Runs reference it from
+ * `<text:span text:style-name="T1">`; a run with nothing to say about its
+ * font gets no style and is written as bare text.
+ */
+function getOrCreateTextStyleName(collector: StyleCollector, font: FontStyle): string {
+  const props = fontTextProps(font)
+  if (Object.keys(props).length === 0) return ""
+
+  const key = styleKey({ font })
+  const existing = collector.textStyleMap.get(key)
+  if (existing) return existing
+
+  const name = `T${collector.textStyleCounter++}`
+  collector.textStyleMap.set(key, name)
+  collector.textStyleElements.set(
+    name,
+    xmlElement(
+      "style:style",
+      { "style:name": name, "style:family": "text" },
+      xmlSelfClose("style:text-properties", props),
+    ),
+  )
+  return name
+}
+
+/** Emit one `<number:*-style>` element and return the name it was given. */
+function emitDataStyle(
+  collector: StyleCollector,
+  def: OdsNumFmtDef,
+  extraChildren: string[] = [],
+  isVolatile = false,
+): string {
+  const name = `N${collector.dataStyleCounter++}`
+  const attrs: Record<string, string> = { "style:name": name }
+  // A style only reachable through another style's <style:map> is marked
+  // volatile so consumers keep it even though no cell references it.
+  if (isVolatile) attrs["style:volatile"] = "true"
+  if (def.attrs) Object.assign(attrs, def.attrs)
+
+  collector.dataStyleElements.set(
+    name,
+    xmlElement(`number:${def.kind}-style`, attrs, [...def.children, ...extraChildren]),
+  )
+  return name
 }
 
 function getOrCreateDataStyleName(collector: StyleCollector, numFmt: string): string | undefined {
   const existing = collector.dataStyleMap.get(numFmt)
   if (existing) return existing
 
-  const def = translateNumFmt(numFmt)
-  if (!def) return undefined
+  const sections = splitFormatSections(numFmt)
+  const positive = translateNumFmt(sections[0]!)
+  if (!positive) return undefined
 
-  const name = `N${collector.dataStyleCounter++}`
+  // Excel packs up to four sections into one code — positive;negative;zero;text
+  // — while ODF gives each its own data style and links them from one
+  // "main" style with <style:map>. Keeping only the first section threw the
+  // rest away. See #405.
+  //
+  // The negative section is the main style and the others hang off it, which
+  // is the shape LibreOffice writes: a style reached through a map renders
+  // the value as-is, so the negative section has to carry its own minus.
+  // The fourth (text) section has no ODF counterpart and is dropped.
+  const negative = sections.length > 1 ? translateNumFmt(sections[1]!) : undefined
+  const zero = sections.length > 2 ? translateNumFmt(sections[2]!) : undefined
+
+  let name: string
+  if (!negative) {
+    name = emitDataStyle(collector, positive)
+  } else {
+    const maps = [
+      xmlSelfClose("style:map", {
+        "style:condition": "value()>0",
+        "style:apply-style-name": emitDataStyle(collector, positive, [], true),
+      }),
+    ]
+    if (zero) {
+      maps.push(
+        xmlSelfClose("style:map", {
+          "style:condition": "value()=0",
+          "style:apply-style-name": emitDataStyle(collector, zero, [], true),
+        }),
+      )
+    }
+    name = emitDataStyle(collector, negative, maps)
+  }
+
   collector.dataStyleMap.set(numFmt, name)
-
-  const tag = `number:${def.kind}-style`
-  const attrs: Record<string, string> = { "style:name": name }
-  if (def.attrs) Object.assign(attrs, def.attrs)
-
-  collector.dataStyleElements.set(name, xmlElement(tag, attrs, def.children))
   return name
 }
 
@@ -482,16 +652,34 @@ function getOrCreateStyleName(collector: StyleCollector, style: CellStyle): stri
 // ── Formula Conversion ──────────────────────────────────────────────
 
 /**
+ * The sheet part of an OpenFormula reference. It lives *inside* the
+ * brackets and carries `$` to mark the sheet absolute, the way LibreOffice
+ * writes it: `[$Sheet2.A1]`. A local reference has no sheet part at all,
+ * just the dot: `[.A1]`.
+ */
+function odsSheetLocator(sheet: string | undefined): string {
+  return sheet ? `$${sheet}` : ""
+}
+
+/**
  * Convert an Excel-style formula to ODS formula syntax.
  * ODS formulas use `of:=` prefix and `[.A1]` cell references.
  */
 function excelFormulaToOds(formula: string): string {
   // Convert cell references like A1, $A$1, A1:B2 to ODS [.A1] notation,
-  // handling ranges (A1:B2 → [.A1:.B2]) while leaving function names
-  // (LOG10), string literals ("AB1"), and embedded identifiers untouched.
-  const converted = replaceA1Ranges(formula, (ref1, ref2) =>
-    ref2 ? `[.${ref1}:.${ref2}]` : `[.${ref1}]`,
-  )
+  // handling ranges (A1:B2 → [.A1:.B2]) and cross-sheet references
+  // (Sheet2!A1 → [$Sheet2.A1]) while leaving function names (LOG10),
+  // string literals ("AB1"), and embedded identifiers untouched.
+  //
+  // The whole reference must be bracketed, sheet included — `Sheet2.[.A1]`
+  // parses as nothing at all and LibreOffice refuses to evaluate the
+  // formula. See #405.
+  const converted = replaceA1Ranges(formula, ({ sheet1, ref1, sheet2, ref2 }) => {
+    const start = `${odsSheetLocator(sheet1)}.${ref1}`
+    // The second half of a range normally omits the sheet — it defaults to
+    // the first half's — and only a 3-D range spells one out.
+    return ref2 ? `[${start}:${odsSheetLocator(sheet2)}.${ref2}]` : `[${start}]`
+  })
   return `of:=${converted}`
 }
 
@@ -507,7 +695,54 @@ interface CellContext {
   rowSpan?: number
 }
 
-function cellToOds(value: CellValue, ctx?: CellContext): string {
+/** Serialize rich-text runs as `<text:span>`s, styled per run. */
+function richTextSpans(runs: RichTextRun[], collector: StyleCollector): string {
+  let out = ""
+  for (const run of runs) {
+    const text = xmlEscape(run.text)
+    const styleName = run.font ? getOrCreateTextStyleName(collector, run.font) : ""
+    out += styleName ? xmlElement("text:span", { "text:style-name": styleName }, text) : text
+  }
+  return out
+}
+
+/**
+ * The `<text:p>` holding a cell's visible content: the rich-text runs when
+ * the cell has any, otherwise `display`.
+ *
+ * In ODF the anchor of a hyperlink *is* the cell's text, so a link on a
+ * number, a date or a boolean is written exactly like one on a string —
+ * the typed value stays in `office:value` / `office:date-value` beside it.
+ * `Hyperlink.display` therefore replaces the text rather than sitting next
+ * to it as it does in OOXML; a string cell whose display text differs from
+ * its value reads back as the display text, because that is the only text
+ * the format stores.
+ */
+function cellTextP(
+  display: string,
+  ctx: CellContext | undefined,
+  collector: StyleCollector,
+): string {
+  const runs = ctx?.cellOverride?.richText
+  const hyperlink = ctx?.cellOverride?.hyperlink
+
+  let content = runs && runs.length > 0 ? richTextSpans(runs, collector) : xmlEscape(display)
+  if (hyperlink) {
+    const anchor = hyperlink.display !== undefined ? xmlEscape(hyperlink.display) : content
+    content = xmlElement(
+      "text:a",
+      { "xlink:href": hyperlink.target, "xlink:type": "simple" },
+      anchor,
+    )
+  }
+  return xmlElement("text:p", undefined, content)
+}
+
+function cellToOds(
+  value: CellValue,
+  ctx: CellContext | undefined,
+  collector: StyleCollector,
+): string {
   const attrs: Record<string, string> = {}
   const children: string[] = []
 
@@ -529,8 +764,26 @@ function cellToOds(value: CellValue, ctx?: CellContext): string {
 
   // Hyperlink
   const hyperlink = ctx?.cellOverride?.hyperlink
+  const richText = ctx?.cellOverride?.richText
+
+  // A rich-text cell keeps its content in the runs and carries no scalar
+  // value, so every branch below would have skipped it and written an empty
+  // cell — the text simply vanished from content.xml. The runs win over
+  // `value` the same way they do in the XLSX writer. See #405.
+  if (richText && richText.length > 0) {
+    attrs["office:value-type"] = "string"
+    children.push(cellTextP("", ctx, collector))
+    return xmlElement("table:table-cell", attrs, children)
+  }
 
   if (value === null || value === undefined) {
+    // A hyperlink with its own display text still has something to show in
+    // an otherwise empty cell; a bare target has no anchor text to use.
+    if (hyperlink?.display !== undefined) {
+      attrs["office:value-type"] = "string"
+      children.push(cellTextP("", ctx, collector))
+      return xmlElement("table:table-cell", attrs, children)
+    }
     if (Object.keys(attrs).length === 0) {
       return xmlSelfClose("table:table-cell")
     }
@@ -539,16 +792,7 @@ function cellToOds(value: CellValue, ctx?: CellContext): string {
 
   if (typeof value === "string") {
     attrs["office:value-type"] = "string"
-    if (hyperlink) {
-      const linkEl = xmlElement(
-        "text:a",
-        { "xlink:href": hyperlink.target, "xlink:type": "simple" },
-        xmlEscape(value),
-      )
-      children.push(xmlElement("text:p", undefined, linkEl))
-    } else {
-      children.push(xmlElement("text:p", undefined, xmlEscape(value)))
-    }
+    children.push(cellTextP(value, ctx, collector))
     return xmlElement("table:table-cell", attrs, children)
   }
 
@@ -561,14 +805,14 @@ function cellToOds(value: CellValue, ctx?: CellContext): string {
     }
     attrs["office:value-type"] = "float"
     attrs["office:value"] = String(value)
-    children.push(xmlElement("text:p", undefined, formatNumberDisplay(value)))
+    children.push(cellTextP(formatNumberDisplay(value), ctx, collector))
     return xmlElement("table:table-cell", attrs, children)
   }
 
   if (typeof value === "boolean") {
     attrs["office:value-type"] = "boolean"
     attrs["office:boolean-value"] = value ? "true" : "false"
-    children.push(xmlElement("text:p", undefined, value ? "TRUE" : "FALSE"))
+    children.push(cellTextP(value ? "TRUE" : "FALSE", ctx, collector))
     return xmlElement("table:table-cell", attrs, children)
   }
 
@@ -582,7 +826,7 @@ function cellToOds(value: CellValue, ctx?: CellContext): string {
     const dateStr = formatOdsDateValue(value)
     attrs["office:value-type"] = "date"
     attrs["office:date-value"] = dateStr
-    children.push(xmlElement("text:p", undefined, dateStr))
+    children.push(cellTextP(dateStr, ctx, collector))
     return xmlElement("table:table-cell", attrs, children)
   }
 
@@ -737,7 +981,7 @@ function rowToOds(
       }
     }
 
-    cellElements.push(cellToOds(cell, ctx))
+    cellElements.push(cellToOds(cell, ctx, styleCollector))
     i++
   }
 
@@ -856,6 +1100,7 @@ function writeContentXml(options: WriteOptions): string {
   const allStyleParts: string[] = [
     ...styleCollector.dataStyleElements.values(),
     ...styleCollector.styleElements.values(),
+    ...styleCollector.textStyleElements.values(),
   ]
   const styleXml =
     allStyleParts.length > 0

--- a/test/ods-date-timezone.test.ts
+++ b/test/ods-date-timezone.test.ts
@@ -1,0 +1,143 @@
+// Regression tests for #415 — ODS dates drifted by the reader's UTC offset
+// on every round trip, and the drift accumulated.
+//
+// These tests only mean anything away from Greenwich: with TZ=UTC the buggy
+// and the correct reading coincide, which is why CI never noticed. Each
+// test therefore pins a non-UTC zone; Asia/Tokyo (+09:00, no DST) makes the
+// shift large enough to change the calendar day within three round trips.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { streamOdsRows } from "../src/ods/stream"
+import { ZipWriter } from "../src/zip/writer"
+import type { CellValue, WriteSheet } from "../src/_types"
+
+const encoder = new TextEncoder()
+
+/** A minimal .ods whose first row holds the given date-typed cells. */
+async function odsWithDates(...dateValues: string[]): Promise<Uint8Array> {
+  const cells = dateValues
+    .map(
+      (v) =>
+        `<table:table-cell office:value-type="date" office:date-value="${v}">` +
+        `<text:p>${v}</text:p></table:table-cell>`,
+    )
+    .join("")
+  const content =
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<office:document-content ` +
+    `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+    `xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" ` +
+    `xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" office:version="1.3">` +
+    `<office:body><office:spreadsheet><table:table table:name="Sheet1">` +
+    `<table:table-row>${cells}</table:table-row>` +
+    `</table:table></office:spreadsheet></office:body></office:document-content>`
+
+  const zip = new ZipWriter()
+  zip.add("mimetype", encoder.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+    compress: false,
+  })
+  zip.add("content.xml", encoder.encode(content))
+  return await zip.build()
+}
+
+describe("ODS #415 — dates do not drift with the reader's time zone", () => {
+  beforeEach(() => {
+    // Node re-reads TZ on the next Date operation, so this takes effect for
+    // the whole test; vi.stubEnv restores the real zone afterwards.
+    vi.stubEnv("TZ", "Asia/Tokyo")
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("survives repeated write → read round trips unchanged", async () => {
+    // The zone has to be in effect while the test runs, not just when the
+    // module loaded — assert it, so the guard cannot quietly go decorative.
+    expect(new Date("2024-01-15T00:00:00Z").getTimezoneOffset()).toBe(-540)
+
+    const original = new Date("2024-01-15T00:00:00Z")
+    let value: CellValue = original
+
+    for (let pass = 0; pass < 4; pass++) {
+      const sheets: WriteSheet[] = [{ name: "Sheet1", rows: [[value]] }]
+      const wb = await readOds(await writeOds({ sheets }))
+      value = wb.sheets[0]!.rows[0]![0]!
+      expect(value).toBeInstanceOf(Date)
+      // Before the fix this lost nine hours per pass: 2024-01-13 by pass 3.
+      expect((value as Date).toISOString()).toBe(original.toISOString())
+    }
+  })
+
+  it("reads an unqualified office:date-value as UTC", async () => {
+    const wb = await readOds(await odsWithDates("2024-01-15T00:00:00"))
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-01-15T00:00:00.000Z")
+  })
+
+  it("honours an explicit offset rather than overriding it", async () => {
+    // LibreOffice may write one, and it means what it says — appending `Z`
+    // unconditionally would move the value by two hours.
+    const wb = await readOds(
+      await odsWithDates("2024-01-15T00:00:00+02:00", "2024-01-15T05:00:00Z"),
+    )
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-01-14T22:00:00.000Z")
+    expect((wb.sheets[0]!.rows[0]![1] as Date).toISOString()).toBe("2024-01-15T05:00:00.000Z")
+  })
+
+  it("reads a date-only value as UTC, as ECMAScript already did", async () => {
+    const wb = await readOds(await odsWithDates("2024-01-15"))
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-01-15T00:00:00.000Z")
+  })
+
+  it("gives the streaming reader the same instant as readOds", async () => {
+    const data = await odsWithDates("2024-01-15T00:00:00")
+    const rows = []
+    for await (const row of streamOdsRows(data)) rows.push(row)
+    expect((rows[0]!.values[0] as Date).toISOString()).toBe("2024-01-15T00:00:00.000Z")
+  })
+
+  it("round-trips the meta.xml document dates", async () => {
+    const created = new Date("2024-01-15T00:00:00Z")
+    const modified = new Date("2024-06-30T12:34:56Z")
+    const data = await writeOds({
+      sheets: [{ name: "Sheet1", rows: [[1]] }],
+      properties: { created, modified },
+    })
+    const wb = await readOds(data)
+    expect(wb.properties!.created!.toISOString()).toBe(created.toISOString())
+    expect(wb.properties!.modified!.toISOString()).toBe(modified.toISOString())
+  })
+
+  it("reads a zone-less meta:creation-date as UTC", async () => {
+    // What LibreOffice writes — no zone designator, sub-second precision.
+    const meta =
+      `<?xml version="1.0" encoding="UTF-8"?>` +
+      `<office:document-meta ` +
+      `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+      `xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" ` +
+      `xmlns:dc="http://purl.org/dc/elements/1.1/" office:version="1.3"><office:meta>` +
+      `<meta:creation-date>2024-01-15T00:00:00.123</meta:creation-date>` +
+      `</office:meta></office:document-meta>`
+
+    const zip = new ZipWriter()
+    zip.add("mimetype", encoder.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+      compress: false,
+    })
+    zip.add("meta.xml", encoder.encode(meta))
+    zip.add(
+      "content.xml",
+      encoder.encode(
+        `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<office:document-content ` +
+          `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" ` +
+          `xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" office:version="1.3">` +
+          `<office:body><office:spreadsheet><table:table table:name="Sheet1"/>` +
+          `</office:spreadsheet></office:body></office:document-content>`,
+      ),
+    )
+    const wb = await readOds(await zip.build())
+    expect(wb.properties!.created!.toISOString()).toBe("2024-01-15T00:00:00.123Z")
+  })
+})

--- a/test/ods-fidelity.test.ts
+++ b/test/ods-fidelity.test.ts
@@ -109,13 +109,13 @@ describe("the facets the README says are not carried", () => {
 
 describe("ODS → ODS is lossless, which is the point of the table", () => {
   it("returns everything it wrote", async () => {
-    // Dates are excluded here on purpose: they drift by the local UTC
-    // offset on every round trip, cumulatively, because the writer emits
-    // UTC components and the reader parses the unqualified string as
-    // local time. Tracked as #415 — asserting the drift here would pin
-    // the bug, and asserting the fix would fail until it lands.
+    // Dates are back in as of #415. They used to drift by the local UTC
+    // offset on every round trip, cumulatively — the writer emitted UTC
+    // components and the reader parsed the unqualified string as local
+    // time — which is silent on a UTC machine and so invisible to CI.
+    // Keep them here: this assertion is the one that would notice.
     const buf = await writeOds({
-      sheets: [{ name: "S", rows: [["a", 1, true, null]] }],
+      sheets: [{ name: "S", rows: [["a", 1, true, new Date(Date.UTC(2024, 0, 15))]] }],
     })
     const first = await readOds(buf)
     const second = await readOds(await writeOds({ sheets: first.sheets as never }))

--- a/test/ods-formula-richtext.test.ts
+++ b/test/ods-formula-richtext.test.ts
@@ -1,0 +1,299 @@
+// Regression tests for #405 — the ODS writer emitted cross-sheet formulas
+// ODF cannot parse, and dropped rich-text cells entirely.
+//
+// The formula assertions deliberately check the *emitted* attribute against
+// what OpenFormula specifies, and the decoding assertions run against
+// content.xml written by hand in LibreOffice's spelling. A round-trip test
+// built only on hucre's own output passed happily while the writer and the
+// reader shared the same wrong idea of the syntax.
+
+import { describe, it, expect } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import { parseXml } from "../src/xml/parser"
+import type { Cell, WriteSheet } from "../src/_types"
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder("utf-8")
+
+async function extractFile(data: Uint8Array, path: string): Promise<string> {
+  const zip = new ZipReader(data)
+  return decoder.decode(await zip.extract(path))
+}
+
+function findChild(el: { children: Array<unknown> }, localName: string): any {
+  return el.children.find((c: any) => typeof c !== "string" && (c.local || c.tag) === localName)
+}
+
+function findChildren(el: { children: Array<unknown> }, localName: string): any[] {
+  return el.children.filter((c: any) => typeof c !== "string" && (c.local || c.tag) === localName)
+}
+
+/** Write one sheet whose A1 carries `formula`, and return A1's attributes. */
+async function writeFormulaCell(formula: string): Promise<Record<string, string>> {
+  const cells = new Map<string, Partial<Cell>>([["0,0", { value: 0, formula }]])
+  const data = await writeOds({ sheets: [{ name: "Sheet1", rows: [[0]], cells }] })
+  const doc = parseXml(await extractFile(data, "content.xml"))
+  const table = findChild(findChild(findChild(doc, "body"), "spreadsheet"), "table")
+  const row = findChild(table, "table-row")
+  return findChild(row, "table-cell").attrs
+}
+
+/** The namespaces a real content.xml declares, for the hand-written fixtures. */
+const NS = [
+  `xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"`,
+  `xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"`,
+  `xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"`,
+  `xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"`,
+  `xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0"`,
+  `xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"`,
+  `xmlns:xlink="http://www.w3.org/1999/xlink"`,
+].join(" ")
+
+/** A minimal .ods holding one cell with the given `table:formula`. */
+async function odsWithFormula(formula: string): Promise<Uint8Array> {
+  const content =
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<office:document-content ${NS} office:version="1.3"><office:body><office:spreadsheet>` +
+    `<table:table table:name="Sheet1"><table:table-row>` +
+    `<table:table-cell table:formula="${formula.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;")}" ` +
+    `office:value-type="float" office:value="3"><text:p>3</text:p></table:table-cell>` +
+    `</table:table-row></table:table>` +
+    `</office:spreadsheet></office:body></office:document-content>`
+
+  const zip = new ZipWriter()
+  zip.add("mimetype", encoder.encode("application/vnd.oasis.opendocument.spreadsheet"), {
+    compress: false,
+  })
+  zip.add("content.xml", encoder.encode(content))
+  return await zip.build()
+}
+
+async function readFormula(odsFormula: string): Promise<string | undefined> {
+  const wb = await readOds(await odsWithFormula(odsFormula))
+  return wb.sheets[0]!.cells?.get("0,0")?.formula
+}
+
+// ── #405.1: cross-sheet formula references ──────────────────────────
+
+describe("ODS #405 — cross-sheet formulas are bracketed as a whole", () => {
+  it("brackets the sheet together with the cell", async () => {
+    const attrs = await writeFormulaCell("Sheet2!A1+1")
+    // OpenFormula: Reference ::= '[' Source? RangeAddress ']', and the
+    // sheet locator lives inside the brackets.
+    expect(attrs["table:formula"]).toBe("of:=[$Sheet2.A1]+1")
+    // The defect emitted "of:=Sheet2.[.A1]+1", which parses as nothing.
+    expect(attrs["table:formula"]).not.toContain("Sheet2.[.")
+  })
+
+  it("accepts the dot spelling of a sheet qualifier too", async () => {
+    // The form used in LibreOffice's own UI, and in the report of #405.
+    const attrs = await writeFormulaCell("Sheet2.A1+1")
+    expect(attrs["table:formula"]).toBe("of:=[$Sheet2.A1]+1")
+  })
+
+  it("omits the sheet on the second half of a cross-sheet range", async () => {
+    const attrs = await writeFormulaCell("SUM(Sheet2!A1:B2)")
+    expect(attrs["table:formula"]).toBe("of:=SUM([$Sheet2.A1:.B2])")
+  })
+
+  it("keeps absolute markers inside the brackets", async () => {
+    const attrs = await writeFormulaCell("Sheet2!$A$1")
+    expect(attrs["table:formula"]).toBe("of:=[$Sheet2.$A$1]")
+  })
+
+  it("quotes a sheet name with a space the way ODF does", async () => {
+    const attrs = await writeFormulaCell("'My Sheet'!A1*2")
+    expect(attrs["table:formula"]).toBe("of:=[$'My Sheet'.A1]*2")
+  })
+
+  it("leaves local references in the plain [.A1] form", async () => {
+    const attrs = await writeFormulaCell("SUM(A1:B2)+C3")
+    expect(attrs["table:formula"]).toBe("of:=SUM([.A1:.B2])+[.C3]")
+  })
+
+  it("still leaves function names and string literals alone", async () => {
+    const attrs = await writeFormulaCell('LOG10(A1)&"Sheet2.A1"')
+    expect(attrs["table:formula"]).toBe('of:=LOG10([.A1])&"Sheet2.A1"')
+  })
+})
+
+describe("ODS #405 — reading the cross-sheet forms LibreOffice writes", () => {
+  it("decodes an absolute sheet locator", async () => {
+    expect(await readFormula("of:=[$Sheet2.A1]+1")).toBe("Sheet2!A1+1")
+  })
+
+  it("decodes a relative sheet locator", async () => {
+    expect(await readFormula("of:=[Sheet2.A1]+1")).toBe("Sheet2!A1+1")
+  })
+
+  it("decodes a range whose second half inherits the sheet", async () => {
+    expect(await readFormula("of:=SUM([$Sheet2.A1:.B2])")).toBe("SUM(Sheet2!A1:B2)")
+  })
+
+  it("decodes a quoted sheet name", async () => {
+    expect(await readFormula("of:=[$'My Sheet'.A1]*2")).toBe("'My Sheet'!A1*2")
+  })
+
+  it("still decodes the local forms", async () => {
+    expect(await readFormula("of:=SUM([.A1:.A10])")).toBe("SUM(A1:A10)")
+    expect(await readFormula("of:=[.$B$4]")).toBe("$B$4")
+  })
+
+  it("leaves a bracketed token that is not an address verbatim", async () => {
+    // A broken reference, and an external one — mangling either would be
+    // worse than passing it through.
+    expect(await readFormula("of:=[#REF!]+1")).toBe("[#REF!]+1")
+    expect(await readFormula("of:=['budget.ods'#$Sheet1.A1]")).toBe("['budget.ods'#$Sheet1.A1]")
+  })
+
+  it("leaves a bracketed token inside a string literal alone", async () => {
+    expect(await readFormula('of:=IF([.A1]="[$Sheet2.A1]";1;2)')).toBe('IF(A1="[$Sheet2.A1]";1;2)')
+  })
+
+  it("round-trips a cross-sheet formula through write → read", async () => {
+    const cells = new Map<string, Partial<Cell>>([["0,0", { value: 6, formula: "Sheet2!A1+1" }]])
+    const sheets: WriteSheet[] = [
+      { name: "Sheet1", rows: [[6]], cells },
+      { name: "Sheet2", rows: [[5]] },
+    ]
+    const wb = await readOds(await writeOds({ sheets }))
+    expect(wb.sheets[0]!.cells!.get("0,0")!.formula).toBe("Sheet2!A1+1")
+  })
+})
+
+// ── #405.2: rich-text cells ─────────────────────────────────────────
+
+describe("ODS #405 — rich-text cells keep their text", () => {
+  const runs = [
+    { text: "Hello ", font: { bold: true } },
+    { text: "world", font: { italic: true, color: { rgb: "FF0000" } } },
+  ]
+
+  async function writeRichText(): Promise<Uint8Array> {
+    const cells = new Map<string, Partial<Cell>>([["0,0", { value: null, richText: runs }]])
+    return await writeOds({ sheets: [{ name: "Sheet1", rows: [[null]], cells }] })
+  }
+
+  it("writes the runs as text:span rather than an empty cell", async () => {
+    const xml = await extractFile(await writeRichText(), "content.xml")
+    // The defect wrote "<table:table-cell/>" and the text was nowhere in
+    // the document.
+    expect(xml).toContain("Hello ")
+    expect(xml).toContain("world")
+    expect(xml).toContain("<text:span")
+    expect(xml).toContain('office:value-type="string"')
+  })
+
+  it("gives each run a text-family automatic style", async () => {
+    const doc = parseXml(await extractFile(await writeRichText(), "content.xml"))
+    const autoStyles = findChild(doc, "automatic-styles")
+    const textStyles = findChildren(autoStyles, "style").filter(
+      (s: any) => s.attrs["style:family"] === "text",
+    )
+    expect(textStyles).toHaveLength(2)
+    const props = textStyles.map((s: any) => findChild(s, "text-properties").attrs)
+    expect(props[0]["fo:font-weight"]).toBe("bold")
+    expect(props[1]["fo:font-style"]).toBe("italic")
+    expect(props[1]["fo:color"]).toBe("#FF0000")
+  })
+
+  it("reads back as the concatenated run text", async () => {
+    // The ODS reader flattens spans (collectText), so the runs come back as
+    // one string rather than as `richText` — the point is that the text
+    // survives at all. It used to read back as undefined.
+    const wb = await readOds(await writeRichText())
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("Hello world")
+  })
+})
+
+// ── #405.3: hyperlinks on typed cells, display text, format sections ─
+
+describe("ODS #405 — hyperlinks on non-string cells", () => {
+  it("keeps the link and the typed value on numbers, dates and booleans", async () => {
+    const date = new Date(Date.UTC(2020, 0, 2))
+    const cells = new Map<string, Partial<Cell>>([
+      ["0,0", { value: 42, hyperlink: { target: "https://example.com/num" } }],
+      ["0,1", { value: date, hyperlink: { target: "https://example.com/date" } }],
+      ["0,2", { value: true, hyperlink: { target: "https://example.com/bool" } }],
+    ])
+    const data = await writeOds({
+      sheets: [{ name: "Sheet1", rows: [[null, null, null]], cells }],
+    })
+
+    const wb = await readOds(data)
+    const sheet = wb.sheets[0]!
+    expect(sheet.cells!.get("0,0")!.hyperlink!.target).toBe("https://example.com/num")
+    expect(sheet.cells!.get("0,1")!.hyperlink!.target).toBe("https://example.com/date")
+    expect(sheet.cells!.get("0,2")!.hyperlink!.target).toBe("https://example.com/bool")
+
+    // The value must survive as its own type, not degrade to text.
+    expect(sheet.rows[0]![0]).toBe(42)
+    // (ODS date values carry no time zone, so compare the calendar date the
+    // reader parsed rather than the instant.)
+    const readDate = sheet.rows[0]![1] as Date
+    expect(readDate).toBeInstanceOf(Date)
+    expect([readDate.getFullYear(), readDate.getMonth(), readDate.getDate()]).toEqual([2020, 0, 2])
+    expect(sheet.rows[0]![2]).toBe(true)
+  })
+
+  it("writes Hyperlink.display as the anchor text", async () => {
+    const cells = new Map<string, Partial<Cell>>([
+      ["0,0", { value: 42, hyperlink: { target: "https://example.com", display: "Click me" } }],
+    ])
+    const data = await writeOds({ sheets: [{ name: "Sheet1", rows: [[null]], cells }] })
+
+    expect(await extractFile(data, "content.xml")).toContain(">Click me</text:a>")
+    const wb = await readOds(data)
+    expect(wb.sheets[0]!.cells!.get("0,0")!.hyperlink!.display).toBe("Click me")
+    expect(wb.sheets[0]!.rows[0]![0]).toBe(42)
+  })
+})
+
+describe("ODS #405 — multi-section number formats", () => {
+  async function styleXml(numFmt: string): Promise<any[]> {
+    const cells = new Map<string, Partial<Cell>>([["0,0", { value: -1234.5, style: { numFmt } }]])
+    const data = await writeOds({ sheets: [{ name: "Sheet1", rows: [[-1234.5]], cells }] })
+    const doc = parseXml(await extractFile(data, "content.xml"))
+    return findChildren(findChild(doc, "automatic-styles"), "number-style")
+  }
+
+  it("gives the negative and zero sections their own mapped data styles", async () => {
+    const styles = await styleXml("#,##0.00;-#,##0.00;0.00")
+    expect(styles).toHaveLength(3)
+
+    // The style a cell points at is the one without style:volatile — the
+    // negative section — and it names the others through <style:map>.
+    const main = styles.find((s: any) => s.attrs["style:volatile"] !== "true")!
+    const maps = findChildren(main, "map")
+    expect(maps.map((m: any) => m.attrs["style:condition"])).toEqual(["value()>0", "value()=0"])
+    for (const m of maps) {
+      const target = styles.find(
+        (s: any) => s.attrs["style:name"] === m.attrs["style:apply-style-name"],
+      )
+      expect(target.attrs["style:volatile"]).toBe("true")
+    }
+
+    // The negative section carries its own minus: a style reached through a
+    // map formats the value as it stands.
+    expect(findChild(main, "text").children.join("")).toBe("-")
+  })
+
+  it("round-trips all three sections", async () => {
+    const numFmt = "#,##0.00;-#,##0.00;0.00"
+    const cells = new Map<string, Partial<Cell>>([["0,0", { value: 1, style: { numFmt } }]])
+    const data = await writeOds({ sheets: [{ name: "Sheet1", rows: [[1]], cells }] })
+    const wb = await readOds(data, { readStyles: true })
+    expect(wb.sheets[0]!.cells!.get("0,0")!.style!.numFmt).toBe(numFmt)
+  })
+
+  it("leaves a single-section format as one unmapped style", async () => {
+    const styles = await styleXml("#,##0.00")
+    expect(styles).toHaveLength(1)
+    expect(findChildren(styles[0], "map")).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Closes #405. Closes #415.

Reproduced against unfixed source first, real output:

```
1. emitted: of:=Sheet2.[.A1]+1
1. emitted: of:=SUM(Sheet2.[.A1]:Sheet2.[.B2])
1. read back: [["0,0","Sheet2.A1+1"]]              <- the round trip "passes"
2. 'Hello' present in content.xml: false
2. row xml: <table:table-row><table:table-cell/></table:table-row>
2. read back: undefined
3a. read back links: [["0,3",{…}]]                 <- only the string cell kept its hyperlink

#415, TZ=Asia/Tokyo:
pass 0: emitted office:date-value="2024-01-15T00:00:00" -> read 2024-01-14T15:00:00.000Z
pass 3: emitted office:date-value="2024-01-13T21:00:00" -> read 2024-01-13T12:00:00.000Z
```

Note the third line of the first block. **The cross-sheet round trip passed against the bug**, because both halves were wrong in the same direction. That test is kept in the suite, labelled, as a demonstration of why the real guards assert emitted XML and decode LibreOffice-shaped fixtures instead.

## Cross-sheet formulas

The root cause was upstream of the ODS writer: `replaceA1Ranges` (`src/cell-utils.ts`) handed its consumer only the `A1` part, so the ODS writer could not bracket a sheet qualifier it never saw — hence `of:=Sheet2.[.A1]+1` instead of `[$Sheet2.A1]`. It now matches the qualifier as part of the reference (Excel `Sheet2!A1` and `'My Sheet'!A1`, and the ODF `Sheet2.A1` spelling) and passes `{sheet1, ref1, sheet2, ref2}`. The lookbehind also rejects `.` and `!` now, so an unparsed qualifier can never end up outside the match.

The reader's inverse is fixed to match: bracket bodies parse as address-with-optional-sheet, `[#REF!]` and external references pass through verbatim, and string literals are skipped the way the writer does.

## Rich text

A `richText` cell was written as `<table:table-cell/>` — the runs simply gone. The issue asked for flattening to plain text as the minimum; text-span support turned out to be cheap, so runs keep their formatting as `<text:span>` with `text`-family automatic styles. Reading them back still flattens.

## Dates (#415)

The writer emitted UTC components and the reader parsed the unqualified string as **local** time, so every round trip shifted by the local offset, cumulatively. New `parseOdsDateTime` reads an unqualified time as UTC and honours an explicit offset when one is present, so a LibreOffice file carrying `+02:00` is still read correctly. Applied to `office:date-value`, `meta:creation-date` and `dc:date`, and to `src/ods/stream.ts` so a streamed row cannot disagree with `readOds`.

The tests stub `Asia/Tokyo` per test and assert the offset is actually in effect — **4 of the 7 fail with `TZ=UTC` against the unfixed code**, which is the point: this bug is invisible on a UTC machine, which is why CI never saw it. The suite passes under `TZ=UTC`, `TZ=Asia/Tokyo` and `TZ=America/Los_Angeles`.

## Also fixed

Hyperlinks on number, date and boolean cells (previously string-only); `Hyperlink.display` as the anchor text; multi-section number formats emitted as one style per section linked by `<style:map>` in LibreOffice's shape, and reassembled back into `pos;neg;zero` on read.

## Where the issue was wrong

- The example input `Sheet2.A1+1` is not hucre's canonical form — the model is Excel-style (`Sheet2!A1`), which was broken too (`of:=Sheet2![.A1]+1`). Both are accepted now; the reader returns the Excel form, so `Sheet2.A1` normalises to `Sheet2!A1`.
- #415 suggested checking the `time` branch: no drift there, since ISO 8601 durations carry no zone. Its real defect (time cells returning `"PT12H30M"`) is #405's last bullet and is left for a duration-type decision.
- #415 flagged `meta.xml` as possibly asymmetric: it was already fine, but it goes through the same parser now anyway, because LibreOffice writes `meta:creation-date` *without* a zone. There is a test for that.

## Left out

ODS `time` cells; Excel's fourth (text) format section and colour tags, which have no ODF data-style counterpart; reading `<text:span>`s back into `cell.richText`. Each is noted in a code comment.

## Verification

**16 of 22** new #405 tests and **4 of 7** #415 tests fail against the unfixed source. No existing test changed, none weakened.

`pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,543 tests, rebased on current main. The ODS fidelity suite added in #416 has its date assertion restored, now that the drift it was avoiding is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
