### PR TITLE
fix(xls,xlsb): recognise every built-in date format id, not twelve of them

### DIFF
--- a/src/_date.ts
+++ b/src/_date.ts
@@ -144,6 +144,22 @@ const DATE_FORMAT_IDS = new Set([
 ])
 
 /**
+ * Whether a built-in `numFmtId` names a date or time format.
+ *
+ * The set covers ECMA-376 §18.8.30's date and time built-ins, including
+ * the CJK block (27-36) and the Thai/Chinese/Korean extended block
+ * (50-58). Those two blocks carry no `formatCode` in the file, so a
+ * reader that misses them has no second chance: the cell falls through
+ * to "not a date" and the serial number is handed back raw.
+ *
+ * The XLS and XLSB readers each used to keep a 12-entry table of their
+ * own, missing both blocks — see #439.
+ */
+export function isBuiltinDateFormatId(id: number): boolean {
+  return DATE_FORMAT_IDS.has(id)
+}
+
+/**
  * Check if an Excel number format string represents a date/time format.
  * Used to distinguish dates from plain numbers when reading cells.
  *

--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -9,10 +9,8 @@ import { ParseError } from "../errors"
 import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 import { readInputToUint8Array } from "../_input"
 import { readCfb } from "../xlsx/crypto/cfb"
-import { isDateFormat, serialToDate } from "../_date"
+import { isBuiltinDateFormatId, isDateFormat, serialToDate } from "../_date"
 import { decodeRk, parseRecords, parseSst, Reader, SID, type BiffRecord } from "./biff"
-
-const BUILTIN_DATE_IDS = new Set([14, 15, 16, 17, 18, 19, 20, 21, 22, 45, 46, 47])
 
 const ERROR_TEXT: Record<number, string> = {
   0x00: "#NULL!",
@@ -146,7 +144,7 @@ function parseWorkbookRecords(stream: Uint8Array, options?: ReadOptions): Workbo
   }
 
   const dateXf = xfFmtIds.map((id) => {
-    if (BUILTIN_DATE_IDS.has(id)) return true
+    if (isBuiltinDateFormatId(id)) return true
     const code = fmtCodes.get(id)
     return code ? isDateFormat(code) : false
   })

--- a/src/xlsx/styles.ts
+++ b/src/xlsx/styles.ts
@@ -15,7 +15,7 @@ import type {
   FillPattern,
 } from "../_types"
 import { parseXml } from "../xml/parser"
-import { isDateFormat } from "../_date"
+import { isBuiltinDateFormatId, isDateFormat } from "../_date"
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -91,14 +91,6 @@ const BUILTIN_NUM_FMTS: Record<number, string> = {
   48: "##0.0E+0",
   49: "@",
 }
-
-// ── Date Format Detection ────────────────────────────────────────────
-
-/** Built-in format IDs that represent date/time formats */
-const DATE_FMT_IDS = new Set([
-  14, 15, 16, 17, 18, 19, 20, 21, 22, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 45, 46, 47, 50, 51,
-  52, 53, 54, 55, 56, 57, 58,
-])
 
 // ── Parser ───────────────────────────────────────────────────────────
 
