### PR TITLE
fix(format): keep literal text in fraction formats, and stop reading a literal as one

### DIFF
--- a/src/_format.ts
+++ b/src/_format.ts
@@ -426,11 +426,31 @@ function formatFraction(value: number, fmt: string): string {
     return String(value)
   }
 
+  const fracAt = fracMatch.index ?? 0
+
+  // Everything outside the numerator/denominator group is literal text, and
+  // it is read with the machinery the plain number path already uses, so a
+  // quoted run, a "\$" escape and a bare "$" mean here exactly what they mean
+  // under "0.00". Building the output from the digits alone dropped all of it
+  // — "$?/?" rendered as "5/2", and worse, the "-" of a negative section
+  // ("# ?/?;-# ?/?") vanished with it, since that section is handed the
+  // absolute value and the sign lives only in the format. See #426.
+  //
+  // Literals sit *outside* the "?" padding, which belongs to the fraction
+  // rather than to the field: 2.5 under "$??/??" is "$ 5/ 2", not " $5/ 2".
+  // The prefix leads the whole part and the suffix trails the denominator.
+  // The prefix also leads the sign, matching formatNumber's "$-1,234.50".
+  const head = extractLiterals(fmt.slice(0, fracAt))
+  // The tail is all literal: nothing after the denominator has a number to
+  // render, so expandLiterals — quotes and escapes to text — is the whole job.
+  const tail = expandLiterals(fmt.slice(fracAt + fracMatch[0].length))
+
   // A whole part is only rendered when the format has a placeholder in front
   // of the fraction — "?" counts just as much as "#" and "0" ("? ?/?" is a
