### PR TITLE
fix: take object-writer columns from every record, not just the first

### DIFF
--- a/src/_objects.ts
+++ b/src/_objects.ts
@@ -115,3 +115,26 @@ export function selectSheet(workbook: Workbook, selector: number | string): Shee
 
   return sheet
 }
+
+/**
+ * The union of every key appearing in a list of objects, in first-seen
+ * order.
+ *
+ * The object writers used to take their column set from `data[0]` alone,
+ * so any key absent from the first record — an optional field, a column
+ * that appears halfway through an export — was dropped along with the
+ * rows that only had it. See #439.
+ */
+export function collectHeaders(rows: Record<string, CellValue>[]): string[] {
+  const seen = new Set<string>()
+  const headers: string[] = []
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key)
+        headers.push(key)
+      }
+    }
+  }
+  return headers
+}

--- a/src/csv/writer.ts
+++ b/src/csv/writer.ts
@@ -1,6 +1,7 @@
 import type { CellValue, CsvWriteOptions } from "../_types"
 import { escapeFormula } from "./formula"
 import { formatDate as formatExcelDate } from "../_date"
+import { collectHeaders } from "../_objects"
 
 // ── BOM constant ─────────────────────────────────────────────────────
 
@@ -100,13 +101,13 @@ export function writeCsvObjects(
     if (data.length === 0) {
       return opts.bom ? UTF8_BOM : ""
     }
-    headers = Object.keys(data[0]!)
+    headers = collectHeaders(data)
   } else {
     // headers === false — no header row, but we still need column order
     if (data.length === 0) {
       return opts.bom ? UTF8_BOM : ""
     }
-    headers = Object.keys(data[0]!)
+    headers = collectHeaders(data)
     // Convert to rows and write without headers
     const rows: CellValue[][] = data.map((obj) =>
       headers.map((key) => {

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -14,7 +14,7 @@ import type {
   TableDefinition,
   TableColumn,
 } from "./_types"
-import { rowsToObjects, selectSheet } from "./_objects"
+import { collectHeaders, rowsToObjects, selectSheet } from "./_objects"
 import { readXlsx } from "./xlsx/reader"
 import { readXlsb, looksLikeXlsb } from "./xlsx/xlsb/reader"
 import { readXls, looksLikeXls } from "./xls/reader"
@@ -268,8 +268,8 @@ export async function writeObjects(
     })
   }
 
-  // Infer columns from first object's keys
-  const keys = Object.keys(data[0]!)
+  // Column set is the union of every record's keys, not just the first's.
+  const keys = collectHeaders(data)
 
   // Build rows: header row + data rows
   const rows: CellValue[][] = []

--- a/src/json/flatten.ts
+++ b/src/json/flatten.ts
@@ -173,19 +173,9 @@ export function reviveDates(value: unknown, maxDepth = 32, depth = 0): unknown {
 }
 
 /**
- * Compute the union of all keys appearing in a list of flattened rows,
- * preserving first-seen order.
+ * The union of every key appearing in a list of flattened rows, in
+ * first-seen order. Lives in `_objects` so the object writers can reach
+ * it without depending on the JSON module; re-exported here because this
+ * is where `hucre/json` has always published it from.
  */
-export function collectHeaders(rows: Record<string, CellValue>[]): string[] {
-  const seen = new Set<string>()
-  const headers: string[] = []
-  for (const row of rows) {
-    for (const key of Object.keys(row)) {
-      if (!seen.has(key)) {
-        seen.add(key)
-        headers.push(key)
-      }
-    }
-  }
-  return headers
-}
+export { collectHeaders } from "../_objects"

--- a/src/ods/objects.ts
+++ b/src/ods/objects.ts
@@ -2,7 +2,7 @@
 // Header-row-based read/write helpers that mirror parseCsvObjects ergonomics.
 
 import type { CellValue, ReadInput, ReadOptions, WriteOutput } from "../_types"
-import { rowsToObjects, selectSheet } from "../_objects"
+import { collectHeaders, rowsToObjects, selectSheet } from "../_objects"
 import { readOds } from "./reader"
 import { writeOds } from "./writer"
 
@@ -91,7 +91,7 @@ export async function writeOdsObjects(
   const sheetName = options?.sheetName ?? "Sheet1"
   const writeHeaders = options?.writeHeaders ?? true
 
-  const headers = options?.headers ?? (data.length > 0 ? Object.keys(data[0]!) : [])
+  const headers = options?.headers ?? collectHeaders(data)
 
   const rows: CellValue[][] = []
   if (writeHeaders) {

--- a/src/xlsx/objects.ts
+++ b/src/xlsx/objects.ts
@@ -2,7 +2,7 @@
 // Header-row-based read/write helpers that mirror parseCsvObjects ergonomics.
 
 import type { CellValue, ReadInput, ReadOptions, WriteOutput } from "../_types"
-import { rowsToObjects, selectSheet } from "../_objects"
+import { collectHeaders, rowsToObjects, selectSheet } from "../_objects"
 import { readXlsx } from "./reader"
 import { writeXlsx } from "./writer"
 
@@ -100,7 +100,7 @@ export async function writeXlsxObjects(
   const sheetName = options?.sheetName ?? "Sheet1"
   const writeHeaders = options?.writeHeaders ?? true
 
-  const headers = options?.headers ?? (data.length > 0 ? Object.keys(data[0]!) : [])
+  const headers = options?.headers ?? collectHeaders(data)
 
   const rows: CellValue[][] = []
   if (writeHeaders) {

--- a/test/object-writer-headers.test.ts
+++ b/test/object-writer-headers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsxObjects, readXlsxObjects } from "../src/xlsx/objects"
+import { writeOdsObjects, readOdsObjects } from "../src/ods/objects"
+import { writeCsvObjects } from "../src/csv/writer"
+import { parseCsvObjects } from "../src/csv/reader"
+import { writeObjects, readObjects } from "../src/defter"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 — every object writer took its column set from `data[0]`, so a key
+// absent from the first record was dropped, and a record made only of
+// such keys became an empty row. The union helper (`collectHeaders`)
+// already existed and was called by nothing but the JSON reader.
+//
+// The shape below is the ordinary one: optional fields, a column that
+// appears partway through an export.
+// ═══════════════════════════════════════════════════════════════════════
+
+const SPARSE: Record<string, CellValue>[] = [{ a: 1 }, { b: 2 }, { a: 3, c: 4 }]
+
+describe("object writers take the union of every record's keys", () => {
+  it("writeXlsxObjects keeps every column and every row", async () => {
+    const bytes = await writeXlsxObjects(SPARSE)
+
+    const { data, headers } = await readXlsxObjects(bytes)
+
+    expect(headers).toEqual(["a", "b", "c"])
+    expect(data).toEqual([
+      { a: 1, b: null, c: null },
+      { a: null, b: 2, c: null },
+      { a: 3, b: null, c: 4 },
+    ])
+  })
+
+  it("writeOdsObjects keeps every column and every row", async () => {
+    const bytes = await writeOdsObjects(SPARSE)
+
+    const { headers, data } = await readOdsObjects(bytes)
+
+    expect(headers).toEqual(["a", "b", "c"])
+    expect(data).toHaveLength(3)
+    expect(data[1]!.b).toBe(2)
+    expect(data[2]!.c).toBe(4)
+  })
+
+  it("writeCsvObjects keeps every column and every row", () => {
+    const csv = writeCsvObjects(SPARSE)
+
+    // Previously: "a\n1\n\n3" — one column, and the middle record blank.
+    expect(csv.split(/\r?\n/)[0]).toBe("a,b,c")
+
+    const { headers, data } = parseCsvObjects(csv, { header: true, typeInference: true })
+
+    expect(headers).toEqual(["a", "b", "c"])
+    expect(data).toHaveLength(3)
+    expect(data[1]!.b).toBe(2)
+    expect(data[2]!.c).toBe(4)
+  })
+
+  it("writeObjects keeps every column and every row", async () => {
+    const bytes = await writeObjects(SPARSE)
+
+    const { headers, data } = await readObjects(bytes)
+
+    expect(headers).toEqual(["a", "b", "c"])
+    expect(data).toHaveLength(3)
+    expect(data[2]!.c).toBe(4)
+  })
+
+  it("still honours an explicit headers option, projecting away the rest", async () => {
+    const bytes = await writeXlsxObjects(SPARSE, { headers: ["c", "a"] })
+
+    const { headers, data } = await readXlsxObjects(bytes)
+
+    // `b` was asked to be left out, so the record that held only `b` has
+    // nothing left and reads back as the empty row it was written as.
+    expect(headers).toEqual(["c", "a"])
+    expect(data).toEqual([
+      { c: null, a: 1 },
+      { c: 4, a: 3 },
+    ])
+  })
+
+  it("keeps first-seen order rather than sorting", async () => {
+    const bytes = await writeXlsxObjects([{ z: 1 }, { a: 2 }, { m: 3 }])
+
+    expect((await readXlsxObjects(bytes)).headers).toEqual(["z", "a", "m"])
+  })
+
+  it("still writes nothing for an empty list", async () => {
+    expect(writeCsvObjects([])).toBe("")
+    expect((await readXlsxObjects(await writeXlsxObjects([]))).headers).toEqual([])
+  })
+})


### PR DESCRIPTION
From the audit in #439, §AX.

## The bug

Every object writer derived its column set from `data[0]` alone:

```
src/defter.ts:272        Object.keys(data[0]!)      // writeObjects
src/ods/objects.ts:94    Object.keys(data[0]!)      // writeOdsObjects
src/xlsx/objects.ts:103  Object.keys(data[0]!)      // writeXlsxObjects
src/csv/writer.ts:102    Object.keys(data[0]!)      // writeCsvObjects
src/csv/writer.ts:108    Object.keys(data[0]!)
```

So the first record decided the schema for the whole set:

```js
const rows = [{ a: 1 }, { b: 2 }, { a: 3, c: 4 }]

writeCsvObjects(rows)   // "a\n1\n\n3"
writeXlsxObjects(rows)  // reads back as { data: [{a:1}, {a:3}], headers: ["a"] }
writeJson(rows)         // '[{"a":1},{"b":2},{"a":3,"c":4}]'   — correct, for contrast
```

Two of three columns gone, and the record that had no `a` became an empty row. Nothing warned. This is the ordinary shape of data with optional fields, or of an export where a column appears partway through.

## What landed

`collectHeaders` already did exactly the union, in first-seen order — and was exported publicly from both `hucre` and `hucre/json` while being called by nothing but the JSON reader.

It moves from `src/json/flatten.ts` to `src/_objects.ts`, beside `rowsToObjects` (its read-side counterpart), so the CSV and `defter` writers can reach it without depending on the JSON module. `json/flatten.ts` re-exports it, so the public surface does not move.

An explicit `headers` option still wins, and still projects away keys it does not name.

## Tests

`test/object-writer-headers.test.ts`, seven assertions: all four writers on the sparse shape, the explicit-`headers` escape hatch, first-seen ordering (not sorted), and the empty-list case.

**Five of the seven fail against `main`.**