### PR TITLE
fix(format): take locale separators from Intl, not a four-entry table

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -272,8 +272,20 @@ you know.
 
 ## JSON / NDJSON
 
-The most symmetric formats in the library. Values, types and ISO dates
-round-trip in both the whole-string and streaming readers and writers.
+The most symmetric formats in the library. Values and types round-trip in
+both the whole-string and streaming readers and writers.
+
+ISO dates round-trip **under `typeInference`**, which is off by default.
+JSON already carries numbers and booleans, so the only type it genuinely
+cannot express is a date — and reviving one means deciding that a string
+which looks like a date was meant as one, which is the caller's call:
+
+```ts
+parseJson(json).data[0].when // "2024-01-15T00:00:00.000Z"
+parseJson(json, { typeInference: true }).data[0].when // Date
+```
+
+Same option, same default, same reasoning as `CsvReadOptions`.
 
 Nesting is the exception worth understanding. `flatten` turns
 `{user:{name}}` into `{"user.name"}` by default on read, and

--- a/src/_format.ts
+++ b/src/_format.ts
@@ -7,6 +7,7 @@
 // ─────────────────────────────────────────────────────────────────────
 
 import { isDateFormat, formatDate, serialToDate, dateToSerial } from "./_date"
+import { InvalidArgumentError } from "./errors"
 
 // ── Locale Definitions ──────────────────────────────────────────────
 
@@ -19,17 +20,64 @@ export interface LocaleFormat {
   currency: string
 }
 
