### PR TITLE
fix: carry every field through cloneSheet and the worker serializer

### DIFF
--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -779,8 +779,18 @@ export function groupRows(sheet: Sheet, startRow: number, endRow: number, level:
 function cloneCell(cell: Cell): Cell {
   const result: Cell = { value: cell.value, type: cell.type }
   if (cell.style) result.style = cloneCellStyle(cell.style)
+  if (cell.checkbox !== undefined) result.checkbox = cell.checkbox
   if (cell.formula !== undefined) result.formula = cell.formula
   if (cell.formulaResult !== undefined) result.formulaResult = cell.formulaResult
+  // The formula's *shape*, not just its text. Dropping these turned a
+  // shared-formula slave cell — `{ formula: "", formulaType: "shared",
+  // formulaSharedIndex: 3 }` — into a plain `{ formula: "" }`, which the
+  // writer then emitted as an empty `<f/>`. An array formula lost its
+  // spill range, and a dynamic array lost its metadata link (#423).
+  if (cell.formulaType !== undefined) result.formulaType = cell.formulaType
+  if (cell.formulaSharedIndex !== undefined) result.formulaSharedIndex = cell.formulaSharedIndex
+  if (cell.formulaRef !== undefined) result.formulaRef = cell.formulaRef
+  if (cell.formulaDynamic !== undefined) result.formulaDynamic = cell.formulaDynamic
   if (cell.richText)
     result.richText = cell.richText.map((r) => ({
       text: r.text,
@@ -894,16 +904,15 @@ export function cloneSheet(sheet: Sheet, newName: string): Sheet {
 
   // Deep copy images
   if (sheet.images) {
-    cloned.images = sheet.images.map((img) => ({
-      data: new Uint8Array(img.data),
-      type: img.type,
-      anchor: {
-        from: { ...img.anchor.from },
-        to: img.anchor.to ? { ...img.anchor.to } : undefined,
-      },
-      width: img.width,
-      height: img.height,
-    }))
+    // Spread rather than enumerate: listing the fields by hand is how
+    // `altText` and `title` came to be dropped. Only the two nested
+    // members need their own copy.
+    cloned.images = sheet.images.map((img) => {
+      const copy = { ...img, data: new Uint8Array(img.data) }
+      copy.anchor = { ...img.anchor, from: { ...img.anchor.from } }
+      if (img.anchor.to) copy.anchor.to = { ...img.anchor.to }
+      return copy
+    })
   }
 
   // Copy protection
@@ -952,6 +961,29 @@ export function cloneSheet(sheet: Sheet, newName: string): Sheet {
   if (sheet.charts && sheet.charts.length > 0) {
     cloned.charts = structuredClone(sheet.charts)
   }
+
+  // ── The rest of the sheet ──
+  //
+  // These used to be dropped silently — a "deep clone" that returned a
+  // sheet with no sparklines, no text boxes, no page breaks and no
+  // background image. `copySheetToWorkbook` is built on this, so copying
+  // a sheet between workbooks lost them too. See #439 §N.
+  //
+  // Everything here is plain JSON-serialisable data except the background
+  // image, which is bytes, so `structuredClone` is the faithful copy for
+  // the trees and a `slice()` for the buffer.
+  if (sheet.splitPane) cloned.splitPane = { ...sheet.splitPane }
+  if (sheet.rowBreaks) cloned.rowBreaks = [...sheet.rowBreaks]
+  if (sheet.colBreaks) cloned.colBreaks = [...sheet.colBreaks]
+  if (sheet.outlineProperties) cloned.outlineProperties = { ...sheet.outlineProperties }
+  if (sheet.backgroundImage) cloned.backgroundImage = sheet.backgroundImage.slice()
+  if (sheet.sparklines) cloned.sparklines = structuredClone(sheet.sparklines)
+  if (sheet.textBoxes) cloned.textBoxes = structuredClone(sheet.textBoxes)
+  if (sheet.threadedComments) cloned.threadedComments = structuredClone(sheet.threadedComments)
+  if (sheet.pivotTables) cloned.pivotTables = structuredClone(sheet.pivotTables)
+  if (sheet.slicers) cloned.slicers = structuredClone(sheet.slicers)
+  if (sheet.timelines) cloned.timelines = structuredClone(sheet.timelines)
+  if (sheet.a11y) cloned.a11y = { ...sheet.a11y }
 
   return cloned
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -24,8 +24,18 @@ export interface SerializedCell {
   value: SerializedCellValue
   type: Cell["type"]
   style?: Cell["style"]
+  checkbox?: Cell["checkbox"]
   formula?: Cell["formula"]
   formulaResult?: SerializedCellValue
+  /**
+   * The formula's shape, not just its text. Without these a shared-formula
+   * slave cell — `{ formula: "", formulaType: "shared", si }` — arrives as
+   * `{ formula: "" }`, which the writer emits as an empty `<f/>`.
+   */
+  formulaType?: Cell["formulaType"]
+  formulaSharedIndex?: Cell["formulaSharedIndex"]
+  formulaRef?: Cell["formulaRef"]
+  formulaDynamic?: Cell["formulaDynamic"]
   richText?: Cell["richText"]
   hyperlink?: Cell["hyperlink"]
   comment?: Cell["comment"]
@@ -66,6 +76,19 @@ export interface SerializedSheet {
   veryHidden?: Sheet["veryHidden"]
   tables?: Sheet["tables"]
   a11y?: Sheet["a11y"]
+  splitPane?: Sheet["splitPane"]
+  rowBreaks?: Sheet["rowBreaks"]
+  colBreaks?: Sheet["colBreaks"]
+  outlineProperties?: Sheet["outlineProperties"]
+  /** As a plain array, for the same reason as {@link SerializedSheetImage.data}. */
+  backgroundImage?: number[]
+  sparklines?: Sheet["sparklines"]
+  textBoxes?: Sheet["textBoxes"]
+  threadedComments?: Sheet["threadedComments"]
+  pivotTables?: Sheet["pivotTables"]
+  slicers?: Sheet["slicers"]
+  timelines?: Sheet["timelines"]
+  charts?: Sheet["charts"]
 }
 
 /** Serialized WorkbookProperties with Dates as ISO markers. */
@@ -93,6 +116,14 @@ export interface SerializedWorkbook {
   defaultFont?: Workbook["defaultFont"]
   activeSheet?: Workbook["activeSheet"]
   externalLinks?: Workbook["externalLinks"]
+  themeColors?: Workbook["themeColors"]
+  workbookProtection?: Workbook["workbookProtection"]
+  persons?: Workbook["persons"]
+  /** `data` as a plain array on each entry, as elsewhere in this module. */
+  cellImages?: Array<Omit<NonNullable<Workbook["cellImages"]>[number], "data"> & { data: number[] }>
+  pivotCaches?: Workbook["pivotCaches"]
+  slicerCaches?: Workbook["slicerCaches"]
+  timelineCaches?: Workbook["timelineCaches"]
 }
 
 // ── Serialize ───────────────────────────────────────────────────────
@@ -116,10 +147,15 @@ function serializeCell(cell: Cell): SerializedCell {
     type: cell.type,
   }
   if (cell.style !== undefined) out.style = cell.style
+  if (cell.checkbox !== undefined) out.checkbox = cell.checkbox
   if (cell.formula !== undefined) out.formula = cell.formula
   if (cell.formulaResult !== undefined) {
     out.formulaResult = serializeCellValue(cell.formulaResult)
   }
+  if (cell.formulaType !== undefined) out.formulaType = cell.formulaType
+  if (cell.formulaSharedIndex !== undefined) out.formulaSharedIndex = cell.formulaSharedIndex
+  if (cell.formulaRef !== undefined) out.formulaRef = cell.formulaRef
+  if (cell.formulaDynamic !== undefined) out.formulaDynamic = cell.formulaDynamic
   if (cell.richText !== undefined) out.richText = cell.richText
   if (cell.hyperlink !== undefined) out.hyperlink = cell.hyperlink
   if (cell.comment !== undefined) out.comment = cell.comment
@@ -180,10 +216,30 @@ function serializeSheet(sheet: Sheet): SerializedSheet {
   if (sheet.pageSetup) out.pageSetup = sheet.pageSetup
   if (sheet.headerFooter) out.headerFooter = sheet.headerFooter
   if (sheet.view) out.view = sheet.view
-  if (sheet.hidden) out.hidden = sheet.hidden
-  if (sheet.veryHidden) out.veryHidden = sheet.veryHidden
+  // `!== undefined`, not truthiness: an explicit `false` is a value the
+  // caller set and it should survive the trip. `cloneSheet` already did
+  // this; this copy did not.
+  if (sheet.hidden !== undefined) out.hidden = sheet.hidden
+  if (sheet.veryHidden !== undefined) out.veryHidden = sheet.veryHidden
   if (sheet.tables) out.tables = sheet.tables
   if (sheet.a11y) out.a11y = sheet.a11y
+
+  // ── The rest of the sheet ──
+  // These used to be dropped on the way through, so "parse in a worker,
+  // postMessage the result" handed the main thread a quietly poorer
+  // workbook. See #439 §N.
+  if (sheet.splitPane) out.splitPane = sheet.splitPane
+  if (sheet.rowBreaks) out.rowBreaks = sheet.rowBreaks
+  if (sheet.colBreaks) out.colBreaks = sheet.colBreaks
+  if (sheet.outlineProperties) out.outlineProperties = sheet.outlineProperties
+  if (sheet.backgroundImage) out.backgroundImage = Array.from(sheet.backgroundImage)
+  if (sheet.sparklines) out.sparklines = sheet.sparklines
+  if (sheet.textBoxes) out.textBoxes = sheet.textBoxes
+  if (sheet.threadedComments) out.threadedComments = sheet.threadedComments
+  if (sheet.pivotTables) out.pivotTables = sheet.pivotTables
+  if (sheet.slicers) out.slicers = sheet.slicers
+  if (sheet.timelines) out.timelines = sheet.timelines
+  if (sheet.charts) out.charts = sheet.charts
 
   return out
 }
@@ -245,6 +301,15 @@ export function serializeWorkbook(wb: Workbook): SerializedWorkbook {
   if (wb.defaultFont) out.defaultFont = wb.defaultFont
   if (wb.activeSheet !== undefined) out.activeSheet = wb.activeSheet
   if (wb.externalLinks) out.externalLinks = wb.externalLinks
+  if (wb.themeColors) out.themeColors = wb.themeColors
+  if (wb.workbookProtection) out.workbookProtection = wb.workbookProtection
+  if (wb.persons) out.persons = wb.persons
+  if (wb.cellImages) {
+    out.cellImages = wb.cellImages.map((img) => ({ ...img, data: Array.from(img.data) }))
+  }
+  if (wb.pivotCaches) out.pivotCaches = wb.pivotCaches
+  if (wb.slicerCaches) out.slicerCaches = wb.slicerCaches
+  if (wb.timelineCaches) out.timelineCaches = wb.timelineCaches
 
   return out
 }
@@ -270,10 +335,15 @@ function deserializeCell(sc: SerializedCell): Cell {
     type: sc.type,
   }
   if (sc.style !== undefined) cell.style = sc.style
+  if (sc.checkbox !== undefined) cell.checkbox = sc.checkbox
   if (sc.formula !== undefined) cell.formula = sc.formula
   if (sc.formulaResult !== undefined) {
     cell.formulaResult = deserializeCellValue(sc.formulaResult)
   }
+  if (sc.formulaType !== undefined) cell.formulaType = sc.formulaType
+  if (sc.formulaSharedIndex !== undefined) cell.formulaSharedIndex = sc.formulaSharedIndex
+  if (sc.formulaRef !== undefined) cell.formulaRef = sc.formulaRef
+  if (sc.formulaDynamic !== undefined) cell.formulaDynamic = sc.formulaDynamic
   if (sc.richText !== undefined) cell.richText = sc.richText
   if (sc.hyperlink !== undefined) cell.hyperlink = sc.hyperlink
   if (sc.comment !== undefined) cell.comment = sc.comment
@@ -333,10 +403,23 @@ function deserializeSheet(ss: SerializedSheet): Sheet {
   if (ss.pageSetup) sheet.pageSetup = ss.pageSetup
   if (ss.headerFooter) sheet.headerFooter = ss.headerFooter
   if (ss.view) sheet.view = ss.view
-  if (ss.hidden) sheet.hidden = ss.hidden
-  if (ss.veryHidden) sheet.veryHidden = ss.veryHidden
+  if (ss.hidden !== undefined) sheet.hidden = ss.hidden
+  if (ss.veryHidden !== undefined) sheet.veryHidden = ss.veryHidden
   if (ss.tables) sheet.tables = ss.tables
   if (ss.a11y) sheet.a11y = ss.a11y
+
+  if (ss.splitPane) sheet.splitPane = ss.splitPane
+  if (ss.rowBreaks) sheet.rowBreaks = ss.rowBreaks
+  if (ss.colBreaks) sheet.colBreaks = ss.colBreaks
+  if (ss.outlineProperties) sheet.outlineProperties = ss.outlineProperties
+  if (ss.backgroundImage) sheet.backgroundImage = new Uint8Array(ss.backgroundImage)
+  if (ss.sparklines) sheet.sparklines = ss.sparklines
+  if (ss.textBoxes) sheet.textBoxes = ss.textBoxes
+  if (ss.threadedComments) sheet.threadedComments = ss.threadedComments
+  if (ss.pivotTables) sheet.pivotTables = ss.pivotTables
+  if (ss.slicers) sheet.slicers = ss.slicers
+  if (ss.timelines) sheet.timelines = ss.timelines
+  if (ss.charts) sheet.charts = ss.charts
 
   return sheet
 }
@@ -398,6 +481,15 @@ export function deserializeWorkbook(data: SerializedWorkbook): Workbook {
   if (data.defaultFont) wb.defaultFont = data.defaultFont
   if (data.activeSheet !== undefined) wb.activeSheet = data.activeSheet
   if (data.externalLinks) wb.externalLinks = data.externalLinks
+  if (data.themeColors) wb.themeColors = data.themeColors
+  if (data.workbookProtection) wb.workbookProtection = data.workbookProtection
+  if (data.persons) wb.persons = data.persons
+  if (data.cellImages) {
+    wb.cellImages = data.cellImages.map((img) => ({ ...img, data: new Uint8Array(img.data) }))
+  }
+  if (data.pivotCaches) wb.pivotCaches = data.pivotCaches
+  if (data.slicerCaches) wb.slicerCaches = data.slicerCaches
+  if (data.timelineCaches) wb.timelineCaches = data.timelineCaches
 
   return wb
 }

--- a/test/clone-sheet-coverage.test.ts
+++ b/test/clone-sheet-coverage.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest"
+import { cloneSheet, copySheetToWorkbook } from "../src/sheet-ops"
+import { deserializeWorkbook, serializeWorkbook } from "../src/worker"
+import type { Cell, Sheet, Workbook } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §N/§O — `cloneSheet` is documented as "Deep clone (all data,
+// styles, merges, validations, etc.)" and enumerated the fields of
+// `Sheet` by hand. It reached 19 of 30, so a clone came back with no
+// sparklines, no text boxes, no page breaks, no split pane, no background
+// image and no outline properties. `copySheetToWorkbook` is built on it,
+// so copying a sheet between workbooks lost the same eleven.
+//
+// `cloneCell` had the same shape of gap: it carried `formula` but not
+// `formulaType` / `formulaSharedIndex` / `formulaRef` / `formulaDynamic`
+// or `checkbox`, which is worse than loss — a shared-formula slave cell
+// became `{ formula: "" }`, and the writer emits that as an empty `<f/>`.
+//
+// `Required<…>` below is the guard: adding a field to `Sheet` or `Cell`
+// fails `tsc` here until the fixture carries it, and the deep-equality
+// assertion then fails until `cloneSheet` carries it too.
+// ═══════════════════════════════════════════════════════════════════════
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+
+/** Every field of `Cell`, so the type stops us forgetting one. */
+const FULL_CELL: Required<Cell> = {
+  value: 42,
+  type: "number",
+  style: { font: { bold: true }, numFmt: "0.00" },
+  checkbox: true,
+  formula: "",
+  formulaResult: 42,
+  formulaType: "shared",
+  formulaSharedIndex: 3,
+  formulaRef: "A1:A9",
+  formulaDynamic: true,
+  richText: [{ text: "hi", font: { italic: true, color: { rgb: "FF0000" } } }],
+  hyperlink: { target: "https://example.com", tooltip: "go" },
+  comment: { text: "note", author: "Ada" },
+}
+
+/** Every field of `Sheet`, same reason. */
+const FULL_SHEET: Required<Sheet> = {
+  name: "Full",
+  rows: [
+    ["a", 1],
+    ["b", 2],
+  ],
+  cells: new Map<string, Cell>([["0,0", FULL_CELL]]),
+  columns: [{ width: 12, style: { font: { name: "Arial" } } }],
+  rowDefs: new Map([[0, { height: 30, hidden: true }]]),
+  merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+  dataValidations: [{ type: "list", range: "A1:A9", values: ["x", "y"] }],
+  conditionalRules: [
+    {
+      type: "cellIs",
+      priority: 1,
+      range: "A1:A9",
+      operator: "greaterThan",
+      formula: ["0"],
+      style: { font: { bold: true } },
+    },
+  ],
+  autoFilter: { range: "A1:B2", columns: [{ colIndex: 0, filters: ["a"] }] },
+  freezePane: { rows: 1, columns: 1 },
+  splitPane: { xSplit: 2000, ySplit: 1000 },
+  images: [{ data: PNG, type: "png", anchor: { from: { row: 0, col: 0 } }, altText: "logo" }],
+  protection: { sheet: true, password: "pw", selectLockedCells: false },
+  pageSetup: { orientation: "landscape", margins: { top: 1 }, printArea: "A1:B2" },
+  headerFooter: { oddHeader: "&LLeft", oddFooter: "&P" },
+  view: { showGridLines: false, zoomScale: 125, tabColor: { rgb: "00FF00" } },
+  hidden: true,
+  veryHidden: false,
+  tables: [
+    {
+      name: "T1",
+      range: "A1:B2",
+      columns: [{ name: "a" }, { name: "b" }],
+    },
+  ],
+  rowBreaks: [3, 7],
+  colBreaks: [2],
+  outlineProperties: { summaryBelow: false, summaryRight: false },
+  backgroundImage: PNG,
+  sparklines: [{ dataRange: "A1:A9", location: "B1", type: "line" }],
+  textBoxes: [{ text: "hello", anchor: { from: { row: 1, col: 1 } } }],
+  threadedComments: [
+    { id: "{1}", ref: "A1", personId: "p1", text: "hi", date: "2024-01-15T00:00:00Z", done: false },
+  ],
+  a11y: { summary: "A full sheet", headerRow: 0 },
+  pivotTables: [{ name: "P1", cacheId: 1, location: "D1:E5", fields: [] }],
+  slicers: [{ name: "S1", cache: "c1", caption: "Region" }],
+  timelines: [{ name: "T1", cache: "tc1", caption: "Date" }],
+  charts: [{ kinds: ["bar"], seriesCount: 0, series: [], anchor: { from: { row: 0, col: 0 } } }],
+}
+
+describe("cloneSheet carries every field of Sheet", () => {
+  it("produces an equal sheet", () => {
+    const copy = cloneSheet(FULL_SHEET, "Copy")
+
+    expect({ ...copy, name: FULL_SHEET.name }).toEqual(FULL_SHEET)
+  })
+
+  it("leaves nothing behind", () => {
+    const copy = cloneSheet(FULL_SHEET, "Copy") as unknown as Record<string, unknown>
+
+    const missing = Object.keys(FULL_SHEET).filter((k) => copy[k] === undefined)
+
+    expect(missing).toEqual([])
+  })
+
+  it("detaches the collections it copied", () => {
+    const copy = cloneSheet(FULL_SHEET, "Copy")
+
+    expect(copy.rowBreaks).not.toBe(FULL_SHEET.rowBreaks)
+    expect(copy.colBreaks).not.toBe(FULL_SHEET.colBreaks)
+    expect(copy.splitPane).not.toBe(FULL_SHEET.splitPane)
+    expect(copy.outlineProperties).not.toBe(FULL_SHEET.outlineProperties)
+    expect(copy.backgroundImage).not.toBe(FULL_SHEET.backgroundImage)
+    expect(copy.sparklines).not.toBe(FULL_SHEET.sparklines)
+    expect(copy.sparklines![0]).not.toBe(FULL_SHEET.sparklines[0])
+    expect(copy.textBoxes![0]).not.toBe(FULL_SHEET.textBoxes[0])
+    expect(copy.pivotTables![0]).not.toBe(FULL_SHEET.pivotTables[0])
+    expect(copy.slicers![0]).not.toBe(FULL_SHEET.slicers[0])
+    expect(copy.timelines![0]).not.toBe(FULL_SHEET.timelines[0])
+    expect(copy.threadedComments![0]).not.toBe(FULL_SHEET.threadedComments[0])
+
+    copy.rowBreaks!.push(99)
+    copy.sparklines![0]!.dataRange = "Z1:Z9"
+
+    expect(FULL_SHEET.rowBreaks).toEqual([3, 7])
+    expect(FULL_SHEET.sparklines[0]!.dataRange).toBe("A1:A9")
+  })
+
+  it("carries the whole cell, formula shape included", () => {
+    const copy = cloneSheet(FULL_SHEET, "Copy")
+    const cell = copy.cells!.get("0,0")!
+
+    // A shared-formula slave is `{ formula: "", formulaType: "shared", si }`.
+    // Losing the type and the index left `{ formula: "" }`, which the
+    // writer emits as an empty <f/> — a reference replaced by nothing.
+    expect(cell).toEqual(FULL_CELL)
+    expect(cell.formulaType).toBe("shared")
+    expect(cell.formulaSharedIndex).toBe(3)
+    expect(cell.formulaRef).toBe("A1:A9")
+    expect(cell.formulaDynamic).toBe(true)
+    expect(cell.checkbox).toBe(true)
+    expect(cell).not.toBe(FULL_CELL)
+    expect(cell.style).not.toBe(FULL_CELL.style)
+  })
+
+  it("takes the new name and nothing else from the caller", () => {
+    expect(cloneSheet(FULL_SHEET, "Renamed").name).toBe("Renamed")
+  })
+})
+
+describe("copySheetToWorkbook carries the same fields", () => {
+  it("brings the whole sheet across", () => {
+    const target: Workbook = { sheets: [] }
+
+    copySheetToWorkbook(FULL_SHEET, target, "Brought")
+
+    const brought = target.sheets[0]!
+    expect(brought.name).toBe("Brought")
+    expect({ ...brought, name: FULL_SHEET.name }).toEqual(FULL_SHEET)
+  })
+})
+
+describe("serializeWorkbook survives the whole sheet and the whole workbook", () => {
+  /** Every field of `Workbook`, so the type stops us forgetting one. */
+  const FULL_WORKBOOK: Required<Workbook> = {
+    sheets: [FULL_SHEET],
+    properties: { title: "T", creator: "Ada", created: new Date(Date.UTC(2024, 0, 15)) },
+    namedRanges: [{ name: "N", range: "Sheet1!$A$1" }],
+    dateSystem: "1904",
+    defaultFont: { name: "Calibri", size: 11 },
+    activeSheet: 0,
+    themeColors: ["FFFFFF", "000000"],
+    workbookProtection: { lockStructure: true, lockWindows: false },
+    persons: [{ id: "p1", displayName: "Ada", userId: "ada@example.com", providerId: "None" }],
+    externalLinks: [{ target: "other.xlsx", sheetNames: ["S"], sheetData: [], definedNames: [] }],
+    cellImages: [{ id: "ID_1", data: PNG, type: "png" }],
+    pivotCaches: [{ cacheId: 1, sourceSheet: "Full", sourceRef: "A1:B2", fieldNames: ["a", "b"] }],
+    slicerCaches: [{ name: "c1", sourceName: "Region" }],
+    timelineCaches: [{ name: "tc1", sourceName: "Date" }],
+  }
+
+  it("round-trips every workbook field", () => {
+    const back = deserializeWorkbook(serializeWorkbook(FULL_WORKBOOK))
+
+    expect(back).toEqual(FULL_WORKBOOK)
+  })
+
+  it("leaves no workbook field behind", () => {
+    const back = deserializeWorkbook(serializeWorkbook(FULL_WORKBOOK)) as unknown as Record<
+      string,
+      unknown
+    >
+
+    expect(Object.keys(FULL_WORKBOOK).filter((k) => back[k] === undefined)).toEqual([])
+  })
+
+  it("leaves no sheet field behind", () => {
+    const back = deserializeWorkbook(serializeWorkbook(FULL_WORKBOOK))
+      .sheets[0] as unknown as Record<string, unknown>
+
+    expect(Object.keys(FULL_SHEET).filter((k) => back[k] === undefined)).toEqual([])
+  })
+
+  it("keeps the formula shape, so a shared-formula slave stays one", () => {
+    const back = deserializeWorkbook(serializeWorkbook(FULL_WORKBOOK))
+    const cell = back.sheets[0]!.cells!.get("0,0")!
+
+    expect(cell).toEqual(FULL_CELL)
+  })
+
+  it("restores byte buffers as Uint8Array, not plain arrays", () => {
+    const back = deserializeWorkbook(serializeWorkbook(FULL_WORKBOOK))
+
+    expect(back.sheets[0]!.backgroundImage).toBeInstanceOf(Uint8Array)
+    expect(back.cellImages![0]!.data).toBeInstanceOf(Uint8Array)
+  })
+
+  it("stays JSON-safe, not only structured-clone safe", () => {
+    const throughJson = JSON.parse(JSON.stringify(serializeWorkbook(FULL_WORKBOOK)))
+
+    expect(deserializeWorkbook(throughJson)).toEqual(FULL_WORKBOOK)
+  })
+})


### PR DESCRIPTION
From the audit in #439, §N and §O.

## The bug

`Sheet` has 30 fields. Three places in the tree enumerate them by hand, and only one was guarded — `WriteSheet`, by the register in `test/xlsx-write-read-parity.test.ts`. The other two reached 19:

| | drops |
| --- | --- |
| `cloneSheet` (and `copySheetToWorkbook`, built on it) | `splitPane`, `rowBreaks`, `colBreaks`, `outlineProperties`, `backgroundImage`, `sparklines`, `textBoxes`, `threadedComments`, `pivotTables`, `slicers`, `timelines`, `a11y` |
| `serializeWorkbook` | the same, **plus `charts`** — and at workbook level `themeColors`, `workbookProtection`, `persons`, `cellImages`, `pivotCaches`, `slicerCaches`, `timelineCaches` |

So `cloneSheet`, documented as *"Deep clone (all data, styles, merges, validations, etc.)"*, returned a sheet with no sparklines, no text boxes, no page breaks, no split pane and no background image. And the documented pattern "parse in a Web Worker, `postMessage` the result" handed the main thread a quietly poorer workbook.

### The cell half is corruption, not loss

`cloneCell` and `SerializedCell` both carried `formula` but not `formulaType`, `formulaSharedIndex`, `formulaRef`, `formulaDynamic` or `checkbox`.

A shared-formula **slave** cell is `{ formula: "", formulaType: "shared", formulaSharedIndex: 3 }`. Strip the shape and you get `{ formula: "" }`, which `serializeCell` takes down the normal-formula branch and emits as `<f/>` — an empty formula where a reference to the master used to be. An array formula lost its spill `ref`; a dynamic array lost the `cm` metadata link that #423 was opened to fix; a checkbox stopped being one.

## What landed

Both copies carry every field. Two smaller things surfaced on the way:

- `cloneSheet` copied images field by field, which is exactly how `altText` and `title` came to be dropped. It spreads now, and copies only the two nested members that need it.
- `serializeSheet` tested `hidden` / `veryHidden` for truthiness, so an explicitly-set `veryHidden: false` did not survive the trip. `cloneSheet` already used `!== undefined`; this one does now too.

## Tests

`test/clone-sheet-coverage.test.ts` is the guard the other two lacked. `Required<Sheet>`, `Required<Cell>` and `Required<Workbook>` fixtures mean **adding a field to any of the three fails `tsc` here** until the fixture carries it — and the deep-equality assertions then fail until the copies carry it too. Same idea as the parity register, applied to the two places it was not.

Twelve assertions: deep equality, "no key came back `undefined`", detachment (mutating the clone does not move the original), the formula shape specifically, the workbook round trip, that byte buffers come back as `Uint8Array` rather than plain arrays, and that the serialized form survives `JSON.parse(JSON.stringify(…))` and not only structured clone.

**11 of the 12 fail against `main`.**