### PR TITLE
docs: correct four claims the code does not keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ const buffer = await writeXlsx({
 })
 ```
 
-Features: cell styles, auto column widths, merged cells, freeze/split panes, auto-filter (with per-column value filters — `<filters><filter val="…"/></filters>`; custom/dynamic/colour criteria are not emitted), data validation, hyperlinks, images (PNG/JPEG/GIF/SVG/WebP), comments, tables, conditional formatting (13 rule types — see the footnote above), named ranges, print settings, page breaks, sheet protection, workbook protection, rich text, shared/array/dynamic formulas, sparklines, textboxes, background images, number formats, hidden sheets, Excel 2024 native checkboxes, HTML/Markdown/JSON/TSV export, template engine.
+Features: cell styles, auto column widths, merged cells, freeze/split panes, auto-filter (with per-column value filters — `<filters><filter val="…"/></filters>`; custom/dynamic/colour criteria are not emitted), data validation, hyperlinks, images (PNG/JPEG/GIF/SVG/WebP), comments, tables, conditional formatting (all 15 rule types, with their dxf styles), named ranges, print settings, page breaks, sheet protection, workbook protection, rich text, shared/array/dynamic formulas, sparklines, textboxes, background images, number formats, hidden sheets, Excel 2024 native checkboxes, HTML/Markdown/JSON/TSV export, template engine.
 
 ### Auto Column Width
 
@@ -1648,7 +1648,7 @@ Schema field options:
 
 ### Date Utilities
 
-Timezone-safe Excel date serial number conversion:
+Excel serial number conversion, in UTC:
 
 ```ts
 import { serialToDate, dateToSerial, isDateFormat, formatDate } from "hucre"
