### PR TITLE
feat(csv): take bytes, honour the byte-order mark, accept an encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1632,8 +1632,9 @@ For new code prefer `writeJson` / `workbookToJson` from `hucre/json` — same re
 ```ts
 import { parseCsv, parseCsvObjects, writeCsv, writeCsvStream, detectDelimiter } from "hucre/csv"
 
-// Parse — auto-detects delimiter, handles RFC 4180 edge cases
+// Parse — takes a string or bytes, auto-detects delimiter, RFC 4180
 const rows = parseCsv(csvString, { typeInference: true })
+const fromDisk = parseCsv(await readFile("data.csv"), { typeInference: true })
 
 // Parse with headers — returns typed objects
 const { data, headers } = parseCsvObjects(csvString, { header: true })
@@ -1669,6 +1670,43 @@ parseCsv(csv, { unescapeFormulae: true, typeInference: true }) // [[-5]]
 every line until `finish()` returns one string, while the function
 flushes as it goes. Writing 3,000,000 rows (254 MB of CSV) under a
 128 MB heap cap, the stream completes; the class runs out of memory.
+
+#### Character encoding
+
+`parseCsv`, `parseCsvObjects` and `streamCsvRows` take **bytes as well as a
+string**. Given bytes they read the byte-order mark, which is the one thing
+a file can say about its own encoding:
+
+| leading bytes | read as                                               |
+| ------------- | ----------------------------------------------------- |
+| `EF BB BF`    | UTF-8                                                 |
+| `FF FE`       | UTF-16LE — what Excel's "Save as Unicode Text" writes |
+| `FE FF`       | UTF-16BE                                              |
+| anything else | UTF-8, unless you say otherwise                       |
+
+There is no detection past the mark. An encoding like windows-1254 leaves
+no trace a parser can read — telling it from windows-1252 means guessing
+from byte frequencies, which is wrong often enough to be worse than
+asking. So name it:
+
+```ts
+// Excel on a Turkish Windows writes CSV as windows-1254
+const rows = parseCsv(bytes, { encoding: "windows-1254" })
+```
+
+Any label `TextDecoder` accepts works — the WHATWG Encoding Standard's
+full set, legacy single-byte encodings included. Passing a string skips
+all of this: you have already decided.
+
+The CLI takes `--encoding` for the same reason, and reads the mark
+without being asked:
+
+```bash
+hucre convert veriler.csv out.xlsx --encoding windows-1254
+```
+
+On the write side there is nothing to configure: `writeCsv` emits UTF-8,
+and `bom: true` is what makes Excel open it correctly on every locale.
 
 ### Schema Validation
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -305,6 +305,14 @@ separator, header handling, `skipHeaderRow`, type inference, leading-zero
 preservation, comment lines, and formula-injection escaping — which now
 has an inverse in `unescapeFormulae`.
 
+**Encoding is read, not guessed.** The readers take bytes and honour a
+byte-order mark — UTF-8, UTF-16LE, UTF-16BE — and fall back to UTF-8.
+Anything else has to be named through `encoding`, because an encoding like
+windows-1254 leaves no trace in the file and distinguishing it from
+windows-1252 by byte frequency is a guess. The write side emits UTF-8
+only; `bom: true` is the option that makes Excel read it correctly on
+every locale.
+
 One-way, and documented on each option:
 
 | option               | why                                                                                                                          |

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1630,6 +1630,22 @@ export interface OutlineProperties {
  * `validateWithSchema` on the parsed rows, which does implement it.
  */
 export interface CsvReadOptions {
+  /**
+   * How to decode byte input. Ignored when a string is passed — the
+   * caller has already decided.
+   *
+   * Any label from the WHATWG Encoding Standard, which is what
+   * `TextDecoder` accepts: `"utf-8"`, `"utf-16le"`, `"windows-1254"`,
+   * `"iso-8859-9"`, and the rest. Default: the encoding the file's
+   * byte-order mark declares, or UTF-8 when it carries none.
+   *
+   * There is no detection beyond the mark. A mark is a statement the file
+   * makes about itself; telling windows-1254 from windows-1252 by byte
+   * frequency is a guess, and a wrong one often enough to be worse than
+   * asking. If your source is a legacy-encoded export — Excel on a
+   * Turkish or Central European Windows, say — name it. See #475.
+   */
+  encoding?: string
   /** Field delimiter. Default: auto-detect */
   delimiter?: string
   /** Quote character. Default: " */

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -104,7 +104,7 @@ export function delimiterForExtension(filePath: string): string {
   return DELIMITERS[extname(filePath).toLowerCase()] ?? ","
 }
 
-export async function readFile(filePath: string): Promise<Workbook> {
+export async function readFile(filePath: string, encoding?: string): Promise<Workbook> {
   const format = detectFormatFromExtension(filePath)
   const data = readFileSync(filePath)
   const input = new Uint8Array(data)
@@ -119,8 +119,16 @@ export async function readFile(filePath: string): Promise<Workbook> {
     case "ods":
       return readOds(input)
     case "csv": {
-      const text = new TextDecoder("utf-8").decode(input)
-      const rows = parseCsv(text, { delimiter: delimiterForExtension(filePath) })
+      // The bytes go to parseCsv, which reads the byte-order mark. This
+      // used to decode UTF-8 unconditionally, so a CSV out of a Turkish or
+      // Central European Excel — windows-1254, windows-1250 — converted to
+      // mojibake, silently, from the one place in the library that has the
+      // bytes and could know better. `--encoding` covers what no mark can
+      // say. See #475.
+      const rows = parseCsv(input, {
+        delimiter: delimiterForExtension(filePath),
+        encoding,
+      })
       return {
         sheets: [{ name: "Sheet1", rows }],
       }
@@ -154,6 +162,12 @@ export const convertCommand = defineCommand({
       description: "Output file path",
       required: true,
     },
+    encoding: {
+      type: "string",
+      description:
+        "Character encoding of a CSV/TSV input (e.g. windows-1254). " +
+        "Default: the file's byte-order mark, or utf-8.",
+    },
   },
   async run({ args }) {
     const inputPath = args.input as string
@@ -161,7 +175,7 @@ export const convertCommand = defineCommand({
     const outputFormat = detectOutputFormat(outputPath)
 
     consola.start(`Reading ${inputPath}...`)
-    const workbook = await readFile(inputPath)
+    const workbook = await readFile(inputPath, args.encoding as string | undefined)
     consola.success(`Read ${workbook.sheets.length} sheet(s)`)
 
     consola.start(`Writing ${outputPath}...`)
@@ -220,12 +234,18 @@ export const inspectCommand = defineCommand({
       type: "string",
       description: "Sheet index to show detailed data (0-based)",
     },
+    encoding: {
+      type: "string",
+      description:
+        "Character encoding of a CSV/TSV input (e.g. windows-1254). " +
+        "Default: the file's byte-order mark, or utf-8.",
+    },
   },
   async run({ args }) {
     const filePath = args.file as string
 
     consola.start(`Inspecting ${filePath}...`)
-    const workbook = await readFile(filePath)
+    const workbook = await readFile(filePath, args.encoding as string | undefined)
 
     consola.info(`Sheets: ${workbook.sheets.length}`)
 
@@ -352,7 +372,7 @@ export const validateCommand = defineCommand({
     }
 
     // Read spreadsheet
-    const workbook = await readFile(filePath)
+    const workbook = await readFile(filePath, args.encoding as string | undefined)
 
     if (sheetIdx < 0 || sheetIdx >= workbook.sheets.length) {
       throw new CliError(

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -10,6 +10,8 @@ export {
 } from "./csv/index"
 export type { CsvObjectsResult } from "./csv/index"
 export { streamCsvRows, CsvStreamWriter, writeCsvStream } from "./csv/stream"
+export { decodeCsvInput, detectBom } from "./csv/encoding"
+export type { CsvInput, BomEncoding } from "./csv/encoding"
 export type { CsvStreamRow, CsvStreamWriterOptions } from "./csv/stream"
 
 // ── Shared types used by this entry point's signatures ──────────────

--- a/src/csv/encoding.ts
+++ b/src/csv/encoding.ts
@@ -1,0 +1,86 @@
+// ── CSV input decoding ───────────────────────────────────────────────
+//
+// Every other reader in the library takes bytes. CSV took a string, so
+// the byte→string step — which is where the actual difficulty of CSV
+// lives — was the caller's alone, and the CLI resolved it by assuming
+// UTF-8. A CSV written by Excel on a Turkish, Polish or Greek Windows is
+// windows-1254 / 1250 / 1253, and came through as mojibake. See #475.
+//
+// What this does is decode, not guess. A byte-order mark is a statement
+// the file makes about itself, so it is honoured; anything else needs the
+// caller to say, because telling windows-1254 from windows-1252 by byte
+// frequency is a research problem that is wrong often enough to be
+// dangerous, and it has no place in a zero-dependency library.
+
+import { InvalidArgumentError } from "../errors"
+
+/** What a byte-order mark says the file is, if it carries one. */
+export type BomEncoding = "utf-8" | "utf-16le" | "utf-16be"
+
+/**
+ * Read the byte-order mark, if there is one.
+ *
+ * `utf-16le` is the one worth knowing about: it is what Excel's "Save as
+ * Unicode Text" produces, and decoded as UTF-8 it becomes a run of
+ * NUL-separated letters that a CSV parser reads as data rather than
+ * rejecting.
+ */
+export function detectBom(bytes: Uint8Array): { encoding: BomEncoding; length: number } | null {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return { encoding: "utf-8", length: 3 }
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return { encoding: "utf-16le", length: 2 }
+  }
+  if (bytes.length >= 2 && bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return { encoding: "utf-16be", length: 2 }
+  }
+  return null
+}
+
+/** Anything a synchronous CSV reader can be handed. */
+export type CsvInput = string | Uint8Array | ArrayBuffer
+
+function toBytes(input: Uint8Array | ArrayBuffer): Uint8Array {
+  return input instanceof Uint8Array ? input : new Uint8Array(input)
+}
+
+/**
+ * Turn CSV input into a string.
+ *
+ * A string passes through untouched — the caller has already decided.
+ * Bytes are decoded with, in order: the `encoding` the caller named, the
+ * encoding the byte-order mark declares, or UTF-8.
+ *
+ * `TextDecoder` does the work, so the set of names accepted is the WHATWG
+ * Encoding Standard's — every label in it, including the legacy
+ * single-byte ones, in every runtime hucre supports.
+ */
+export function decodeCsvInput(input: CsvInput, encoding?: string): string {
+  if (typeof input === "string") return input
+
+  const bytes = toBytes(input)
+  const bom = detectBom(bytes)
+
+  // A named encoding wins over the mark. The caller knows something we do
+  // not, and a file can carry a mark that is simply wrong.
+  const label = encoding ?? bom?.encoding ?? "utf-8"
+
+  let decoder: TextDecoder
+  try {
+    decoder = new TextDecoder(label)
+  } catch (error) {
+    throw new InvalidArgumentError(
+      `Unknown encoding "${label}". Pass a label from the WHATWG Encoding Standard ` +
+        `— "utf-8", "utf-16le", "windows-1254", "iso-8859-9" and so on — or omit ` +
+        "`encoding` to use the byte-order mark, or UTF-8 when there is none.",
+      { cause: error },
+    )
+  }
+
+  // TextDecoder strips a UTF-8 BOM itself, but not a UTF-16 one when the
+  // caller named the encoding rather than letting the mark speak — and it
+  // strips nothing when the mark disagrees with the label. Cutting it here
+  // makes the three paths behave the same.
+  return decoder.decode(bom ? bytes.subarray(bom.length) : bytes)
+}

--- a/src/csv/fetch.ts
+++ b/src/csv/fetch.ts
@@ -1,10 +1,29 @@
 import type { CsvReadOptions, CellValue } from "../_types"
 import { parseCsv } from "./reader"
 
-/** Fetch a CSV from a URL and parse it (requires fetch API — Node.js/Deno) */
+/**
+ * Fetch a CSV from a URL and parse it (requires the fetch API).
+ *
+ * The response's own `Content-Type; charset=` wins when it names one,
+ * because the server is asserting something. Otherwise the bytes are
+ * handed to `parseCsv`, which reads the byte-order mark — this used to go
+ * through `response.text()`, which assumes UTF-8 in that case and turns a
+ * UTF-16 export into NUL-separated letters. `options.encoding` overrides
+ * both. See #475.
+ */
 export async function fetchCsv(url: string, options?: CsvReadOptions): Promise<CellValue[][]> {
   const response = await fetch(url)
   if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`)
