### PR TITLE
feat(xlsx): let streamed rows carry cell styles, heights and merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,24 @@ return new Response(
   },
 )
 
+// A streamed row can carry formatting per cell, not just per column —
+// enough for a title, a subtotal line or a header band. A cell that brings
+// its own style overrides its column's; a bare value still inherits it.
+// Row heights and merges travel alongside, so a report header no longer
+// forces a fall back to writeXlsx.
+writeXlsxStream(
+  [
+    [{ value: "Q3 Report", style: { font: { size: 20, bold: true } } }, null, null],
+    [{ formula: "SUM(A3:A99)" }, "Total"],
+    ...dataRows,
+  ],
+  {
+    name: "Report",
+    rowDefs: new Map([[0, { height: 30 }]]),
+    merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }],
+  },
+)
+
 // Incremental write — serializes each row on arrival, but holds the
 // serialized parts until finish() returns one buffer. Use it when you
 // need a Uint8Array anyway; use writeXlsxStream for constant memory.

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
   XlsxStreamWriterOptions,
   XlsxWriteStreamOptions,
   XlsxStreamRow,
+  StreamStyledCell,
 } from "./xlsx/stream-writer"
 export { readXlsxObjects, writeXlsxObjects } from "./xlsx/objects"
 export type {

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -24,6 +24,7 @@ export type {
   XlsxStreamWriterOptions,
   XlsxWriteStreamOptions,
   XlsxStreamRow,
+  StreamStyledCell,
 } from "./xlsx/stream-writer"
 
 // ── Sizing & theme helpers ─────────────────────────────────────────

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -60,7 +60,9 @@ export interface StreamWriterOptions {
    */
   repeatHeaders?: boolean
   /**
-   * Row-level properties keyed by 0-based row index — today only `height`.
+   * Row-level properties — `height`, `hidden`, `outlineLevel`, `collapsed` —
+   * keyed by 0-based row index, counted the way the caller sees it: the key
+   * keeps rising past a rollover, where the per-sheet index restarts at 0.
    * Consulted as each row is emitted, so it costs nothing per row that has
    * no entry.
    */

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -11,14 +11,14 @@
 //   source on demand and the ZIP is emitted chunk by chunk, so peak
 //   memory is O(distinct styles), independent of row count.
 
-import type { CellValue, CellStyle, ColumnDef, FreezePane } from "../_types"
+import type { CellValue, CellStyle, ColumnDef, FreezePane, MergeRange, RowDef } from "../_types"
 import { ZipWriter } from "../zip/writer"
 import { zipStream, type ZipStreamEntry } from "../zip/stream-writer"
 import { writeContentTypes } from "./content-types-writer"
 import { writeRootRels, writeWorkbookRels } from "./workbook-writer"
 import { createStylesCollector, type StylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml } from "./worksheet-writer"
-import { cellRef } from "./worksheet-writer"
+import { cellRef, hasRowAttributes, rowAttributes } from "./worksheet-writer"
 import type { SharedStringsCollector } from "./worksheet-writer"
 import { writeThemeXml } from "./theme-writer"
 import { validateSheetName } from "../_validate"
@@ -59,6 +59,17 @@ export interface StreamWriterOptions {
    * Set to `false` to leave new sheets without a header row.
    */
   repeatHeaders?: boolean
+  /**
+   * Row-level properties keyed by 0-based row index — today only `height`.
+   * Consulted as each row is emitted, so it costs nothing per row that has
+   * no entry.
+   */
+  rowDefs?: Map<number, RowDef>
+  /**
+   * Merged ranges. Written after the sheet data of the first sheet, so they
+   * do not have to be known before the rows are streamed.
+   */
+  merges?: MergeRange[]
 }
 
 /**
@@ -95,8 +106,53 @@ export interface XlsxWriteStreamOptions extends StreamWriterOptions {
   zip64?: boolean
 }
 
+/**
+ * A cell that carries its own formatting inside a streamed row.
+ *
+ * Without it a streamed sheet can only be styled a whole column at a time,
+ * which cannot express a title, a subtotal or a header band — the parts of a
+ * report that differ from the data rows below them.
+ */
+export interface StreamStyledCell {
+  value?: CellValue
+  style?: CellStyle
+  formula?: string
+}
+
 /** A streamed row: positional values, or an object read through `columns[].key`. */
-export type XlsxStreamRow = CellValue[] | Record<string, unknown>
+export type XlsxStreamRow = Array<CellValue | StreamStyledCell> | Record<string, unknown>
+
+function serializeMergeCells(merges: MergeRange[]): string {
+  return xmlElement(
+    "mergeCells",
+    { count: merges.length },
+    merges.map((merge) =>
+      xmlSelfClose("mergeCell", {
+        ref: `${cellRef(merge.startRow, merge.startCol)}:${cellRef(merge.endRow, merge.endCol)}`,
+      }),
+    ),
+  )
+}
+
+/**
+ * Copy a captured header row. `slice()` alone keeps a reference to each styled
+ * cell, so a caller reusing one wrapper for later rows would see the header
+ * repeated on rolled-over sheets carrying the mutated value.
+ */
+function snapshotRow(
+  values: Array<CellValue | StreamStyledCell>,
+): Array<CellValue | StreamStyledCell> {
+  return values.map((value) => (isStreamStyledCell(value) ? { ...value } : value))
+}
+
+function isStreamStyledCell(value: CellValue | StreamStyledCell): value is StreamStyledCell {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !(value instanceof Date) &&
+    ("value" in value || "style" in value || "formula" in value)
+  )
+}
 
 /** Excel's hard row limit since Excel 2007 (2^20). */
 export const XLSX_MAX_ROWS_PER_SHEET = 1_048_576
@@ -135,24 +191,43 @@ class RowSerializer {
   }
 
   /** Serialize one row. Returns `null` when every cell was empty. */
-  serializeRow(rowIndex: number, values: CellValue[]): string | null {
+  serializeRow(
+    rowIndex: number,
+    values: Array<CellValue | StreamStyledCell>,
+    rowDef?: RowDef,
+  ): string | null {
     const cellElements: string[] = []
 
     for (let c = 0; c < values.length; c++) {
       const colDef = this.columns?.[c]
-      let style: CellStyle | undefined = colDef?.style
+      const raw = values[c]
+      const styled = isStreamStyledCell(raw)
+      const value = styled ? (raw.value ?? null) : (raw as CellValue)
+      let style: CellStyle | undefined = (styled && raw.style) || colDef?.style
 
       // If numFmt on column but not in style, merge
       if (colDef?.numFmt && (!style || !style.numFmt)) {
         style = { ...style, numFmt: colDef.numFmt }
       }
 
-      const cellXml = this.serializeCell(rowIndex, c, values[c], style)
+      const cellXml = this.serializeCell(
+        rowIndex,
+        c,
+        value,
+        style,
+        styled ? raw.formula : undefined,
+      )
       if (cellXml) cellElements.push(cellXml)
     }
 
-    if (cellElements.length === 0) return null
-    return xmlElement("row", { r: rowIndex + 1 }, cellElements)
+    const attrs = rowAttributes(rowIndex, rowDef)
+
+    if (cellElements.length === 0) {
+      // A row with no cells still has to be emitted when its definition asks
+      // for something — a height, or a hidden/grouped row the caller wants.
+      return hasRowAttributes(rowDef) ? xmlSelfClose("row", attrs) : null
+    }
+    return xmlElement("row", attrs, cellElements)
   }
 
   private serializeCell(
@@ -160,6 +235,7 @@ class RowSerializer {
     col: number,
     value: CellValue,
     style: CellStyle | undefined,
+    formula?: string,
   ): string | null {
     let effectiveStyle = style
 
@@ -174,6 +250,32 @@ class RowSerializer {
     }
 
     const ref = cellRef(row, col)
+
+    if (formula !== undefined) {
+      const attrs: Record<string, string | number> = { r: ref }
+      if (styleIdx !== 0) attrs.s = styleIdx
+      const children = [xmlElement("f", undefined, xmlEscape(formula))]
+
+      // Cached result, typed the way the worksheet writer types it: a bare
+      // <v> is read as a number, so text and booleans need their `t`.
+      if (typeof value === "string") {
+        attrs.t = "str"
+        children.push(xmlElement("v", undefined, xmlEscape(value)))
+      } else if (typeof value === "boolean") {
+        attrs.t = "b"
+        children.push(xmlElement("v", undefined, value ? "1" : "0"))
+      } else if (typeof value === "number") {
+        // Same guard as the plain numeric branch: NaN and the infinities have
+        // no OOXML representation, so the cache is dropped rather than written
+        // as something no reader can parse.
+        if (Number.isFinite(value)) {
+          children.push(xmlElement("v", undefined, String(value)))
+        }
+      } else if (value instanceof Date) {
+        children.push(xmlElement("v", undefined, String(dateToSerial(value, this.is1904))))
+      }
+      return xmlElement("c", attrs, children)
+    }
 
     // Null — skip if no style
     if (value === null || value === undefined) {
@@ -374,6 +476,8 @@ export class XlsxStreamWriter {
   private columns: ColumnDef[] | undefined
   private freezePane: FreezePane | undefined
   private dateSystem: "1900" | "1904"
+  private rowDefs: Map<number, RowDef> | undefined
+  private merges: MergeRange[] | undefined
   private maxRowsPerSheet: number
   private repeatHeaders: boolean
   private serializer: RowSerializer
@@ -388,7 +492,7 @@ export class XlsxStreamWriter {
   private rowCount = 0
   private maxCols = 0
   /** Captured for `repeatHeaders`. Set when the first row is written. */
-  private headerRowValues: CellValue[] | null = null
+  private headerRowValues: Array<CellValue | StreamStyledCell> | null = null
 
   constructor(options: XlsxStreamWriterOptions) {
     this.sheetName = options.name
@@ -397,6 +501,8 @@ export class XlsxStreamWriter {
     this.dateSystem = options.dateSystem ?? "1900"
     this.maxRowsPerSheet = options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET
     this.repeatHeaders = options.repeatHeaders ?? true
+    this.rowDefs = options.rowDefs
+    this.merges = options.merges
     this.serializer = new RowSerializer({
       columns: options.columns,
       dateSystem: this.dateSystem,
@@ -416,13 +522,13 @@ export class XlsxStreamWriter {
     }
   }
 
-  /** Add a row of values */
-  addRow(values: CellValue[]): void {
+  /** Add a row of values, each optionally carrying its own style or formula. */
+  addRow(values: Array<CellValue | StreamStyledCell>): void {
     // Capture the very first row as a fallback header for repeatHeaders, in
     // case the caller didn't supply column definitions but does want their
     // first row repeated when sheets roll over.
     if (this.rowCount === 0 && !this.headerRowValues) {
-      this.headerRowValues = values.slice()
+      this.headerRowValues = snapshotRow(values)
     }
 
     // Roll over before writing this row when the current sheet is full.
@@ -431,6 +537,7 @@ export class XlsxStreamWriter {
     }
 
     const rowIndex = this.currentSheetRowCount
+    const globalRow = this.rowCount
     this.currentSheetRowCount++
     this.rowCount++
 
@@ -438,7 +545,9 @@ export class XlsxStreamWriter {
       this.maxCols = values.length
     }
 
-    this.emit(rowIndex, values)
+    // rowDefs are keyed by the caller's row number, which keeps counting past
+    // a rollover — `rowIndex` restarts at 0 on every generated sheet.
+    this.emit(rowIndex, values, globalRow)
   }
 
   /**
@@ -455,12 +564,18 @@ export class XlsxStreamWriter {
       // the rollover guard at the top.
       const rowIndex = this.currentSheetRowCount
       this.currentSheetRowCount++
-      this.emit(rowIndex, this.headerRowValues)
+      // The repeated header is the same logical row as the original, so it
+      // carries the same row definition.
+      this.emit(rowIndex, this.headerRowValues, 0)
     }
   }
 
-  private emit(rowIndex: number, values: CellValue[]): void {
-    const xml = this.serializer.serializeRow(rowIndex, values)
+  private emit(
+    rowIndex: number,
+    values: Array<CellValue | StreamStyledCell>,
+    globalRow: number,
+  ): void {
+    const xml = this.serializer.serializeRow(rowIndex, values, this.rowDefs?.get(globalRow))
     if (xml) {
       this.sheetFragments[this.sheetFragments.length - 1]!.push(xml)
     }
@@ -521,6 +636,12 @@ export class XlsxStreamWriter {
       const worksheetParts: string[] = []
       worksheetParts.push(...sheetPrelude)
       worksheetParts.push(xmlElement("sheetData", undefined, fragments.length > 0 ? fragments : ""))
+      // Merges belong to the first sheet: a rollover splits one logical sheet
+      // into several, and a range copied onto the continuation would cover
+      // rows it was never meant to.
+      if (s === 0 && this.merges?.length) {
+        worksheetParts.push(serializeMergeCells(this.merges))
+      }
       const worksheetXml = xmlDocument(
         "worksheet",
         { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R },
@@ -626,7 +747,7 @@ async function* xlsxStreamEntries(
   const prelude = buildSheetPrelude(columns, options.freezePane).join("")
   const cursor = createRowCursor(rows)
 
-  let headerRow = headerFromColumns(columns)
+  let headerRow: Array<CellValue | StreamStyledCell> | null = headerFromColumns(columns)
   let globalRowCount = 0
 
   /** Stream one worksheet, stopping at the row cap or when rows run out. */
@@ -646,7 +767,8 @@ async function* xlsxStreamEntries(
     // Sheet 0 emits the column header as a real row (matching the
     // incremental writer); later sheets repeat it when asked to.
     if (headerRow && (sheetIndex === 0 || repeatHeaders)) {
-      const xml = serializer.serializeRow(rowIndex, headerRow)
+      // The header is the caller's row 0, whichever sheet it is repeated on.
+      const xml = serializer.serializeRow(rowIndex, headerRow, options.rowDefs?.get(0))
       rowIndex++
       if (sheetIndex === 0) globalRowCount++
       if (xml) {
@@ -663,10 +785,12 @@ async function* xlsxStreamEntries(
 
       // Without column headers the first row doubles as the repeated header.
       if (globalRowCount === 0 && !headerRow) {
-        headerRow = values.slice()
+        headerRow = snapshotRow(values)
       }
 
-      const xml = serializer.serializeRow(rowIndex, values)
+      // rowDefs are keyed by the caller's row number, which keeps counting
+      // past a rollover — `rowIndex` restarts at 0 on every generated sheet.
+      const xml = serializer.serializeRow(rowIndex, values, options.rowDefs?.get(globalRowCount))
       rowIndex++
       globalRowCount++
       if (xml) {
@@ -675,7 +799,17 @@ async function* xlsxStreamEntries(
       }
     }
 
-    const closeChunk = chunker.push("</sheetData></worksheet>")
+    let sheetTail = "</sheetData>"
+    if (sheetIndex === 0 && options.merges?.length) {
+      const mergeElements = options.merges.map((merge) =>
+        xmlSelfClose("mergeCell", {
+          ref: `${cellRef(merge.startRow, merge.startCol)}:${cellRef(merge.endRow, merge.endCol)}`,
+        }),
+      )
+      sheetTail += xmlElement("mergeCells", { count: options.merges.length }, mergeElements)
+    }
+    sheetTail += "</worksheet>"
+    const closeChunk = chunker.push(sheetTail)
     if (closeChunk) yield closeChunk
     const tail = chunker.flush()
     if (tail) yield tail

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -2,6 +2,7 @@
 // Generates xl/worksheets/sheetN.xml for an XLSX package.
 
 import type {
+  RowDef,
   WriteSheet,
   CellValue,
   CellStyle,
@@ -85,6 +86,36 @@ export function colToLetter(col: number): string {
 }
 
 /** Build a cell reference like "A1" from 0-based row and col */
+/**
+ * The `<row>` attributes a row definition asks for. Shared with the streaming
+ * writers so a `RowDef` means the same thing whichever writer serialises it.
+ */
+export function rowAttributes(
+  rowIndex: number,
+  rowDef?: RowDef,
+): Record<string, string | number | boolean> {
+  const attrs: Record<string, string | number | boolean> = { r: rowIndex + 1 }
+  if (rowDef?.height !== undefined) {
+    attrs["ht"] = rowDef.height
+    attrs["customHeight"] = 1
+  }
+  if (rowDef?.hidden) attrs["hidden"] = 1
+  if (rowDef?.outlineLevel) attrs["outlineLevel"] = rowDef.outlineLevel
+  if (rowDef?.collapsed) attrs["collapsed"] = 1
+  return attrs
+}
+
+/** True when a row definition asks for anything at all. */
+export function hasRowAttributes(rowDef?: RowDef): boolean {
+  return (
+    rowDef !== undefined &&
+    (rowDef.height !== undefined ||
+      Boolean(rowDef.hidden) ||
+      Boolean(rowDef.outlineLevel) ||
+      Boolean(rowDef.collapsed))
+  )
+}
+
 export function cellRef(row: number, col: number): string {
   return colToLetter(col) + (row + 1)
 }
@@ -444,20 +475,7 @@ export function writeWorksheetXml(
     }
 
     if (hasAnyCells || hasRowDef) {
-      const rowAttrs: Record<string, string | number | boolean> = { r: r + 1 }
-      if (rowDef?.height !== undefined) {
-        rowAttrs["ht"] = rowDef.height
-        rowAttrs["customHeight"] = 1
-      }
-      if (rowDef?.hidden) {
-        rowAttrs["hidden"] = 1
-      }
-      if (rowDef?.outlineLevel) {
-        rowAttrs["outlineLevel"] = rowDef.outlineLevel
-      }
-      if (rowDef?.collapsed) {
-        rowAttrs["collapsed"] = 1
-      }
+      const rowAttrs = rowAttributes(r, rowDef)
       if (hasAnyCells) {
         rowElements.push(xmlElement("row", rowAttrs, cellElements))
       } else {

--- a/test/xlsx-stream-styled-cells.test.ts
+++ b/test/xlsx-stream-styled-cells.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsxStream, XlsxStreamWriter, type StreamStyledCell } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import type { CellStyle } from "../src/_types"
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+const title: CellStyle = {
+  font: { name: "Manrope", size: 20, bold: true },
+  alignment: { horizontal: "center" },
+}
+const data: CellStyle = { font: { name: "Arial", size: 8 } }
+
+describe("writeXlsxStream — per-cell formatting", () => {
+  it("styles a single cell without styling the column it sits in", async () => {
+    const bytes = await collect(
+      writeXlsxStream(
+        [
+          [{ value: "Report", style: title }, "plain"],
+          ["a", "b"],
+        ],
+        { name: "S", columns: [{ style: data }, { style: data }] },
+      ),
+    )
+
+    const wb = await readXlsx(bytes, { readStyles: true })
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.style!.font!.name).toBe("Manrope")
+    expect(cells.get("0,1")!.style!.font!.name).toBe("Arial")
+    expect(cells.get("1,0")!.style!.font!.name).toBe("Arial")
+  })
+
+  it("keeps the column style for cells that do not carry one", async () => {
+    const bytes = await collect(
+      writeXlsxStream([[{ value: 1 }, 2]], {
+        name: "S",
+        columns: [{ style: data }, { style: data }],
+      }),
+    )
+
+    const wb = await readXlsx(bytes, { readStyles: true })
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.style!.font!.size).toBe(8)
+    expect(cells.get("0,1")!.style!.font!.size).toBe(8)
+  })
+
+  it("writes a formula, with the cached result when one is given", async () => {
+    const bytes = await collect(
+      writeXlsxStream(
+        [
+          [
+            { formula: "SUM(B1:B9)", style: data },
+            { value: 3, formula: "1+2" },
+          ],
+        ],
+        { name: "S" },
+      ),
+    )
+
+    const wb = await readXlsx(bytes)
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.formula).toBe("SUM(B1:B9)")
+    expect(cells.get("0,1")!.formula).toBe("1+2")
+    expect(cells.get("0,1")!.value).toBe(3)
+  })
+
+  it("applies row heights from rowDefs, including on an otherwise empty row", async () => {
+    const bytes = await collect(
+      writeXlsxStream([["a"], [], ["b"]], {
+        name: "S",
+        rowDefs: new Map([
+          [0, { height: 30 }],
+          [1, { height: 44 }],
+        ]),
+      }),
+    )
+
+    const wb = await readXlsx(bytes)
+    const rowDefs = wb.sheets[0]!.rowDefs!
+
+    expect(rowDefs.get(0)!.height).toBe(30)
+    expect(rowDefs.get(1)!.height).toBe(44)
+  })
+
+  it("emits merged ranges after the streamed rows", async () => {
+    const bytes = await collect(
+      writeXlsxStream([[{ value: "wide", style: title }, null, null]], {
+        name: "S",
+        merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }],
+      }),
+    )
+
+    const wb = await readXlsx(bytes)
+
+    expect(wb.sheets[0]!.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }])
+  })
+
+  it("treats a Date as a value, not as a styled cell", async () => {
+    const bytes = await collect(writeXlsxStream([[new Date(Date.UTC(2024, 0, 1))]], { name: "S" }))
+
+    const wb = await readXlsx(bytes)
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBeInstanceOf(Date)
+  })
+
+  it("keeps a text or boolean formula result instead of dropping it", async () => {
+    const bytes = await collect(
+      writeXlsxStream(
+        [
+          [
+            { value: "ok", formula: 'IF(1=1,"ok","no")' },
+            { value: true, formula: "1=1" },
+          ],
+        ],
+        { name: "S" },
+      ),
+    )
+
+    const wb = await readXlsx(bytes)
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.value).toBe("ok")
+    expect(cells.get("0,1")!.value).toBe(true)
+  })
+})
+
+describe("XlsxStreamWriter — the same options the generator takes", () => {
+  it("honours styled cells, rowDefs and merges", async () => {
+    const writer = new XlsxStreamWriter({
+      name: "S",
+      rowDefs: new Map([[0, { height: 30 }]]),
+      merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }],
+    })
+
+    writer.addRow([{ value: "wide", style: title }, null, null])
+    writer.addRow(["data"])
+
+    const wb = await readXlsx(await writer.finish(), { readStyles: true })
+    const sheet = wb.sheets[0]!
+
+    expect(sheet.cells!.get("0,0")!.style!.font!.name).toBe("Manrope")
+    expect(sheet.rowDefs!.get(0)!.height).toBe(30)
+    expect(sheet.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }])
+  })
+
+  it("keys rowDefs by the caller's row number across a sheet rollover", async () => {
+    const writer = new XlsxStreamWriter({
+      name: "S",
+      maxRowsPerSheet: 2,
+      repeatHeaders: false,
+      rowDefs: new Map([
+        [0, { height: 11 }],
+        [2, { height: 33 }],
+      ]),
+    })
+
+    writer.addRow(["r0"])
+    writer.addRow(["r1"])
+    writer.addRow(["r2"])
+
+    const wb = await readXlsx(await writer.finish())
+
+    // Row 0 of the first sheet, and row 2 — the first row of the second
+    // sheet, which restarts the per-sheet index at 0.
+    expect(wb.sheets[0]!.rowDefs!.get(0)!.height).toBe(11)
+    expect(wb.sheets[1]!.rowDefs!.get(0)!.height).toBe(33)
+    // The definition for row 0 must not be reapplied to the new sheet.
+    expect(wb.sheets[1]!.rowDefs!.get(0)!.height).not.toBe(11)
+  })
+
+  it("drops a non-finite formula result instead of writing it", async () => {
+    const bytes = await collect(
+      writeXlsxStream(
+        [
+          [
+            { value: Number.NaN, formula: "0/0" },
+            { value: Number.POSITIVE_INFINITY, formula: "1/0" },
+            { value: 2, formula: "1+1" },
+          ],
+        ],
+        { name: "S" },
+      ),
+    )
+
+    const wb = await readXlsx(bytes)
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.formula).toBe("0/0")
+    expect(cells.get("0,0")!.value).toBeNull()
+    expect(cells.get("0,1")!.value).toBeNull()
+    expect(cells.get("0,2")!.value).toBe(2)
+  })
+
+  it("serializes every rowDef property, not only the height", async () => {
+    const writer = new XlsxStreamWriter({
+      name: "S",
+      rowDefs: new Map([
+        [0, { height: 20, hidden: true }],
+        [1, { outlineLevel: 2, collapsed: true }],
+      ]),
+    })
+
+    writer.addRow(["a"])
+    writer.addRow(["b"])
+
+    const wb = await readXlsx(await writer.finish())
+    const rowDefs = wb.sheets[0]!.rowDefs!
+
+    expect(rowDefs.get(0)).toMatchObject({ height: 20, hidden: true })
+    expect(rowDefs.get(1)).toMatchObject({ outlineLevel: 2, collapsed: true })
+  })
+
+  it("emits an otherwise empty row when its definition asks to hide it", async () => {
+    const bytes = await collect(
+      writeXlsxStream([["a"], [], ["c"]], {
+        name: "S",
+        rowDefs: new Map([[1, { hidden: true }]]),
+      }),
+    )
+
+    const wb = await readXlsx(bytes)
+
+    expect(wb.sheets[0]!.rowDefs!.get(1)!.hidden).toBe(true)
+  })
+
+  it("repeats the header as first emitted, even if the caller reuses the cell object", async () => {
+    const cell: StreamStyledCell = { value: "H", style: title }
+    const writer = new XlsxStreamWriter({
+      name: "S",
+      maxRowsPerSheet: 2,
+      repeatHeaders: true,
+    })
+
+    writer.addRow([cell])
+    cell.value = "mutated"
+    writer.addRow([cell])
+    writer.addRow(["overflow"])
+
+    const wb = await readXlsx(await writer.finish())
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("H")
+    expect(wb.sheets[0]!.rows[1]![0]).toBe("mutated")
+    // The rolled-over sheet repeats the header as it was first emitted.
+    expect(wb.sheets[1]!.rows[0]![0]).toBe("H")
+  })
+})


### PR DESCRIPTION
## The gap

`writeXlsxStream` is the only writer whose peak memory is independent of row count. But it resolved formatting from one place:

```ts
const colDef = this.columns?.[c]
let style: CellStyle | undefined = colDef?.style
```

A whole column at a time. That cannot express a title, a subtotal line, or a header band — the rows of a report that differ from the data below them. So any sheet with a report header had to fall back to `writeXlsx` and hold the whole workbook in memory, which is exactly where constant memory was worth the most. Row heights had the same problem; merges were absent from the streaming path entirely.

## What landed

- **`StreamStyledCell`** — `{ value?, style?, formula? }`, mixable with plain values in a streamed row. A cell that carries a style overrides its column's; one that does not still inherits it. Detected structurally, with `Date` excluded so a date value is never mistaken for a styled cell.
- **Typed formula results.** A bare `<v>` reads back as a number, so a cached result is typed the way `worksheet-writer` types it: `t="str"` for text, `t="b"` for booleans, the serial for dates. `NaN` and the infinities are dropped rather than written as something no reader can parse.
- **`rowDefs?: Map<number, RowDef>`**, keyed by the caller's row number — that number keeps counting past a rollover, while the per-sheet index restarts at 0. Their attributes come from **`rowAttributes`, now shared with the worksheet writer**, so `height` / `hidden` / `outlineLevel` / `collapsed` mean the same thing whichever writer serialises them.
- **`merges?: MergeRange[]`**, written after the sheet data, so they need not be known before the rows are streamed. First sheet only: a rollover splits one logical sheet, and a range copied onto the continuation would cover rows it was never meant to.
- **A captured header row is snapshotted**, not sliced — the array alone keeps a reference to each styled cell, and a caller reusing one wrapper would see the repeated header carry the mutated value.
- **`XlsxStreamWriter` implements both**, and its `addRow` takes styled cells, rather than the shared options type promising what the class ignores.
- **`StreamStyledCell` re-exported** from `src/index.ts` and `src/xlsx.ts`.

## Review feedback

Eight P2s from @chatgpt-codex-connector, all of which held up, in three rounds.

Three were the API promising more than it delivered — [generator-only options on the class type](https://github.com/productdevbook/hucre/pull/436#discussion_r3714724795), [`addRow` still typed `CellValue[]`](https://github.com/productdevbook/hucre/pull/436#discussion_r3714845296), [the type not exported](https://github.com/productdevbook/hucre/pull/436#discussion_r3714724801). Five were defects in what it wrote: [non-numeric formula results discarded](https://github.com/productdevbook/hucre/pull/436#discussion_r3714724798), [non-finite numbers written raw](https://github.com/productdevbook/hucre/pull/436#discussion_r3714845309), [`rowDefs` misindexed across a rollover](https://github.com/productdevbook/hucre/pull/436#discussion_r3714845303), [only `height` honoured out of `RowDef`](https://github.com/productdevbook/hucre/pull/436#discussion_r3715023832), [the header repeated after mutation](https://github.com/productdevbook/hucre/pull/436#discussion_r3715023837).

Two I would not have found: the rollover indexing — `rowDefs.get(2)` could never reach the third streamed row under a limit of 2, while `rowDefs.get(0)` was reapplied to every generated sheet — and the header snapshot, which only became reachable once rows could carry mutable wrappers.

## Measurements

22 columns, 13 populated, report header (title, subtotal formula, merge, row height), one style object per cell:

| | time | peak RSS |
| --- | --- | --- |
| `writeXlsx`, 50k rows | 2324 ms | 761 MB |
| `writeXlsxStream`, 50k rows | 1111 / 1105 ms | 107 / 106 MB |
| `writeXlsxStream`, 200k rows | 4360 / 4420 ms | 141 / 123 MB |

Peak stays flat as rows grow — the property `writeXlsxStream` already promised, now reachable for sheets that need formatting.

## Tests

`test/xlsx-stream-styled-cells.test.ts`, thirteen assertions: a styled cell does not leak into its column and a bare cell still inherits it; formulas round-trip with text, boolean and numeric caches and drop non-finite ones; every `RowDef` property is serialised, including on a row that has no cells; `rowDefs` survive a rollover at the caller's indices; a repeated header keeps the values it was emitted with; merges survive; a `Date` stays a value; and `XlsxStreamWriter` honours all of it.

Each round's assertions were confirmed failing against the revision they were written for — five against `main`, two against the second revision, three against the third.

## What I did not verify

- No Excel here, and the repo ships no XLSX fixtures, so the check is `readXlsx` round-tripping what the stream wrote. LibreOffice was not tried either.
- Merges stay on the first sheet after a rollover. Repeating them blindly seemed worse, but I do not know which you would prefer.
- The header snapshot copies the wrapper, not the style object inside it. [@chatgpt-codex-connector followed that thread](https://github.com/productdevbook/hucre/pull/436#discussion_r3715089477) to the collector, which keeps style objects until `toXml()` and so lets a later mutation restyle earlier cells. That one is **not from this PR** — it reproduces on `main` through `columns[].style` alone — so it is fixed separately in #437 rather than folded in here.
- `pnpm build && node scripts/verify-package.mjs` passes.
- `main` currently has two failing tests (`coverage-gaps`, `ods-formula-richtext`); they fail on unmodified `main` too.
