### PR TITLE
feat(xlsx): model the rest of CT_PageSetup — closes #470

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -69,9 +69,14 @@ hyperlinks with tooltips, comments, checkboxes, the full cell style model
 (fonts, pattern and gradient fills, borders including diagonal, every
 alignment field, number formats, protection), merges, data validations,
 all 15 conditional-rule types **including their dxf styles**, auto-filters
-with value filters, freeze and split panes, sheet protection, page setup
-including print areas, print titles and every OOXML paper size (by
-name where hucre has one, by code otherwise), headers and footers, sheet views
+with value filters, freeze and split panes, sheet protection, every
+attribute of `CT_PageSetup` bar one — print areas, print titles, every
+OOXML paper size (by name where hucre has one, by code otherwise) plus
+custom `paperWidth` / `paperHeight` for the sizes that have none, page
+order, first page number, draft and black-and-white, comment and error
+printing, copies, DPI and printer defaults; the exception is `r:id`,
+which points at a binary printer-settings part and has no portable
+meaning — headers and footers, sheet views
 and tab colours, hidden and very-hidden sheets, tables, row and column
 definitions, manual page breaks, outline properties, sparklines, text
 boxes, background images, images, document properties, named ranges, the

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -495,6 +495,54 @@ export interface PageSetup {
   showRowColHeaders?: boolean
   horizontalCentered?: boolean
   verticalCentered?: boolean
+  /**
+   * Page number to print on the first page. Excel only honours it when
+   * `useFirstPageNumber` is also set, and the writer sets that flag for
+   * you whenever this is present — a `firstPageNumber` that silently did
+   * nothing would be worse than not having the field.
+   */
+  firstPageNumber?: number
+  /**
+   * Whether {@link firstPageNumber} is used at all. Written implicitly
+   * with `firstPageNumber`; carried here so a file that sets the flag
+   * without the number, or vice versa, round-trips as it was.
+   */
+  useFirstPageNumber?: boolean
+  /**
+   * Order pages are laid out in when the sheet is wider and taller than
+   * one page. Default: `"downThenOver"`.
+   */
+  pageOrder?: "downThenOver" | "overThenDown"
+  /** Print without colour. */
+  blackAndWhite?: boolean
+  /** Print without graphics. */
+  draft?: boolean
+  /** Where cell comments are printed. Default: `"none"`. */
+  cellComments?: "none" | "asDisplayed" | "atEnd"
+  /** How cells holding errors are printed. Default: `"displayed"`. */
+  errors?: "displayed" | "blank" | "dash" | "NA"
+  /** Number of copies. Default: 1. */
+  copies?: number
+  /** Horizontal print resolution in DPI. Default: 600. */
+  horizontalDpi?: number
+  /** Vertical print resolution in DPI. Default: 600. */
+  verticalDpi?: number
+  /**
+   * Custom page width as an ST_PositiveUniversalMeasure — a number with a
+   * unit, e.g. `"210mm"`, `"8.5in"`, `"21cm"`. The only way to express a
+   * page size that has no {@link PaperSize} code.
+   *
+   * Excel reads this in preference to `paperSize` when both are present.
+   * Set it together with {@link paperHeight}; one alone describes nothing.
+   */
+  paperWidth?: string
+  /** Custom page height; see {@link paperWidth}. */
+  paperHeight?: string
+  /**
+   * Whether the printer's own defaults are used for the settings this
+   * sheet does not name. Default: true.
+   */
+  usePrinterDefaults?: boolean
 }
 
 export interface PageMargins {

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -1348,6 +1348,36 @@ function serializePageSetup(ps: PageSetup): string {
     }
   }
 
