### PR TITLE
fix(xlsx): snapshot a style when registering it, not at toXml time

### DIFF
--- a/src/xlsx/styles-writer.ts
+++ b/src/xlsx/styles-writer.ts
@@ -2,14 +2,15 @@
 // Generates xl/styles.xml for an XLSX package.
 
 import type {
-  CellStyle,
-  FontStyle,
-  FillStyle,
-  BorderStyle,
   AlignmentStyle,
-  Color,
   BorderSide,
+  BorderStyle,
   CellProtection,
+  CellStyle,
+  Color,
+  FillStyle,
+  FontStyle,
+  PatternFill,
 } from "../_types"
 import { xmlDocument, xmlElement, xmlSelfClose } from "../xml/writer"
 
@@ -259,6 +260,56 @@ interface XfEntry {
   hasCheckboxFeature?: boolean
 }
 
+/**
+ * The collector keeps the style objects it is handed until `toXml()` runs, so
+ * a caller that mutates one after use would retroactively change formatting
+ * already assigned to earlier cells — and leave the stored dedup key
+ * disagreeing with the value serialised under it. Snapshot on the way in.
+ *
+ * Only reached when a format is registered for the first time, so this costs
+ * one shallow copy per distinct format, not per cell.
+ */
+function cloneColor(color?: Color): Color | undefined {
+  return color === undefined ? undefined : { ...color }
+}
+
+function cloneFont(font: FontStyle): FontStyle {
+  const copy: FontStyle = { ...font }
+  if (font.color) copy.color = cloneColor(font.color)
+  return copy
+}
+
+function cloneFill(fill: FillStyle): FillStyle {
+  if (fill.type === "gradient") {
+    return {
+      ...fill,
+      stops: fill.stops.map((stop) => ({
+        ...stop,
+        color: { ...stop.color },
+      })),
+    }
+  }
+  const copy: PatternFill = { ...fill }
+  if (fill.fgColor) copy.fgColor = cloneColor(fill.fgColor)
+  if (fill.bgColor) copy.bgColor = cloneColor(fill.bgColor)
+  return copy
+}
+
+function cloneBorderSide(side?: BorderSide): BorderSide | undefined {
+  if (side === undefined) return undefined
+  const copy: BorderSide = { ...side }
+  if (side.color) copy.color = cloneColor(side.color)
+  return copy
+}
+
+function cloneBorder(border: BorderStyle): BorderStyle {
+  const copy: BorderStyle = { ...border }
+  for (const side of ["top", "right", "bottom", "left", "diagonal"] as const) {
+    if (border[side]) copy[side] = cloneBorderSide(border[side])
+  }
+  return copy
+}
+
 export function createStylesCollector(defaultFont?: FontStyle): StylesCollector {
   // ── Defaults ──
   // Default font (Calibri 11)
@@ -310,7 +361,7 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
     if (existing !== undefined) return existing
 
     const id = fonts.length
-    fonts.push({ key, font })
+    fonts.push({ key, font: cloneFont(font) })
     fontMap.set(key, id)
     return id
   }
@@ -321,7 +372,7 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
     if (existing !== undefined) return existing
 
     const id = fills.length
-    fills.push({ key, fill })
+    fills.push({ key, fill: cloneFill(fill) })
     fillMap.set(key, id)
     return id
   }
@@ -332,7 +383,7 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
     if (existing !== undefined) return existing
 
     const id = borders.length
-    borders.push({ key, border })
+    borders.push({ key, border: cloneBorder(border) })
     borderMap.set(key, id)
     return id
   }
@@ -427,8 +478,8 @@ export function createStylesCollector(defaultFont?: FontStyle): StylesCollector 
       fontId,
       fillId,
       borderId,
-      alignment: style.alignment,
-      protection: style.protection,
+      alignment: style.alignment ? { ...style.alignment } : undefined,
+      protection: style.protection ? { ...style.protection } : undefined,
       hasCheckboxFeature: checkbox || undefined,
     })
     xfMap.set(key, id)

