### PR TITLE
fix(zip): refuse a duplicate part — which found saveXlsx emitting one

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -213,6 +213,23 @@ reads back with its direct formatting only.
 See [What ODS carries](../README.md#what-ods-carries) for the consequences
 worth knowing before relying on it.
 
+## `Sheet.rows` is not guaranteed rectangular
+
+Every reader returns `rows: CellValue[][]`, and they do not agree on the
+shape of an empty row. `readXlsx` pads to the sheet's bounding box, so an
+all-empty row comes back as `[null, null, …]`; `readOds` returns `[]` for
+it, and `parseCsv` returns whatever the file had, so a short line stays
+short.
+
+Code that walks a sheet generically — `sheetToObjects`, `toHtml`,
+`toMarkdown`, `a11y.audit`, the schema validator — has to read
+`row[i] ?? null` rather than assume a slot exists. That is what they all
+do; it is written down here because nothing said so.
+
+The streaming readers _do_ agree: `streamXlsxRows` and `streamOdsRows`
+both skip an entirely empty row and keep the true index on `StreamRow`,
+so a gap in the indexes is the signal.
+
 ## Read options, per reader
 
 `ReadOptions` is one interface for `readXlsx`, `readOds`, `readXlsb`,

--- a/src/xlsx/feature-property-bag.ts
+++ b/src/xlsx/feature-property-bag.ts
@@ -26,6 +26,9 @@ export const FPB_REL_TYPE =
 /** Content-type for the part. */
 export const FPB_CONTENT_TYPE = "application/vnd.ms-excel.featurepropertybag+xml"
 
+/** Where the part lives in the package, lower-cased for path comparison. */
+export const FEATURE_PROPERTY_BAG_PART_PATH = "xl/featurepropertybag/featurepropertybag.xml"
+
 /** Path inside the XLSX archive. */
 export const FPB_PART_PATH = "xl/featurePropertyBag/featurePropertyBag.xml"
 

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -27,7 +27,7 @@ import {
 import { parseRelationships } from "./relationships"
 import { createStylesCollector } from "./styles-writer"
 import { createSharedStrings, writeSharedStringsXml, writeWorksheetXml } from "./worksheet-writer"
-import { writeFeaturePropertyBagXml } from "./feature-property-bag"
+import { FEATURE_PROPERTY_BAG_PART_PATH, writeFeaturePropertyBagXml } from "./feature-property-bag"
 import { METADATA_PART_PATH, writeMetadataXml } from "./metadata"
 import type { WorksheetResult } from "./worksheet-writer"
 import { writeDrawing } from "./drawing-writer"
@@ -753,6 +753,11 @@ export async function saveXlsx(
     }
   }
 
+  // Known before the preservation walk because the worksheets were
+  // serialized far above — the walk needs it to skip the opened package's
+  // own copy of the part we are about to emit.
+  const hasFeaturePropertyBag = styles.hasCheckboxFeature()
+
   // Build ZIP archive
   const zip = new ZipWriter()
 
@@ -791,6 +796,15 @@ export async function saveXlsx(
       if (!isRegenerated && hasMetadata && lowerPath === METADATA_PART_PATH) {
         isRegenerated = true
       }
+      // Same for the feature property bag, which had no such rule: a
+      // workbook opened with Excel 2024 checkboxes had its bag preserved
+      // *and* re-emitted, so the saved package carried the part twice.
+      // Excel treats a package with two parts of one name as damaged.
+      // `ZipWriter` used to accept the duplicate silently, which is how
+      // this survived — see #439 §AY.
+      if (!isRegenerated && hasFeaturePropertyBag && lowerPath === FEATURE_PROPERTY_BAG_PART_PATH) {
+        isRegenerated = true
+      }
       // Drawings whose only contents are chart graphicFrames don't get
       // re-emitted by hucre's drawing writer; force-preserve them so
       // the chart references survive intact.
@@ -815,7 +829,6 @@ export async function saveXlsx(
   // Worksheets are already serialized by this point, so the collector
   // knows whether any cell asked for a checkbox xf. Previously hardcoded
   // false, which dropped Excel 2024 checkboxes on every round trip (#359).
-  const hasFeaturePropertyBag = styles.hasCheckboxFeature()
   const ctOpts: ContentTypesOptions = {
     sheetCount: writeSheets.length,
     hasSharedStrings,

--- a/src/zip/writer.ts
+++ b/src/zip/writer.ts
@@ -4,6 +4,7 @@
 
 import { crc32, deflate } from "./deflate"
 import { canDeflateRaw } from "./capability"
+import { ZipError } from "../errors"
 
 // ── ZIP Signatures ──────────────────────────────────────────────────
 
@@ -60,9 +61,18 @@ interface PendingEntry {
 
 export class ZipWriter {
   private entries: PendingEntry[] = []
+  private paths = new Set<string>()
 
   /** Add a file entry to the archive */
   add(path: string, data: Uint8Array, options?: { compress?: boolean }): void {
+    // An OOXML package with two parts of one name is a file Excel refuses
+    // to open, and `extract` would quietly hand back whichever came last.
+    // The streaming writer has always refused this; the buffered one
+    // accepted it silently. See #439 §AY.
+    if (this.paths.has(path)) {
+      throw new ZipError(`Duplicate ZIP entry: "${path}"`)
+    }
+    this.paths.add(path)
     const compress = options?.compress ?? true
     this.entries.push({ path, data, compress })
   }

--- a/test/edge-cases-bugs.test.ts
+++ b/test/edge-cases-bugs.test.ts
@@ -10,6 +10,7 @@ import { writeCsv } from "../src/csv/writer"
 import { validateWithSchema } from "../src/_schema"
 import { serialToDate, dateToSerial } from "../src/_date"
 import { ZipWriter } from "../src/zip/writer"
+import { ZipError } from "../src/errors"
 import { ZipReader } from "../src/zip/reader"
 import { parseXml } from "../src/xml/parser"
 import { writeOds } from "../src/ods/writer"
@@ -369,21 +370,19 @@ describe("CSV: unusual content", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("ZIP: edge cases", () => {
-  it("add same path twice - last one wins", async () => {
+  it("refuses the same path twice", () => {
     const zip = new ZipWriter()
     const enc = new TextEncoder()
 
     zip.add("file.txt", enc.encode("first"))
-    zip.add("file.txt", enc.encode("second"))
 
-    const data = await zip.build()
-    const reader = new ZipReader(data)
-
-    // Both entries exist in the archive
-    const entries = reader.entries()
-    const fileEntries = entries.filter((e) => e === "file.txt")
-    // ZIP allows duplicate entries
-    expect(fileEntries.length).toBeGreaterThanOrEqual(1)
+    // The container format tolerates duplicates; an OOXML *package* does
+    // not — Excel treats two parts of one name as damaged, and `extract`
+    // would quietly hand back whichever came last. The streaming writer
+    // has always refused this; the buffered one accepted it silently,
+    // which is how saveXlsx came to emit the feature property bag twice.
+    // See #439 §AY.
+    expect(() => zip.add("file.txt", enc.encode("second"))).toThrow(ZipError)
   })
 
   it("very small data (just 'PK' signature) rejects", () => {

--- a/test/no-duplicate-parts.test.ts
+++ b/test/no-duplicate-parts.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { writeXlsx } from "../src/xlsx/writer"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §AY asked for a guard: `ZipWriter.add` accepted two entries with
+// one path and `extract` returned whichever came last. I filed it as a
+// guard-rail request, since ZipWriter is internal.
+//
+// Adding the guard found a shipping bug. `saveXlsx` preserved the opened
+// package's `xl/featurePropertyBag/featurePropertyBag.xml` *and* emitted
+// its own, so a round-tripped workbook with Excel 2024 checkboxes carried
+// the part twice — which Excel treats as damaged. The metadata part had
+// an explicit "skip the opened copy" rule; the feature bag never got one.
+// ═══════════════════════════════════════════════════════════════════════
+
+const CHECKBOX_CELLS = new Map([["0,0", { value: true, checkbox: true }]])
+
+function pathsIn(bytes: Uint8Array): string[] {
+  return new ZipReader(bytes).entries()
+}
+
+function duplicates(paths: string[]): string[] {
+  const seen = new Set<string>()
+  const twice = new Set<string>()
+  for (const path of paths) {
+    if (seen.has(path)) twice.add(path)
+    seen.add(path)
+  }
+  return [...twice]
+}
+
+describe("a saved package has each part once", () => {
+  it("round-trips a workbook with checkboxes without duplicating the feature bag", async () => {
+    const original = await writeXlsx({
+      sheets: [{ name: "S", rows: [[true]], cells: CHECKBOX_CELLS as never }],
+    })
+
+    // The part has to be there in the first place, or the test proves nothing.
+    expect(pathsIn(original)).toContain("xl/featurePropertyBag/featurePropertyBag.xml")
+
+    const saved = await saveXlsx(await openXlsx(original))
+
+    expect(duplicates(pathsIn(saved))).toEqual([])
+    expect(pathsIn(saved)).toContain("xl/featurePropertyBag/featurePropertyBag.xml")
+  })
+
+  it("survives a second round trip", async () => {
+    const original = await writeXlsx({
+      sheets: [{ name: "S", rows: [[true]], cells: CHECKBOX_CELLS as never }],
+    })
+
+    const once = await saveXlsx(await openXlsx(original))
+    const twice = await saveXlsx(await openXlsx(once))
+
+    expect(duplicates(pathsIn(twice))).toEqual([])
+  })
+
+  it("keeps the checkbox through the round trip", async () => {
+    const original = await writeXlsx({
+      sheets: [{ name: "S", rows: [[true]], cells: CHECKBOX_CELLS as never }],
+    })
+
+    const saved = await saveXlsx(await openXlsx(original))
+    const xml = new TextDecoder().decode(
+      await new ZipReader(saved).extract("xl/featurePropertyBag/featurePropertyBag.xml"),
+    )
+
+    expect(xml).toContain("Checkbox")
+  })
+
+  it("has no duplicates on an ordinary workbook either", async () => {
+    const original = await writeXlsx({
+      sheets: [
+        { name: "One", rows: [["a", 1]] },
+        { name: "Two", rows: [["b", 2]] },
+      ],
+      properties: { title: "T" },
+    })
+
+    const saved = await saveXlsx(await openXlsx(original))
+
+    expect(duplicates(pathsIn(saved))).toEqual([])
+  })
+})

--- a/test/roundtrip.test.ts
+++ b/test/roundtrip.test.ts
@@ -61,14 +61,18 @@ async function injectEntries(
 ): Promise<Uint8Array> {
   const zip = new ZipReader(original)
   const writer = new ZipWriter()
+  const replacing = new Set(extras.map((e) => e.path))
 
-  // Copy all original entries
+  // Copy the original entries, skipping any the caller is replacing. This
+  // used to append the extras on top and rely on ZipWriter tolerating a
+  // duplicate path — which produced an archive with two entries of one
+  // name, something Excel treats as damaged. ZipWriter refuses now.
   for (const path of zip.entries()) {
+    if (replacing.has(path)) continue
     const data = await zip.extract(path)
     writer.add(path, data, { compress: false })
   }
 
-  // Add extra entries
   for (const entry of extras) {
     writer.add(entry.path, entry.data, { compress: false })
   }


### PR DESCRIPTION
From the audit in #439, §AY and §AO.

## The guard, and what it caught

§AY asked for a guard: `ZipWriter.add` accepted two entries with one path and `extract` returned whichever came last. I filed it as a *guard-rail request* — `ZipWriter` is internal and nothing was known to produce a duplicate.

Adding it found one.

```
ZipError: Duplicate ZIP entry: "xl/featurePropertyBag/featurePropertyBag.xml"
  at test/roundtrip-preservation.test.ts > keeps Excel 2024 checkboxes
```

**`saveXlsx` preserved the opened package's feature-property-bag part and emitted its own.** A round-tripped workbook with Excel 2024 checkboxes carried the part twice, and Excel treats a package with two parts of one name as damaged.

The metadata part has an explicit "skip the opened copy, we are emitting ours" rule (`roundtrip.ts:791`). The feature bag never got one. Preferring the opened copy instead would have been wrong: the bag indexes xfs by position and `saveXlsx` regenerates `styles.xml`, so a preserved bag points at the wrong formats.

`hasFeaturePropertyBag` moves up to function scope so the preservation walk can see it — the worksheets are serialized long before, so the styles collector already knows the answer.

## Two test changes, both because they relied on the tolerance

- **`injectEntries`** in `test/roundtrip.test.ts` copied every original entry and then appended the extras, so injecting `xl/theme/theme1.xml` produced an archive with two of them. It replaces now. That one was the helper's own doing, not a product bug.
- **`"add same path twice - last one wins"`** asserted the old behaviour. It asserts the throw now, with the reason: the container format tolerates duplicates, an OOXML *package* does not.

## Also: `Sheet.rows` is not guaranteed rectangular

§AO. `readXlsx` pads an all-empty row to the sheet's bounding box (`[null, null, …]`), `readOds` returns `[]`, and `parseCsv` keeps a short line short. Anything walking a sheet generically has to read `row[i] ?? null` — which they all do, but nothing said so. Now in `docs/PARITY.md`, along with the note that the *streaming* readers do agree with each other: both skip an empty row and keep the true index on `StreamRow`.

## Tests

`test/no-duplicate-parts.test.ts`, 4 assertions: no duplicate paths after a round trip of a checkbox workbook, after a *second* round trip, that the checkbox itself survives, and that an ordinary workbook is clean too.

**2 of the 4 fail against `main`.**