### PR TITLE
feat(types): declare SpreadsheetStreamWriter and implement it — closes #468

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,8 +451,9 @@ Run `pnpm bench` to see both on your own machine.
 
 #### One surface across the incremental writers
 
-`XlsxStreamWriter`, `CsvStreamWriter`, and `NdjsonStreamWriter` share one
-vocabulary, so a format-agnostic export helper can be written once:
+`XlsxStreamWriter`, `CsvStreamWriter`, and `NdjsonStreamWriter` all
+implement `SpreadsheetStreamWriter`, so a format-agnostic export helper
+can be written once:
 
 | Method            | Behaviour                                                         |
 | ----------------- | ----------------------------------------------------------------- |
@@ -461,8 +462,29 @@ vocabulary, so a format-agnostic export helper can be written once:
 | `finish()`        | Close the writer and return its output (`string` or `Uint8Array`) |
 | `toStream()`      | Output as a `ReadableStream<Uint8Array>`                          |
 
-Two caveats worth stating plainly:
+```ts
+import type { SpreadsheetStreamWriter } from "hucre"
 
+async function exportAll(writer: SpreadsheetStreamWriter, rows: Array<Record<string, CellValue>>) {
+  for (const row of rows) writer.addObject(row)
+  return await writer.finish() // string | Uint8Array — narrow at the call site
+}
+```
+
+This was a convention until v1.0.1 and nothing enforced it: there was no
+shared interface, so when `XlsxStreamWriter.addRow` widened to accept
+styled cells, nothing failed and the drift was left for a reader to
+find. The `implements` is what makes the next divergence a compile error
+(#468).
+
+Four caveats worth stating plainly:
+
+- **`finish()` is not one type.** The text writers return `string`, XLSX
+  returns `Promise<Uint8Array>`, and the interface says so rather than
+  pretending otherwise. `await` covers both; narrow before use.
+- **Construction is not shared.** `XlsxStreamWriter` takes a sheet `name`
+  and `ColumnDef[]`; the two text writers take a plain key list. The
+  helper is written once — building the writer is still per-format.
 - `toStream()` on `XlsxStreamWriter` and `CsvStreamWriter` **does not bound
   memory**. Both buffer everything until `finish()`; the stream just hands
   you the finished bytes. `writeXlsxStream` / `writeCsvStream` are the

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1883,3 +1883,40 @@ export interface StreamRow {
 
 export type ReadInput = Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>
 export type WriteOutput = Uint8Array
+
+// ── Incremental writers ────────────────────────────────────────────
+
+/**
+ * The vocabulary `XlsxStreamWriter`, `CsvStreamWriter` and
+ * `NdjsonStreamWriter` share, so a format-agnostic export helper can be
+ * written once.
+ *
+ * The README has claimed this since before v1 and nothing enforced it:
+ * there was no `implements` anywhere in `src/`, so when #436 widened
+ * `XlsxStreamWriter.addRow` to accept `StreamStyledCell`, nothing failed
+ * and the drift was left for a reader to discover. Declaring the type is
+ * what turns the next divergence into a compile error. See #468.
+ *
+ * Two of the members are deliberately loose, because the three writers
+ * genuinely differ and pretending otherwise would be worse than saying so:
+ *
+ * - **`finish()`** returns `string` from the text writers and
+ *   `Promise<Uint8Array>` from XLSX. A helper written against this
+ *   interface has to `await` it — which is harmless on a `string` — and
+ *   narrow the result before using it. Converging the two is a real API
+ *   decision and a breaking one; the interface is worth having either way.
+ * - **`addRow` / `addObject`** promise only the narrow parameter here.
+ *   `XlsxStreamWriter` accepts more (`StreamStyledCell`, `unknown`
+ *   values), which is contravariant and therefore fine — a writer may
+ *   take more than the interface promises, never less.
+ */
+export interface SpreadsheetStreamWriter {
+  /** Append a row of positional values. */
+  addRow(values: CellValue[]): void
+  /** Append a row from an object, projected through the writer's columns. */
+  addObject(item: Record<string, CellValue>): void
+  /** Close the writer and return its output. */
+  finish(): string | Promise<Uint8Array>
+  /** Output as a `ReadableStream<Uint8Array>`. */
+  toStream(): ReadableStream<Uint8Array>
+}

--- a/src/csv/stream.ts
+++ b/src/csv/stream.ts
@@ -11,7 +11,7 @@
 //   source on demand and encoded lines are flushed as they accumulate,
 //   so peak memory is independent of the row count.
 
-import type { CellValue, CsvReadOptions, CsvWriteOptions } from "../_types"
+import type { CellValue, CsvReadOptions, CsvWriteOptions, SpreadsheetStreamWriter } from "../_types"
 import { stripBom, detectDelimiter } from "./reader"
 import { escapeFormula, unescapeFormula } from "./formula"
 import { inferType } from "../_infer"
@@ -377,7 +377,7 @@ export type CsvStreamWriterOptions = CsvWriteOptions
  * until {@link CsvStreamWriter.finish} joins them, so peak memory scales
  * with the data. For constant-memory output use {@link writeCsvStream}.
  */
-export class CsvStreamWriter {
+export class CsvStreamWriter implements SpreadsheetStreamWriter {
   private formatter: CsvRowFormatter
   private lineSeparator: string
   private bom: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,6 +322,11 @@ export {
 
 // ── Types ──────────────────────────────────────────────────────────
 export type {
+  /**
+   * The vocabulary the three incremental writers share. Implemented by
+   * `XlsxStreamWriter`, `CsvStreamWriter` and `NdjsonStreamWriter`. See #468.
+   */
+  SpreadsheetStreamWriter,
   // Cell
   CellValue,
   CellType,

--- a/src/json/stream.ts
+++ b/src/json/stream.ts
@@ -1,7 +1,7 @@
 // ── NDJSON Streaming ─────────────────────────────────────────────────
 // CF Workers / Deno / Node 18+ compatible: uses WHATWG ReadableStream only.
 
-import type { CellValue } from "../_types"
+import type { CellValue, SpreadsheetStreamWriter } from "../_types"
 import { InvalidArgumentError, ParseError } from "../errors"
 import { flattenValue, reviveDates, type FlattenOptions } from "./flatten"
 import { unflattenRow } from "./unflatten"
@@ -48,7 +48,7 @@ export interface NdjsonStreamWriterOptions {
  * return new Response(body, { headers: { 'content-type': 'application/x-ndjson' } })
  * ```
  */
-export class NdjsonStreamWriter {
+export class NdjsonStreamWriter implements SpreadsheetStreamWriter {
   private buffer: string[] = []
   private done = false
   private columns: string[] | undefined

--- a/src/xlsx/stream-writer.ts
+++ b/src/xlsx/stream-writer.ts
@@ -11,7 +11,15 @@
 //   source on demand and the ZIP is emitted chunk by chunk, so peak
 //   memory is O(distinct styles), independent of row count.
 
-import type { CellValue, CellStyle, ColumnDef, FreezePane, MergeRange, RowDef } from "../_types"
+import type {
+  CellValue,
+  CellStyle,
+  ColumnDef,
+  FreezePane,
+  MergeRange,
+  RowDef,
+  SpreadsheetStreamWriter,
+} from "../_types"
 import { ZipWriter } from "../zip/writer"
 import { zipStream, type ZipStreamEntry } from "../zip/stream-writer"
 import { writeContentTypes } from "./content-types-writer"
@@ -491,7 +499,7 @@ function validateMaxRowsPerSheet(value: number): void {
  * assembles the archive, so peak memory still scales with the data.
  * For constant-memory output use {@link writeXlsxStream} instead.
  */
-export class XlsxStreamWriter {
+export class XlsxStreamWriter implements SpreadsheetStreamWriter {
   private sheetName: string
   private columns: ColumnDef[] | undefined
   private freezePane: FreezePane | undefined

--- a/test/stream-writer-interface.test.ts
+++ b/test/stream-writer-interface.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest"
+import { XlsxStreamWriter } from "../src/xlsx/stream-writer"
+import { CsvStreamWriter } from "../src/csv/stream"
+import { NdjsonStreamWriter } from "../src/json/stream"
+import { readXlsx } from "../src/xlsx/reader"
+import { parseCsv } from "../src/csv/reader"
+import type { CellValue, SpreadsheetStreamWriter } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #468 — the README has promised since before v1 that the three
+// incremental writers "share one vocabulary, so a format-agnostic export
+// helper can be written once". There was no `implements` anywhere in
+// `src/` and no shared interface, so nothing held them to it — and they
+// had already drifted: #436 widened `XlsxStreamWriter.addRow` to accept
+// `StreamStyledCell` and nothing failed.
+//
+// The interface is the enforcement. This file is the claim: the helper
+// the README describes, actually written once, actually run against all
+// three.
+// ═══════════════════════════════════════════════════════════════════════
+
+// Construction is NOT part of the shared vocabulary and this is where
+// that shows: XLSX wants `ColumnDef[]` and a sheet name, the two text
+// writers want a plain key list. The interface covers the four methods,
+// which is what "the helper is written once" actually means — each
+// writer is still built its own way. `tsc` catches a mix-up here, which
+// is how this comment came to exist.
+const KEYS = ["name", "qty"]
+const COLUMN_DEFS = [
+  { header: "Name", key: "name" },
+  { header: "Qty", key: "qty" },
+]
+
+const ROWS: Array<Record<string, CellValue>> = [
+  { name: "Widget", qty: 3 },
+  { name: "Gadget", qty: 7 },
+]
+
+/**
+ * The helper. Written against the interface and nothing else — no
+ * `instanceof`, no per-format branch.
+ *
+ * `finish()` is the one place the three genuinely differ, and the
+ * interface says so: `string | Promise<Uint8Array>`. `await` covers both,
+ * and the caller narrows.
+ */
+async function exportAll(writer: SpreadsheetStreamWriter): Promise<string | Uint8Array> {
+  for (const row of ROWS) writer.addObject(row)
+  return await writer.finish()
+}
+
+function writers(): Array<[string, SpreadsheetStreamWriter]> {
+  return [
+    ["XlsxStreamWriter", new XlsxStreamWriter({ name: "Sheet1", columns: COLUMN_DEFS })],
+    ["CsvStreamWriter", new CsvStreamWriter({ columns: KEYS, headers: ["Name", "Qty"] })],
+    ["NdjsonStreamWriter", new NdjsonStreamWriter({ columns: KEYS })],
+  ]
+}
+
+describe("the three writers satisfy one interface", () => {
+  it("every one of them is assignable to it", () => {
+    // The assignment itself is the assertion — this file fails `tsc`
+    // before it fails vitest if any of the three drifts.
+    for (const [name, writer] of writers()) {
+      expect(typeof writer.addRow, name).toBe("function")
+      expect(typeof writer.addObject, name).toBe("function")
+      expect(typeof writer.finish, name).toBe("function")
+      expect(typeof writer.toStream, name).toBe("function")
+    }
+  })
+
+  it("the one helper produces real output from each", async () => {
+    const out = new Map<string, string | Uint8Array>()
+    for (const [name, writer] of writers()) out.set(name, await exportAll(writer))
+
+    // XLSX: bytes, and a workbook that reads back.
+    const xlsxBytes = out.get("XlsxStreamWriter")
+    expect(xlsxBytes).toBeInstanceOf(Uint8Array)
+    const wb = await readXlsx(xlsxBytes as Uint8Array)
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["Name", "Qty"],
+      ["Widget", 3],
+      ["Gadget", 7],
+    ])
+
+    // CSV: text, and rows that parse back.
+    const csv = out.get("CsvStreamWriter")
+    expect(typeof csv).toBe("string")
+    expect(parseCsv(csv as string)).toEqual([
+      ["Name", "Qty"],
+      ["Widget", "3"],
+      ["Gadget", "7"],
+    ])
+
+    // NDJSON: one object per line.
+    const ndjson = out.get("NdjsonStreamWriter")
+    expect(typeof ndjson).toBe("string")
+    expect(
+      (ndjson as string)
+        .trim()
+        .split("\n")
+        .map((l) => JSON.parse(l)),
+    ).toEqual(ROWS)
+  })
+
+  it("toStream is the same shape on all three", async () => {
+    for (const [name, writer] of writers()) {
+      writer.addRow(["a", 1])
+      const stream = writer.toStream()
+      expect(stream, name).toBeInstanceOf(ReadableStream)
+
+      const reader = stream.getReader()
+      const first = await reader.read()
+      expect(first.done, name).toBe(false)
+      expect(first.value, name).toBeInstanceOf(Uint8Array)
+      await reader.cancel()
+    }
+  })
+})
+
+describe("what the interface deliberately does not promise", () => {
+  it("XlsxStreamWriter still takes more than the interface asks for", async () => {
+    // Contravariance: a writer may accept more than the interface
+    // promises, never less. The interface narrowing to `CellValue[]` is
+    // what makes the helper portable; it does not take styling away.
+    const w = new XlsxStreamWriter({ name: "Sheet1", columns: COLUMN_DEFS })
+    w.addRow(["Widget", { value: 3, style: { font: { bold: true } } }])
+
+    const wb = await readXlsx(await w.finish(), { readStyles: true })
+    expect(wb.sheets[0]!.rows[1]).toEqual(["Widget", 3])
+    expect(wb.sheets[0]!.cells?.get("1,1")?.style?.font?.bold).toBe(true)
+  })
+
+  it("finish() is not one type, and the interface says so rather than lying", async () => {
+    // Converging these is a real API decision and a breaking one. What
+    // the interface buys today is that a caller who `await`s and narrows
+    // is correct for all three, forever.
+    const xlsx = await new XlsxStreamWriter({ name: "Sheet1", columns: COLUMN_DEFS }).finish()
+    const csv = new CsvStreamWriter({ columns: KEYS, headers: ["Name", "Qty"] }).finish()
+
+    expect(xlsx).toBeInstanceOf(Uint8Array)
+    expect(typeof csv).toBe("string")
+  })
+})


### PR DESCRIPTION
Closes #468.

The README has promised since before v1 that the three incremental writers "share one vocabulary, so a format-agnostic export helper can be written once". There was no `implements` anywhere in `src/` and no shared interface, so nothing held them to it — and they had already drifted: #436 widened `XlsxStreamWriter.addRow` to accept `StreamStyledCell` and nothing failed.

## The interface

`SpreadsheetStreamWriter` is now a real type in `_types.ts`, exported from the root, and all three classes declare it.

Verified as **enforcement rather than decoration**, by breaking each writer on purpose and checking `tsc`:

| mutation | result |
| --- | --- |
| narrow `CsvStreamWriter.addObject` to `Record<string, string>` | 8 type errors |
| change `CsvStreamWriter.finish()` to return `number` | `TS2416: Property 'finish' … is not assignable to the same property in base type 'SpreadsheetStreamWriter'` |

## Two members are deliberately loose

Stated in the doc comment rather than left to be discovered:

- **`finish()`** stays `string | Promise<Uint8Array>`. Converging it is a real API decision and a breaking one; an interface that lied about it would be worse than one that does not. `await` covers both and the caller narrows.
- **`addRow` / `addObject`** promise only the narrow parameter. `XlsxStreamWriter` accepting `StreamStyledCell` and `unknown` values is contravariant — a writer may take more than the interface promises, never less — so the styling API is untouched. There is a test for exactly that.

## One thing the audit did not have

Writing the helper for the test turned up that **construction is not shared either**. `XlsxStreamWriter` takes a sheet `name` and `ColumnDef[]`; the two text writers take a plain key list. My first draft passed `ColumnDef[]` to all three and `tsc` rejected it — which is the interface doing its job on the very first use.

The interface covers the four methods, which is what "written once" actually means. The README now says that, and carries the helper as runnable code instead of a claim.

## Tests

`test/stream-writer-interface.test.ts` — 5 cases. The helper is written once against `SpreadsheetStreamWriter` with no `instanceof` and no per-format branch, then run against all three: the XLSX output reads back through `readXlsx`, the CSV through `parseCsv`, the NDJSON through `JSON.parse` per line.

`pnpm lint`, `pnpm typecheck`, 9972 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)