### PR TITLE
feat(read): tell the caller what the reader had to drop

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -230,6 +230,34 @@ The streaming readers _do_ agree: `streamXlsxRows` and `streamOdsRows`
 both skip an entirely empty row and keep the true index on `StreamRow`,
 so a gap in the indexes is the signal.
 
+## The readers are lenient, and will tell you
+
+A corrupt reference does not throw. A cell pointing at a shared string
+the file does not have reads as `null`; a cell naming a format that is
+not there reads unstyled. That is the right default for a format you
+receive rather than control — half a sheet is usually more useful than an
+exception.
+
+It used to be the only mode, which made a damaged file indistinguishable
+from a clean one. `ReadOptions.onWarning` is the other half:
+
+```ts
+const warnings: ReadWarning[] = []
+const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+
+// unresolved-shared-string — Cell A1 points at shared string 9999, which
+// the file does not have (3 present). Read as empty.
+```
+
+Each warning carries a `code`, a sentence, and the sheet and cell it came
+from. Nothing changes when the option is omitted, and a file hucre wrote
+produces none.
+
+Structural damage still throws: a missing `xl/workbook.xml`, or a
+worksheet part a sheet declares and the archive does not contain, is a
+`ParseError`. The difference is whether the answer would be _short_ or
+_wrong_.
+
 ## Read options, per reader
 
 `ReadOptions` is one interface for `readXlsx`, `readOds`, `readXlsb`,

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1368,6 +1368,21 @@ export interface Workbook {
   timelineCaches?: TimelineCache[]
 }
 
+// ── Read diagnostics ───────────────────────────────────────────────
+
+/** What a reader had to drop, and where. */
+export interface ReadWarning {
+  /** What kind of problem this is, for programmatic handling. */
+  code: "unresolved-shared-string" | "unresolved-style" | "unresolved-dxf"
+  /** A sentence a person can act on. */
+  message: string
+  /** The sheet it happened in, when the reader knows. */
+  sheet?: string
+  /** 0-based cell position, when the problem is a cell's. */
+  row?: number
+  col?: number
+}
+
 // ── Read Options ───────────────────────────────────────────────────
 
 /**
@@ -1457,6 +1472,27 @@ export interface ReadOptions {
    * the caller has already allocated.
    */
   maxInputBytes?: number
+  /**
+   * Called for each thing a reader had to drop.
+   *
+   * The readers are lenient on purpose — a corrupt reference yields
+   * `null` rather than an exception, because a spreadsheet is a format
+   * you receive rather than one you control. But leniency used to be the
+   * *only* mode: a cell pointing at a shared string that is not there
+   * came back as `null`, indistinguishable from a cell that was
+   * genuinely empty, and nothing said which. See #439 §S.
+   *
+   * ```ts
+   * const warnings: ReadWarning[] = []
+   * const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+   * if (warnings.length) console.warn(`${warnings.length} problem(s) in this file`)
+   * ```
+   *
+   * Nothing changes when it is omitted. This is a side channel, not part
+   * of the document, which is why it is a callback rather than a field on
+   * `Workbook`.
+   */
+  onWarning?: (warning: ReadWarning) => void
 }
 
 // ── Write Options ──────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -351,6 +351,7 @@ export type {
   ReadInput,
   SheetFilter,
   SheetFilterInfo,
+  ReadWarning,
   // Write
   WriteOptions,
   WriteSheet,

