### PR TITLE
fix: honour maxRows and range in readOds, and transformHeader everywhere

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -181,6 +181,25 @@ reads back with its direct formatting only.
 See [What ODS carries](../README.md#what-ods-carries) for the consequences
 worth knowing before relying on it.
 
+## Read options, per reader
+
+`ReadOptions` is one interface for `readXlsx`, `readOds`, `readXlsb`,
+`readXls` and `read`. Not every option means something to every format:
+
+| option          | `readXlsx` | `readOds` | `readXlsb` | `readXls` |
+| --------------- | :--------: | :-------: | :--------: | :-------: |
+| `maxInputBytes` |    yes     |    yes    |    yes     |    yes    |
+| `sheets`        |    yes     |    yes    |     —      |     —     |
+| `readStyles`    |    yes     |    yes    |    n/a     |    n/a    |
+| `dateSystem`    |    yes     |    n/a    |    yes     |    yes    |
+| `password`      |    yes     |     —     |    yes     |     —     |
+| `maxRows`       |    yes     |    yes    |     —      |     —     |
+| `range`         |    yes     |    yes    |     —      |     —     |
+
+`n/a` means the option cannot apply: ODS stores ISO date strings, so
+there is no 1900/1904 system to pick, and neither legacy reader surfaces
+styles at all. A `—` is a gap, not a decision.
+
 ## XLS and XLSB — read only
 
 No writer exists for either. What the readers surface is narrower than

--- a/src/csv/reader.ts
+++ b/src/csv/reader.ts
@@ -143,6 +143,19 @@ export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][]
   // The row is captured before it goes, because transformValue names its
   // columns from it either way, and it drops before maxRows so that limit
   // counts data rows in both readers.
