### PR TITLE
fix(xlsx): name background-image parts after the format they actually are

### DIFF
--- a/src/xlsx/background-image.ts
+++ b/src/xlsx/background-image.ts
@@ -1,0 +1,110 @@
+// ── Sheet background images ──────────────────────────────────────────
+// Shared by the authoring writer and the round-trip writer. They used to
+// hold one copy of this logic each, which is how they came to share one
+// bug: both hard-coded `.png` for every background image, so a JPEG was
+// stored at `xl/media/imageN.png` and declared `image/png`. See #427.
+
+import type { SheetImage } from "../_types"
+
+/** The formats hucre declares a content type for. Matches `SheetImage["type"]`. */
+type ImageFormat = SheetImage["type"]
+
+/**
+ * Identify an image from its leading bytes.
+ *
+ * A background image arrives as a bare `Uint8Array` — `Sheet.background
+ * Image` carries no type, and the reader discards the source extension —
+ * so the bytes are the only thing left to be faithful to. They are enough:
+ * every format below is self-describing in its first few bytes, which is
+ * also why adding a `type` field to the public shape would be API surface
+ * for something derivable, and would do nothing for the round-trip path.
+ *
+ * Falls back to `"png"` for anything unrecognised, which is what the code
+ * did unconditionally before — so an exotic format is no worse off than it
+ * already was.
+ */
+export function sniffImageFormat(data: Uint8Array): ImageFormat {
+  const b = data
+
+  // \x89 P N G \r \n \x1a \n
+  if (b.length >= 8 && b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    return "png"
+  }
+
+  // SOI marker, then any JFIF/Exif/raw variant.
+  if (b.length >= 3 && b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) return "jpeg"
+
+  // "GIF87a" / "GIF89a"
+  if (b.length >= 6 && b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46) return "gif"
+
+  // "RIFF" .... "WEBP" — the size field sits between them, so check both.
+  if (
+    b.length >= 12 &&
+    b[0] === 0x52 &&
+    b[1] === 0x49 &&
+    b[2] === 0x46 &&
+    b[3] === 0x46 &&
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50
+  ) {
+    return "webp"
+  }
+
+  // SVG is text, and may lead with an XML declaration, a doctype, a BOM
+  // or whitespace before the root element — so look for the tag rather
+  // than anchoring at byte 0. Bounded to the head: a long binary file
+  // must not be scanned end to end on the off-chance it spells "<svg".
+  if (isSvg(b)) return "svg"
+
+  return "png"
+}
+
+/** Bytes to inspect when sniffing SVG. Room for a declaration and a doctype. */
+const SVG_SNIFF_BYTES = 1024
+
+function isSvg(data: Uint8Array): boolean {
+  const head = data.subarray(0, SVG_SNIFF_BYTES)
+  // Latin-1 rather than UTF-8: the markers are ASCII, and decoding a
+  // truncated multi-byte sequence must not throw.
+  let text = ""
+  for (let i = 0; i < head.length; i++) text += String.fromCharCode(head[i]!)
+  const trimmed = text.trimStart().replace(/^﻿/, "")
+  if (!trimmed.startsWith("<")) return false
+  return /<svg[\s>]/i.test(trimmed)
+}
+
+/**
+ * Assign a media path to every sheet that has a background image, in the
+ * shared `xl/media/imageN` numbering.
+ *
+ * The counter is shared with drawing images on purpose: both land in
+ * `xl/media`, so numbering them independently would collide and one would
+ * overwrite the other.
+ *
+ * Returns one entry per sheet — `null` where the sheet has no background —
+ * plus the advanced counter, and records each extension used so the
+ * content types can declare it.
+ */
+export function assignBackgroundImagePaths(
+  sheets: ReadonlyArray<{ backgroundImage?: Uint8Array }>,
+  startIndex: number,
+  imageExtensions: Set<string>,
+): { paths: Array<string | null>; nextIndex: number } {
+  const paths: Array<string | null> = []
+  let index = startIndex
+
+  for (const sheet of sheets) {
+    if (!sheet.backgroundImage) {
+      paths.push(null)
+      continue
+    }
+    const ext = sniffImageFormat(sheet.backgroundImage)
+    paths.push(`xl/media/image${index}.${ext}`)
+    imageExtensions.add(ext)
+    index++
+  }
+
+  return { paths, nextIndex: index }
+}

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -36,6 +36,7 @@ import { cloneChart } from "./chart-clone"
 import { isOle2Container } from "../_input"
 import { EncryptedFileError, InvalidArgumentError } from "../errors"
 import { decryptAgile, encryptAgile } from "./crypto/agile"