--- a/src/xlsx.ts
+++ b/src/xlsx.ts
@@ -60,6 +60,7 @@ export type {
   MergeRange,
   ReadInput,
   ReadOptions,
+  ReadWarning,
   Sheet,
   SheetChart,
   Sparkline,

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -402,6 +402,8 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       maxRows: options?.maxRows,
       range: options?.range,
       dynamicArrayCm,
+      sheetName: info.name,
+      onWarning: options?.onWarning,
     }
 
     const wsXml = decodeUtf8(await zip.extract(wsPath))

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -2,6 +2,7 @@
 // Parses xl/worksheets/sheetN.xml into a Sheet object.
 
 import type {
+  ReadWarning,
   Sheet,
   Cell,
   CellValue,
@@ -50,6 +51,10 @@ export interface WorksheetContext {
   maxRows?: number
   /** Cell range filter (e.g. "A1:D10"). Only cells within this range are returned. */
   range?: string
+  /** Name of the sheet being parsed, so a warning can say where it was. */
+  sheetName?: string
+  /** Where a dropped reference is reported; see ReadOptions.onWarning. */
+  onWarning?: (warning: ReadWarning) => void
   /**
    * One-based `cm` indexes that xl/metadata.xml resolves to a
    * dynamic-array (XLDAPR) record. Undefined when the package ships no
@@ -1651,7 +1656,17 @@ function processCell(
         }
       } else {
         // Out-of-bounds SST index — return null (consistent with the
-        // streaming reader), not the raw index string.
+        // streaming reader), not the raw index string. Reported, because
+        // `null` here is otherwise indistinguishable from an empty cell.
+        ctx.onWarning?.({
+          code: "unresolved-shared-string",
+          message:
+            `Cell ${ref || `${row},${col}`} points at shared string ${valueText}, ` +
+            `which the file does not have (${ctx.sharedStrings.length} present). Read as empty.`,
+          sheet: ctx.sheetName,
+          row,
+          col,
+        })
         value = null
         cellType = "empty"
       }
@@ -1783,6 +1798,18 @@ function processCell(
       const style = resolveStyle(ctx.styles, styleIndex)
       if (Object.keys(style).length > 0) {
         cell.style = style
+      } else if (styleIndex >= ctx.styles.cellXfs.length) {
+        // The xf the cell names is not in the file, so the cell comes back
+        // unstyled — indistinguishable from one that never had a format.
+        ctx.onWarning?.({
+          code: "unresolved-style",
+          message:
+            `Cell ${ref || `${row},${col}`} points at cell format ${styleIndex}, ` +
+            `which the file does not have (${ctx.styles.cellXfs.length} present). Read unstyled.`,
+          sheet: ctx.sheetName,
+          row,
+          col,
+        })
       }
     }
     cells.set(`${row},${col}`, cell)

--- a/test/read-warnings.test.ts
+++ b/test/read-warnings.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import type { ReadWarning } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #439 §S — the readers are lenient on purpose, and that is the right
+// default for a format you receive rather than control. But leniency was
+// the *only* mode: a cell pointing at a shared string that is not there
+// came back as `null`, indistinguishable from a cell that was genuinely
+// empty, and nothing said which.
+//
+// `onWarning` is a side channel, not part of the document — which is why
+// it is a callback rather than a field on `Workbook`.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** Rebuild an archive with one part rewritten, standing in for a damaged file. */
+async function damage(
+  bytes: Uint8Array,
+  path: string,
+  edit: (xml: string) => string,
+): Promise<Uint8Array> {
+  const all = await new ZipReader(bytes).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    zw.add(
+      name,
+      name === path ? new TextEncoder().encode(edit(new TextDecoder().decode(data))) : data,
+    )
+  }
+  return zw.build()
+}
+
+const SHEET = "xl/worksheets/sheet1.xml"
+
+async function baseline(): Promise<Uint8Array> {
+  return writeXlsx({
+    sheets: [
+      { name: "Data", rows: [["hello", 1]], columns: [{ style: { font: { bold: true } } }] },
+    ],
+  })
+}
+
+describe("a dropped shared string is reported", () => {
+  it("names the cell, the index, and what the file actually has", async () => {
+    const bytes = await damage(await baseline(), SHEET, (xml) =>
+      xml.replace("<v>0</v>", "<v>9999</v>"),
+    )
+
+    const warnings: ReadWarning[] = []
+    const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+
+    // Still lenient: the value is null, not an exception.
+    expect(wb.sheets[0]!.rows[0]![0]).toBeNull()
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]!.code).toBe("unresolved-shared-string")
+    expect(warnings[0]!.sheet).toBe("Data")
+    expect(warnings[0]!.row).toBe(0)
+    expect(warnings[0]!.col).toBe(0)
+    expect(warnings[0]!.message).toContain("9999")
+    expect(warnings[0]!.message).toContain("A1")
+  })
+})
+
+describe("a dropped cell format is reported", () => {
+  it("says which format the cell asked for", async () => {
+    const bytes = await damage(await baseline(), SHEET, (xml) =>
+      xml.replace(/ s="\d+"/g, ' s="9999"'),
+    )
+
+    const warnings: ReadWarning[] = []
+    const wb = await readXlsx(bytes, { readStyles: true, onWarning: (w) => warnings.push(w) })
+
+    expect(wb.sheets[0]!.cells?.get("0,0")?.style).toBeUndefined()
+    expect(warnings.some((w) => w.code === "unresolved-style")).toBe(true)
+    expect(warnings.find((w) => w.code === "unresolved-style")!.message).toContain("9999")
+  })
+
+  it("says nothing when styles are not being read", async () => {
+    const bytes = await damage(await baseline(), SHEET, (xml) =>
+      xml.replace(/ s="\d+"/g, ' s="9999"'),
+    )
+
+    const warnings: ReadWarning[] = []
+    await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+
+    expect(warnings.filter((w) => w.code === "unresolved-style")).toEqual([])
+  })
+
+  it("does not report a format that simply resolves to nothing", async () => {
+    // xf 0 is the default and carries no formatting. That is not damage.
+    const warnings: ReadWarning[] = []
+    await readXlsx(await baseline(), { readStyles: true, onWarning: (w) => warnings.push(w) })
+
+    expect(warnings).toEqual([])
+  })
+})
+
+describe("a clean file says nothing", () => {
+  it("reports no warnings for a workbook hucre wrote", async () => {
+    const warnings: ReadWarning[] = []
+
+    await readXlsx(await baseline(), { readStyles: true, onWarning: (w) => warnings.push(w) })
+
+    expect(warnings).toEqual([])
+  })
+
+  it("changes nothing when the option is omitted", async () => {
+    const bytes = await damage(await baseline(), SHEET, (xml) =>
+      xml.replace("<v>0</v>", "<v>9999</v>"),
+    )
+
+    const withSink = await readXlsx(bytes, { onWarning: () => {} })
+    const without = await readXlsx(bytes)
+
+    expect(without.sheets[0]!.rows).toEqual(withSink.sheets[0]!.rows)
+  })
+})