+  // A custom page size, for the sizes that have no code. Excel reads
+  // these in preference to `paperSize` when both are present, which is
+  // why they are emitted alongside rather than instead. See #470.
+  if (ps.paperWidth !== undefined) attrs["paperWidth"] = ps.paperWidth
+  if (ps.paperHeight !== undefined) attrs["paperHeight"] = ps.paperHeight
+
+  // `firstPageNumber` on its own does nothing in Excel — the flag is what
+  // turns it on. Writing the number without the flag would be a field
+  // that looks set and prints 1, so the flag is implied by the number
+  // unless the caller says otherwise.
+  if (ps.firstPageNumber !== undefined) attrs["firstPageNumber"] = ps.firstPageNumber
+  const useFirst = ps.useFirstPageNumber ?? (ps.firstPageNumber !== undefined ? true : undefined)
+  if (useFirst !== undefined) attrs["useFirstPageNumber"] = useFirst ? 1 : 0
+
+  // Everything below is written only when it differs from the CT_PageSetup
+  // default, so a sheet that sets none of them emits no <pageSetup> at all.
+  if (ps.pageOrder !== undefined && ps.pageOrder !== "downThenOver") {
+    attrs["pageOrder"] = ps.pageOrder
+  }
+  if (ps.blackAndWhite) attrs["blackAndWhite"] = 1
+  if (ps.draft) attrs["draft"] = 1
+  if (ps.cellComments !== undefined && ps.cellComments !== "none") {
+    attrs["cellComments"] = ps.cellComments
+  }
+  if (ps.errors !== undefined && ps.errors !== "displayed") attrs["errors"] = ps.errors
+  if (ps.copies !== undefined) attrs["copies"] = ps.copies
+  if (ps.horizontalDpi !== undefined) attrs["horizontalDpi"] = ps.horizontalDpi
+  if (ps.verticalDpi !== undefined) attrs["verticalDpi"] = ps.verticalDpi
+  if (ps.usePrinterDefaults === false) attrs["usePrinterDefaults"] = 0
+
   // Only emit if there are attributes beyond default
   if (Object.keys(attrs).length === 0) {
     return ""

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -1950,7 +1950,63 @@ function parsePageSetupAttrs(attrs: Record<string, string>): PageSetup {
     ps.verticalCentered = true
   }
 
+  // ── The rest of CT_PageSetup (#470) ──────────────────────────────
+  // Read unconditionally, defaults included: this is the roundtrip path
+  // as well as the read path, and dropping an attribute because it
+  // happened to equal its default would rewrite a file the caller only
+  // opened. The writer is the side that elides defaults.
+  if (attrs["paperWidth"]) ps.paperWidth = attrs["paperWidth"]
+  if (attrs["paperHeight"]) ps.paperHeight = attrs["paperHeight"]
+
+  const firstPageNumber = intAttr(attrs["firstPageNumber"])
+  if (firstPageNumber !== undefined) ps.firstPageNumber = firstPageNumber
+  if (attrs["useFirstPageNumber"] !== undefined) {
+    ps.useFirstPageNumber = isTruthyAttr(attrs["useFirstPageNumber"])
+  }
+
+  if (attrs["pageOrder"] === "overThenDown" || attrs["pageOrder"] === "downThenOver") {
+    ps.pageOrder = attrs["pageOrder"]
+  }
+  if (isTruthyAttr(attrs["blackAndWhite"])) ps.blackAndWhite = true
+  if (isTruthyAttr(attrs["draft"])) ps.draft = true
+
+  const comments = attrs["cellComments"]
+  if (comments === "none" || comments === "asDisplayed" || comments === "atEnd") {
+    ps.cellComments = comments
+  }
+
+  const errors = attrs["errors"]
+  if (errors === "displayed" || errors === "blank" || errors === "dash" || errors === "NA") {
+    ps.errors = errors
+  }
+
+  const copies = intAttr(attrs["copies"])
+  if (copies !== undefined) ps.copies = copies
+  const hDpi = intAttr(attrs["horizontalDpi"])
+  if (hDpi !== undefined) ps.horizontalDpi = hDpi
+  const vDpi = intAttr(attrs["verticalDpi"])
+  if (vDpi !== undefined) ps.verticalDpi = vDpi
+  if (attrs["usePrinterDefaults"] !== undefined) {
+    ps.usePrinterDefaults = isTruthyAttr(attrs["usePrinterDefaults"])
+  }
+
   return ps
+}
+
+/** `"1"` / `"true"` — the two spellings ECMA-376 allows for xsd:boolean. */
+function isTruthyAttr(value: string | undefined): boolean {
+  return value === "1" || value === "true"
+}
+
+/**
+ * A non-negative integer attribute, or `undefined` when it is absent or
+ * not one. A hostile `copies="NaN"` becoming `NaN` on the model would
+ * serialize back out as the literal string `NaN`.
+ */
+function intAttr(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined
+  const n = Number(value)
+  return Number.isInteger(n) && n >= 0 ? n : undefined
 }
 
 // ── Color Attribute Parser ──────────────────────────────────────────────

