### PR TITLE
perf(xlsx): reuse the cell format across cells that share a style object

### DIFF
--- a/src/xlsx/styles-writer.ts
+++ b/src/xlsx/styles-writer.ts
@@ -259,7 +259,25 @@ interface XfEntry {
   hasCheckboxFeature?: boolean
 }
 
-export function createStylesCollector(defaultFont?: FontStyle): StylesCollector {
+export interface StylesCollectorOptions {
+  /**
+   * Reuse a cell format across cells that pass the *same* style object,
+   * skipping the key rebuild. Only sound when the caller cannot mutate a
+   * style between the cells that use it — true for `writeXlsx`, which is
+   * handed the whole document and serialises it without yielding, and false
+   * for the streaming writers, which take rows from caller code.
+   *
+   * Default: false.
+   */
+  reuseStyleIdentity?: boolean
+}
+
+export function createStylesCollector(
+  defaultFont?: FontStyle,
+  options?: StylesCollectorOptions,
+): StylesCollector {
+  const reuseStyleIdentity = options?.reuseStyleIdentity ?? false
+
   // ── Defaults ──
   // Default font (Calibri 11)
   const baseFont: FontStyle = {
@@ -401,7 +419,23 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
     return registerXf(style ?? {}, true)
   }
 
+  // One style object is typically shared by a whole column, or by the whole
+  // sheet. Keying it by identity skips rebuilding the font/fill/border keys —
+  // each of which serialises part of the style into a string — once per cell.
+  //
+  // Off by default, because it is only sound when the caller cannot mutate a
+  // style between the cells that use it. `writeXlsx` gets the whole document
+  // up front and serialises it without yielding, so nothing of the caller's
+  // runs in between; the streaming writers take rows from caller code and do
+  // not enable it. See `reuseStyleIdentity`.
+  const xfByStyleIdentity = reuseStyleIdentity ? new WeakMap<CellStyle, number>() : undefined
+
   function registerXf(style: CellStyle, checkbox: boolean): number {
+    if (xfByStyleIdentity && !checkbox) {
+      const cached = xfByStyleIdentity.get(style)
+      if (cached !== undefined) return cached
+    }
+
     const fontId = style.font ? addFont(style.font) : 0
     const fillId = style.fill ? addFill(style.fill) : 0
     const borderId = style.border ? addBorder(style.border) : 0
@@ -418,7 +452,10 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
     ].join("|")
 
     const existing = xfMap.get(key)
-    if (existing !== undefined) return existing
+    if (existing !== undefined) {
+      if (xfByStyleIdentity && !checkbox) xfByStyleIdentity.set(style, existing)
+      return existing
+    }
 
     const id = xfs.length
     xfs.push({
@@ -432,6 +469,7 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
       hasCheckboxFeature: checkbox || undefined,
     })
     xfMap.set(key, id)
+    if (xfByStyleIdentity && !checkbox) xfByStyleIdentity.set(style, id)
     return id
   }
 

--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -82,7 +82,9 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
   const properties = effectiveProperties(options)
 
   // Create shared collectors
-  const styles = createStylesCollector(defaultFont)
+  // Safe here: the document arrives whole and is serialised without yielding
+  // to caller code, so a style object cannot change between the cells using it.
+  const styles = createStylesCollector(defaultFont, { reuseStyleIdentity: true })
   const sharedStrings = createSharedStrings()
 
   // Pre-compute global table start indices per sheet

--- a/test/styles-xf-identity.test.ts
+++ b/test/styles-xf-identity.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+import { createStylesCollector } from "../src/xlsx/styles-writer"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeXlsxStream } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import type { CellStyle } from "../src/_types"
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+describe("styles collector — xf reuse", () => {
+  it("gives one xf to a style object reused across cells", () => {
+    const styles = createStylesCollector(undefined, { reuseStyleIdentity: true })
+    const shared: CellStyle = {
+      font: { name: "Arial", size: 8 },
+      border: { top: { style: "thin" }, bottom: { style: "thin" } },
+    }
+
+    const ids = Array.from({ length: 100 }, () => styles.addStyle(shared))
+
+    expect(new Set(ids).size).toBe(1)
+  })
+
+  it("still collapses distinct objects that describe the same format", () => {
+    const styles = createStylesCollector(undefined, { reuseStyleIdentity: true })
+
+    const first = styles.addStyle({ font: { name: "Arial", size: 8 } })
+    const second = styles.addStyle({ font: { name: "Arial", size: 8 } })
+
+    expect(second).toBe(first)
+  })
+
+  it("keeps different formats apart", () => {
+    const styles = createStylesCollector(undefined, { reuseStyleIdentity: true })
+
+    const arial = styles.addStyle({ font: { name: "Arial", size: 8 } })
+    const manrope = styles.addStyle({ font: { name: "Manrope", size: 20 } })
+
+    expect(manrope).not.toBe(arial)
+  })
+
+  it("emits one cellXfs entry per distinct format, whatever the call pattern", () => {
+    const styles = createStylesCollector(undefined, { reuseStyleIdentity: true })
+    const shared: CellStyle = { font: { name: "Arial", size: 8 } }
+
+    styles.addStyle(shared)
+    styles.addStyle({ font: { name: "Arial", size: 8 } })
+    styles.addStyle(shared)
+    styles.addStyle({ font: { name: "Manrope", size: 20 } })
+
+    const xml = styles.toXml()
+
+    expect(xml.match(/<cellXfs count="(\d+)"/)?.[1]).toBe("3")
+  })
+
+  it("re-reads a mutated style when identity reuse is off", () => {
+    const styles = createStylesCollector()
+    const shared: CellStyle = { numFmt: "0.00" }
+
+    const before = styles.addStyle(shared)
+    shared.numFmt = "0.0000"
+    const after = styles.addStyle(shared)
+
+    expect(after).not.toBe(before)
+  })
+})
+
+describe("style identity reuse is scoped to the writer that can rely on it", () => {
+  it("writeXlsx reuses the format across rows of a column", async () => {
+    const style: CellStyle = { numFmt: "0.00", font: { name: "Arial" } }
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", columns: [{ style }], rows: [[1], [2], [3]] }],
+    })
+
+    const wb = await readXlsx(bytes, { readStyles: true })
+    const cells = wb.sheets[0]!.cells!
+
+    for (const ref of ["0,0", "1,0", "2,0"]) {
+      expect(cells.get(ref)!.style!.numFmt).toBe("0.00")
+    }
+    expect(bytes.length).toBeGreaterThan(0)
+  })
+
+  it("writeXlsxStream still sees a style mutated between rows", async () => {
+    const style: CellStyle = { numFmt: "0.00" }
+
+    function* rows() {
+      yield [1]
+      style.numFmt = "0.0000"
+      yield [2]
+    }
+
+    const bytes = await collect(writeXlsxStream(rows(), { name: "S", columns: [{ style }] }))
+    const wb = await readXlsx(bytes, { readStyles: true })
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.style!.numFmt).toBe("0.00")
+    expect(cells.get("1,0")!.style!.numFmt).toBe("0.0000")
+  })
+})


