### PR TITLE
fix(sheet-ops): sortRows moves what belongs to a row, findCells takes a RegExp

### DIFF
--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -5,6 +5,7 @@ import type { Sheet, MergeRange, RowDef, Workbook, Cell, CellValue } from "./_ty
 import { parseCellRef } from "./xlsx/worksheet"
 import { rangeRef } from "./xlsx/worksheet-writer"
 import { cloneCellStyle } from "./_style"
+import { InvalidArgumentError } from "./errors"
 
 // ── Range Helpers ────────────────────────────────────────────────────
 
@@ -237,8 +238,17 @@ export function deleteRows(sheet: Sheet, rowIndex: number, count: number): void 
       }
     }
 
-    // Remove degenerate merges (start > end)
-    sheet.merges = sheet.merges.filter((m) => m.startRow <= m.endRow && m.startCol <= m.endCol)
+    // Drop merges that no longer merge anything. `start > end` is
+    // incoherent; `start === end` on both axes is a one-cell merge, which
+    // is not what any spreadsheet means by the word — Excel writes
+    // `<mergeCell ref="B3:B3"/>` for nothing, and a shrunk range should
+    // disappear the way a fully-deleted one already does.
+    sheet.merges = sheet.merges.filter(
+      (m) =>
+        m.startRow <= m.endRow &&
+        m.startCol <= m.endCol &&
+        !(m.startRow === m.endRow && m.startCol === m.endCol),
+    )
   }
 
   // Update data validations
@@ -511,7 +521,14 @@ export function deleteColumns(sheet: Sheet, colIndex: number, count: number): vo
       }
     }
 
-    sheet.merges = sheet.merges.filter((m) => m.startRow <= m.endRow && m.startCol <= m.endCol)
+    // Same rule as deleteRows: a range shrunk to one cell is no longer a
+    // merge.
+    sheet.merges = sheet.merges.filter(
+      (m) =>
+        m.startRow <= m.endRow &&
+        m.startCol <= m.endCol &&
+        !(m.startRow === m.endRow && m.startCol === m.endCol),
+    )
   }
 
   // Update data validations