+  // `transformHeader` used to be honoured by parseCsvObjects alone, where
+  // it renames the object keys — even though CsvReadOptions says every one
+  // of its options "means the same thing in all three" readers. Here and in
+  // streamCsvRows it rewrites the header row itself, which then names the
+  // columns `transformValue` sees. See #439 §V.
+  const transformHeader = options?.transformHeader
+  if (opts.header && transformHeader && filtered.length > 0) {
+    filtered = [
+      filtered[0]!.map((value, index) => transformHeader(String(value ?? ""), index)),
+      ...filtered.slice(1),
+    ]
+  }
+
   const headerRow = opts.header && filtered.length > 0 ? filtered[0]! : null
   if (opts.header && opts.skipHeaderRow && filtered.length > 0) {
     filtered = filtered.slice(1)

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -56,6 +56,7 @@ export function* streamCsvRows(
   const maxRows = options?.maxRows
   const skipLines = options?.skipLines ?? 0
   const transformValue = options?.transformValue
+  const transformHeader = options?.transformHeader
   const onRow = options?.onRow
   // Fast mode trades quote handling for speed, exactly as in parseCsv —
   // fields are split on the delimiter with no quote awareness at all.
@@ -192,8 +193,15 @@ export function* streamCsvRows(
     // the row is still yielded, and is used to name columns for
     // transformValue. `skipHeaderRow` is the opt-in that consumes it.
     const isHeaderRowNow = isFirstRow && isHeaderMode
+    let emitFields = fields
     if (isHeaderRowNow) {
-      headerRow = fields
+      // Same contract as parseCsv: `transformHeader` rewrites the header
+      // row, and the rewritten names are what `transformValue` sees. This
+      // reader used not to read the option at all. See #439 §V.
+      emitFields = transformHeader
+        ? fields.map((value, index) => transformHeader(String(value ?? ""), index))
+        : fields
+      headerRow = emitFields
     }
     isFirstRow = false
 
@@ -208,8 +216,8 @@ export function* streamCsvRows(
 
     // Apply type inference if requested
     let outRow: CellValue[] = doTypeInference
-      ? fields.map((v) => inferType(v, preserveLeadingZeros))
-      : fields
+      ? emitFields.map((v) => inferType(v, preserveLeadingZeros))
+      : emitFields
 
     // transformValue — after type inference, matching parseCsv's ordering.
     if (transformValue) {

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -17,6 +17,7 @@ import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseXml } from "../xml/parser"
+import { parseRange } from "../cell-utils"
 import { MAX_COL_INDEX, MAX_REPEAT_COUNT, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 
 /**
@@ -564,7 +565,16 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
     let currentRow = 0
     let pendingEmptyRows = 0
 
+    // `maxRows` and `range` are on the shared `ReadOptions`, whose doc makes
+    // no format-specific claim — but this reader used to read neither, so a
+    // caller bounding a large ODS file got the whole thing and no warning.
+    // See #439 §U. `maxRows` stops the walk; `range` masks afterwards,
+    // matching what readXlsx returns for the same option.
+    const maxRowsLimit = options?.maxRows ?? 0 // 0 = unlimited
+    const rangeFilter = options?.range ? parseRange(options.range) : undefined
+
     for (const tableRow of tableRows) {
+      if (maxRowsLimit > 0 && rows.length >= maxRowsLimit) break
       const rowRepeat = Number(tableRow.attrs["table:number-rows-repeated"] ?? "1")
 
       // Collect cell entries with their repeat counts first,
@@ -752,6 +762,26 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
     // this is a backstop rather than the mechanism.
     while (rows.length > 0 && rows[rows.length - 1].length === 0) {
       rows.pop()
+    }
+
+    // `maxRows` can overshoot by the tail of a repeated row, since a single
+    // <table-row table:number-rows-repeated="N"> expands after the check.
+    if (maxRowsLimit > 0 && rows.length > maxRowsLimit) rows.length = maxRowsLimit
+
+    // `range` masks rather than drops, so column indexes stay stable and a
+    // row outside the span is present and empty — the same shape readXlsx
+    // returns for the same option.
+    if (rangeFilter) {
+      for (let r = 0; r < rows.length; r++) {
+        const row = rows[r]!
+        const inRowSpan = r >= rangeFilter.startRow && r <= rangeFilter.endRow
+        for (let c = 0; c < row.length; c++) {
+          if (!inRowSpan || c < rangeFilter.startCol || c > rangeFilter.endCol) {
+            row[c] = null
+            cells.delete(`${r},${c}`)
+          }
+        }
+      }
     }
 
     const sheet: Sheet = { name, rows }

--- a/test/ignored-options.test.ts
+++ b/test/ignored-options.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest"
+import { readOds } from "../src/ods/reader"
+import { writeOds } from "../src/ods/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { parseCsv, parseCsvObjects } from "../src/csv/reader"
+import { streamCsvRows } from "../src/csv/stream"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §U and §V — options a shared type promises and the code ignored.
+//
+// The project already decided this pattern is unacceptable, twice:
+// `CsvReadOptions.schema` was removed before v1 because no CSV reader
+// honoured it, and `WriteSheet.threadedComments` was removed in #404
+// because "a typed field that is silently discarded is worse than no
+// field at all". The rule was right; it just was not applied here.
+// ═══════════════════════════════════════════════════════════════════════
+
+const GRID = [
+  [1, 2, 3],
+  [4, 5, 6],
+  [7, 8, 9],
+]
+
+describe("readOds honours maxRows and range", () => {
+  it("bounds the rows it returns", async () => {
+    const bytes = await writeOds({ sheets: [{ name: "S", rows: GRID }] })
+
+    const wb = await readOds(bytes, { maxRows: 2 })
+
+    expect(wb.sheets[0]!.rows).toEqual([
+      [1, 2, 3],
+      [4, 5, 6],
+    ])
+  })
+
+  it("masks cells outside the range, keeping column indexes stable", async () => {
+    const bytes = await writeOds({ sheets: [{ name: "S", rows: GRID }] })
+
+    const wb = await readOds(bytes, { range: "B2:C3" })
+
+    // The same shape readXlsx returns: a row outside the span is present
+    // and empty, a column outside it is null.
+    expect(wb.sheets[0]!.rows).toEqual([
+      [null, null, null],
+      [null, 5, 6],
+      [null, 8, 9],
+    ])
+  })
+
+  it("returns the same shape readXlsx does for the same options", async () => {
+    const ods = await readOds(await writeOds({ sheets: [{ name: "S", rows: GRID }] }), {
+      range: "B2:C3",
+    })
+    const xlsx = await readXlsx(await writeXlsx({ sheets: [{ name: "S", rows: GRID }] }), {
+      range: "B2:C3",
+    })
+
+    expect(ods.sheets[0]!.rows).toEqual(xlsx.sheets[0]!.rows)
+  })
+
+  it("drops the cell overrides it masked", async () => {
+    const bytes = await writeOds({
+      sheets: [{ name: "S", rows: GRID, cells: new Map([["0,0", { value: 1, formula: "1+0" }]]) }],
+    })
+
+    const wb = await readOds(bytes, { range: "B2:C3" })
+
+    expect(wb.sheets[0]!.cells?.get("0,0")).toBeUndefined()
+  })
+
+  it("leaves everything alone when neither option is set", async () => {
+    const bytes = await writeOds({ sheets: [{ name: "S", rows: GRID }] })
+
+    expect((await readOds(bytes)).sheets[0]!.rows).toEqual(GRID)
+  })
+})
+
+describe("transformHeader means the same thing in all three CSV readers", () => {
+  const CSV = "name,age\nAda,36"
+  const upper = (h: string) => h.toUpperCase()
+
+  it("rewrites the header row in parseCsv", () => {
+    expect(parseCsv(CSV, { header: true, transformHeader: upper })).toEqual([
+      ["NAME", "AGE"],
+      ["Ada", "36"],
+    ])
+  })
+
+  it("rewrites the header row in streamCsvRows", () => {
+    expect([...streamCsvRows(CSV, { header: true, transformHeader: upper })]).toEqual([
+      ["NAME", "AGE"],
+      ["Ada", "36"],
+    ])
+  })
+
+  it("still renames the object keys in parseCsvObjects", () => {
+    const { data, headers } = parseCsvObjects(CSV, { header: true, transformHeader: upper })
+
+    expect(headers).toEqual(["NAME", "AGE"])
+    expect(data).toEqual([{ NAME: "Ada", AGE: "36" }])
+  })
+
+  it("names transformValue's columns by the transformed header", () => {
+    const seen: string[] = []
+    parseCsv(CSV, {
+      header: true,
+      transformHeader: upper,
+      transformValue: (value, header) => {
+        seen.push(header)
+        return value
+      },
+    })
+
+    expect(seen).toContain("NAME")
+    expect(seen).not.toContain("name")
+  })
+
+  it("gets the same header names in the streaming reader", () => {
+    const seen: string[] = []
+    for (const _row of streamCsvRows(CSV, {
+      header: true,
+      transformHeader: upper,
+      transformValue: (value, header) => {
+        seen.push(header)
+        return value
+      },
+    })) {
+      // drained for the side effect
+    }
+
+    expect(seen).toContain("NAME")
+  })
+
+  it("does nothing without header: true", () => {
+    expect(parseCsv(CSV, { transformHeader: upper })).toEqual([
+      ["name", "age"],
+      ["Ada", "36"],
+    ])
+  })
+
+  it("still drops the header row when skipHeaderRow asks", () => {
+    expect(parseCsv(CSV, { header: true, skipHeaderRow: true, transformHeader: upper })).toEqual([
+      ["Ada", "36"],
+    ])
+  })
+})


### PR DESCRIPTION
From the audit in #439, §U and §V. Two options a shared type promised and the code ignored.

## 1. `readOds` read neither `maxRows` nor `range`

```js
const wb = await readOds(bytes, { range: "B2:C3", maxRows: 2 })
wb.sheets[0].rows   // [[1,2,3],[4,5,6],[7,8,9]] — all of it
```

Both are on `ReadOptions` with no format-specific caveat — *"Maximum number of data rows to read per sheet"*, *"Only cells within this range are returned"* — so a caller bounding a large ODS file got the whole file and no warning.

`maxRows` now stops the row walk. `range` masks afterwards, so column indexes stay stable and a row outside the span comes back present and empty — **the same shape `readXlsx` returns**, which one of the tests asserts directly rather than by eye. Cell overrides that were masked are dropped with their values.

`docs/PARITY.md` gains the per-reader matrix, because some of these are decisions and some are gaps and a reader deserves to know which:

| option | `readXlsx` | `readOds` | `readXlsb` | `readXls` |
| --- | :-: | :-: | :-: | :-: |
| `sheets` | yes | yes | — | — |
| `readStyles` | yes | yes | n/a | n/a |
| `dateSystem` | yes | n/a | yes | yes |
| `password` | yes | — | yes | — |
| `maxRows` | yes | **yes** | — | — |
| `range` | yes | **yes** | — | — |

## 2. `transformHeader` was honoured by one of the three readers its doc names

`CsvReadOptions`' own doc block says:

> Options shared by `parseCsv`, `parseCsvObjects` and `streamCsvRows` — **every one of them means the same thing in all three.**

Only `parseCsvObjects` read it, where it renames the object keys. `parseCsv` stripped it on the way through (`csv/reader.ts:208-213`) and `streamCsvRows` never mentioned it:

```js
const opts = { header: true, transformHeader: (h) => h.toUpperCase() }
parseCsv("name,age\nAda,36", opts)           // [["name","age"], ...]  ← ignored
[...streamCsvRows("name,age\nAda,36", opts)] // [["name","age"], ...]  ← ignored
parseCsvObjects("name,age\nAda,36", opts)    // keys NAME / AGE        ← honoured
```

Both now rewrite the header row, and the rewritten names are what `transformValue` sees — the natural reading of *"Transform each header string when `header: true`. Called on each header value."* `transformValue` was already honoured by all three, so this was the one outlier.

## Why this shape matters

The project already removed this pattern twice, deliberately: `CsvReadOptions.schema`, *"honoured by no CSV reader at all… removed rather than frozen"*, and `WriteSheet.threadedComments`, removed in #404 because *"a typed field that is silently discarded is worse than no field at all"*. The rule was right; it just was not applied to these.

## Tests

`test/ignored-options.test.ts`, 12 assertions. **8 fail against `main`.**