### PR TITLE
fix(xlsx): keep the chart when a sheet also has images — closes #465

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -138,6 +138,15 @@ column, line, pie, scatter, area, doughnut). `bar3D`, `line3D`, `pie3D`,
 `area3D`, `bubble`, `radar`, `surface`, `surface3D`, `stock` and `ofPie`
 read and survive `saveXlsx`, but `SheetChart` cannot express them.
 
+That last sentence has one exception, and it follows from the format: a
+worksheet carries exactly one `<drawing>` element, so images and charts on
+a sheet have to share one drawing part. When a sheet has hucre-managed
+images, hucre regenerates that part — and can only put back the charts it
+can author. So on **a sheet that also has images**, a chart of one of the
+nine unauthorable kinds is dropped; the seven authorable kinds survive
+with their anchors. A chart on a sheet hucre leaves alone is preserved as
+raw bytes regardless of kind, which is the common case. See #465.
+
 ### Pivot tables
 
 Read and written, but **the two types are disjoint**. `PivotTable` (what

--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -312,12 +312,18 @@ export async function saveXlsx(
   const drawingResults: Array<DrawingResult | null> = []
   const drawingIndices: number[] = []
   const imageExtensions = new Set<string>()
+  // Where each sheet's images started in the global media numbering. The
+  // chart pass below rebuilds some of these drawings and has to hand
+  // `writeDrawing` the same start index, or the second pass would number
+  // the media parts differently from the ones actually written. See #465.
+  const imageStartIndices: number[] = []
   let globalImageIndex = 1
 
   for (let i = 0; i < writeSheets.length; i++) {
     const sheet = writeSheets[i]
     const images = sheet.images ?? []
     const hasTextBoxes = sheet.textBoxes !== undefined && sheet.textBoxes.length > 0
+    imageStartIndices.push(globalImageIndex)
     // A drawing part hosts images *and* text boxes. Gating on images
     // alone meant a text-box-only sheet produced no drawing, and a sheet
     // with both produced one that silently dropped the text boxes —
@@ -578,10 +584,10 @@ export async function saveXlsx(
   //      and Excel drops the chart on next open.
   //
   // For sheets that hucre *does* regenerate (because the sheet has
-  // hucre-managed images), the chart graphicFrame inside the drawing
-  // is currently rebuilt without the chart anchor; that's a Phase 2
-  // limitation — for now we still preserve the chart bodies so a
-  // future merge step can re-anchor them.
+  // hucre-managed images), the charts are re-authored from the model
+  // into that same drawing by the model-chart pass below, anchors and
+  // all — see #465. Preserving the original bodies here still matters
+  // for every sheet hucre leaves alone.
   const chartIndices: number[] = []
   const chartStyleIndices: number[] = []
   const chartColorsIndices: number[] = []
@@ -679,14 +685,18 @@ export async function saveXlsx(
   // charts appended to a workbook after openXlsx — are serialized here
   // through the same drawing + chart pipeline the fresh writer uses.
   //
-  // SAFETY: we only emit model charts for a sheet that has NO drawing of
-  // its own already in play — no hucre-regenerated image drawing
-  // (`drawingResults[i]`), no preserved original chart drawing
-  // (`sheetPreservedDrawingTargets[i]`), and no other original drawing
-  // relationship. That keeps this purely additive: it never rewrites or
-  // collides with a drawing the roundtrip is already preserving. Adding
-  // a chart to a sheet that already owns a drawing is out of scope for
-  // the roundtrip path — use the fresh writeXlsx path for that.
+  // SAFETY: we never touch a drawing the roundtrip is *preserving* —
+  // a preserved original chart drawing (`sheetPreservedDrawingTargets[i]`)
+  // or any other original drawing relationship is left exactly alone, so
+  // this can neither rewrite nor collide with foreign XML.
+  //
+  // A drawing hucre itself regenerated this run (`drawingResults[i]`, for
+  // images and text boxes) is different: hucre owns every byte of it, so
+  // the charts are folded into that same drawing rather than skipped.
+  // Skipping was the old behaviour and it lost the chart outright — a
+  // sheet with both an image and a chart came back with the image and no
+  // chart at all, because the worksheet carries one `<drawing>` element
+  // and the regenerated one had no graphicFrame in it. See #465.
   type ChartFileEntry = { globalIndex: number; xml: string; rels: string }
   interface ModelChartDrawing {
     drawing: DrawingResult
@@ -694,6 +704,8 @@ export async function saveXlsx(
     charts: ChartFileEntry[]
   }
   const modelChartDrawings: Array<ModelChartDrawing | null> = sheets.map(() => null)
+  /** Chart bodies folded into a sheet's regenerated *image* drawing (#465). */
+  const imageDrawingCharts: Array<ChartFileEntry[]> = sheets.map(() => [])
   const newModelChartIndices: number[] = []
   {
     const sheetHasOriginalDrawingRel = (i: number): boolean => {
@@ -723,16 +735,18 @@ export async function saveXlsx(
     for (let i = 0; i < sheets.length; i++) {
       const srcCharts = sheets[i].charts
       if (!srcCharts || srcCharts.length === 0) continue
-      // Skip sheets that already own a drawing — see SAFETY note above.
-      if (drawingResults[i]) continue
-      if (sheetPreservedDrawingTargets[i] !== undefined) continue
-      if (sheetHasOriginalDrawingRel(i)) continue
+      // Never touch a drawing we are preserving — see SAFETY note above.
+      // A drawing hucre regenerated this run is ours to extend, and is
+      // handled by the `ownsImageDrawing` branch below.
+      const ownsImageDrawing = drawingResults[i] !== null
+      if (!ownsImageDrawing) {
+        if (sheetPreservedDrawingTargets[i] !== undefined) continue
+        if (sheetHasOriginalDrawingRel(i)) continue
+      }
 
       const writeCharts = toWriteCharts(srcCharts as Array<Chart | SheetChart>)
       if (writeCharts.length === 0) continue
 
-      const drawingNumber = nextDrawingNumber++
-      const drawing = writeDrawing([], globalImageIndex, undefined, writeCharts, nextChartNumber)
       const charts: ChartFileEntry[] = []
       for (let c = 0; c < writeCharts.length; c++) {
         const written = writeChart(writeCharts[c], sheets[i].name)
@@ -740,12 +754,32 @@ export async function saveXlsx(
         charts.push({ globalIndex: g, xml: written.chartXml, rels: written.chartRels })
         newModelChartIndices.push(g)
       }
+
+      if (ownsImageDrawing) {
+        // Rebuild the drawing hucre already produced for this sheet's
+        // images and text boxes, this time with the graphicFrames in it.
+        // Same drawing number (i + 1) and same media start index, so the
+        // worksheet's existing `<drawing>` reference and every image part
+        // this loop already accounted for stay exactly as they were.
+        const sheet = writeSheets[i]
+        drawingResults[i] = writeDrawing(
+          sheet.images ?? [],
+          imageStartIndices[i],
+          sheet.textBoxes,
+          writeCharts,
+          nextChartNumber,
+        )
+        imageDrawingCharts[i] = charts
+      } else {
+        const drawingNumber = nextDrawingNumber++
+        const drawing = writeDrawing([], globalImageIndex, undefined, writeCharts, nextChartNumber)
+        modelChartDrawings[i] = { drawing, drawingNumber, charts }
+        drawingIndices.push(drawingNumber)
+        regeneratedPaths.add(`xl/drawings/drawing${drawingNumber}.xml`)
+        regeneratedPaths.add(`xl/drawings/_rels/drawing${drawingNumber}.xml.rels`)
+      }
       nextChartNumber += writeCharts.length
 
-      modelChartDrawings[i] = { drawing, drawingNumber, charts }
-      drawingIndices.push(drawingNumber)
-      regeneratedPaths.add(`xl/drawings/drawing${drawingNumber}.xml`)
-      regeneratedPaths.add(`xl/drawings/_rels/drawing${drawingNumber}.xml.rels`)
       for (const cf of charts) {
         regeneratedPaths.add(`xl/charts/chart${cf.globalIndex}.xml`)
         regeneratedPaths.add(`xl/charts/_rels/chart${cf.globalIndex}.xml.rels`)
@@ -1167,6 +1201,11 @@ export async function saveXlsx(
       zip.add(`xl/drawings/_rels/drawing${i + 1}.xml.rels`, encoder.encode(drawing.drawingRels))
       for (const img of drawing.images) {
         zip.add(img.path, img.data, { compress: false })
+      }
+      // Charts folded into this same drawing (#465).
+      for (const cf of imageDrawingCharts[i]) {
+        zip.add(`xl/charts/chart${cf.globalIndex}.xml`, encoder.encode(cf.xml))
+        zip.add(`xl/charts/_rels/chart${cf.globalIndex}.xml.rels`, encoder.encode(cf.rels))
       }
     }
 

--- a/test/coverage-roundtrip-pivot.test.ts
+++ b/test/coverage-roundtrip-pivot.test.ts
@@ -735,7 +735,7 @@ describe("chart parts survive the roundtrip", () => {
 })
 
 describe("model charts added to an opened workbook", () => {
-  it("skips a sheet that already owns a hucre-managed image drawing", async () => {
+  it("folds into the drawing a sheet already owns for its images", async () => {
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
     const wb = await openXlsx(
       await writeXlsx({
@@ -749,12 +749,16 @@ describe("model charts added to an opened workbook", () => {
     )
     // @ts-expect-error Sheet.charts is the read model; the roundtrip
     // bridge accepts write-model entries here (issue #136).
-    wb.sheets[0].charts = [chartOn(7, "Too late")]
+    wb.sheets[0].charts = [chartOn(7, "In time")]
     const saved = await saveXlsx(wb)
 
-    // The image drawing is rebuilt; adding a chart to it is out of scope,
-    // so no chart part appears.
-    expect(entries(saved).some((n) => n.startsWith("xl/charts/"))).toBe(false)
+    // hucre authored that image drawing this run, so it is hucre's to
+    // extend — the chart goes into it rather than being dropped. Skipping
+    // was the old behaviour and it lost the chart outright. See #465.
+    expect(entries(saved).some((n) => n.startsWith("xl/charts/"))).toBe(true)
+    expect(entries(saved).filter((n) => /^xl\/drawings\/drawing\d+\.xml$/.test(n))).toEqual([
+      "xl/drawings/drawing1.xml",
+    ])
   })
 
   it("skips a sheet whose original drawing hucre is no longer rebuilding", async () => {

--- a/test/roundtrip-chart-anchors.test.ts
+++ b/test/roundtrip-chart-anchors.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { getCharts } from "../src/xlsx/chart-helpers"
+import { ZipReader } from "../src/zip/reader"
+import type { SheetChart, WriteSheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #465 — a worksheet carries exactly one `<drawing>` element, so images
+// and charts on the same sheet have to share one drawing part. The
+// roundtrip built that part twice over: once for the images, and once,
+// separately, for the charts — and then skipped the chart pass entirely
+// for any sheet that had already produced an image drawing.
+//
+// The visible result was that the chart vanished. Not the anchor, not
+// the styling: the whole chart, silently, on save. This proves both live
+// in the one regenerated drawing, with their anchors intact.
+// ═══════════════════════════════════════════════════════════════════════
+
+const decoder = new TextDecoder("utf-8")
+
+async function readPart(data: Uint8Array, path: string): Promise<string> {
+  return decoder.decode(await new ZipReader(data).extract(path))
+}
+
+/** A 1×1 PNG — the smallest thing that makes a sheet own a drawing. */
+const PNG = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82,
+])
+
+function dataSheet(): WriteSheet {
+  return {
+    name: "Data",
+    rows: [
+      ["Quarter", "Revenue"],
+      ["Q1", 12000],
+      ["Q2", 15500],
+      ["Q3", 14000],
+      ["Q4", 17800],
+    ],
+  }
+}
+
+const CHART: SheetChart = {
+  type: "column",
+  title: "Quarterly Revenue",
+  series: [{ name: "Revenue", values: "B2:B5", categories: "A2:A5" }],
+  anchor: { from: { row: 8, col: 1 }, to: { row: 22, col: 9 } },
+}
+
+/** A workbook whose one sheet owns a hucre-managed image. */
+async function withImage(): Promise<Uint8Array> {
+  const sheet = dataSheet()
+  sheet.images = [{ data: PNG, type: "png", anchor: { from: { row: 0, col: 4 } } }]
+  return writeXlsx({ sheets: [sheet] })
+}
+
+/** Attach a model chart to an opened workbook's sheet. */
+function attachChart(wb: Awaited<ReturnType<typeof openXlsx>>, index = 0): void {
+  // The roundtrip Sheet is the read model; the writer accepts write-model
+  // SheetChart entries here — the same bridge issue #136 established.
+  ;(wb.sheets[index] as unknown as { charts: SheetChart[] }).charts = [CHART]
+}
+
+describe("a sheet with both an image and a chart keeps both", () => {
+  it("emits the chart part at all", async () => {
+    const wb = await openXlsx(await withImage())
+    attachChart(wb)
+
+    const saved = await saveXlsx(wb)
+    const names = new ZipReader(saved).entries()
+
+    expect(names.some((n) => /^xl\/charts\/chart\d+\.xml$/.test(n))).toBe(true)
+    expect(names.some((n) => /^xl\/charts\/_rels\/chart\d+\.xml\.rels$/.test(n))).toBe(true)
+    // The image is still there too — this is not a trade.
+    expect(names.some((n) => /^xl\/media\/image\d+\.png$/.test(n))).toBe(true)
+  })
+
+  it("puts both in the one drawing the worksheet points at", async () => {
+    const wb = await openXlsx(await withImage())
+    attachChart(wb)
+
+    const saved = await saveXlsx(wb)
+
+    // A worksheet carries a single <drawing r:id>. Whatever it resolves
+    // to has to hold the picture and the graphicFrame together.
+    const sheetXml = await readPart(saved, "xl/worksheets/sheet1.xml")
+    const rId = /<drawing r:id="(rId\d+)"/.exec(sheetXml)?.[1]
+    expect(rId).toBeDefined()
+
+    const rels = await readPart(saved, "xl/worksheets/_rels/sheet1.xml.rels")
+    const target = new RegExp(`Id="${rId}"[^>]*Target="([^"]+)"`).exec(rels)?.[1]
+    expect(target).toBeDefined()
+
+    const drawing = await readPart(saved, `xl/${target!.replace(/^\.\.\//, "")}`)
+    expect(drawing).toContain("<xdr:pic>")
+    expect(drawing).toContain("<xdr:graphicFrame")
+  })
+
+  it("keeps the chart's anchor rather than dropping it", async () => {
+    const wb = await openXlsx(await withImage())
+    attachChart(wb)
+
+    const saved = await saveXlsx(wb)
+    const re = await openXlsx(saved)
+    const charts = getCharts(re)
+
+    expect(charts.length).toBe(1)
+    expect(charts[0].chart.title).toBe("Quarterly Revenue")
+
+    // The anchor is the thing #465 named. Row 8 / col 1 is where it was
+    // put, and a rebuilt-without-anchor graphicFrame reads back as 0,0.
+    const anchor = charts[0].chart.anchor
+    expect(anchor).toBeDefined()
+    expect(anchor!.from).toEqual({ row: 8, col: 1 })
+    expect(anchor!.to).toEqual({ row: 22, col: 9 })
+  })
+
+  it("declares the chart in [Content_Types].xml", async () => {
+    const wb = await openXlsx(await withImage())
+    attachChart(wb)
+
+    const ct = await readPart(await saveXlsx(wb), "[Content_Types].xml")
+
+    expect(ct).toContain("drawingml.chart+xml")
+    expect(ct).toContain('Extension="png"')
+  })
+})
+
+describe("the case as reported", () => {
+  it("a file that already had both survives a plain open-and-save", async () => {
+    // No editing, no appending: open the file and write it straight back.
+    // On the old code the chart came back as `[]` — the sheet had images,
+    // so hucre regenerated the drawing, and the chart pass then skipped
+    // the sheet for exactly that reason. Nothing warned.
+    const sheet = dataSheet()
+    sheet.images = [{ data: PNG, type: "png", anchor: { from: { row: 0, col: 6 } } }]
+    sheet.charts = [CHART]
+    const original = await writeXlsx({ sheets: [sheet] })
+
+    const before = getCharts(await openXlsx(original))
+    const after = getCharts(await openXlsx(await saveXlsx(await openXlsx(original))))
+
+    expect(before.length).toBe(1)
+    expect(after.length).toBe(1)
+    expect(after[0].chart.title).toBe(before[0].chart.title)
+    expect(after[0].chart.anchor).toEqual(before[0].chart.anchor)
+  })
+})
+
+describe("the media numbering survives the second pass", () => {
+  it("numbers the image the same whether or not a chart joins it", async () => {
+    // The chart pass rebuilds the image drawing. Handing writeDrawing a
+    // different start index there would point the drawing at a media
+    // part that was never written.
+    const plain = await openXlsx(await withImage())
+    const plainNames = new ZipReader(await saveXlsx(plain))
+      .entries()
+      .filter((n) => n.startsWith("xl/media/"))
+
+    const withChart = await openXlsx(await withImage())
+    attachChart(withChart)
+    const savedNames = new ZipReader(await saveXlsx(withChart))
+      .entries()
+      .filter((n) => n.startsWith("xl/media/"))
+
+    expect(savedNames).toEqual(plainNames)
+
+    // And the drawing references a part that exists.
+    const saved = await saveXlsx(withChart)
+    const all = new ZipReader(saved).entries()
+    const rels = await readPart(saved, "xl/drawings/_rels/drawing1.xml.rels")
+    for (const m of rels.matchAll(/Target="\.\.\/(media\/[^"]+)"/g)) {
+      expect(all).toContain(`xl/${m[1]}`)
+    }
+  })
+})
+
+describe("a preserved foreign drawing is still left alone", () => {
+  it("does not rebuild a drawing hucre did not author", async () => {
+    // The SAFETY boundary: hucre extends only drawings it generated this
+    // run. A sheet whose chart came from the opened package keeps its
+    // original parts byte-for-byte.
+    const sheet = dataSheet()
+    sheet.charts = [CHART]
+    const original = await writeXlsx({ sheets: [sheet] })
+
+    const wb = await openXlsx(original)
+    const saved = await saveXlsx(wb)
+
+    expect(await readPart(saved, "xl/drawings/drawing1.xml")).toBe(
+      await readPart(original, "xl/drawings/drawing1.xml"),
+    )
+  })
+})


### PR DESCRIPTION
Closes #465.

A worksheet carries exactly one `<drawing>` element, so images and charts on the same sheet have to share one drawing part. The roundtrip built that part twice over — once for the images, once for the charts — and then resolved the collision by skipping the chart pass entirely for any sheet that had already produced an image drawing.

The code called this a Phase 2 limitation and described it as losing the chart's *anchor*. It was worse than that. Measured against `main`:

```
FRESH: [{"t":"Original","a":{"from":{"row":8,"col":1},"to":{"row":22,"col":9}}}]
SAVED: []
```

That is a plain `openXlsx` → `saveXlsx` with no editing at all. The chart went, silently.

## What changed

hucre authored that image drawing itself, this run, so it is hucre's to extend. The charts are now folded into it — same drawing number, same media start index, so nothing the first pass already accounted for moves:

```ts
if (ownsImageDrawing) {
  drawingResults[i] = writeDrawing(
    sheet.images ?? [], imageStartIndices[i], sheet.textBoxes, writeCharts, nextChartNumber,
  )
  imageDrawingCharts[i] = charts
}
```

The `SAFETY` note is unchanged in substance and now says the thing that actually matters: a drawing hucre is **preserving** is never touched, because that is foreign XML. A drawing hucre **generated this run** is a different thing entirely, and was only being treated the same way for convenience.

## The limit that remains

The regenerated drawing can only carry charts hucre can author, so on a sheet that also has images, one of the nine unauthorable kinds (`bubble`, `radar`, `surface`, the 3D ones, …) is still lost. Seven of sixteen kinds survive there where none did before. That is a consequence of the one-`<drawing>`-per-sheet rule rather than something left undone, so it is written into `docs/PARITY.md` instead of left to be discovered.

## Tests

`test/roundtrip-chart-anchors.test.ts` — 7 cases, including the reported one verbatim. Mutation-checked: 5 fail against `main`. The two that pass on both sides are deliberate guards against regressions this change could introduce — that the media numbering is identical with and without a chart, and that a preserved foreign drawing still comes back byte-for-byte.

One existing test changed meaning: `coverage-roundtrip-pivot.test.ts` pinned `expect(...startsWith("xl/charts/")).toBe(false)` with the comment "adding a chart to it is out of scope". That was the bug written down as intent; it is now inverted, and additionally asserts that only one drawing part is emitted.

`pnpm lint`, `pnpm typecheck`, 9958 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)