### PR TITLE
feat(xlsx): stream workbooks that hold more than one sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,12 @@ await writeXlsx({
 Process large files row-by-row without loading everything into memory:
 
 ```ts
-import { streamXlsxRows, writeXlsxStream, XlsxStreamWriter } from "hucre/xlsx"
+import {
+  streamXlsxRows,
+  writeXlsxStream,
+  writeXlsxStreamSheets,
+  XlsxStreamWriter,
+} from "hucre/xlsx"
 
 // Stream read — async generator yields rows one at a time
 for await (const row of streamXlsxRows(buffer)) {
@@ -352,6 +357,21 @@ return new Response(
   },
 )
 
+// Stream write, several sheets — same guarantee across a workbook that
+// holds more than one sheet. Each sheet brings its own name, columns and
+// rows; the row sources are pulled one sheet at a time, in order.
+return new Response(
+  writeXlsxStreamSheets([
+    { name: "Accepted", rows: accepted(), columns },
+    { name: "Rejected", rows: rejected(), columns },
+  ]),
+  {
+    headers: {
+      "content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    },
+  },
+)
+
 // Incremental write — serializes each row on arrival, but holds the
 // serialized parts until finish() returns one buffer. Use it when you
 // need a Uint8Array anyway; use writeXlsxStream for constant memory.
@@ -368,12 +388,13 @@ const buffer = await writer.finish()
 
 #### Which writer to use
 
-|             | `writeXlsxStream()`             | `XlsxStreamWriter`                |
-| ----------- | ------------------------------- | --------------------------------- |
-| Output      | `ReadableStream<Uint8Array>`    | `Promise<Uint8Array>`             |
-| Rows        | pulled from an (async) iterable | pushed via `addRow` / `addObject` |
-| Peak memory | O(distinct styles) — flat       | O(data)                           |
-| Strings     | inline by default               | shared string table               |
+|             | `writeXlsxStream()`                          | `XlsxStreamWriter`                |
+| ----------- | -------------------------------------------- | --------------------------------- |
+| Output      | `ReadableStream<Uint8Array>`                 | `Promise<Uint8Array>`             |
+| Rows        | pulled from an (async) iterable              | pushed via `addRow` / `addObject` |
+| Peak memory | O(distinct styles) — flat                    | O(data)                           |
+| Strings     | inline by default                            | shared string table               |
+| Sheets      | one, or several with `writeXlsxStreamSheets` | one, plus auto-split parts        |
 
 Measured on 5 columns of mixed text/number/date data, writing to a sink
 that discards the bytes (Node 24):

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,19 @@ export { calculateColumnWidth, measureValueWidth, calculateRowHeight } from "./x
 export { parseThemeColors, resolveThemeColor } from "./xlsx/theme"
 export { streamXlsxRows } from "./xlsx/stream-reader"
 export type { StreamRow } from "./xlsx/stream-reader"
-export { XlsxStreamWriter, writeXlsxStream, XLSX_MAX_ROWS_PER_SHEET } from "./xlsx/stream-writer"
+export {
+  XlsxStreamWriter,
+  writeXlsxStream,
+  writeXlsxStreamSheets,
+  XLSX_MAX_ROWS_PER_SHEET,
+} from "./xlsx/stream-writer"
 export type {
   StreamWriterOptions,
   XlsxStreamWriterOptions,
   XlsxWriteStreamOptions,
+  XlsxWriteStreamWorkbookOptions,
   XlsxStreamRow,
+  XlsxStreamSheet,
 } from "./xlsx/stream-writer"
 export { readXlsxObjects, writeXlsxObjects } from "./xlsx/objects"
 export type {

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -18,12 +18,19 @@ export type { RoundtripWorkbook } from "./xlsx/roundtrip"
 export { hashSheetPassword } from "./xlsx/password"
 export { streamXlsxRows } from "./xlsx/stream-reader"
 export type { StreamRow } from "./xlsx/stream-reader"
-export { XlsxStreamWriter, writeXlsxStream, XLSX_MAX_ROWS_PER_SHEET } from "./xlsx/stream-writer"
+export {
+  XlsxStreamWriter,
+  writeXlsxStream,
+  writeXlsxStreamSheets,
+  XLSX_MAX_ROWS_PER_SHEET,
+} from "./xlsx/stream-writer"
 export type {
   StreamWriterOptions,
   XlsxStreamWriterOptions,
   XlsxWriteStreamOptions,
+  XlsxWriteStreamWorkbookOptions,
   XlsxStreamRow,
+  XlsxStreamSheet,
 } from "./xlsx/stream-writer"
 
 // ── Sizing & theme helpers ─────────────────────────────────────────

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -21,7 +21,7 @@ import { createSharedStrings, writeSharedStringsXml } from "./worksheet-writer"
 import { cellRef } from "./worksheet-writer"
 import type { SharedStringsCollector } from "./worksheet-writer"
 import { writeThemeXml } from "./theme-writer"
-import { validateSheetName } from "../_validate"
+import { MAX_SHEET_NAME_LENGTH, validateSheetName, validateSheetNames } from "../_validate"
 import { InvalidArgumentError } from "../errors"
 import { dateToSerial } from "../_date"
 import { xmlDocument, xmlDeclaration, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
@@ -98,6 +98,56 @@ export interface XlsxWriteStreamOptions extends StreamWriterOptions {
 /** A streamed row: positional values, or an object read through `columns[].key`. */
 export type XlsxStreamRow = CellValue[] | Record<string, unknown>
 
+/**
+ * One sheet of a streamed workbook, with its own name and layout.
+ *
+ * `rows` is pulled only as the consumer reads, exactly as in
+ * {@link writeXlsxStream} — it is the sheet *list* that is eager, not the
+ * data. See {@link writeXlsxStreamSheets}.
+ */
+export interface XlsxStreamSheet {
+  /**
+   * Sheet name. Must be unique across the workbook, compared
+   * case-insensitively, because Excel compares them that way.
+   */
+  name: string
+  /** Rows for this sheet, pulled on demand. */
+  rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>
+  /** Column definitions for this sheet. */
+  columns?: ColumnDef[]
+  /** Freeze pane for this sheet. */
+  freezePane?: FreezePane
+  /** Overrides the workbook-level rollover cap for this sheet alone. */
+  maxRowsPerSheet?: number
+  /** Overrides the workbook-level header repetition for this sheet alone. */
+  repeatHeaders?: boolean
+}
+
+/**
+ * Workbook-wide options for {@link writeXlsxStreamSheets}.
+ *
+ * The per-sheet half of {@link XlsxWriteStreamOptions} — `name`,
+ * `columns`, `freezePane` — moves to {@link XlsxStreamSheet}, since a
+ * multi-sheet workbook has one of each *per sheet*. What is left is what
+ * a workbook has exactly one of: the date system, the string strategy,
+ * and the ZIP settings. `maxRowsPerSheet` and `repeatHeaders` stay here
+ * as defaults every sheet inherits unless it sets its own.
+ */
+export interface XlsxWriteStreamWorkbookOptions {
+  /** Date system. Default: "1900" */
+  dateSystem?: "1900" | "1904"
+  /** Default rollover cap; see {@link XlsxWriteStreamOptions.maxRowsPerSheet}. */
+  maxRowsPerSheet?: number
+  /** Default header repetition; see {@link XlsxWriteStreamOptions.repeatHeaders}. */
+  repeatHeaders?: boolean
+  /** See {@link XlsxWriteStreamOptions.inlineStrings}. */
+  inlineStrings?: boolean
+  /** DEFLATE the parts. Default `true`. */
+  compress?: boolean
+  /** See {@link XlsxWriteStreamOptions.zip64}. */
+  zip64?: boolean
+}
+
 /** Excel's hard row limit since Excel 2007 (2^20). */
 export const XLSX_MAX_ROWS_PER_SHEET = 1_048_576
 
@@ -114,6 +164,15 @@ interface RowSerializerOptions {
   columns?: ColumnDef[]
   dateSystem?: "1900" | "1904"
   inlineStrings?: boolean
+  /**
+   * Collectors to write into. A multi-sheet workbook hands the same two
+   * to every sheet's serializer, because `xl/styles.xml` and
+   * `xl/sharedStrings.xml` are workbook-wide parts: a style registered
+   * while serializing sheet 2 has to end up in the same table sheet 1
+   * indexes into. Omitted, each serializer gets its own pair.
+   */
+  styles?: StylesCollector
+  sharedStrings?: SharedStringsCollector
 }
 
 /**
@@ -122,13 +181,15 @@ interface RowSerializerOptions {
  * one of these so their output stays byte-identical.
  */
 class RowSerializer {
-  readonly styles: StylesCollector = createStylesCollector()
-  readonly sharedStrings: SharedStringsCollector = createSharedStrings()
+  readonly styles: StylesCollector
+  readonly sharedStrings: SharedStringsCollector
   private columns: ColumnDef[] | undefined
   private is1904: boolean
   private inlineStrings: boolean
 
   constructor(options: RowSerializerOptions) {
+    this.styles = options.styles ?? createStylesCollector()
+    this.sharedStrings = options.sharedStrings ?? createSharedStrings()
     this.columns = options.columns
     this.is1904 = options.dateSystem === "1904"
     this.inlineStrings = options.inlineStrings ?? false
@@ -312,21 +373,51 @@ function buildSheetPrelude(columns: ColumnDef[] | undefined, freezePane: FreezeP
 function generateSheetNames(baseName: string, count: number): string[] {
   const names: string[] = []
   for (let i = 0; i < count; i++) {
-    if (i === 0) {
-      names.push(truncateSheetName(baseName))
-    } else {
-      const suffix = `_${i + 1}`
-      const room = 31 - suffix.length
-      const base = baseName.length > room ? baseName.slice(0, room) : baseName
-      names.push(base + suffix)
-    }
+    names.push(i === 0 ? truncateSheetName(baseName) : suffixSheetName(baseName, i + 1))
   }
   return names
 }
 
+/** `{baseName}_{ordinal}`, trimmed so the whole name still fits Excel's cap. */
+function suffixSheetName(baseName: string, ordinal: number): string {
+  const suffix = `_${ordinal}`
+  const room = MAX_SHEET_NAME_LENGTH - suffix.length
+  const base = baseName.length > room ? baseName.slice(0, room) : baseName
+  return base + suffix
+}
+
+/**
+ * Name the `part`-th worksheet a single sheet rolled over into, skipping
+ * any name already taken.
+ *
+ * One sheet's rollover can land on a name another sheet declared: a
+ * workbook holding `Data` and `Data_2` rolls `Data` straight into the
+ * name its neighbour owns, and Excel refuses to open a file with two
+ * sheets of the same name. Bumping the ordinal until the name is free
+ * keeps the rollover invisible to callers who never hit it, and keeps
+ * the file valid for the ones who do.
+ */
+function claimSheetName(baseName: string, part: number, taken: Set<string>): string {
+  let ordinal = part + 1
+  let candidate = part === 0 ? truncateSheetName(baseName) : suffixSheetName(baseName, ordinal)
+
+  while (taken.has(candidate.toLowerCase())) {
+    ordinal++
+    candidate = suffixSheetName(baseName, ordinal)
+  }
+
+  taken.add(candidate.toLowerCase())
+  return candidate
+}
+
 /** Build xl/workbook.xml for `count` sheets carrying the base name. */
 function buildWorkbookXml(baseName: string, count: number, dateSystem: "1900" | "1904"): string {
-  const sheetNames = generateSheetNames(baseName, count)
+  return buildWorkbookXmlFor(generateSheetNames(baseName, count), dateSystem)
+}
+
+/** Build xl/workbook.xml for sheets whose names are already resolved. */
+function buildWorkbookXmlFor(sheetNames: string[], dateSystem: "1900" | "1904"): string {
+  const count = sheetNames.length
   const sheetElements: string[] = []
   for (let s = 0; s < count; s++) {
     sheetElements.push(
@@ -600,113 +691,183 @@ export function writeXlsxStream(
   rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
   options: XlsxWriteStreamOptions,
 ): ReadableStream<Uint8Array> {
-  // Validate before returning the stream, not inside the generator.
-  // Generator bodies do not run until first pull, so a deferred throw
-  // would surface only after the caller had already handed the stream to
-  // a Response — too late to do anything about. See #364.
-  validateSheetName(options.name, 0)
-  validateMaxRowsPerSheet(options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET)
+  const { name, columns, freezePane, ...workbook } = options
 
-  return zipStream(xlsxStreamEntries(options, rows), { zip64: options.zip64 })
+  return writeXlsxStreamSheets([{ name, rows, columns, freezePane }], workbook)
+}
+
+/**
+ * Write a multi-sheet XLSX workbook as a byte stream, pulling each
+ * sheet's rows only as the consumer reads.
+ *
+ * {@link writeXlsxStream} streams a single sheet; a workbook that needs
+ * two of them — a report and its rejects, say — had no streaming path at
+ * all and had to fall back to {@link writeXlsx}, which builds the whole
+ * object model first. This keeps the same guarantee across any number of
+ * sheets: peak memory tracks the *distinct styles and strings*, not the
+ * rows.
+ *
+ * ```ts
+ * return new Response(
+ *   writeXlsxStreamSheets([
+ *     { name: "Accepted", rows: accepted, columns },
+ *     { name: "Rejected", rows: rejected, columns },
+ *   ]),
+ *   { headers: { "content-type": XLSX_MIME } },
+ * )
+ * ```
+ *
+ * The sheet *list* is eager while the rows stay lazy. Sheets are few and
+ * their names have to be validated before this returns, for the reason
+ * given in {@link writeXlsxStream}: a generator that throws on first pull
+ * throws after the caller already handed the stream to a `Response`.
+ *
+ * Notes:
+ * - Sheets are written in the order given, and each one is drained before
+ *   the next is pulled — the source for sheet 2 is not touched until
+ *   sheet 1 runs out.
+ * - `xl/styles.xml` and `xl/sharedStrings.xml` are workbook-wide, so a
+ *   style or string is registered once no matter how many sheets use it.
+ * - A sheet past its row cap rolls over exactly as in
+ *   {@link writeXlsxStream}, and the rollover skips names already taken
+ *   by another sheet.
+ */
+export function writeXlsxStreamSheets(
+  sheets: readonly XlsxStreamSheet[],
+  options: XlsxWriteStreamWorkbookOptions = {},
+): ReadableStream<Uint8Array> {
+  if (sheets.length === 0) {
+    throw new InvalidArgumentError("A workbook needs at least one sheet")
+  }
+
+  validateSheetNames(sheets)
+  for (const sheet of sheets) {
+    validateMaxRowsPerSheet(
+      sheet.maxRowsPerSheet ?? options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET,
+    )
+  }
+
+  return zipStream(xlsxStreamEntries(sheets, options), { zip64: options.zip64 })
 }
 
 /** Lazily produce the ZIP entries for a streamed workbook. */
 async function* xlsxStreamEntries(
-  options: XlsxWriteStreamOptions,
-  rows: AsyncIterable<XlsxStreamRow> | Iterable<XlsxStreamRow>,
+  sheets: readonly XlsxStreamSheet[],
+  options: XlsxWriteStreamWorkbookOptions,
 ): AsyncGenerator<ZipStreamEntry> {
   const dateSystem = options.dateSystem ?? "1900"
-  const maxRowsPerSheet = options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET
-  const repeatHeaders = options.repeatHeaders ?? true
   const inlineStrings = options.inlineStrings ?? true
   const compress = options.compress ?? true
-  const columns = options.columns
 
-  const serializer = new RowSerializer({ columns, dateSystem, inlineStrings })
-  const prelude = buildSheetPrelude(columns, options.freezePane).join("")
-  const cursor = createRowCursor(rows)
+  // Workbook-wide parts: every sheet writes into the same two tables.
+  const styles = createStylesCollector()
+  const sharedStrings = createSharedStrings()
 
-  let headerRow = headerFromColumns(columns)
-  let globalRowCount = 0
+  const sheetNames: string[] = []
+  const takenNames = new Set(sheets.map((sheet) => sheet.name.toLowerCase()))
 
-  /** Stream one worksheet, stopping at the row cap or when rows run out. */
-  async function* sheetChunks(sheetIndex: number): AsyncGenerator<Uint8Array> {
-    const chunker = new XmlChunker()
+  for (const sheet of sheets) {
+    const maxRowsPerSheet =
+      sheet.maxRowsPerSheet ?? options.maxRowsPerSheet ?? XLSX_MAX_ROWS_PER_SHEET
+    const repeatHeaders = sheet.repeatHeaders ?? options.repeatHeaders ?? true
 
-    const open =
-      xmlDeclaration() +
-      `<worksheet xmlns="${NS_SPREADSHEET}" xmlns:r="${NS_R}">` +
-      prelude +
-      "<sheetData>"
-    const openChunk = chunker.push(open)
-    if (openChunk) yield openChunk
+    const serializer = new RowSerializer({
+      columns: sheet.columns,
+      dateSystem,
+      inlineStrings,
+      styles,
+      sharedStrings,
+    })
+    const prelude = buildSheetPrelude(sheet.columns, sheet.freezePane).join("")
+    const cursor = createRowCursor(sheet.rows)
 
-    let rowIndex = 0
+    let headerRow = headerFromColumns(sheet.columns)
+    let sheetRowCount = 0
 
-    // Sheet 0 emits the column header as a real row (matching the
-    // incremental writer); later sheets repeat it when asked to.
-    if (headerRow && (sheetIndex === 0 || repeatHeaders)) {
-      const xml = serializer.serializeRow(rowIndex, headerRow)
-      rowIndex++
-      if (sheetIndex === 0) globalRowCount++
-      if (xml) {
-        const chunk = chunker.push(xml)
-        if (chunk) yield chunk
+    /** Stream one worksheet, stopping at the row cap or when rows run out. */
+    async function* sheetChunks(part: number): AsyncGenerator<Uint8Array> {
+      const chunker = new XmlChunker()
+
+      const open =
+        xmlDeclaration() +
+        `<worksheet xmlns="${NS_SPREADSHEET}" xmlns:r="${NS_R}">` +
+        prelude +
+        "<sheetData>"
+      const openChunk = chunker.push(open)
+      if (openChunk) yield openChunk
+
+      let rowIndex = 0
+
+      // The first part emits the column header as a real row (matching the
+      // incremental writer); later parts repeat it when asked to.
+      if (headerRow && (part === 0 || repeatHeaders)) {
+        const xml = serializer.serializeRow(rowIndex, headerRow)
+        rowIndex++
+        if (part === 0) sheetRowCount++
+        if (xml) {
+          const chunk = chunker.push(xml)
+          if (chunk) yield chunk
+        }
       }
+
+      while (rowIndex < maxRowsPerSheet) {
+        const row = await cursor.next()
+        if (row === undefined) break
+
+        const values = Array.isArray(row) ? row : objectToValues(row, requireColumns(sheet.columns))
+
+        // Without column headers the first row doubles as the repeated header.
+        if (sheetRowCount === 0 && !headerRow) {
+          headerRow = values.slice()
+        }
+
+        const xml = serializer.serializeRow(rowIndex, values)
+        rowIndex++
+        sheetRowCount++
+        if (xml) {
+          const chunk = chunker.push(xml)
+          if (chunk) yield chunk
+        }
+      }
+
+      const closeChunk = chunker.push("</sheetData></worksheet>")
+      if (closeChunk) yield closeChunk
+      const tail = chunker.flush()
+      if (tail) yield tail
     }
 
-    while (rowIndex < maxRowsPerSheet) {
-      const row = await cursor.next()
-      if (row === undefined) break
+    try {
+      for (let part = 0; ; part++) {
+        // The declared name is already reserved; a rollover has to claim
+        // a free one.
+        sheetNames.push(
+          part === 0 ? truncateSheetName(sheet.name) : claimSheetName(sheet.name, part, takenNames),
+        )
 
-      const values = Array.isArray(row) ? row : objectToValues(row, requireColumns(columns))
-
-      // Without column headers the first row doubles as the repeated header.
-      if (globalRowCount === 0 && !headerRow) {
-        headerRow = values.slice()
+        yield {
+          path: `xl/worksheets/sheet${sheetNames.length}.xml`,
+          data: sheetChunks(part),
+          compress,
+        }
+        // The ZIP writer drains each entry before pulling the next, so by
+        // now the sheet above is closed and the cursor is positioned on the
+        // first row that didn't fit.
+        if ((await cursor.peek()) === undefined) break
       }
-
-      const xml = serializer.serializeRow(rowIndex, values)
-      rowIndex++
-      globalRowCount++
-      if (xml) {
-        const chunk = chunker.push(xml)
-        if (chunk) yield chunk
-      }
+    } finally {
+      await cursor.close()
     }
-
-    const closeChunk = chunker.push("</sheetData></worksheet>")
-    if (closeChunk) yield closeChunk
-    const tail = chunker.flush()
-    if (tail) yield tail
   }
 
-  let sheetCount = 0
-  try {
-    for (;;) {
-      const sheetIndex = sheetCount++
-      yield {
-        path: `xl/worksheets/sheet${sheetIndex + 1}.xml`,
-        data: sheetChunks(sheetIndex),
-        compress,
-      }
-      // The ZIP writer drains each entry before pulling the next, so by
-      // now the sheet above is closed and the cursor is positioned on the
-      // first row that didn't fit.
-      if ((await cursor.peek()) === undefined) break
-    }
-  } finally {
-    await cursor.close()
-  }
+  const sheetCount = sheetNames.length
+  const hasSharedStrings = sharedStrings.count() > 0
 
-  const hasSharedStrings = serializer.sharedStrings.count() > 0
-
-  yield { path: "xl/styles.xml", data: encoder.encode(serializer.styles.toXml()), compress }
+  yield { path: "xl/styles.xml", data: encoder.encode(styles.toXml()), compress }
 
   if (hasSharedStrings) {
     yield {
       path: "xl/sharedStrings.xml",
-      data: encoder.encode(writeSharedStringsXml(serializer.sharedStrings)),
+      data: encoder.encode(writeSharedStringsXml(sharedStrings)),
       compress,
     }
   }
@@ -715,7 +876,7 @@ async function* xlsxStreamEntries(
 
   yield {
     path: "xl/workbook.xml",
-    data: encoder.encode(buildWorkbookXml(options.name, sheetCount, dateSystem)),
+    data: encoder.encode(buildWorkbookXmlFor(sheetNames, dateSystem)),
     compress,
   }
 
@@ -835,5 +996,5 @@ function objectToValues(item: Record<string, unknown>, columns: ColumnDef[]): Ce
 
 /** Excel sheet names cap at 31 characters. */
 function truncateSheetName(name: string): string {
-  return name.length > 31 ? name.slice(0, 31) : name
+  return name.length > MAX_SHEET_NAME_LENGTH ? name.slice(0, MAX_SHEET_NAME_LENGTH) : name
 }

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -95,6 +95,7 @@ exports[`export surface snapshot > hucre/xlsx 1`] = `
   "writeXlsx",
   "writeXlsxObjects",
   "writeXlsxStream",
+  "writeXlsxStreamSheets",
 ]
 `;
 
@@ -238,6 +239,7 @@ exports[`export surface snapshot > root 1`] = `
   "writeXlsx",
   "writeXlsxObjects",
   "writeXlsxStream",
+  "writeXlsxStreamSheets",
   "writeXml",
 ]
 `;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -55,7 +55,12 @@ import type {
 } from "../src/csv"
 import type { OdsObjectsResult, OdsStreamRow } from "../src/ods"
 import type { JsonReadResult, NdjsonStreamWriterOptions } from "../src/json"
-import type { XlsxObjectsResult, XlsxStreamWriterOptions } from "../src/xlsx"
+import type {
+  XlsxObjectsResult,
+  XlsxStreamSheet,
+  XlsxStreamWriterOptions,
+  XlsxWriteStreamWorkbookOptions,
+} from "../src/xlsx"
 
 /** Referencing each type keeps the imports load-bearing rather than unused. */
 type _SurfaceCheck = [
@@ -97,7 +102,9 @@ type _SurfaceCheck = [
   WriteOptions,
   WriteSheet,
   XlsxObjectsResult,
+  XlsxStreamSheet,
   XlsxStreamWriterOptions,
+  XlsxWriteStreamWorkbookOptions,
 ]
 
 /**
@@ -148,7 +155,13 @@ describe("hucre/xlsx", () => {
   it("exports the streaming API", () => {
     expectExports(
       xlsx,
-      ["streamXlsxRows", "XlsxStreamWriter", "writeXlsxStream", "XLSX_MAX_ROWS_PER_SHEET"],
+      [
+        "streamXlsxRows",
+        "XlsxStreamWriter",
+        "writeXlsxStream",
+        "writeXlsxStreamSheets",
+        "XLSX_MAX_ROWS_PER_SHEET",
+      ],
       "hucre/xlsx",
     )
   })

--- a/test/stream-writer-multi-sheet.test.ts
+++ b/test/stream-writer-multi-sheet.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from "vitest"
+import {
+  writeXlsxStream,
+  writeXlsxStreamSheets,
+  type XlsxStreamRow,
+} from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { InvalidArgumentError } from "../src/errors"
+
+// ── Streamed workbooks holding more than one sheet ───────────────────
+// `writeXlsxStream` streams a single sheet, so a workbook needing two of
+// them had to fall back to `writeXlsx` and build the whole object model
+// first. These tests pin the multi-sheet path and the guarantees it
+// inherits from the single-sheet one.
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  for await (const chunk of stream) {
+    chunks.push(chunk)
+    total += chunk.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+async function extract(workbook: Uint8Array, path: string): Promise<string> {
+  return new TextDecoder().decode(await new ZipReader(workbook).extract(path))
+}
+
+function countChunks(stream: ReadableStream<Uint8Array>): Promise<number> {
+  return (async () => {
+    let chunks = 0
+    for await (const _chunk of stream) chunks++
+    return chunks
+  })()
+}
+
+describe("writeXlsxStreamSheets", () => {
+  it("writes every sheet under its own name, in the order given", async () => {
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets([
+          { name: "Accepted", rows: [["a", 1]] },
+          { name: "Rejected", rows: [["b", 2]] },
+          { name: "Summary", rows: [["c", 3]] },
+        ]),
+      ),
+    )
+
+    expect(wb.sheets.map((sheet) => sheet.name)).toEqual(["Accepted", "Rejected", "Summary"])
+    expect(wb.sheets[0]!.rows).toEqual([["a", 1]])
+    expect(wb.sheets[1]!.rows).toEqual([["b", 2]])
+    expect(wb.sheets[2]!.rows).toEqual([["c", 3]])
+  })
+
+  it("gives each sheet its own columns and freeze pane", async () => {
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets([
+          {
+            name: "Wide",
+            rows: [[1, 2]],
+            columns: [{ width: 40 }, { width: 12 }],
+            freezePane: { rows: 1 },
+          },
+          {
+            name: "Narrow",
+            rows: [[3]],
+            columns: [{ width: 5 }],
+          },
+        ]),
+      ),
+    )
+
+    expect(wb.sheets[0]!.columns?.map((column) => column.width)).toEqual([40, 12])
+    expect(wb.sheets[1]!.columns?.map((column) => column.width)).toEqual([5])
+    expect(wb.sheets[0]!.freezePane).toEqual({ rows: 1 })
+    expect(wb.sheets[1]!.freezePane).toBeUndefined()
+  })
+
+  it("resolves each sheet's header from its own columns", async () => {
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets([
+          {
+            name: "People",
+            rows: [{ id: 1, name: "Ada" }],
+            columns: [
+              { key: "id", header: "ID" },
+              { key: "name", header: "Name" },
+            ],
+          },
+          {
+            name: "Places",
+            rows: [{ city: "Lisbon" }],
+            columns: [{ key: "city", header: "City" }],
+          },
+        ]),
+      ),
+    )
+
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["ID", "Name"],
+      [1, "Ada"],
+    ])
+    expect(wb.sheets[1]!.rows).toEqual([["City"], ["Lisbon"]])
+  })
+
+  it("writes one style table holding the formats of every sheet", async () => {
+    // xl/styles.xml is a workbook-wide part written once. A per-sheet
+    // style table would leave only the last sheet's formats in it, and the
+    // earlier sheets' cells would index into entries that are not there.
+    const bytes = await drain(
+      writeXlsxStreamSheets([
+        { name: "One", rows: [[1]], columns: [{ numFmt: "0.000" }] },
+        { name: "Two", rows: [[2]], columns: [{ numFmt: "#,##0.00" }] },
+      ]),
+    )
+
+    const styles = await extract(bytes, "xl/styles.xml")
+
+    expect(styles).toContain("0.000")
+    expect(styles).toContain("#,##0.00")
+  })
+
+  it("writes one string table shared by every sheet", async () => {
+    const bytes = await drain(
+      writeXlsxStreamSheets(
+        [
+          { name: "One", rows: [["repeated"]] },
+          { name: "Two", rows: [["repeated"]] },
+        ],
+        { inlineStrings: false },
+      ),
+    )
+    const wb = await readXlsx(bytes)
+
+    expect(wb.sheets[0]!.rows).toEqual([["repeated"]])
+    expect(wb.sheets[1]!.rows).toEqual([["repeated"]])
+
+    // Both sheets point at the same entry, so the string is stored once.
+    const table = await extract(bytes, "xl/sharedStrings.xml")
+
+    expect(table.match(/<si>/g)).toHaveLength(1)
+    expect(table).toContain('uniqueCount="1"')
+  })
+
+  it("does not touch a sheet's rows until the previous sheet runs out", async () => {
+    const pulled: string[] = []
+
+    function* track(label: string, rows: XlsxStreamRow[]): Generator<XlsxStreamRow> {
+      for (const row of rows) {
+        pulled.push(label)
+        yield row
+      }
+    }
+
+    const stream = writeXlsxStreamSheets([
+      { name: "First", rows: track("first", [[1], [2]]) },
+      { name: "Second", rows: track("second", [[3]]) },
+    ])
+
+    await drain(stream)
+
+    expect(pulled).toEqual(["first", "first", "second"])
+  })
+
+  it("emits the workbook in chunks instead of one buffer", async () => {
+    const rows = Array.from({ length: 4_000 }, (_, index) => [index, `row ${index}`])
+
+    const chunks = await countChunks(
+      writeXlsxStreamSheets([
+        { name: "One", rows },
+        { name: "Two", rows },
+      ]),
+    )
+
+    expect(chunks).toBeGreaterThan(1)
+  })
+
+  it("rolls a sheet over past its cap, keeping the sheets after it intact", async () => {
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets(
+          [
+            { name: "Big", rows: Array.from({ length: 5 }, (_, index) => [index]) },
+            { name: "Small", rows: [["tail"]] },
+          ],
+          { maxRowsPerSheet: 2, repeatHeaders: false },
+        ),
+      ),
+    )
+
+    expect(wb.sheets.map((sheet) => sheet.name)).toEqual(["Big", "Big_2", "Big_3", "Small"])
+    expect(wb.sheets[3]!.rows).toEqual([["tail"]])
+  })
+
+  it("lets a single sheet override the workbook-wide cap", async () => {
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets(
+          [
+            { name: "Capped", rows: [[1], [2], [3], [4]] },
+            { name: "Uncapped", rows: [[1], [2], [3], [4]], maxRowsPerSheet: Infinity },
+          ],
+          { maxRowsPerSheet: 2, repeatHeaders: false },
+        ),
+      ),
+    )
+
+    expect(wb.sheets.map((sheet) => sheet.name)).toEqual(["Capped", "Capped_2", "Uncapped"])
+  })
+
+  it("skips a rollover name another sheet already owns", async () => {
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets(
+          [
+            { name: "Data", rows: [[1], [2], [3]] },
+            { name: "Data_2", rows: [["taken"]] },
+          ],
+          { maxRowsPerSheet: 2, repeatHeaders: false },
+        ),
+      ),
+    )
+
+    // "Data" rolls over, but "Data_2" belongs to the second sheet, so the
+    // rolled part has to take the next free ordinal — Excel refuses a
+    // workbook with two sheets of the same name.
+    expect(wb.sheets.map((sheet) => sheet.name)).toEqual(["Data", "Data_3", "Data_2"])
+    expect(wb.sheets[2]!.rows).toEqual([["taken"]])
+  })
+
+  it("rejects duplicate sheet names before returning the stream", () => {
+    expect(() =>
+      writeXlsxStreamSheets([
+        { name: "Data", rows: [[1]] },
+        { name: "data", rows: [[2]] },
+      ]),
+    ).toThrow(InvalidArgumentError)
+  })
+
+  it("rejects an invalid sheet name before returning the stream", () => {
+    expect(() => writeXlsxStreamSheets([{ name: "with/slash", rows: [[1]] }])).toThrow(
+      InvalidArgumentError,
+    )
+  })
+
+  it("rejects a workbook with no sheets", () => {
+    expect(() => writeXlsxStreamSheets([])).toThrow(InvalidArgumentError)
+  })
+
+  it("rejects an unusable row cap before returning the stream", () => {
+    expect(() =>
+      writeXlsxStreamSheets([{ name: "Data", rows: [[1]], maxRowsPerSheet: 1 }]),
+    ).toThrow(InvalidArgumentError)
+  })
+
+  it("accepts async row sources", async () => {
+    async function* rows(): AsyncGenerator<XlsxStreamRow> {
+      yield ["a"]
+      yield ["b"]
+    }
+
+    const wb = await readXlsx(await drain(writeXlsxStreamSheets([{ name: "Async", rows: rows() }])))
+
+    expect(wb.sheets[0]!.rows).toEqual([["a"], ["b"]])
+  })
+
+  it("honours the 1904 date system for the whole workbook", async () => {
+    const date = new Date(Date.UTC(2020, 0, 2))
+    const wb = await readXlsx(
+      await drain(
+        writeXlsxStreamSheets(
+          [
+            { name: "One", rows: [[date]] },
+            { name: "Two", rows: [[date]] },
+          ],
+          { dateSystem: "1904" },
+        ),
+      ),
+    )
+
+    expect(wb.sheets[0]!.rows[0]![0]).toEqual(date)
+    expect(wb.sheets[1]!.rows[0]![0]).toEqual(date)
+  })
+})
+
+describe("writeXlsxStream — single-sheet behaviour is unchanged", () => {
+  it("produces the same bytes as the multi-sheet writer given one sheet", async () => {
+    const rows = [
+      ["a", 1],
+      ["b", 2],
+    ]
+    const columns = [{ width: 20 }, { width: 8 }]
+
+    const single = await drain(writeXlsxStream(rows, { name: "Report", columns }))
+    const multi = await drain(writeXlsxStreamSheets([{ name: "Report", rows, columns }]))
+
+    expect(single).toEqual(multi)
+  })
+})


### PR DESCRIPTION
## The gap

`writeXlsxStream` is the writer whose peak memory is independent of row count. It writes one sheet:

```ts
export interface StreamWriterOptions {
  /** Sheet name */
  name: string
```

A workbook holding two — a report and its rejects, an accepted/refused pair — had no streaming path at all. `XlsxStreamWriter` opens further sheets, but only by rolling over at the row cap, under a name derived from the first (`{name}_2`), and `rolloverSheet` is private. So the only way to write two *named* sheets was `writeXlsx`, which builds the whole object model first — and the sheets that need several tabs tend to be the reports that are also large, which is exactly where constant memory was worth the most.

Nothing in the ZIP layer stood in the way: each worksheet is already an independent part, and the loop that emits them was already lazy. What was single-sheet was the *configuration* — one name, one `columns`, one `freezePane`, one serializer.

## What landed

- **`writeXlsxStreamSheets(sheets, options?)`** — takes a list of sheets, each with its own `name`, `rows`, `columns` and `freezePane`, and pulls one row source at a time, in order. Sheet 2's source is not touched until sheet 1 runs out.
- **The sheet list is eager; the rows stay lazy.** Sheets are few, and their names have to be validated before the stream is returned — the reason #364 gives for validating up front applies here word for word: a generator that throws on first pull throws after the caller already handed the stream to a `Response`. `validateSheetNames` gets it uniqueness, case-insensitively, for free.
- **The style and string collectors now span the workbook**, not the sheet. `xl/styles.xml` and `xl/sharedStrings.xml` are workbook-wide parts written once: a style registered while serializing sheet 2 has to land in the same table sheet 1 indexes into. `RowSerializer` takes both as options and still defaults to its own pair, so the single-sheet path is untouched.
- **A rollover skips names another sheet already declared.** A workbook holding `Data` and `Data_2` used to roll `Data` straight onto its neighbour's name, and Excel opens a file with two sheets of one name as damaged. The ordinal now advances until the name is free, which is invisible to callers who never hit a rollover.
- **`maxRowsPerSheet` and `repeatHeaders` are per sheet**, defaulting to the workbook-level value — one sheet can opt out of a cap the rest share.
- **`writeXlsxStream` delegates** to the new function with a one-sheet list. A test asserts the two produce identical bytes for the same input.

`XlsxWriteStreamWorkbookOptions` is what is left of `XlsxWriteStreamOptions` once the per-sheet half moves to `XlsxStreamSheet`: what a workbook has exactly one of — the date system, the string strategy, the ZIP settings.

## Measurements

12 columns of mixed text and numbers, two sheets, writing to a sink that discards the bytes (Node 25):

| rows (across 2 sheets) | `writeXlsx` | `writeXlsxStreamSheets` |
| ---: | ---: | ---: |
| 50,000 | 330 MB / 1.07 s | **90 MB / 0.70 s** |
| 100,000 | 626 MB / 1.64 s | **98 MB / 1.27 s** |
| 200,000 | 889 MB / 3.62 s | **106 MB / 2.70 s** |
| 500,000 | 2,721 MB / 8.83 s | **133 MB / 6.33 s** |

Peak stays flat as the data grows 10×, and flat as the sheets multiply: the same 500,000 rows split across **four** sheets peak at 133 MB — the same figure as two.

## Tests

`test/stream-writer-multi-sheet.test.ts`, 17 cases: sheet order and per-sheet names, per-sheet columns and freeze pane, per-sheet headers from `columns[].header`, one style table holding both sheets' formats, one string table with `uniqueCount="1"` for a string both sheets use, laziness (a generator records which sheet was pulled and when), chunked output, rollover with a following sheet intact, a per-sheet cap override, the rollover name collision, the four up-front validation errors, async row sources, `dateSystem: "1904"` across sheets, and single-sheet byte equality with `writeXlsxStream`.

I checked the two load-bearing ones by mutation rather than trusting they were green: dropping the shared collectors fails the style, string and 1904 tests; dropping the name-collision skip fails only the collision test.

## What I did not verify

- **Excel itself.** The assertions go through `readXlsx` and, for the workbook-wide parts, the raw XML out of `ZipReader`. I have not opened the output in Excel or LibreOffice.
- **Merges and `rowDefs` per sheet.** They are not in `StreamWriterOptions` on `main`; #436 adds them. If that one lands first, they want the same move to `XlsxStreamSheet` — a rollover already restricts merges to the first part, and the same reasoning holds per sheet.
- **Two pre-existing failures** on `main` in my environment, in `coverage-gaps` (CSV) and `ods-formula-richtext`, both date-related and both failing identically before this branch. I left them alone.