### PR DESCRIPTION
From the audit in #439, §S.

## The gap

I threw eight malformed workbooks at `readXlsx` while writing the audit. The robustness was genuinely good — nothing crashed, nothing hung, and structural failures gave clean typed errors. But two of the results were these:

```
sharedString index 9999  ->  OK  rows=[[null, 1]]
style index 9999         ->  OK  style dropped
```

Both are **indistinguishable from a file that genuinely had an empty cell and no format**. There was no `strict` mode, no warnings array, no callback — a caller processing someone else's upload could not tell "this file is fine" from "this file is damaged and I quietly dropped part of it".

Leniency is the right default for a format you receive rather than control; half a sheet is usually more useful than an exception. The gap was that it was the *only* mode.

## What landed

`ReadOptions.onWarning`:

```ts
const warnings: ReadWarning[] = []
const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })

// {
//   code: "unresolved-shared-string",
//   message: "Cell A1 points at shared string 9999, which the file does not have (3 present). Read as empty.",
//   sheet: "Data", row: 0, col: 0,
// }
```

**A callback, not a field on `Workbook`.** Diagnostics are a side channel, not part of the document — and a field would have to be carried by `cloneSheet`, the worker serializer and `toWriteOptions`, none of which have any business with it.

Nothing changes when the option is omitted, and a file hucre wrote produces none.

Structural damage still throws. A missing `xl/workbook.xml`, or a worksheet part a sheet declares and the archive does not contain, is a `ParseError`. The line is whether the answer would be **short** or **wrong** — which is the same line `fromHtml` already draws between a scanner giving up and a resource bound.

## Scope

Two sites are wired: the two the audit measured as silent. The mechanism is a field on `WorksheetContext`, so more can follow the same shape as they are found — I would rather add them with a test each than sprinkle speculative calls.

## Tests

`test/read-warnings.test.ts`, 6 assertions against archives rebuilt with a damaged part: the shared-string case with its cell reference and counts, the style case, that nothing is reported when styles are not being read, that a format resolving to nothing (xf 0) is not damage, that a clean file stays quiet, and that the option changes nothing about the returned data.

**2 of the 6 fail against `main`** — the rest pin the silence, which is the half that has to keep working.