### PR TITLE
fix(xlsx): make hucre's own output readable by hucre, and register the surface so it stays that way

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -215,7 +215,11 @@ export interface Cell {
   formulaSharedIndex?: number
   /** Range this formula applies to (ref attribute on master cell) */
   formulaRef?: string
-  /** Dynamic array flag (cm="1") */
+  /**
+   * Dynamic array flag (`cm="1"`). Independent of {@link formulaType} —
+   * a spilling function set as a plain formula carries it just as an
+   * explicit `"array"` formula does.
+   */
   formulaDynamic?: boolean
   richText?: RichTextRun[]
   hyperlink?: Hyperlink
@@ -233,9 +237,13 @@ export interface ColumnDef {
   width?: number
   /** Auto-calculate optimal width from cell content */
   autoWidth?: boolean
-  /** Default style for the column */
+  /**
+   * Default style for every cell in the column. Applies whether the rows
+   * come from {@link WriteSheet.data} or {@link WriteSheet.rows} — on the
+   * `data[]` path the generated header row gets it too.
+   */
   style?: CellStyle
-  /** Number format */
+  /** Number format. Folded into {@link style}; an explicit `style.numFmt` wins. */
   numFmt?: string
   /** Hide column */
   hidden?: boolean
@@ -419,8 +427,17 @@ export interface PageSetup {
   fitToHeight?: number
   scale?: number
   margins?: PageMargins
+  /**
+   * Print area as a bare A1 range (e.g. `"$A$1:$D$50"`), without a sheet
+   * qualifier. Stored in the file as the reserved `_xlnm.Print_Area`
+   * defined name; the reader folds that name back into this field rather
+   * than surfacing it in {@link Workbook.namedRanges}, so the setting has
+   * one representation in both directions.
+   */
   printArea?: string
+  /** Rows repeated at the top of every page (e.g. `"$1:$1"`). Stored in `_xlnm.Print_Titles`. */
   printTitlesRow?: string
+  /** Columns repeated at the left of every page (e.g. `"$A:$A"`). Stored in `_xlnm.Print_Titles`. */
   printTitlesColumn?: string
   showGridLines?: boolean
   showRowColHeaders?: boolean
@@ -547,6 +564,11 @@ export interface SheetImage {
     from: { row: number; col: number }
     to?: { row: number; col: number }
   }
+  /**
+   * Rendered size in pixels at 96 DPI, stored as EMU in the drawing's
+   * `<a:ext>`. Absent on write means the writer's own default size, which
+   * is then what the reader reports — a file records a size either way.
+   */
   width?: number
   height?: number
   /** Alternative text for screen readers (lands in xdr:cNvPr/@descr). */
@@ -700,7 +722,11 @@ export interface TableDefinition {
   showRowStripes?: boolean
   /** Show banded columns. Default: false */
   showColumnStripes?: boolean
-  /** Show auto-filter. Default: true */
+  /**
+   * Show auto-filter. Default when writing: true. On read this reports
+   * whether the table part actually carries an `<autoFilter>` — a table
+   * without one has no filter dropdowns, so it reads back `false`.
+   */
   showAutoFilter?: boolean
   /** Show total row. Default: false */
   showTotalRow?: boolean
@@ -1217,9 +1243,18 @@ export interface Workbook {
   namedRanges?: NamedRange[]
   /** Date system: 1900 (default/Windows) or 1904 (Mac) */
   dateSystem?: "1900" | "1904"
-  /** Default font for the workbook */
+  /**
+   * Default font for the workbook — `fonts[0]` in `xl/styles.xml`, the
+   * entry every cell format inherits from unless it names another.
+   */
   defaultFont?: FontStyle
-  /** Active sheet index */
+  /**
+   * Active sheet index — the tab the file opens on.
+   *
+   * Undefined when the file opens on the first tab: `activeTab="0"` is the
+   * OOXML default and is indistinguishable from a file that says nothing,
+   * so both collapse to `undefined` and round-trip identically.
+   */
   activeSheet?: number
   /** Theme color palette (resolved from xl/theme/theme1.xml) */
   themeColors?: string[]

--- a/src/xlsx/chart-clone.ts
+++ b/src/xlsx/chart-clone.ts
@@ -2827,8 +2827,15 @@ export function cloneChart(source: Chart, options: CloneChartOptions): SheetChar
   }
 
   if (options.showTitle !== undefined) out.showTitle = options.showTitle
-  if (options.altText !== undefined) out.altText = options.altText
-  if (options.frameTitle !== undefined) out.frameTitle = options.frameTitle
+
+  // Accessibility metadata lives on the source's host drawing frame, not
+  // in its chart part; the reader surfaces it on `Chart` so a clone can
+  // carry it forward. Override wins, absence inherits — same rule as the
+  // rest of the clone surface.
+  const altText = options.altText !== undefined ? options.altText : source.altText
+  if (altText !== undefined) out.altText = altText
+  const frameTitle = options.frameTitle !== undefined ? options.frameTitle : source.frameTitle
+  if (frameTitle !== undefined) out.frameTitle = frameTitle
 
   // `titleOverlay` only renders inside `<c:title>`, so a clone that
   // omits the title (resolved title is undefined or `showTitle === false`)

--- a/src/xlsx/chart/types.ts
+++ b/src/xlsx/chart/types.ts
@@ -7437,6 +7437,18 @@ export interface Chart {
    */
   anchor?: ChartAnchor
   /**
+   * Alternative text for screen readers, pulled from the host drawing's
+   * `<xdr:graphicFrame><xdr:cNvPr @descr>`. Lives on the drawing rather
+   * than in `chartN.xml`, which is why it arrives alongside
+   * {@link anchor} rather than from the chart part itself.
+   */
+  altText?: string
+  /**
+   * Caption on the chart frame, from `<xdr:cNvPr @title>`. Distinct from
+   * {@link title}, which is the `<c:title>` rendered above the plot area.
+   */
+  frameTitle?: string
+  /**
    * Legend placement pulled from `<c:legend><c:legendPos val=".."/>`.
    * Reported as `false` when the chart explicitly omits the legend
    * element (Excel's "no legend" state). `undefined` means the chart

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -2,6 +2,7 @@
 // Reads Office Open XML (.xlsx) spreadsheet files.
 
 import type {
+  Sheet,
   Workbook,
   ReadOptions,
   ReadInput,
@@ -179,6 +180,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     dateSystem,
     namedRanges,
     workbookProtection,
+    activeSheet,
     pivotCacheRefs,
   } = parseWorkbookXml(workbookXml, options)
 
@@ -417,6 +419,8 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
             const chart = parseChart(chartXml)
             if (!chart) continue
             if (chartRef.anchor) chart.anchor = chartRef.anchor
+            if (chartRef.altText) chart.altText = chartRef.altText
+            if (chartRef.frameTitle) chart.frameTitle = chartRef.frameTitle
             charts.push(chart)
           }
           if (charts.length > 0) sheet.charts = charts
@@ -615,8 +619,9 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     dateSystem,
   }
 
-  if (namedRanges.length > 0) {
-    workbook.namedRanges = namedRanges
+  const remainingNames = applyPrintDefinedNames(sheets, namedRanges)
+  if (remainingNames.length > 0) {
+    workbook.namedRanges = remainingNames
   }
 
   if (properties) {
@@ -629,6 +634,18 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
 
   if (workbookProtection) {
     workbook.workbookProtection = workbookProtection
+  }
+
+  if (activeSheet !== undefined) {
+    workbook.activeSheet = activeSheet
+  }
+
+  // The workbook's default font is fonts[0] in styles.xml — the entry
+  // every xf inherits from unless it names another. Surfacing it closes
+  // the WriteOptions.defaultFont round trip.
+  const baseFont = parsedStyles?.fonts[0]
+  if (baseFont && Object.keys(baseFont).length > 0) {
+    workbook.defaultFont = baseFont
   }
 
   if (persons && persons.length > 0) {
@@ -719,6 +736,10 @@ interface DrawingChartRef {
   path: string
   /** Cell anchor surfaced through {@link Chart.anchor}. */
   anchor?: ChartAnchor
+  /** `<xdr:cNvPr @descr>` surfaced through {@link Chart.altText}. */
+  altText?: string
+  /** `<xdr:cNvPr @title>` surfaced through {@link Chart.frameTitle}. */
+  frameTitle?: string
 }
 
 interface DrawingExtraction {
@@ -793,6 +814,14 @@ async function extractSheetDrawing(
           const anchor = local === "absoluteAnchor" ? undefined : parseChartCellAnchor(child, local)
           const ref: DrawingChartRef = { path: chartPath }
           if (anchor) ref.anchor = anchor
+          // Accessibility metadata sits on the frame in the drawing, not
+          // in the chart part — collect it while we still have the anchor.
+          const frame = findChildEl(child, "graphicFrame")
+          if (frame) {
+            const meta = findCNvPrMeta(frame, "nvGraphicFramePr")
+            if (meta.altText) ref.altText = meta.altText
+            if (meta.title) ref.frameTitle = meta.title
+          }
           chartRefs.push(ref)
         }
       }
@@ -817,6 +846,8 @@ async function extractSheetDrawing(
             type: imageInfo.type,
             anchor: imageInfo.anchor,
           }
+          if (imageInfo.width !== undefined) img.width = imageInfo.width
+          if (imageInfo.height !== undefined) img.height = imageInfo.height
           if (imageInfo.altText !== undefined) img.altText = imageInfo.altText
           if (imageInfo.title !== undefined) img.title = imageInfo.title
           images.push(img)
@@ -912,6 +943,8 @@ function parseTwoCellAnchor(
   mediaPath: string
   type: SheetImage["type"]
   anchor: SheetImage["anchor"]
+  width?: number
+  height?: number
   altText?: string
   title?: string
 } | null {
@@ -922,6 +955,7 @@ function parseTwoCellAnchor(
   let embedId: string | undefined
   let altText: string | undefined
   let title: string | undefined
+  let size: { width: number; height: number } | undefined
 
   for (const child of el.children) {
     if (typeof child === "string") continue
@@ -946,6 +980,7 @@ function parseTwoCellAnchor(
       const meta = findCNvPrMeta(c, "nvPicPr")
       altText = meta.altText
       title = meta.title
+      size = findShapeExtent(c)
     }
   }
 
@@ -962,6 +997,8 @@ function parseTwoCellAnchor(
     mediaPath: string
     type: SheetImage["type"]
     anchor: SheetImage["anchor"]
+    width?: number
+    height?: number
     altText?: string
     title?: string
   } = {
@@ -972,9 +1009,40 @@ function parseTwoCellAnchor(
       to: { row: toRow, col: toCol },
     },
   }
+  if (size) {
+    result.width = size.width
+    result.height = size.height
+  }
   if (altText) result.altText = altText
   if (title) result.title = title
   return result
+}
+
+/**
+ * Pull the rendered size off a `<xdr:pic>` / `<xdr:sp>` shape's
+ * `<xdr:spPr><a:xfrm><a:ext cx cy>`, converted from EMU to pixels.
+ *
+ * On a `twoCellAnchor` the from/to cells are what Excel actually honours,
+ * but `a:ext` is still required by the schema and every writer — hucre's
+ * included — records the intended size there. Reading it is the only way
+ * to recover {@link SheetImage.width} from a hucre-written file, which
+ * always uses `twoCellAnchor` (#407).
+ */
+function findShapeExtent(shapeEl: {
+  children: Array<unknown>
+}): { width: number; height: number } | undefined {
+  const spPr = findChildEl(shapeEl, "spPr")
+  if (!spPr) return undefined
+  const xfrm = findChildEl(spPr, "xfrm")
+  if (!xfrm) return undefined
+  const ext = findChildEl(xfrm, "ext")
+  if (!ext) return undefined
+  const cx = Number(ext.attrs["cx"])
+  const cy = Number(ext.attrs["cy"])
+  // A zero / absent extent is a placeholder, not a 0×0 shape — the chart
+  // writer emits exactly that. Report nothing rather than a size of 0.
+  if (!(cx > 0) || !(cy > 0)) return undefined
+  return { width: Math.round(cx / EMU_PER_PIXEL), height: Math.round(cy / EMU_PER_PIXEL) }
 }
 
 /** Parse a twoCellAnchor element that contains a textbox shape (sp with txBox="1") */
@@ -1074,6 +1142,12 @@ function parseTwoCellAnchorTextBox(el: { children: Array<unknown> }): SheetTextB
       from: { row: fromRow, col: fromCol },
       to: { row: toRow, col: toCol },
     },
+  }
+
+  const size = findShapeExtent(spElement)
+  if (size) {
+    tb.width = size.width
+    tb.height = size.height
   }
 
   // Pull alt text / title off cNvPr so screen-reader metadata round-trips.
@@ -1265,14 +1339,15 @@ function parseOneCellAnchor(
 }
 
 /**
- * Walk a `<xdr:pic>` or `<xdr:sp>` element and extract `descr=`/`title=`
- * from its `xdr:cNvPr`. The cNvPr element lives inside an `nv*Pr`
- * wrapper named `nvPicPr` (pictures) or `nvSpPr` (shapes). Returns
- * empty fields when neither attribute is present.
+ * Walk a `<xdr:pic>`, `<xdr:sp>` or `<xdr:graphicFrame>` element and
+ * extract `descr=`/`title=` from its `xdr:cNvPr`. The cNvPr element lives
+ * inside an `nv*Pr` wrapper named `nvPicPr` (pictures), `nvSpPr` (shapes)
+ * or `nvGraphicFramePr` (charts). Returns empty fields when neither
+ * attribute is present.
  */
 function findCNvPrMeta(
   parentEl: { children: Array<unknown> },
-  wrapperName: "nvPicPr" | "nvSpPr",
+  wrapperName: "nvPicPr" | "nvSpPr" | "nvGraphicFramePr",
 ): { altText?: string; title?: string } {
   const wrapper = findChildEl(parentEl, wrapperName)
   if (!wrapper) return {}
@@ -1342,6 +1417,75 @@ function findEmbedAttr(attrs: Record<string, string>): string | undefined {
   return undefined
 }
 
+// ── Print Defined Names ──────────────────────────────────────────────
+
+/**
+ * Fold the reserved `_xlnm.Print_Area` / `_xlnm.Print_Titles` defined
+ * names back into the owning sheet's {@link PageSetup} and return the
+ * defined names that remain.
+ *
+ * The writer only ever *derives* these two names from `pageSetup`
+ * (`buildNamedRanges`), so `pageSetup` is the single authoring surface.
+ * Leaving them in `namedRanges` as well would give the same setting two
+ * unconnected representations depending on the direction of travel
+ * (#407) — and would make `openXlsx` → `saveXlsx` emit each name twice,
+ * once from the carried-over `namedRanges` entry and once re-derived
+ * from `pageSetup`. So they are consumed, not copied.
+ *
+ * A name we cannot attribute to a sheet we actually read — no
+ * `localSheetId`, or a sheet skipped by `ReadOptions.sheets` — is left
+ * alone; dropping it would lose information with nowhere else to go.
+ */
+function applyPrintDefinedNames(sheets: Sheet[], namedRanges: NamedRange[]): NamedRange[] {
+  if (namedRanges.length === 0) return namedRanges
+
+  const byName = new Map<string, Sheet>()
+  for (const sheet of sheets) byName.set(sheet.name, sheet)
+
+  const remaining: NamedRange[] = []
+  for (const nr of namedRanges) {
+    const isPrintArea = nr.name === "_xlnm.Print_Area"
+    const isPrintTitles = nr.name === "_xlnm.Print_Titles"
+    const sheet = nr.scope !== undefined ? byName.get(nr.scope) : undefined
+    if ((!isPrintArea && !isPrintTitles) || !sheet) {
+      remaining.push(nr)
+      continue
+    }
+
+    const pageSetup = sheet.pageSetup ?? (sheet.pageSetup = {})
+    if (isPrintArea) {
+      const area = nr.range
+        .split(",")
+        .map(stripSheetQualifier)
+        .filter((part) => part.length > 0)
+        .join(",")
+      if (area) pageSetup.printArea = area
+    } else {
+      // Print_Titles packs the repeat-rows and repeat-columns ranges into
+      // one comma-separated value, in either order. A row range is all
+      // digits ("$1:$1"), a column range all letters ("$A:$A").
+      for (const raw of nr.range.split(",")) {
+        const part = stripSheetQualifier(raw)
+        if (!part) continue
+        if (/\d/.test(part)) pageSetup.printTitlesRow = part
+        else pageSetup.printTitlesColumn = part
+      }
+    }
+  }
+
+  return remaining
+}
+
+/**
+ * Drop the `Sheet1!` / `'My Sheet'!` prefix from one range of a defined
+ * name, leaving the bare A1 reference that {@link PageSetup} stores.
+ */
+function stripSheetQualifier(range: string): string {
+  const trimmed = range.trim()
+  const bang = trimmed.lastIndexOf("!")
+  return bang === -1 ? trimmed : trimmed.slice(bang + 1)
+}
+
 // ── Workbook XML Parsing ─────────────────────────────────────────────
 
 interface SheetInfo {
@@ -1359,6 +1503,13 @@ function parseWorkbookXml(
   dateSystem: "1900" | "1904"
   namedRanges: NamedRange[]
   workbookProtection?: { lockStructure?: boolean; lockWindows?: boolean }
+  /**
+   * `<bookViews><workbookView activeTab>` — the tab Excel opens on.
+   * Omitted when the file declares tab 0, which is the OOXML default and
+   * therefore indistinguishable from "the file said nothing"; the same
+   * collapse the chart reader applies to `<c:overlay val="0"/>`.
+   */
+  activeSheet?: number
   /**
    * Pivot cache wiring read off the workbook's `<pivotCaches>` block.
    * Each entry maps a cacheId (Excel's stable handle) to an rId in
@@ -1381,6 +1532,7 @@ function parseWorkbookXml(
   }
 
   let wbProtection: { lockStructure?: boolean; lockWindows?: boolean } | undefined
+  let activeSheet: number | undefined
 
   // First pass: collect sheets (needed for resolving localSheetId)
   for (const child of doc.children) {
@@ -1406,6 +1558,18 @@ function parseWorkbookXml(
         wbProtection = {}
         if (lockStructure) wbProtection.lockStructure = true
         if (lockWindows) wbProtection.lockWindows = true
+      }
+    }
+
+    if (local === "bookViews") {
+      for (const viewChild of child.children) {
+        if (typeof viewChild === "string") continue
+        const viewLocal = viewChild.local || viewChild.tag
+        if (viewLocal !== "workbookView") continue
+        const tab = Number(viewChild.attrs["activeTab"])
+        // Excel writes one workbookView per window; the first is the one
+        // that decides the opening tab.
+        if (Number.isInteger(tab) && tab > 0 && activeSheet === undefined) activeSheet = tab
       }
     }
 
@@ -1493,6 +1657,7 @@ function parseWorkbookXml(
     dateSystem,
     namedRanges,
     workbookProtection: wbProtection,
+    activeSheet,
     pivotCacheRefs,
   }
 }
@@ -1570,7 +1735,10 @@ function parseTableXml(xml: string): TableDefinition | null {
   let style: string | undefined
   let showRowStripes: boolean | undefined
   let showColumnStripes: boolean | undefined
-  let showAutoFilter = true
+  // The filter dropdowns exist only if <autoFilter> does — a table part
+  // with no such child renders none. Starting from `true` made a table
+  // written with `showAutoFilter: false` read back as `true` (#407).
+  let showAutoFilter = false
 
   for (const child of doc.children) {
     if (typeof child === "string") continue
@@ -1635,9 +1803,7 @@ function parseTableXml(xml: string): TableDefinition | null {
   if (showColumnStripes !== undefined) {
     tableDef.showColumnStripes = showColumnStripes
   }
-  if (showAutoFilter !== undefined) {
-    tableDef.showAutoFilter = showAutoFilter
-  }
+  tableDef.showAutoFilter = showAutoFilter
   if (showTotalRow) {
     tableDef.showTotalRow = true
   }

--- a/src/xlsx/styles.ts
+++ b/src/xlsx/styles.ts
@@ -25,6 +25,13 @@ export interface ParsedStyles {
   fills: FillStyle[]
   borders: BorderStyle[]
   cellXfs: CellXf[]
+  /**
+   * Differential formats from `<dxfs>`, indexed by the `dxfId` that
+   * conditional-formatting rules (and table styles) reference. Unlike
+   * cellXfs these carry their font/fill/border inline rather than by id,
+   * so each entry is already a complete {@link CellStyle}.
+   */
+  dxfs: CellStyle[]
 }
 
 export interface CellXf {
@@ -107,6 +114,7 @@ export function parseStyles(xml: string): ParsedStyles {
   const fills: FillStyle[] = []
   const borders: BorderStyle[] = []
   const cellXfs: CellXf[] = []
+  const dxfs: CellStyle[] = []
 
   for (const child of doc.children) {
     if (typeof child === "string") continue
@@ -128,10 +136,13 @@ export function parseStyles(xml: string): ParsedStyles {
       case "cellXfs":
         parseCellXfs(child, cellXfs)
         break
+      case "dxfs":
+        parseDxfs(child, dxfs)
+        break
     }
   }
 
-  return { numFmts, fonts, fills, borders, cellXfs }
+  return { numFmts, fonts, fills, borders, cellXfs, dxfs }
 }
 
 // ── Number Formats ───────────────────────────────────────────────────
@@ -424,6 +435,65 @@ function parseCellXf(el: XmlElement): CellXf {
   }
 
   return xf
+}
+
+// ── Differential Formats (dxf) ───────────────────────────────────────
+
+function parseDxfs(el: XmlElement, dxfs: CellStyle[]): void {
+  for (const child of el.children) {
+    if (typeof child === "string") continue
+    const local = child.local || child.tag
+    if (local === "dxf") {
+      dxfs.push(parseDxf(child))
+    }
+  }
+}
+
+/**
+ * A `<dxf>` is a *sparse* format: every child is optional and whatever it
+ * omits is inherited from the cell it applies to. So each absent child
+ * must stay absent on the resulting {@link CellStyle} — filling in a
+ * default here would turn "leave the cell's own font alone" into "force
+ * Calibri 11", which is what Excel would then render.
+ */
+function parseDxf(el: XmlElement): CellStyle {
+  const style: CellStyle = {}
+
+  for (const child of el.children) {
+    if (typeof child === "string") continue
+    const local = child.local || child.tag
+
+    switch (local) {
+      case "font":
+        style.font = parseFont(child)
+        break
+      case "numFmt": {
+        // dxf number formats carry their format string inline; the id is
+        // local to the dxfs block and means nothing outside it. Fall back
+        // to the builtin table only when a writer emitted the id alone.
+        const formatCode = child.attrs["formatCode"]
+        if (formatCode) {
+          style.numFmt = formatCode
+        } else {
+          const id = Number(child.attrs["numFmtId"])
+          const builtin = Number.isNaN(id) ? undefined : BUILTIN_NUM_FMTS[id]
+          if (builtin) style.numFmt = builtin
+        }
+        break
+      }
+      case "fill":
+        style.fill = parseFill(child)
+        break
+      case "border":
+        style.border = parseBorder(child)
+        break
+      case "alignment":
+        style.alignment = parseAlignment(child)
+        break
+    }
+  }
+
+  return style
 }
 
 const FPB_XF_EXT_URI = "{C7286773-470A-42A8-94C5-96B5CB345126}"

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -5,6 +5,7 @@ import type {
   WriteSheet,
   CellValue,
   CellStyle,
+  ColumnDef,
   ConditionalRule,
   DataValidation,
   SheetProtection,
@@ -240,6 +241,13 @@ export function writeWorksheetXml(
         outlineAttrs["summaryRight"] = sheet.outlineProperties.summaryRight ? 1 : 0
       }
       sheetPrChildren.push(xmlSelfClose("outlinePr", outlineAttrs))
+    }
+    // `<pageSetup fitToWidth>` alone does nothing in Excel — the scaling
+    // mode is switched by this flag, and the fit counts are read only
+    // once it is on. It also carries `fitToPage: true` on its own, which
+    // previously emitted no XML whatsoever. See #407.
+    if (sheet.pageSetup?.fitToPage) {
+      sheetPrChildren.push(xmlSelfClose("pageSetUpPr", { fitToPage: 1 }))
     }
     if (sheetPrChildren.length > 0) {
       parts.push(xmlElement("sheetPr", undefined, sheetPrChildren))
@@ -629,6 +637,17 @@ export function writeWorksheetXml(
 
 // ── Row Resolution ─────────────────────────────────────────────────
 
+/**
+ * The default cell style a column contributes to every cell beneath it.
+ * `numFmt` is folded into the style object, but an explicit
+ * `style.numFmt` wins — it is the more specific of the two spellings.
+ */
+function columnCellStyle(col: ColumnDef | undefined): CellStyle | undefined {
+  if (!col) return undefined
+  if (col.numFmt && !col.style?.numFmt) return { ...col.style, numFmt: col.numFmt }
+  return col.style
+}
+
 function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
   const resolved: Array<Array<ResolvedCell | null>> = []
 
@@ -655,13 +674,9 @@ function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
       for (let c = 0; c < keys.length; c++) {
         const key = keys[c]
         const raw = key !== undefined ? (obj[key] ?? null) : null
-        const col = sheet.columns[c]
         const cell: ResolvedCell = {
           value: isHyperlinkValue(raw) ? raw.text : raw,
-          style: col.style,
-          ...(col.numFmt && !col.style?.numFmt
-            ? { style: { ...col.style, numFmt: col.numFmt } }
-            : {}),
+          style: columnCellStyle(sheet.columns[c]),
         }
         if (isHyperlinkValue(raw)) cell.hyperlink = toHyperlink(raw)
         row.push(cell)
@@ -669,12 +684,18 @@ function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
       resolved.push(row)
     }
   } else if (sheet.rows) {
-    // Array-based rows
+    // Array-based rows. `columns` means the same thing here as on the
+    // `data[]` path: its style and numFmt are the column's default
+    // formatting. They used to apply only to `data[]`, so the same
+    // `columns` array meant two different things depending on which row
+    // source you picked (#407). Unlike `data[]` there is no header row to
+    // exempt — hucre cannot tell which of the caller's rows is one.
     for (const row of sheet.rows) {
       const resolvedRow: Array<ResolvedCell | null> = []
       for (let c = 0; c < row.length; c++) {
         const value = row[c]
-        resolvedRow.push({ value })
+        const style = sheet.columns ? columnCellStyle(sheet.columns[c]) : undefined
+        resolvedRow.push(style ? { value, style } : { value })
       }
       resolved.push(resolvedRow)
     }
@@ -793,8 +814,10 @@ function serializeCell(
       if (formulaDynamic) fAttrs["cm"] = 1
       fElement = xmlElement("f", fAttrs, xmlEscape(formula))
     } else {
-      // Normal formula
-      fElement = xmlElement("f", undefined, xmlEscape(formula))
+      // Normal formula. `formulaDynamic` used to be honoured only inside
+      // the `t="array"` branch above, so a spilling function written
+      // without `formulaType: "array"` silently lost the flag (#407).
+      fElement = xmlElement("f", formulaDynamic ? { cm: 1 } : undefined, xmlEscape(formula))
     }
 
     const children: string[] = [fElement]

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -5,6 +5,7 @@ import type {
   Sheet,
   Cell,
   CellValue,
+  CellStyle,
   MergeRange,
   RichTextRun,
   FontStyle,
@@ -170,6 +171,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   // Sheet view settings (gridlines, zoom, RTL, tab color)
   let sheetView: SheetView | undefined
   let inSheetPr = false
+  let fitToPageFlag = false
   let outlineProperties: import("../_types").OutlineProperties | undefined
 
   // Freeze/Split pane parsed from <pane> element
@@ -464,6 +466,15 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
                 attrs["summaryRight"] === "1" || attrs["summaryRight"] === "true"
             }
             if (Object.keys(outline).length > 0) outlineProperties = outline
+          }
+          break
+        case "pageSetUpPr":
+          // The real home of the fit-to-page toggle: <pageSetup> only
+          // carries the page counts. Recorded separately from the
+          // <pageSetup> attributes because the two elements are far apart
+          // in the document and either may be absent. See #407.
+          if (inSheetPr) {
+            fitToPageFlag = attrs["fitToPage"] === "1" || attrs["fitToPage"] === "true"
           }
           break
         case "tabColor":
@@ -935,6 +946,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
               dbColor,
               isCfvos,
               isAttrs,
+              ctx.styles?.dxfs,
             )
             if (cfRule) {
               conditionalRules.push(cfRule)
@@ -1170,10 +1182,13 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   }
 
   // Attach page setup (merge margins into pageSetup if present)
-  if (pageSetup || pageMargins) {
+  if (pageSetup || pageMargins || fitToPageFlag) {
     const ps: PageSetup = pageSetup ?? {}
     if (pageMargins) {
       ps.margins = pageMargins
+    }
+    if (fitToPageFlag) {
+      ps.fitToPage = true
     }
     sheet.pageSetup = ps
   }
@@ -1390,6 +1405,7 @@ function buildConditionalRule(
   dbColor: string,
   isCfvos: Array<{ type: string; value?: string }>,
   isAttrsObj: Record<string, string>,
+  dxfs: CellStyle[] | undefined,
 ): ConditionalRule | null {
   const typeStr = attrs["type"]
   if (!typeStr || !VALID_CF_TYPES.has(typeStr)) return null
@@ -1407,8 +1423,17 @@ function buildConditionalRule(
     rule.operator = operatorStr as ValidationOperator
   }
 
-  // dxfId — we store it but don't resolve to a style (dxf styles are not parsed in the reader yet)
-  // The round-trip test will check the type/priority/formulas; style is write-only for now.
+  // dxfId indexes the workbook's <dxfs> block, so the rule's formatting
+  // only exists once styles.xml has been parsed. A file can legitimately
+  // reference a dxfId we have no entry for (styles.xml missing, or the
+  // index out of range); leave `style` absent rather than invent one.
+  const dxfId = Number(attrs["dxfId"])
+  if (dxfs && !Number.isNaN(dxfId)) {
+    const dxf = dxfs[dxfId]
+    // An empty <dxf/> carries no formatting — surfacing `{}` would claim
+    // a style the rule does not have.
+    if (dxf && Object.keys(dxf).length > 0) rule.style = dxf
+  }
 
   // stopIfTrue
   if (attrs["stopIfTrue"] === "1" || attrs["stopIfTrue"] === "true") {
@@ -1672,9 +1697,12 @@ function processCell(
         if (formulaRef) {
           cell.formulaRef = formulaRef
         }
-        if (formulaCm) {
-          cell.formulaDynamic = true
-        }
+      }
+      // The dynamic-array flag is independent of the formula type — the
+      // reader used to surface it only for `t="array"`, mirroring the
+      // writer's matching restriction (#407).
+      if (formulaCm) {
+        cell.formulaDynamic = true
       }
     }
     if (richText) {

--- a/test/named-ranges.test.ts
+++ b/test/named-ranges.test.ts
@@ -275,7 +275,14 @@ describe("named ranges — reading (round-trip)", () => {
     expect(nr.comment).toBe("Annual budget data")
   })
 
-  it("reads print area as named range", async () => {
+  // These two used to assert the reader surfaced the print area *only* as
+  // an opaque `_xlnm.Print_Area` entry in `namedRanges`, with
+  // `pageSetup.printArea` left undefined. That is the defect from #407 —
+  // the same setting having one representation on write and a different,
+  // unconnected one on read — written down as an expectation. They are
+  // replaced rather than relaxed: the reserved names are now folded back
+  // into the `pageSetup` they were derived from.
+  it("reads print area back into pageSetup, not namedRanges", async () => {
     const data = await writeXlsx({
       sheets: [
         {
@@ -287,31 +294,55 @@ describe("named ranges — reading (round-trip)", () => {
     })
 
     const workbook = await readXlsx(data)
-    expect(workbook.namedRanges).toBeDefined()
-
-    const printArea = workbook.namedRanges!.find((nr) => nr.name === "_xlnm.Print_Area")
-    expect(printArea).toBeDefined()
-    expect(printArea!.range).toBe("Sheet1!$A$1:$D$50")
-    expect(printArea!.scope).toBe("Sheet1")
+    expect(workbook.sheets[0].pageSetup?.printArea).toBe("$A$1:$D$50")
+    expect(workbook.namedRanges).toBeUndefined()
   })
 
-  it("reads print titles as named range", async () => {
+  it("reads print titles back into pageSetup, not namedRanges", async () => {
     const data = await writeXlsx({
       sheets: [
         {
           name: "Sheet1",
           rows: [["Header"]],
-          pageSetup: { printTitlesRow: "$1:$1" },
+          pageSetup: { printTitlesRow: "$1:$1", printTitlesColumn: "$A:$A" },
         },
       ],
     })
 
     const workbook = await readXlsx(data)
+    expect(workbook.sheets[0].pageSetup?.printTitlesRow).toBe("$1:$1")
+    expect(workbook.sheets[0].pageSetup?.printTitlesColumn).toBe("$A:$A")
+    expect(workbook.namedRanges).toBeUndefined()
+  })
 
-    const printTitles = workbook.namedRanges!.find((nr) => nr.name === "_xlnm.Print_Titles")
-    expect(printTitles).toBeDefined()
-    expect(printTitles!.range).toBe("Sheet1!$1:$1")
-    expect(printTitles!.scope).toBe("Sheet1")
+  it("keeps user-defined names alongside a consumed print area", async () => {
+    const data = await writeXlsx({
+      namedRanges: [{ name: "Budget", range: "Sheet1!$A$1:$A$5" }],
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [["Data"]],
+          pageSetup: { printArea: "$A$1:$D$50" },
+        },
+      ],
+    })
+
+    const workbook = await readXlsx(data)
+    expect(workbook.namedRanges).toEqual([{ name: "Budget", range: "Sheet1!$A$1:$A$5" }])
+    expect(workbook.sheets[0].pageSetup?.printArea).toBe("$A$1:$D$50")
+  })
+
+  it("leaves an unscoped print area in namedRanges", async () => {
+    // A workbook-level _xlnm.Print_Area cannot be attributed to a sheet,
+    // so there is no pageSetup to fold it into. Dropping it would lose it.
+    const data = await writeXlsx({
+      namedRanges: [{ name: "_xlnm.Print_Area", range: "Sheet1!$A$1:$B$2" }],
+      sheets: [{ name: "Sheet1", rows: [["Data"]] }],
+    })
+
+    const workbook = await readXlsx(data)
+    expect(workbook.namedRanges).toEqual([{ name: "_xlnm.Print_Area", range: "Sheet1!$A$1:$B$2" }])
+    expect(workbook.sheets[0].pageSetup?.printArea).toBeUndefined()
   })
 
   it("no namedRanges property when none exist", async () => {

--- a/test/print-settings.test.ts
+++ b/test/print-settings.test.ts
@@ -129,6 +129,26 @@ describe("page setup — writing", () => {
     expect(ps).toBeDefined()
     expect(ps.attrs["fitToWidth"]).toBe("1")
     expect(ps.attrs["fitToHeight"]).toBe("0")
+
+    // The page counts do nothing on their own — Excel reads them only once
+    // the scaling mode is switched by <sheetPr><pageSetUpPr fitToPage>.
+    const sheetPr = findChild(doc, "sheetPr")
+    expect(findChild(sheetPr, "pageSetUpPr").attrs["fitToPage"]).toBe("1")
+  })
+
+  it("writes fitToPage on its own", () => {
+    // `fitToPage: true` with neither count used to emit nothing at all:
+    // no <pageSetup>, no <pageSetUpPr>, no warning. See #407.
+    const sheet: WriteSheet = {
+      name: "Test",
+      rows: [["Data"]],
+      pageSetup: { fitToPage: true },
+    }
+
+    const doc = parseSheet(writeXml(sheet))
+    const sheetPr = findChild(doc, "sheetPr")
+    expect(sheetPr).toBeDefined()
+    expect(findChild(sheetPr, "pageSetUpPr").attrs["fitToPage"]).toBe("1")
   })
 
   it("writes all paper sizes correctly", () => {
@@ -424,6 +444,18 @@ describe("page setup — round-trip", () => {
     expect(ps!.fitToPage).toBe(true)
     expect(ps!.fitToWidth).toBe(1)
     expect(ps!.fitToHeight).toBe(0)
+  })
+
+  it("round-trips fitToPage on its own", async () => {
+    const data = await writeXlsx({
+      sheets: [{ name: "Sheet1", rows: [["Data"]], pageSetup: { fitToPage: true } }],
+    })
+
+    const workbook = await readXlsx(data)
+    const ps = workbook.sheets[0].pageSetup
+    expect(ps!.fitToPage).toBe(true)
+    expect(ps!.fitToWidth).toBeUndefined()
+    expect(ps!.fitToHeight).toBeUndefined()
   })
 
   it("round-trips all paper sizes", async () => {

--- a/test/xlsx-write-read-parity.test.ts
+++ b/test/xlsx-write-read-parity.test.ts
@@ -1,0 +1,609 @@
+// ── Write → read parity over the whole WriteSheet / WriteOptions surface ──
+//
+// The invariant: anything `writeXlsx` accepts, `readXlsx` gives back.
+// It was broken in eight places at once (#407) — each silently, with no
+// error and no warning, just `undefined` where a value had been.
+//
+// Rather than eight regression tests, this file registers every field of
+// `WriteSheet` and `WriteOptions` exactly once. The registers are typed as
+// mapped types over `keyof Required<...>`, so adding a field to either
+// interface fails `tsc` until it is registered here — as a probe that
+// round-trips, or as a deliberate one-way entry with the reason it is one.
+// That, not the eight fixes, is what stops the ninth.
+//
+// Each probe gets its own sheet, named after the field it covers, so no
+// two fields can interact and a failure names the field directly.
+
+import { describe, expect, it } from "vitest"
+import { readXlsx, writeXlsx } from "../src/xlsx"
+import { ZipReader } from "../src/zip"
+import type { Sheet, WriteOptions, WriteSheet, Workbook } from "../src/_types"
+
+// ── Register shapes ──────────────────────────────────────────────────
+
+/** A field that must survive write → read. */
+interface Probe<T> {
+  /** The value written into the fixture. */
+  value: NonNullable<T>
+  /** Pull the same information back out of the parsed workbook. */
+  read: (sheet: Sheet, workbook: Workbook) => unknown
+  /**
+   * What `read` must return. Defaults to `value`; set it where the read
+   * model spells the same information differently (a `data[]` sheet comes
+   * back as `rows[][]`, a `SheetChart` as a `Chart`, and so on).
+   */
+  expected?: unknown
+  /** Extra fields the probe needs to be meaningful (e.g. `data` needs `columns`). */
+  with?: Partial<WriteSheet>
+}
+
+/**
+ * A field that deliberately does not come back, and why. Every entry here
+ * is a decision someone made, not a gap someone tolerated — if a reason
+ * reads like "not implemented yet", it belongs in an issue, not here.
+ */
+interface OneWay {
+  oneWay: string
+}
+
+type Entry<T> = Probe<T> | OneWay
+
+function isOneWay<T>(entry: Entry<T>): entry is OneWay {
+  return "oneWay" in entry
+}
+
+const BASE_ROWS = [
+  ["Region", "Amount"],
+  ["North", 10],
+  ["South", 20],
+]
+
+const PNG_1X1 = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+])
+
+// ── WriteSheet register ──────────────────────────────────────────────
+
+const SHEET_FIELDS: { [K in keyof Required<WriteSheet>]: Entry<WriteSheet[K]> } = {
+  // Every probe's sheet is named after its own key, so locating the sheet
+  // by name is itself the check that `name` survived.
+  name: { value: "name", read: (sheet) => sheet.name },
+
+  columns: {
+    value: [
+      { header: "Region", width: 18, hidden: false, outlineLevel: 1 },
+      { header: "Amount", width: 12, numFmt: "0.000", style: { font: { bold: true } } },
+    ],
+    // This sheet supplies its rows as `rows[][]`, so it also pins the
+    // other half of #407: `style` and `numFmt` used to apply on the
+    // `data[]` path only, silently doing nothing here.
+    read: (sheet) => ({
+      cols: sheet.columns?.map((c) => ({ width: c.width, outlineLevel: c.outlineLevel })),
+      bodyStyle: sheet.cells?.get("1,1")?.style,
+    }),
+    // `header` is data, not column metadata: it is written into row 0 on
+    // the `data[]` path and read back as a cell there. `<cols>` carries
+    // width and outline level, and that is what comes back.
+    expected: {
+      cols: [
+        { width: 18, outlineLevel: 1 },
+        { width: 12, outlineLevel: undefined },
+      ],
+      bodyStyle: { numFmt: "0.000", font: { bold: true } },
+    },
+  },
+
+  rows: { value: BASE_ROWS, read: (sheet) => sheet.rows },
+
+  data: {
+    value: [
+      { region: "North", amount: 10 },
+      { region: "South", amount: 20 },
+    ],
+    with: {
+      columns: [
+        { header: "Region", key: "region" },
+        { header: "Amount", key: "amount" },
+      ],
+    },
+    // Object rows are a write-side convenience; the file stores a grid, so
+    // the reader hands back the grid the objects were flattened into.
+    read: (sheet) => sheet.rows,
+    expected: BASE_ROWS,
+  },
+
+  cells: {
+    value: new Map([
+      ["1,0", { value: "North", comment: { text: "a note", author: "hucre" } }],
+      ["1,1", { formula: "SUM(B2:B3)", formulaDynamic: true }],
+    ]),
+    read: (sheet) => ({
+      comment: sheet.cells?.get("1,0")?.comment?.text,
+      formula: sheet.cells?.get("1,1")?.formula,
+      dynamic: sheet.cells?.get("1,1")?.formulaDynamic,
+    }),
+    expected: { comment: "a note", formula: "SUM(B2:B3)", dynamic: true },
+  },
+
+  merges: {
+    value: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+    read: (sheet) => sheet.merges,
+  },
+
+  dataValidations: {
+    value: [{ type: "list", values: ["North", "South"], range: "A2:A3", allowBlank: true }],
+    read: (sheet) => sheet.dataValidations?.map((v) => ({ type: v.type, range: v.range })),
+    expected: [{ type: "list", range: "A2:A3" }],
+  },
+
+  conditionalRules: {
+    value: [
+      {
+        type: "cellIs",
+        priority: 1,
+        operator: "greaterThan",
+        formula: "15",
+        range: "B2:B3",
+        style: { font: { bold: true, color: { rgb: "9C0006" } } },
+      },
+    ],
+    read: (sheet) => sheet.conditionalRules,
+  },
+
+  autoFilter: { value: { range: "A1:B3" }, read: (sheet) => sheet.autoFilter },
+
+  freezePane: { value: { rows: 1, columns: 1 }, read: (sheet) => sheet.freezePane },
+
+  splitPane: { value: { xSplit: 2000, ySplit: 1000 }, read: (sheet) => sheet.splitPane },
+
+  images: {
+    value: [
+      {
+        data: PNG_1X1,
+        type: "png",
+        anchor: { from: { row: 4, col: 0 }, to: { row: 9, col: 3 } },
+        width: 120,
+        height: 80,
+        altText: "a chart of nothing",
+        title: "Figure 1",
+      },
+    ],
+    read: (sheet) =>
+      sheet.images?.map((i) => ({
+        type: i.type,
+        anchor: i.anchor,
+        width: i.width,
+        height: i.height,
+        altText: i.altText,
+        title: i.title,
+        bytes: i.data.length,
+      })),
+    expected: [
+      {
+        type: "png",
+        anchor: { from: { row: 4, col: 0 }, to: { row: 9, col: 3 } },
+        width: 120,
+        height: 80,
+        altText: "a chart of nothing",
+        title: "Figure 1",
+        bytes: PNG_1X1.length,
+      },
+    ],
+  },
+
+  protection: {
+    value: { password: "s3cret", sheet: true, formatCells: true, sort: true },
+    read: (sheet) => ({
+      sheet: sheet.protection?.sheet,
+      formatCells: sheet.protection?.formatCells,
+      sort: sheet.protection?.sort,
+      // Declared one-way below, and asserted here so the claim stays true:
+      // the file stores a hash, and a hash is not the password.
+      password: sheet.protection?.password,
+    }),
+    expected: { sheet: true, formatCells: true, sort: true, password: undefined },
+  },
+
+  pageSetup: {
+    value: {
+      paperSize: "a4",
+      orientation: "landscape",
+      fitToPage: true,
+      fitToWidth: 1,
+      scale: 90,
+      printArea: "$A$1:$B$3",
+      printTitlesRow: "$1:$1",
+      printTitlesColumn: "$A:$A",
+      horizontalCentered: true,
+      margins: { top: 1, bottom: 1, left: 0.5, right: 0.5, header: 0.3, footer: 0.3 },
+    },
+    read: (sheet) => sheet.pageSetup,
+  },
+
+  headerFooter: {
+    value: { oddHeader: "&Ltitle", oddFooter: "&Cpage &P" },
+    read: (sheet) => sheet.headerFooter,
+  },
+
+  view: {
+    value: { showGridLines: false, zoomScale: 125, rightToLeft: true, tabColor: { rgb: "FF0000" } },
+    read: (sheet) => sheet.view,
+  },
+
+  hidden: { value: true, read: (sheet) => sheet.hidden },
+
+  veryHidden: { value: true, read: (sheet) => sheet.veryHidden },
+
+  tables: {
+    value: [
+      {
+        name: "Sales",
+        range: "A1:B3",
+        columns: [{ name: "Region" }, { name: "Amount" }],
+        style: "TableStyleMedium2",
+        showRowStripes: true,
+        showAutoFilter: false,
+      },
+    ],
+    read: (sheet) =>
+      sheet.tables?.map((t) => ({
+        name: t.name,
+        range: t.range,
+        style: t.style,
+        showRowStripes: t.showRowStripes,
+        showAutoFilter: t.showAutoFilter,
+      })),
+    expected: [
+      {
+        name: "Sales",
+        range: "A1:B3",
+        style: "TableStyleMedium2",
+        showRowStripes: true,
+        showAutoFilter: false,
+      },
+    ],
+  },
+
+  rowBreaks: { value: [1], read: (sheet) => sheet.rowBreaks },
+
+  colBreaks: { value: [1], read: (sheet) => sheet.colBreaks },
+
+  rowDefs: {
+    value: new Map([[1, { height: 30, hidden: false, outlineLevel: 1 }]]),
+    read: (sheet) => ({
+      height: sheet.rowDefs?.get(1)?.height,
+      outlineLevel: sheet.rowDefs?.get(1)?.outlineLevel,
+    }),
+    expected: { height: 30, outlineLevel: 1 },
+  },
+
+  outlineProperties: {
+    value: { summaryBelow: false, summaryRight: false },
+    read: (sheet) => sheet.outlineProperties,
+  },
+
+  backgroundImage: {
+    value: PNG_1X1,
+    read: (sheet) => sheet.backgroundImage?.length,
+    expected: PNG_1X1.length,
+  },
+
+  sparklines: {
+    value: [{ location: "C2", dataRange: "sparklines!A2:B2", type: "column", color: "376092" }],
+    read: (sheet) => sheet.sparklines,
+  },
+
+  textBoxes: {
+    value: [
+      {
+        text: "a caption",
+        anchor: { from: { row: 4, col: 0 }, to: { row: 7, col: 3 } },
+        width: 200,
+        height: 60,
+        altText: "caption alt",
+        title: "Caption",
+      },
+    ],
+    read: (sheet) => sheet.textBoxes,
+    expected: [
+      {
+        text: "a caption",
+        anchor: { from: { row: 4, col: 0 }, to: { row: 7, col: 3 } },
+        width: 200,
+        height: 60,
+        altText: "caption alt",
+        title: "Caption",
+        // The writer always paints a shape and always sizes its text; the
+        // reader reports both, so a text box with no `style` comes back
+        // carrying the writer's defaults rather than nothing.
+        style: { fontSize: 11, fillColor: "FFFFFF", borderColor: "000000" },
+      },
+    ],
+  },
+
+  charts: {
+    value: [
+      {
+        type: "column",
+        title: "Sales by region",
+        anchor: { from: { row: 4, col: 0 }, to: { row: 14, col: 6 } },
+        series: [{ name: "Amount", values: "charts!$B$2:$B$3", categories: "charts!$A$2:$A$3" }],
+        altText: "column chart of sales",
+        frameTitle: "Sales frame",
+      },
+    ],
+    // Charts read back as `Chart` (an inspection view of chartN.xml), not
+    // as the `SheetChart` that authored them.
+    read: (sheet) =>
+      sheet.charts?.map((c) => ({
+        kinds: c.kinds,
+        title: c.title,
+        anchor: c.anchor,
+        altText: c.altText,
+        frameTitle: c.frameTitle,
+      })),
+    expected: [
+      {
+        kinds: ["bar"],
+        title: "Sales by region",
+        anchor: { from: { row: 4, col: 0 }, to: { row: 14, col: 6 } },
+        altText: "column chart of sales",
+        frameTitle: "Sales frame",
+      },
+    ],
+  },
+
+  pivotTables: {
+    value: [
+      {
+        name: "ByRegion",
+        sourceRange: "A1:B3",
+        targetCell: "D1",
+        rows: ["Region"],
+        values: [{ field: "Amount", function: "sum" }],
+      },
+    ],
+    // `targetCell` is the anchor; the reader reports the rendered extent
+    // the writer computed from it (header + one row per Region + total).
+    read: (sheet) => sheet.pivotTables?.map((p) => ({ name: p.name, location: p.location })),
+    expected: [{ name: "ByRegion", location: "D1:E3" }],
+  },
+
+  a11y: {
+    oneWay:
+      "Authoring metadata with no cell in the file to live in. `summary` is " +
+      "promoted into `properties.description` by writeXlsx (asserted in " +
+      "a11y.test.ts) and reads back there; `headerRow` has no OOXML home at " +
+      "all — the nearest thing, a table's headerRowCount, means something " +
+      "narrower. Neither is a field the reader can honestly reconstruct.",
+  },
+}
+
+// ── WriteOptions register ────────────────────────────────────────────
+
+const OPTION_FIELDS: { [K in keyof Required<WriteOptions>]: Entry<WriteOptions[K]> } = {
+  sheets: {
+    oneWay: "The container for everything above, covered field by field by SHEET_FIELDS.",
+  },
+
+  properties: {
+    value: { title: "Parity", creator: "hucre", company: "ACME", custom: { Reviewed: "yes" } },
+    read: (_sheet, wb) => ({
+      title: wb.properties?.title,
+      creator: wb.properties?.creator,
+      company: wb.properties?.company,
+      custom: wb.properties?.custom,
+    }),
+    expected: {
+      title: "Parity",
+      creator: "hucre",
+      company: "ACME",
+      custom: { Reviewed: "yes" },
+    },
+  },
+
+  namedRanges: {
+    value: [{ name: "Budget", range: "name!$A$1:$B$3", comment: "the numbers" }],
+    read: (_sheet, wb) => wb.namedRanges,
+  },
+
+  defaultFont: {
+    value: { name: "Georgia", size: 13 },
+    read: (_sheet, wb) => wb.defaultFont,
+    expected: { name: "Georgia", size: 13 },
+  },
+
+  dateSystem: { value: "1904", read: (_sheet, wb) => wb.dateSystem },
+
+  activeSheet: { value: 2, read: (_sheet, wb) => wb.activeSheet },
+
+  workbookProtection: {
+    value: { lockStructure: true, lockWindows: true, password: "s3cret" },
+    read: (_sheet, wb) => wb.workbookProtection,
+    // Same one-way hash as sheet protection; the flags come back, the
+    // password does not.
+    expected: { lockStructure: true, lockWindows: true },
+  },
+
+  stringMode: {
+    oneWay:
+      "A storage choice, not a property of the workbook: `shared` and " +
+      "`inline` describe two encodings of the identical cell values, and " +
+      "the reader resolves both to the same strings. There is no field to " +
+      "surface, and a reader that reported one would be reporting on the " +
+      "file's compression, not its content.",
+  },
+
+  vbaProject: {
+    oneWay:
+      "`Workbook` has no VBA field and should not grow one — handing " +
+      "callers a macro binary is a different feature from reading a " +
+      "spreadsheet. The part survives the openXlsx → saveXlsx path " +
+      "verbatim, which is where preserving it matters (roundtrip.ts).",
+  },
+
+  encryption: {
+    oneWay:
+      "A property of the container, not of the model. The round trip is " +
+      "`readXlsx(bytes, { password })` returning the same workbook, which " +
+      "encryption.test.ts asserts; there is no encryption field on " +
+      "`Workbook` because a decrypted workbook is just a workbook.",
+  },
+}
+
+// ── One-way register, restated as its own assertion ──────────────────
+//
+// The two passwords are the entries the issue singled out as correctly
+// one-way. They are not in the registers above as `oneWay` because the
+// fields they sit on (`protection`, `workbookProtection`) do round-trip —
+// it is one key inside each that does not.
+
+const ONE_WAY_PASSWORDS = [
+  {
+    field: "WriteSheet.protection.password",
+    why: "Stored as the legacy 16-bit sheet-protection hash. The hash is what the format defines; the password is not recoverable from it, by design.",
+  },
+  {
+    field: "WriteOptions.workbookProtection.password",
+    why: "Same hash, same reason — <workbookProtection workbookPassword> holds a digest, not the secret.",
+  },
+]
+
+// ── Fixture ──────────────────────────────────────────────────────────
+
+// The registers are declared as mapped types so `tsc` enforces that every
+// field is covered. Iterating them is a different job: `Object.entries`
+// collapses the per-key value types into a union no loop body can satisfy,
+// so walk them through one erased view. The exhaustiveness check lives in
+// the declarations above and is unaffected.
+type AnyEntry = Entry<unknown>
+
+function entriesOf(register: Record<string, unknown>): Array<[string, AnyEntry]> {
+  return Object.entries(register) as Array<[string, AnyEntry]>
+}
+
+const SHEET_ENTRIES = entriesOf(SHEET_FIELDS)
+const OPTION_ENTRIES = entriesOf(OPTION_FIELDS)
+
+function buildFixture(): WriteOptions {
+  const sheets: WriteSheet[] = []
+
+  for (const [key, entry] of SHEET_ENTRIES) {
+    if (isOneWay(entry)) continue
+    sheets.push({
+      name: key,
+      rows: BASE_ROWS,
+      ...entry.with,
+      [key]: entry.value,
+    } as WriteSheet)
+  }
+
+  const options: Record<string, unknown> = { sheets }
+  for (const [key, entry] of OPTION_ENTRIES) {
+    if (isOneWay(entry)) continue
+    options[key] = entry.value
+  }
+  return options as unknown as WriteOptions
+}
+
+describe("xlsx write → read parity", () => {
+  it("gives back everything the writer was given", async () => {
+    const fixture = buildFixture()
+    const bytes = await writeXlsx(fixture)
+    const workbook = await readXlsx(bytes, { readStyles: true })
+
+    const byName = new Map(workbook.sheets.map((s) => [s.name, s]))
+    const failures: string[] = []
+
+    for (const [key, entry] of SHEET_ENTRIES) {
+      if (isOneWay(entry)) continue
+      const sheet = byName.get(key)
+      if (!sheet) {
+        failures.push(`WriteSheet.${key}: sheet "${key}" is missing from the parsed workbook`)
+        continue
+      }
+      const actual = entry.read(sheet, workbook)
+      const expected = "expected" in entry ? entry.expected : entry.value
+      try {
+        expect(actual).toEqual(expected)
+      } catch {
+        failures.push(
+          `WriteSheet.${key}: wrote ${JSON.stringify(expected)}, read ${JSON.stringify(actual)}`,
+        )
+      }
+    }
+
+    // Option-level probes read off the workbook; the sheet argument is the
+    // first one purely so the two registers share a signature.
+    const anySheet = workbook.sheets[0]
+    for (const [key, entry] of OPTION_ENTRIES) {
+      if (isOneWay(entry)) continue
+      const actual = entry.read(anySheet, workbook)
+      const expected = "expected" in entry ? entry.expected : entry.value
+      try {
+        expect(actual).toEqual(expected)
+      } catch {
+        failures.push(
+          `WriteOptions.${key}: wrote ${JSON.stringify(expected)}, read ${JSON.stringify(actual)}`,
+        )
+      }
+    }
+
+    expect(failures).toEqual([])
+  })
+
+  it("states a reason for every field that does not come back", () => {
+    const oneWays = [
+      ...SHEET_ENTRIES.map(([k, e]) => [`WriteSheet.${k}`, e] as const),
+      ...OPTION_ENTRIES.map(([k, e]) => [`WriteOptions.${k}`, e] as const),
+    ].filter(([, e]) => isOneWay(e))
+
+    for (const [field, entry] of oneWays) {
+      const reason = (entry as OneWay).oneWay
+      // A one-way entry earns its place by explaining itself. A bare
+      // "TODO" or an empty string is a gap wearing a register's clothes.
+      expect(reason.length, `${field} has no stated reason`).toBeGreaterThan(40)
+      expect(reason).not.toMatch(/\bTODO\b|not implemented|for now/i)
+    }
+
+    // Pin the shape of the register so a field cannot be quietly demoted
+    // from "round-trips" to "one-way" without the change showing up here.
+    expect(oneWays.map(([f]) => f)).toEqual([
+      "WriteSheet.a11y",
+      "WriteOptions.sheets",
+      "WriteOptions.stringMode",
+      "WriteOptions.vbaProject",
+      "WriteOptions.encryption",
+    ])
+  })
+
+  it("keeps sheet and workbook passwords one-way, and says so", async () => {
+    for (const entry of ONE_WAY_PASSWORDS) {
+      expect(entry.why.length).toBeGreaterThan(40)
+    }
+
+    const bytes = await writeXlsx({
+      workbookProtection: { lockStructure: true, password: "s3cret" },
+      sheets: [{ name: "S", rows: [["x"]], protection: { sheet: true, password: "s3cret" } }],
+    })
+    const workbook = await readXlsx(bytes)
+    const zip = new ZipReader(bytes)
+    const sheetXml = new TextDecoder().decode(await zip.extract("xl/worksheets/sheet1.xml"))
+    const bookXml = new TextDecoder().decode(await zip.extract("xl/workbook.xml"))
+
+    // Not merely absent — absent *because* the file holds a digest. Asserting
+    // the digest is present keeps "one-way" distinguishable from "dropped":
+    // the protection is really in the file, only the secret is not.
+    expect(workbook.sheets[0].protection?.password).toBeUndefined()
+    expect(sheetXml).toMatch(/<sheetProtection[^>]*password="[0-9A-F]{4}"/)
+    expect(sheetXml).not.toContain("s3cret")
+
+    expect(workbook.workbookProtection?.lockStructure).toBe(true)
+    expect(bookXml).toMatch(/<workbookProtection[^>]*workbookPassword="[0-9A-F]{4}"/)
+    expect(bookXml).not.toContain("s3cret")
+  })
+})


### PR DESCRIPTION
Closes #407.

The invariant being restored: **hucre's reader must be able to read hucre's writer's output.** Eleven fields were written and then ignored — silently, no error, just `undefined` where a value had been. Reproduced against unfixed source first:

```
=== ConditionalRule.style ===
{"type":"cellIs","priority":1,"range":"A1:B2","operator":"greaterThan","formula":"5"}   <- no style
showAutoFilter = true      (wrote false)
activeSheet = undefined    (wrote 1)
defaultFont = undefined    (wrote Georgia/13)
image w/h = undefined undefined
namedRanges = [{"name":"_xlnm.Print_Area","range":"One!A1:D10","scope":"One"}, …]
<c r="A1"><f>UNIQUE(B1:B5)</f></c>                       <- formulaDynamic dropped
data[] A2 = {"numFmt":"0.000","font":{"bold":true}} / rows[][] A2 = undefined
```

All eleven are fixed — the eight reader losses and the three write-side items.

## The part that matters more than the eleven fixes

`test/xlsx-write-read-parity.test.ts` registers every field of `WriteSheet` and `WriteOptions` exactly once, as a mapped type over `keyof Required<…>`. **Adding a field to either interface fails `tsc` until it is registered** — as a probe that round-trips, or as a deliberate one-way entry carrying the reason.

Verified in both directions. Deleting one entry:

```
test/xlsx-write-read-parity.test.ts(71,7): error TS2741:
  Property 'merges' is missing in type … but required in type …
```

and against the unfixed source the suite reports ten distinct losses, one per defect. Each probe gets its own sheet named after its field, so no two fields interact and a failure names the field directly.

The one-way register is five entries, each a decision rather than a shortfall: `sheets` is the container, `stringMode` is an encoding with nothing to surface, `vbaProject` has no `Workbook` field and should not grow one, `encryption` is a container property, `a11y` is authoring metadata with no cell to live in. A second test asserts every reason is stated and that none of them reads like a deferral (`/TODO|not implemented|for now/`) — so the register cannot quietly become a list of things someone gave up on. The two passwords keep their own test: absent from the model *because* the file holds a digest, with the digest asserted present, so "one-way" stays distinguishable from "dropped".

## `printArea`: consumed, not copied

The reader folds `_xlnm.Print_Area` / `_xlnm.Print_Titles` into `pageSetup` and removes them from `namedRanges`. Two reasons, one decisive: they are reserved builtins rather than the user-defined names `NamedRange` documents, and keeping both would make `openXlsx` → `saveXlsx` emit each name twice — once carried over, once re-derived from `pageSetup` — breaking files that round-trip cleanly today. Verified no duplication after the change. A name with no resolvable sheet stays in `namedRanges`, since there is no `pageSetup` to fold it into.

## Existing tests changed

Two in `named-ranges.test.ts` asserted that a print area surfaces *only* as an opaque `namedRanges` entry with `pageSetup.printArea` undefined. That is the defect written down as an expectation, so they were replaced rather than relaxed, with new cases for user-defined names that must survive and an unscoped name that must not be consumed. Nothing was weakened.

## Where the issue was wrong

- **`ColumnDef.style` on the `data[]` path is not simply "working".** It only reads back under `readXlsx(…, { readStyles: true })`; a plain read returns `undefined` on both paths. The underlying `data[]`-versus-`rows[][]` asymmetry was real.
- Several line references had drifted (`worksheet-writer.ts:793/797` were at 800/804).
- **The issue understates one item.** `<pageSetup fitToWidth>` without `<pageSetUpPr fitToPage="1"/>` does nothing in Excel — so fit-to-page was broken for *real files*, not only round trips. Fixed for both spellings.
- README:177's "dynamic formulas" needed no caveat in the end; the fix made the claim true.

## Flagged, not fixed

hucre writes `cm="1"` on `<f>`. Per ECMA-376 `cm` is a `CT_Cell` attribute, not `CT_CellFormula`, and Excel pairs it with an `xl/metadata.xml` part hucre does not emit. The already-shipped spelling was extended to plain formulas rather than relocated, because moving it needs the metadata part and is a distinct change. Worth its own issue.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,520 tests, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