@@ -615,7 +607,7 @@ export function isDateStyle(styles: ParsedStyles, styleIndex: number): boolean {
 
   // A workbook may redefine a built-in id (ECMA-376 §18.8.30), and
   // resolveStyle already honours that — `numFmts.get(id) ?? BUILTIN[id]`.
-  // Consulting DATE_FMT_IDS first disagreed with it: a file redefining
+  // Consulting the built-in id table first disagreed with it: a file redefining
   // id 14 as "#,##0" resolved to a numeric format *and* reported as a
   // date, so the reader converted the serial to a Date and then formatted
   // it numerically. The reverse — id 3 redefined as "yyyy-mm-dd" — was
@@ -627,7 +619,7 @@ export function isDateStyle(styles: ParsedStyles, styleIndex: number): boolean {
 
   // Built-in date format IDs, several of which are locale-dependent and
   // carry no format string to inspect.
-  if (DATE_FMT_IDS.has(numFmtId)) {
+  if (isBuiltinDateFormatId(numFmtId)) {
     return true
   }
 

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -12,7 +12,7 @@ import { decryptAgile } from "../crypto/agile"
 import { ZipReader } from "../../zip/reader"
 import { parseRelationships } from "../relationships"
 import { matchesRelType } from "../reader"
-import { isDateFormat, serialToDate } from "../../_date"
+import { isBuiltinDateFormatId, isDateFormat, serialToDate } from "../../_date"
 import { Cursor, decodeRk, iterateRecords } from "./record"
 import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../../limits"
 
@@ -44,8 +44,6 @@ const REL_WORKBOOK = "officeDocument"
 const REL_WORKSHEET = "worksheet"
 const REL_SHARED_STRINGS = "sharedStrings"
 const REL_STYLES = "styles"
-
-const BUILTIN_DATE_IDS = new Set([14, 15, 16, 17, 18, 19, 20, 21, 22, 45, 46, 47])
 
 const ERROR_TEXT: Record<number, string> = {
   0x00: "#NULL!",
@@ -256,7 +254,7 @@ function parseStylesBin(bin: Uint8Array): boolean[] {
     }
   }
   return cellXfFmtIds.map((id) => {
-    if (BUILTIN_DATE_IDS.has(id)) return true
+    if (isBuiltinDateFormatId(id)) return true
     const code = numFmtCodes.get(id)
     return code ? isDateFormat(code) : false
   })

--- a/test/xls.test.ts
+++ b/test/xls.test.ts
@@ -63,7 +63,7 @@ function sstRecord(strings: string[]): number[] {
   return record(SID.SST, body)
 }
 
-function buildXls(): Uint8Array {
+function buildXls(opts: { dateFmtId?: number } = {}): Uint8Array {
   const strings = ["Name", "Score", "Ada"]
 
   const sheet = concat([
@@ -96,7 +96,13 @@ function buildXls(): Uint8Array {
       bof(0x0005),
       record(SID.DATEMODE, u16(0)),
       record(SID.XF, [...u16(0), ...u16(0), ...Array.from({ length: 16 }, () => 0)]), // general
-      record(SID.XF, [...u16(0), ...u16(14), ...Array.from({ length: 16 }, () => 0)]), // date (builtin 14)
+      // The date xf's built-in format id is a parameter: the built-in date
+      // set is wider than the familiar 14-22 block. See the CJK case below.
+      record(SID.XF, [
+        ...u16(0),
+        ...u16(opts.dateFmtId ?? 14),
+        ...Array.from({ length: 16 }, () => 0),
+      ]),
       sstRecord(strings),
       record(SID.BOUNDSHEET, [...u32(sheetPos), 0, 0, ...shortStr("Sheet1")]),
       eof(),
@@ -126,6 +132,31 @@ describe("XLS (BIFF8) reader", () => {
     expect(rows[3][0]).toBe(10)
     expect(rows[3][1]).toBe(20)
     expect(wb.sheets[0].merges).toEqual([{ startRow: 0, endRow: 0, startCol: 0, endCol: 1 }])
+  })
+
+  // ── #439: the built-in date set is wider than 14-22 / 45-47 ──────────
+  // Built-ins 27-36 (CJK) and 50-58 (Thai/Chinese/Korean) are date and
+  // time formats, and they carry no FORMAT record — so a reader that does
+  // not know them falls through to "not a date" and hands back the raw
+  // serial. This reader used to keep a 12-entry table of its own.
+  describe("built-in date format ids outside the familiar block", () => {
+    const CJK_AND_EXTENDED = [
+      27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+    ]
+
+    for (const id of CJK_AND_EXTENDED) {
+      it(`reads a cell styled with built-in format ${id} as a Date`, async () => {
+        const wb = await readXls(buildXls({ dateFmtId: id }))
+
+        expect(wb.sheets[0].rows[1][3]).toBeInstanceOf(Date)
+      })
+    }
+
+    it("still treats a non-date built-in as a number", async () => {
+      const wb = await readXls(buildXls({ dateFmtId: 3 }))
+
+      expect(wb.sheets[0].rows[1][3]).toBe(45000)
+    })
   })
 
   it("is auto-detected by read()", async () => {

--- a/test/xlsb.test.ts
+++ b/test/xlsb.test.ts
@@ -88,18 +88,23 @@ const NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 const wbProp = (date1904: boolean): Uint8Array =>
   rec(BrtWbProp, concat([u32(date1904 ? 1 : 0), u32(0), nwstr(null)]))
 
-async function buildXlsb(opts: { date1904?: boolean } = {}): Promise<Uint8Array> {
+async function buildXlsb(
+  opts: { date1904?: boolean; dateFmtId?: number } = {},
+): Promise<Uint8Array> {
   // Shared strings: 0:"Name" 1:"Score" 2:"Ada"
   const sst = concat([
     rec(BrtSSTItem, concat([[0], wstr("Name")])),
     rec(BrtSSTItem, concat([[0], wstr("Score")])),
     rec(BrtSSTItem, concat([[0], wstr("Ada")])),
   ])
-  // Styles: xf0 general (iFmt 0), xf1 date (iFmt 14 builtin)
+  // Styles: xf0 general (iFmt 0), xf1 date (a built-in date iFmt).
+  // The id is a parameter because the built-in date set is wider than the
+  // familiar 14-22 block — see the CJK case below.
+  const dateFmtId = opts.dateFmtId ?? 14
   const styles = concat([
     rec(BrtBeginCellXFs, u32(2)),
     rec(BrtXF, concat([u16(0), u16(0), u16(0), u16(0), u16(0), [0, 0]])),
-    rec(BrtXF, concat([u16(0), u16(14), u16(0), u16(0), u16(0), [0, 0]])),
+    rec(BrtXF, concat([u16(0), u16(dateFmtId), u16(0), u16(0), u16(0), [0, 0]])),
     rec(BrtEndCellXFs, []),
   ])
   // Worksheet rows.
@@ -245,6 +250,33 @@ describe("XLSB reader", () => {
         dateSystem: "1904",
       })
       expect(serial45000(pinned1904)).toBe("2027-03-16T00:00:00.000Z")
+    })
+  })
+
+  // ── #439: the built-in date set is wider than 14-22 / 45-47 ──────────
+  // The CJK block (27-36) and the Thai/Chinese/Korean block (50-58) are
+  // date and time formats too, and they carry no formatCode in the file —
+  // so a reader that does not know them has no fallback and hands back the
+  // raw serial. This reader used to keep a 12-entry table of its own.
+  describe("built-in date format ids outside the familiar block", () => {
+    const CJK_AND_EXTENDED = [
+      27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 50, 51, 52, 53, 54, 55, 56, 57, 58,
+    ]
+
+    for (const id of CJK_AND_EXTENDED) {
+      it(`reads a cell styled with built-in format ${id} as a Date`, async () => {
+        const wb = await readXlsb(await buildXlsb({ dateFmtId: id }))
+
+        expect(wb.sheets[0].rows[1][3]).toBeInstanceOf(Date)
+      })
+    }
+
+    it("still treats a non-date built-in as a number", async () => {
+      // 3 is "#,##0" — a numeric built-in, and one that carries no
+      // formatCode either, so it exercises the same fallback path.
+      const wb = await readXlsb(await buildXlsb({ dateFmtId: 3 }))
+
+      expect(wb.sheets[0].rows[1][3]).toBe(45000)
     })
   })
 


### PR DESCRIPTION
From the audit in #439, §AM.

## The bug

Four tables in the tree answer "is this built-in `numFmtId` a date format", and two of them were short:

| | ids | contents |
| --- | ---: | --- |
| `_date.ts DATE_FORMAT_IDS` | 31 | 14–22, **27–36**, 45–47, **50–58** |
| `xlsx/styles.ts DATE_FMT_IDS` | 31 | identical |
| `xls/reader.ts BUILTIN_DATE_IDS` | **12** | 14–22, 45–47 |
| `xlsb/reader.ts BUILTIN_DATE_IDS` | **12** | 14–22, 45–47 |

The two legacy readers were missing twenty ids — the CJK block (27–36) and the Thai/Chinese/Korean extended block (50–58).

There is no second chance for them. A built-in id carries no `formatCode` in the file, so the fallback

```ts
const code = fmtCodes.get(id)
return code ? isDateFormat(code) : false
```

has nothing to consult, and the cell is declared a non-date. **A `.xls` or `.xlsb` cell formatted with id 27 came back as `45000` instead of a `Date`.**

That lands in exactly the files where it hurts: BIFF8 and XLSB are what you reach for when opening someone's legacy workbook, and 27–36 are what a Japanese, Chinese or Korean Excel writes by default. `docs/PARITY.md` promises for both formats: *"Dates, honouring the file's 1900/1904 flag — yes."*

## What landed

`isBuiltinDateFormatId` in `_date.ts` is now the single answer, backed by the same 31-id set, and all three readers call it — `xlsx/styles.ts`'s third copy of the table goes too.

The correct set was already in the tree and already reachable: `isDateFormat` has consulted `DATE_FORMAT_IDS` for numeric ids all along.

## Tests

Both legacy test builders now take the date xf's built-in format id as a parameter, so each of the twenty ids is asserted end to end, plus built-in `3` (`#,##0`) to show the fallback still answers "not a date" for a numeric built-in that likewise carries no format code.

**38 of the new assertions fail against `main`.**

## Note

The reason a table that was 61% complete passed 9,725 tests is that no file produced by a real Excel is in the suite — see #439 §G1. That is a separate piece of work.