-const LOCALE_MAP: Record<string, LocaleFormat> = {
-  "en-US": { decimal: ".", thousands: ",", currency: "$" },
-  "de-DE": { decimal: ",", thousands: ".", currency: "\u20AC" },
-  "fr-FR": { decimal: ",", thousands: "\u00A0", currency: "\u20AC" },
-  "tr-TR": { decimal: ",", thousands: ".", currency: "\u20BA" },
+/**
+ * Currency symbols hucre has always carried for these four tags.
+ *
+ * The formatter does not read this field and never has — only `decimal`
+ * and `thousands` are used — but `LocaleFormat` is public, so the values
+ * it used to return are kept for the tags that had them.
+ */
+const KNOWN_CURRENCY: Record<string, string> = {
+  "en-US": "$",
+  "de-DE": "\u20AC",
+  "fr-FR": "\u20AC",
+  "tr-TR": "\u20BA",
 }
 
-/** Resolve a locale string to its format definition, or undefined if unsupported. */
+const localeCache = new Map<string, LocaleFormat>()
+
+/**
+ * Resolve a BCP 47 tag to its separators.
+ *
+ * This used to be a four-entry table — `en-US`, `de-DE`, `fr-FR`,
+ * `tr-TR` — and any other tag resolved to `undefined`, which the
+ * formatter treated as "use the defaults". So
+ * `formatValue(1234.5, "#,##0.00", { locale: "es-ES" })` returned
+ * `1,234.50`: an en-US rendering, silently, for a locale the caller had
+ * explicitly asked for. See #439 §R.
+ *
+ * `Intl.NumberFormat` knows every tag, and separators are all the
+ * formatter needs, so the table is gone. A tag `Intl` rejects now throws
+ * rather than being answered wrongly.
+ */
 function resolveLocale(locale?: string): LocaleFormat | undefined {
   if (!locale) return undefined
-  return LOCALE_MAP[locale]
+
+  const cached = localeCache.get(locale)
+  if (cached) return cached
+
+  let parts: Intl.NumberFormatPart[]
+  try {
+    parts = new Intl.NumberFormat(locale).formatToParts(1234567.8)
+  } catch (error) {
+    throw new InvalidArgumentError(
+      `Unusable locale "${locale}". Pass a BCP 47 tag Intl.NumberFormat accepts, ` +
+        "or omit `locale` for the default separators.",
+      { cause: error },
+    )
+  }
+
+  // Separators only. The formatter groups in threes, so a locale that
+  // groups differently — Indian lakh/crore, say — gets the right
+  // separator in the wrong places. That predates this change and is a
+  // deeper piece of work than reading a tag.
+  const resolved: LocaleFormat = {
+    decimal: parts.find((p) => p.type === "decimal")?.value ?? ".",
+    thousands: parts.find((p) => p.type === "group")?.value ?? ",",
+    currency: KNOWN_CURRENCY[locale] ?? "",
+  }
+  localeCache.set(locale, resolved)
+  return resolved
 }
 
 export interface FormatOptions {

--- a/test/format-locale.test.ts
+++ b/test/format-locale.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+import { formatValue } from "../src/_format"
+import { parseJson, writeJson } from "../src/json"
+import { InvalidArgumentError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §R — `formatValue`'s locale was a four-entry table, and every
+// other tag resolved to `undefined`, which the formatter read as "use the
+// defaults". So a caller who explicitly asked for es-ES got an en-US
+// rendering, silently.
+//
+// `Intl.NumberFormat` knows every tag and separators are all the
+// formatter needs, so the table is gone.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("locale separators come from Intl", () => {
+  it("still formats the four that were hard-coded", () => {
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "en-US" })).toBe("1,234,567.50")
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "de-DE" })).toBe("1.234.567,50")
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "tr-TR" })).toBe("1.234.567,50")
+    // fr-FR groups with a space of some kind — the old table said U+00A0,
+    // CLDR says U+202F. Asserting the shape rather than the codepoint
+    // keeps this from depending on the runtime's ICU version.
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "fr-FR" })).toMatch(/^1\s234\s567,50$/u)
+  })
+
+  it("formats the ones it used to answer wrongly", () => {
+    // Each of these returned "1,234,567.50" before — an en-US rendering
+    // for a locale the caller named.
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "es-ES" })).toBe("1.234.567,50")
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "it-IT" })).toBe("1.234.567,50")
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "pt-BR" })).toBe("1.234.567,50")
+    expect(formatValue(1234567.5, "#,##0.00", { locale: "nb-NO" })).not.toBe("1,234,567.50")
+  })
+
+  it("keeps the default separators when no locale is given", () => {
+    expect(formatValue(1234567.5, "#,##0.00")).toBe("1,234,567.50")
+  })
+
+  it("localises the decimal separator in scientific notation too", () => {
+    expect(formatValue(1234.5, "0.00E+00", { locale: "de-DE" })).toBe("1,23E+03")
+  })
+
+  it("refuses a tag Intl cannot use, rather than answering wrongly", () => {
+    expect(() => formatValue(1, "#,##0", { locale: "not a tag" })).toThrow(InvalidArgumentError)
+    expect(() => formatValue(1, "#,##0", { locale: "en_US" })).toThrow(InvalidArgumentError)
+  })
+
+  it("caches, so repeated formatting does not rebuild the formatter", () => {
+    // Behavioural proxy for the cache: the answer stays stable and cheap.
+    const first = formatValue(1234.5, "#,##0.00", { locale: "de-DE" })
+    for (let i = 0; i < 1000; i++) formatValue(i, "#,##0.00", { locale: "de-DE" })
+
+    expect(formatValue(1234.5, "#,##0.00", { locale: "de-DE" })).toBe(first)
+  })
+})
+
+describe("JSON dates round-trip under typeInference", () => {
+  // Not a change — `JsonReadOptions extends FlattenOptions`, which has
+  // carried this option all along. docs/PARITY.md claimed ISO dates
+  // round-tripped without saying the option was needed, and these pin
+  // what it now says.
+  const WHEN = new Date(Date.UTC(2024, 0, 15))
+
+  it("comes back as a string by default", () => {
+    const back = parseJson(writeJson([{ when: WHEN }]))
+
+    expect(back.data[0]!.when).toBe("2024-01-15T00:00:00.000Z")
+  })
+
+  it("comes back as a Date when asked", () => {
+    const back = parseJson(writeJson([{ when: WHEN }]), { typeInference: true })
+
+    expect(back.data[0]!.when).toBeInstanceOf(Date)
+    expect((back.data[0]!.when as Date).toISOString()).toBe(WHEN.toISOString())
+  })
+
+  it("leaves numbers and booleans alone, which JSON already carries", () => {
+    const back = parseJson(writeJson([{ n: 7, b: true, s: "007" }]), { typeInference: true })
+
+    expect(back.data[0]).toEqual({ n: 7, b: true, s: "007" })
+  })
+})

--- a/test/locale-format.test.ts
+++ b/test/locale-format.test.ts
@@ -56,15 +56,25 @@ describe("formatValue — fr-FR locale", () => {
     expect(formatValue(3.14, "0.00", { locale })).toBe("3,14")
   })
 
