### PR TITLE
fix: stop losing a column to a repeated header

### DIFF
--- a/src/_objects.ts
+++ b/src/_objects.ts
@@ -37,6 +37,37 @@ export interface ObjectsResult<T extends Record<string, CellValue> = Record<stri
 }
 
 /**
+ * Make a header list usable as object keys, by renaming only what would
+ * otherwise be lost.
+ *
+ * A header that is unique — **including a single blank one** — is left
+ * exactly as it is. An empty header keying `""` is a settled contract
+ * across every `*Objects` reader and is pinned by several tests; the loss
+ * was never the blank key, it was the *second* column sharing it.
+ *
+ * So only repeats are renamed. A repeated name gets `_2`, `_3`; a
+ * repeated blank gets `column<N>` for its 1-based position, since `_2`
+ * alone would read as nothing at all.
+ */
+export function disambiguate(headers: string[]): string[] {
+  const used = new Set<string>()
+  return headers.map((header, index) => {
+    if (!used.has(header)) {
+      used.add(header)
+      return header
+    }
+    let name = header === "" ? `column${index + 1}` : `${header}_2`
+    let ordinal = 2
+    while (used.has(name)) {
+      ordinal++
+      name = header === "" ? `column${index + 1}_${ordinal}` : `${header}_${ordinal}`
+    }
+    used.add(name)
+    return name
+  })
+}
+
+/**
  * Project `rows` onto objects keyed by the header row.
  *
  * `rowIndex` handed to `transformValue` is the index into `rows`, not the
@@ -67,6 +98,15 @@ export function rowsToObjects<T extends Record<string, CellValue> = Record<strin
   if (transformHeader) {
     headers = headers.map((h, i) => transformHeader(h, i))
   }
+
+  // Two columns sharing a header used to collapse into one key: the later
+  // column overwrote the earlier and its values were gone. That is not
+  // exotic input — it is what a real spreadsheet looks like when someone
+  // repeated a label or left two spacer columns. See #439 §AG.
+  //
+  // Only repeats are renamed; the first column with a given name keeps it,
+  // which is what a caller reading `data[0].name` expects.
+  headers = disambiguate(headers)
 
   const data: T[] = []
   for (let i = headerRowIdx + 1; i < rows.length; i++) {

--- a/test/duplicate-headers.test.ts
+++ b/test/duplicate-headers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import { disambiguate } from "../src/_objects"
+import { sheetToObjects } from "../src/sheet-utils"
+import { parseCsvObjects } from "../src/csv/reader"
+import { readXlsxObjects } from "../src/xlsx/objects"
+import { writeXlsx } from "../src/xlsx/writer"
+import type { Sheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §AG — two columns sharing a header collapsed into one key, and the
+// later column's values overwrote the earlier's:
+//
+//   sheetToObjects({ rows: [["a","a","",null],[1,2,3,4]] })
+//   // { data: [{ a: 2, "": 4 }], headers: ["a","a","",""] }
+//
+// Four columns in, two keys out, nothing warned. That is what a real
+// spreadsheet looks like when someone repeated a label or left two spacer
+// columns — and every objects-shaped API funnels through this projection.
+//
+// The blank key itself was never the problem: `""` for a single unnamed
+// column is a settled contract across the readers and is pinned
+// elsewhere. Only repeats are renamed.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("disambiguate", () => {
+  it("leaves a list with no repeats exactly as it is", () => {
+    expect(disambiguate(["a", "b", "c"])).toEqual(["a", "b", "c"])
+  })
+
+  it("leaves a single blank header blank", () => {
+    // `""` as a key is the established behaviour of every *Objects reader.
+    expect(disambiguate(["a", "", "b"])).toEqual(["a", "", "b"])
+  })
+
+  it("keeps the first of a repeated name and suffixes the rest", () => {
+    expect(disambiguate(["a", "a", "a"])).toEqual(["a", "a_2", "a_3"])
+  })
+
+  it("names a repeated blank by its position", () => {
+    // `_2` alone would read as nothing at all.
+    expect(disambiguate(["", ""])).toEqual(["", "column2"])
+    expect(disambiguate(["a", "", "b", ""])).toEqual(["a", "", "b", "column4"])
+  })
+
+  it("does not collide with a name that is already taken", () => {
+    expect(disambiguate(["a", "a_2", "a"])).toEqual(["a", "a_2", "a_3"])
+    expect(disambiguate(["a", "a", "a_2"])).toEqual(["a", "a_2", "a_2_2"])
+  })
+})
+
+describe("no column is lost to a repeated header", () => {
+  const ROWS = [
+    ["a", "a", "", null],
+    [1, 2, 3, 4],
+  ]
+
+  it("keeps all four values in sheetToObjects", () => {
+    const sheet: Sheet = { name: "D", rows: ROWS }
+
+    const { data, headers } = sheetToObjects(sheet)
+
+    expect(headers).toEqual(["a", "a_2", "", "column4"])
+    expect(data).toEqual([{ a: 1, a_2: 2, "": 3, column4: 4 }])
+  })
+
+  it("keeps all four in parseCsvObjects", () => {
+    const { data, headers } = parseCsvObjects("a,a,,\n1,2,3,4", {
+      header: true,
+      typeInference: true,
+    })
+
+    expect(headers).toEqual(["a", "a_2", "", "column4"])
+    expect(data).toEqual([{ a: 1, a_2: 2, "": 3, column4: 4 }])
+  })
+
+  it("keeps all four in readXlsxObjects", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] })
+
+    const { data, headers } = await readXlsxObjects(bytes)
+
+    expect(headers).toEqual(["a", "a_2", "", "column4"])
+    expect(data).toEqual([{ a: 1, a_2: 2, "": 3, column4: 4 }])
+  })
+
+  it("reports the names it actually keyed by", () => {
+    // A caller who wants the original spelling has `sheet.rows[0]`; what
+    // `headers` has to be is the keys of `data`, or the two disagree.
+    const { data, headers } = sheetToObjects({ name: "D", rows: ROWS })
+
+    expect(Object.keys(data[0]!)).toEqual(headers)
+  })
+
+  it("runs transformHeader first, so a transform can prevent the collision", () => {
+    // `sheetToObjects` takes no transform hooks by design; the readers do.
+    const { headers } = parseCsvObjects("a,a\n1,2", {
+      header: true,
+      transformHeader: (h, i) => `${h}${i}`,
+    })
+
+    expect(headers).toEqual(["a0", "a1"])
+  })
+})


### PR DESCRIPTION
From the audit in #439, §AG.

## The bug

```js
sheetToObjects({ name: "D", rows: [["a", "a", "", null], [1, 2, 3, 4]] })
// { data: [ { a: 2, "": 4 } ], headers: ["a", "a", "", ""] }
```

Four columns in, two keys out. Column 0's value is overwritten by column 1's, column 2's by column 3's, and nothing warns.

That is not exotic input — it is what a real spreadsheet looks like when someone repeated a label or left two spacer columns. And every objects-shaped API in the library funnels through this one projection: `readXlsxObjects`, `readOdsObjects`, `parseCsvObjects`, `readObjects`, `sheetToObjects`.

## What landed, and what deliberately did not

**Only repeats are renamed.** My first pass also gave blank headers positional names, and it broke four existing tests — `"keeps empty-string header keys everywhere"`, `"keys empty-string headers like the format-specific readers do"`, and two more. Reading them, `""` as a key for a single unnamed column is a settled contract across the readers, and one of the tests is in the migration guide (*"where it used to drop them"*), so it was a decision someone made on purpose.

The blank key was never the problem. The loss was always the **second** column sharing a name.

So a header that is unique is left exactly as it is, blank included:

```js
disambiguate(["a", "", "b"])   // ["a", "", "b"]        unchanged
disambiguate(["a", "a", "a"])  // ["a", "a_2", "a_3"]
disambiguate(["", ""])         // ["", "column2"]
disambiguate(["a", "a_2", "a"])// ["a", "a_2", "a_3"]   no collision with a taken name
```

A repeated blank gets `column<N>` for its 1-based position, because `_2` on its own would read as nothing at all.

The first column with a given name keeps it — that is what a caller reading `data[0].name` expects — and `headers` reports the names the data is actually keyed by, since otherwise the two disagree with each other.

`transformHeader` still runs first, so a caller can prevent a collision rather than have it renamed for them.

## Tests

`test/duplicate-headers.test.ts`, 10 assertions: `disambiguate` on its own, then the same four-column shape through `sheetToObjects`, `parseCsvObjects` and `readXlsxObjects`, plus `Object.keys(data[0])` matching `headers`, and `transformHeader` running first.

**9 of the 10 fail against `main`.**