### PR TITLE
fix(build): annotate the exports oxc can't infer so their .d.mts ship

### DIFF
--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -11,7 +11,7 @@
 // Run: node scripts/verify-package.mjs
 
 import { execFileSync } from "node:child_process"
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -65,6 +65,25 @@ check("dist/cli.mjs imports nothing outside node: and its own dist", () => {
     external.length === 0,
     `bare imports would not resolve for an installed user: ${[...new Set(external)].join(", ")}`,
   )
+})
+
+// ── Static check: every shipped module keeps its types ─────────────
+//
+// A declaration oxc cannot infer under --isolatedDeclarations only warns
+// during the build: the .mjs is written, the .d.mts is not, and the
+// package ships an entry whose types resolve to nothing. Only the bundled
+// CLI (built with `dts: false`) and its inlined chunks are exempt.
+
+check("every shipped module has a matching .d.mts", () => {
+  const distDir = join(repoRoot, "dist")
+  const orphans = readdirSync(distDir, { recursive: true })
+    .map((entry) => String(entry).replaceAll("\\", "/"))
+    .filter(
+      (entry) => entry.endsWith(".mjs") && entry !== "cli.mjs" && !entry.startsWith("_chunks/"),
+    )
+    .filter((entry) => !existsSync(join(distDir, `${entry.slice(0, -4)}.d.mts`)))
+
+  assert(orphans.length === 0, `declaration files missing for: ${orphans.join(", ")}`)
 })
 
 check("package.json declares no runtime dependencies", () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,7 +17,7 @@ export class HucreError extends Error {
  * `instanceof DefterError` check keeps working. It will be removed in a
  * future major version.
  */
-export const DefterError = HucreError
+export const DefterError: typeof HucreError = HucreError
 
 /**
  * @deprecated Renamed to {@link HucreError}. Type-side alias kept so

--- a/src/json/stream.ts
+++ b/src/json/stream.ts
@@ -261,4 +261,4 @@ function tryParseLine(
  * reader in the library reads `stream*Rows`. This alias will be removed
  * in a future major.
  */
-export const readNdjsonStream = streamNdjsonRows
+export const readNdjsonStream: typeof streamNdjsonRows = streamNdjsonRows

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -329,7 +329,7 @@ export async function parseSaxStream(
  * documents still see exactly one `onText` call per run and nothing about
  * their parse changes.
  */
-export const SAX_TEXT_FLUSH_CHARS = 256 * 1024
+export const SAX_TEXT_FLUSH_CHARS: number = 256 * 1024
 
 /** Longest run treated as a possibly-incomplete entity reference (`&#x1F600;` is 9). */
 const MAX_ENTITY_CHARS = 64

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -10,7 +10,11 @@
   // `process` and `Buffer` leak into the platform-neutral library.
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    // The CLI is bundled with `dts: false` — nothing ever emits declarations
+    // for it — so the isolated-declarations rule the library is held to
+    // (see tsconfig.json) would only be annotation busywork here.
+    "isolatedDeclarations": false
   },
   "include": [
     "src/cli.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,16 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitOverride": true,
     "noEmit": true,
+    // obuild emits .d.mts through oxc's isolated-declarations transform: it
+    // looks at one file at a time and refuses to guess a type it cannot read
+    // off the source. When it refuses, the build *warns* and moves on — the
+    // .mjs ships, the .d.mts silently does not, and `dist/index.d.mts` is
+    // left importing a declaration file that was never written. v0.6.2 went
+    // out that way, missing types for `errors`, `json/stream` and
+    // `xml/parser`. Typechecking under the same rule turns that warning into
+    // a `pnpm test` failure, where it is impossible to miss.
+    "declaration": true,
+    "isolatedDeclarations": true,
     // No ambient types, deliberately. The library is platform-neutral —
     // Web APIs only, no `node:` imports — and leaving `process`, `Buffer`
     // and friends undeclared is what keeps it that way: reaching for one


### PR DESCRIPTION
## The bug

`pnpm build` was not clean — it printed three `TS9010` parse errors and three `[obuild] declaration emit skipped …` warnings, then exited 0:

```
WARN  TS9010: Variable must have an explicit type annotation with --isolatedDeclarations.
      errors.ts:20  export const DefterError = HucreError
WARN  [obuild] declaration emit skipped for ./src/errors.ts (--isolatedDeclarations); .mjs still emitted, .d.mts missing
```

obuild emits declarations through oxc's isolated-declarations transform, which reads one file at a time and gives up on any exported binding whose type it cannot see in the source. When it gives up it only warns — the `.mjs` is written, the `.d.mts` is not.

So `dist/` shipped `errors.mjs`, `json/stream.mjs` and `xml/parser.mjs` with no declaration files, while `dist/index.d.mts` imports from `"./errors.mjs"`. **v0.6.2 on npm has no types for any error class** — `HucreError`, `ParseError`, `ValidationError` and the rest.

## The fix

Three annotations, one per offending export:

- `src/errors.ts` — `DefterError: typeof HucreError`
- `src/json/stream.ts` — `readNdjsonStream: typeof streamNdjsonRows`
- `src/xml/parser.ts` — `SAX_TEXT_FLUSH_CHARS: number`

The build is now warning-free and all three `.d.mts` files are emitted.

## Not recurring

A warning that leaves a green build is exactly the shape of #357, so two guards:

- **`tsconfig.json` typechecks under `--isolatedDeclarations`** — the same rule oxc applies, so the build's warning becomes a `pnpm test` failure. `src` and `test` already pass it; `tsconfig.cli.json` opts out, as the CLI is bundled with `dts: false` and never emits declarations.
- **`verify-package.mjs` asserts every shipped module has a sibling `.d.mts`** — artifact-level, alongside the existing bare-import check. Exempts `dist/cli.mjs` and `dist/_chunks/`.

## Verified

- `pnpm build` — clean, no warnings
- `pnpm typecheck` — passes under the new flag, both projects
- `vitest run` — 9659 tests, 157 files, all pass
- `pnpm verify:package` — all 7 checks ok (and the new one does fail when a `.d.mts` is removed by hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)