### PR TITLE
fix(csv): render dates through the library's own formatter

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1575,7 +1575,14 @@ export interface CsvWriteOptions {
   /** Prepend UTF-8 BOM (for Excel compatibility). Default: false */
   bom?: boolean
   /**
-   * Date format string. Default: ISO 8601
+   * Date format string. Default: ISO 8601 (`toISOString()`).
+   *
+   * Takes the same tokens as the exported `formatDate` and as a `numFmt`
+   * anywhere else in the library — `yyyy`/`yy`, `mmmm`/`mmm`/`mm`/`m`,
+   * `dddd`/`ddd`/`dd`/`d`, `hh`/`h`, `mm`/`m` (minutes, after an hour
+   * token), `ss`, `AM/PM` — and is case-insensitive, so `YYYY-MM-DD` and
+   * `yyyy-mm-dd` both work. Components are read in **UTC**, matching the
+   * ISO default and every other date path in the library.
    *
    * **One-way.** The readers recognize ISO 8601 and nothing else, so a
    * `Date` written with the default round-trips as a `Date` under

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -15,6 +15,7 @@ import type { CellValue, CsvReadOptions, CsvWriteOptions } from "../_types"
 import { stripBom, detectDelimiter } from "./reader"
 import { escapeFormula, unescapeFormula } from "./formula"
 import { inferType } from "../_infer"
+import { formatDate as formatExcelDate } from "../_date"
 
 const TEXT_ENCODER = /* @__PURE__ */ new TextEncoder()
 
@@ -330,28 +331,13 @@ class CsvRowFormatter {
     return String(n)
   }
 
+  /** Same contract as the buffered writer's — see src/csv/writer.ts. */
   private formatDate(d: Date): string {
-    if (!this.dateFormat) {
-      // See #364 — an unparseable Date threw a raw RangeError, and in a
-      // streaming writer that lands after bytes have gone to the client.
-      if (Number.isNaN(d.getTime())) return ""
-      return d.toISOString()
-    }
-
-    const year = d.getFullYear()
-    const month = d.getMonth() + 1
-    const day = d.getDate()
-    const hours = d.getHours()
-    const minutes = d.getMinutes()
-    const seconds = d.getSeconds()
-
-    return this.dateFormat
-      .replace("YYYY", String(year))
-      .replace("MM", String(month).padStart(2, "0"))
-      .replace("DD", String(day).padStart(2, "0"))
-      .replace("HH", String(hours).padStart(2, "0"))
-      .replace("mm", String(minutes).padStart(2, "0"))
-      .replace("ss", String(seconds).padStart(2, "0"))
+    // See #364 — an unparseable Date threw a raw RangeError, and in a
+    // streaming writer that lands after bytes have gone to the client.
+    if (Number.isNaN(d.getTime())) return ""
+    if (!this.dateFormat) return d.toISOString()
+    return formatExcelDate(d, this.dateFormat)
   }
 }
 

--- a/src/csv/writer.ts
+++ b/src/csv/writer.ts
@@ -1,5 +1,6 @@
 import type { CellValue, CsvWriteOptions } from "../_types"
 import { escapeFormula } from "./formula"
+import { formatDate as formatExcelDate } from "../_date"
 
 // ── BOM constant ─────────────────────────────────────────────────────
 
@@ -228,26 +229,20 @@ function formatNumber(n: number): string {
   return String(n)
 }
 
+/**
+ * Render a `Date` for CSV output.
+ *
+ * Delegates to the library's own {@link formatExcelDate}, so a format
+ * string means the same thing here as it does in a `numFmt`, in
+ * `formatValue`, and in the public `formatDate` export. This file used to
+ * carry a private substitute that accepted a different vocabulary
+ * (`YYYY MM DD HH mm ss`), read *local* time components while the
+ * no-format path read UTC, and substituted with a non-global `.replace()`
+ * so a repeated token stayed literal. See #439.
+ */
 function formatDate(d: Date, format?: string): string {
-  if (!format) {
-    // See #364 — an unparseable Date threw a raw RangeError mid-write.
-    if (Number.isNaN(d.getTime())) return ""
-    return d.toISOString()
-  }
-
-  // Simple date format placeholders
-  const year = d.getFullYear()
-  const month = d.getMonth() + 1
-  const day = d.getDate()
-  const hours = d.getHours()
-  const minutes = d.getMinutes()
-  const seconds = d.getSeconds()
-
-  return format
-    .replace("YYYY", String(year))
-    .replace("MM", String(month).padStart(2, "0"))
-    .replace("DD", String(day).padStart(2, "0"))
-    .replace("HH", String(hours).padStart(2, "0"))
-    .replace("mm", String(minutes).padStart(2, "0"))
-    .replace("ss", String(seconds).padStart(2, "0"))
+  // See #364 — an unparseable Date threw a raw RangeError mid-write.
+  if (Number.isNaN(d.getTime())) return ""
+  if (!format) return d.toISOString()
+  return formatExcelDate(d, format)
 }