### PR DESCRIPTION
## What the profiler showed

`writeXlsx`, 100k rows × 22 columns. `registerXf` and the key builders it calls — `borderKey`, `fontKey`, `alignmentKey`, `addFont`, `addFill`, `addBorder` — add up to **~15% of samples**, with V8 overhead at 24.5%, consistent with the string churn they produce.

Each of those serialises part of the style into a string, once per cell, for what is by identity the same object every time.

## What landed

- **`createStylesCollector(defaultFont, { reuseStyleIdentity })`** — caches the resolved xf index in a `WeakMap` keyed by the style object. Off by default.
- **`writeXlsx` turns it on.** It is handed the whole document and serialises it without yielding, so nothing of the caller's runs between the cells that share a style.
- **The streaming writers leave it off.** They take rows from caller code, which can mutate a shared column style between rows — that has to keep being picked up.
- `checkbox` styles bypass the cache: they key on a dimension the object alone does not carry.

## Why an option, and not just a cache

Two review comments pulled in opposite directions, and both were right.

[The first](https://github.com/productdevbook/hucre/pull/435#discussion_r3714712139): a workbook-wide cache misses a style mutated between rows of `writeXlsxStream` — `{ numFmt: "0.00" }` changed to `"0.0000"` between two yields kept the old format. [The second](https://github.com/productdevbook/hucre/pull/435#discussion_r3714836701): scoping the cache to a row, which was my answer to the first, guarantees a miss for `columns[i].style`, since each column's object is met exactly once per row.

Measured, 40k × 22:

| | shared object across cells | `columns[].style` |
| --- | --- | --- |
| `main` | 1048 ms | 1162 ms |
| workbook-wide | 832 ms | 827 ms |
| row-scoped | 820 ms | **1201 ms — slower than `main`** |

The cache has to survive across rows to be worth anything, and it cannot survive across rows when the caller can mutate in between. What resolves that is not a smarter cache: the two writers genuinely differ in whether the caller can interfere, so the reuse is an option and only `writeXlsx` takes it.

## Measurements

40k rows × 22 columns, 13 populated. Minimum of 9 runs, three rounds, branches checked out clean between rounds:

| | shared object across cells | `columns[].style` |
| --- | --- | --- |
| `main` | 1374 / 1161 / 1158 ms | 1545 / 1336 / 1300 ms |
| this branch | **843 / 857 / 931 ms** | **749 / 822 / 795 ms** |

~27% and ~42%. The streaming path is unchanged, by design.

## Output

Every part of the archive is identical to `main`'s except `docProps/core.xml`, which carries the write timestamp and differs between any two runs — including two runs of `main` itself (6359 vs 6360 bytes, that part the only difference). `styles.xml` is unchanged.

## Tests

`test/styles-xf-identity.test.ts`, seven assertions. The three that matter: **with reuse off a mutated style is re-read**, **`writeXlsx` applies the shared column format across rows**, and **`writeXlsxStream` still sees a style mutated between rows** — the reported case, end to end. The rest pin the dedup invariants the cache must not break (equal content still collapses, different formats stay apart, `cellXfs count` unchanged).

## What I did not verify

- No Excel here. The evidence for "unchanged" is the part-by-part archive comparison plus the `styles.xml` count assertion.
- A `writeXlsx` workbook where every cell carries a freshly allocated style object now takes one extra `WeakMap` miss per cell. I did not measure that case.
- `main` currently has two failing tests (`coverage-gaps`, `ods-formula-richtext`); they fail on unmodified `main` too.