### PR TITLE
fix(xlsx): put cm on the cell and write the metadata part it points at

### DIFF
--- a/src/xlsx/content-types-writer.ts
+++ b/src/xlsx/content-types-writer.ts
@@ -2,6 +2,7 @@
 // Generates [Content_Types].xml for an XLSX package.
 
 import { xmlDocument, xmlSelfClose } from "../xml/writer"
+import { METADATA_CONTENT_TYPE, METADATA_PART_PATH } from "./metadata"
 
 const NS_CONTENT_TYPES = "http://schemas.openxmlformats.org/package/2006/content-types"
 
@@ -137,6 +138,8 @@ export interface ContentTypesOptions {
   hasMacros?: boolean
   /** Whether Excel 2024 checkbox FeaturePropertyBag is present. */
   hasFeaturePropertyBag?: boolean
+  /** Whether `xl/metadata.xml` (dynamic-array cell metadata) is present. */
+  hasMetadata?: boolean
 }
 
 /** Generate [Content_Types].xml for XLSX */
@@ -423,6 +426,16 @@ export function writeContentTypes(
         }),
       )
     }
+  }
+
+  // Override for the cell-metadata part (dynamic arrays)
+  if (opts.hasMetadata) {
+    children.push(
+      xmlSelfClose("Override", {
+        PartName: `/${METADATA_PART_PATH}`,
+        ContentType: METADATA_CONTENT_TYPE,
+      }),
+    )
   }
 
   // Override for FeaturePropertyBag (Excel 2024 checkboxes)

