### PR TITLE
fix(xlsx): a column's format and a sheet's defaults reach the file

### DIFF
--- a/src/_types.ts
+++ b/src/_types.ts
@@ -774,6 +774,22 @@ export interface Sheet {
   columns?: ColumnDef[]
   /** Row-level properties (keyed by 0-based row index) */
   rowDefs?: Map<number, RowDef>
+  /**
+   * Default row height in points, for rows with no `rowDefs` entry.
+   * Excel's own default is 15. Written to `<sheetFormatPr defaultRowHeight>`.
+   *
+   * Before this existed the writer emitted a hard-coded 15 and the reader
+   * looked at `<sheetFormatPr>` not at all, so a workbook whose default was
+   * 24 came back through readXlsx → writeXlsx with every unstyled row
+   * shortened. See #439 §X.
+   */
+  defaultRowHeight?: number
+  /**
+   * Default column width in characters, for columns with no `columns[]`
+   * entry. Written to `<sheetFormatPr defaultColWidth>`; absent means
+   * Excel picks its own from the default font.
+   */
+  defaultColWidth?: number
   merges?: MergeRange[]
   dataValidations?: DataValidation[]
   conditionalRules?: ConditionalRule[]
@@ -1447,6 +1463,22 @@ export interface WriteSheet {
   data?: Array<Record<string, CellValue | HyperlinkValue>>
   /** Detailed cell overrides (keyed by "row,col") */
   cells?: Map<string, Partial<Cell>>
+  /**
+   * Default row height in points, for rows with no `rowDefs` entry.
+   * Excel's own default is 15. Written to `<sheetFormatPr defaultRowHeight>`.
+   *
+   * Before this existed the writer emitted a hard-coded 15 and the reader
+   * looked at `<sheetFormatPr>` not at all, so a workbook whose default was
+   * 24 came back through readXlsx → writeXlsx with every unstyled row
+   * shortened. See #439 §X.
+   */
+  defaultRowHeight?: number
+  /**
+   * Default column width in characters, for columns with no `columns[]`
+   * entry. Written to `<sheetFormatPr defaultColWidth>`; absent means
+   * Excel picks its own from the default font.
+   */
+  defaultColWidth?: number
   merges?: MergeRange[]
   dataValidations?: DataValidation[]
   conditionalRules?: ConditionalRule[]

--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -1001,6 +1001,8 @@ export function cloneSheet(sheet: Sheet, newName: string): Sheet {
   if (sheet.slicers) cloned.slicers = structuredClone(sheet.slicers)
   if (sheet.timelines) cloned.timelines = structuredClone(sheet.timelines)
   if (sheet.a11y) cloned.a11y = { ...sheet.a11y }
+  if (sheet.defaultRowHeight !== undefined) cloned.defaultRowHeight = sheet.defaultRowHeight
+  if (sheet.defaultColWidth !== undefined) cloned.defaultColWidth = sheet.defaultColWidth
 
   return cloned
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -76,6 +76,8 @@ export interface SerializedSheet {
   veryHidden?: Sheet["veryHidden"]
   tables?: Sheet["tables"]
   a11y?: Sheet["a11y"]
+  defaultRowHeight?: Sheet["defaultRowHeight"]
+  defaultColWidth?: Sheet["defaultColWidth"]
   splitPane?: Sheet["splitPane"]
   rowBreaks?: Sheet["rowBreaks"]
   colBreaks?: Sheet["colBreaks"]
@@ -228,6 +230,8 @@ function serializeSheet(sheet: Sheet): SerializedSheet {
   // These used to be dropped on the way through, so "parse in a worker,
   // postMessage the result" handed the main thread a quietly poorer
   // workbook. See #439 §N.
+  if (sheet.defaultRowHeight !== undefined) out.defaultRowHeight = sheet.defaultRowHeight
+  if (sheet.defaultColWidth !== undefined) out.defaultColWidth = sheet.defaultColWidth
   if (sheet.splitPane) out.splitPane = sheet.splitPane
   if (sheet.rowBreaks) out.rowBreaks = sheet.rowBreaks
   if (sheet.colBreaks) out.colBreaks = sheet.colBreaks
@@ -408,6 +412,8 @@ function deserializeSheet(ss: SerializedSheet): Sheet {
   if (ss.tables) sheet.tables = ss.tables
   if (ss.a11y) sheet.a11y = ss.a11y
 
+  if (ss.defaultRowHeight !== undefined) sheet.defaultRowHeight = ss.defaultRowHeight
+  if (ss.defaultColWidth !== undefined) sheet.defaultColWidth = ss.defaultColWidth
   if (ss.splitPane) sheet.splitPane = ss.splitPane
   if (ss.rowBreaks) sheet.rowBreaks = ss.rowBreaks
   if (ss.colBreaks) sheet.colBreaks = ss.colBreaks

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -379,7 +379,16 @@ export function writeWorksheetXml(
   )
 
   // ── SheetFormatPr ──
-  parts.push(xmlSelfClose("sheetFormatPr", { defaultRowHeight: 15 }))
+  // `defaultRowHeight` is required by the schema, so 15 — Excel's own
+  // default — stands in when the sheet does not say. It used to be
+  // hard-coded, which meant a file whose default was 24 lost it on the way
+  // through. See #439 §X.
+  const formatPrAttrs: Record<string, string | number> = {
+    defaultRowHeight: sheet.defaultRowHeight ?? 15,
+  }
+  if (sheet.defaultRowHeight !== undefined) formatPrAttrs["customHeight"] = 1
+  if (sheet.defaultColWidth !== undefined) formatPrAttrs["defaultColWidth"] = sheet.defaultColWidth
+  parts.push(xmlSelfClose("sheetFormatPr", formatPrAttrs))
 
   // ── Columns ──
   if (sheet.columns && sheet.columns.length > 0) {
@@ -402,7 +411,26 @@ export function writeWorksheetXml(
         })
       }
 
-      if (effectiveWidth !== undefined || col.hidden || col.outlineLevel || col.collapsed) {
+      // A column format has to land on `<col style="N">` as well as on the
+      // cells. Stamping the cells alone made it look right for the rows
+      // hucre wrote and nowhere else: in Excel a column format applies to
+      // every cell in the column including ones nobody has typed in yet,
+      // so a "currency" column stopped being one the moment the user
+      // added a row. It also meant the format vanished on read, since the
+      // reader has only `<col>` to look at. See #439 §W.
+      const columnStyle: CellStyle | undefined =
+        col.numFmt && !col.style?.numFmt
+          ? { ...col.style, numFmt: col.numFmt }
+          : (col.style ?? undefined)
+      const columnStyleId = columnStyle ? styles.addStyle(columnStyle) : 0
+
+      if (
+        effectiveWidth !== undefined ||
+        col.hidden ||
+        col.outlineLevel ||
+        col.collapsed ||
+        columnStyleId !== 0
+      ) {
         const colAttrs: Record<string, string | number | boolean> = {
           min: i + 1,
           max: i + 1,
@@ -410,6 +438,9 @@ export function writeWorksheetXml(
         if (effectiveWidth !== undefined) {
           colAttrs["width"] = effectiveWidth
           colAttrs["customWidth"] = true
+        }
+        if (columnStyleId !== 0) {
+          colAttrs["style"] = columnStyleId
         }
         if (col.hidden) {
           colAttrs["hidden"] = true

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -31,6 +31,7 @@ import type { SharedString } from "./shared-strings"
 import type { ParsedStyles } from "./styles"
 import type { Relationship } from "./relationships"
 import { resolveStyle, isDateStyle } from "./styles"
+import { cloneCellStyle } from "../_style"
 import { serialToDate } from "../_date"
 import { parseSax, decodeOoxmlEscapes } from "../xml/parser"
 import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
@@ -242,6 +243,8 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
 
   // Column definitions (width, hidden, outlineLevel, collapsed) parsed from <col> elements
   const columnDefs: import("../_types").ColumnDef[] = []
+  let defaultRowHeight: number | undefined
+  let defaultColWidth: number | undefined
   let inCols = false
 
   // SAX parsing state
@@ -334,6 +337,15 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
             const hidden = attrs["hidden"] === "1" || attrs["hidden"] === "true"
             const outlineLevel = attrs["outlineLevel"] ? Number(attrs["outlineLevel"]) : undefined
             const collapsed = attrs["collapsed"] === "1" || attrs["collapsed"] === "true"
+            const bestFit = attrs["bestFit"] === "1" || attrs["bestFit"] === "true"
+            // `style` is the column's default cell format — the thing that
+            // makes a whole column currency, including the cells nobody has
+            // typed in. It was read by neither side; see #439 §W.
+            const styleIndex = attrs["style"] !== undefined ? Number(attrs["style"]) : undefined
+            const columnStyle =
+              ctx.readStyles && ctx.styles && styleIndex !== undefined && styleIndex >= 0
+                ? resolveStyle(ctx.styles, styleIndex)
+                : undefined
 
             // Expand column range (min and max are 1-based in OOXML)
             for (let c = minCol; c <= maxCol2; c++) {
@@ -349,12 +361,37 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
                 def.outlineLevel = outlineLevel
               }
               if (collapsed) def.collapsed = true
+              if (bestFit) def.autoWidth = true
+              if (columnStyle && Object.keys(columnStyle).length > 0) {
+                // Each column gets its own copy: `columnDefs` is the caller's
+                // to edit, and `resolveStyle` hands out shared records.
+                def.style = cloneCellStyle(columnStyle)
+              }
               if (Object.keys(def).length > 0) {
                 columnDefs[idx] = def
               }
             }
           }
           break
+        case "sheetFormatPr": {
+          const dh = attrs["defaultRowHeight"]
+          const dw = attrs["defaultColWidth"]
+          // Excel writes 15 whether or not the sheet means anything by it,
+          // so only a value that differs is a statement worth surfacing —
+          // otherwise every sheet would come back carrying a default it
+          // never set.
+          if (dh !== undefined) {
+            const height = Number(dh)
+            if (Number.isFinite(height) && height > 0 && height !== 15) {
+              defaultRowHeight = height
+            }
+          }
+          if (dw !== undefined) {
+            const widthValue = Number(dw)
+            if (Number.isFinite(widthValue) && widthValue > 0) defaultColWidth = widthValue
+          }
+          break
+        }
         case "sheetData":
           inSheetData = true
           break
@@ -1180,6 +1217,9 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
     sheet.cells = cells
   }
   // Attach column definitions (width, hidden, outlineLevel, collapsed)
+  if (defaultRowHeight !== undefined) sheet.defaultRowHeight = defaultRowHeight
+  if (defaultColWidth !== undefined) sheet.defaultColWidth = defaultColWidth
+
   if (columnDefs.some((c) => Object.keys(c).length > 0)) {
     sheet.columns = columnDefs
   }

--- a/test/clone-sheet-coverage.test.ts
+++ b/test/clone-sheet-coverage.test.ts
@@ -50,6 +50,8 @@ const FULL_SHEET: Required<Sheet> = {
   cells: new Map<string, Cell>([["0,0", FULL_CELL]]),
   columns: [{ width: 12, style: { font: { name: "Arial" } } }],
   rowDefs: new Map([[0, { height: 30, hidden: true }]]),
+  defaultRowHeight: 24,
+  defaultColWidth: 18,
   merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
   dataValidations: [{ type: "list", range: "A1:A9", values: ["x", "y"] }],
   conditionalRules: [

--- a/test/column-and-sheet-defaults.test.ts
+++ b/test/column-and-sheet-defaults.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §W and §X — two things that describe a whole column or a whole
+// sheet, and that never reached the file.
+//
+// `ColumnDef.style` was stamped onto the cells hucre wrote and nowhere
+// else, so it looked right for those rows and vanished everywhere else:
+// in Excel a column format applies to every cell in the column including
+// ones nobody has typed in, and on read there was only `<col>` to look at.
+//
+// `<sheetFormatPr defaultRowHeight>` was hard-coded to 15 and never read,
+// so a workbook whose default was 24 came back with every unstyled row
+// shortened.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function part(bytes: Uint8Array, path: string): Promise<string> {
+  return new TextDecoder().decode(await new ZipReader(bytes).extract(path))
+}
+
+/** Rebuild an archive with one part rewritten, to stand in for another tool's output. */
+async function rewrite(
+  bytes: Uint8Array,
+  path: string,
+  edit: (xml: string) => string,
+): Promise<Uint8Array> {
+  const all = await new ZipReader(bytes).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    zw.add(
+      name,
+      name === path ? new TextEncoder().encode(edit(new TextDecoder().decode(data))) : data,
+    )
+  }
+  return zw.build()
+}
+
+const CURRENCY: CellStyle = { numFmt: '"$"#,##0.00', font: { italic: true } }
+
+describe("a column format reaches the file", () => {
+  it("writes it onto <col style>", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], columns: [{ width: 12, style: CURRENCY }] }],
+    })
+
+    const xml = await part(bytes, "xl/worksheets/sheet1.xml")
+
+    expect(xml).toMatch(/<col [^>]*style="\d+"/)
+  })
+
+  it("survives a round trip", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], columns: [{ width: 12, style: CURRENCY }] }],
+    })
+
+    const back = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.columns![0]!
+
+    expect(back.width).toBe(12)
+    expect(back.style!.numFmt).toBe('"$"#,##0.00')
+    expect(back.style!.font!.italic).toBe(true)
+  })
+
+  it("folds ColumnDef.numFmt into the column style, as it does for cells", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], columns: [{ numFmt: "0.000" }] }],
+    })
+
+    const back = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.columns![0]!
+
+    expect(back.style!.numFmt).toBe("0.000")
+  })
+
+  it("lets an explicit style.numFmt win over the shorthand", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], columns: [{ numFmt: "0.000", style: { numFmt: "0%" } }] }],
+    })
+
+    const back = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.columns![0]!
+
+    expect(back.style!.numFmt).toBe("0%")
+  })
+
+  it("still stamps the cells, so a written row carries the format too", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], columns: [{ style: CURRENCY }] }],
+    })
+
+    const cell = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.cells!.get("0,0")!
+
+    expect(cell.style!.numFmt).toBe('"$"#,##0.00')
+  })
+
+  it("gives each column its own style object on read", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1, 2]], columns: [{ style: CURRENCY }, { style: CURRENCY }] }],
+    })
+
+    const columns = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.columns!
+
+    expect(columns[0]!.style).not.toBe(columns[1]!.style)
+    columns[0]!.style!.numFmt = "changed"
+    expect(columns[1]!.style!.numFmt).toBe('"$"#,##0.00')
+  })
+
+  it("reads another tool's bestFit back as autoWidth", async () => {
+    // hucre resolves `autoWidth` to a concrete width on write, so its own
+    // files carry a width rather than the flag. Excel writes the flag, and
+    // it used to be read by nobody.
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a value"]], columns: [{ width: 10 }] }],
+    })
+
+    const patched = await rewrite(bytes, "xl/worksheets/sheet1.xml", (xml) =>
+      xml.replace("<col ", '<col bestFit="1" '),
+    )
+
+    expect((await readXlsx(patched)).sheets[0]!.columns![0]!.autoWidth).toBe(true)
+  })
+
+  it("emits no <col> at all when a column says nothing", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[1]], columns: [{}] }] })
+
+    expect(await part(bytes, "xl/worksheets/sheet1.xml")).not.toContain("<cols>")
+  })
+})
+
+describe("sheet format defaults reach the file", () => {
+  it("writes and reads back a default row height", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], defaultRowHeight: 24 }],
+    })
+
+    expect(await part(bytes, "xl/worksheets/sheet1.xml")).toContain('defaultRowHeight="24"')
+    expect((await readXlsx(bytes)).sheets[0]!.defaultRowHeight).toBe(24)
+  })
+
+  it("writes and reads back a default column width", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[1]], defaultColWidth: 18 }],
+    })
+
+    expect(await part(bytes, "xl/worksheets/sheet1.xml")).toContain('defaultColWidth="18"')
+    expect((await readXlsx(bytes)).sheets[0]!.defaultColWidth).toBe(18)
+  })
+
+  it("survives readXlsx → writeXlsx", async () => {
+    const first = await writeXlsx({ sheets: [{ name: "S", rows: [[1]], defaultRowHeight: 30 }] })
+    const wb = await readXlsx(first)
+
+    const second = await writeXlsx({
+      sheets: [
+        { name: "S", rows: wb.sheets[0]!.rows, defaultRowHeight: wb.sheets[0]!.defaultRowHeight },
+      ],
+    })
+
+    expect((await readXlsx(second)).sheets[0]!.defaultRowHeight).toBe(30)
+  })
+
+  it("still emits the schema-required attribute when the sheet says nothing", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[1]] }] })
+
+    expect(await part(bytes, "xl/worksheets/sheet1.xml")).toContain('defaultRowHeight="15"')
+  })
+
+  it("does not surface Excel's own default as a setting the author made", async () => {
+    // Every file carries defaultRowHeight="15" whether or not it means
+    // anything, so reporting it would put a value on every sheet read.
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[1]] }] })
+
+    expect((await readXlsx(bytes)).sheets[0]!.defaultRowHeight).toBeUndefined()
+  })
+})