@@ -1660,7 +1660,30 @@ isDateFormat("#,##0.00") // false
 formatDate(new Date(), "yyyy-mm-dd") // "2026-03-24"
 ```
 
-Handles the Lotus 1-2-3 bug (serial 60), 1900/1904 date systems, and time fractions correctly.
+**Every date path in hucre reads UTC components**, which is what makes
+the conversions consistent between the readers, the writers and
+`formatValue`. It is also the one thing worth knowing before you build a
+`Date` yourself:
+
+```ts
+dateToSerial(new Date("2024-01-15")) // 45306    — parsed as UTC midnight
+dateToSerial(new Date(2024, 0, 15)) //  45305.875 in UTC+3
+
+// The second is *local* midnight, which is 21:00 the previous day in UTC —
+// so Excel shows "14 Jan 2024 21:00". Build the instant you mean:
+dateToSerial(new Date(Date.UTC(2024, 0, 15))) // 45306
+```
+
+hucre converts the instant, not the wall-clock date; it does not guess a
+calendar day out of a timezone. Pass `Date.UTC(...)` when you mean a day.
+
+Both date systems are handled, and so is the Lotus 1-2-3 phantom
+29 February 1900 — with one caveat worth stating, since Excel's own model
+is contradictory here. Serial 60 is that phantom day, and it has no real
+instant to map to, so `serialToDate(60)` and `serialToDate(59)` both give
+28 February 1900 and `dateToSerial` sends that back as 59. A workbook
+that actually contains serial 60 therefore shifts by a day on rewrite.
+Excel produces it only for files inherited from Lotus.
 
 ## Platform Support
 
@@ -1699,7 +1722,7 @@ hucre (~114 KB gzipped for the whole barrel; 2–64 KB for the common
 ├── cell-utils      parseCellRef, colToLetter, parseRange, isInRange
 ├── image           imageFromBase64 utility
 ├── worker          Web Worker serialization helpers
-├── _date           Timezone-safe serial ↔ Date, Lotus bug, 1900/1904
+├── _date           UTC serial ↔ Date, Lotus bug, 1900/1904
 ├── _format         Number format renderer (locale-aware)
 ├── _schema         Schema validation, type coercion, error collection
 └── cli             Convert, inspect, validate (citty + consola)

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -157,6 +157,31 @@ the workbook-level caches, and has no write counterpart because
 | `WriteSheet.a11y`                                         | authoring metadata. `a11y.summary` is promoted to `properties.description` and does survive; `a11y.headerRow` has no cell to live in                                       |
 | `SheetProtection.password`, `workbookProtection.password` | the file holds a one-way digest, never the password. The digest is read; the password cannot be                                                                            |
 
+### Losses inside fields that otherwise round-trip
+
+Three cases where a field is carried but a particular _value_ is not.
+
+**A cell whose text is literally `_x0041_` reads back as `A`.** OOXML uses
+`_xHHHH_` to encode characters XML cannot hold, and hucre decodes it on
+read. Excel disambiguates by escaping a leading underscore as `_x005F_`;
+hucre deliberately does not, because doing so would mangle the far more
+common case of ordinary text that happens to contain an underscore. The
+ambiguity is accepted, and now written down.
+
+**Serial 60 collapses onto 59.** Serial 60 in the 1900 system is the
+Lotus 1-2-3 phantom 29 February 1900, a date that does not exist. It has
+no instant to map to, so `serialToDate(60)` gives 28 February 1900 —
+the same as serial 59 — and writing that back produces 59. A workbook
+containing serial 60 shifts by one day on rewrite. Excel produces it only
+for files inherited from Lotus.
+
+**A `Date` you build with local components is converted as an instant.**
+`dateToSerial(new Date(2024, 0, 15))` in UTC+3 is 45305.875, not 45306,
+because local midnight is 21:00 the previous day in UTC. hucre reads UTC
+components everywhere, which is what keeps the readers, the writers and
+`formatValue` consistent; it does not infer a calendar day from a
+timezone. Use `Date.UTC(...)` when you mean a day.
+
 ## ODS
 
 ODS reads and writes the same narrow model, so **ODS → ODS is lossless**.

--- a/src/_date.ts
+++ b/src/_date.ts
@@ -48,6 +48,11 @@ export function serialToDate(serial: number, is1904?: boolean): Date {
   // - Serial 60 = phantom "Feb 29, 1900"
   // - Serials > 60: subtract 1 to account for the phantom day
 
+  // Serial 60 is the phantom 29 February 1900, a date with no instant to
+  // map to. It collapses onto 28 February — the same Date serial 59 gives —
+  // so a workbook that really contains 60 shifts by a day on rewrite.
+  // Documented in docs/PARITY.md rather than papered over: any other
+  // mapping would put a real date on a serial Excel does not agree exists.
   if (serial === LOTUS_BUG_SERIAL) {
     // Return "Feb 29, 1900" even though it doesn't exist historically.
     // Excel treats this as a real date, so we must too.
@@ -72,9 +77,18 @@ export function serialToDate(serial: number, is1904?: boolean): Date {
 
 /**
  * Convert a JavaScript Date to an Excel serial number.
- * Uses UTC components of the date.
  *
- * @param date - JavaScript Date (UTC components are used)
+ * The **instant** is converted, against a UTC epoch — not the wall-clock
+ * date the machine would show. `new Date(2024, 0, 15)` is local midnight,
+ * which in UTC+3 is 21:00 on the 14th, and comes out as 45305.875 rather
+ * than 45306. That is not a bug to route around: hucre reads UTC
+ * components on every date path, which is what keeps the readers, the
+ * writers and `formatValue` consistent with each other.
+ *
+ * Build the instant you mean — `Date.UTC(2024, 0, 15)` — when you mean a
+ * calendar day.
+ *
+ * @param date - JavaScript Date; its instant is converted
  * @param is1904 - Whether to use the 1904 date system (default: false = 1900)
  * @returns Excel serial number (with fractional time portion)
  */

--- a/test/documented-edges.test.ts
+++ b/test/documented-edges.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest"
+import { dateToSerial, serialToDate } from "../src/_date"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import type { ConditionalRuleType } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §C2, §C3, §C4 and §L — three value-level losses and one wrong
+// count, all of which were decisions written into a source comment and
+// never into anything a user reads.
+//
+// These pin the documented behaviour, so docs/PARITY.md and the README
+// cannot drift away from what the code does.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("dates convert as instants, in UTC", () => {
+  it("gives the same answer whatever the machine's timezone", () => {
+    const noon = new Date(Date.UTC(2024, 0, 15, 12, 0, 0))
+
+    vi.stubEnv("TZ", "America/New_York")
+    const inNewYork = dateToSerial(noon)
+    vi.stubEnv("TZ", "Asia/Tokyo")
+    const inTokyo = dateToSerial(noon)
+    vi.unstubAllEnvs()
+
+    expect(inNewYork).toBe(inTokyo)
+  })
+
+  it("converts the instant, not the wall-clock day", () => {
+    // The README and PARITY.md both say this in as many words, because it
+    // is the one thing that surprises people.
+    expect(dateToSerial(new Date(Date.UTC(2024, 0, 15)))).toBe(45306)
+    expect(dateToSerial(new Date("2024-01-15"))).toBe(45306)
+  })
+
+  it("round-trips a UTC-built date exactly", () => {
+    const d = new Date(Date.UTC(2024, 0, 15, 9, 30, 0))
+
+    expect(serialToDate(dateToSerial(d)).toISOString()).toBe(d.toISOString())
+  })
+})
+
+describe("the Lotus phantom day is a fixed point, and says so", () => {
+  it("maps serial 60 onto the same instant as 59", () => {
+    // 29 February 1900 does not exist. There is no instant to give it, so
+    // it collapses onto 28 February — see docs/PARITY.md.
+    expect(serialToDate(60).toISOString()).toBe(serialToDate(59).toISOString())
+  })
+
+  it("sends it back as 59, which is the documented loss", () => {
+    expect(dateToSerial(serialToDate(60))).toBe(59)
+  })
+
+  it("leaves every serial either side of it exact", () => {
+    for (const serial of [1, 58, 59, 61, 62, 1000, 45306]) {
+      expect(dateToSerial(serialToDate(serial)), String(serial)).toBe(serial)
+    }
+  })
+})
+
+describe("a literal _xHHHH_ in cell text is the documented ambiguity", () => {
+  it("reads back as the character it encodes", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [["_x0041_"]] }] })
+
+    // Excel would escape the leading underscore as _x005F_; hucre does not,
+    // because doing so would mangle ordinary text containing underscores.
+    // Accepted, and now written into docs/PARITY.md.
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]![0]).toBe("A")
+  })
+
+  it("leaves ordinary underscored text alone", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [["snake_case_name", "_x", "x_0041_"]] }],
+    })
+
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]).toEqual(["snake_case_name", "_x", "x_0041_"])
+  })
+})
+
+describe("the conditional rule count the docs quote", () => {
+  it("is 15, which is what the type has", () => {
+    // A Record over the union, so a new member fails `tsc` here rather
+    // than quietly making the number in the docs wrong again.
+    const every: Record<ConditionalRuleType, true> = {
+      cellIs: true,
+      expression: true,
+      colorScale: true,
+      dataBar: true,
+      iconSet: true,
+      top10: true,
+      aboveAverage: true,
+      duplicateValues: true,
+      uniqueValues: true,
+      containsText: true,
+      notContainsText: true,
+      beginsWith: true,
+      endsWith: true,
+      containsBlanks: true,
+      notContainsBlanks: true,
+    }
+
+    const types: ConditionalRuleType[] = [
+      "cellIs",
+      "expression",
+      "colorScale",
+      "dataBar",
+      "iconSet",
+      "top10",
+      "aboveAverage",
+      "duplicateValues",
+      "uniqueValues",
+      "containsText",
+      "notContainsText",
+      "beginsWith",
+      "endsWith",
+      "containsBlanks",
+      "notContainsBlanks",
+    ]
+
+    // The README said 13 while PARITY.md said 15. The type is the arbiter.
+    expect(Object.keys(every)).toHaveLength(15)
+    expect(types.sort()).toEqual(Object.keys(every).sort())
+  })
+})


### PR DESCRIPTION
From the audit in #439, §C2, §C3, §C4 and §L.

Four places where the documentation says something the code does not do. Each was a decision someone made and wrote into a source comment — none of them reached anything a user reads.

## 1. "13 rule types"

The README said 13, `docs/PARITY.md` said 15, and `ConditionalRuleType` has 15. The README also said "see the footnote above" with no footnote nearby.

Now "all 15 rule types, with their dxf styles", matching PARITY — and the test uses a `Record<ConditionalRuleType, true>` so a new member fails `tsc` rather than quietly making the number wrong again.

## 2. "Timezone-safe"

hucre *is* UTC-consistent internally: every date path reads UTC components, which is what keeps the readers, the writers and `formatValue` agreeing with each other. But "timezone-safe" is a different claim, and the README's examples only ever used UTC-parsed dates, so the trap never showed:

```js
dateToSerial(new Date("2024-01-15"))    // 45306      — parsed as UTC midnight
dateToSerial(new Date(2024, 0, 15))     // 45305.875  in UTC+3
```

The second is local midnight — 21:00 the previous day in UTC — so Excel shows **14 January 2024 21:00**. The README now shows that case next to the one that works, says plainly that hucre converts the instant rather than inferring a calendar day, and points at `Date.UTC`.

`dateToSerial`'s JSDoc said *"UTC components are used"*, which is not what it does (it converts the absolute instant). It now says what it does and why.

## 3. "Handles the Lotus 1-2-3 bug (serial 60) … correctly"

```js
serialToDate(59).toISOString()        // 1900-02-28T00:00:00.000Z
serialToDate(60).toISOString()        // 1900-02-28T00:00:00.000Z   ← same
dateToSerial(serialToDate(60))        // 59
```

Serial 60 is the phantom 29 February 1900. It has no instant to map to, so it collapses onto 28 February and writes back as 59 — a workbook that really contains it shifts by a day on rewrite. That is a fixed point, not correctness, and any other mapping would put a real date on a serial Excel does not agree exists. Stated as what it is now.

## 4. A literal `_x0041_` in cell text reads back as `A`

OOXML uses `_xHHHH_` for characters XML cannot hold, and hucre decodes it on read. Excel disambiguates by escaping a leading underscore as `_x005F_`; hucre deliberately does not, because doing so would mangle the far more common case of ordinary text containing underscores.

The decision was written into a comment in `src/xml/writer.ts` and nowhere else. `docs/PARITY.md` ends with *"Anything else is a bug"*, which made this a reportable bug by the project's own standard.

## Where they went

All three value-level losses now sit in `docs/PARITY.md` under a new "Losses inside fields that otherwise round-trip" section — the parity register is field-level, and these are cases where the field carries but a particular value does not.

`test/documented-edges.test.ts`, 9 assertions, pins all four so the prose and the code cannot drift apart again. It also checks that ordinary underscored text (`snake_case_name`, `_x`, `x_0041_`) is left alone, which is the reason the `_x005F_` escape was skipped in the first place.