--- a/src/xlsx/metadata.ts
+++ b/src/xlsx/metadata.ts
@@ -1,0 +1,206 @@
+// ── Cell Metadata (dynamic arrays) ───────────────────────────────────
+// xl/metadata.xml is the part the `cm` attribute on `<c>` indexes into.
+// Without it a `cm` points at nothing, which is what hucre shipped
+// before #423 (and it wrote `cm` on `<f>`, where the schema has no such
+// attribute at all).
+//
+// Spec trail, since none of this is guessable from the schema alone:
+//
+//   • ISO/IEC 29500-1 §18.9 (Metadata) defines the part — `metadata`,
+//     `metadataTypes` / `metadataType` (§18.9.10), `futureMetadata`
+//     (§18.9.4), `cellMetadata`, `bk` (metadata block) and `rc`
+//     (metadata record: @t selects the metadata type, @v the block
+//     inside that type's futureMetadata).
+//   • ISO/IEC 29500-1 §18.3.1.4 (c) calls @cm "a zero-based index" and
+//     names no collection. [MS-OI29500] §18.3.1.4 note (a) corrects
+//     both halves for Office: "Office specifies that @cm is a one-based
+//     index into the cellMetadata collection in the metadata part."
+//     hucre writes and reads what Office does, not what the base
+//     standard's prose says.
+//   • The dynamic-array payload is a Microsoft extension on top:
+//     [MS-XLSX] "Metadata" pairs futureMetadata @name="XLDAPR" with the
+//     ext @uri {BDBB8CDC-FA1E-496E-A857-3C3F30C029C3} carrying
+//     `<xda:dynamicArrayProperties>`.
+//
+// The concrete attribute set on `<metadataType>` below is not derivable
+// from the spec — it is behavioural policy Excel writes verbatim — so it
+// is copied from XlsxWriter's `metadata.py`, a producer whose output
+// Excel is known to accept. It is *not* verified against an Excel-made
+// file here: this repo ships no XLSX fixtures to compare against.
+
+import { parseXml } from "../xml/parser"
+import type { XmlElement } from "../xml/parser"
+import { xmlDocument, xmlElement, xmlSelfClose } from "../xml/writer"
+
+const NS_SPREADSHEET = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+/** Microsoft dynamic-array namespace, introduced with Excel 365 spilling. */
+const NS_XDA = "http://schemas.microsoft.com/office/spreadsheetml/2017/dynamicarray"
+
+/** Metadata type name Excel reserves for dynamic-array properties. */
+export const XLDAPR = "XLDAPR"
+
+/** ext URI that carries `<xda:dynamicArrayProperties>` ([MS-XLSX] Metadata). */
+export const XLDAPR_EXT_URI = "{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}"
+
+/** Path of the part inside the XLSX archive. */
+export const METADATA_PART_PATH = "xl/metadata.xml"
+
+/** Content type for the Override in [Content_Types].xml. */
+export const METADATA_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml"
+
+/** Workbook relationship type for the part. */
+export const METADATA_REL_TYPE =
+  "http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata"
+
+/**
+ * The `cm` value hucre puts on every dynamic-array cell. One-based, and
+ * hucre only ever emits one cellMetadata block, so it is always 1.
+ */
+export const DYNAMIC_ARRAY_CM = 1
+
+/**
+ * Emit the fixed metadata part that backs `cm="1"`.
+ *
+ * The shape is the same for every workbook regardless of how many cells
+ * spill: all of them share the single "this is a dynamic array" record,
+ * exactly as Excel and XlsxWriter do. `minSupportedVersion="120000"` is
+ * the value Office requires for its own metadata types ([MS-OI29500]
+ * §18.9.10 states the requirement for XLMDX; XLDAPR is written with the
+ * same value by every producer we could inspect).
+ */
+export function writeMetadataXml(): string {
+  const metadataType = xmlSelfClose("metadataType", {
+    name: XLDAPR,
+    minSupportedVersion: 120000,
+    copy: 1,
+    pasteAll: 1,
+    pasteValues: 1,
+    merge: 1,
+    splitFirst: 1,
+    rowColShift: 1,
+    clearFormats: 1,
+    clearComments: 1,
+    assign: 1,
+    coerce: 1,
+    cellMeta: 1,
+  })
+
+  // futureMetadata block 0 for XLDAPR: the properties `rc/@v` points at.
+  const futureBlock = xmlElement("bk", undefined, [
+    xmlElement("extLst", undefined, [
+      xmlElement("ext", { uri: XLDAPR_EXT_URI }, [
+        xmlSelfClose("xda:dynamicArrayProperties", { fDynamic: 1, fCollapsed: 0 }),
+      ]),
+    ]),
+  ])
+
+  // cellMetadata block 1 (one-based, per [MS-OI29500] §18.3.1.4): type 1
+  // is the XLDAPR entry declared above, value 0 its futureMetadata block.
+  const cellBlock = xmlElement("bk", undefined, [xmlSelfClose("rc", { t: 1, v: 0 })])
+
+  return xmlDocument("metadata", { xmlns: NS_SPREADSHEET, "xmlns:xda": NS_XDA }, [
+    xmlElement("metadataTypes", { count: 1 }, [metadataType]),
+    xmlElement("futureMetadata", { name: XLDAPR, count: 1 }, [futureBlock]),
+    xmlElement("cellMetadata", { count: 1 }, [cellBlock]),
+  ])
+}
+
+/**
+ * Resolve which `cm` indexes in this package mean "dynamic array".
+ *
+ * Returns the set of one-based cellMetadata indexes whose record
+ * resolves, through `rc/@t` → metadataType and `rc/@v` → futureMetadata
+ * block, to an XLDAPR entry. A `cm` outside the set points at some other
+ * kind of cell metadata and says nothing about spilling.
+ */
+export function parseDynamicArrayCellMetadata(xml: string): Set<number> {
+  const dynamic = new Set<number>()
+  const root = parseXml(xml)
+  const meta = root.local === "metadata" ? root : findChild(root, "metadata")
+  if (!meta) return dynamic
+
+  // `rc/@t` is a one-based index into the metadataTypes collection.
+  const typeNames: string[] = []
+  const types = findChild(meta, "metadataTypes")
+  if (types) {
+    for (const type of childElements(types)) {
+      if (type.local === "metadataType") typeNames.push(type.attrs["name"] ?? "")
+    }
+  }
+
+  // `rc/@v` is a zero-based index into the futureMetadata blocks of the
+  // record's own type. Excel writes fDynamic="0" for an array formula
+  // that is *not* spilling, so the block has the final say.
+  const blocksByType = new Map<string, boolean[]>()
+  for (const future of childElements(meta)) {
+    if (future.local !== "futureMetadata") continue
+    const name = future.attrs["name"] ?? ""
+    const blocks = blocksByType.get(name) ?? []
+    for (const bk of childElements(future)) {
+      if (bk.local === "bk") blocks.push(blockIsDynamicArray(bk))
+    }
+    blocksByType.set(name, blocks)
+  }
+
+  const cellMetadata = findChild(meta, "cellMetadata")
+  if (!cellMetadata) return dynamic
+
+  let index = 0
+  for (const bk of childElements(cellMetadata)) {
+    if (bk.local !== "bk") continue
+    index++ // one-based
+    for (const rc of childElements(bk)) {
+      if (rc.local !== "rc") continue
+      if (typeNames[parseIntOr(rc.attrs["t"], 0) - 1] !== XLDAPR) continue
+      const blocks = blocksByType.get(XLDAPR)
+      const v = parseIntOr(rc.attrs["v"], -1)
+      // With no futureMetadata block to consult, the type name is all we
+      // have — and XLDAPR exists for exactly one purpose.
+      if (!blocks || v < 0 || v >= blocks.length || blocks[v]) dynamic.add(index)
+    }
+  }
+
+  return dynamic
+}
+
+/** Whether a futureMetadata `<bk>` carries dynamic-array properties. */
+function blockIsDynamicArray(bk: XmlElement): boolean {
+  for (const extLst of childElements(bk)) {
+    if (extLst.local !== "extLst") continue
+    for (const ext of childElements(extLst)) {
+      if (ext.local !== "ext") continue
+      // GUIDs are case-insensitive; [MS-XLSX] prints this one uppercase,
+      // Excel and XlsxWriter both write it lowercase.
+      if ((ext.attrs["uri"] ?? "").toLowerCase() !== XLDAPR_EXT_URI) continue
+      for (const props of childElements(ext)) {
+        if (props.local !== "dynamicArrayProperties") continue
+        const fDynamic = props.attrs["fDynamic"]
+        return fDynamic !== "0" && fDynamic !== "false"
+      }
+    }
+  }
+  // No extension at all: the block asserts nothing, so defer to the type.
+  return true
+}
+
+function childElements(el: XmlElement): XmlElement[] {
+  const out: XmlElement[] = []
+  for (const child of el.children) {
+    if (typeof child !== "string") out.push(child)
+  }
+  return out
+}
+
+function findChild(el: XmlElement, localName: string): XmlElement | undefined {
+  for (const child of el.children) {
+    if (typeof child !== "string" && child.local === localName) return child
+  }
+  return undefined
+}
+
+function parseIntOr(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) return fallback
+  const n = parseInt(raw, 10)
+  return Number.isNaN(n) ? fallback : n
+}

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -36,6 +36,7 @@ import { parseRelationships } from "./relationships"
 import { parseSharedStrings } from "./shared-strings"
 import { parseStyles } from "./styles"
 import { parseWorksheet } from "./worksheet"
+import { parseDynamicArrayCellMetadata } from "./metadata"
 import type { ParsedStyles } from "./styles"
 import type { SharedString } from "./shared-strings"
 import type { Relationship } from "./relationships"
@@ -345,6 +346,19 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     if (cache) timelineCaches.push(cache)
   }
 