--- a/test/csv-date-format.test.ts
+++ b/test/csv-date-format.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest"
+import { writeCsv, writeCsvObjects } from "../src/csv/writer"
+import { CsvStreamWriter, writeCsvStream } from "../src/csv/stream"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 — `CsvWriteOptions.dateFormat` used to go through a private
+// formatter that had nothing to do with the library's own. It accepted a
+// different token vocabulary (`YYYY MM DD HH mm ss`), read local-time
+// components while the no-format path read UTC, and substituted with a
+// non-global `.replace()`.
+//
+// These pin all four consequences. The CSV writers now delegate to
+// `formatDate`, so a format string means one thing everywhere.
+// ═══════════════════════════════════════════════════════════════════════
+
+const AT = new Date(Date.UTC(2024, 0, 15, 2, 30, 45))
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const chunks: string[] = []
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(decoder.decode(value, { stream: true }))
+  }
+  chunks.push(decoder.decode())
+  return chunks.join("")
+}
+
+describe("CSV dateFormat", () => {
+  it("accepts the library's own Excel-style tokens", () => {
+    // Against the old formatter this produced the literal text
+    // "yyyy-30-dd": `mm` matched *minutes* and nothing matched yyyy or dd.
+    expect(writeCsv([[AT]], { dateFormat: "yyyy-mm-dd" })).toBe("2024-01-15")
+  })
+
+  it("still accepts the uppercase spelling", () => {
+    expect(writeCsv([[AT]], { dateFormat: "YYYY-MM-DD" })).toBe("2024-01-15")
+    expect(writeCsv([[AT]], { dateFormat: "DD/MM/YYYY" })).toBe("15/01/2024")
+  })
+
+  it("substitutes every occurrence of a token, not only the first", () => {
+    // The old `.replace()` had no /g, so the second MM stayed literal.
+    expect(writeCsv([[AT]], { dateFormat: "MM/DD/YYYY MM" })).toBe("01/15/2024 01")
+  })
+
+  it("reads UTC components, so the output does not depend on the machine", () => {
+    // 02:30 UTC is the previous day in New York. The old formatter used
+    // getFullYear()/getMonth()/getDate() and produced 2024-01-14 there,
+    // while the no-format path produced an ISO string in UTC — so passing
+    // a format silently changed the timezone basis.
+    vi.stubEnv("TZ", "America/New_York")
+    expect(writeCsv([[AT]], { dateFormat: "YYYY-MM-DD HH:mm:ss" })).toBe("2024-01-15 02:30:45")
+    vi.stubEnv("TZ", "Asia/Tokyo")
+    expect(writeCsv([[AT]], { dateFormat: "YYYY-MM-DD HH:mm:ss" })).toBe("2024-01-15 02:30:45")
+    vi.unstubAllEnvs()
+  })
+
+  it("keeps the ISO default and the invalid-date guard", () => {
+    expect(writeCsv([[AT]])).toBe("2024-01-15T02:30:45.000Z")
+    expect(writeCsv([[new Date("nonsense")]])).toBe("")
+    expect(writeCsv([[new Date("nonsense")]], { dateFormat: "YYYY-MM-DD" })).toBe("")
+  })
+
+  it("supports the tokens the private formatter never had", () => {
+    expect(writeCsv([[AT]], { dateFormat: "d mmm yyyy" })).toBe("15 Jan 2024")
+    expect(writeCsv([[AT]], { dateFormat: "h:mm AM/PM" })).toBe("2:30 AM")
+  })
+
+  it("means the same thing in every CSV writer", async () => {
+    const format = "yyyy-mm-dd"
+    const expected = "2024-01-15"
+
+    expect(writeCsv([[AT]], { dateFormat: format })).toBe(expected)
+    expect(writeCsvObjects([{ d: AT }], { dateFormat: format })).toContain(expected)
+
+    const incremental = new CsvStreamWriter({ dateFormat: format })
+    incremental.addRow([AT])
+    expect(incremental.finish()).toBe(expected)
+
+    expect(await drain(writeCsvStream([[AT]], { dateFormat: format }))).toBe(expected)
+  })
+})


