### PR TITLE
fix(xlsx): declare xml:space on inline strings, and stop copying the check

### DIFF
--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -24,7 +24,14 @@ import { writeThemeXml } from "./theme-writer"
 import { MAX_SHEET_NAME_LENGTH, validateSheetName, validateSheetNames } from "../_validate"
 import { InvalidArgumentError } from "../errors"
 import { dateToSerial } from "../_date"
-import { xmlDocument, xmlDeclaration, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
+import {
+  xmlDocument,
+  xmlDeclaration,
+  xmlElement,
+  xmlSelfClose,
+  xmlEscape,
+  xmlTextElement,
+} from "../xml/writer"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
 
@@ -358,7 +365,7 @@ class RowSerializer {
       if (this.inlineStrings) {
         const attrs: Record<string, string | number> = { r: ref, t: "inlineStr" }
         if (styleIdx !== 0) attrs["s"] = styleIdx
-        return xmlElement("c", attrs, [xmlElement("is", undefined, [textElement(value)])])
+        return xmlElement("c", attrs, [xmlElement("is", undefined, [xmlTextElement(value)])])
       }
       const ssIdx = this.sharedStrings.add(value)
       const attrs: Record<string, string | number> = { r: ref, t: "s" }
@@ -397,20 +404,6 @@ class RowSerializer {
 
     return null
   }
-}
-
-/** `<t>` element, preserving significant whitespace like the shared-string writer. */
-function textElement(value: string): string {
-  const escaped = xmlEscape(value)
-  const needsPreserve =
-    value.length > 0 &&
-    (value[0] === " " ||
-      value[value.length - 1] === " " ||
-      value.includes("\n") ||
-      value.includes("\t"))
-  return needsPreserve
-    ? `<t xml:space="preserve">${escaped}</t>`
-    : xmlElement("t", undefined, escaped)
 }
 
 // ── Shared Sheet Scaffolding ────────────────────────────────────────

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -24,7 +24,7 @@ import type {
 import type { StylesCollector } from "./styles-writer"
 import { dateToSerial } from "../_date"
 import { isHyperlinkValue } from "./hyperlink"
-import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
+import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape, xmlTextElement } from "../xml/writer"
 import { calculateColumnWidth } from "./auto-width"
 import { DYNAMIC_ARRAY_CM } from "./metadata"
 import { hashSheetPassword } from "./password"
@@ -177,14 +177,7 @@ export function writeSharedStringsXml(sharedStrings: SharedStringsCollector): st
 
   const children: string[] = []
   for (const str of strings) {
-    const escaped = xmlEscape(str)
-    const needsPreserve =
-      str.length > 0 &&
-      (str[0] === " " || str[str.length - 1] === " " || str.includes("\n") || str.includes("\t"))
-    const tElement = needsPreserve
-      ? `<t xml:space="preserve">${escaped}</t>`
-      : xmlElement("t", undefined, escaped)
-    children.push(xmlElement("si", undefined, [tElement]))
+    children.push(xmlElement("si", undefined, [xmlTextElement(str)]))
   }
 
   return xmlDocument("sst", { xmlns: NS_SPREADSHEET, count, uniqueCount: count }, children)
@@ -915,9 +908,7 @@ function serializeCell(
       // Inline string: <c t="inlineStr"><is><t>value</t></is></c>
       const attrs: Record<string, string | number> = { r: ref, t: "inlineStr" }
       if (styleIdx !== 0) attrs["s"] = styleIdx
-      return xmlElement("c", attrs, [
-        xmlElement("is", undefined, [xmlElement("t", undefined, xmlEscape(value))]),
-      ])
+      return xmlElement("c", attrs, [xmlElement("is", undefined, [xmlTextElement(value)])])
     }
     const ssIdx = sharedStrings.add(value)
     const attrs: Record<string, string | number> = { r: ref, t: "s" }
@@ -1336,20 +1327,8 @@ function serializeRichTextRuns(runs: RichTextRun[]): string[] {
       }
     }
 
-    // Run text (<t>)
-    // Use xml:space="preserve" to preserve whitespace
-    const text = xmlEscape(run.text)
-    const needsPreserve =
-      run.text.length > 0 &&
-      (run.text[0] === " " ||
-        run.text[run.text.length - 1] === " " ||
-        run.text.includes("\n") ||
-        run.text.includes("\t"))
-    if (needsPreserve) {
-      runChildren.push(`<t xml:space="preserve">${text}</t>`)
-    } else {
-      runChildren.push(xmlElement("t", undefined, text))
-    }
+    // Run text (<t>), with xml:space="preserve" when the run needs it.
+    runChildren.push(xmlTextElement(run.text))
 
     elements.push(xmlElement("r", undefined, runChildren))
   }

--- a/src/xml/writer.ts
+++ b/src/xml/writer.ts
@@ -156,6 +156,30 @@ export function xmlSelfClose(tag: string, attrs?: Record<string, AttrValue>): st
   return `<${tag}${serializeAttrs(attrs)}/>`
 }
 
