### PR TITLE
chore: Node 24 is the floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The versions the toolchain runs on. pnpm 11 requires Node 22.13,
-        # so the package's *supported* floor is checked by the `runtime`
-        # job below against the built artifact instead — which is the more
-        # honest test anyway: what ships is dist/, not the dev setup.
-        node: [22, lts/*]
+        # Node 24 is the floor — see CLAUDE.md. `lts/*` is kept alongside
+        # the pinned version so a new LTS shows up here rather than in
+        # someone's install.
+        node: [24, lts/*]
     name: node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v5
@@ -64,7 +63,7 @@ jobs:
       - run: corepack enable
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
@@ -72,39 +71,25 @@ jobs:
   runtime:
     # Does the *shipped* artifact run where the README says it does?
     #
-    # This is separate from `build` on purpose. The toolchain needs a
-    # recent Node (pnpm 11 requires 22.13), but what users install is
-    # dist/, and its floor is whatever Web APIs the code touches —
-    # CompressionStream, ReadableStream, crypto.subtle. So: build once on
-    # a version the toolchain likes, then run a smoke test under each
-    # runtime the package claims.
-    #
-    # Node 18 and Deno and Bun were all advertised and none was ever
-    # exercised.
+    # Separate from `build` because what users install is dist/, not the
+    # dev setup — and because Bun and Deno are advertised and were never
+    # exercised. Node itself is covered by the matrix above.
     runs-on: ubuntu-latest
     name: runtime ${{ matrix.runtime }}
     strategy:
       fail-fast: false
       matrix:
-        runtime: [node18, node20, bun, deno]
+        runtime: [bun, deno]
     steps:
       - uses: actions/checkout@v5
       - run: corepack enable
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      - if: matrix.runtime == 'node18'
-        uses: actions/setup-node@v6
-        with:
-          node-version: 18
-      - if: matrix.runtime == 'node20'
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
       - if: matrix.runtime == 'bun'
         uses: oven-sh/setup-bun@v2
       - if: matrix.runtime == 'deno'
@@ -114,8 +99,6 @@ jobs:
 
       # A smoke test, not the suite: vitest is a Node harness, and the
       # question here is whether dist/ loads and works on this runtime.
-      - if: startsWith(matrix.runtime, 'node')
-        run: node --version && node scripts/smoke.mjs
       - if: matrix.runtime == 'bun'
         run: bun scripts/smoke.mjs
       - if: matrix.runtime == 'deno'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+Notes for anyone — human or agent — writing code in this repo.
+
+## Node 24 is the floor
+
+**Do not write code that has to work on Node below 24.** No polyfills, no
+capability shims for older runtimes, no "this exists from 20 onward"
+branches. If a Web API is in Node 24, use it.
+
+`package.json` says `"engines": { "node": ">=24" }`, CI runs 24 and
+`lts/*`, and the release workflow publishes from 24. Those four have to
+stay in step — if you raise one, raise them all.
+
+The repo used to claim Node 18+. Nothing tested it, and when a matrix was
+finally added it turned out `writeXlsxStream` did not work there at all:
+Node 18's `CompressionStream` has no `deflate-raw`. A floor nobody
+verifies is not a floor.
+
+## Still no Node APIs in the library
+
+Separate rule, and it has not changed. `src/` outside the CLI uses **Web
+APIs only** — no `node:` imports, no `process`, no `Buffer`.
+`tsconfig.json` sets `"types": []` so reaching for one is a compile error
+rather than something that quietly works on your machine.
+
+That is what makes the Deno, Bun, browser and Workers claims true. The
+CLI is the exception and is checked by `tsconfig.cli.json`; tests that
+read from disk belong in that project's include list.
+
+Raising the Node floor does not licence `node:fs` in a reader.
+
+## The rest
+
+`CONTRIBUTING.md` has the working conventions — the gate (`pnpm test`),
+the registers that break when a field is added and a copy forgets it, and
+the two habits this codebase holds to: a test that fails _before_ the fix,
+and a reason written into the code rather than only into the PR.
+
+`docs/PARITY.md` is the statement of what hucre reads versus what it
+writes, and it ends with "Anything else is a bug". If a change adds a
+loss, that page has to say so in the same PR.
+
+`bench/` has reproducible measurements. If a change is about speed or
+memory, run it and put the numbers in the PR — one process per
+measurement, because `maxRSS` is a high-water mark for the whole process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,12 @@ the thing it points at rather than the test:
 writes. It ends with "Anything else is a bug", which is a commitment: if
 your change adds a loss, the page has to say so in the same PR.
 
+## Node 24 is the floor
+
+Do not write code that has to work below it — see CLAUDE.md. `engines`,
+the CI matrix and the release workflow all say 24, and they have to stay
+in step.
+
 ## Platform neutrality
 
 The library core uses Web APIs only — no `node:` imports, no `process`, no

--- a/README.md
+++ b/README.md
@@ -1757,7 +1757,7 @@ hucre works everywhere — no Node.js APIs (`fs`, `crypto`, `Buffer`) in core.
 
 | Runtime               | Status       |
 | --------------------- | ------------ |
-| Node.js 18+           | Full support |
+| Node.js 24+           | Full support |
 | Deno                  | Full support |
 | Bun                   | Full support |
 | Modern browsers       | Full support |

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "vitest": "^4.1.10"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24"
   },
   "packageManager": "pnpm@11.15.1"
 }

--- a/src/zip/capability.ts
+++ b/src/zip/capability.ts
@@ -1,9 +1,13 @@
 // ── Compression capability ───────────────────────────────────────────
 //
 // `deflate-raw` is the format a ZIP needs, and it is not the same
-// question as "does this runtime have CompressionStream". Node 18 has the
-// constructor and rejects `deflate-raw`: it shipped with `gzip` and
-// `deflate` only, and the raw format arrived in Node 20.
+// question as "does this runtime have CompressionStream". Node 18 had the
+// constructor and rejected `deflate-raw` — it shipped with `gzip` and
+// `deflate`, and the raw format arrived in Node 20.
+//
+// Node is no longer the case this defends against: the floor is 24 (see
+// CLAUDE.md). It stays because hucre runs in browsers and on Workers too,
+// where the same split exists and the version is not ours to choose.
 //
 // Four modules each kept their own memoized flag, and every one of them
 // probed the constructor's *existence*. The buffered writer got away with


### PR DESCRIPTION
Requested directly: stop writing for Node below 24, write the rule down, and take the older versions out of the workflows.

## The floor

`>=18` was a claim nothing tested. When #454 finally added a matrix, `runtime node18` failed immediately — **`writeXlsxStream` did not work on Node 18 at all**, because its `CompressionStream` has no `deflate-raw`. A floor nobody verifies is not a floor.

It is 24 now, and it is one number in four places that have to stay in step:

| | |
| --- | --- |
| `package.json` | `"engines": { "node": ">=24" }` |
| `ci.yml` build matrix | `[24, lts/*]` |
| `ci.yml` install/TZ jobs | `24` |
| `release.yml` | `24` |

`lts/*` stays alongside the pin so a new LTS shows up in CI rather than in someone's install.

## Workflows

The `runtime` matrix loses `node18` and `node20`. It is `[bun, deno]` now, which is what that job was actually for — Node is covered by the matrix above it, and the point of the runtime job was that Bun and Deno were advertised and never exercised.

## CLAUDE.md

States the rule, and the one it does **not** change:

> `src/` outside the CLI uses **Web APIs only** — no `node:` imports, no `process`, no `Buffer`. `tsconfig.json` sets `"types": []` so reaching for one is a compile error rather than something that quietly works on your machine.
>
> Raising the Node floor does not licence `node:fs` in a reader.

That separation is what makes the Deno, Bun, browser and Workers claims true, and it is easy to read a higher Node floor as permission to forget it.

## One thing kept on purpose

`src/zip/capability.ts` keeps its `deflate-raw` probe. Node is no longer the case it defends against, but hucre runs in browsers and on Cloudflare Workers, where the same split exists and the version is not ours to choose. The comment now says that, rather than leaving the next reader to wonder why a Node-18 workaround is still there.