### PR DESCRIPTION
From the audit in #439, Part 8.

## The bug

`CsvWriteOptions.dateFormat` went through a private `formatDate` in `src/csv/writer.ts:231`, duplicated byte-for-byte at `src/csv/stream.ts:333`. Measured, same `Date`, two timezones:

```
input: new Date(Date.UTC(2024, 0, 15, 2, 30, 45))

                                    TZ=UTC                    TZ=America/New_York
no dateFormat                       2024-01-15T02:30:45.000Z  2024-01-15T02:30:45.000Z
dateFormat: "yyyy-mm-dd"            yyyy-30-dd                yyyy-30-dd
dateFormat: "YYYY-MM-DD"            2024-01-15                2024-01-14
dateFormat: "MM/DD/YYYY MM"         01/15/2024 MM             01/14/2024 MM
dateFormat: "YYYY-MM-DD HH:mm:ss"   2024-01-15 02:30:45       2024-01-14 21:30:45
```

Four defects:

1. **Wrong vocabulary.** The rest of the library takes Excel-style lowercase tokens — the exported `formatDate`, every `numFmt`, `formatValue`, and the README's own example `formatDate(new Date(), "yyyy-mm-dd")`. The private copy took `YYYY MM DD HH mm ss`, so `mm` matched **minutes** and the cell got the literal text `yyyy-30-dd`. This is the most likely way a user calls the option, because it is the spelling the docs teach everywhere else.
2. **Local time.** It read `getFullYear()` / `getMonth()` / `getDate()` / `getHours()` while the no-format path returned `toISOString()`. Passing a format silently changed the timezone basis, so the exported file depended on the machine that produced it. This is the disagreement #415 fixed for ODS, living on in a different file — every other date path in the library uses `getUTC*`.
3. **`.replace()` with no `/g`.** Only the first occurrence of each token was substituted.
4. **A third of the real formatter.** No `yy`, `d`, `m`, `mmm`, `mmmm`, `ddd`, `dddd`, AM/PM, literal text, or elapsed forms.

## Why the suite could not see it

Every existing test uses the private vocabulary, because the tests were written against the implementation:

```
test/csv-writer.test.ts:157          dateFormat: "YYYY-MM-DD"
test/csv-stream-write.test.ts:83     dateFormat: "YYYY-MM-DD HH:mm:ss"
test/csv-roundtrip-options.test.ts   dateFormat: "DD/MM/YYYY"
test/coverage-gaps.test.ts:337       dateFormat: "YYYY-MM-DD"
```

And CI runs in UTC, so the local/UTC split never showed.

## What landed

Both private copies are gone; the two writers call `formatDate` from `_date.ts`.

**This is not a breaking change for the formats currently in use.** The tokenizer is case-insensitive, so all four strings above render byte-identically — I checked each one before switching. What changes is that the lowercase spelling now works, repeated tokens substitute, the extra tokens are available, and the output no longer depends on the machine's timezone.

`CsvWriteOptions.dateFormat` now documents which tokens it takes and that components are read in UTC. That omission is what let the two vocabularies drift apart unnoticed — `_types.ts` had a bare `dateFormat?: string`.

## Tests

`test/csv-date-format.test.ts`, seven assertions covering `writeCsv`, `writeCsvObjects`, `CsvStreamWriter` and `writeCsvStream`: Excel tokens, the uppercase spelling still working, repeated tokens, timezone independence (stubbed to New York and Tokyo), the ISO default and the `#364` invalid-date guard, and the tokens the private formatter never had.

**Six of the seven fail against `main`.**