+import { assignBackgroundImagePaths } from "./background-image"
 import { writeComments } from "./comments-writer"
 import type { CommentsResult } from "./comments-writer"
 import { writeTable } from "./table-writer"
@@ -330,18 +331,15 @@ export async function saveXlsx(
 
   // Background images live in xl/media alongside drawing images, so the
   // index has to come from the same counter — numbering them
-  // independently would collide. This mirrors writer.ts. See #367.
-  const backgroundImagePaths: Array<string | null> = []
-  for (const sheet of writeSheets) {
-    if (sheet.backgroundImage) {
-      const bgPath = `xl/media/image${globalImageIndex}.png`
-      backgroundImagePaths.push(bgPath)
-      imageExtensions.add("png")
-      globalImageIndex++
-    } else {
-      backgroundImagePaths.push(null)
-    }
-  }
+  // independently would collide. Shared with writer.ts rather than
+  // mirrored: two copies is how both ended up hard-coding .png for every
+  // image, whatever it was. See #367, #427.
+  const { paths: backgroundImagePaths, nextIndex: afterBackgrounds } = assignBackgroundImagePaths(
+    writeSheets,
+    globalImageIndex,
+    imageExtensions,
+  )
+  globalImageIndex = afterBackgrounds
 
   // Generate comments data for sheets that have comments
   const commentsResults: Array<CommentsResult | null> = []
@@ -1025,7 +1023,7 @@ export async function saveXlsx(
           xmlSelfClose("Relationship", {
             Id: result.pictureRId,
             Type: REL_IMAGE,
-            // "xl/media/imageN.png" → "../media/imageN.png"
+            // "xl/media/imageN.<ext>" → "../media/imageN.<ext>"
             Target: `../${bgMediaPath.slice(3)}`,
           }),
         )

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -19,6 +19,7 @@ import { createStylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer"
 import type { WorksheetResult } from "./worksheet-writer"
 import { unwrapCellValue } from "./hyperlink"
+import { assignBackgroundImagePaths } from "./background-image"
 import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
 import { writeChart } from "./chart-writer"
@@ -188,20 +189,14 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     }
   }
 
-  // Track background image paths per sheet (for picture relationships)
-  const backgroundImagePaths: Array<string | null> = []
-  for (let i = 0; i < sheets.length; i++) {
-    const sheet = sheets[i]
-    if (sheet.backgroundImage) {
-      // Background images are stored as PNG by default
-      const bgPath = `xl/media/image${globalImageIndex}.png`
-      backgroundImagePaths.push(bgPath)
-      imageExtensions.add("png")
-      globalImageIndex++
-    } else {
-      backgroundImagePaths.push(null)
-    }
-  }
+  // Track background image paths per sheet (for picture relationships).
+  // The format comes from the bytes, not from a guess — see #427.
+  const { paths: backgroundImagePaths, nextIndex: afterBackgrounds } = assignBackgroundImagePaths(
+    sheets,
+    globalImageIndex,
+    imageExtensions,
+  )
+  globalImageIndex = afterBackgrounds
 
   // Generate comments data for sheets that have comments
   const commentsResults: Array<CommentsResult | null> = []
