### PR TITLE
feat(sheet-ops): move the references when rows and columns move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,21 @@ const copy = cloneSheet(sheet, "Copy") // Deep clone
 moveSheet(workbook, 0, 2) // Reorder sheets
 ```
 
+`insertRows`, `deleteRows`, `insertColumns` and `deleteColumns` move the
+references too — formula text, the formulas inside data validations and
+conditional rules, sparkline ranges, page breaks and text-box anchors —
+so a formula below an insertion still points at its own arguments. A
+reference into a deleted row becomes `#REF!`; a range the deletion clips
+shrinks; a reference qualified with another sheet is left alone.
+
+Two limits worth knowing:
+
+- **Workbook-level references are out of reach.** These functions take a
+  `Sheet`, so `Workbook.namedRanges`, defined names, external-link caches
+  and pivot caches cannot be updated from here.
+- **`sortRows` does not rewrite formulas.** Sorting has no correct answer
+  for a relative reference, which is why Excel warns about it too.
+
 ### HTML & Markdown Export
 
 ```ts

--- a/src/_refs.ts
+++ b/src/_refs.ts
@@ -1,0 +1,174 @@
+// ── Shifting references when rows or columns move ────────────────────
+//
+// Adjusting formula references is the *defining* behaviour of "insert a
+// row" in a spreadsheet, and `sheet-ops` did none of it: a formula below
+// an insertion still pointed where its arguments used to be. So did every
+// range in a data validation, a conditional rule, an auto-filter, a
+// sparkline. The cells moved and the references stayed. See #439 §D.
+//
+// The machinery was already here — `replaceA1Ranges` in cell-utils walks
+// the references in a formula while leaving string literals, function
+// names and embedded identifiers alone. It just was not wired to
+// anything but the ODS writer.
+
+import { colToLetter, letterToCol, replaceA1Ranges, type A1RangeMatch } from "./cell-utils"
+
+/** What moved, from where, by how much. */
+export interface RefShift {
+  axis: "row" | "col"
+  /** 0-based index at which the insertion or deletion starts. */
+  at: number
+  /**
+   * Positive to insert, negative to delete. `delete` also means the
+   * `|delta|` indexes from `at` are gone, and a reference into them
+   * becomes `#REF!`.
+   */
+  delta: number
+  /**
+   * The sheet the operation happened on. A reference qualified with a
+   * *different* sheet is left alone — `Sheet2!A5` does not move because
+   * a row was inserted in Sheet1.
+   */
+  sheetName?: string
+}
+
+/** A parsed A1 reference, keeping the `$` of each coordinate. */
+interface ParsedRef {
+  colAbs: boolean
+  col: number
+  rowAbs: boolean
+  row: number
+}
+
+const REF_PATTERN = /^(\$?)([A-Z]{1,3})(\$?)(\d+)$/i
+
+function parseRef(ref: string): ParsedRef | null {
+  const m = REF_PATTERN.exec(ref)
+  if (!m) return null
+  const row = Number(m[4]) - 1
+  if (!Number.isInteger(row) || row < 0) return null
+  return {
+    colAbs: m[1] === "$",
+    col: letterToCol(m[2]!.toUpperCase()),
+    rowAbs: m[3] === "$",
+    row,
+  }
+}
+
+function formatRef(ref: ParsedRef): string {
+  return `${ref.colAbs ? "$" : ""}${colToLetter(ref.col)}${ref.rowAbs ? "$" : ""}${ref.row + 1}`
+}
+
+const REF_ERROR = "#REF!"
+
+/**
+ * Where one coordinate lands after the shift.
+ *
+ * `null` means the row or column it names was deleted. Note that `$` does
+ * not exempt a reference: absoluteness governs what happens when a
+ * formula is *copied*, not when the grid moves underneath it, and Excel
+ * shifts `$A$5` on an insert exactly as it shifts `A5`.
+ */
+function shiftCoordinate(value: number, shift: RefShift): number | null {
+  if (shift.delta > 0) {
+    return value >= shift.at ? value + shift.delta : value
+  }
+  const removed = -shift.delta
+  if (value >= shift.at + removed) return value - removed
+  if (value >= shift.at) return null
+  return value
+}
+
+/** Which coordinate of a reference this shift moves. */
+function coordinateOf(ref: ParsedRef, axis: "row" | "col"): number {
+  return axis === "row" ? ref.row : ref.col
+}
+
+function withCoordinate(ref: ParsedRef, axis: "row" | "col", value: number): ParsedRef {
+  return axis === "row" ? { ...ref, row: value } : { ...ref, col: value }
+}
+
+/**
+ * Rewrite the references in a formula for a row or column that moved.
+ *
+ * Ranges are handled as ranges, not as two independent endpoints: a range
+ * that a deletion swallows whole becomes `#REF!` once, rather than
+ * `#REF!:#REF!`, and one the deletion clips simply shrinks.
+ */
+export function shiftFormula(formula: string, shift: RefShift): string {
+  if (shift.delta === 0) return formula
+
+  return replaceA1Ranges(formula, (match) => shiftMatch(match, shift))
+}
+
+function qualifierOf(match: A1RangeMatch): string {
+  return match.sheet1 === undefined ? "" : `${quoteSheet(match.sheet1)}!`
+}
+
+function quoteSheet(name: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${name.replace(/'/g, "''")}'`
+}
+
+function shiftMatch(match: A1RangeMatch, shift: RefShift): string {
+  // A reference into another sheet is not affected by this sheet's rows
+  // moving. An unqualified one is local by definition.
+  if (match.sheet1 !== undefined && match.sheet1 !== shift.sheetName) {
+    return rebuild(match)
+  }
+
+  const start = parseRef(match.ref1)
+  if (!start) return rebuild(match)
+
+  if (match.ref2 === undefined) {
+    const moved = shiftCoordinate(coordinateOf(start, shift.axis), shift)
+    if (moved === null) return REF_ERROR
+    return `${qualifierOf(match)}${formatRef(withCoordinate(start, shift.axis, moved))}`
+  }
+
+  const end = parseRef(match.ref2)
+  if (!end) return rebuild(match)
+
+  const startAt = coordinateOf(start, shift.axis)
+  const endAt = coordinateOf(end, shift.axis)
+
+  if (shift.delta < 0) {
+    const removed = -shift.delta
+    // The deletion covers the whole span, so there is nothing left to
+    // point at.
+    if (startAt >= shift.at && endAt < shift.at + removed) return REF_ERROR
+  }
+
+  // Clamp each endpoint into the surviving grid rather than letting it
+  // become #REF!: a range clipped by a deletion shrinks, which is what
+  // Excel does and what the caller means.
+  const movedStart = shiftCoordinate(startAt, shift) ?? shift.at
+  const movedEnd = shiftCoordinate(endAt, shift) ?? Math.max(shift.at - 1, 0)
+
+  const lo = Math.min(movedStart, movedEnd)
+  const hi = Math.max(movedStart, movedEnd)
+
+  return (
+    `${qualifierOf(match)}${formatRef(withCoordinate(start, shift.axis, lo))}` +
+    `:${formatRef(withCoordinate(end, shift.axis, hi))}`
+  )
+}
+
+function rebuild(match: A1RangeMatch): string {
+  const head = `${qualifierOf(match)}${match.ref1}`
+  if (match.ref2 === undefined) return head
+  const tail = match.sheet2 === undefined ? match.ref2 : `${quoteSheet(match.sheet2)}!${match.ref2}`
+  return `${head}:${tail}`
+}
+
+/**
+ * Rewrite a bare A1 range — `"A1:D10"`, the shape `DataValidation.range`,
+ * `ConditionalRule.range`, `AutoFilter.range` and `TableDefinition.range`
+ * all use.
+ *
+ * Returns `undefined` when the whole range was deleted, so the caller can
+ * drop the thing that owned it rather than keep a `#REF!` range.
+ */
+export function shiftRangeRef(range: string, shift: RefShift): string | undefined {
+  const shifted = shiftFormula(range, shift)
+  return shifted.includes(REF_ERROR) ? undefined : shifted
+}

--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -6,6 +6,7 @@ import { parseCellRef } from "./xlsx/worksheet"
 import { rangeRef } from "./xlsx/worksheet-writer"
 import { cloneCellStyle } from "./_style"
 import { InvalidArgumentError } from "./errors"
+import { shiftFormula, shiftRangeRef, type RefShift } from "./_refs"
 
 // ── Range Helpers ────────────────────────────────────────────────────
 
@@ -51,6 +52,102 @@ function shiftRangeCols(range: string, threshold: number, delta: number): string
   if (r.startCol >= threshold) r.startCol += delta
   if (r.endCol >= threshold) r.endCol += delta
   return buildRange(r)
+}
+
+// ── Reference maintenance ────────────────────────────────────────────
+
+/**
+ * Move everything on a sheet that *names* a position rather than
+ * occupying one: formula text, the formulas inside data validations and
+ * conditional rules, sparkline ranges, page breaks and text-box anchors.
+ *
+ * The cells themselves are moved by the caller; this is the other half,
+ * and it was missing entirely. A formula below an insertion still pointed
+ * where its arguments used to be, which is the one thing "insert a row"
+ * is supposed to take care of. See #439 §D.
+ *
+ * Not covered, and not coverable from here: `Workbook.namedRanges`,
+ * defined names, external-link caches and pivot caches all live on the
+ * workbook, and these operations are handed a `Sheet`.
+ */
+function shiftReferences(sheet: Sheet, shift: RefShift): void {
+  if (sheet.cells) {
+    for (const cell of sheet.cells.values()) {
+      if (cell.formula) cell.formula = shiftFormula(cell.formula, shift)
+      if (cell.formulaRef) cell.formulaRef = shiftFormula(cell.formulaRef, shift)
+    }
+  }
+
+  if (sheet.dataValidations) {
+    for (const dv of sheet.dataValidations) {
+      if (dv.formula1) dv.formula1 = shiftFormula(dv.formula1, shift)
+      if (dv.formula2) dv.formula2 = shiftFormula(dv.formula2, shift)
+    }
+  }
+
+  if (sheet.conditionalRules) {
+    for (const rule of sheet.conditionalRules) {
+      if (Array.isArray(rule.formula)) {
+        rule.formula = rule.formula.map((f) => shiftFormula(f, shift))
+      } else if (typeof rule.formula === "string") {
+        rule.formula = shiftFormula(rule.formula, shift)
+      }
+    }
+  }
+
+  if (sheet.sparklines) {
+    // A sparkline whose whole source was deleted has nothing left to draw.
+    sheet.sparklines = sheet.sparklines.filter((sparkline) => {
+      const dataRange = shiftRangeRef(sparkline.dataRange, shift)
+      if (dataRange === undefined) return false
+      sparkline.dataRange = dataRange
+      const location = shiftRangeRef(sparkline.location, shift)
+      if (location === undefined) return false
+      sparkline.location = location
+      return true
+    })
+  }
+
+  const breaks = shift.axis === "row" ? sheet.rowBreaks : sheet.colBreaks
+  if (breaks) {
+    const moved: number[] = []
+    for (const at of breaks) {
+      const next = shiftIndex(at, shift)
+      if (next !== null && !moved.includes(next)) moved.push(next)
+    }
+    moved.sort((a, b) => a - b)
+    if (shift.axis === "row") sheet.rowBreaks = moved
+    else sheet.colBreaks = moved
+  }
+
+  if (sheet.textBoxes) {
+    for (const box of sheet.textBoxes) {
+      shiftAnchor(box.anchor, shift)
+    }
+  }
+}
+
+/** One index, or `null` when the row or column it names was deleted. */
+function shiftIndex(value: number, shift: RefShift): number | null {
+  if (shift.delta > 0) return value >= shift.at ? value + shift.delta : value
+  const removed = -shift.delta
+  if (value >= shift.at + removed) return value - removed
+  if (value >= shift.at) return null
+  return value
+}
+
+/** Move a drawing anchor's corners, clamping one that lands in the gap. */
+function shiftAnchor(
+  anchor: { from: { row: number; col: number }; to?: { row: number; col: number } },
+  shift: RefShift,
+): void {
+  const key = shift.axis === "row" ? "row" : "col"
+  const from = shiftIndex(anchor.from[key], shift)
+  anchor.from[key] = from ?? shift.at
+  if (anchor.to) {
+    const to = shiftIndex(anchor.to[key], shift)
+    anchor.to[key] = to ?? shift.at
+  }
 }
 
 // ── Row Width Helper ─────────────────────────────────────────────────
@@ -172,6 +269,8 @@ export function insertRows(sheet: Sheet, rowIndex: number, count: number): void 
       }
     }
   }