+/**
+ * Build an OOXML `<t>` element, declaring `xml:space="preserve"` when the
+ * text has whitespace an XML consumer is entitled to collapse.
+ *
+ * Every `<t>` in the package has to make this decision — shared strings,
+ * inline strings, and each rich-text run — and the check used to be
+ * copy-pasted at each site. The inline-string branch of the worksheet
+ * writer was the copy that never got it, so `writeXlsx` with
+ * `stringMode: "inline"` emitted `<t>  padded  </t>` and Excel trimmed
+ * the padding. One function, so there is nothing left to forget.
+ */
+export function xmlTextElement(value: string): string {
+  const escaped = xmlEscape(value)
+  const needsPreserve =
+    value.length > 0 &&
+    (value[0] === " " ||
+      value[value.length - 1] === " " ||
+      value.includes("\n") ||
+      value.includes("\t"))
+  return needsPreserve
+    ? `<t xml:space="preserve">${escaped}</t>`
+    : xmlElement("t", undefined, escaped)
+}
+
 /** Build an XML element string with optional children */
 export function xmlElement(
   tag: string,

--- a/test/xml-space-preserve.test.ts
+++ b/test/xml-space-preserve.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeXlsxStream } from "../src/xlsx/stream-writer"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// A `<t>` whose text starts or ends with a space, or holds a newline or a
+// tab, has to declare `xml:space="preserve"` — without it an XML consumer
+// is entitled to collapse the whitespace, and Excel does.
+//
+// The check used to be copy-pasted at each of the four sites that emit a
+// `<t>`. Three had it; the inline-string branch of the worksheet writer
+// did not, so `writeXlsx({ stringMode: "inline" })` shipped padding Excel
+// silently trimmed. hucre's own reader does not trim, so a round-trip
+// assertion could never see it — these read the emitted XML instead.
+// ═══════════════════════════════════════════════════════════════════════
+
+const PADDED = "  padded  "
+const TABBED = "a\tb"
+const LINES = "a\nb"
+
+async function part(bytes: Uint8Array, path: string): Promise<string> {
+  return new TextDecoder().decode(await new ZipReader(bytes).extract(path))
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+describe("xml:space=preserve on every <t> that needs it", () => {
+  it("declares it on an inline string", async () => {
+    const bytes = await writeXlsx({
+      stringMode: "inline",
+      sheets: [{ name: "S", rows: [[PADDED]] }],
+    })
+
+    const xml = await part(bytes, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain(`<t xml:space="preserve">${PADDED}</t>`)
+  })
+
+  it("declares it on a shared string", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[PADDED]] }] })
+
+    const xml = await part(bytes, "xl/sharedStrings.xml")
+
+    expect(xml).toContain(`<t xml:space="preserve">${PADDED}</t>`)
+  })
+
+  it("declares it on a rich-text run", async () => {
+    const cells = new Map([["0,0", { richText: [{ text: PADDED, font: { bold: true } }] }]])
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[null]], cells }] })
+
+    const xml = await part(bytes, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain(`<t xml:space="preserve">${PADDED}</t>`)
+  })
+
+  it("declares it on a streamed inline string", async () => {
+    const bytes = await collect(writeXlsxStream([[PADDED]], { name: "S" }))
+
+    const xml = await part(bytes, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain(`<t xml:space="preserve">${PADDED}</t>`)
+  })
+
+  it("covers tabs and newlines, not only leading and trailing spaces", async () => {
+    const bytes = await writeXlsx({
+      stringMode: "inline",
+      sheets: [{ name: "S", rows: [[TABBED], [LINES]] }],
+    })
+
+    const xml = await part(bytes, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain(`<t xml:space="preserve">${TABBED}</t>`)
+    expect(xml).toContain(`<t xml:space="preserve">${LINES}</t>`)
+  })
+
+  it("leaves it off text that does not need it", async () => {
+    const bytes = await writeXlsx({
+      stringMode: "inline",
+      sheets: [{ name: "S", rows: [["plain"]] }],
+    })
+
+    const xml = await part(bytes, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toContain("<t>plain</t>")
+    expect(xml).not.toContain('xml:space="preserve"')
+  })
+})


### PR DESCRIPTION
From the audit in #439, §C1.

## The bug

`writeXlsx` with `stringMode: "inline"` writes a `<t>` with no `xml:space="preserve"`:

```
<c r="A1" t="inlineStr"><is><t>  padded  </t></is></c>
```

Per XML rules an consumer may collapse that whitespace, and Excel does — the cell opens as `padded`. The default shared-strings path was never affected, which is why this survived: it only appears on an option most callers never set.

## Why the suite could not see it

hucre's own reader does not trim, so `writeXlsx` → `readXlsx` agrees with itself. Only Excel disagrees. The new tests read the emitted XML instead of round-tripping.

## What landed

Four places in the package emit a `<t>` — shared strings, inline strings, rich-text runs, and the streaming writer — and each carried its own copy of the same seven-line whitespace check. Three copies had it; the inline-string branch was the one that did not.

`xmlTextElement` in `src/xml/writer.ts` is now the single decision, and all four call it. `stream-writer`'s private `textElement`, which was the same seven lines a fourth time, is gone.

## Tests

`test/xml-space-preserve.test.ts`, six assertions: inline strings, shared strings, a rich-text run, a streamed inline string, tabs and newlines rather than only spaces, and that plain text still gets a bare `<t>`.

**Two of the six fail against `main`** — the inline-string case and the tab/newline case — which is the point.

## What I did not verify

No Excel here. The evidence is the emitted XML against the OOXML rule, plus the fact that the other three writers in this same package already made the opposite choice for the same input.