### PR TITLE
fix: recognise single-placeholder fraction formats

### DIFF
--- a/src/_format.ts
+++ b/src/_format.ts
@@ -402,11 +402,21 @@ function formatExponentialString(expStr: string, fmt: string): string {
 const FRACTION_PARTS = /([?#0]+)\/(\d+|[?#0]+)/
 
 function isFractionFormat(fmt: string): boolean {
-  // Matches patterns like "# ?/?", "# ??/??", "# ?/8", etc.
-  // The denominator may be a fixed number — Excel's built-in "As halves"
-  // (`# ?/2`), "As eighths" (`# ?/8`) and "As sixteenths" (`# ??/16`).
-  // But not date formats or paths
-  return /[#0?]\s*[?#0]+\/(?:\d+|[?#0]+)/.test(fmt)
+  // A slash with digit placeholders against it: "# ?/?", "# ??/??", and the
+  // fixed-denominator built-ins "As halves" (`# ?/2`), "As eighths" (`# ?/8`),
+  // "As sixteenths" (`# ??/16`).
+  //
+  // One placeholder either side is enough — "?/?" and "0/2" are as much
+  // fractions as "??/??" is. The old pattern wanted a placeholder *before*
+  // the numerator run, so a one-character numerator never matched and the
+  // format fell through to formatNumber, which renders the "/" as a literal
+  // and loses the numerator: 2.5 under "?/?" came out " /3". See #402.
+  //
+  // Recognising and parsing off the same pattern keeps the two from
+  // disagreeing about what a fraction is. Nothing else is dragged in: dates
+  // are claimed before this is reached and put no placeholder against their
+  // slashes, and an escaped slash ("0\/0") still carries its backslash.
+  return FRACTION_PARTS.test(fmt)
 }
 
 function formatFraction(value: number, fmt: string): string {
@@ -431,7 +441,11 @@ function formatFraction(value: number, fmt: string): string {
 
   const denomLen = fracMatch[2].length
 
-  // Check for fixed denominator (all digits)
+  // A denominator written in digits is fixed ("?/16"); one written in
+  // placeholders is searched for. "0" and "00" are both at once, but a
+  // literal denominator of zero means nothing, so they parse to 0 and the
+  // guard below sends them to the search — which is where Excel puts them,
+  // since "0" is a placeholder character.
   const fixedDenom = /^\d+$/.test(fracMatch[2]) ? Number.parseInt(fracMatch[2], 10) : 0
 
   let bestNum: number

--- a/test/coverage-number-format.test.ts
+++ b/test/coverage-number-format.test.ts
@@ -454,6 +454,79 @@ describe("formatValue — Excel parity", () => {
     expect(formatValue(3.1, "# ??/??")).toBe("3  1/10")
   })
 
+  // ── #402 ──────────────────────────────────────────────────────────
+  //
+  // One placeholder either side of the slash is a fraction. Recognition
+  // used to demand two before it, so "?/?" was formatted as a plain number
+  // — which renders the "/" as a literal and puts the digits in the one
+  // placeholder it can see, losing the numerator entirely: 2.5 came out
+  // " /3".
+  it("reads a single placeholder either side of the slash as a fraction", () => {
+    expect(formatValue(2.5, "?/?")).toBe("5/2")
+    expect(formatValue(0.5, "?/?")).toBe("1/2")
+    expect(formatValue(0.125, "?/?")).toBe("1/8")
+  })
+
+  // Padding follows the width of the format, so the one-character form has
+  // nothing to pad — "?/?" gives "5/2" where "??/??" gives " 5/ 2".
+  it("pads a one-character fraction to its own width, not the two-character one", () => {
+    expect(formatValue(2.5, "?/?")).toBe("5/2")
+    expect(formatValue(2.5, "??/??")).toBe(" 5/ 2")
+  })
+
+  // No placeholder ahead of the slash, so the whole part folds into the
+  // numerator exactly as it does under "??/??".
+  it("folds the whole part into a single-placeholder numerator", () => {
+    expect(formatValue(3, "?/?")).toBe("3/1")
+    expect(formatValue(-2.5, "?/?")).toBe("-5/2")
+    expect(formatValue(-0.5, "?/?")).toBe("-1/2")
+  })
+
+  // A one-character denominator holds a one-digit search, the same rule the
+  // wider formats follow: "?/?" searches to 9, "?/???" to 999.
+  it("keeps the denominator search at one digit for a one-character denominator", () => {
+    expect(formatValue(3.1, "?/?")).toBe("28/9")
+    expect(formatValue(3.1, "??/??")).toBe("31/10")
+  })
+
+  // A literal denominator still reads as literal when the numerator is one
+  // character: "0/2" is halves, not a one-digit search.
+  it("honours a fixed denominator behind a single-placeholder numerator", () => {
+    expect(formatValue(0.5, "0/2")).toBe("1/2")
+    expect(formatValue(2.5, "0/2")).toBe("5/2")
+    expect(formatValue(0.125, "?/8")).toBe("1/8")
+    expect(formatValue(2.5, "?/8")).toBe("20/8")
+  })
+
+  // "#", "0" and "?" are all digit placeholders, so these are the same
+  // format as "?/?" wearing different padding rules — none of which show
+  // for a numerator that fills its width anyway.
+  it("treats #, 0 and ? alike on either side of the slash", () => {
+    expect(formatValue(2.5, "#/#")).toBe("5/2")
+    expect(formatValue(2.5, "0/0")).toBe("5/2")
+    expect(formatValue(2.5, "0/0")).toBe(formatValue(2.5, "?/?"))
+  })
+
+  // The whole-part detection from #397 reads the text in front of the
+  // fraction, so a one-character fraction group changes nothing about it.
+  it("still finds the whole part in front of a one-character fraction", () => {
+    expect(formatValue(2.5, "# ?/?")).toBe("2 1/2")
+    expect(formatValue(3, "# ?/?")).toBe("3")
+    expect(formatValue(3.1, "# ?/2")).toBe("3")
+  })
+
+  // The widened pattern must not drag non-fractions in with it. A date
+  // format is claimed before fractions are considered, and neither it nor a
+  // plain number puts a digit placeholder against a slash.
+  it("leaves formats that are not fractions alone", () => {
+    expect(formatValue(45000, "m/d/yyyy")).toBe("3/15/2023")
+    expect(formatValue(45000, "yyyy/mm/dd")).toBe("2023/03/15")
+    expect(formatValue(3.7, "0")).toBe("4")
+    expect(formatValue(3.7, "0.00")).toBe("3.70")
+    expect(formatValue(1234.5, "#,##0.00")).toBe("1,234.50")
+    expect(formatValue(0.5, "0%")).toBe("50%")
+  })
+
   // "?" renders insignificant decimals as spaces so decimal points line up
   // down a column, where "0" would render them as zeros.
   it("pads insignificant decimals with spaces for a ? placeholder", () => {


### PR DESCRIPTION
Closes #402.

Reproduced against unfixed source first:

```
"?/?"    2.5    " /3"
"?/?"    0.5    " /1"
"?/8"    0.125  "0/8"
"#/#"    2.5    "/3"
"0/0"    2.5    "0/3"
```

`" /3"` is not a mis-rounded fraction — it has no numerator. `isFractionFormat` wanted a placeholder *before* the numerator run, so a one-character numerator never matched, the format fell through to `formatNumber`, and the `/` came out as a literal.

## The fix

`isFractionFormat` now returns `FRACTION_PARTS.test(fmt)` — the same regex the parse uses — instead of keeping its own, wider-by-one-placeholder copy. Recognition and parsing can no longer disagree about what a fraction is, which is the actual defect: two patterns for one concept.

Nothing downstream needed changing, and the issue's worry about `fracMatch[2]` turned out unfounded: `denomLen` is 1 for a one-character denominator, which is exactly the one-digit search `# ?/?` already runs; `/^\d+$/` still sees `"2"` in `0/2`, so the fixed-denominator branch is taken; and `hasIntPart` reads the text *before* the group, so a narrower group does not affect the #397 whole-part logic.

One comment added on `fixedDenom`, because an all-zeros denominator (`0`, `00`) parses to 0 and falls to the search path — a case only newly reachable now that `0/0` is recognised.

## Regression checking

A full old-versus-new diff over ~46 formats × 14 values (old code obtained by copying the file aside, not `git stash` — that stack is shared across worktrees here). **The only outputs that moved are formats with a one-character numerator.**

Byte-identical, including every case the issue flagged as risky: `m/d/yyyy`, `yyyy/mm/dd`, `dd/mm/yy`, `d/m/yyyy h:mm`, `[h]:mm:ss`, `h:mm AM/PM`, `mmm d, yyyy`, `yyyy-mm-dd`, `General`, `0`, `0.00`, `#,##0`, `#,##0.00`, `#,##0,`, `0.0%`, `0.00E+00`, `@`, `0.???`, the Special and accounting formats, `0" m/s"`, `#,##0.00" km/h"`, the escaped `0\/0`, and both multi-section forms including `# ?/?;-# ?/?`.

## Not verified against Excel

Stated here rather than assumed:

- `#/#` and `0/0` now render as fractions. Reasoned, not observed: `#`, `0` and `?` are all digit placeholders, and the old output (`/3`, `0/3`) was meaningless regardless.
- `0.0/0.0` moved from `2.500` to `2 1/2`. Excel rejects decimal-plus-fraction formats at entry, so no real file should carry one.
- `$?/?` loses its `$` — but `formatFraction` has always ignored literal text around the fraction (`$??/??` drops it today too). Pre-existing, worth its own issue.

## Where the issue was wrong

Both mine to own:

1. It expects `formatValue(2.5, "?/?")` → `" 5/ 2"`. That is the `"??/??"` output. Padding follows the format's width, so the one-character form pads to nothing: `"5/2"`.
2. It lists `formatValue(0.5, "0/2")` as broken. That one printed `"1/2"` — accidentally correct, because `formatNumber` happened to land on the same digits. The genuine breakage at that format is `2.5`, which printed `"3/2"` where the fraction path gives `"5/2"`.

## Tests

8 assertions appended to the #397 block in `test/coverage-number-format.test.ts`. Six fail against the unfixed code; the other two are deliberate guards — the #397 whole-part cases and the non-fraction formats — that must pass both before and after. No existing test changed or weakened; none asserted single-placeholder behaviour.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test`, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
