### PR TITLE
feat(xlsx): every OOXML paper size, by name or by code

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -64,7 +64,8 @@ hyperlinks with tooltips, comments, checkboxes, the full cell style model
 alignment field, number formats, protection), merges, data validations,
 all 15 conditional-rule types **including their dxf styles**, auto-filters
 with value filters, freeze and split panes, sheet protection, page setup
-including print areas and print titles, headers and footers, sheet views
+including print areas, print titles and every OOXML paper size (by
+name where hucre has one, by code otherwise), headers and footers, sheet views
 and tab colours, hidden and very-hidden sheets, tables, row and column
 definitions, manual page breaks, outline properties, sparklines, text
 boxes, background images, images, document properties, named ranges, the

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -416,16 +416,60 @@ export interface NamedRange {
 
 // ── Page Setup / Print ─────────────────────────────────────────────
 
-export type PaperSize =
+/**
+ * A paper size, either by name or by its raw OOXML `paperSize` code.
+ *
+ * The names cover what people ask for; the number is the escape hatch.
+ * Excel defines about 120 codes and hucre used to model nine, dropping
+ * anything else **silently** on read — so a workbook set to A6 lost its
+ * page size with no error and nothing in the parity statement. A code
+ * with no name here now round-trips as the number it is. See #439 §Q.
+ */
+export type PaperSize = PaperSizeName | (number & {})
+
+export type PaperSizeName =
   | "letter"
+  | "letterSmall"
+  | "tabloid"
+  | "ledger"
   | "legal"
+  | "statement"
+  | "executive"
   | "a3"
   | "a4"
+  | "a4Small"
   | "a5"
   | "b4"
   | "b5"
-  | "executive"
-  | "tabloid"
+  | "folio"
+  | "quarto"
+  | "note"
+  | "envelope9"
+  | "envelope10"
+  | "envelope11"
+  | "envelope12"
+  | "envelope14"
+  | "cSheet"
+  | "dSheet"
+  | "eSheet"
+  | "envelopeDL"
+  | "envelopeC5"
+  | "envelopeC3"
+  | "envelopeC4"
+  | "envelopeC6"
+  | "envelopeC65"
+  | "envelopeB4"
+  | "envelopeB5"
+  | "envelopeB6"
+  | "envelopeItaly"
+  | "envelopeMonarch"
+  | "envelopePersonal"
+  | "fanfoldUS"
+  | "fanfoldGermanStd"
+  | "fanfoldGermanLegal"
+  | "a6"
+  | "japanesePostcard"
+  | "japaneseDoublePostcard"
 
 export interface PageSetup {
   paperSize?: PaperSize

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,6 +372,7 @@ export type {
   Sparkline,
   SheetTextBox,
   PaperSize,
+  PaperSizeName,
   ValidationType,
   ValidationOperator,
   ConditionalRuleType,

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -14,6 +14,7 @@ import type {
   PageMargins,
   HeaderFooter,
   PaperSize,
+  PaperSizeName,
   RichTextRun,
   FontStyle,
   Color,
@@ -1174,22 +1175,70 @@ export function collectHyperlinks(
 
 // ── Paper Size Map ──────────────────────────────────────────────────
 
-const PAPER_SIZE_MAP: Record<PaperSize, number> = {
+/**
+ * Named paper sizes → the OOXML `paperSize` code (ECMA-376 §18.3.1.63).
+ *
+ * A code with no name here is still writable and readable — `PaperSize`
+ * admits a raw number — so the nine names this used to hold are no longer
+ * the whole of what a sheet can say. See #439 §Q.
+ */
+export const PAPER_SIZE_MAP: Record<PaperSizeName, number> = {
   letter: 1,
+  letterSmall: 2,
+  tabloid: 3,
+  ledger: 4,
   legal: 5,
+  statement: 6,
+  executive: 7,
   a3: 8,
   a4: 9,
+  a4Small: 10,
   a5: 11,
   b4: 12,
   b5: 13,
-  executive: 7,
-  tabloid: 3,
+  folio: 14,
+  quarto: 15,
+  note: 18,
+  envelope9: 19,
+  envelope10: 20,
+  envelope11: 21,
+  envelope12: 22,
+  envelope14: 23,
+  cSheet: 24,
+  dSheet: 25,
+  eSheet: 26,
+  envelopeDL: 27,
+  envelopeC5: 28,
+  envelopeC3: 29,
+  envelopeC4: 30,
+  envelopeC6: 31,
+  envelopeC65: 32,
+  envelopeB4: 33,
+  envelopeB5: 34,
+  envelopeB6: 35,
+  envelopeItaly: 36,
+  envelopeMonarch: 37,
+  envelopePersonal: 38,
+  fanfoldUS: 39,
+  fanfoldGermanStd: 40,
+  fanfoldGermanLegal: 41,
+  a6: 70,
+  japanesePostcard: 43,
+  japaneseDoublePostcard: 69,
 }
 
-/** Reverse map: XLSX paper size number → PaperSize string */
-export const PAPER_SIZE_REVERSE: Record<number, PaperSize> = {}
+/** Reverse map: OOXML paper size code → the name, when there is one. */
+export const PAPER_SIZE_REVERSE: Record<number, PaperSizeName> = {}
 for (const [name, num] of Object.entries(PAPER_SIZE_MAP)) {
-  PAPER_SIZE_REVERSE[num] = name as PaperSize
+  PAPER_SIZE_REVERSE[num] = name as PaperSizeName
+}
+
+/** Resolve a `PaperSize` to the code that goes in the file. */
+export function paperSizeCode(size: PaperSize): number | undefined {
+  if (typeof size === "number") {
+    return Number.isInteger(size) && size > 0 ? size : undefined
+  }
+  return PAPER_SIZE_MAP[size as PaperSizeName]
 }
 
 // ── Page Margins Serialization ──────────────────────────────────────
@@ -1247,8 +1296,8 @@ function serializePrintOptions(ps: PageSetup | undefined): string {
 function serializePageSetup(ps: PageSetup): string {
   const attrs: Record<string, string | number> = {}
 
-  if (ps.paperSize) {
-    const num = PAPER_SIZE_MAP[ps.paperSize]
+  if (ps.paperSize !== undefined) {
+    const num = paperSizeCode(ps.paperSize)
     if (num !== undefined) {
       attrs["paperSize"] = num
     }

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -32,6 +32,7 @@ import type { ParsedStyles } from "./styles"
 import type { Relationship } from "./relationships"
 import { resolveStyle, isDateStyle } from "./styles"
 import { cloneCellStyle } from "../_style"
+import { PAPER_SIZE_REVERSE } from "./worksheet-writer"
 import { serialToDate } from "../_date"
 import { parseSax, decodeOoxmlEscapes } from "../xml/parser"
 import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
@@ -1859,17 +1860,9 @@ function parsePageMarginsAttrs(attrs: Record<string, string>): PageMargins {
 // ── Page Setup Parser ──────────────────────────────────────────────────
 
 /** Reverse map: XLSX paper size number → PaperSize string */
-const PAPER_SIZE_REVERSE: Record<number, PaperSize> = {
-  1: "letter",
-  3: "tabloid",
-  5: "legal",
-  7: "executive",
-  8: "a3",
-  9: "a4",
-  11: "a5",
-  12: "b4",
-  13: "b5",
-}
+// The name↔code table lives with the writer, so the two cannot disagree —
+// there used to be a second copy here, and keeping two tables in step is
+// exactly the kind of thing nobody checks. See #439 §Q.
 
 /**
  * Merge `<printOptions>` attributes into the sheet's page setup.
@@ -1898,8 +1891,8 @@ function parsePageSetupAttrs(attrs: Record<string, string>): PageSetup {
 
   if (attrs["paperSize"]) {
     const num = Number(attrs["paperSize"])
-    const name = PAPER_SIZE_REVERSE[num]
-    if (name) ps.paperSize = name
+    // A code with no name round-trips as the number rather than vanishing.
+    if (Number.isInteger(num) && num > 0) ps.paperSize = PAPER_SIZE_REVERSE[num] ?? num
   }
 
   if (attrs["orientation"] === "landscape" || attrs["orientation"] === "portrait") {

--- a/test/coverage-xlsx-worksheet.test.ts
+++ b/test/coverage-xlsx-worksheet.test.ts
@@ -694,10 +694,16 @@ describe("conditional formatting", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("page setup", () => {
-  it("ignores a paper size hucre has no name for", () => {
-    // The reverse map only covers the sizes the writer can emit; an
-    // unmapped number is dropped rather than surfaced as a raw code.
+  it("keeps a paper size hucre has no name for, as the code it is", () => {
+    // Dropping it lost the page size with no error and nothing in the
+    // parity statement. `PaperSize` admits a raw code, so an unnamed one
+    // round-trips as the number. See #439 §Q.
     const s = sheet(`<sheetData/><pageSetup paperSize="256" orientation="sideways" scale="80"/>`)
+    expect(s.pageSetup).toEqual({ paperSize: 256, scale: 80 })
+  })
+
+  it("still ignores a paper size that is not a usable code", () => {
+    const s = sheet(`<sheetData/><pageSetup paperSize="0" scale="80"/>`)
     expect(s.pageSetup).toEqual({ scale: 80 })
   })
 

--- a/test/paper-size.test.ts
+++ b/test/paper-size.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { PAPER_SIZE_MAP } from "../src/xlsx/worksheet-writer"
+import type { PaperSize } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §Q — `PaperSize` was a closed union of nine names, and the reader
+// dropped anything else outright:
+//
+//   const name = PAPER_SIZE_REVERSE[num]
+//   if (name) ps.paperSize = name
+//
+// So a workbook set to A6, or to any envelope, lost its page size on read
+// with no error and nothing in the parity statement — and a caller who
+// knew the OOXML code could not pass it either.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function roundTrip(paperSize: PaperSize): Promise<PaperSize | undefined> {
+  const bytes = await writeXlsx({
+    sheets: [{ name: "S", rows: [[1]], pageSetup: { paperSize } }],
+  })
+  return (await readXlsx(bytes)).sheets[0]!.pageSetup?.paperSize
+}
+
+describe("named paper sizes", () => {
+  it("round-trips every name in the table", async () => {
+    for (const name of Object.keys(PAPER_SIZE_MAP) as Array<keyof typeof PAPER_SIZE_MAP>) {
+      expect(await roundTrip(name), name).toBe(name)
+    }
+  })
+
+  it("still round-trips the nine that were there before", async () => {
+    for (const name of ["letter", "legal", "a3", "a4", "a5", "b4", "b5", "executive", "tabloid"]) {
+      expect(await roundTrip(name as PaperSize), name).toBe(name)
+    }
+  })
+
+  it("covers the sizes people actually hit", async () => {
+    expect(await roundTrip("a6")).toBe("a6")
+    expect(await roundTrip("envelopeDL")).toBe("envelopeDL")
+    expect(await roundTrip("japanesePostcard")).toBe("japanesePostcard")
+    expect(await roundTrip("ledger")).toBe("ledger")
+  })
+})
+
+describe("a raw OOXML code is the escape hatch", () => {
+  it("writes and reads back a code with no name", async () => {
+    // 256 is in the printer-defined range, which Excel leaves to the driver.
+    expect(await roundTrip(256)).toBe(256)
+  })
+
+  it("normalises a code that does have a name", async () => {
+    // 9 is A4. Round-tripping it as the name is more useful than as 9, and
+    // both mean the same thing to Excel.
+    expect(await roundTrip(9)).toBe("a4")
+  })
+
+  it("ignores a code that is not usable", async () => {
+    expect(await roundTrip(0)).toBeUndefined()
+    expect(await roundTrip(-1)).toBeUndefined()
+    expect(await roundTrip(1.5)).toBeUndefined()
+  })
+})
+
+describe("the name↔code table has one home", () => {
+  it("maps each name to a distinct code", () => {
+    const codes = Object.values(PAPER_SIZE_MAP)
+
+    expect(new Set(codes).size).toBe(codes.length)
+  })
+
+  it("uses the codes ECMA-376 assigns", () => {
+    expect(PAPER_SIZE_MAP.letter).toBe(1)
+    expect(PAPER_SIZE_MAP.a4).toBe(9)
+    expect(PAPER_SIZE_MAP.a6).toBe(70)
+    expect(PAPER_SIZE_MAP.envelopeDL).toBe(27)
+  })
+})


### PR DESCRIPTION
From the audit in #439, §Q.

## The bug

`PaperSize` was a closed union of nine names — `letter`, `legal`, `a3`, `a4`, `a5`, `b4`, `b5`, `executive`, `tabloid`. Excel defines about 120 codes, and the reader dropped everything else outright:

```ts
const name = PAPER_SIZE_REVERSE[num]
if (name) ps.paperSize = name        // worksheet.ts
```

So a workbook set to **A6, or to any envelope size**, lost its page size on read with no error and nothing in `docs/PARITY.md`, which listed "page setup including print areas and print titles" at parity. There was no escape hatch either: the union admitted no number, so a caller who knew the OOXML code could not pass it.

## What landed

`PaperSize` is now `PaperSizeName | number`.

The name table grows from 9 to **42**, covering the ECMA-376 §18.3.1.63 block people actually hit — letter/letterSmall/legal/ledger/tabloid/statement/executive, A3–A6, B4/B5, folio, quarto, note, the eleven envelope sizes, the fanfold sizes, and the Japanese postcards.

A code with no name round-trips as the number it is. A code that *does* have a name normalises to the name — both mean the same thing to Excel, and the name is the more useful thing to hand back.

The name↔code table had **two copies**, one per direction, in two files (`worksheet-writer.ts` derived the reverse map from the forward one; `worksheet.ts` had a second literal). The reader imports the writer's now, so they cannot drift.

## A pinned assertion changes meaning

`test/coverage-xlsx-worksheet.test.ts` had:

```ts
it("ignores a paper size hucre has no name for", () => {
  // The reverse map only covers the sizes the writer can emit; an
  // unmapped number is dropped rather than surfaced as a raw code.
  expect(s.pageSetup).toEqual({ scale: 80 })
})
```

It is the opposite assertion now, with the reasoning in the comment — plus a new one that a code which is genuinely unusable (`0`, negative, fractional) is still ignored.

## Tests

`test/paper-size.test.ts`, 8 assertions: a round trip for **all 42 names**, the nine originals specifically, the raw-code escape hatch, normalisation of a named code, rejection of unusable codes, and the table's own invariants (distinct codes, correct ECMA values).

**6 of the 8 fail against `main`.**