@@ -1149,18 +1166,31 @@ export function removeSheet(workbook: Workbook, index: number): void {
  */
 export function findCells(
   sheet: Sheet,
-  predicate: CellValue | ((value: CellValue, row: number, col: number) => boolean),
+  predicate: CellValue | RegExp | ((value: CellValue, row: number, col: number) => boolean),
 ): Array<{ row: number; col: number; value: CellValue }> {
   const results: Array<{ row: number; col: number; value: CellValue }> = []
   const isFn = typeof predicate === "function"
+  // `replaceCells` has always taken a RegExp; this one took a predicate
+  // instead, so "find the cells I am about to replace" could not be
+  // written with the same argument. Both take all three forms now.
+  const isRegExp = predicate instanceof RegExp
 
   for (let r = 0; r < sheet.rows.length; r++) {
     const row = sheet.rows[r]!
     for (let c = 0; c < row.length; c++) {
       const value = row[c] ?? null
-      const match = isFn
-        ? (predicate as (value: CellValue, row: number, col: number) => boolean)(value, r, c)
-        : value === predicate
+      let match: boolean
+      if (isFn) {
+        match = (predicate as (value: CellValue, row: number, col: number) => boolean)(value, r, c)
+      } else if (isRegExp) {
+        // Same rule as replaceCells: a RegExp tests strings only. `lastIndex`
+        // on a /g pattern would make the result depend on call order, so it
+        // is reset before each test.
+        predicate.lastIndex = 0
+        match = typeof value === "string" && predicate.test(value)
+      } else {
+        match = value === predicate
+      }
       if (match) {
         results.push({ row: r, col: c, value })
       }
@@ -1229,23 +1259,38 @@ export function replaceCells(sheet: Sheet, find: CellValue | RegExp, replace: Ce
 export function sortRows(sheet: Sheet, colIndex: number, order?: "asc" | "desc"): void {
   const desc = order === "desc"
 
-  // When the sheet carries a per-cell override Map (styles/formulas/
-  // hyperlinks keyed by "row,col"), the row reordering has to be mirrored
-  // there or every override lands on the wrong row. Tag each row with its
-  // original index, sort, then rebuild the Map from old→new index.
+  // A merged range pins cells to positions, and a sort moves rows past
+  // those positions — there is no arrangement that keeps both. Excel
+  // refuses the operation outright for the same reason; sorting anyway
+  // left the merge covering whatever happened to land there. A merge
+  // wholly inside one row is unaffected, since that row moves as a unit.
+  const spansRows = sheet.merges?.some((m) => m.endRow > m.startRow)
+  if (spansRows) {
+    throw new InvalidArgumentError(
+      "Cannot sort rows: the sheet has a merged range spanning more than one row, " +
+        "and no ordering can keep both the sort and the merge. Remove the merge first.",
+    )
+  }
+
+  // Everything keyed by row index has to move with its row: the per-cell
+  // override Map (styles, formulas, hyperlinks), the row definitions
+  // (heights, hidden, outline levels), and single-row merges. Tag each row
+  // with its original index, sort, then remap through old→new.
+  const tagged = sheet.rows.map((row, i) => ({ row, i }))
+  tagged.sort((a, b) => {
+    const va = colIndex < a.row.length ? (a.row[colIndex] ?? null) : null
+    const vb = colIndex < b.row.length ? (b.row[colIndex] ?? null) : null
+    return compareCellValues(va, vb, desc)
+  })
+
+  const oldToNew = new Map<number, number>()
+  for (let newIdx = 0; newIdx < tagged.length; newIdx++) {
+    oldToNew.set(tagged[newIdx]!.i, newIdx)
+  }
+
+  sheet.rows = tagged.map((t) => t.row)
+
   if (sheet.cells && sheet.cells.size > 0) {
-    const tagged = sheet.rows.map((row, i) => ({ row, i }))
-    tagged.sort((a, b) => {
-      const va = colIndex < a.row.length ? (a.row[colIndex] ?? null) : null
-      const vb = colIndex < b.row.length ? (b.row[colIndex] ?? null) : null
-      return compareCellValues(va, vb, desc)
-    })
-
-    const oldToNew = new Map<number, number>()
-    for (let newIdx = 0; newIdx < tagged.length; newIdx++) {
-      oldToNew.set(tagged[newIdx]!.i, newIdx)
-    }
-
     const remapped = new Map<string, Cell>()
     for (const [key, cell] of sheet.cells) {
       const comma = key.indexOf(",")
@@ -1255,17 +1300,26 @@ export function sortRows(sheet: Sheet, colIndex: number, order?: "asc" | "desc")
       // Keep non-positional keys untouched if any slipped in.
       remapped.set(newRow === undefined ? key : `${newRow},${col}`, cell)
     }
-
-    sheet.rows = tagged.map((t) => t.row)
     sheet.cells = remapped
-    return
   }
 
-  sheet.rows.sort((a, b) => {
-    const va = colIndex < a.length ? (a[colIndex] ?? null) : null
-    const vb = colIndex < b.length ? (b[colIndex] ?? null) : null
-    return compareCellValues(va, vb, desc)
-  })
+  if (sheet.rowDefs && sheet.rowDefs.size > 0) {
+    const remapped = new Map<number, RowDef>()
+    for (const [row, def] of sheet.rowDefs) {
+      remapped.set(oldToNew.get(row) ?? row, def)
+    }
+    sheet.rowDefs = remapped
+  }
+
+  if (sheet.merges) {
+    for (const merge of sheet.merges) {
+      const moved = oldToNew.get(merge.startRow)
+      if (moved !== undefined) {
+        merge.startRow = moved
+        merge.endRow = moved
+      }
+    }
+  }
 }
 
 /**

--- a/test/sheet-ops-helpers.test.ts
+++ b/test/sheet-ops-helpers.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest"
+import { deleteColumns, deleteRows, findCells, replaceCells, sortRows } from "../src/sheet-ops"
+import { InvalidArgumentError } from "../src/errors"
+import type { Cell, Sheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §AD, §AE, §AK — three small disagreements in the sheet helpers.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("sortRows moves everything that is keyed by row", () => {
+  function sheet(): Sheet {
+    const cells = new Map<string, Cell>([
+      ["0,0", { value: 3, type: "number", style: { font: { bold: true } } }],
+    ])
+    return {
+      name: "S",
+      rows: [[3], [1], [2]],
+      cells,
+      rowDefs: new Map([
+        [0, { height: 99 }],
+        [2, { hidden: true }],
+      ]),
+    }
+  }
+
+  it("takes the row definitions with their rows", () => {
+    const s = sheet()
+
+    sortRows(s, 0, "asc")
+
+    // 3 was row 0 and is now row 2; 2 was row 2 and is now row 1.
+    expect(s.rows).toEqual([[1], [2], [3]])
+    expect(s.rowDefs!.get(2)).toEqual({ height: 99 })
+    expect(s.rowDefs!.get(1)).toEqual({ hidden: true })
+    expect(s.rowDefs!.get(0)).toBeUndefined()
+  })
+
+  it("takes the cell overrides too, as it always did", () => {
+    const s = sheet()
+
+    sortRows(s, 0, "asc")
+
+    expect([...s.cells!.keys()]).toEqual(["2,0"])
+    expect(s.cells!.get("2,0")!.style!.font!.bold).toBe(true)
+  })
+
+  it("carries a single-row merge with its row", () => {
+    const s: Sheet = {
+      name: "S",
+      rows: [
+        [3, "a"],
+        [1, "b"],
+      ],
+      merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+    }
+
+    sortRows(s, 0, "asc")
+
+    expect(s.rows).toEqual([
+      [1, "b"],
+      [3, "a"],
+    ])
+    expect(s.merges).toEqual([{ startRow: 1, startCol: 0, endRow: 1, endCol: 1 }])
+  })
+
+  it("refuses to sort past a merge that spans rows", () => {
+    const s: Sheet = {
+      name: "S",
+      rows: [[3], [1], [2]],
+      merges: [{ startRow: 0, startCol: 0, endRow: 1, endCol: 0 }],
+    }
+
+    // Excel refuses the same operation for the same reason: no ordering
+    // keeps both the sort and the merge.
+    expect(() => sortRows(s, 0, "asc")).toThrow(InvalidArgumentError)
+    expect(s.rows).toEqual([[3], [1], [2]])
+  })
+
+  it("still sorts a sheet with no overrides at all", () => {
+    const s: Sheet = { name: "S", rows: [[3], [1], [2]] }
+
+    sortRows(s, 0, "desc")
+
+    expect(s.rows).toEqual([[3], [2], [1]])
+  })
+})
+
+describe("findCells takes the same forms as replaceCells", () => {
+  const sheet = (): Sheet => ({
+    name: "S",
+    rows: [
+      ["b1", "x"],
+      ["B2", 7],
+    ],
+  })
+
+  it("accepts a RegExp", () => {
+    const found = findCells(sheet(), /^b/)
+
+    expect(found).toEqual([{ row: 0, col: 0, value: "b1" }])
+  })
+
+  it("finds exactly what replaceCells would replace", () => {
+    const pattern = /b/i
+    const s = sheet()
+
+    const found = findCells(s, pattern)
+    const replaced = replaceCells(s, pattern, "X")
+
+    expect(found).toHaveLength(replaced)
+  })
+
+  it("does not let a /g pattern's lastIndex depend on call order", () => {
+    const found = findCells(sheet(), /b/gi)
+
+    expect(found.map((f) => f.value)).toEqual(["b1", "B2"])
+  })
+
+  it("still accepts a plain value and a predicate", () => {
+    expect(findCells(sheet(), 7)).toEqual([{ row: 1, col: 1, value: 7 }])
+    expect(findCells(sheet(), (v) => typeof v === "number")).toEqual([{ row: 1, col: 1, value: 7 }])
+  })
+
+  it("does not match a RegExp against a non-string cell", () => {
+    expect(findCells(sheet(), /7/)).toEqual([])
+  })
+})
+
+describe("a merge shrunk to one cell is no longer a merge", () => {
+  it("drops it after deleteColumns", () => {
+    const s: Sheet = {
+      name: "S",
+      rows: [["a", "b", "c"]],
+      merges: [{ startRow: 0, startCol: 1, endRow: 0, endCol: 2 }],
+    }
+
+    deleteColumns(s, 1, 1)
+
+    expect(s.merges).toEqual([])
+  })
+
+  it("drops it after deleteRows", () => {
+    const s: Sheet = {
+      name: "S",
+      rows: [["a"], ["b"], ["c"]],
+      merges: [{ startRow: 1, startCol: 0, endRow: 2, endCol: 0 }],
+    }
+
+    deleteRows(s, 1, 1)
+
+    expect(s.merges).toEqual([])
+  })
+
+  it("keeps a merge that still spans more than one cell", () => {
+    const s: Sheet = {
+      name: "S",
+      rows: [["a", "b", "c", "d"]],
+      merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 2 }],
+    }
+
+    deleteColumns(s, 0, 1)
+
+    expect(s.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }])
+  })
+})


### PR DESCRIPTION
From the audit in #439, §AD, §AE and §AK. Three small disagreements in the sheet helpers.

## 1. `sortRows` moved two of the four things attached to a row

```js
rows:    [[3],[1],[2]]   cells: {"0,0": bold 3}   rowDefs: {0: {height:99}}   merges: [{0,0,0,0}]
sortRows(sheet, 0, "asc")

// before
rows:    [[1],[2],[3]]        // sorted
cells:   {"2,0": 3}           // followed its value
rowDefs: {0: {height:99}}     // stayed at position 0
merges:  [{0,0,0,0}]          // untouched
```

A tall row's data moved and its height did not. Row definitions now move with their rows, and so do merges that sit inside a single row.

**A merge that spans rows is now refused** with `InvalidArgumentError`. There is no ordering that keeps both the sort and the merge, which is why Excel refuses the same operation; sorting anyway left the merge covering whatever happened to land there.

The two code paths — with and without a `cells` map — also collapse into one, since both now need the old→new permutation.

## 2. `findCells` could not take a RegExp while `replaceCells` could

```ts
replaceCells(sheet, /b/, "X")   // fine — `find: CellValue | RegExp`
findCells(sheet, /b/)
// error TS2345: Argument of type 'RegExp' is not assignable to parameter of type
//   '((value: CellValue, row: number, col: number) => boolean) | CellValue'
```

They are documented as a pair and sit next to each other in the export list, but "find the cells I am about to replace" could not be written with the same argument. Both take a value, a RegExp or a predicate now, with the same string-only rule `replaceCells` already used — plus a `lastIndex` reset so a `/g` pattern does not make the result depend on call order.

## 3. A merge shrunk to one cell stayed a merge

```js
merges: [{ startRow: 2, startCol: 1, endRow: 2, endCol: 2 }]
deleteColumns(sheet, 1, 1)
// before: [{ startRow: 2, startCol: 1, endRow: 2, endCol: 1 }]   — B3:B3
// after:  []
```

`deleteRows` / `deleteColumns` already dropped ranges that fell entirely inside the deleted span, and ranges that went incoherent (`start > end`). A range that shrank to a single cell is neither, and `<mergeCell ref="B3:B3"/>` is not what any spreadsheet means by the word.

## Tests

`test/sheet-ops-helpers.test.ts`, 13 assertions. **8 fail against `main`.**