@@ -454,7 +449,7 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
       // Background image (picture) relationship
       if (hasPicture && result.pictureRId && backgroundImagePaths[i]) {
         const bgMediaPath = backgroundImagePaths[i]!
-        const relTarget = `../${bgMediaPath.slice(3)}` // Remove "xl/" prefix → "../media/imageN.png"
+        const relTarget = `../${bgMediaPath.slice(3)}` // strip "xl/" → "../media/imageN.<ext>"
         relElements.push(
           xmlSelfClose("Relationship", {
             Id: result.pictureRId,

--- a/test/background-image-format.test.ts
+++ b/test/background-image-format.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { ZipReader } from "../src/zip/reader"
+import { sniffImageFormat } from "../src/xlsx/background-image"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #427 — a background image was written to xl/media/imageN.png and
+// declared image/png whatever it actually was, on both the authoring and
+// the round-trip path. Excel sniffs image bytes and renders it anyway,
+// which is why it went unnoticed; the package still declared a content
+// type that did not match the part it pointed at.
+//
+// `Sheet.backgroundImage` is a bare Uint8Array and the reader discards
+// the source extension, so the bytes are the only thing left to be
+// faithful to — hence sniffing rather than a new type field.
+// ═══════════════════════════════════════════════════════════════════════
+
+const PNG = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+])
+const JPEG = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+  0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+])
+const GIF = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00])
+const WEBP = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x20,
+])
+const SVG = new TextEncoder().encode(
+  '<?xml version="1.0"?>\n<svg xmlns="http://www.w3.org/2000/svg"/>',
+)
+
+const media = (zip: ZipReader): string[] => zip.entries().filter((e) => e.startsWith("xl/media/"))
+
+const defaults = async (zip: ZipReader): Promise<string> =>
+  new TextDecoder().decode(await zip.extract("[Content_Types].xml"))
+
+describe("sniffImageFormat", () => {
+  const cases: Array<[string, Uint8Array, string]> = [
+    ["PNG", PNG, "png"],
+    ["JPEG", JPEG, "jpeg"],
+    ["GIF", GIF, "gif"],
+    ["WebP", WEBP, "webp"],
+    ["SVG behind an XML declaration", SVG, "svg"],
+    ["SVG with no declaration", new TextEncoder().encode("<svg viewBox='0 0 1 1'/>"), "svg"],
+  ]
+
+  for (const [label, bytes, expected] of cases) {
+    it(`identifies ${label}`, () => {
+      expect(sniffImageFormat(bytes)).toBe(expected)
+    })
+  }
+
+  it("falls back to png for bytes it does not recognise", () => {
+    // The same thing the code did unconditionally before, so an exotic
+    // format is no worse off than it already was.
+    expect(sniffImageFormat(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]))).toBe("png")
+    expect(sniffImageFormat(new Uint8Array(0))).toBe("png")
+  })
+
+  it("does not mistake a binary file that merely contains '<svg' for SVG", () => {
+    const data = new Uint8Array(2048)
+    data.set(new TextEncoder().encode("<svg "), 1500)
+    expect(sniffImageFormat(data)).toBe("png")
+  })
+
+  it("does not read past the sniff window looking for it", () => {
+    // A 5 MB blob must not be scanned end to end on the off-chance.
+    const big = new Uint8Array(5 * 1024 * 1024)
+    big.set(JPEG, 0)
+    expect(sniffImageFormat(big)).toBe("jpeg")
+  })
+})
+
+describe("writeXlsx names the media part after the real format", () => {
+  const cases: Array<[string, Uint8Array, string, string]> = [
+    ["png", PNG, "xl/media/image1.png", "image/png"],
+    ["jpeg", JPEG, "xl/media/image1.jpeg", "image/jpeg"],
+    ["gif", GIF, "xl/media/image1.gif", "image/gif"],
+    ["webp", WEBP, "xl/media/image1.webp", "image/webp"],
+    ["svg", SVG, "xl/media/image1.svg", "image/svg+xml"],
+  ]
+
+  for (const [label, bytes, path, contentType] of cases) {
+    it(`stores a ${label} background as ${path}`, async () => {
+      const buf = await writeXlsx({
+        sheets: [{ name: "S", rows: [["a"]], backgroundImage: bytes }],
+      })
+      const zip = new ZipReader(buf)
+      expect(media(zip)).toEqual([path])
+      expect(await defaults(zip)).toContain(`ContentType="${contentType}"`)
+      expect([...(await zip.extract(path))]).toEqual([...bytes])
+    })
+  }
+
+  it("points the picture relationship at the part it wrote", async () => {
+    const buf = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]], backgroundImage: JPEG }],
+    })
+    const zip = new ZipReader(buf)
+    const rels = new TextDecoder().decode(await zip.extract("xl/worksheets/_rels/sheet1.xml.rels"))
+    expect(rels).toContain("../media/image1.jpeg")
+    expect(rels).not.toContain(".png")
+  })
+})
+
+describe("saveXlsx keeps the format across a round trip", () => {
+  it("does not turn a JPEG into a part named .png", async () => {
+    const original = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]], backgroundImage: JPEG }],
+    })
+    const saved = await saveXlsx(await openXlsx(original))
+    const zip = new ZipReader(saved)
+
+    expect(media(zip)).toEqual(["xl/media/image1.jpeg"])
+    expect(await defaults(zip)).toContain('ContentType="image/jpeg"')
+
+    const back = await readXlsx(saved)
+    expect([...(back.sheets[0].backgroundImage ?? [])]).toEqual([...JPEG])
+  })
+
+  it("keeps two sheets' backgrounds apart when their formats differ", async () => {
+    const original = await writeXlsx({
+      sheets: [
+        { name: "One", rows: [["a"]], backgroundImage: PNG },
+        { name: "Two", rows: [["b"]], backgroundImage: GIF },
+      ],
+    })
+    const saved = await saveXlsx(await openXlsx(original))
+    const zip = new ZipReader(saved)
+
+    expect(media(zip).sort()).toEqual(["xl/media/image1.png", "xl/media/image2.gif"].sort())
+    const ct = await defaults(zip)
+    expect(ct).toContain('ContentType="image/png"')
+    expect(ct).toContain('ContentType="image/gif"')
+
+    const back = await readXlsx(saved)
+    expect([...(back.sheets[0].backgroundImage ?? [])]).toEqual([...PNG])
+    expect([...(back.sheets[1].backgroundImage ?? [])]).toEqual([...GIF])
+  })
+
+  it("still shares the media counter with drawing images", async () => {
+    // Both land in xl/media, so numbering them independently would
+    // collide and one would overwrite the other.
+    const original = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          images: [{ data: PNG, type: "png", anchor: { from: { row: 0, col: 0 } } }],
+          backgroundImage: JPEG,
+        },
+      ],
+    })
+    const saved = await saveXlsx(await openXlsx(original))
+    expect(new Set(media(new ZipReader(saved))).size).toBe(2)
+  })
+})