--- a/test/xlsx-write-read-parity.test.ts
+++ b/test/xlsx-write-read-parity.test.ts
@@ -281,6 +281,19 @@ const SHEET_FIELDS: { [K in keyof Required<WriteSheet>]: Entry<WriteSheet[K]> } 
     expected: { height: 30, outlineLevel: 1 },
   },
 
+  defaultRowHeight: {
+    // Not 15: that is Excel's own default, and the reader deliberately
+    // does not surface it — every sheet carries it whether or not the
+    // author meant anything by it.
+    value: 24,
+    read: (sheet) => sheet.defaultRowHeight,
+  },
+
+  defaultColWidth: {
+    value: 18,
+    read: (sheet) => sheet.defaultColWidth,
+  },
+
   outlineProperties: {
     value: { summaryBelow: false, summaryRight: false },
     read: (sheet) => sheet.outlineProperties,


### PR DESCRIPTION
From the audit in #439, §W and §X. Two things that describe a whole column or a whole sheet, and that never reached the file.

## 1. `ColumnDef.style` / `.numFmt` were simulated, not stored

The writer stamped the format onto the cells it wrote and emitted:

```xml
<cols><col min="1" max="1" width="12" customWidth="true"/></cols>
```

No `style` attribute. The reader never looked for one either.

```js
sent:      [{ width: 12, numFmt: "0.00", style: { font: { italic: true } } }]
read back: [{ width: 12 }]
```

Two consequences:

- **In Excel a column format applies to every cell in the column**, including ones nobody has typed in yet. hucre only reached the rows it wrote, so a "currency" column stopped being one the moment the user added a row.
- **It did not survive a round trip**, and a real Excel file carrying `<col style="5">` lost its column formatting on read — an interop loss, not just a hucre-to-hucre one.

`docs/PARITY.md` listed "row and column definitions" under *"Read + write, at parity"* with no exception.

The writer now registers the column's format and writes `style="N"`; the reader resolves it back into `ColumnDef.style`, one copy per column. `bestFit` is read too, as `autoWidth` — hucre resolves that to a concrete width on write, but Excel writes the flag and nobody was reading it.

## 2. `<sheetFormatPr>` was hard-coded and never read

```ts
parts.push(xmlSelfClose("sheetFormatPr", { defaultRowHeight: 15 }))   // unconditionally
```

So a workbook whose default row height was 24 came back through `readXlsx` → `writeXlsx` with **every unstyled row shortened**, and `defaultColWidth` was never written at all.

`Sheet.defaultRowHeight` and `Sheet.defaultColWidth` model it now, on both `Sheet` and `WriteSheet`. 15 still stands in when the sheet says nothing — the attribute is required by the schema — and the reader deliberately does **not** surface a bare 15, since every file carries it whether or not the author meant anything by it.

## The registers did their job

Adding two fields to `Sheet` broke `test/xlsx-write-read-parity.test.ts` and `test/clone-sheet-coverage.test.ts` at `tsc`, exactly as designed, and they stayed red until the fixtures, `cloneSheet` and the worker serializer all carried them.

## Tests

`test/column-and-sheet-defaults.test.ts`, 13 assertions: the `<col style>` attribute in the emitted XML, the round trip, `numFmt` folding and an explicit `style.numFmt` winning, cells still being stamped, each column getting its own style object, `bestFit` read out of a rebuilt archive standing in for another tool's output, and the four `sheetFormatPr` cases.

**9 of the 13 fail against `main`.**