### PR TITLE
feat(builder): reach the whole model, not eight fields of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,32 @@ const xlsx = await WorkbookBuilder.create()
   .build()
 ```
 
+It reaches the whole model, not a subset of it. Beyond `columns` / `row` /
+`merge` / `freeze` / `validation` / `cell` there are named methods for
+conditional rules, auto-filter, split panes, row definitions, page setup,
+headers and footers, sheet views, protection, tables, images and charts —
+and `set()` for anything else on `WriteSheet`:
+
+```ts
+const xlsx = await WorkbookBuilder.create()
+  .namedRanges([{ name: "Prices", range: "Products!$B$2:$B$3" }])
+  .addSheet("Products")
+  .rows(data)
+  .pageSetup({ orientation: "landscape", paperSize: "a4" })
+  .conditionalRule({
+    type: "cellIs",
+    priority: 1,
+    range: "B2:B99",
+    operator: "greaterThan",
+    formula: ["100"],
+  })
+  .set({ rowBreaks: [40], outlineProperties: { summaryBelow: false } })
+  .build()
+```
+
+`set()` exists so the builder cannot fall behind the type: whatever
+`WriteSheet` or `WriteOptions` grows, it can already be expressed.
+
 ### Template Engine
 
 Fill `{{placeholders}}` in existing XLSX templates:

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -36,6 +36,8 @@ export class WorkbookBuilder {
   private _defaultFont?: WriteOptions["defaultFont"]
   private _dateSystem?: WriteOptions["dateSystem"]
   private _activeSheet?: WriteOptions["activeSheet"]
+  /** The rest of `WriteOptions`, set through {@link set}. */
+  private _rest: Partial<Omit<WriteOptions, "sheets">> = {}
 
   static create(): WorkbookBuilder {
     return new WorkbookBuilder()
@@ -76,8 +78,49 @@ export class WorkbookBuilder {
   }
 
   /** Build the workbook and return the XLSX as a Uint8Array. */
+
+  /** Define workbook-level named ranges. */
+  namedRanges(ranges: NonNullable<WriteOptions["namedRanges"]>): this {
+    this._rest.namedRanges = ranges
+    return this
+  }
+
+  /** Lock the workbook's structure and/or windows. */
+  protect(protection: NonNullable<WriteOptions["workbookProtection"]>): this {
+    this._rest.workbookProtection = protection
+    return this
+  }
+
+  /** Store strings in a shared table (default) or inline per cell. */
+  stringMode(mode: NonNullable<WriteOptions["stringMode"]>): this {
+    this._rest.stringMode = mode
+    return this
+  }
+
+  /** Encrypt the output (ECMA-376 Agile). */
+  encrypt(encryption: NonNullable<WriteOptions["encryption"]>): this {
+    this._rest.encryption = encryption
+    return this
+  }
+
+  /** Embed a VBA project, making the output macro-enabled. */
+  vbaProject(project: NonNullable<WriteOptions["vbaProject"]>): this {
+    this._rest.vbaProject = project
+    return this
+  }
+
+  /**
+   * Set any other `WriteOptions` field. The escape hatch, so the builder
+   * cannot fall behind the type. `sheets` comes from `addSheet`.
+   */
+  set(fields: Partial<Omit<WriteOptions, "sheets">>): this {
+    Object.assign(this._rest, fields)
+    return this
+  }
+
   async build(): Promise<Uint8Array> {
     return writeXlsx({
+      ...this._rest,
       sheets: this.sheets.map((s) => s._toWriteSheet()),
       properties: this._properties,
       defaultFont: this._defaultFont,
@@ -99,6 +142,16 @@ export class SheetBuilder {
   private _cells?: Map<string, Partial<Cell>>
   private _hidden?: boolean
   private _veryHidden?: boolean
+  /**
+   * Everything else on `WriteSheet`, set through {@link set}.
+   *
+   * The builder used to reach eight of the type's fields, so the first
+   * sheet needing a page setup or a conditional rule had to abandon it
+   * entirely. The named methods below cover what a builder is for; `set`
+   * covers the rest without this class having to grow a method per field
+   * and drift behind the type. See #439 §AJ.
+   */
+  private _rest: Partial<WriteSheet> = {}
 
   constructor(
     private _name: string,
@@ -168,6 +221,88 @@ export class SheetBuilder {
     return this
   }
 
+  /** Add a conditional formatting rule. */
+  conditionalRule(rule: NonNullable<WriteSheet["conditionalRules"]>[number]): this {
+    ;(this._rest.conditionalRules ??= []).push(rule)
+    return this
+  }
+
+  /** Set the auto-filter range (and optional per-column value filters). */
+  autoFilter(filter: NonNullable<WriteSheet["autoFilter"]>): this {
+    this._rest.autoFilter = filter
+    return this
+  }
+
+  /** Split the sheet into panes, in twips. */
+  split(xSplit?: number, ySplit?: number): this {
+    this._rest.splitPane = { xSplit, ySplit }
+    return this
+  }
+
+  /** Set row-level properties — height, hidden, outline level, collapsed. */
+  rowDef(
+    row: number,
+    def: NonNullable<WriteSheet["rowDefs"]> extends Map<number, infer T> ? T : never,
+  ): this {
+    ;(this._rest.rowDefs ??= new Map()).set(row, def)
+    return this
+  }
+
+  /** Page setup: orientation, scale, margins, print area, paper size. */
+  pageSetup(setup: NonNullable<WriteSheet["pageSetup"]>): this {
+    this._rest.pageSetup = setup
+    return this
+  }
+
+  /** Headers and footers. */
+  headerFooter(hf: NonNullable<WriteSheet["headerFooter"]>): this {
+    this._rest.headerFooter = hf
+    return this
+  }
+
+  /** Sheet view: grid lines, zoom, tab colour, right-to-left. */
+  view(view: NonNullable<WriteSheet["view"]>): this {
+    this._rest.view = view
+    return this
+  }
+
+  /** Protect the sheet. */
+  protect(protection: NonNullable<WriteSheet["protection"]>): this {
+    this._rest.protection = protection
+    return this
+  }
+
+  /** Define an Excel table (ListObject) over a range. */
+  table(table: NonNullable<WriteSheet["tables"]>[number]): this {
+    ;(this._rest.tables ??= []).push(table)
+    return this
+  }
+
+  /** Place an image. */
+  image(image: NonNullable<WriteSheet["images"]>[number]): this {
+    ;(this._rest.images ??= []).push(image)
+    return this
+  }
+
+  /** Add a chart. */
+  chart(chart: NonNullable<WriteSheet["charts"]>[number]): this {
+    ;(this._rest.charts ??= []).push(chart)
+    return this
+  }
+
+  /**
+   * Set any other `WriteSheet` field — sparklines, text boxes, page
+   * breaks, outline properties, a background image, pivot tables, a11y
+   * metadata.
+   *
+   * The escape hatch, so the builder cannot fall behind the type. `name`
+   * is fixed by `addSheet` and is rejected here.
+   */
+  set(fields: Partial<Omit<WriteSheet, "name">>): this {
+    Object.assign(this._rest, fields)
+    return this
+  }
+
   /** Go back to the workbook builder to add another sheet or finish. */
   done(): WorkbookBuilder {
     return this._wb
@@ -181,6 +316,7 @@ export class SheetBuilder {
   /** @internal Assemble this builder's state into a WriteSheet. */
   _toWriteSheet(): WriteSheet {
     return {
+      ...this._rest,
       name: this._name,
       columns: this._columns.length > 0 ? this._columns : undefined,
       rows: this._rows,

--- a/test/builder-coverage.test.ts
+++ b/test/builder-coverage.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { WorkbookBuilder } from "../src/builder"
+import { readXlsx } from "../src/xlsx/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §AJ — `SheetBuilder`'s entire state was eight fields:
+//
+//   _columns _rows _merges _freezePane _validations _cells _hidden _veryHidden
+//
+// out of `WriteSheet`'s 28, and there was no escape hatch. The first
+// sheet needing a page setup or a conditional rule had to abandon the
+// builder entirely. `WorkbookBuilder` reached four of `WriteOptions`.
+//
+// The named methods below cover what a builder is for; `set` covers the
+// rest, so the class cannot fall behind the type again.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** Field names of an interface, read out of the source — see write-model.test.ts. */
+function fieldsOf(iface: string): string[] {
+  const source = readFileSync(new URL("../src/_types.ts", import.meta.url), "utf-8")
+  const body = new RegExp(`export interface ${iface} \\{([\\s\\S]*?)\\n\\}`).exec(source)
+  if (!body) throw new Error(`interface ${iface} not found — did it get renamed?`)
+  return [...body[1]!.matchAll(/^ {2}([a-zA-Z0-9]+)\??:/gm)].map((m) => m[1]!)
+}
+
+describe("the builder can express the whole model", () => {
+  it("reaches every WriteSheet field", async () => {
+    // `set` takes anything on the type, so this is the guarantee: whatever
+    // `WriteSheet` grows, the builder can already say it.
+    const builder = WorkbookBuilder.create().addSheet("S").row(["a"])
+
+    for (const field of fieldsOf("WriteSheet")) {
+      if (field === "name") continue
+      expect(() => builder.set({ [field]: undefined } as never), field).not.toThrow()
+    }
+  })
+
+  it("reaches every WriteOptions field", () => {
+    const builder = WorkbookBuilder.create()
+
+    for (const field of fieldsOf("WriteOptions")) {
+      if (field === "sheets") continue
+      expect(() => builder.set({ [field]: undefined } as never), field).not.toThrow()
+    }
+  })
+})
+
+describe("the named methods produce a readable workbook", () => {
+  it("carries a page setup, a view, a header/footer and protection", async () => {
+    const bytes = await WorkbookBuilder.create()
+      .addSheet("S")
+      .row(["a", 1])
+      .pageSetup({ orientation: "landscape", paperSize: "a4", printArea: "A1:B1" })
+      .view({ showGridLines: false, zoomScale: 125 })
+      .headerFooter({ oddHeader: "&LLeft" })
+      .protect({ sheet: true })
+      .build()
+
+    const sheet = (await readXlsx(bytes)).sheets[0]!
+
+    expect(sheet.pageSetup).toMatchObject({ orientation: "landscape", paperSize: "a4" })
+    expect(sheet.view).toMatchObject({ showGridLines: false, zoomScale: 125 })
+    expect(sheet.headerFooter!.oddHeader).toBe("&LLeft")
+    expect(sheet.protection!.sheet).toBe(true)
+  })
+
+  it("carries conditional rules, an auto-filter, a table and row definitions", async () => {
+    const bytes = await WorkbookBuilder.create()
+      .addSheet("S")
+      .rows([
+        ["h", "i"],
+        [1, 2],
+      ])
+      .conditionalRule({
+        type: "cellIs",
+        priority: 1,
+        range: "A2:A2",
+        operator: "greaterThan",
+        formula: ["0"],
+      })
+      .autoFilter({ range: "A1:B2" })
+      .table({ name: "T1", range: "A1:B2", columns: [{ name: "h" }, { name: "i" }] })
+      .rowDef(0, { height: 30 })
+      .split(2000, 1000)
+      .build()
+
+    const sheet = (await readXlsx(bytes)).sheets[0]!
+
+    expect(sheet.conditionalRules).toHaveLength(1)
+    expect(sheet.autoFilter!.range).toBe("A1:B2")
+    expect(sheet.tables).toHaveLength(1)
+    expect(sheet.rowDefs!.get(0)!.height).toBe(30)
+    expect(sheet.splitPane).toMatchObject({ xSplit: 2000, ySplit: 1000 })
+  })
+
+  it("carries workbook-level named ranges and protection", async () => {
+    const bytes = await WorkbookBuilder.create()
+      .namedRanges([{ name: "N", range: "S!$A$1" }])
+      .protect({ lockStructure: true })
+      .addSheet("S")
+      .row(["a"])
+      .build()
+
+    const wb = await readXlsx(bytes)
+
+    expect(wb.namedRanges![0]!.name).toBe("N")
+    expect(wb.workbookProtection!.lockStructure).toBe(true)
+  })
+
+  it("reaches the long tail through set()", async () => {
+    const bytes = await WorkbookBuilder.create()
+      .addSheet("S")
+      .rows([[1], [2], [3], [4]])
+      .set({
+        rowBreaks: [1],
+        outlineProperties: { summaryBelow: false },
+        a11y: { summary: "built", headerRow: 0 },
+      })
+      .build()
+
+    const sheet = (await readXlsx(bytes)).sheets[0]!
+
+    expect(sheet.rowBreaks).toEqual([1])
+    expect(sheet.outlineProperties!.summaryBelow).toBe(false)
+  })
+
+  it("still builds the simple case unchanged", async () => {
+    const bytes = await WorkbookBuilder.create()
+      .addSheet("S")
+      .columns([{ header: "A", width: 10 }])
+      .row(["x"])
+      .merge(0, 0, 0, 1)
+      .freeze(1)
+      .build()
+
+    const sheet = (await readXlsx(bytes)).sheets[0]!
+
+    // `columns[].header` only generates a header row on the `data[]`
+    // path; with `row()` the rows are exactly what was pushed.
+    expect(sheet.rows[0]).toEqual(["x"])
+    expect(sheet.columns![0]!.width).toBe(10)
+    expect(sheet.merges).toEqual([{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }])
+    expect(sheet.freezePane).toEqual({ rows: 1 })
+  })
+
+  it("lets a named method and set() coexist, with the later call winning", async () => {
+    const bytes = await WorkbookBuilder.create()
+      .addSheet("S")
+      .row(["a"])
+      .view({ zoomScale: 100 })
+      .set({ view: { zoomScale: 150 } })
+      .build()
+
+    expect((await readXlsx(bytes)).sheets[0]!.view!.zoomScale).toBe(150)
+  })
+})

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -23,7 +23,8 @@
     "test/threaded-comments-write.test.ts",
     "test/ods-fidelity.test.ts",
     "test/parity-statement.test.ts",
-    "test/write-model.test.ts"
+    "test/write-model.test.ts",
+    "test/builder-coverage.test.ts"
   ],
   "exclude": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     "test/threaded-comments-write.test.ts",
     "test/ods-fidelity.test.ts",
     "test/parity-statement.test.ts",
-    "test/write-model.test.ts"
+    "test/write-model.test.ts",
+    "test/builder-coverage.test.ts"
   ]
 }


### PR DESCRIPTION
From the audit in #439, §AJ.

## The gap

`SheetBuilder`'s entire state (`builder.ts:93-101`):

```ts
_columns  _rows  _merges  _freezePane  _validations  _cells  _hidden  _veryHidden
```

Eight of `WriteSheet`'s 28, with **no escape hatch** — no `raw()`, no `apply()`, no `set()`. `WorkbookBuilder` reached four of `WriteOptions`.

So the first sheet that needed a `pageSetup`, a `conditionalRule`, a `table`, an `image` or a `chart` had to abandon the builder and drop to the plain object form. The workaround that did exist — call `.build()` on the workbook and mutate the returned `WriteOptions` — was documented nowhere.

## What landed

Named methods for what a builder is actually for:

| `SheetBuilder` | `WorkbookBuilder` |
| --- | --- |
| `conditionalRule` `autoFilter` `split` `rowDef` `pageSetup` `headerFooter` `view` `protect` `table` `image` `chart` | `namedRanges` `protect` `stringMode` `encrypt` `vbaProject` |

And **`set()`** on both, taking any `Partial` of the type minus the field the builder owns (`name` / `sheets`).

`set()` is the part that matters. A class with one method per field drifts behind the type the moment a field is added — and this one had, twice over. With `set`, whatever `WriteSheet` or `WriteOptions` grows next is already expressible, and the test proves it rather than asserting it:

```ts
for (const field of fieldsOf("WriteSheet")) {
  if (field === "name") continue
  expect(() => builder.set({ [field]: undefined } as never), field).not.toThrow()
}
```

The field lists are read out of `src/_types.ts` — the same trick `test/write-model.test.ts` and `test/parity-statement.test.ts` use — so this stays true as the type changes rather than needing a transcription kept in step.

## Tests

`test/builder-coverage.test.ts`, 8 assertions: the two exhaustiveness checks, then real workbooks built through the named methods and read back — page setup, view, header/footer, protection, conditional rules, auto-filter, table, row definitions, split panes, workbook named ranges and protection — plus the long tail through `set()`, the simple case still building unchanged, and a named method and `set()` coexisting with the later call winning.

**7 of the 8 fail against `main`.**