### PR DESCRIPTION
A background image was written to xl/media/imageN.png and declared
image/png whatever it actually was. Verified with a real JPEG:

  writeXlsx media parts : [ 'xl/media/image1.png' ]
  content-type defaults : <Default Extension="png" ContentType="image/png"/>
  bytes at image1.png   : magic = 0xff 0xd8 0xff   (JPEG)
  saveXlsx media parts  : [ 'xl/media/image1.png' ]

So the OPC package declared a content type that did not match the part it
pointed at. Excel sniffs image bytes and renders it anyway, which is why
nobody noticed — but it is a spec violation, a validator flags it, and a
workbook that came out of Excel with a JPEG background came back from
hucre mislabelled.

Sniffing the format from the bytes rather than adding a `type` field to
match SheetImage. Sheet.backgroundImage is a bare Uint8Array and the
reader discards the source extension, so by the time the writer runs the
bytes are the only thing left to be faithful to — a type field would be
public API surface for something derivable, and would do nothing for the
round-trip path, which never had a type to carry. Unrecognised bytes
still fall back to png, so an exotic format is no worse off than before.

The sniffer returns SheetImage["type"], which is exactly the set the
content-type map declares, so the two cannot drift apart.

writeXlsx and saveXlsx had one copy each of the media-path loop, which is
how they came to share one bug — they now share one helper instead.

Found while reviewing PR #375 against what landed in #380. The two
implementations agree with each other, including on this.

SVG is the one that needed care: it is text, so it has no magic number.
The check looks for the root tag within a bounded head rather than
anchoring at byte 0 (a declaration, doctype, BOM or whitespace can come
first) and refuses to scan a large binary end to end on the chance it
spells "<svg" somewhere — there is a test for each half of that.

7 of the 18 new tests fail against the unfixed code.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,633 tests.

Closes #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD