### PR TITLE
refactor(xlsx): one implementation of <c>, shared by all three writers

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -15,6 +15,12 @@ open an issue. That is the whole point of writing it down.
 XLSX has **two** write paths, and they have different fidelity. Most
 confusion about what hucre preserves comes from conflating them.
 
+(Both, and the streaming writers, now serialize a cell through one
+implementation — so an error value, `xml:space` handling and formula
+result typing mean the same thing whichever writer you use. What differs
+between the paths is what the _model_ can express, not how a cell is
+written.)
+
 |                | entry points             | behaviour                                                                                                                         |
 | -------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
 | **Authoring**  | `readXlsx` / `writeXlsx` | the workbook is rebuilt from the model. Only what `WriteSheet` and `WriteOptions` describe comes out                              |

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -18,20 +18,18 @@ import { writeContentTypes } from "./content-types-writer"
 import { writeRootRels, writeWorkbookRels } from "./workbook-writer"
 import { createStylesCollector, type StylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml } from "./worksheet-writer"
-import { cellRef, hasRowAttributes, rowAttributes } from "./worksheet-writer"
+import {
+  cellRef,
+  hasRowAttributes,
+  rowAttributes,
+  serializeCell,
+  type ResolvedCell,
+} from "./worksheet-writer"
 import type { SharedStringsCollector } from "./worksheet-writer"
 import { writeThemeXml } from "./theme-writer"
 import { MAX_SHEET_NAME_LENGTH, validateSheetName, validateSheetNames } from "../_validate"
 import { InvalidArgumentError } from "../errors"
-import { dateToSerial } from "../_date"
-import {
-  xmlDocument,
-  xmlDeclaration,
-  xmlElement,
-  xmlSelfClose,
-  xmlEscape,
-  xmlTextElement,
-} from "../xml/writer"
+import { xmlDocument, xmlDeclaration, xmlElement, xmlSelfClose } from "../xml/writer"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
 
@@ -221,10 +219,6 @@ export interface XlsxWriteStreamWorkbookOptions {
 /** Excel's hard row limit since Excel 2007 (2^20). */
 export const XLSX_MAX_ROWS_PER_SHEET = 1_048_576
 
-// ── Default date format ─────────────────────────────────────────────
-
-const DEFAULT_DATE_FORMAT = "yyyy-mm-dd"
-
 /** Flush the XML accumulator once it crosses this many characters. */
 const CHUNK_THRESHOLD = 64 * 1024
 
@@ -305,6 +299,15 @@ class RowSerializer {
     return xmlElement("row", attrs, cellElements)
   }
 
+  /**
+   * Hand one cell to the shared serializer.
+   *
+   * This used to be a second implementation of `<c>`, and the two had
+   * drifted in both directions — see the note on `serializeCell` in
+   * worksheet-writer. Building a `ResolvedCell` and delegating means a
+   * streamed row now gets error values, the `xml:space` handling and the
+   * formula-result typing from the same place the authoring path does.
+   */
   private serializeCell(
     row: number,
     col: number,
@@ -312,97 +315,23 @@ class RowSerializer {
     style: CellStyle | undefined,
     formula?: string,
   ): string | null {
-    let effectiveStyle = style
-
-    // Add default date format for Date values without explicit format
-    if (value instanceof Date && (!effectiveStyle || !effectiveStyle.numFmt)) {
-      effectiveStyle = { ...effectiveStyle, numFmt: DEFAULT_DATE_FORMAT }
-    }
-
-    let styleIdx = 0
-    if (effectiveStyle) {
-      styleIdx = this.styles.addStyle(effectiveStyle)
-    }
-
-    const ref = cellRef(row, col)
-
+    const resolved: ResolvedCell = { value, style }
     if (formula !== undefined) {
-      const attrs: Record<string, string | number> = { r: ref }
-      if (styleIdx !== 0) attrs.s = styleIdx
-      const children = [xmlElement("f", undefined, xmlEscape(formula))]
-
-      // Cached result, typed the way the worksheet writer types it: a bare
-      // <v> is read as a number, so text and booleans need their `t`.
-      if (typeof value === "string") {
-        attrs.t = "str"
-        children.push(xmlElement("v", undefined, xmlEscape(value)))
-      } else if (typeof value === "boolean") {
-        attrs.t = "b"
-        children.push(xmlElement("v", undefined, value ? "1" : "0"))
-      } else if (typeof value === "number") {
-        // Same guard as the plain numeric branch: NaN and the infinities have
-        // no OOXML representation, so the cache is dropped rather than written
-        // as something no reader can parse.
-        if (Number.isFinite(value)) {
-          children.push(xmlElement("v", undefined, String(value)))
-        }
-      } else if (value instanceof Date) {
-        children.push(xmlElement("v", undefined, String(dateToSerial(value, this.is1904))))
-      }
-      return xmlElement("c", attrs, children)
+      resolved.formula = formula
+      // A streamed cell carries one value, and when it also carries a
+      // formula that value is the cached result.
+      resolved.formulaResult = value
+      resolved.value = null
     }
-
-    // Null — skip if no style
-    if (value === null || value === undefined) {
-      if (styleIdx !== 0) {
-        return xmlSelfClose("c", { r: ref, s: styleIdx })
-      }
-      return null
-    }
-
-    // String
-    if (typeof value === "string") {
-      if (this.inlineStrings) {
-        const attrs: Record<string, string | number> = { r: ref, t: "inlineStr" }
-        if (styleIdx !== 0) attrs["s"] = styleIdx
-        return xmlElement("c", attrs, [xmlElement("is", undefined, [xmlTextElement(value)])])
-      }
-      const ssIdx = this.sharedStrings.add(value)
-      const attrs: Record<string, string | number> = { r: ref, t: "s" }
-      if (styleIdx !== 0) attrs["s"] = styleIdx
-      return xmlElement("c", attrs, [xmlElement("v", undefined, String(ssIdx))])
-    }
-
-    // Number
-    if (typeof value === "number") {
-      // Infinity, -Infinity, and NaN cannot be represented in OOXML — emit as empty cell
-      if (!Number.isFinite(value)) {
-        if (styleIdx !== 0) {
-          return xmlSelfClose("c", { r: ref, s: styleIdx })
-        }
-        return null
-      }
-      const attrs: Record<string, string | number> = { r: ref }
-      if (styleIdx !== 0) attrs["s"] = styleIdx
-      return xmlElement("c", attrs, [xmlElement("v", undefined, String(value))])
-    }
-
-    // Boolean
-    if (typeof value === "boolean") {
-      const attrs: Record<string, string | number> = { r: ref, t: "b" }
-      if (styleIdx !== 0) attrs["s"] = styleIdx
-      return xmlElement("c", attrs, [xmlElement("v", undefined, value ? "1" : "0")])
-    }
-
-    // Date — convert to serial number
-    if (value instanceof Date) {
-      const serial = dateToSerial(value, this.is1904)
-      const attrs: Record<string, string | number> = { r: ref }
-      if (styleIdx !== 0) attrs["s"] = styleIdx
-      return xmlElement("c", attrs, [xmlElement("v", undefined, String(serial))])
-    }
-
-    return null
+    return serializeCell(
+      row,
+      col,
+      resolved,
+      this.styles,
+      this.sharedStrings,
+      this.is1904,
+      this.inlineStrings,
+    )
   }
 }
 

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -186,7 +186,13 @@ export function writeSharedStringsXml(sharedStrings: SharedStringsCollector): st
 
 // ── Resolved Cell Data ─────────────────────────────────────────────
 
-interface ResolvedCell {
+/**
+ * One cell, with everything the serializer needs already worked out.
+ *
+ * Exported because the streaming writers build these too — see
+ * {@link serializeCell}.
+ */
+export interface ResolvedCell {
   value: CellValue
   style?: CellStyle
   checkbox?: boolean
@@ -814,7 +820,19 @@ function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
 
 // ── Cell Serialization ─────────────────────────────────────────────
 
-function serializeCell(
+/**
+ * Serialize one `<c>`.
+ *
+ * The single implementation. There used to be a second one inside
+ * `stream-writer`'s `RowSerializer`, and the two had drifted in both
+ * directions: the streaming copy could not write an error value, rich
+ * text, a checkbox xf, a shared or array formula, or the dynamic-array
+ * `cm`, while this one was the copy that forgot `xml:space="preserve"`.
+ * Every feature added to one had to be re-derived in the other, and #436
+ * had to do exactly that for formula-result typing and the non-finite
+ * guard. See #439 §B.
+ */
+export function serializeCell(
   row: number,
   col: number,
   resolved: ResolvedCell,
@@ -903,7 +921,8 @@ function serializeCell(
 
     const children: string[] = [fElement]
 
-    // Cached formula result
+    // Cached formula result. A bare <v> reads back as a number, so text
+    // and booleans need their `t`.
     if (formulaResult !== undefined && formulaResult !== null) {
       if (typeof formulaResult === "string") {
         cellAttrs["t"] = "str"
@@ -912,7 +931,16 @@ function serializeCell(
         cellAttrs["t"] = "b"
         children.push(xmlElement("v", undefined, formulaResult ? "1" : "0"))
       } else if (typeof formulaResult === "number") {
-        children.push(xmlElement("v", undefined, String(formulaResult)))
+        // Same guard as the plain numeric branch below: NaN and the
+        // infinities have no OOXML representation, so the cache is
+        // dropped rather than written as something no reader can parse.
+        // #436 added this to the streaming copy of the serializer; this
+        // one never had it, and merging the two is what surfaced that.
+        if (Number.isFinite(formulaResult)) {
+          children.push(xmlElement("v", undefined, String(formulaResult)))
+        }
+      } else if (formulaResult instanceof Date) {
+        children.push(xmlElement("v", undefined, String(dateToSerial(formulaResult, is1904))))
       }
     }
 

--- a/test/one-cell-serializer.test.ts
+++ b/test/one-cell-serializer.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeXlsxStream } from "../src/xlsx/stream-writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §B — XLSX had two independent implementations of `<c>`, and they
+// had drifted in *both* directions:
+//
+//   the streaming copy could not write   an error value (t="e"), rich
+//                                        text, a checkbox xf, a shared or
+//                                        array formula, the dynamic-array cm
+//   the authoring copy could not write   xml:space="preserve" on an
+//                                        inline string (fixed in #441),
+//                                        and had no non-finite guard on a
+//                                        cached formula result
+//
+// Every feature added to one had to be re-derived in the other, and #436
+// had to do exactly that. There is one implementation now; these pin what
+// the streaming path gained, and that the authoring path did not regress.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+    total += value.length
+  }
+  const out = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    out.set(chunk, offset)
+    offset += chunk.length
+  }
+  return out
+}
+
+async function sheetXml(bytes: Uint8Array): Promise<string> {
+  return new TextDecoder().decode(await new ZipReader(bytes).extract("xl/worksheets/sheet1.xml"))
+}
+
+describe("a streamed error value is an error, not a string", () => {
+  it('writes t="e"', async () => {
+    const bytes = await collect(writeXlsxStream([["#REF!", "#DIV/0!"]], { name: "S" }))
+
+    const xml = await sheetXml(bytes)
+
+    expect(xml).toContain('t="e"')
+    expect(xml).toContain("<v>#REF!</v>")
+  })
+
+  it("reads back as the error it was, not as text", async () => {
+    const bytes = await collect(
+      writeXlsxStream([["#VALUE!", "#N/A", "#SPILL!", "ordinary"]], { name: "S" }),
+    )
+
+    const cells = (await readXlsx(bytes)).sheets[0]!.cells!
+
+    expect(cells.get("0,0")!.type).toBe("error")
+    expect(cells.get("0,1")!.type).toBe("error")
+    // #SPILL! is one of the two dynamic-array errors ECMA does not list;
+    // hucre knows them because #423 needed it to.
+    expect(cells.get("0,2")!.type).toBe("error")
+    // An ordinary string needs no cell entry at all, so check the value.
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]![3]).toBe("ordinary")
+  })
+
+  it("agrees with the authoring writer, cell for cell", async () => {
+    const rows = [["#REF!", 1, "text", true, null]]
+
+    const streamed = await readXlsx(await collect(writeXlsxStream(rows, { name: "S" })))
+    const authored = await readXlsx(await writeXlsx({ sheets: [{ name: "S", rows }] }))
+
+    expect(streamed.sheets[0]!.rows).toEqual(authored.sheets[0]!.rows)
+    expect(streamed.sheets[0]!.cells!.get("0,0")!.type).toBe(
+      authored.sheets[0]!.cells!.get("0,0")!.type,
+    )
+  })
+})
+
+describe("a non-finite cached result is dropped by both writers", () => {
+  // #436 added this guard to the streaming copy only. Sharing the
+  // serializer surfaced that the authoring path never had it — NaN went
+  // out as `<v>NaN</v>`, which no reader can parse as a number.
+  // On the authoring path the cached result is `formulaResult`; `value`
+  // is the cell's own value. The streaming path has one slot for both,
+  // which is why StreamStyledCell documents `value` as the cache.
+  const cells = new Map([
+    ["0,0", { value: null, formula: "0/0", formulaResult: Number.NaN }],
+    ["0,1", { value: null, formula: "1/0", formulaResult: Number.POSITIVE_INFINITY }],
+    ["0,2", { value: null, formula: "1+1", formulaResult: 2 }],
+  ])
+
+  it("drops it on the authoring path", async () => {
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[null, null, null]], cells }],
+    })
+
+    const xml = await sheetXml(bytes)
+    expect(xml).not.toContain("NaN")
+    expect(xml).not.toContain("Infinity")
+
+    const back = (await readXlsx(bytes)).sheets[0]!.cells!
+    expect(back.get("0,0")!.formula).toBe("0/0")
+    expect(back.get("0,0")!.value).toBeNull()
+    expect(back.get("0,2")!.value).toBe(2)
+  })
+
+  it("drops it on the streaming path", async () => {
+    const bytes = await collect(
+      writeXlsxStream(
+        [
+          [
+            { value: Number.NaN, formula: "0/0" },
+            { value: 2, formula: "1+1" },
+          ],
+        ],
+        { name: "S" },
+      ),
+    )
+
+    const xml = await sheetXml(bytes)
+    expect(xml).not.toContain("NaN")
+
+    const back = (await readXlsx(bytes)).sheets[0]!.cells!
+    expect(back.get("0,0")!.value).toBeNull()
+    expect(back.get("0,1")!.value).toBe(2)
+  })
+})
+
+describe("the authoring path did not regress", () => {
+  it("still writes rich text, checkboxes and shared formulas", async () => {
+    const cells = new Map<string, Record<string, unknown>>([
+      ["0,0", { richText: [{ text: "bold", font: { bold: true } }] }],
+      ["1,0", { value: true, checkbox: true }],
+      ["2,0", { value: 3, formula: "A1+A2", formulaType: "shared", formulaSharedIndex: 0 }],
+      ["3,0", { value: 1, formula: "SEQUENCE(3)", formulaDynamic: true }],
+    ])
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[null], [null], [null], [null]], cells: cells as never }],
+    })
+
+    const xml = await sheetXml(bytes)
+
+    expect(xml).toContain("<is>")
+    expect(xml).toContain('t="shared"')
+    expect(xml).toContain('si="0"')
+    expect(xml).toMatch(/cm="\d+"/)
+  })
+
+  it("still round-trips a plain sheet unchanged", async () => {
+    const rows = [
+      ["Name", "Amount", "When"],
+      ["Ada", 1234.5, new Date(Date.UTC(2024, 0, 15))],
+    ]
+
+    const back = await readXlsx(await writeXlsx({ sheets: [{ name: "S", rows }] }))
+
+    expect(back.sheets[0]!.rows[1]![0]).toBe("Ada")
+    expect(back.sheets[0]!.rows[1]![1]).toBe(1234.5)
+    expect(back.sheets[0]!.rows[1]![2]).toBeInstanceOf(Date)
+  })
+})