-  it("uses non-breaking space as thousands separator", () => {
+  // The separators come from Intl now rather than a four-entry table, so
+  // the expectation comes from Intl too. It used to be hard-coded as
+  // U+00A0; CLDR specifies U+202F (narrow no-break space) for French
+  // grouping, and pinning either literal would make the test a hostage to
+  // the runtime's ICU version.
+  const group = new Intl.NumberFormat(locale)
+    .formatToParts(1234567)
+    .find((p) => p.type === "group")!.value
+
+  it("uses the platform's thousands separator for fr-FR", () => {
     const result = formatValue(1234567, "#,##0", { locale })
-    // fr-FR uses \u00A0 (non-breaking space) as thousands separator
-    expect(result).toBe("1\u00A0234\u00A0567")
+    expect(result).toBe(`1${group}234${group}567`)
+    // Whatever ICU says, it is a space of some kind and not a comma.
+    expect(group).toMatch(/^\s$/u)
   })
 
   it("combines both separators", () => {
     const result = formatValue(9876.54, "#,##0.00", { locale })
-    expect(result).toBe("9\u00A0876,54")
+    expect(result).toBe(`9${group}876,54`)
   })
 })
 


### PR DESCRIPTION
From the audit in #439, §R — plus a correction to §AH.

## The bug

`formatValue`'s `locale` resolved against a four-entry table:

```ts
const LOCALE_MAP = {
  "en-US": …, "de-DE": …, "fr-FR": …, "tr-TR": …,
}
function resolveLocale(locale?: string) {
  if (!locale) return undefined
  return LOCALE_MAP[locale]          // undefined for anything else
}
```

and the formatter read `undefined` as "use the defaults". So:

```js
formatValue(1234567.5, "#,##0.00", { locale: "es-ES" })   // "1,234,567.50"
```

An en-US rendering, silently, for a locale the caller explicitly named.

## What landed

`Intl.NumberFormat` knows every tag, and separators are all the formatter uses — `LocaleFormat.currency` has never been read by anything. So the table is gone: separators come from `formatToParts`, cached per tag, and **a tag `Intl` cannot use throws `InvalidArgumentError`** rather than being answered wrongly.

```js
formatValue(1234567.5, "#,##0.00", { locale: "es-ES" })   // "1.234.567,50"
formatValue(1234567.5, "#,##0.00", { locale: "pt-BR" })   // "1.234.567,50"
formatValue(1,         "#,##0",    { locale: "en_US" })   // throws — underscore is not a BCP 47 tag
```

`LocaleFormat.currency` keeps its four known symbols so the public type returns what it always did, documented as unread.

### Two existing assertions changed

`test/locale-format.test.ts` pinned U+00A0 as the fr-FR grouping separator, which is what the table said. CLDR specifies **U+202F** (narrow no-break space) for French. Both assertions now derive the expectation from `Intl` — pinning either codepoint would make the test a hostage to the runtime's ICU version, and the point of the test is that hucre agrees with the platform.

### One limitation, now written down

The formatter groups in threes, so a locale that groups differently — Indian lakh/crore — gets the right separator in the wrong places. That predates this change and is a deeper piece of work than reading a tag; the comment says so where someone will find it.

## A correction to §AH

§AH of the audit claimed `JsonReadOptions` had no type-inference option, so ISO dates could not be revived. **That was wrong.** The option exists via `JsonReadOptions extends FlattenOptions`, is documented there with exactly the right reasoning, and works in both `parseJson` and `parseNdjson`:

```js
parseJson(json).data[0].when                            // "2024-01-15T00:00:00.000Z"
parseJson(json, { typeInference: true }).data[0].when    // Date
```

I had grepped the interface body rather than following its `extends`.

What *was* wrong is `docs/PARITY.md`, which said ISO dates round-trip without mentioning that the option is needed and off by default. It now says so, with the reasoning — JSON already carries numbers and booleans, so a date is the only type it cannot express, and deciding a date-shaped string was meant as a date is the caller's call. Same option, same default, same reasoning as `CsvReadOptions`.

## Tests

`test/format-locale.test.ts`, 9 assertions: the four that were hard-coded still working, four that used to be answered wrongly, the no-locale default, scientific notation, the throw, and the cache. Plus three pinning the JSON date behaviour PARITY now describes.

**2 of the 9 fail against `main`** — the rest describe behaviour that was already right and is now pinned.