### PR TITLE
chore(bench): make the README's numbers reproducible, and publish the other half

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist
 .vercel
 coverage
 .claude/worktrees
+
+# bench fixtures are generated, and large
+bench/.fixtures

--- a/README.md
+++ b/README.md
@@ -415,14 +415,39 @@ const buffer = await writer.finish()
 | Strings     | inline by default                            | shared string table               |
 | Sheets      | one, or several with `writeXlsxStreamSheets` | one, plus auto-split parts        |
 
-Measured on 5 columns of mixed text/number/date data, writing to a sink
-that discards the bytes (Node 24):
+Measured with `pnpm bench` — the scenarios are in `bench/`, so these are
+reproducible rather than quoted. 5 columns of mixed text/number/date data,
+writing to a sink that discards the bytes (Node 24):
 
 |      Rows | `writeXlsxStream` peak heap | `XlsxStreamWriter` peak heap |
 | --------: | --------------------------: | ---------------------------: |
 |   300,000 |                       41 MB |                       328 MB |
 | 1,000,000 |                       67 MB |                     1,037 MB |
 | 3,000,000 |                       70 MB |                   not viable |
+
+#### What the streaming _reader_ costs
+
+The write table above is the flattering half. `streamXlsxRows` is
+constant-memory in **rows** and linear in **distinct strings**, because
+`xl/sharedStrings.xml` is a workbook-wide part that has to be read up
+front. Two fixtures of the same shape and size, 100,000 rows × 12
+columns, differing only in how many distinct strings they contain:
+
+|                              | 400,000 distinct strings | 10 distinct strings |
+| ---------------------------- | -----------------------: | ------------------: |
+| `readXlsx`                   |        2,721 ms / 662 MB |   1,896 ms / 392 MB |
+| `readXlsx` + `maxRows: 1000` |        1,953 ms / 656 MB |   1,150 ms / 221 MB |
+| `streamXlsxRows`             |        2,446 ms / 556 MB |    1,592 ms / 90 MB |
+
+Two things worth knowing before you rely on either:
+
+- An export of names, SKUs or free text is the high-cardinality case, and
+  there the streaming reader is not much better than the buffering one.
+- **`maxRows` bounds the output, not the work.** Asking for 1,000 rows of
+  100,000 saved 28% of the time and 1% of the memory on the
+  high-cardinality fixture.
+
+Run `pnpm bench` to see both on your own machine.
 
 #### One surface across the incremental writers
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,70 @@
+# bench
+
+Reproducible measurements for the claims in the README, and for anyone
+changing a hot path.
+
+```bash
+pnpm build     # bench runs against dist/, which is what users get
+pnpm bench     # every scenario, one process each
+```
+
+Or one at a time:
+
+```bash
+node bench/write.mjs writeXlsxStream 300000
+node bench/read.mjs streamXlsxRows high-cardinality
+```
+
+## Why one process per measurement
+
+`process.resourceUsage().maxRSS` is a high-water mark for the **whole
+process**. Measure two things in one run and the second inherits the
+first's peak — which is how a streaming writer can appear to use 800 MB.
+`pnpm bench` forks a child per scenario for that reason, and the numbers
+below were taken that way.
+
+## The scenarios
+
+`write.mjs` — 12 columns of mixed text, number and date, through each of
+the three XLSX write paths.
+
+`read.mjs` — the same sheet read back four ways, against **two** fixtures
+that differ in one line:
+
+```js
+c % 3 === 0 ? `text ${i}-${c}`        // high cardinality: ~400k distinct strings
+c % 3 === 0 ? WORDS[(i + c) % 10]     // low cardinality: 10 distinct strings
+```
+
+That one line is the difference between 90 MB and 556 MB in
+`streamXlsxRows`, which is the thing worth knowing about the streaming
+reader: its peak tracks the number of **distinct strings**, not the number
+of rows, because `xl/sharedStrings.xml` has to be read up front.
+
+## Numbers to compare against
+
+Taken on Linux, Node 24, 100,000 rows × 12 columns. Yours will differ;
+the ratios are the point.
+
+| write              |     time |  peak RSS |
+| ------------------ | -------: | --------: |
+| `writeXlsxStream`  | 2,230 ms | **92 MB** |
+| `XlsxStreamWriter` | 2,877 ms |    604 MB |
+| `writeXlsx`        | 3,186 ms |    758 MB |
+
+At 300,000 rows `writeXlsxStream` grows to 126 MB and `XlsxStreamWriter`
+to 1,515 MB — flat against linear, which is the promise the README makes.
+
+| read                         |      high cardinality |      low cardinality |
+| ---------------------------- | --------------------: | -------------------: |
+| `readXlsx`                   |     2,721 ms / 662 MB |    1,896 ms / 392 MB |
+| `readXlsx` + `maxRows: 1000` |     1,953 ms / 656 MB |    1,150 ms / 221 MB |
+| `streamXlsxRows`             | 2,446 ms / **556 MB** | 1,592 ms / **90 MB** |
+
+Two things fall out of that table and are worth keeping in view when
+changing the readers:
+
+- `streamXlsxRows` is constant-memory in rows and **linear in distinct
+  strings**.
+- `maxRows` bounds the output, not the work: on the high-cardinality
+  fixture it saved 28% of the time and 1% of the memory.