### PR DESCRIPTION
From the audit in #439, §B.

## The problem

XLSX had **two** independent implementations of `<c>` — `worksheet-writer.serializeCell` (authoring and round-trip) and `RowSerializer.serializeCell` (both streaming writers) — and they had drifted in **both** directions:

| | authoring | streaming |
| --- | :-: | :-: |
| Excel error values → `t="e"` | yes | **no** — `"#REF!"` was written as an ordinary string |
| Rich text | yes | **no** |
| Excel 2024 checkbox xfs | yes | **no** |
| Shared / array formulas, `si`, `ref` | yes | **no** |
| Dynamic-array `cm` | yes | **no** |
| `xml:space="preserve"` on `<t>` | **no** (fixed in #441) | yes |
| Non-finite guard on a cached formula result | **no** | yes (#436) |

`RowSerializer`'s own class comment said *"Both writers share one of these so their output stays byte-identical"* — true of the two streaming writers, and of nothing else.

Every feature added to one had to be re-derived in the other. #436 had to do exactly that, for formula-result typing and for the NaN guard, and review caught both. That was the cost being paid per PR.

## What landed

`serializeCell` in `worksheet-writer` is the implementation. `RowSerializer` builds a `ResolvedCell` and delegates.

**Merging them immediately surfaced the divergence that was still live**: `writeXlsx` wrote `<v>NaN</v>` for a non-finite cached result — which no reader can parse as a number — because #436's guard only ever went into the streaming copy. That guard is now in the shared implementation, along with a `Date` branch the streaming copy had and this one lacked.

What the streaming path gains, at no cost to the caller:

```
writeXlsxStream([["#REF!"]], { name: "S" })

before:  <c r="A1" t="inlineStr"><is><t>#REF!</t></is></c>
after:   <c r="A1" t="e"><v>#REF!</v></c>
```

The dead code the merge left behind — a second `DEFAULT_DATE_FORMAT`, and imports of `dateToSerial`, `xmlEscape` and `xmlTextElement` — goes with it.

## Note on the two models

`StreamStyledCell` still has `{ value, style, formula }` while `Cell` has a separate `formulaResult`. Sharing the serializer does not merge those: the streaming type documents `value` as the cached result when a `formula` is present, and the adapter maps it. Widening `StreamStyledCell` to carry rich text or a shared-formula index is a separate decision about the streaming API, not something to smuggle into a refactor.

## Tests

`test/one-cell-serializer.test.ts`, 7 assertions: the streamed error value in the emitted XML and read back, the two writers agreeing cell for cell, both dropping a non-finite cache, and the authoring path still writing rich text, checkboxes, shared formulas and the dynamic-array marker.

**4 of the 7 fail against `main`.**