--- a/test/page-setup-attributes.test.ts
+++ b/test/page-setup-attributes.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { ZipReader } from "../src/zip/reader"
+import type { PageSetup } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #470 — `PageSetup` modelled 15 of CT_PageSetup's attributes. Nothing
+// claimed otherwise, but print settings were the thinnest part of an
+// otherwise complete sheet model, and PARITY.md listed page setup under
+// "read + write, at parity".
+//
+// The register at the bottom is the part that lasts: `Required<PageSetup>`
+// means the next attribute added to the type fails `tsc` here until it is
+// also written, read, and proven to survive a roundtrip.
+// ═══════════════════════════════════════════════════════════════════════
+
+const decoder = new TextDecoder("utf-8")
+
+async function sheetXml(bytes: Uint8Array): Promise<string> {
+  return decoder.decode(await new ZipReader(bytes).extract("xl/worksheets/sheet1.xml"))
+}
+
+async function write(pageSetup: PageSetup): Promise<Uint8Array> {
+  return writeXlsx({ sheets: [{ name: "S", rows: [["a"]], pageSetup }] })
+}
+
+/** Write, read back, and return just the page setup. */
+async function roundtrip(pageSetup: PageSetup): Promise<PageSetup> {
+  const wb = await readXlsx(await write(pageSetup))
+  return wb.sheets[0]!.pageSetup ?? {}
+}
+
+describe("the three the issue called out first", () => {
+  it("firstPageNumber starts numbering somewhere other than 1", async () => {
+    const xml = await sheetXml(await write({ firstPageNumber: 7 }))
+
+    expect(xml).toContain('firstPageNumber="7"')
+    // The number alone does nothing in Excel — the flag is what turns it
+    // on, so a `firstPageNumber` that printed 1 anyway would be a field
+    // that looks set and is not.
+    expect(xml).toContain('useFirstPageNumber="1"')
+
+    expect(await roundtrip({ firstPageNumber: 7 })).toMatchObject({
+      firstPageNumber: 7,
+      useFirstPageNumber: true,
+    })
+  })
+
+  it("lets a caller set the flag off explicitly", async () => {
+    // Implied, not forced: a file can carry the number with the flag
+    // clear, and that has to survive being opened and saved.
+    const xml = await sheetXml(await write({ firstPageNumber: 7, useFirstPageNumber: false }))
+
+    expect(xml).toContain('useFirstPageNumber="0"')
+  })
+
+  it("pageOrder picks the direction pages run", async () => {
+    expect(await sheetXml(await write({ pageOrder: "overThenDown" }))).toContain(
+      'pageOrder="overThenDown"',
+    )
+    expect((await roundtrip({ pageOrder: "overThenDown" })).pageOrder).toBe("overThenDown")
+  })
+
+  it("does not write pageOrder when it is the default", async () => {
+    // `downThenOver` is the CT_PageSetup default; emitting it is noise
+    // in the diff of every file hucre touches.
+    expect(await sheetXml(await write({ pageOrder: "downThenOver" }))).not.toContain("pageOrder")
+  })
+
+  it("paperWidth/paperHeight express a size that has no code", async () => {
+    const custom: PageSetup = { paperWidth: "210mm", paperHeight: "297mm" }
+    const xml = await sheetXml(await write(custom))
+
+    expect(xml).toContain('paperWidth="210mm"')
+    expect(xml).toContain('paperHeight="297mm"')
+    expect(await roundtrip(custom)).toMatchObject(custom)
+  })
+
+  it("keeps paperSize alongside a custom size rather than instead of it", async () => {
+    // Excel reads the explicit dimensions in preference when both are
+    // present, so dropping the code would lose information a reader of
+    // the file might still want.
+    const xml = await sheetXml(
+      await write({ paperSize: "a4", paperWidth: "1m", paperHeight: "2m" }),
+    )
+
+    expect(xml).toContain('paperSize="9"')
+    expect(xml).toContain('paperWidth="1m"')
+  })
+})
+
+describe("the rest of CT_PageSetup", () => {
+  it("writes and reads the flags", async () => {
+    const flags: PageSetup = { blackAndWhite: true, draft: true }
+    const xml = await sheetXml(await write(flags))
+
+    expect(xml).toContain('blackAndWhite="1"')
+    expect(xml).toContain('draft="1"')
+    expect(await roundtrip(flags)).toMatchObject(flags)
+  })
+
+  it("writes and reads the enumerations", async () => {
+    const enums: PageSetup = { cellComments: "atEnd", errors: "dash" }
+    const xml = await sheetXml(await write(enums))
+
+    expect(xml).toContain('cellComments="atEnd"')
+    expect(xml).toContain('errors="dash"')
+    expect(await roundtrip(enums)).toMatchObject(enums)
+  })
+
+  it("writes and reads the numbers", async () => {
+    const nums: PageSetup = { copies: 3, horizontalDpi: 300, verticalDpi: 300 }
+    const xml = await sheetXml(await write(nums))
+
+    expect(xml).toContain('copies="3"')
+    expect(xml).toContain('horizontalDpi="300"')
+    expect(await roundtrip(nums)).toMatchObject(nums)
+  })
+
+  it("elides every default, so a bare sheet emits no pageSetup", async () => {
+    const xml = await sheetXml(
+      await write({ cellComments: "none", errors: "displayed", pageOrder: "downThenOver" }),
+    )
+
+    expect(xml).not.toContain("<pageSetup")
+  })
+
+  it("refuses a value that is not the integer it claims to be", async () => {
+    // `copies="NaN"` reaching the model would serialize back out as the
+    // literal string NaN — a file hucre made worse by opening it.
+    const bytes = await write({ copies: 3 })
+    const patched = new TextEncoder().encode(
+      (await sheetXml(bytes)).replace('copies="3"', 'copies="oops"'),
+    )
+
+    const { ZipWriter } = await import("../src/zip/writer")
+    const zw = new ZipWriter()
+    for (const [name, data] of await new ZipReader(bytes).extractAll()) {
+      zw.add(name, name === "xl/worksheets/sheet1.xml" ? patched : data)
+    }
+
+    const wb = await readXlsx(await zw.build())
+    expect(wb.sheets[0]!.pageSetup?.copies).toBeUndefined()
+  })
+})
+
+describe("openXlsx -> saveXlsx keeps them", () => {
+  it("carries every attribute through the roundtrip path", async () => {
+    const full: PageSetup = {
+      orientation: "landscape",
+      firstPageNumber: 12,
+      pageOrder: "overThenDown",
+      blackAndWhite: true,
+      draft: true,
+      cellComments: "asDisplayed",
+      errors: "NA",
+      copies: 2,
+      horizontalDpi: 1200,
+      verticalDpi: 1200,
+      paperWidth: "8.5in",
+      paperHeight: "11in",
+    }
+
+    const saved = await saveXlsx(await openXlsx(await write(full)))
+    const wb = await readXlsx(saved)
+
+    expect(wb.sheets[0]!.pageSetup).toMatchObject(full)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// The register. `Required<PageSetup>` is the point: adding a field to the
+// type breaks `tsc` here until it is listed, and listing it without
+// wiring the writer or reader breaks the roundtrip assertion below.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** Every field of PageSetup, with a value that is not its default. */
+const EVERY_FIELD: Required<PageSetup> = {
+  paperSize: "a3",
+  orientation: "landscape",
+  fitToPage: true,
+  fitToWidth: 2,
+  fitToHeight: 3,
+  scale: 80,
+  margins: { top: 1, right: 1, bottom: 1, left: 1, header: 0.5, footer: 0.5 },
+  printArea: "$A$1:$D$50",
+  printTitlesRow: "$1:$1",
+  printTitlesColumn: "$A:$A",
+  showGridLines: true,
+  showRowColHeaders: true,
+  horizontalCentered: true,
+  verticalCentered: true,
+  firstPageNumber: 5,
+  useFirstPageNumber: true,
+  pageOrder: "overThenDown",
+  blackAndWhite: true,
+  draft: true,
+  cellComments: "atEnd",
+  errors: "blank",
+  copies: 4,
+  horizontalDpi: 300,
+  verticalDpi: 300,
+  paperWidth: "210mm",
+  paperHeight: "297mm",
+  usePrinterDefaults: false,
+}
+
+describe("register: every PageSetup field survives a roundtrip", () => {
+  it("writes and reads back all of them", async () => {
+    const wb = await readXlsx(await write(EVERY_FIELD))
+    const got = wb.sheets[0]!.pageSetup
+
+    expect(got).toBeDefined()
+    for (const [key, want] of Object.entries(EVERY_FIELD)) {
+      expect(got![key as keyof PageSetup], `PageSetup.${key}`).toEqual(want)
+    }
+  })
+})


### PR DESCRIPTION
Closes #470.

`PageSetup` carried 15 of CT_PageSetup's attributes. Nothing claimed otherwise, but print settings were the thinnest part of an otherwise complete sheet model, and `docs/PARITY.md` listed page setup under *read + write, at parity*.

## Added

Twelve more, read and written — the three the issue named first plus the rest of the table, because doing 3 of 11 leaves the same complaint standing:

`firstPageNumber` / `useFirstPageNumber` · `pageOrder` · `blackAndWhite` · `draft` · `cellComments` · `errors` · `copies` · `horizontalDpi` / `verticalDpi` · `paperWidth` / `paperHeight` · `usePrinterDefaults`

The **only** attribute still absent is `r:id`, which points at a binary printer-settings part and has no portable meaning. PARITY.md now says exactly that rather than the vaguer claim it carried.

## Two decisions worth naming

**`firstPageNumber` implies `useFirstPageNumber`.** The number alone does nothing in Excel — the flag is what turns it on. A `firstPageNumber: 7` that printed 1 anyway would be a field that looks set and is not, so the writer sets the flag whenever the number is present. A caller who wants the number recorded with the flag clear can still say `useFirstPageNumber: false`, and files that carry that combination round-trip as they were.

**The writer elides defaults; the reader takes everything.** `pageOrder: "downThenOver"` writes nothing, so a sheet that sets only defaults emits no `<pageSetup>` at all. The reader is deliberately the other way round, because it is also the roundtrip path — dropping an attribute for equalling its default would rewrite a file the caller only opened.

## The register

`Required<PageSetup>` in the test is the part that lasts: the next attribute added to the type fails `tsc` here until it is listed, and listing it without wiring the writer or the reader fails the roundtrip assertion below it. Same shape as the `WriteSheet` register, applied to the one sub-model that had grown without one.

Writing it caught something immediately: my first fixture said `paperSize: "A4"` and the whole attribute silently vanished, because the map is keyed `a4`.

## Tests

`test/page-setup-attributes.test.ts` — 13 cases, covering the XML written, the values read back, the `openXlsx` → `saveXlsx` path, default elision, and a hostile `copies="oops"` that must not reach the model as `NaN` (which would serialize back out as the literal string). Mutation-checked: 10 fail against `main`.

`pnpm lint`, `pnpm typecheck`, 9985 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)