+  // 7i. Parse cell metadata (xl/metadata.xml). Cells point into its
+  // cellMetadata collection with `cm`; for hucre the only records that
+  // matter are the dynamic-array (XLDAPR) ones. Resolved once for the
+  // whole package because the part is workbook-level.
+  let dynamicArrayCm: Set<number> | undefined
+  const metadataRel = workbookRels.find((r) => matchesRelType(r.type, "sheetMetadata"))
+  if (metadataRel) {
+    const metadataPath = resolvePath(workbookDir, metadataRel.target)
+    if (zip.has(metadataPath)) {
+      dynamicArrayCm = parseDynamicArrayCellMetadata(decodeUtf8(await zip.extract(metadataPath)))
+    }
+  }
+
   // 8. Build a map of rId → sheet relationship for worksheet paths
   const sheetRelMap = new Map<string, string>()
   for (const rel of workbookRels) {
@@ -387,6 +401,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       worksheetRels,
       maxRows: options?.maxRows,
       range: options?.range,
+      dynamicArrayCm,
     }
 
     const wsXml = decodeUtf8(await zip.extract(wsPath))

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -28,6 +28,7 @@ import { parseRelationships } from "./relationships"
 import { createStylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer"
 import { writeFeaturePropertyBagXml } from "./feature-property-bag"
+import { METADATA_PART_PATH, writeMetadataXml } from "./metadata"
 import type { WorksheetResult } from "./worksheet-writer"
 import { writeDrawing } from "./drawing-writer"
 import type { DrawingResult } from "./drawing-writer"
@@ -300,6 +301,12 @@ export async function saveXlsx(
   }
 
   const hasSharedStrings = sharedStrings.count() > 0
+  // Any cell written with `cm` needs xl/metadata.xml alongside it. When
+  // the opened package already carried one we drop those bytes and emit
+  // ours instead: the indexes on the cells are ours (always 1), so the
+  // records they resolve against have to be too — and two entries for
+  // the same path would be a corrupt archive. See #423.
+  const hasMetadata = worksheetResults.some((r) => r.hasDynamicArray)
 
   // Generate drawing data for sheets that have images
   const drawingResults: Array<DrawingResult | null> = []
@@ -511,6 +518,7 @@ export async function saveXlsx(
     !!workbook.hasMacros,
     false, // featurePropertyBag — not yet roundtripped
     hasPersons,
+    hasMetadata,
   )
   const externalLinkRels = externalLinkIndices.map((idx) => ({
     rId: `rId${nextWorkbookRelId++}`,
@@ -778,6 +786,11 @@ export async function saveXlsx(
       if (isRegenerated && cellImageMediaPaths.has(lowerPath)) {
         isRegenerated = false
       }
+      // The opened package's own metadata part is replaced, not kept,
+      // whenever we emit ours — see `hasMetadata` above.
+      if (!isRegenerated && hasMetadata && lowerPath === METADATA_PART_PATH) {
+        isRegenerated = true
+      }
       // Drawings whose only contents are chart graphicFrames don't get
       // re-emitted by hucre's drawing writer; force-preserve them so
       // the chart references survive intact.
@@ -831,6 +844,7 @@ export async function saveXlsx(
     hasAppProps: true,
     hasMacros: workbook.hasMacros,
     hasFeaturePropertyBag,
+    hasMetadata,
   }
   zip.add("[Content_Types].xml", encoder.encode(writeContentTypes(ctOpts)))
 
@@ -878,12 +892,19 @@ export async function saveXlsx(
         slicerCacheRels.length > 0 ? slicerCacheRels : undefined,
         timelineCacheRels.length > 0 ? timelineCacheRels : undefined,
         hasCellImages,
+        hasMetadata,
       ),
     ),
   )
 
   // xl/styles.xml
   zip.add("xl/styles.xml", encoder.encode(styles.toXml()))
+
+  // xl/metadata.xml — declared above, so the part has to exist. Any
+  // copy the opened package carried was skipped during preservation.
+  if (hasMetadata) {
+    zip.add(METADATA_PART_PATH, encoder.encode(writeMetadataXml()))
+  }
 
   // xl/featurePropertyBag/featurePropertyBag.xml — declared above, so
   // the part has to exist.
@@ -1416,8 +1437,8 @@ function collectSheetPivotTableTargets(
  * Mirror the `nextRid` counter inside `writeWorkbookRels` to determine
  * the starting rId for external link relationships. Keep this in sync
  * with `writeWorkbookRels` — order is: worksheets, styles, optional
- * sharedStrings, theme, optional vbaProject, optional FeaturePropertyBag,
- * optional persons, then externalLinks.
+ * sharedStrings, theme, optional metadata, optional vbaProject, optional
+ * FeaturePropertyBag, optional persons, then externalLinks.
  */
 function computeExternalLinkRelStart(
   sheetCount: number,
@@ -1425,11 +1446,13 @@ function computeExternalLinkRelStart(
   hasMacros: boolean,
   hasFeaturePropertyBag: boolean,
   hasPersons: boolean,
+  hasMetadata: boolean,
 ): number {
   let next = sheetCount + 1 // worksheets occupy rId1..rId{sheetCount}
   next++ // styles
   if (hasSharedStrings) next++
   next++ // theme
+  if (hasMetadata) next++
   if (hasMacros) next++
   if (hasFeaturePropertyBag) next++
   if (hasPersons) next++

--- a/src/xlsx/workbook-writer.ts
+++ b/src/xlsx/workbook-writer.ts
@@ -4,6 +4,7 @@
 import type { WriteSheet, NamedRange } from "../_types"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 import { hashSheetPassword } from "./password"
+import { METADATA_REL_TYPE } from "./metadata"
 
 const NS_SPREADSHEET = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 const NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
@@ -253,6 +254,7 @@ export function writeWorkbookRels(
   slicerCacheRels?: ReadonlyArray<CacheRel>,
   timelineCacheRels?: ReadonlyArray<CacheRel>,
   hasCellImages?: boolean,
+  hasMetadata?: boolean,
 ): string {
   const children: string[] = []
 
@@ -299,6 +301,21 @@ export function writeWorkbookRels(
     }),
   )
   nextRid++
+
+  // Cell metadata relationship (dynamic arrays). Placed between
+  // sharedStrings/theme and vbaProject, where Excel and XlsxWriter put
+  // it; `computeExternalLinkRelStart` in roundtrip.ts mirrors this
+  // position and has to move with it.
+  if (hasMetadata) {
+    children.push(
+      xmlSelfClose("Relationship", {
+        Id: `rId${nextRid}`,
+        Type: METADATA_REL_TYPE,
+        Target: "metadata.xml",
+      }),
+    )
+    nextRid++
+  }
 
   // VBA project relationship (for macro-enabled workbooks)
   if (hasMacros) {

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -25,6 +25,7 @@ import { dateToSerial } from "../_date"
 import { isHyperlinkValue } from "./hyperlink"
 import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
 import { calculateColumnWidth } from "./auto-width"
+import { DYNAMIC_ARRAY_CM } from "./metadata"
 import { hashSheetPassword } from "./password"
 import { validateColumnIndex } from "../_validate"
 
@@ -56,6 +57,11 @@ export interface WorksheetResult {
    * `xl/pivotTables/pivotTableN.xml` path.
    */
   pivotTables: Array<{ rId: string; globalPivotIndex: number }>
+  /**
+   * Whether any cell was written with `cm`. The package must then ship
+   * xl/metadata.xml, or the index points at nothing — see ./metadata.ts.
+   */
+  hasDynamicArray: boolean
 }
 
 const NS_SPREADSHEET = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -185,7 +191,16 @@ function toHyperlink(hv: HyperlinkValue): Hyperlink {
 
 const DEFAULT_DATE_FORMAT = "yyyy-mm-dd"
 
-/** Known Excel error value strings */
+/**
+ * Known Excel error value strings.
+ *
+ * The first eight are the ST_CellType `e` values ECMA-376 enumerates.
+ * `#SPILL!` and `#CALC!` are the two errors dynamic arrays introduced —
+ * they are not in the standard's list, but Excel stores them the same
+ * way (`t="e"` with the literal text in `<v>`), and without them a
+ * `#SPILL!` read out of a real workbook came back as a *shared string*
+ * on the way in again, losing its error type entirely (#423).
+ */
 const EXCEL_ERRORS = new Set([
   "#VALUE!",
   "#REF!",
@@ -195,6 +210,8 @@ const EXCEL_ERRORS = new Set([
   "#DIV/0!",
   "#NUM!",
   "#GETTING_DATA",
+  "#SPILL!",
+  "#CALC!",
 ])
 
 // ── Worksheet Writer ───────────────────────────────────────────────
@@ -389,6 +406,7 @@ export function writeWorksheetXml(
 
   // ── Sheet Data ──
   const rowElements: string[] = []
+  let hasDynamicArray = false
 
   for (let r = 0; r < rowCount; r++) {
     const row = resolvedRows[r]
@@ -406,6 +424,16 @@ export function writeWorksheetXml(
       for (let c = 0; c < row.length; c++) {
         const resolved = row[c]
         if (!resolved) continue
+
+        // Mirrors the condition serializeCell applies below: `cm` only
+        // goes out on a cell that actually carries a formula.
+        if (
+          resolved.formulaDynamic &&
+          resolved.formula !== undefined &&
+          resolved.formula !== null
+        ) {
+          hasDynamicArray = true
+        }
 
         const cellXml = serializeCell(r, c, resolved, styles, sharedStrings, is1904, inlineStrings)
         if (cellXml) {
@@ -632,6 +660,7 @@ export function writeWorksheetXml(
     tables: tableEntries,
     pictureRId,
     pivotTables: pivotEntries,
+    hasDynamicArray,
   }
 }
 
@@ -795,6 +824,12 @@ function serializeCell(
   if (formula !== undefined && formula !== null) {
     const cellAttrs: Record<string, string | number> = { r: ref }
     if (styleIdx !== 0) cellAttrs["s"] = styleIdx
+    // `cm` is a CT_Cell attribute (§18.3.1.4) — hucre used to write it on
+    // `<f>`, where the schema has no such attribute, so Excel ignored it
+    // and the flag survived only because hucre also read it back from
+    // there (#423). The index is one-based into xl/metadata.xml's
+    // cellMetadata collection; see ./metadata.ts for the part itself.
+    if (formulaDynamic) cellAttrs["cm"] = DYNAMIC_ARRAY_CM
 
     // Build <f> element with appropriate attributes
     let fElement: string
@@ -811,13 +846,13 @@ function serializeCell(
     } else if (formulaType === "array") {
       const fAttrs: Record<string, string | number> = { t: "array" }
       if (formulaRef) fAttrs["ref"] = formulaRef
-      if (formulaDynamic) fAttrs["cm"] = 1
       fElement = xmlElement("f", fAttrs, xmlEscape(formula))
     } else {
       // Normal formula. `formulaDynamic` used to be honoured only inside
       // the `t="array"` branch above, so a spilling function written
-      // without `formulaType: "array"` silently lost the flag (#407).
-      fElement = xmlElement("f", formulaDynamic ? { cm: 1 } : undefined, xmlEscape(formula))
+      // without `formulaType: "array"` silently lost the flag (#407); it
+      // now lands on `<c>` for both shapes.
+      fElement = xmlElement("f", undefined, xmlEscape(formula))
     }
 
     const children: string[] = [fElement]

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -49,6 +49,27 @@ export interface WorksheetContext {
   maxRows?: number
   /** Cell range filter (e.g. "A1:D10"). Only cells within this range are returned. */
   range?: string
+  /**
+   * One-based `cm` indexes that xl/metadata.xml resolves to a
+   * dynamic-array (XLDAPR) record. Undefined when the package ships no
+   * metadata part — see {@link isDynamicArrayCm}.
+   */
+  dynamicArrayCm?: Set<number>
+}
+
+/**
+ * Decide whether a cell's `cm` index marks a dynamic array.
+ *
+ * With a metadata part present the index is resolved properly. Without
+ * one there is nothing to resolve against, and the only producer known
+ * to emit a bare `cm` is hucre itself before #423 — which always meant
+ * "dynamic array" — so any non-zero index is taken at its word.
+ */
+function isDynamicArrayCm(raw: string | undefined, ctx: WorksheetContext): boolean {
+  if (raw === undefined) return false
+  const index = Number(raw)
+  if (!Number.isFinite(index) || index <= 0) return false
+  return ctx.dynamicArrayCm ? ctx.dynamicArrayCm.has(index) : true
 }
 
 // ── Cell Reference Parsing ───────────────────────────────────────────
@@ -399,7 +420,12 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
             cellFormulaType = ""
             cellFormulaSi = -1
             cellFormulaRef = ""
-            cellFormulaCm = false
+            // `cm` lives on `<c>` (§18.3.1.4) and is a one-based index
+            // into xl/metadata.xml's cellMetadata collection, not a
+            // boolean. hucre used to both write and read it on `<f>`,
+            // which round-tripped with itself and with nothing else
+            // (#423).
+            cellFormulaCm = isDynamicArrayCm(attrs["cm"], ctx)
             inlineText = ""
             inlineRichText = []
           }
@@ -420,7 +446,10 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
             if (attrs["ref"]) {
               cellFormulaRef = attrs["ref"]
             }
-            if (attrs["cm"] === "1") {
+            // Every hucre release up to 0.6 wrote the marker here, so
+            // keep honouring it — those files are in the wild and the
+            // attribute is meaningless on `<f>` for any other reason.
+            if (attrs["cm"] !== undefined && isDynamicArrayCm(attrs["cm"], ctx)) {
               cellFormulaCm = true
             }
           }

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -12,6 +12,7 @@ import type {
 import { ZipWriter } from "../zip/writer"
 import { writeContentTypes } from "./content-types-writer"
 import { writeFeaturePropertyBagXml } from "./feature-property-bag"
+import { METADATA_PART_PATH, writeMetadataXml } from "./metadata"
 import type { ContentTypesOptions } from "./content-types-writer"
 import { writeRootRels, writeWorkbookXml, writeWorkbookRels } from "./workbook-writer"
 import type { PivotCacheRef, PivotCacheRel } from "./workbook-writer"
@@ -279,6 +280,9 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
   // [Content_Types].xml
   const hasMacros = options.vbaProject !== undefined && options.vbaProject.length > 0
   const hasFeaturePropertyBag = styles.hasCheckboxFeature()
+  // A `cm` on a cell is an index into xl/metadata.xml; the part has to
+  // ship with it or the index resolves to nothing (#423).
+  const hasMetadata = worksheetResults.some((r) => r.hasDynamicArray)
 
   const ctOpts: ContentTypesOptions = {
     sheetCount: sheets.length,
@@ -296,6 +300,7 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     hasCustomProps,
     hasMacros,
     hasFeaturePropertyBag,
+    hasMetadata,
   }
   zip.add("[Content_Types].xml", encoder.encode(writeContentTypes(ctOpts)))
 
@@ -345,6 +350,10 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
         undefined,
         undefined,
         pivotCacheRels.length > 0 ? pivotCacheRels : undefined,
+        undefined,
+        undefined,
+        undefined,
+        hasMetadata,
       ),
     ),
   )
@@ -358,6 +367,12 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
   // xl/sharedStrings.xml (if any strings)
   if (hasSharedStrings) {
     zip.add("xl/sharedStrings.xml", encoder.encode(writeSharedStringsXml(sharedStrings)))
+  }
+
+  // xl/metadata.xml — declared in the content types and related from
+  // the workbook above, so the part itself has to be here.
+  if (hasMetadata) {
+    zip.add(METADATA_PART_PATH, encoder.encode(writeMetadataXml()))
   }
 
   // xl/vbaProject.bin (if macros provided)

--- a/test/coverage-xlsx-parts.test.ts
+++ b/test/coverage-xlsx-parts.test.ts
@@ -15,6 +15,7 @@ import {
   parseTimelines,
 } from "../src/xlsx/slicer-reader"
 import { parseComments } from "../src/xlsx/comments-reader"
+import { parseDynamicArrayCellMetadata } from "../src/xlsx/metadata"
 import { parsePersons, parseThreadedComments } from "../src/xlsx/threaded-comments-reader"
 import { parseCsv, parseCsvObjects } from "../src/csv/reader"
 
@@ -890,6 +891,57 @@ describe("parseCsv — type inference", () => {
     expect(parseCsv('"1,234.56";"1,23"', { typeInference: true, delimiter: ";" })).toEqual([
       [1234.56, "1,23"],
     ])
+  })
+})
+
+// ── xl/metadata.xml (what `cm` on a cell points at) ──────────────────
+//
+// `cm` is a one-based index into the cellMetadata collection
+// ([MS-OI29500] §18.3.1.4 note a); resolving it means walking
+// rc/@t → metadataType and rc/@v → futureMetadata block.
+
+describe("parseDynamicArrayCellMetadata", () => {
+  const metadataXml = (body: string): string =>
+    `${XML_DECL}<metadata xmlns="${NS_MAIN}" xmlns:xda="xda">${body}</metadata>`
+
+  const XLDAPR_TYPE =
+    '<metadataTypes count="1"><metadataType name="XLDAPR" minSupportedVersion="120000" cellMeta="1"/></metadataTypes>'
+  const XLDAPR_FUTURE =
+    '<futureMetadata name="XLDAPR" count="1"><bk><extLst><ext uri="{BDBB8CDC-FA1E-496E-A857-3C3F30C029C3}"><xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/></ext></extLst></bk></futureMetadata>'
+
+  it("resolves the block Excel writes for a spilling formula", () => {
+    const xml = metadataXml(
+      `${XLDAPR_TYPE}${XLDAPR_FUTURE}<cellMetadata count="1"><bk><rc t="1" v="0"/></bk></cellMetadata>`,
+    )
+    expect([...parseDynamicArrayCellMetadata(xml)]).toEqual([1])
+  })
+
+  it("counts cellMetadata blocks from one, skipping non-XLDAPR records", () => {
+    const xml = metadataXml(
+      '<metadataTypes count="2"><metadataType name="XLMDX"/><metadataType name="XLDAPR"/></metadataTypes>' +
+        '<futureMetadata name="XLDAPR" count="1"><bk/></futureMetadata>' +
+        '<cellMetadata count="2"><bk><rc t="1" v="0"/></bk><bk><rc t="2" v="0"/></bk></cellMetadata>',
+    )
+    expect([...parseDynamicArrayCellMetadata(xml)]).toEqual([2])
+  })
+
+  it("honours fDynamic=0 — an array formula that is not spilling", () => {
+    const xml = metadataXml(
+      `${XLDAPR_TYPE}<futureMetadata name="XLDAPR" count="1"><bk><extLst><ext uri="{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}"><xda:dynamicArrayProperties fDynamic="0"/></ext></extLst></bk></futureMetadata>` +
+        '<cellMetadata count="1"><bk><rc t="1" v="0"/></bk></cellMetadata>',
+    )
+    expect(parseDynamicArrayCellMetadata(xml).size).toBe(0)
+  })
+
+  it("trusts the type name when there is no futureMetadata block to check", () => {
+    const xml = metadataXml(
+      `${XLDAPR_TYPE}<cellMetadata count="1"><bk><rc t="1" v="7"/></bk></cellMetadata>`,
+    )
+    expect([...parseDynamicArrayCellMetadata(xml)]).toEqual([1])
+  })
+
+  it("returns nothing for a part with no cellMetadata at all", () => {
+    expect(parseDynamicArrayCellMetadata(metadataXml(XLDAPR_TYPE)).size).toBe(0)
   })
 })
 

--- a/test/coverage-xlsx-worksheet.test.ts
+++ b/test/coverage-xlsx-worksheet.test.ts
@@ -833,15 +833,36 @@ describe("formulas", () => {
     })
   })
 
-  it("flags a dynamic array formula", () => {
+  it("flags a dynamic array formula from cm on the cell", () => {
     const s = data(
-      `<row r="1"><c r="A1"><f t="array" ref="A1:A3" cm="1">SEQUENCE(3)</f>` + `<v>1</v></c></row>`,
+      `<row r="1"><c r="A1" cm="1"><f t="array" ref="A1:A3">SEQUENCE(3)</f>` + `<v>1</v></c></row>`,
+      { dynamicArrayCm: new Set([1]) },
     )
     expect(s.cells!.get("0,0")).toMatchObject({
       formulaType: "array",
       formulaRef: "A1:A3",
       formulaDynamic: true,
     })
+  })
+
+  // hucre wrote `cm` here up to 0.6 (#423). The attribute means nothing
+  // on `<f>` per the schema, so those files can only have come from
+  // hucre — keep reading them rather than silently dropping the flag.
+  it("still flags a dynamic array formula from cm on <f> (pre-0.7 hucre files)", () => {
+    const s = data(
+      `<row r="1"><c r="A1"><f t="array" ref="A1:A3" cm="1">SEQUENCE(3)</f>` + `<v>1</v></c></row>`,
+    )
+    expect(s.cells!.get("0,0")).toMatchObject({ formulaDynamic: true })
+  })
+
+  it("ignores a cm that the metadata part does not map to a dynamic array", () => {
+    const s = data(
+      `<row r="1"><c r="A1" cm="2"><f>SUM(B1:B3)</f><v>1</v></c></row>`,
+      // Only index 1 is XLDAPR in this package; 2 is some other kind of
+      // cell metadata and says nothing about spilling.
+      { dynamicArrayCm: new Set([1]) },
+    )
+    expect(s.cells!.get("0,0")!.formulaDynamic).toBeUndefined()
   })
 })
 

--- a/test/coverage-xlsx-writer.test.ts
+++ b/test/coverage-xlsx-writer.test.ts
@@ -139,6 +139,22 @@ describe("styled cells of every value shape", () => {
     expect(xml).toMatch(/<c r="A1" t="e" s="\d+"><v>#DIV\/0!<\/v><\/c>/)
   })
 
+  // The two errors dynamic arrays brought with them. ECMA-376 doesn't
+  // enumerate them, so they used to fall through to the string branch
+  // and came back from a read as text, not as errors (#423).
+  it("writes the dynamic-array errors as error cells", async () => {
+    const xml = await sheetXml({
+      name: "S",
+      cells: cellMap([
+        ["0,0", { value: "#SPILL!" }],
+        ["0,1", { value: "#CALC!" }],
+      ]),
+    })
+
+    expect(xml).toContain('<c r="A1" t="e"><v>#SPILL!</v></c>')
+    expect(xml).toContain('<c r="B1" t="e"><v>#CALC!</v></c>')
+  })
+
   it("keeps the style index on an inline string when stringMode is inline", async () => {
     const xml = await sheetXml(
       { name: "S", cells: cellMap([["0,0", { value: "hello", style: styled }]]) },

--- a/test/formulas-advanced.test.ts
+++ b/test/formulas-advanced.test.ts
@@ -200,7 +200,10 @@ describe("array formula writing", () => {
     expect(fEl.attrs["cm"]).toBeUndefined()
   })
 
-  it("writes dynamic array formula with cm=1", async () => {
+  // This used to assert `cm` on `<f>`, i.e. it pinned the bug in #423:
+  // CT_Cell carries `cm` (§18.3.1.4), CT_CellFormula has no such
+  // attribute, so Excel never saw the marker at all.
+  it("writes dynamic array formula with cm=1 on the cell, not the formula", async () => {
     const cells = new Map<string, Partial<Cell>>()
     cells.set("1,1", {
       formula: "SORT(A2:A10)",
@@ -224,10 +227,101 @@ describe("array formula writing", () => {
     const b2 = allCells.find((c: any) => c.attrs["r"] === "B2")
     const fEl = findChild(b2, "f")
 
+    expect(b2.attrs["cm"]).toBe("1")
+    expect(fEl.attrs["cm"]).toBeUndefined()
     expect(fEl.attrs["t"]).toBe("array")
     expect(fEl.attrs["ref"]).toBe("B2:B10")
-    expect(fEl.attrs["cm"]).toBe("1")
     expect(getElementText(fEl)).toBe("SORT(A2:A10)")
+  })
+
+  it("marks a plain (non-array) dynamic formula on the cell too", async () => {
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", { formula: "UNIQUE(B1:B5)", formulaDynamic: true })
+
+    const xlsx = await writeXlsx({ sheets: [{ name: "Sheet1", rows: [[null]], cells }] })
+    const doc = parseXml(await extractXml(xlsx, "xl/worksheets/sheet1.xml"))
+    const a1 = findCellElements(doc).find((c: any) => c.attrs["r"] === "A1")
+
+    expect(a1.attrs["cm"]).toBe("1")
+    expect(findChild(a1, "f").attrs["cm"]).toBeUndefined()
+  })
+})
+
+// ── The metadata part `cm` indexes into ──────────────────────────────
+
+describe("dynamic array cell metadata part", () => {
+  const dynamicSheet: WriteSheet = {
+    name: "Sheet1",
+    rows: [[null]],
+    cells: new Map<string, Partial<Cell>>([
+      ["0,0", { formula: "UNIQUE(B1:B5)", formulaDynamic: true }],
+    ]),
+  }
+
+  it("ships xl/metadata.xml with the XLDAPR records cm=1 resolves through", async () => {
+    const xlsx = await writeXlsx({ sheets: [dynamicSheet] })
+    const doc = parseXml(await extractXml(xlsx, "xl/metadata.xml"))
+
+    // metadataTypes[0] is XLDAPR, so `rc/@t="1"` (one-based) selects it.
+    const type = findChild(findChild(doc, "metadataTypes"), "metadataType")
+    expect(type.attrs["name"]).toBe("XLDAPR")
+    expect(type.attrs["cellMeta"]).toBe("1")
+    expect(type.attrs["minSupportedVersion"]).toBe("120000")
+
+    // futureMetadata block 0 holds the dynamic-array properties, which
+    // is what `rc/@v="0"` points at ([MS-XLSX] Metadata).
+    const future = findChild(doc, "futureMetadata")
+    expect(future.attrs["name"]).toBe("XLDAPR")
+    const ext = findChild(findChild(findChild(future, "bk"), "extLst"), "ext")
+    expect(ext.attrs["uri"].toLowerCase()).toBe("{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}")
+    expect(findChild(ext, "dynamicArrayProperties").attrs["fDynamic"]).toBe("1")
+
+    // cellMetadata block 1 — the one `cm="1"` on the cell indexes.
+    const rc = findChild(findChild(findChild(doc, "cellMetadata"), "bk"), "rc")
+    expect(rc.attrs["t"]).toBe("1")
+    expect(rc.attrs["v"]).toBe("0")
+  })
+
+  it("declares the part and relates it from the workbook", async () => {
+    const xlsx = await writeXlsx({ sheets: [dynamicSheet] })
+
+    const contentTypes = await extractXml(xlsx, "[Content_Types].xml")
+    expect(contentTypes).toContain(
+      '<Override PartName="/xl/metadata.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml"/>',
+    )
+
+    const rels = await extractXml(xlsx, "xl/_rels/workbook.xml.rels")
+    expect(rels).toContain(
+      'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sheetMetadata" Target="metadata.xml"',
+    )
+
+    // Whatever else is declared must be in the archive as well — a part
+    // that is announced and missing is what Excel calls corrupt (#367).
+    const zip = new ZipReader(xlsx)
+    for (const match of contentTypes.matchAll(/PartName="\/([^"]+)"/g)) {
+      expect(zip.has(match[1]!), `missing part ${match[1]}`).toBe(true)
+    }
+    // ...and every workbook relationship has to resolve, too.
+    for (const match of rels.matchAll(/Target="([^"]+)"/g)) {
+      expect(zip.has(`xl/${match[1]}`), `dangling rel ${match[1]}`).toBe(true)
+    }
+  })
+
+  it("writes no metadata part when nothing is a dynamic array", async () => {
+    const xlsx = await writeXlsx({
+      sheets: [
+        {
+          name: "Sheet1",
+          rows: [[1]],
+          cells: new Map<string, Partial<Cell>>([
+            ["0,1", { formula: "SUM(A1:A2)", formulaType: "array", formulaRef: "B1:B1" }],
+          ]),
+        },
+      ],
+    })
+    const zip = new ZipReader(xlsx)
+    expect(zip.has("xl/metadata.xml")).toBe(false)
+    expect(await extractXml(xlsx, "[Content_Types].xml")).not.toContain("sheetMetadata")
   })
 })
 

--- a/test/roundtrip-preservation.test.ts
+++ b/test/roundtrip-preservation.test.ts
@@ -192,6 +192,34 @@ describe("openXlsx → saveXlsx preserves workbook-level state", () => {
     expect(zip.has("xl/featurePropertyBag/featurePropertyBag.xml")).toBe(true)
   })
 
+  it("keeps dynamic arrays without ever shipping two metadata parts", async () => {
+    // The written file already carries xl/metadata.xml, so saveXlsx has
+    // to replace it rather than preserve it alongside its own — two
+    // entries for one path is a corrupt archive, and a preserved foreign
+    // one would not match the `cm` indexes hucre re-emits (#423).
+    const { saved, workbook } = await cycle({
+      sheets: [
+        {
+          name: "S",
+          rows: [[null]],
+          cells: new Map([["0,0", { formula: "UNIQUE(B1:B5)", formulaDynamic: true }]]),
+        },
+      ],
+    })
+
+    expect(workbook.sheets[0].cells?.get("0,0")?.formulaDynamic).toBe(true)
+
+    const zip = new ZipReader(saved)
+    const metadataEntries = zip.entries().filter((e) => e.toLowerCase() === "xl/metadata.xml")
+    expect(metadataEntries).toHaveLength(1)
+
+    const rels = new TextDecoder().decode(await zip.extract("xl/_rels/workbook.xml.rels"))
+    expect(rels).toContain('Target="metadata.xml"')
+    // rIds must stay unique once the metadata relationship joins them.
+    const ids = [...rels.matchAll(/Id="([^"]+)"/g)].map((m) => m[1])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
   it("does not emit a featurePropertyBag part when nothing uses one", async () => {
     const { saved } = await cycle({ sheets: [sheetWith({})] })
     const zip = new ZipReader(saved)


### PR DESCRIPTION
Closes #423.

## The reproduction, and why a passing test proved nothing

Emitted XML for `{ formula: "UNIQUE(A1:A3)", formulaDynamic: true }` on unmodified main:

```xml
<row r="2"><c r="A2"><f cm="1">UNIQUE(A1:A3)</f></c></row>
```

Archive: `[Content_Types].xml, _rels/.rels, docProps/…, xl/workbook.xml, xl/_rels/workbook.xml.rels, xl/styles.xml, xl/theme/theme1.xml, xl/sharedStrings.xml, xl/worksheets/sheet1.xml` — no metadata part, no override, no relationship.

And the read-back returned `formulaDynamic: true`. **The round trip passed while the file was wrong on both counts** — the attribute on the wrong element, and pointing at a collection that did not exist. That is the reason this issue was held back from #407 rather than fixed alongside it.

## What landed

- **`src/xlsx/metadata.ts`** writes `xl/metadata.xml`: one `XLDAPR` `metadataType`, one `futureMetadata` block carrying `<xda:dynamicArrayProperties fDynamic="1" fCollapsed="0"/>` under ext uri `{bdbb8cdc-fa1e-496e-a857-3c3f30c029c3}`, one `cellMetadata` record `<rc t="1" v="0"/>`. Structure per **ISO/IEC 29500-1 §18.9** (§18.9.10 `metadataType`, §18.9.4 `futureMetadata`); the XLDAPR / ext-uri pairing per **[MS-XLSX] "Metadata"**.
- **`cm` moved to `<c>`.** The load-bearing citation is **[MS-OI29500] §18.3.1.4 note (a)**: the standard calls `@cm` zero-based and names no collection, and *"Office specifies that @cm is a one-based index into the cellMetadata collection in the metadata part."* Hence `cm="1"` against a single record.
- Content-type override and workbook relationship, emitted **only when a cell actually carries `cm`** — a plain workbook grows no part and no attribute.
- **Reader** resolves `cm` through `rc/@t` → type name and `rc/@v` → futureMetadata block, so a `cm` pointing at a non-XLDAPR record no longer reads as dynamic. `cm` on `<f>` is still honoured, for files written by hucre before this.
- **`saveXlsx`** drops any `xl/metadata.xml` the opened package carried when it emits its own, and the external-link relationship start index moved with the new relationship.

## A second bug the same script surfaced

`{ value: "#SPILL!", type: "error" }` came out as `<c r="A4" t="s"><v>1</v></c>` — a shared string — and read back as a plain string with the error type gone. `#SPILL!` and `#CALC!` were simply missing from `EXCEL_ERRORS`. They travel with this feature, so they are fixed here.

## What I could not verify, stated rather than implied

There is no Excel here, and the repo ships **no XLSX fixtures at all** (`find` for `*.xlsx`/`*.xlsb`/`*.xls`/`*.ods` returns nothing), so there was no Excel-produced metadata part to diff against. Recorded in the commit message and in code comments:

1. The behavioural attribute set on `<metadataType>` (`copy` … `cellMeta`, `minSupportedVersion="120000"`) is taken from XlsxWriter's `metadata.py`. The spec fixes none of those values for XLDAPR — [MS-OI29500] §18.9.10 pins `minSupportedVersion` only for `XLMDX`.
2. Record ordering follows the `CT_Metadata` sequence and XlsxWriter; whether Excel is order-sensitive is unknown.
3. `vm` appears not to matter here — [MS-OI29500] §18.3.1.4 note (b) describes it identically, but it addresses value metadata (rich values), not spilling. hucre neither reads nor writes it, before or after.
4. Whether Excel expects `cm` only on a spill anchor or on every flagged cell.

## Package integrity

This is the failure class that produced #367 — a part added without its plumbing — so it was checked directly rather than assumed. Over three consecutive `openXlsx` → `saveXlsx` cycles: 11 entries each time, no duplicate paths, no declared part missing from the archive, no duplicate rIds, exactly one metadata part. A workbook with no dynamic-array cell grows neither the part nor the attribute.

## Existing tests changed

- `test/formulas-advanced.test.ts` — "writes dynamic array formula with cm=1" asserted `fEl.attrs["cm"] === "1"`. **That test was pinning the bug.** Replaced with `cm` on `<c>` and absent from `<f>`.
- `test/coverage-xlsx-worksheet.test.ts` — the reader case fed `cm` on `<f>`. **Kept**, relabelled as the pre-0.7 compatibility path, and joined by a `<c>` case. Nothing weakened or deleted.

Seven new behavioural assertions were confirmed failing against `HEAD` src before being made to pass.

## Left out deliberately

- A foreign `xl/metadata.xml` in an opened package with no dynamic-array cells stays preserved-raw and undeclared, as today. Declaring a part whose companion rich-data parts hucre already drops looked riskier than the orphan.
- Spill ranges are not computed — hucre evaluates no formulas, so `ref` stays whatever the caller or the file supplied.
- No per-cell `<extLst>` marker: the only dynamic-array `extLst` [MS-XLSX] documents is the one inside `futureMetadata`, which is implemented.

Verified: `pnpm lint`, `pnpm typecheck` (both projects), `pnpm test`, rebased on current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PcNafqfbSmpXZG3HEbkAD