-  // mixed number, "??/??" is improper.)
-  const wholeFmt = fmt.slice(0, fracMatch.index)
-  const hasIntPart = /[#0?]/.test(wholeFmt)
+  // mixed number, "??/??" is improper). Reading it off `head.core` rather
+  // than the raw text keeps a placeholder character that is only literal
+  // ('"#"?/?') from being mistaken for an integer slot.
+  const hasIntPart = /[#0?]/.test(head.core)
 
   const intPart = Math.trunc(value)
   // With no whole-part placeholder there is nowhere to put the integer, so
@@ -470,25 +490,30 @@ function formatFraction(value: number, fmt: string): string {
   // halves). Excel prints the whole part rather than a zero numerator —
   // "3 0/2" is not something it ever renders. See #397.
   if (bestNum === 0) {
-    // Show integer only for whole numbers
-    const showInt = fmt.includes("#") || /^[0?]/.test(fmt.trim())
-    if (showInt && intPart !== 0) {
-      return String(intPart)
+    // Whether there is an integer slot is the same question `hasIntPart`
+    // already answered; asking it a second time off the raw format text is
+    // how the two answers drift apart (a "$" prefix defeated the old test).
+    // The blanked fraction area stays between the number and the suffix.
+    if (hasIntPart && intPart !== 0) {
+      return head.prefix + String(intPart) + tail
     }
-    return String(intPart) + "      " // padded like Excel
+    return head.prefix + String(intPart) + "      " + tail // padded like Excel
   }
 
   // Build the formatted string.
   // The sign has to come from the value: Math.trunc(-0.5) is -0, which is
   // neither `!== 0` nor `< 0`, so the sign would be lost for -1 < value < 0.
-  const sign = value < 0 ? "-" : ""
-  const whole = hasIntPart && intPart !== 0 ? String(Math.abs(intPart)) + " " : ""
-  const prefix = sign + whole
+  // A format that writes its own "-" is left to it, as formatNumber does.
+  const sign = value < 0 && !head.prefix.includes("-") ? "-" : ""
+  // What separates the whole part from the numerator is whatever the format
+  // put there — the space in "# ?/?" is literal text, not punctuation the
+  // formatter owns.
+  const whole = hasIntPart && intPart !== 0 ? String(Math.abs(intPart)) + head.suffix : ""
 
   const numStr = String(bestNum).padStart(fracMatch[1].length, " ")
   const denStr = String(bestDen).padStart(fracMatch[2].length, " ")
 
-  return prefix + numStr + "/" + denStr
+  return head.prefix + sign + whole + numStr + "/" + denStr + tail
 }
 
 function findBestFraction(value: number, maxDen: number): { num: number; den: number } {

--- a/src/_format.ts
+++ b/src/_format.ts
@@ -416,12 +416,66 @@ function isFractionFormat(fmt: string): boolean {
   // disagreeing about what a fraction is. Nothing else is dragged in: dates
   // are claimed before this is reached and put no placeholder against their
   // slashes, and an escaped slash ("0\/0") still carries its backslash.
-  return FRACTION_PARTS.test(fmt)
+  return FRACTION_PARTS.test(maskLiterals(fmt))
 }
 
+/**
+ * Blank out quoted runs and escaped characters, keeping the string the
+ * same length so an index into the result still points at the original.
+ *
+ * Fraction detection scans for placeholders around a slash, and a literal
+ * can contain both: `0.00" 0/2"` was read as a fraction spec and rendered
+ * `"3 1/2"` instead of `"3.50 0/2"`. See #429 — a regression from #402,
+ * where unifying detection with the parse regex inherited the parse
+ * regex's blind spot. The old pattern excluded this case by accident,
+ * through the same quirk that made `"?/?"` unrecognisable.
+ *
+ * This shares its definition of "literal" with {@link extractLiterals} —
+ * a quoted run, or a backslash and the character after it. A test pins
+ * the two in agreement, because two implementations of one concept is
+ * what caused #429 in the first place.
+ */
+function maskLiterals(fmt: string): string {
+  let out = ""
+  let i = 0
+
+  while (i < fmt.length) {
+    const ch = fmt[i]
+
+    if (ch === '"') {
+      const close = fmt.indexOf('"', i + 1)
+      // An unterminated quote runs to the end, matching extractLiterals,
+      // which consumes to the end rather than treating the quote as data.
+      const end = close === -1 ? fmt.length : close + 1
+      out += MASK.repeat(end - i)
+      i = end
+      continue
+    }
+
+    if (ch === "\\") {
+      // The backslash and whatever it escapes, even at the very end.
+      const span = i + 1 < fmt.length ? 2 : 1
+      out += MASK.repeat(span)
+      i += span
+      continue
+    }
+
+    out += ch
+    i++
+  }
+
+  return out
+}
+
+/** Stands in for a literal character: never a placeholder, never a slash. */
+const MASK = "\u0001"
+
 function formatFraction(value: number, fmt: string): string {
-  // Determine denominator precision from format
-  const fracMatch = fmt.match(FRACTION_PARTS)
+  // Determine denominator precision from format. Matched against the
+  // masked form so a slash inside a literal cannot be mistaken for the
+  // fraction bar; the mask preserves length, so the index and the
+  // placeholder groups still describe the real format. See #429.
+  const fracMatch = maskLiterals(fmt).match(FRACTION_PARTS)
   if (!fracMatch) {
     return String(value)
   }

--- a/test/coverage-number-format.test.ts
+++ b/test/coverage-number-format.test.ts
@@ -527,6 +527,67 @@ describe("formatValue — Excel parity", () => {
     expect(formatValue(0.5, "0%")).toBe("50%")
   })
 
+  // ── #426 ──────────────────────────────────────────────────────────
+  //
+  // The fraction path built its output from the digits alone, so literal
+  // text was dropped where every other path keeps it — "$?/?" rendered as
+  // "5/2". Literals are read with the same `extractLiterals` the plain
+  // number path uses, so a bare "$", a quoted run and a "\$" escape mean
+  // the same thing under a fraction as under "0.00".
+  it("keeps literal text around a fraction", () => {
+    expect(formatValue(2.5, "$?/?")).toBe("$5/2")
+    expect(formatValue(2.5, '"USD "?/?')).toBe("USD 5/2")
+    expect(formatValue(2.5, '?/?" kg"')).toBe("5/2 kg")
+    expect(formatValue(2.5, "\\$# ?/?")).toBe("$2 1/2")
+    expect(formatValue(2.5, "# ?/?\\!")).toBe("2 1/2!")
+  })
+
+  // The padding belongs to the fraction, not to the field, so a prefix
+  // lands outside it: "$ 5/ 2", never " $5/ 2".
+  it("puts a literal prefix outside the placeholder padding", () => {
+    expect(formatValue(2.5, "$??/??")).toBe("$ 5/ 2")
+    expect(formatValue(2.5, '# ??/??" in"')).toBe("2  1/ 2 in")
+  })
+
+  // The prefix leads the sign, as it does for "$#,##0.00" — the two paths
+  // agree on where the minus goes.
+  it("writes a literal prefix ahead of the sign", () => {
+    expect(formatValue(-2.5, "$# ?/?")).toBe("$-2 1/2")
+    expect(formatValue(-2.5, "$#,##0.00")).toBe("$-2.50")
+  })
+
+  // Whole numbers and zero take an earlier exit out of the formatter; the
+  // literals have to survive that route too.
+  it("keeps literals on the paths that print no fraction", () => {
+    expect(formatValue(3, "$# ?/?")).toBe("$3")
+    expect(formatValue(3.1, "$# ?/2")).toBe("$3")
+    expect(formatValue(0, "$# ?/?")).toBe("$0      ")
+  })
+
+  // A negative section is handed the absolute value, so its "-" is literal
+  // text in the format — dropping literals dropped the sign with them, and
+  // -2.5 read back as positive.
+  it("keeps the sign a negative fraction section writes for itself", () => {
+    expect(formatValue(-2.5, "# ?/?;-# ?/?")).toBe("-2 1/2")
+    expect(formatValue(-2.5, "$# ?/?;($# ?/?)")).toBe("($2 1/2)")
+  })
+
+  // Sections are split before any of this, so one section's literals cannot
+  // reach another's output.
+  it("keeps each section's literals to itself", () => {
+    expect(formatValue(2.5, '"a"# ?/?;"b"# ?/?')).toBe("a2 1/2")
+    expect(formatValue(-2.5, '"a"# ?/?;"b"# ?/?')).toBe("b2 1/2")
+  })
+
+  // What separates the whole part from the numerator is the format's own
+  // literal text — the space in "# ?/?" is not punctuation the formatter
+  // owns, and a quoted placeholder character is text rather than an
+  // integer slot, so '"#"?/?' is an improper fraction.
+  it("takes the whole-part separator from the format", () => {
+    expect(formatValue(2.5, '#" and "?/?')).toBe("2 and 1/2")
+    expect(formatValue(2.5, '"#"?/?')).toBe("#5/2")
+  })
+
   // "?" renders insignificant decimals as spaces so decimal points line up
   // down a column, where "0" would render them as zeros.
   it("pads insignificant decimals with spaces for a ? placeholder", () => {

--- a/test/coverage-number-format.test.ts
+++ b/test/coverage-number-format.test.ts
@@ -588,6 +588,65 @@ describe("formatValue — Excel parity", () => {
     expect(formatValue(2.5, '"#"?/?')).toBe("#5/2")
   })
 
+  // ── #429 ──────────────────────────────────────────────────────────
+  //
+  // Detection scanned the raw format for placeholders around a slash, so a
+  // *literal* containing both was read as a fraction spec and the whole
+  // format was reinterpreted. A regression from #402: unifying detection
+  // with the parse regex inherited the parse regex's blind spot, where the
+  // old pattern had excluded this case by accident.
+
+  it("does not read a quoted literal as a fraction spec", () => {
+    expect(formatValue(3.5, '0.00" 0/2"')).toBe("3.50 0/2")
+    expect(formatValue(3.5, '#,##0.00" 0/2"')).toBe("3.50 0/2")
+  })
+
+  it("does not read an escaped slash as a fraction bar", () => {
+    expect(formatValue(3.5, "0.00\\/2")).toBe("3.50/2")
+  })
+
+  it("still leaves the formats that never tripped it alone", () => {
+    // "1" is not a placeholder, so these were unaffected either way —
+    // pinned so the mask cannot start eating them.
+    expect(formatValue(3.5, '0.00" 1/2"')).toBe("3.50 1/2")
+    expect(formatValue(3.5, '0" m/s"')).toBe("4 m/s")
+    expect(formatValue(3.5, '#,##0.00" km/h"')).toBe("3.50 km/h")
+  })
+
+  it("still recognises a real fraction that also carries literals", () => {
+    // The mask must not blind detection to the fraction itself.
+    expect(formatValue(2.5, '?/?" kg"')).toBe("5/2 kg")
+    expect(formatValue(2.5, '"about "# ?/?')).toBe("about 2 1/2")
+  })
+
+  // maskLiterals and extractLiterals are both private, so their agreement
+  // is checked through behaviour: each literal shape has to mean the same
+  // thing under a number format and under a fraction format. Two
+  // implementations of one concept is what produced #429.
+  it("means the same thing by 'literal' on both paths", () => {
+    const shapes: Array<[string, string, string]> = [
+      // literal, number format, fraction format
+      ['"x"', '"x"0.00', '"x"# ?/?'],
+      ["\\x", "\\x0.00", "\\x# ?/?"],
+      ['" 0/2"', '0.00" 0/2"', '# ?/?" 0/2"'],
+    ]
+    for (const [, numFmt, fracFmt] of shapes) {
+      const asNumber = formatValue(2.5, numFmt)
+      const asFraction = formatValue(2.5, fracFmt)
+      // Same leading literal, same trailing literal — only the middle,
+      // which is the actual number, differs.
+      expect(asNumber.startsWith("x") ? asFraction.startsWith("x") : true).toBe(true)
+      expect(asNumber.endsWith(" 0/2") ? asFraction.endsWith(" 0/2") : true).toBe(true)
+    }
+  })
+
+  it("survives an unterminated quote without swallowing the fraction", () => {
+    // extractLiterals consumes an unterminated quote to the end of the
+    // format; the mask has to agree, or the two disagree about where the
+    // literal stops.
+    expect(formatValue(2.5, '# ?/?"trailing')).toBe("2 1/2trailing")
+  })
+
   // "?" renders insignificant decimals as spaces so decimal points line up
   // down a column, where "0" would render them as zeros.
   it("pads insignificant decimals with spaces for a ? placeholder", () => {


### PR DESCRIPTION
Closes #426. Closes #429.

Two changes to `formatFraction`, in one PR because the second is a regression the first uncovered and both live in the same function.

## #426 — literals were dropped

Reproduced against unmodified main:

```
"$?/?"           2.5   =>  "5/2"
"$??/??"         2.5   =>  " 5/ 2"
'?/?" kg"'       2.5   =>  "5/2"
"# ?/?;-# ?/?"  -2.5   =>  "2 1/2"      <- sign lost
```

The fraction path built its output from the numerator, denominator and whole part alone, so any literal text in the format was discarded — while every other path in `_format.ts` carries literals through (`0" m/s"`, `#,##0.00" km/h"` both keep theirs, with tests).

**The last line was not in the issue and is the worst of them.** A negative section is handed the absolute value, so the `-` in `"# ?/?;-# ?/?"` *is* literal text. Dropping literals dropped the sign, and −2.5 rendered as positive.

The fix reuses the existing machinery rather than adding a third literal parser: the format head (everything before the numerator, located by the `FRACTION_PARTS` match index) goes through `extractLiterals` — the same call `formatNumber` makes — and the tail through `expandLiterals`. `extractLiterals` could not simply be run over the whole format: it treats digits 1–9 as literal text, so `"# ??/16"` loses its fixed denominator into the suffix. Splitting at the fraction match avoids that.

Placement, stated in a comment because it is not derivable from the code: literals sit **outside** the `?` padding — `$??/??` of 2.5 is `"$ 5/ 2"`, not `" $5/ 2"`. The prefix leads the whole part and the sign, matching `formatNumber`'s existing `"$-1,234.50"`.

Two follow-ons fell out. Whole-part detection now reads `head.core` rather than the raw text, so a quoted placeholder (`'"#"?/?'`) is not mistaken for an integer slot. And the zero-numerator branch reuses that same `hasIntPart` instead of its own differently-worded test (`fmt.includes("#") || /^[0?]/.test(fmt.trim())`), which a `$` prefix defeated — a second copy of one concept, which is the #402 trap again.

## #429 — a regression I introduced in #402

Recorded plainly, because the fix needs to know where it came from.

#402 changed `isFractionFormat` to reuse `FRACTION_PARTS` instead of keeping its own copy. That was right for the bug it fixed — the two had drifted, so `"?/?"` was unrecognisable and rendered `" /3"`. But the patterns were not equivalent in one respect:

| format | old detection | new detection |
| --- | --- | --- |
| `0.00" 0/2"` | `false` | **`true`** |
| `0.00" 1/2"` | `false` | `false` |
| `0" m/s"` | `false` | `false` |

The old pattern required a placeholder *before* the numerator run, which excluded a placeholder-and-slash inside a quoted literal **by accident** — the same accident that made `"?/?"` unrecognisable. Unifying them inherited the parse regex's blind spot:

```
formatValue(3.5, '0.00" 0/2"')  ->  "3 1/2"     expected  "3.50 0/2"
```

The whole format is reinterpreted: the numeric part is discarded and the literal text used as the spec.

Detection now runs against a masked copy with quoted runs and escapes blanked. The mask preserves length, so the match index and the placeholder groups still describe the real format and nothing downstream changes. `maskLiterals` sits beside `extractLiterals` and shares its definition of a literal, including an unterminated quote running to the end; both are private, so a test checks their agreement through behaviour — each literal shape must mean the same thing under a number format and under a fraction format.

**Only one of the five new #429 assertions fails without the mask.** The window is narrow — `"1"` is not a placeholder, so `" 1/2"` was never affected — but the failure is silent and total rather than partial, and `0.00" 0/2"` is a format someone would plausibly write.

## Regression checking

A 72-format × 20-value before/after matrix for #426. **Only literal-bearing fraction formats moved.** Confirmed unchanged: `0`, `0.00`, `#,##0.00`, `#,##0.00;-#,##0.00`, `#,##0.00_);(#,##0.00)`, `0" m/s"`, `#,##0.00" km/h"`, `"USD "0.00`, `\$0.00`, `0.00\!`, `"N/A"`, `@`, `0%`, `0.00E+00`, `$#,##0.00`, `000-00-0000`, `(000) 000-0000`, `0.???`, `#,##0,,`, `[Red]#,##0.00`, `[$$-409]#,##0.00`, `[>100]0.00;0`, `m/d/yyyy`, `d/m/yy h:mm`, `[h]:mm:ss`, `0\/0`, plus every literal-free fraction format including all of #397's and #402's cases.

Multi-section: `'"a"# ?/?;"b"# ?/?'` gives `a2 1/2` / `b2 1/2` — no leak between sections.

## Not verified against Excel

- Where a prefix sits relative to the minus sign for a negative fraction (`$-2 1/2` versus `-$2 1/2`). MS docs confirm literals render in fraction formats but are silent on ordering; `formatNumber`'s existing convention was followed.
- Where a suffix sits relative to the six spaces that blank the fraction area of a whole number. That padding is a pre-existing approximation; the suffix was placed after it.

No existing test changed — none encoded either defect, and the whole suite passed against the #426 fix before any assertion was added.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test` — 9,646 tests, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
