### PR TITLE
chore: test the package on the runtimes it claims — and fix the one that was broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,39 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The package claims Node 18+. Nothing checked that, and the one
+        # job that ran was whatever `lts/*` resolved to on the day.
+        node: [18, 20, 22, lts/*]
+    name: node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      # `pnpm test` is lint + typecheck + vitest, so running the first two
+      # again here would double every job's work for nothing.
+      - name: Test
+        run: pnpm test
+      - name: Build
+        run: pnpm build
+      - name: Verify packaged artifact
+        run: node scripts/verify-package.mjs
+
+  timezone:
+    # Everything above runs in UTC, which is where a whole class of date bug
+    # hides: #415 was silent in CI for exactly that reason, and the CSV
+    # dateFormat defect in #439 Part 8 was too. One non-UTC job closes it.
+    runs-on: ubuntu-latest
+    name: node lts (TZ=Asia/Tokyo)
+    env:
+      TZ: Asia/Tokyo
     steps:
       - uses: actions/checkout@v5
       - run: corepack enable
@@ -31,15 +64,37 @@ jobs:
         with:
           node-version: lts/*
           cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Lint
-        run: pnpm lint
-      - name: Typecheck
-        run: pnpm typecheck
-      - name: Test
-        run: pnpm test
-      - name: Build
-        run: pnpm build
-      - name: Verify packaged artifact
-        run: node scripts/verify-package.mjs
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  runtimes:
+    # The package advertises Deno and Bun. Neither was ever exercised.
+    runs-on: ubuntu-latest
+    name: ${{ matrix.runtime }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [bun, deno]
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+
+      - if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@v2
+      - if: matrix.runtime == 'deno'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      # A smoke test, not the suite: the point is that the built ESM loads
+      # and the core paths run on a runtime that is not Node.
+      - if: matrix.runtime == 'bun'
+        run: bun scripts/smoke.mjs
+      - if: matrix.runtime == 'deno'
+        run: deno run --allow-read scripts/smoke.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The package claims Node 18+. Nothing checked that, and the one
-        # job that ran was whatever `lts/*` resolved to on the day.
-        node: [18, 20, 22, lts/*]
+        # The versions the toolchain runs on. pnpm 11 requires Node 22.13,
+        # so the package's *supported* floor is checked by the `runtime`
+        # job below against the built artifact instead — which is the more
+        # honest test anyway: what ships is dist/, not the dev setup.
+        node: [22, lts/*]
     name: node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v5
@@ -67,14 +69,24 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
-  runtimes:
-    # The package advertises Deno and Bun. Neither was ever exercised.
+  runtime:
+    # Does the *shipped* artifact run where the README says it does?
+    #
+    # This is separate from `build` on purpose. The toolchain needs a
+    # recent Node (pnpm 11 requires 22.13), but what users install is
+    # dist/, and its floor is whatever Web APIs the code touches —
+    # CompressionStream, ReadableStream, crypto.subtle. So: build once on
+    # a version the toolchain likes, then run a smoke test under each
+    # runtime the package claims.
+    #
+    # Node 18 and Deno and Bun were all advertised and none was ever
+    # exercised.
     runs-on: ubuntu-latest
-    name: ${{ matrix.runtime }}
+    name: runtime ${{ matrix.runtime }}
     strategy:
       fail-fast: false
       matrix:
-        runtime: [bun, deno]
+        runtime: [node18, node20, bun, deno]
     steps:
       - uses: actions/checkout@v5
       - run: corepack enable
@@ -85,6 +97,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
+      - if: matrix.runtime == 'node18'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 18
+      - if: matrix.runtime == 'node20'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
       - if: matrix.runtime == 'bun'
         uses: oven-sh/setup-bun@v2
       - if: matrix.runtime == 'deno'
@@ -92,8 +112,10 @@ jobs:
         with:
           deno-version: v2.x
 
-      # A smoke test, not the suite: the point is that the built ESM loads
-      # and the core paths run on a runtime that is not Node.
+      # A smoke test, not the suite: vitest is a Node harness, and the
+      # question here is whether dist/ loads and works on this runtime.
+      - if: startsWith(matrix.runtime, 'node')
+        run: node --version && node scripts/smoke.mjs
       - if: matrix.runtime == 'bun'
         run: bun scripts/smoke.mjs
       - if: matrix.runtime == 'deno'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Verify packaged artifact
+        run: node scripts/verify-package.mjs
+
       - name: Publish to npm
         run: pnpm publish --provenance --access public --no-git-checks
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Thanks for looking. This is a short page — most of what you need is in the
+code, and the rest is here.
+
+## Getting set up
+
+```bash
+pnpm install
+pnpm test        # lint + typecheck + vitest
+```
+
+`pnpm test` is the whole gate, and it is what CI runs. `pnpm dev` starts
+vitest in watch mode.
+
+## What a change looks like here
+
+**A test that fails before your fix.** Not "a test that passes after" —
+the two are different, and only the first proves the change does
+something. Say so in the PR: _"three of the five fail against `main`"_ is
+the most useful sentence you can write.
+
+**A reason in the code, not just in the PR.** The comments in this
+codebase explain _why_ a thing is the way it is, usually with the issue
+number that caused it. A PR moves on; the comment stays with the line
+someone will be reading in a year.
+
+**No silently accepted options.** A typed field that is discarded is worse
+than no field at all — that is why `WriteSheet.threadedComments` and
+`CsvReadOptions.schema` were removed rather than left in place. If the
+code cannot honour something, do not accept it.
+
+## The registers
+
+Several tests exist to fail when someone adds a field and forgets a place
+that has to carry it. If one of these breaks, it is doing its job — fix
+the thing it points at rather than the test:
+
+| test                                  | guards                                                                                                  |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `test/xlsx-write-read-parity.test.ts` | every `WriteSheet` / `WriteOptions` field either round-trips or is registered one-way **with a reason** |
+| `test/parity-statement.test.ts`       | `docs/PARITY.md` and the README still describe the types as they are                                    |
+| `test/clone-sheet-coverage.test.ts`   | `cloneSheet`, `cloneCell` and the worker serializer carry every field of `Sheet`, `Cell` and `Workbook` |
+| `test/write-model.test.ts`            | `toWriteOptions` names every read-model field that has no write counterpart                             |
+| `test/exports.test.ts`                | the public surface of each entry point                                                                  |
+
+## Read/write parity
+
+`docs/PARITY.md` is the statement of what hucre reads versus what it
+writes. It ends with "Anything else is a bug", which is a commitment: if
+your change adds a loss, the page has to say so in the same PR.
+
+## Platform neutrality
+
+The library core uses Web APIs only — no `node:` imports, no `process`, no
+`Buffer`. `tsconfig.json` sets `"types": []` so reaching for one is a
+compile error rather than something that quietly works on your machine.
+The CLI is the exception and is checked by `tsconfig.cli.json`.
+
+Tests that read from disk belong in `tsconfig.cli.json`'s include list for
+the same reason.
+
+## Commits and PRs
+
+Conventional commits — `fix(xlsx):`, `feat:`, `docs:`, `perf(csv):`. The
+scope is the format or the module.
+
+For the PR body, the shape that works is: what was wrong, shown with real
+input and output; why the tests did not catch it; what landed; and what
+you did **not** verify. That last one matters more than it sounds — most
+of this library's output cannot be checked without Excel, and saying "I
+did not open this in Excel" is more useful than implying you did.
+
+## Performance claims
+
+If a change is about speed or memory, measure it and put the numbers in
+the PR, with the shape of the input and how many runs. One process per
+measurement if you are quoting peak RSS — `maxRSS` is a high-water mark
+for the whole process, so a second measurement in the same run inherits
+the first one's peak.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security
+
+hucre parses files it did not write. That is the whole point of it, and it
+is also where the risk is: a spreadsheet is an archive of XML, and both
+layers have well-known ways to make a parser allocate forever.
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for a security problem.
+
+Use GitHub's private reporting — [Security → Report a
+vulnerability](https://github.com/productdevbook/hucre/security/advisories/new)
+— or email <mehmet.k.hob@gmail.com>.
+
+Include the input that triggers it if you can. A file, or the few lines of
+markup or XML that reproduce it, is worth more than a description.
+
+You should get an acknowledgement within a few days. Fixes go out as a
+patch release, and the advisory is published once one is available.
+
+## What is in scope
+
+- Reading any supported format — XLSX, XLSM, XLSB, XLS, ODS, CSV, JSON,
+  NDJSON, XML, HTML — from untrusted input.
+- The ZIP and OLE2/CFB container readers.
+- The XML parser and the HTML importer.
+- Encryption and decryption (ECMA-376 Agile).
+- Anything that makes hucre allocate without bound, hang, or read outside
+  the input it was given.
+
+## What is not
+
+- Writing a file with content a caller supplied. `writeXlsx` escapes what
+  it writes, but hucre is a serialiser: if you put a formula in a cell, it
+  writes a formula. Deciding what is safe to put in a spreadsheet is the
+  caller's, which is why `escapeFormulae` exists on the CSV writer and is
+  opt-in.
+- Denial of service through input the caller chose to accept above the
+  documented bounds — see below.
+- Anything requiring the attacker to control your own source code or
+  dependencies.
+
+## The bounds hucre already enforces
+
+`src/limits.ts` is the list, and each entry says what it is defending
+against:
+
+| bound                    | default                                 | what it stops                                                                         |
+| ------------------------ | --------------------------------------- | ------------------------------------------------------------------------------------- |
+| `MAX_DECOMPRESSED_BYTES` | 2 GiB per entry                         | ZIP bombs — a small entry claiming a small compressed size and expanding to gigabytes |
+| `MAX_INPUT_BYTES`        | 1 GiB, overridable with `maxInputBytes` | a `ReadableStream` that never ends                                                    |
+| `MAX_TOTAL_CELLS`        | 20,000,000                              | two legal cells at opposite corners describing a 1.7e10-slot rectangle                |
+| `MAX_REPEAT_COUNT`       | 100,000                                 | ODS `text:c="900000000"`, a gigabyte of spaces in one cell                            |
+| `MAX_SPAN_CELLS`         | 1,000,000                               | HTML `rowspan` × `colspan` bombs                                                      |
+| `MAX_SPIN_COUNT`         | 10,000,000                              | a hostile encrypted file pinning a CPU in key derivation                              |
+
+Two structural properties are worth naming because they remove whole
+classes of attack rather than bounding them:
+
+- **The XML parser expands no DTD.** It handles the five predefined
+  entities and numeric character references, and nothing else, so
+  entity-expansion attacks — billion laughs, quadratic blowup — have
+  nothing to work with. There is no external-entity resolution either, so
+  XXE is not reachable.
+- **The library reads no filesystem and opens no network.** There are no
+  `node:` imports in `src/` outside the CLI, and `tsconfig.json` sets
+  `"types": []` so reaching for one is a compile error. A malicious file
+  cannot make hucre fetch anything.
+
+If you find input that gets past a bound, or a path where one is not
+applied, that is a vulnerability and worth reporting.
+
+## Supported versions
+
+The latest minor of the current major receives security fixes.

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
   },
   "files": [
     "dist",
-    "MIGRATION.md"
+    "MIGRATION.md",
+    "docs/PARITY.md"
   ],
   "type": "module",
+  "sideEffects": false,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
@@ -92,6 +94,9 @@
     "oxlint": "^1.76.0",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "packageManager": "pnpm@11.15.1"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:recommended"]
 }

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,93 @@
+// ── Cross-runtime smoke test ─────────────────────────────────────────
+//
+// The package advertises Deno, Bun, browsers, Workers and Edge, and the
+// core is written to Web APIs only for exactly that reason — but nothing
+// ever ran it anywhere but Node on Linux. This is the smallest thing that
+// would have caught a runtime-specific break: load the built ESM and run
+// one round trip through each format that touches the platform.
+//
+// It is deliberately not the test suite. Vitest is a Node harness; the
+// question here is whether `dist/` works where the README says it does.
+
+import {
+  parseCsv,
+  readXlsx,
+  writeCsv,
+  writeXlsx,
+  writeXlsxStream,
+  readOds,
+  writeOds,
+} from "../dist/index.mjs"
+
+let failures = 0
+
+function check(what, condition) {
+  if (condition) {
+    console.log(`  ok   ${what}`)
+  } else {
+    console.log(`  FAIL ${what}`)
+    failures++
+  }
+}
+
+async function drain(stream) {
+  const chunks = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+const ROWS = [
+  ["Name", "Amount", "When"],
+  ["Ada", 1234.5, new Date(Date.UTC(2024, 0, 15))],
+]
+
+console.log("csv")
+{
+  const csv = writeCsv(ROWS)
+  const back = parseCsv(csv, { typeInference: true })
+  check("round trip", back[1][0] === "Ada" && back[1][1] === 1234.5)
+}
+
+console.log("xlsx")
+{
+  // Exercises DEFLATE via CompressionStream and the ZIP writer.
+  const bytes = await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] })
+  const wb = await readXlsx(bytes)
+  check("round trip", wb.sheets[0].rows[1][0] === "Ada")
+  check("numbers survive", wb.sheets[0].rows[1][1] === 1234.5)
+  check("dates survive", wb.sheets[0].rows[1][2] instanceof Date)
+}
+
+console.log("xlsx streaming")
+{
+  // Exercises the streaming ZIP writer and backpressure across ReadableStream.
+  const bytes = await drain(writeXlsxStream(ROWS, { name: "S" }))
+  const wb = await readXlsx(bytes)
+  check("round trip", wb.sheets[0].rows[1][0] === "Ada")
+}
+
+console.log("ods")
+{
+  const bytes = await writeOds({ sheets: [{ name: "S", rows: ROWS }] })
+  const wb = await readOds(bytes)
+  check("round trip", wb.sheets[0].rows[1][0] === "Ada")
+}
+
+if (failures > 0) {
+  console.log(`\n${failures} check(s) failed`)
+  throw new Error(`smoke test failed: ${failures} check(s)`)
+}
+console.log("\nall checks passed")

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -22,7 +22,6 @@ import type {
   PageSetup,
   PageMargins,
   HeaderFooter,
-  PaperSize,
   FreezePane,
   SplitPane,
   Sparkline,

--- a/src/zip/capability.ts
+++ b/src/zip/capability.ts
@@ -1,0 +1,47 @@
+// ── Compression capability ───────────────────────────────────────────
+//
+// `deflate-raw` is the format a ZIP needs, and it is not the same
+// question as "does this runtime have CompressionStream". Node 18 has the
+// constructor and rejects `deflate-raw`: it shipped with `gzip` and
+// `deflate` only, and the raw format arrived in Node 20.
+//
+// Four modules each kept their own memoized flag, and every one of them
+// probed the constructor's *existence*. The buffered writer got away with
+// it because it also wrapped the construction in a try/catch and fell back
+// to the pure-TypeScript DEFLATE; the streaming writer constructed
+// outside any try and threw `ERR_INVALID_ARG_VALUE` on the first chunk —
+// so `writeXlsxStream` did not work on the Node version the package
+// claims as its floor. See #439 §AN.
+//
+// The only probe that answers the question is to build one and see.
+
+let deflateRaw: boolean | undefined
+let inflateRaw: boolean | undefined
+
+/** Whether this runtime can DEFLATE with the raw format a ZIP entry needs. */
+export function canDeflateRaw(): boolean {
+  if (deflateRaw === undefined) {
+    try {
+      // Constructed, not just referenced: Node 18 has CompressionStream
+      // and throws here.
+      new CompressionStream("deflate-raw")
+      deflateRaw = typeof ReadableStream !== "undefined"
+    } catch {
+      deflateRaw = false
+    }
+  }
+  return deflateRaw
+}
+
+/** Whether this runtime can inflate the raw format a ZIP entry carries. */
+export function canInflateRaw(): boolean {
+  if (inflateRaw === undefined) {
+    try {
+      new DecompressionStream("deflate-raw")
+      inflateRaw = typeof ReadableStream !== "undefined"
+    } catch {
+      inflateRaw = false
+    }
+  }
+  return inflateRaw
+}

--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -6,6 +6,7 @@ import { ZipError } from "../errors"
 import { MAX_DECOMPRESSED_BYTES } from "../limits"
 import { byteLimitStream } from "./byte-limit"
 import { crc32, inflate } from "./deflate"
+import { canInflateRaw } from "./capability"
 
 // ── ZIP Signatures ──────────────────────────────────────────────────
 
@@ -38,27 +39,11 @@ interface CentralDirEntry {
 
 // ── Decompression ───────────────────────────────────────────────────
 
-let hasDecompressionStream: boolean | undefined
-
-function checkDecompressionStream(): boolean {
-  if (hasDecompressionStream === undefined) {
-    try {
-      hasDecompressionStream =
-        typeof DecompressionStream !== "undefined" &&
-        typeof ReadableStream !== "undefined" &&
-        typeof Response !== "undefined"
-    } catch {
-      hasDecompressionStream = false
-    }
-  }
-  return hasDecompressionStream
-}
-
 async function decompressDeflateRaw(
   data: Uint8Array,
   maxBytes = MAX_DECOMPRESSED_BYTES,
 ): Promise<Uint8Array> {
-  if (checkDecompressionStream()) {
+  if (canInflateRaw()) {
     try {
       const ds = new DecompressionStream("deflate-raw")
       const writer = ds.writable.getWriter()
@@ -538,7 +523,7 @@ export class ZipReader {
           ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
           : MAX_DECOMPRESSED_BYTES
 
-      if (checkDecompressionStream()) {
+      if (canInflateRaw()) {
         const inputStream = new ReadableStream({
           start(controller) {
             controller.enqueue(compressedData)

--- a/src/zip/stream-reader.ts
+++ b/src/zip/stream-reader.ts
@@ -20,6 +20,7 @@ import { byteLimitStream } from "./byte-limit"
 import { inflate } from "./deflate"
 import { ParseError, ZipError } from "../errors"
 import { MAX_DECOMPRESSED_BYTES, MAX_INPUT_BYTES } from "../limits"
+import { canInflateRaw } from "./capability"
 
 const SIG_LOCAL_FILE = 0x04034b50
 const SIG_CENTRAL_DIR = 0x02014b50
@@ -27,21 +28,6 @@ const ZIP64_SENTINEL = 0xffffffff
 const FLAG_DATA_DESCRIPTOR = 0x0008
 
 const EMPTY = new Uint8Array(0)
-
-let hasDecompressionStream: boolean | undefined
-function checkDecompressionStream(): boolean {
-  if (hasDecompressionStream === undefined) {
-    try {
-      hasDecompressionStream =
-        typeof DecompressionStream !== "undefined" &&
-        typeof ReadableStream !== "undefined" &&
-        typeof Response !== "undefined"
-    } catch {
-      hasDecompressionStream = false
-    }
-  }
-  return hasDecompressionStream
-}
 
 /** One local-file-header record surfaced by {@link ZipStreamReader.nextEntry}. */
 export interface ZipStreamEntry {
@@ -230,7 +216,7 @@ export class ZipStreamReader {
       entry.uncompressedSize > 0
         ? Math.min(entry.uncompressedSize, MAX_DECOMPRESSED_BYTES)
         : MAX_DECOMPRESSED_BYTES
-    if (checkDecompressionStream()) {
+    if (canInflateRaw()) {
       return (
         raw.pipeThrough(
           new DecompressionStream("deflate-raw") as unknown as ReadableWritablePair<

--- a/src/zip/stream-writer.ts
+++ b/src/zip/stream-writer.ts
@@ -15,6 +15,7 @@
 
 import { CRC32_INIT, crc32Update, crc32Final } from "./deflate"
 import { ZipError } from "../errors"
+import { canDeflateRaw } from "./capability"
 
 // ── ZIP Signatures ──────────────────────────────────────────────────
 
@@ -79,19 +80,6 @@ export interface ZipStreamOptions {
 }
 
 // ── Compression ─────────────────────────────────────────────────────
-
-let hasCompressionStream: boolean | undefined
-
-function checkCompressionStream(): boolean {
-  if (hasCompressionStream === undefined) {
-    try {
-      hasCompressionStream = typeof CompressionStream !== "undefined"
-    } catch {
-      hasCompressionStream = false
-    }
-  }
-  return hasCompressionStream
-}
 
 /** Pipe chunks through `deflate-raw`, preserving backpressure both ways. */
 async function* deflateRawChunks(source: AsyncIterable<Uint8Array>): AsyncGenerator<Uint8Array> {
@@ -357,7 +345,7 @@ export async function* zipStreamChunks(
   const records: CentralRecord[] = []
   const seen = new Set<string>()
   let offset = 0
-  const canDeflate = checkCompressionStream()
+  const canDeflate = canDeflateRaw()
 
   for await (const entry of entries) {
     if (seen.has(entry.path)) {

--- a/src/zip/writer.ts
+++ b/src/zip/writer.ts
@@ -3,6 +3,7 @@
 // Supports STORE (method 0) and DEFLATE (method 8).
 
 import { crc32, deflate } from "./deflate"
+import { canDeflateRaw } from "./capability"
 
 // ── ZIP Signatures ──────────────────────────────────────────────────
 
@@ -12,24 +13,8 @@ const SIG_END_OF_CENTRAL_DIR = 0x06054b50
 
 // ── Compression ─────────────────────────────────────────────────────
 
-let hasCompressionStream: boolean | undefined
-
-function checkCompressionStream(): boolean {
-  if (hasCompressionStream === undefined) {
-    try {
-      hasCompressionStream =
-        typeof CompressionStream !== "undefined" &&
-        typeof ReadableStream !== "undefined" &&
-        typeof Response !== "undefined"
-    } catch {
-      hasCompressionStream = false
-    }
-  }
-  return hasCompressionStream
-}
-
 async function compressDeflateRaw(data: Uint8Array): Promise<Uint8Array> {
-  if (checkCompressionStream()) {
+  if (canDeflateRaw()) {
     try {
       const cs = new CompressionStream("deflate-raw")
       const writer = cs.writable.getWriter()

--- a/test/zip-capability.test.ts
+++ b/test/zip-capability.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeXlsxStream } from "../src/xlsx/stream-writer"
+
+// ═══════════════════════════════════════════════════════════════════════
+// The CI matrix added in this PR found this on its first run.
+//
+// `deflate-raw` is the format a ZIP entry needs, and "does this runtime
+// have CompressionStream" is a different question. Node 18 has the
+// constructor and rejects `deflate-raw` — it shipped with `gzip` and
+// `deflate` only, and the raw format arrived in Node 20.
+//
+// Four modules each memoized their own flag and every one probed the
+// constructor's existence. The buffered writer survived because it also
+// wrapped the construction in a try/catch; the streaming writer threw
+// ERR_INVALID_ARG_VALUE on the first chunk, so `writeXlsxStream` did not
+// work on the Node version the package claims as its floor.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+const ROWS = [
+  ["Name", "Amount"],
+  ["Ada", 1234.5],
+]
+
+/**
+ * Stand in for Node 18: the constructor exists and refuses `deflate-raw`.
+ * The modules cache their answer, so this runs in an isolated module
+ * registry — otherwise the first test in the file would fix the answer
+ * for the rest.
+ */
+function withoutDeflateRaw<T>(body: () => Promise<T>): Promise<T> {
+  const real = globalThis.CompressionStream
+  class Node18CompressionStream {
+    constructor(format: string) {
+      if (format === "deflate-raw") {
+        throw new TypeError("The argument 'format' is invalid. Received 'deflate-raw'")
+      }
+      return new real(format as CompressionFormat)
+    }
+  }
+  vi.stubGlobal("CompressionStream", Node18CompressionStream)
+  return body().finally(() => vi.unstubAllGlobals())
+}
+
+describe("a runtime whose CompressionStream lacks deflate-raw", () => {
+  it("still writes a readable workbook through the streaming writer", async () => {
+    const bytes = await withoutDeflateRaw(async () => {
+      vi.resetModules()
+      const { writeXlsxStream: fresh } = await import("../src/xlsx/stream-writer")
+      return drain(fresh(ROWS, { name: "S" }))
+    })
+
+    // Before the fix this threw ERR_INVALID_ARG_VALUE on the first chunk.
+    const wb = await readXlsx(bytes)
+    expect(wb.sheets[0]!.rows).toEqual(ROWS)
+  })
+
+  it("still writes a readable workbook through the buffered writer", async () => {
+    const bytes = await withoutDeflateRaw(async () => {
+      vi.resetModules()
+      const { writeXlsx: fresh } = await import("../src/xlsx/writer")
+      return fresh({ sheets: [{ name: "S", rows: ROWS }] })
+    })
+
+    const wb = await readXlsx(bytes)
+    expect(wb.sheets[0]!.rows).toEqual(ROWS)
+  })
+})
+
+describe("a runtime that does support deflate-raw", () => {
+  it("compresses, and the two writers agree on the content", async () => {
+    const streamed = await drain(writeXlsxStream(ROWS, { name: "S" }))
+    const buffered = await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] })
+
+    expect((await readXlsx(streamed)).sheets[0]!.rows).toEqual(ROWS)
+    expect((await readXlsx(buffered)).sheets[0]!.rows).toEqual(ROWS)
+  })
+})


### PR DESCRIPTION
From the audit in #439, §H, §M and §AN.

The package advertises Node 18+, Deno, Bun, browsers, Cloudflare Workers and Vercel Edge, and the core is written to Web APIs only so that claim can hold. Nothing checked any of it — CI ran **one** job, on `ubuntu-latest`, on whatever `lts/*` resolved to that day, in UTC.

## The matrix found a real bug on its first run

`runtime node18` failed while `runtime node20` passed:

```
TypeError [ERR_INVALID_ARG_VALUE]: The argument 'format' is invalid. Received 'deflate-raw'
    at new CompressionStream (node:internal/webstreams/compression:65:15)
    at deflateRawChunks (dist/zip/stream-writer.mjs:50:13)
```

**`writeXlsxStream` did not work on Node 18** — the version the README names as the floor.

`deflate-raw` is the format a ZIP entry needs, and *"does this runtime have `CompressionStream`"* is a different question. Node 18 has the constructor and rejects `deflate-raw`; it shipped with `gzip` and `deflate`, and the raw format arrived in Node 20.

Four modules each memoized their own flag, and every one probed the constructor's **existence**:

```
zip/writer.ts         typeof CompressionStream !== "undefined" && …
zip/stream-writer.ts  typeof CompressionStream !== "undefined"
zip/reader.ts         typeof DecompressionStream !== "undefined" && …
zip/stream-reader.ts  typeof DecompressionStream !== "undefined" && …
```

`zip/writer` got away with it because it *also* wrapped the construction in a try/catch and fell back to the pure-TypeScript DEFLATE. `zip/stream-writer` constructed outside any try and threw on the first chunk.

`src/zip/capability.ts` is now the single answer, and it probes the only way that answers the question: build one and see. All four modules ask it, and the streaming writer's existing STORE fallback then does what its own doc already promised.

`test/zip-capability.test.ts` stubs a Node 18-shaped `CompressionStream` and asserts both writers still produce a readable workbook. It fails against the previous behaviour.

## CI

- **Node matrix** for the toolchain — 22, `lts/*`. pnpm 11 requires Node 22.13, so the *supported floor* is checked separately, against the built artifact, which is the more honest test anyway: what ships is `dist/`, not the dev setup.
- **`runtime` matrix** — Node 18, Node 20, Bun, Deno — builds once and runs `scripts/smoke.mjs` against `dist/` under each. A round trip through CSV, XLSX (which exercises `CompressionStream` and the ZIP writer), the streaming XLSX writer, and ODS. Deliberately not the suite; vitest is a Node harness.
- **One job at `TZ=Asia/Tokyo`.** #415 was silent in CI because CI is UTC; the CSV `dateFormat` defect fixed in #442 was silent for the same reason.
- `lint` and `typecheck` are no longer separate steps — `pnpm test` is already `lint && typecheck && vitest run`, so both ran twice per job.

## package.json

- **`"sideEffects": false`.** Tree-shaking already worked with rolldown — `parseCsv` from the root entry is 4 KB minified against `writeXlsx`'s 129 KB — but bundlers that rely on the flag rather than their own purity analysis could not prove it. Re-measured after adding it; unchanged.
- **`"engines": { "node": ">=18" }`**, which the `runtime node18` job now makes true rather than aspirational.
- **`docs/PARITY.md` added to `files`.** The README links to it and it was not shipped, so the link 404s on the npm page.

## release.yml

Runs `verify-package.mjs`. CI did; the workflow that actually publishes did not.

## renovate.json

`config:base` → `config:recommended`. The preset was renamed upstream.

## SECURITY.md

A library whose job is parsing files it did not write, that ships ECMA-376 crypto and enforces six documented DoS bounds, had no disclosure path. It lists the bounds from `src/limits.ts` with what each one stops, scope in and out, and the two structural properties worth stating plainly: **the XML parser expands no DTD** (so entity expansion and XXE have nothing to work with), and **nothing in `src/` outside the CLI can reach a filesystem or a network**.

## CONTRIBUTING.md

How to run the gate, the five registers that exist to break when someone adds a field and forgets a place that carries it, and the two conventions this codebase holds to — a test that fails *before* the fix, and a reason written into the code rather than only into the PR.

## What I did not do

`.github/` still has no issue or PR templates and no CODEOWNERS. Those are decisions about how the maintainer wants contributions shaped, not something to settle in a cleanup PR.