-  const text = await response.text()
-  return parseCsv(text, options)
+
+  const declared = charsetOf(response.headers.get("content-type"))
+  const bytes = new Uint8Array(await response.arrayBuffer())
+
+  return parseCsv(bytes, { ...options, encoding: options?.encoding ?? declared })
+}
+
+/** The `charset=` of a Content-Type header, if it carries one. */
+function charsetOf(contentType: string | null): string | undefined {
+  if (!contentType) return undefined
+  const match = /;\s*charset\s*=\s*"?([^";]+)"?/i.exec(contentType)
+  return match ? match[1]!.trim() : undefined
 }

--- a/src/csv/reader.ts
+++ b/src/csv/reader.ts
@@ -2,6 +2,7 @@ import type { CellValue, CsvReadOptions } from "../_types"
 import { rowsToObjects } from "../_objects"
 import { unescapeFormula } from "./formula"
 import { inferType } from "../_infer"
+import { decodeCsvInput, type CsvInput } from "./encoding"
 
 // ── Public API ───────────────────────────────────────────────────────
 
@@ -57,11 +58,15 @@ export function detectDelimiter(input: string): string {
 /**
  * Parse a CSV string into a 2D array of cell values.
  */
-export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][] {
+export function parseCsv(input: CsvInput, options?: CsvReadOptions): CellValue[][] {
   const opts = normalizeReadOptions(options)
 
+  // Bytes are decoded here, honouring the byte-order mark; a string is
+  // whatever the caller already decoded. See ./encoding.ts.
+  let text = decodeCsvInput(input, options?.encoding)
+
   if (opts.skipBom) {
-    input = stripBom(input)
+    text = stripBom(text)
   }
 
   // Skip the first N lines before parsing
@@ -69,11 +74,11 @@ export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][]
   if (skipLines && skipLines > 0) {
     let linesSkipped = 0
     let pos = 0
-    while (linesSkipped < skipLines && pos < input.length) {
-      const ch = input[pos]!
+    while (linesSkipped < skipLines && pos < text.length) {
+      const ch = text[pos]!
       if (ch === "\r") {
         linesSkipped++
-        if (pos + 1 < input.length && input[pos + 1] === "\n") {
+        if (pos + 1 < text.length && text[pos + 1] === "\n") {
           pos += 2
         } else {
           pos++
@@ -85,23 +90,23 @@ export function parseCsv(input: string, options?: CsvReadOptions): CellValue[][]
         pos++
       }
     }
-    input = input.slice(pos)
+    text = text.slice(pos)
   }
 
-  if (input.length === 0) return []
+  if (text.length === 0) return []
 
-  const delimiter = opts.delimiter ?? detectDelimiter(input)
+  const delimiter = opts.delimiter ?? detectDelimiter(text)
   const quote = opts.quote
   const escape = opts.escape
 
   let rows: string[][]
   let firstFieldQuoted: boolean[]
   if (options?.fastMode) {
-    rows = parseFast(input, delimiter)
+    rows = parseFast(text, delimiter)
     // Fast mode does no quote handling, so no field is ever "quoted".
     firstFieldQuoted = Array.from({ length: rows.length }, () => false)
   } else {
-    const parsed = parseRaw(input, delimiter, quote, escape)
+    const parsed = parseRaw(text, delimiter, quote, escape)
     rows = parsed.rows
     firstFieldQuoted = parsed.firstFieldQuoted
   }
@@ -214,7 +219,7 @@ export interface CsvObjectsResult<T extends Record<string, CellValue> = Record<s
  * and the detected headers.
  */
 export function parseCsvObjects<T extends Record<string, CellValue> = Record<string, CellValue>>(
-  input: string,
+  input: CsvInput,
   options?: CsvReadOptions & { header: true },
 ): CsvObjectsResult<T> {
   // Pass through without transformValue/transformHeader to parseCsv — we handle them here

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -15,6 +15,7 @@ import type { CellValue, CsvReadOptions, CsvWriteOptions } from "../_types"
 import { stripBom, detectDelimiter } from "./reader"
 import { escapeFormula, unescapeFormula } from "./formula"
 import { inferType } from "../_infer"
+import { decodeCsvInput, type CsvInput } from "./encoding"
 import { formatDate as formatExcelDate } from "../_date"
 
 const TEXT_ENCODER = /* @__PURE__ */ new TextEncoder()
@@ -39,9 +40,18 @@ function startsWith(str: string, prefix: string, offset: number): boolean {
  * Processes the string incrementally and yields one row at a time.
  */
 export function* streamCsvRows(
-  input: string,
+  input: CsvInput,
   options?: CsvReadOptions,
 ): Generator<CellValue[], void, undefined> {
+  // Same decoding as parseCsv — see ./encoding.ts. This generator walks a
+  // whole string either way, so taking bytes costs nothing and removes
+  // the trap of the caller decoding chunks by hand.
+  //
+  // For a genuinely chunked source, pipe it through `TextDecoderStream`
+  // before joining: a multi-byte character split across two chunks is the
+  // thing that decoder exists to handle.
+  let text = decodeCsvInput(input, options?.encoding)
+
   const skipBom = options?.skipBom !== false
   const quote = options?.quote ?? '"'
   const escape = options?.escape ?? '"'
@@ -63,13 +73,13 @@ export function* streamCsvRows(
   const fastMode = options?.fastMode ?? false
 
   if (skipBom) {
-    input = stripBom(input)
+    text = stripBom(text)
   }
 
-  if (input.length === 0) return
+  if (text.length === 0) return
 
-  const delimiter = options?.delimiter ?? detectDelimiter(input)
-  const len = input.length
+  const delimiter = options?.delimiter ?? detectDelimiter(text)
+  const len = text.length
 
   let i = 0
   let isFirstRow = true
@@ -89,11 +99,11 @@ export function* streamCsvRows(
     let rowFirstQuoted = false
 
     while (i < len && !rowDone) {
-      const ch = input[i]!
+      const ch = text[i]!
 
       if (inQuoted) {
         // Check for escape sequence
-        if (ch === escape && i + 1 < len && input[i + 1] === quote) {
+        if (ch === escape && i + 1 < len && text[i + 1] === quote) {
           currentField += quote
           i += 2
           continue
@@ -111,7 +121,7 @@ export function* streamCsvRows(
       }
 
       // Not in quoted field
-      if (startsWith(input, delimiter, i)) {
+      if (startsWith(text, delimiter, i)) {
         if (row.length === 0) rowFirstQuoted = fieldWasQuoted
         row.push(currentField)
         currentField = ""
@@ -126,7 +136,7 @@ export function* streamCsvRows(
         row.push(currentField)
         currentField = ""
         fieldWasQuoted = false
-        if (i + 1 < len && input[i + 1] === "\n") {
+        if (i + 1 < len && text[i + 1] === "\n") {
           i += 2
         } else {
           i++
@@ -159,7 +169,7 @@ export function* streamCsvRows(
       i++
     }
 
-    // End of input without trailing newline.
+    // End of text without trailing newline.
     // Preserve a final row whose single field was an explicit quoted-empty
     // field ("").
     if (!rowDone) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,8 @@ export {
 } from "./csv/index"
 export type { CsvObjectsResult } from "./csv/index"
 export { streamCsvRows, CsvStreamWriter, writeCsvStream } from "./csv/stream"
+export { decodeCsvInput, detectBom } from "./csv/encoding"
+export type { CsvInput, BomEncoding } from "./csv/encoding"
 export type { CsvStreamRow, CsvStreamWriterOptions } from "./csv/stream"
 
 // ── JSON ───────────────────────────────────────────────────────────

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -3,6 +3,8 @@
 exports[`export surface snapshot > hucre/csv 1`] = `
 [
   "CsvStreamWriter",
+  "decodeCsvInput",
+  "detectBom",
   "detectDelimiter",
   "fetchCsv",
   "formatCsvValue",
@@ -147,9 +149,11 @@ exports[`export surface snapshot > root 1`] = `
   "copyRange",
   "copySheetToWorkbook",
   "dateToSerial",
+  "decodeCsvInput",
   "deleteColumns",
   "deleteRows",
   "deserializeWorkbook",
+  "detectBom",
   "detectDelimiter",
   "fetchCsv",
   "fillTemplate",

--- a/test/csv-encoding.test.ts
+++ b/test/csv-encoding.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+import { parseCsv, parseCsvObjects } from "../src/csv/reader"
+import { streamCsvRows } from "../src/csv/stream"
+import { detectBom, decodeCsvInput } from "../src/csv/encoding"
+import { InvalidArgumentError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #475 — `parseCsv` took a string while every other reader took bytes, so
+// the byte→string step was the caller's alone. That is where the actual
+// difficulty of CSV lives: Excel on a Turkish Windows writes
+// windows-1254, and "Save as Unicode Text" writes UTF-16LE with a BOM.
+//
+// What this does is decode, not guess. A byte-order mark is a statement
+// the file makes about itself and is honoured; anything else has to be
+// named, because telling windows-1254 from windows-1252 by byte frequency
+// is a guess wrong often enough to be worse than asking.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** `ad,şehir\nÖzgür,İstanbul` as Excel-on-Turkish-Windows writes it. */
+const WINDOWS_1254 = new Uint8Array([
+  0x61,
+  0x64,
+  0x2c,
+  0xfe,
+  0x65,
+  0x68,
+  0x69,
+  0x72,
+  0x0a, // ad,şehir
+  0xd6,
+  0x7a,
+  0x67,
+  0xfc,
+  0x72,
+  0x2c,
+  0xdd,
+  0x73,
+  0x74,
+  0x61,
+  0x6e,
+  0x62,
+  0x75,
+  0x6c, // Özgür,İstanbul
+])
+
+const TEXT = "ad,şehir\nÖzgür,İstanbul"
+const EXPECTED = [
+  ["ad", "şehir"],
+  ["Özgür", "İstanbul"],
+]
+
+function utf8(text: string, bom = false): Uint8Array {
+  return new TextEncoder().encode(bom ? `﻿${text}` : text)
+}
+
+function utf16(text: string, littleEndian: boolean): Uint8Array {
+  const withBom = `﻿${text}`
+  const out = new Uint8Array(withBom.length * 2)
+  const view = new DataView(out.buffer)
+  for (let i = 0; i < withBom.length; i++) {
+    view.setUint16(i * 2, withBom.charCodeAt(i), littleEndian)
+  }
+  return out
+}
+
+describe("detectBom", () => {
+  it("reads the three marks", () => {
+    expect(detectBom(utf8(TEXT, true))).toEqual({ encoding: "utf-8", length: 3 })
+    expect(detectBom(utf16(TEXT, true))).toEqual({ encoding: "utf-16le", length: 2 })
+    expect(detectBom(utf16(TEXT, false))).toEqual({ encoding: "utf-16be", length: 2 })
+  })
+
+  it("says nothing when there is no mark", () => {
+    expect(detectBom(utf8(TEXT))).toBeNull()
+    expect(detectBom(WINDOWS_1254)).toBeNull()
+    expect(detectBom(new Uint8Array([]))).toBeNull()
+    expect(detectBom(new Uint8Array([0xef]))).toBeNull()
+  })
+})
+
+describe("parseCsv takes bytes", () => {
+  it("reads plain UTF-8", () => {
+    expect(parseCsv(utf8(TEXT))).toEqual(EXPECTED)
+  })
+
+  it("reads UTF-8 with a BOM without leaving it in the first header", () => {
+    const rows = parseCsv(utf8(TEXT, true))
+
+    expect(rows).toEqual(EXPECTED)
+    expect(rows[0]![0]).toBe("ad")
+  })
+
+  it('reads UTF-16LE, which is what Excel\'s "Unicode Text" writes', () => {
+    // Decoded as UTF-8 this is a run of NUL-separated letters that a CSV
+    // parser reads as data rather than rejecting.
+    expect(parseCsv(utf16(TEXT, true))).toEqual(EXPECTED)
+  })
+
+  it("reads UTF-16BE", () => {
+    expect(parseCsv(utf16(TEXT, false))).toEqual(EXPECTED)
+  })
+
+  it("reads a named legacy encoding no mark can declare", () => {
+    expect(parseCsv(WINDOWS_1254, { encoding: "windows-1254" })).toEqual(EXPECTED)
+  })
+
+  it("does not guess at that encoding", () => {
+    // Without being told, these bytes are read as UTF-8 and come back as
+    // replacement characters. That is the honest answer — there is nothing
+    // in the file that says otherwise.
+    expect(parseCsv(WINDOWS_1254)[0]![1]).not.toBe("şehir")
+  })
+
+  it("lets an explicit encoding override the mark", () => {
+    // A file can carry a mark that is simply wrong; the caller knows.
+    expect(parseCsv(utf8(TEXT, true), { encoding: "utf-8" })).toEqual(EXPECTED)
+  })
+
+  it("takes an ArrayBuffer as well as a Uint8Array", () => {
+    const bytes = utf8(TEXT)
+    const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+
+    expect(parseCsv(buffer as ArrayBuffer)).toEqual(EXPECTED)
+  })
+
+  it("leaves a string exactly as it was", () => {
+    expect(parseCsv(TEXT)).toEqual(EXPECTED)
+  })
+
+  it("refuses an encoding label TextDecoder cannot use", () => {
+    expect(() => parseCsv(utf8(TEXT), { encoding: "not-an-encoding" })).toThrow(
+      InvalidArgumentError,
+    )
+  })
+})
+
+describe("the other readers take bytes too", () => {
+  it("parseCsvObjects", () => {
+    const { data, headers } = parseCsvObjects(WINDOWS_1254, {
+      header: true,
+      encoding: "windows-1254",
+    })
+
+    expect(headers).toEqual(["ad", "şehir"])
+    expect(data).toEqual([{ ad: "Özgür", şehir: "İstanbul" }])
+  })
+
+  it("streamCsvRows", () => {
+    expect([...streamCsvRows(utf16(TEXT, true))]).toEqual(EXPECTED)
+    expect([...streamCsvRows(WINDOWS_1254, { encoding: "windows-1254" })]).toEqual(EXPECTED)
+  })
+
+  it("streamCsvRows still takes a string", () => {
+    expect([...streamCsvRows(TEXT)]).toEqual(EXPECTED)
+  })
+})
+
+describe("decodeCsvInput", () => {
+  it("prefers the named encoding, then the mark, then utf-8", () => {
+    expect(decodeCsvInput(WINDOWS_1254, "windows-1254")).toBe(TEXT)
+    expect(decodeCsvInput(utf16(TEXT, true))).toBe(TEXT)
+    expect(decodeCsvInput(utf8(TEXT))).toBe(TEXT)
+  })
+
+  it("strips the mark whichever path decoded it", () => {
+    // TextDecoder drops a UTF-8 BOM itself but not a UTF-16 one when the
+    // caller named the encoding, so the three paths would otherwise differ.
+    expect(decodeCsvInput(utf16(TEXT, true), "utf-16le")).toBe(TEXT)
+    expect(decodeCsvInput(utf8(TEXT, true), "utf-8")).toBe(TEXT)
+  })
+})


### PR DESCRIPTION
Closes #475.

## The gap

`parseCsv`, `parseCsvObjects` and `streamCsvRows` took `input: string`. Every other reader in the library takes bytes. So for CSV — and only CSV — the byte→string step was the caller's, and that step is where the actual difficulty of CSV lives.

`stripBom` looked like it covered this and did not: it takes a *string* and drops a leading `U+FEFF` code point, which is the residue of a decode rather than a byte-order mark. `TextDecoder` already strips that itself, so on the common path it was a belt-and-braces for callers who decoded some other way.

Measured against `dist/` before this change:

```
the platform can already do it:
  windows-1254 supported: true
  decoded correctly:      "ad,şehir\nÖzgür,İstanbul\n"

the obvious wrong way (what the CLI did):
  utf-8 decode:           "ad,�ehir\n�zg�r,�stanbul\n"
```

`hucre convert veriler.csv out.xlsx` hard-coded UTF-8, so a CSV out of a Turkish or Central European Excel converted to mojibake **silently**, from the one place in the library that had the bytes and could have known better. And Excel's "Save as Unicode Text" is UTF-16LE with a BOM, which decoded as UTF-8 becomes a run of NUL-separated letters the parser reads as three rows of data rather than rejecting.

## What landed

The three readers take `string | Uint8Array | ArrayBuffer`. Bytes are decoded with, in order:

1. the encoding the caller named
2. the encoding the byte-order mark declares
3. UTF-8

| leading bytes | read as |
| --- | --- |
| `EF BB BF` | utf-8 |
| `FF FE` | utf-16le |
| `FE FF` | utf-16be |
| anything else | the `encoding` option, else utf-8 |

**This decodes; it does not guess.** A mark is a statement the file makes about itself, so it is honoured. Anything else has to be named:

```ts
parseCsv(bytes, { encoding: "windows-1254" })
```

Statistical charset sniffing is deliberately absent — telling windows-1254 from windows-1252 by byte frequency is a research problem, wrong often enough to be dangerous, and out of scope for a zero-dependency library. One of the tests pins that: undeclared windows-1254 bytes come back as replacement characters, which is the honest answer.

`TextDecoder` does the work, so the accepted labels are the WHATWG Encoding Standard's — legacy single-byte encodings included — in every runtime hucre supports. An unusable label throws `InvalidArgumentError` rather than falling back.

## Also

- **`fetchCsv`** used `response.text()`, which assumes UTF-8 when the response declares no charset. It reads the bytes now, so the mark is honoured; a `charset=` in `Content-Type` still wins, because the server is asserting something.
- **`convert`, `inspect` and `validate` take `--encoding`**, and read the mark without being asked.
- **`detectBom` and `decodeCsvInput` are exported**, for callers who want to sniff without parsing.

## The write side is unchanged

It needs nothing. `writeCsv` emits UTF-8 and `bom: true` is what makes Excel open it correctly on every locale. There is no reason to *write* a legacy encoding.

## Tests

`test/csv-encoding.test.ts`, 17 assertions: the three marks and their absence, all four encodings through `parseCsv`, an explicit encoding overriding a mark, `ArrayBuffer` input, a string passing through untouched, the throw on a bad label, that undeclared legacy bytes are *not* guessed at, and the same through `parseCsvObjects` and `streamCsvRows`.

**11 of the 17 fail against `main`.**