--- a/test/styles-snapshot-on-register.test.ts
+++ b/test/styles-snapshot-on-register.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import { createStylesCollector } from "../src/xlsx/styles-writer"
+import { writeXlsxStream } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import type { CellStyle } from "../src/_types"
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+describe("styles are snapshotted when registered", () => {
+  it("keeps the font a cell was given after the caller mutates it", () => {
+    const styles = createStylesCollector()
+    const font = { name: "Arial", bold: false }
+
+    styles.addStyle({ font })
+    font.bold = true
+
+    expect(styles.toXml()).toContain('<name val="Arial"/>')
+    expect(styles.toXml().match(/<b\/>/g) ?? []).toHaveLength(0)
+  })
+
+  it("keeps the fill colour a cell was given", () => {
+    const styles = createStylesCollector()
+    const fgColor = { rgb: "FFFF0000" }
+
+    styles.addStyle({ fill: { type: "pattern", pattern: "solid", fgColor } })
+    fgColor.rgb = "FF00FF00"
+
+    expect(styles.toXml()).toContain('rgb="FFFF0000"')
+    expect(styles.toXml()).not.toContain('rgb="FF00FF00"')
+  })
+
+  it("keeps the border a cell was given", () => {
+    const styles = createStylesCollector()
+    const top = { style: "thin" as const }
+
+    styles.addStyle({ border: { top } })
+    top.style = "thick" as typeof top.style
+
+    expect(styles.toXml()).toContain('style="thin"')
+    expect(styles.toXml()).not.toContain('style="thick"')
+  })
+
+  it("keeps the alignment a cell was given", () => {
+    const styles = createStylesCollector()
+    const alignment = { horizontal: "left" as const }
+
+    styles.addStyle({ alignment })
+    alignment.horizontal = "right" as typeof alignment.horizontal
+
+    expect(styles.toXml()).toContain('horizontal="left"')
+    expect(styles.toXml()).not.toContain('horizontal="right"')
+  })
+
+  it("does not retroactively restyle earlier rows of a stream", async () => {
+    const font = { name: "Arial", bold: false }
+    const style: CellStyle = { font }
+
+    function* rows() {
+      yield [1]
+      font.bold = true
+      yield [2]
+    }
+
+    const bytes = await collect(writeXlsxStream(rows(), { name: "S", columns: [{ style }] }))
+    const wb = await readXlsx(bytes, { readStyles: true })
+    const cells = wb.sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.style!.font!.bold ?? false).toBe(false)
+    expect(cells.get("1,0")!.style!.font!.bold).toBe(true)
+  })
+})


### PR DESCRIPTION
## The reproduction

`createStylesCollector` keeps the font, fill, border and alignment objects it is handed — `fonts.push({ key, font })` — and reads them again when `toXml()` runs. A caller that mutates one after use therefore changes formatting **already assigned to earlier cells**, and leaves the stored dedup key disagreeing with the value serialised under it.

Reachable on unmodified `main` through `writeXlsxStream`, which takes rows from caller code:

```js
const font = { name: "Arial", bold: false }
function* rows() {
  yield [1]
  font.bold = true      // after row 1 has been written
  yield [2]
}
writeXlsxStream(rows(), { name: "S", columns: [{ style: { font } }] })
```

| | row 1 | row 2 |
| --- | --- | --- |
| `main` | **bold** | bold |
| this branch | not bold | bold |

Row 1 was written before the mutation, and comes out bold anyway: there is one `<font>` record, registered under the key for `bold: false`, serialised from an object that says `bold: true`.

## What landed

- **`src/xlsx/styles-writer.ts`** — `addFont`, `addFill`, `addBorder` and the `alignment` / `protection` fields of `registerXf` copy what they are given.

The copies are taken **on the registration path only**, after the dedup early return, so this costs one shallow copy per *distinct format* rather than per cell. Colours, border sides and gradient stops are copied too, since those are the nested objects a caller is most likely to reuse.

## How I found it

It came out of review on #436, as a consequence of that PR letting streamed rows carry style objects. It is not caused by it — the reproduction above uses only `columns[].style`, which `main` has always accepted — so it is here on its own rather than folded into a feature branch.

## Tests

`test/styles-snapshot-on-register.test.ts`, five assertions: the font, fill colour, border and alignment a cell was given survive a later mutation of the object it came from, and an earlier row of a stream is not retroactively restyled.

**All five were confirmed failing against `main`** before being made to pass.

## What I did not verify

- No Excel here. The assertions read `styles.xml` and the `readXlsx` round trip, not a rendered workbook.
- `writeXlsx` cannot hit this today — it is handed the document and serialises it without yielding — so the fix is invisible there. It matters for the streaming writers, and for any future path that lets caller code run mid-write.
- Deep-frozen or exotic style objects: the copies are structural (`{ ...obj }` plus known nested fields), not `structuredClone`, so a style carrying something unusual is copied field by field like everywhere else in the writer.
- `main` currently has two failing tests (`coverage-gaps`, `ods-formula-richtext`); they fail on unmodified `main` too.