--- a/bench/index.mjs
+++ b/bench/index.mjs
@@ -1,0 +1,42 @@
+// ── pnpm bench ───────────────────────────────────────────────────────
+//
+// Runs every scenario, one child process each, so `maxRSS` measures that
+// scenario and nothing else. Takes a couple of minutes.
+//
+//   pnpm bench            # 100k rows
+//   pnpm bench 300000     # or however many
+
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const rows = process.argv[2] ?? "100000"
+const here = (name) => fileURLToPath(new URL(name, import.meta.url))
+
+if (!existsSync(fileURLToPath(new URL("../dist/index.mjs", import.meta.url)))) {
+  console.error("dist/ not found — run `pnpm build` first.")
+  process.exit(1)
+}
+
+const runs = [
+  ["write.mjs", "writeXlsx", rows],
+  ["write.mjs", "writeXlsxStream", rows],
+  ["write.mjs", "XlsxStreamWriter", rows],
+  ["read.mjs", "readXlsx", "high-cardinality", rows],
+  ["read.mjs", "readXlsxMaxRows", "high-cardinality", rows],
+  ["read.mjs", "streamXlsxRows", "high-cardinality", rows],
+  ["read.mjs", "readXlsx", "low-cardinality", rows],
+  ["read.mjs", "readXlsxMaxRows", "low-cardinality", rows],
+  ["read.mjs", "streamXlsxRows", "low-cardinality", rows],
+]
+
+let failed = 0
+for (const [script, ...args] of runs) {
+  const result = spawnSync(process.execPath, [here(script), ...args], { stdio: "inherit" })
+  if (result.status !== 0) failed++
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} scenario(s) failed`)
+  process.exit(1)
+}

--- a/bench/read.mjs
+++ b/bench/read.mjs
@@ -1,0 +1,114 @@
+// ── XLSX read paths ──────────────────────────────────────────────────
+//
+//   node bench/read.mjs [scenario] [fixture] [rows]
+//
+// The fixture is written by a child process and read here, so the read's
+// peak RSS is not the write's. The two fixtures differ in one line — the
+// number of *distinct* strings — which is what the streaming reader's
+// memory actually tracks. See bench/README.md.
+
+import { mkdirSync, existsSync, writeFileSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { readXlsx, streamXlsxRows, writeXlsx } from "../dist/index.mjs"
+
+const SCENARIOS = ["readXlsx", "readXlsxStyles", "readXlsxMaxRows", "streamXlsxRows"]
+const FIXTURES = ["high-cardinality", "low-cardinality"]
+
+const scenario = process.argv[2] ?? "readXlsx"
+const fixture = process.argv[3] ?? "high-cardinality"
+const rowCount = Number(process.argv[4] ?? 100000)
+const COLS = 12
+const WORDS = [
+  "alpha",
+  "beta",
+  "gamma",
+  "delta",
+  "epsilon",
+  "zeta",
+  "eta",
+  "theta",
+  "iota",
+  "kappa",
+]
+
+const peakMb = () => Math.round(process.resourceUsage().maxRSS / 1024)
+const nowMs = () => Number(process.hrtime.bigint() / 1000000n)
+
+/**
+ * The one line that matters. High cardinality gives every text cell its
+ * own string, so `xl/sharedStrings.xml` holds ~400k entries; low
+ * cardinality reuses ten.
+ */
+function makeRow(i, distinct) {
+  const row = []
+  for (let c = 0; c < COLS; c++) {
+    row.push(
+      c % 3 === 0
+        ? distinct
+          ? `text ${i}-${c}`
+          : WORDS[(i + c) % WORDS.length]
+        : c % 3 === 1
+          ? i * c
+          : new Date(Date.UTC(2024, 0, 1 + (i % 28))),
+    )
+  }
+  return row
+}
+
+async function fixturePath() {
+  const dir = fileURLToPath(new URL("./.fixtures/", import.meta.url))
+  mkdirSync(dir, { recursive: true })
+  const path = `${dir}${fixture}-${rowCount}.xlsx`
+  if (!existsSync(path)) {
+    const distinct = fixture === "high-cardinality"
+    const rows = Array.from({ length: rowCount }, (_, i) => makeRow(i, distinct))
+    writeFileSync(path, await writeXlsx({ sheets: [{ name: "S", rows }] }))
+  }
+  return path
+}
+
+async function run() {
+  const path = await fixturePath()
+
+  // Building the fixture in this process would put its peak into our
+  // measurement, so the parent builds and a child measures.
+  if (process.env.HUCRE_BENCH_READY !== "1") {
+    const { spawnSync } = await import("node:child_process")
+    const result = spawnSync(
+      process.execPath,
+      [fileURLToPath(import.meta.url), scenario, fixture, String(rowCount)],
+      { stdio: "inherit", env: { ...process.env, HUCRE_BENCH_READY: "1" } },
+    )
+    process.exitCode = result.status ?? 0
+    return
+  }
+
+  const buf = new Uint8Array(readFileSync(path))
+  const started = nowMs()
+  let rows
+  if (scenario === "readXlsx") {
+    rows = (await readXlsx(buf)).sheets[0].rows.length
+  } else if (scenario === "readXlsxStyles") {
+    rows = (await readXlsx(buf, { readStyles: true })).sheets[0].rows.length
+  } else if (scenario === "readXlsxMaxRows") {
+    rows = (await readXlsx(buf, { maxRows: 1000 })).sheets[0].rows.length
+  } else {
+    rows = 0
+    for await (const _row of streamXlsxRows(buf)) rows++
+  }
+
+  const ms = nowMs() - started
+  console.log(
+    `${scenario.padEnd(18)} ${fixture.padEnd(17)} ${String(ms).padStart(6)} ms  ` +
+      `peakRSS ${String(peakMb()).padStart(5)} MB  ${rows} rows  (${buf.length} bytes in)`,
+  )
+}
+
+if (!SCENARIOS.includes(scenario) || !FIXTURES.includes(fixture)) {
+  console.error(
+    `usage: node bench/read.mjs <${SCENARIOS.join("|")}> <${FIXTURES.join("|")}> [rows]`,
+  )
+  process.exitCode = 1
+} else {
+  await run()
+}

--- a/bench/write.mjs
+++ b/bench/write.mjs
@@ -1,0 +1,82 @@
+// ── XLSX write paths ─────────────────────────────────────────────────
+//
+//   node bench/write.mjs [scenario] [rows]
+//
+// One scenario per process, deliberately: maxRSS is a high-water mark for
+// the whole process, so a second measurement in the same run inherits the
+// first one's peak. See bench/README.md.
+
+import { writeXlsx, writeXlsxStream, XlsxStreamWriter } from "../dist/index.mjs"
+
+const SCENARIOS = ["writeXlsx", "writeXlsxStream", "XlsxStreamWriter"]
+
+const scenario = process.argv[2] ?? "writeXlsxStream"
+const rowCount = Number(process.argv[3] ?? 100000)
+const COLS = 12
+
+function makeRow(i) {
+  const row = []
+  for (let c = 0; c < COLS; c++) {
+    row.push(
+      c % 3 === 0
+        ? `text ${i}-${c}`
+        : c % 3 === 1
+          ? i * c
+          : new Date(Date.UTC(2024, 0, 1 + (i % 28))),
+    )
+  }
+  return row
+}
+
+const peakMb = () => Math.round(process.resourceUsage().maxRSS / 1024)
+const nowMs = () => Number(process.hrtime.bigint() / 1000000n)
+
+async function drain(stream) {
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    total += value.length
+  }
+  return total
+}
+
+async function run() {
+  let started
+  let bytes
+
+  if (scenario === "writeXlsx") {
+    // The whole model is built first, which is the cost being measured —
+    // so it is built before the clock starts.
+    const rows = Array.from({ length: rowCount }, (_, i) => makeRow(i))
+    started = nowMs()
+    bytes = (await writeXlsx({ sheets: [{ name: "S", rows }] })).length
+  } else if (scenario === "writeXlsxStream") {
+    function* rows() {
+      for (let i = 0; i < rowCount; i++) yield makeRow(i)
+    }
+    started = nowMs()
+    bytes = await drain(writeXlsxStream(rows(), { name: "S" }))
+  } else {
+    started = nowMs()
+    const writer = new XlsxStreamWriter({ name: "S" })
+    for (let i = 0; i < rowCount; i++) writer.addRow(makeRow(i))
+    bytes = (await writer.finish()).length
+  }
+
+  const ms = nowMs() - started
+  console.log(
+    `${scenario.padEnd(18)} rows=${String(rowCount).padStart(7)}  ` +
+      `${String(ms).padStart(6)} ms  peakRSS ${String(peakMb()).padStart(5)} MB  ` +
+      `${Math.round((rowCount * COLS) / (ms / 1000)).toLocaleString("en-US")} cells/s  ` +
+      `${bytes} bytes`,
+  )
+}
+
+if (!SCENARIOS.includes(scenario)) {
+  console.error(`unknown scenario "${scenario}" — one of: ${SCENARIOS.join(", ")}`)
+  process.exitCode = 1
+} else {
+  await run()
+}

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     }
   },
   "scripts": {
+    "bench": "node bench/index.mjs",
     "build": "obuild",
     "verify:package": "pnpm build && node scripts/verify-package.mjs",
     "dev": "vitest",


### PR DESCRIPTION
From the audit in #439, §G4 and Part 5.

## Why

`scripts/` held one file and there was no `bench/`. The README published memory tables nobody could reproduce from the repo, and the last four perf-motivated PRs (#434, #435, #438, and the streaming work before them) each justified themselves with numbers measured locally and then discarded — #434's description even had to add a correction about `docProps/core.xml` differing between two runs of the *same* branch, which is the kind of thing a checked-in harness settles once.

## What landed

`pnpm bench` runs nine scenarios, **one child process each**. That is the whole reason it is a runner rather than one script: `process.resourceUsage().maxRSS` is a high-water mark for the *process*, so measuring two things in one run makes the second inherit the first's peak. It is how a streaming writer can appear to use 800 MB.

The read scenarios use two fixtures that differ in exactly one line:

```js
c % 3 === 0 ? `text ${i}-${c}`        // high cardinality: ~400k distinct strings
c % 3 === 0 ? WORDS[(i + c) % 10]     // low cardinality:  10 distinct strings
```

## The half the docs never showed

The write table in the README is the flattering one, and it holds up. The read side does not:

| | 400,000 distinct strings | 10 distinct strings |
| --- | ---: | ---: |
| `readXlsx` | 2,721 ms / 662 MB | 1,896 ms / 392 MB |
| `readXlsx` + `maxRows: 1000` | 1,953 ms / 656 MB | 1,150 ms / 221 MB |
| `streamXlsxRows` | 2,446 ms / **556 MB** | 1,592 ms / **90 MB** |

Same shape, same row count, same file size. Two things fall out, and both are now in the README rather than being folklore:

- **`streamXlsxRows` is constant-memory in rows and linear in distinct strings**, because `xl/sharedStrings.xml` is a workbook-wide part that has to be read up front. An export of names, SKUs or free text is the high-cardinality case, and there the streaming reader is not much better than the buffering one. The docs described it as the constant-memory read path with no caveat.
- **`maxRows` bounds the output, not the work.** Asking for 1,000 rows out of 100,000 saved 28% of the time and **1%** of the memory on the high-cardinality fixture. That matters because `maxRows` is what the `MAX_TOTAL_CELLS` error recommends when a sheet is too big.

## Not a gate

Deliberately. The point is that anyone can run it before and after a change and put real numbers in a PR — which is what the last four needed and did not have. `bench/README.md` explains the one-process-per-measurement rule so the next person does not have to rediscover it.