+
+  shiftReferences(sheet, { axis: "row", at: rowIndex, delta: count })
 }
 
 // ── Delete Rows ──────────────────────────────────────────────────────
@@ -330,6 +429,8 @@ export function deleteRows(sheet: Sheet, rowIndex: number, count: number): void 
       }
     }
   }
+
+  shiftReferences(sheet, { axis: "row", at: rowIndex, delta: -count })
 }
 
 /**
@@ -451,6 +552,8 @@ export function insertColumns(sheet: Sheet, colIndex: number, count: number): vo
       }
     }
   }
+
+  shiftReferences(sheet, { axis: "col", at: colIndex, delta: count })
 }
 
 // ── Delete Columns ───────────────────────────────────────────────────
@@ -593,6 +696,8 @@ export function deleteColumns(sheet: Sheet, colIndex: number, count: number): vo
       }
     }
   }
+
+  shiftReferences(sheet, { axis: "col", at: colIndex, delta: -count })
 }
 
 /**

--- a/test/shift-references.test.ts
+++ b/test/shift-references.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest"
+import { deleteColumns, deleteRows, insertColumns, insertRows } from "../src/sheet-ops"
+import { shiftFormula } from "../src/_refs"
+import type { Cell, Sheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §D — adjusting references is the *defining* behaviour of "insert a
+// row", and sheet-ops did none of it. The cells moved and everything that
+// named a position stayed:
+//
+//   insertRows(sheet, 0, 2)
+//   cell key:   "4,0" -> "6,0"          correct
+//   formula:    "SUM(A1:A4)" unchanged  WRONG — should be SUM(A3:A6)
+//   rowBreaks:  [3] unchanged           WRONG — should be [5]
+//   sparkline:  "A1:A4" unchanged       WRONG
+//
+// The rewriter was already in cell-utils and wired to nothing but the ODS
+// writer.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("shiftFormula", () => {
+  it("moves references at or after the insertion point", () => {
+    expect(shiftFormula("SUM(A1:A4)", { axis: "row", at: 0, delta: 2 })).toBe("SUM(A3:A6)")
+  })
+
+  it("leaves references before it alone", () => {
+    expect(shiftFormula("SUM(A5:A9)", { axis: "row", at: 10, delta: 2 })).toBe("SUM(A5:A9)")
+  })
+
+  it("moves an absolute reference too", () => {
+    // `$` governs what happens when a formula is *copied*, not when the
+    // grid moves underneath it. Excel shifts $A$5 on an insert as well.
+    expect(shiftFormula("$A$5+B5", { axis: "row", at: 0, delta: 2 })).toBe("$A$7+B7")
+  })
+
+  it("turns a reference into a deleted row into #REF!", () => {
+    expect(shiftFormula("A3", { axis: "row", at: 2, delta: -2 })).toBe("#REF!")
+  })
+
+  it("collapses a range the deletion swallowed whole", () => {
+    // Once, not as `#REF!:#REF!`.
+    expect(shiftFormula("SUM(A3:A4)", { axis: "row", at: 2, delta: -2 })).toBe("SUM(#REF!)")
+  })
+
+  it("shrinks a range the deletion clips", () => {
+    expect(shiftFormula("SUM(A1:A10)", { axis: "row", at: 2, delta: -2 })).toBe("SUM(A1:A8)")
+  })
+
+  it("moves columns on the column axis", () => {
+    expect(shiftFormula("SUM(B1:D1)", { axis: "col", at: 0, delta: 1 })).toBe("SUM(C1:E1)")
+  })
+
+  it("leaves another sheet's references where they are", () => {
+    const shift = { axis: "row", at: 0, delta: 2, sheetName: "Sheet1" } as const
+
+    expect(shiftFormula("Sheet2!A5", shift)).toBe("Sheet2!A5")
+    expect(shiftFormula("Sheet1!A5", shift)).toBe("Sheet1!A7")
+  })
+
+  it("does not touch string literals or function names", () => {
+    const shift = { axis: "row", at: 0, delta: 2 } as const
+
+    expect(shiftFormula('IF(A5="A5","A5",A5)', shift)).toBe('IF(A7="A5","A5",A7)')
+    expect(shiftFormula("LOG10(A5)", shift)).toBe("LOG10(A7)")
+  })
+})
+
+function sheet(): Sheet {
+  const cells = new Map<string, Cell>([
+    ["4,0", { value: 10, type: "number", formula: "SUM(A1:A4)" }],
+    ["4,1", { value: 1, type: "number", formula: "Other!B1+A5" }],
+  ])
+  return {
+    name: "S",
+    rows: [[1], [2], [3], [4], [10]],
+    cells,
+    rowBreaks: [3],
+    colBreaks: [1],
+    sparklines: [{ dataRange: "A1:A4", location: "B5", type: "line" }],
+    dataValidations: [{ type: "list", range: "C1:C9", formula1: "$A$1:$A$4" }],
+    conditionalRules: [
+      { type: "cellIs", priority: 1, range: "A1:A9", operator: "greaterThan", formula: ["$A$5"] },
+    ],
+    textBoxes: [{ text: "note", anchor: { from: { row: 4, col: 0 } } }],
+  }
+}
+
+describe("insertRows moves what names a position", () => {
+  it("rewrites the formula whose arguments moved", () => {
+    const s = sheet()
+
+    insertRows(s, 0, 2)
+
+    expect(s.cells!.get("6,0")!.formula).toBe("SUM(A3:A6)")
+  })
+
+  it("leaves another sheet's part of a formula alone", () => {
+    const s = sheet()
+
+    insertRows(s, 0, 2)
+
+    expect(s.cells!.get("6,1")!.formula).toBe("Other!B1+A7")
+  })
+
+  it("moves the page breaks", () => {
+    const s = sheet()
+
+    insertRows(s, 0, 2)
+
+    expect(s.rowBreaks).toEqual([5])
+    expect(s.colBreaks).toEqual([1])
+  })
+
+  it("moves the sparkline's source and location", () => {
+    const s = sheet()
+
+    insertRows(s, 0, 2)
+
+    expect(s.sparklines![0]).toMatchObject({ dataRange: "A3:A6", location: "B7" })
+  })
+
+  it("moves the formulas inside validations and conditional rules", () => {
+    const s = sheet()
+
+    insertRows(s, 0, 2)
+
+    expect(s.dataValidations![0]!.formula1).toBe("$A$3:$A$6")
+    expect(s.conditionalRules![0]!.formula).toEqual(["$A$7"])
+  })
+
+  it("moves a text box anchored below the insertion", () => {
+    const s = sheet()
+
+    insertRows(s, 0, 2)
+
+    expect(s.textBoxes![0]!.anchor.from.row).toBe(6)
+  })
+})
+
+describe("deleteRows leaves #REF! where a reference pointed", () => {
+  it("marks a formula that pointed into the deleted rows", () => {
+    const s: Sheet = {
+      name: "S",
+      rows: [[1], [2], [3]],
+      cells: new Map<string, Cell>([["2,0", { value: 1, type: "number", formula: "A2" }]]),
+    }
+
+    deleteRows(s, 1, 1)
+
+    expect(s.cells!.get("1,0")!.formula).toBe("#REF!")
+  })
+
+  it("shrinks a range the deletion clipped", () => {
+    const s = sheet()
+
+    deleteRows(s, 1, 2)
+
+    expect(s.cells!.get("2,0")!.formula).toBe("SUM(A1:A2)")
+  })
+
+  it("moves the page breaks up", () => {
+    const s = sheet()
+
+    deleteRows(s, 0, 2)
+
+    expect(s.rowBreaks).toEqual([1])
+  })
+
+  it("drops a sparkline whose whole source was deleted", () => {
+    const s = sheet()
+
+    deleteRows(s, 0, 4)
+
+    expect(s.sparklines).toEqual([])
+  })
+})
+
+describe("the column operations do the same on the other axis", () => {
+  const withFormula = (): Sheet => ({
+    name: "S",
+    rows: [[1, 2, 3]],
+    cells: new Map<string, Cell>([["0,2", { value: 3, type: "number", formula: "SUM(A1:B1)" }]]),
+    colBreaks: [2],
+  })
+
+  it("moves references right on insert", () => {
+    const s = withFormula()
+
+    insertColumns(s, 0, 1)
+
+    expect(s.cells!.get("0,3")!.formula).toBe("SUM(B1:C1)")
+    expect(s.colBreaks).toEqual([3])
+  })
+
+  it("moves references left on delete, shrinking a clipped range", () => {
+    const s = withFormula()
+
+    deleteColumns(s, 0, 1)
+
+    // A is gone and B slides into its place, so the range shrinks to the
+    // one column that survived rather than going #REF!. Only a range the
+    // deletion swallows *whole* has nothing left to point at.
+    expect(s.cells!.get("0,1")!.formula).toBe("SUM(A1:A1)")
+    expect(s.colBreaks).toEqual([1])
+  })
+})


### PR DESCRIPTION
From the audit in #439, §D.

## The gap

```js
insertRows(sheet, 0, 2)

cell key:   "4,0" -> "6,0"          // correct
merges:     row 3 -> row 5          // correct
formula:    "SUM(A1:A4)" unchanged  // should be SUM(A3:A6)
rowBreaks:  [3] unchanged           // should be [5]
sparkline:  "A1:A4" unchanged
```

Adjusting references is the *defining* behaviour of "insert a row" in a spreadsheet, and `sheet-ops` did none of it. The cells moved; everything that **named** a position stayed. The README's Sheet Operations section did not mention it either.

## What landed

`src/_refs.ts`, on top of `replaceA1Ranges` — which was already in `cell-utils`, already skips quoted literals, function names and embedded identifiers, and was wired to nothing but the ODS writer.

`insertRows` / `deleteRows` / `insertColumns` / `deleteColumns` now move: formula text and `formulaRef`, the formulas inside data validations and conditional rules, sparkline `dataRange` and `location`, row and column page breaks, and text-box anchors. The `.range` fields were already handled.

The semantics follow Excel:

| | |
| --- | --- |
| `SUM(A1:A4)`, insert 2 rows at 0 | `SUM(A3:A6)` |
| `$A$5+B5`, insert 2 rows at 0 | `$A$7+B7` — `$` governs *copying*, not the grid moving underneath |
| `A3`, delete rows 2–3 | `#REF!` |
| `SUM(A3:A4)`, delete rows 2–3 | `SUM(#REF!)` — once, not `#REF!:#REF!` |
| `SUM(A1:A10)`, delete rows 2–3 | `SUM(A1:A8)` — a clipped range shrinks |
| `Sheet2!A5`, insert in Sheet1 | unchanged |
| `IF(A5="A5","A5",A5)` | `IF(A7="A5","A5",A7)` — literals untouched |

A sparkline whose entire source was deleted is dropped rather than left pointing at `#REF!`.

## Two limits, documented rather than papered over

- **Workbook-level references are unreachable.** These functions take a `Sheet`, so `Workbook.namedRanges`, defined names, external-link caches and pivot caches cannot be updated from here. Fixing that means changing the signatures, which is a bigger decision than this PR.
- **`sortRows` still does not rewrite formulas.** A sort has no correct answer for a relative reference — which is why Excel warns about it too. (It *does* now move row definitions and single-row merges, from #449.)

Both are in the README next to the example.

## Tests

`test/shift-references.test.ts`, 21 assertions: ten on the rewriter directly, then the four operations against a sheet carrying a formula, a cross-sheet formula, page breaks on both axes, a sparkline, a validation formula, a conditional-rule formula and a text box.

**12 of the 21 fail against `main`.**