### PR TITLE
perf(xlsx): stop resolving the sheet grid twice per write

### DIFF
--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -514,7 +514,10 @@ export function writeWorksheetXml(
   }
 
   // ── Hyperlinks ──
-  const { xml: hyperlinksXml, relationships: hyperlinkRelationships } = collectHyperlinks(sheet)
+  const { xml: hyperlinksXml, relationships: hyperlinkRelationships } = collectHyperlinks(
+    sheet,
+    resolvedRows,
+  )
   if (hyperlinksXml) {
     parts.push(hyperlinksXml)
   }
@@ -1072,13 +1075,18 @@ function serializeDataValidations(validations: DataValidation[]): string {
  * Collect hyperlinks from the sheet's cell overrides and generate
  * the `<hyperlinks>` XML section plus external relationship entries.
  */
-export function collectHyperlinks(sheet: WriteSheet): {
+export function collectHyperlinks(
+  sheet: WriteSheet,
+  preResolved?: Array<Array<ResolvedCell | null>>,
+): {
   xml: string
   relationships: HyperlinkRelationship[]
 } {
   // Resolve the full grid so links from both inline `data` values and the
   // `cells` override map are collected from a single source, in row-major order.
-  const resolved = resolveRows(sheet)
+  // `writeWorksheetXml` has already paid for that grid, so it hands it over
+  // rather than making us rebuild every cell of the sheet a second time.
+  const resolved = preResolved ?? resolveRows(sheet)
 
   const hyperlinkElements: string[] = []
   const relationships: HyperlinkRelationship[] = []

--- a/test/hyperlinks.test.ts
+++ b/test/hyperlinks.test.ts
@@ -40,6 +40,36 @@ function zipHas(data: Uint8Array, path: string): boolean {
 // ── collectHyperlinks unit tests ─────────────────────────────────────
 
 describe("collectHyperlinks", () => {
+  it("produces the same result from a pre-resolved grid as it does on its own", () => {
+    const cells = new Map<string, Partial<Cell>>()
+    cells.set("0,0", {
+      value: "Click me",
+      hyperlink: { target: "https://example.com" },
+    })
+    cells.set("1,2", {
+      value: "Internal",
+      hyperlink: { target: "", location: "Sheet2!A1" },
+    })
+    const sheet: WriteSheet = {
+      name: "Sheet1",
+      rows: [["Click me"], [null, null, "Internal"]],
+      cells,
+    }
+
+    // The grid writeWorksheetXml has already built, in the shape resolveRows
+    // returns: row-major, with the `cells` overrides folded in.
+    const preResolved = [
+      [{ value: "Click me", hyperlink: { target: "https://example.com" } }],
+      [null, null, { value: "Internal", hyperlink: { target: "", location: "Sheet2!A1" } }],
+    ]
+
+    const onItsOwn = collectHyperlinks(sheet)
+    const fromCaller = collectHyperlinks(sheet, preResolved)
+
+    expect(fromCaller).toEqual(onItsOwn)
+    expect(fromCaller.relationships).toHaveLength(1)
+  })
+
   it("returns empty when no cells", () => {
     const sheet: WriteSheet = { name: "Sheet1", rows: [["Hello"]] }
     const result = collectHyperlinks(sheet)


### PR DESCRIPTION
## What the profiler showed

CPU profile of `writeXlsx` on a 100k-row × 22-column sheet, styled per cell:

```
543.8ms (12.5%)  resolveRows      src/xlsx/worksheet-writer.ts
  <- 309.9ms ( 7.1%)  writeWorksheetXml
  <- 233.9ms ( 5.4%)  collectHyperlinks
```

`writeWorksheetXml` resolves the full grid, and then `collectHyperlinks` resolves it again from scratch — a second pass over every cell, allocating a second `{ value, style, … }` object per cell that is retained while the first grid is still alive. The sheet in that profile carried no hyperlink at all.

## What landed

- **`src/xlsx/worksheet-writer.ts`** — `collectHyperlinks` takes the grid the caller already resolved. The parameter is optional and falls back to `resolveRows(sheet)`, so the exported signature stays source-compatible and the standalone unit tests keep calling it with one argument.

## Measurements

50k rows × 22 columns, 13 populated, one style object per cell. Three runs each, `writeXlsx`, peak RSS via `process.resourceUsage().maxRSS`:

| | time | peak RSS |
| --- | --- | --- |
| `main` | 1653 / 2127 / 1617 ms | 764 MB |
| this branch | 1509 / 1501 / 1505 ms | 661 / 644 / 643 MB |

The gain that matters here is the ~15% off peak — the second grid is what it stops allocating.

## Output

Every part of the archive is identical to `main`'s, including `docProps/core.xml` in the run I compared. Worth noting for anyone reproducing: that part carries the write timestamp, so it differs between any two runs a second apart — including two runs of `main`. Every other part is byte-identical.

*(An earlier revision of this description said "byte-identical" without that caveat.)*

## Tests

One assertion added to `test/hyperlinks.test.ts`: `collectHyperlinks` produces the same result from a caller-supplied grid as it does resolving on its own, over a sheet with both an external link and an internal one. It fails to compile against `main` (`Expected 1 arguments, but got 2`), which is the point.

The rest of the hyperlink suite exercises the fallback path unchanged.

## What I did not verify

- No Excel here — the check is that the emitted parts do not change, not that Excel renders them the same.
- `main` currently has two failing tests, `coverage-gaps.test.ts` ("all CsvWriteOptions together") and `ods-formula-richtext.test.ts` ("hyperlinks on non-string cells"). They fail on unmodified `main` too — not from this change.