### PR TITLE
fix: three correctness items from the audit — refs #474

### DIFF
--- a/README.md
+++ b/README.md
@@ -1259,6 +1259,12 @@ cell over `maxWidth` characters (default 50) with a `...` suffix and turns
 newlines into `<br>`. Both are one-way, and there is no `fromMarkdown` —
 nor will there be. Use CSV or JSON to move data.
 
+Cell text is escaped so it renders as itself: a cell reading
+`*not emphasis*` comes out as those words rather than as emphasis. Pass
+`escapeInline: false` when the cells hold Markdown you want rendered — a
+column of `**bold**` labels, say. Pipes and newlines are escaped either
+way, because losing those loses the table.
+
 ### Reading HTML tables
 
 `fromHtml` parses a table — anyone's table, not just hucre's — into a sheet:

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -83,6 +83,20 @@ boxes, background images, images, document properties, named ranges, the
 1904 date system, workbook protection, theme colours, Excel 2024
 checkboxes, and encryption.
 
+### Formula results are write-only in practice
+
+`writeXlsx` writes the `formulaResult` you give it into `<v>`, so the
+value is genuinely in the file. But hucre has no formula engine, so it
+cannot know whether that cached value still matches the formula — and a
+stale `<v>` is a workbook that shows the wrong number. Every workbook
+hucre writes therefore carries `calcPr fullCalcOnLoad="1"`, which tells
+Excel to recalculate everything on open and discard the cached results.
+
+The practical consequence: **`formulaResult` survives a hucre round-trip
+and does not survive being opened in Excel.** Set it when something other
+than Excel will read the file — a second tool, a diff, hucre itself — and
+do not rely on it as the number a person will see.
+
 `test/xlsx-write-read-parity.test.ts` holds every field of `WriteSheet`
 and `WriteOptions` in a register typed over `keyof Required<…>`. Adding a
 field to either interface fails `tsc` until it is registered — as a probe

--- a/src/_date.ts
+++ b/src/_date.ts
@@ -594,6 +594,28 @@ export function reviveIsoDate(value: string): Date | null {
 }
 
 /**
+ * Parse an ISO-8601-shaped date-time, reading an unqualified time as UTC.
+ *
+ * `new Date("2024-01-15T10:30:00")` is **local** time under ECMA-262, so
+ * the same file read in Istanbul and in Tokyo produces instants six hours
+ * apart. Every format hucre reads records an absolute moment, so a bare
+ * time is taken to mean UTC — an explicit `Z` or `+02:00` is what the
+ * file says and is honoured untouched.
+ *
+ * Third home for this fix: ODS cell values (#415), ODS streaming, and now
+ * `docProps/core.xml`, where a non-compliant producer that omits the zone
+ * designator W3CDTF requires used to shift `created` / `modified` by the
+ * reader's offset. See #474.
+ */
+export function parseUtcDefaultDateTime(text: string): Date | undefined {
+  const trimmed = text.trim()
+  const timeAt = trimmed.indexOf("T")
+  const zoned = timeAt >= 0 && /(?:Z|[+-]\d{2}:?\d{2})$/.test(trimmed.slice(timeAt + 1))
+  const date = new Date(timeAt >= 0 && !zoned ? `${trimmed}Z` : trimmed)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
+/**
  * Parse a date string into a Date (UTC).
  * Supports ISO 8601 and common US/EU formats.
  *

--- a/src/_format.ts
+++ b/src/_format.ts
@@ -18,6 +18,16 @@ export interface LocaleFormat {
   thousands: string
   /** Currency symbol */
   currency: string
+  /**
+   * Digits per group, right to left: the first entry is the rightmost
+   * group and the last repeats for everything further left.
+   *
+   * `[3]` for most locales. `[3, 2]` for the Indian system, where
+   * 12,345,678 is written 1,23,45,678 — the separator was already right
+   * there and the positions were not. Read from `Intl`, so any locale
+   * that groups unusually is covered without a table. See #474.
+   */
+  groupSizes: number[]
 }
 
 /**
@@ -67,17 +77,68 @@ function resolveLocale(locale?: string): LocaleFormat | undefined {
     )
   }
 
-  // Separators only. The formatter groups in threes, so a locale that
-  // groups differently — Indian lakh/crore, say — gets the right
-  // separator in the wrong places. That predates this change and is a
-  // deeper piece of work than reading a tag.
   const resolved: LocaleFormat = {
     decimal: parts.find((p) => p.type === "decimal")?.value ?? ".",
     thousands: parts.find((p) => p.type === "group")?.value ?? ",",
     currency: KNOWN_CURRENCY[locale] ?? "",
+    groupSizes: readGroupSizes(locale),
   }
   localeCache.set(locale, resolved)
   return resolved
+}
+
+/**
+ * Ask `Intl` where a locale puts its group separators, by formatting a
+ * number long enough to show three groups and measuring the digit runs.
+ *
+ * Deriving beats tabulating: `en-IN`, `hi-IN`, `bn-IN`, `ne-NP` and the
+ * rest come out right without anyone listing them, and a locale whose
+ * grouping `Intl` later revises follows along.
+ */
+function readGroupSizes(locale: string): number[] {
+  let formatted: string
+  try {
+    formatted = new Intl.NumberFormat(locale, { useGrouping: true }).format(1234567890)
+  } catch {
+    return [3]
+  }
+
+  // Runs of digits, left to right; reverse so index 0 is the rightmost.
+  const runs = (formatted.match(/\d+/g) ?? []).map((r) => r.length).reverse()
+  if (runs.length < 2) return [3]
+
+  // The leftmost run is whatever digits were left over, not a group size.
+  const sizes = runs.slice(0, -1)
+  // Collapse a uniform tail: [3, 3, 3] is [3], [3, 2, 2] is [3, 2].
+  while (sizes.length > 1 && sizes[sizes.length - 1] === sizes[sizes.length - 2]) {
+    sizes.pop()
+  }
+  return sizes.every((n) => n > 0) ? sizes : [3]
+}
+
+/**
+ * Re-group an already-grouped integer string for a locale.
+ *
+ * The formatter groups in threes with `,` before this runs, which is
+ * right for almost every locale and wrong for the Indian system. Anything
+ * that is not plain digits and commas is left alone — a Special format
+ * like `000-00-0000` interleaves literals, and re-grouping those digits
+ * would be nonsense.
+ */
+function regroup(intStr: string, sizes: number[], separator: string): string {
+  if (!/^[\d,]*$/.test(intStr)) return intStr.replace(/,/g, separator)
+
+  const digits = intStr.replace(/,/g, "")
+  if (digits.length === 0) return intStr
+
+  const out: string[] = []
+  let remaining = digits
+  for (let i = 0; remaining.length > 0; i++) {
+    const size = sizes[Math.min(i, sizes.length - 1)]!
+    out.unshift(remaining.slice(-size))
+    remaining = remaining.slice(0, -size)
+  }
+  return out.join(separator)
 }
 
 export interface FormatOptions {
@@ -692,8 +753,11 @@ function formatNumber(value: number, fmt: string, locale?: LocaleFormat): string
   let localizedInt = formattedInt
   let localizedDec = formattedDec
   if (locale) {
-    if (locale.thousands !== "," && useThousandSep) {
-      localizedInt = localizedInt.replace(/,/g, locale.thousands)
+    // Unconditional when the format asked for grouping: the separator and
+    // the positions both come from the locale, and a locale that matches
+    // the defaults regroups to the same string anyway.
+    if (useThousandSep) {
+      localizedInt = regroup(localizedInt, locale.groupSizes, locale.thousands)
     }
     if (locale.decimal !== "." && localizedDec.length > 0) {
       // Replace the leading "." with locale decimal

--- a/src/export/markdown.ts
+++ b/src/export/markdown.ts
@@ -14,19 +14,46 @@ export interface MarkdownExportOptions {
   alignment?: Array<"left" | "center" | "right">
   /** Max column width (truncate with ...). Default: 50 */
   maxWidth?: number
+  /**
+   * Escape Markdown's inline syntax inside cells, so a cell reading
+   * `*not emphasis*` renders as those words rather than as emphasis.
+   * Default: true.
+   *
+   * Set false when the cells hold Markdown you want rendered — a column
+   * of `**bold**` labels, say. The table's own structural characters
+   * (pipes, newlines) are escaped either way, because losing those loses
+   * the table. See #474.
+   */
+  escapeInline?: boolean
 }
+
+/**
+ * Characters that change how a table cell renders. `\\` leads, so the
+ * escapes this function adds are not themselves re-escaped.
+ *
+ * `_` is here despite GFM not treating intraword underscores as emphasis:
+ * `_total_` is emphasis and `sub_total` is not, and telling them apart
+ * needs the flanking rules. Escaping both is the honest trade — a cell of
+ * `sub\_total` reads correctly even if it looks noisy in the source, and
+ * `escapeInline: false` is there for anyone who disagrees.
+ */
+const MARKDOWN_INLINE = /[\\`*_[\]<]/g
 
 /**
  * Escape characters that would break a Markdown table cell: pipes (column
  * separators) and newlines (row separators). A literal newline inside a
  * cell is rendered as `<br>` (GFM) so the table structure survives.
+ *
+ * With `escapeInline` (the default) the inline-formatting characters go
+ * too. The `<br>` is inserted after that pass, so it is not escaped by it.
  */
-function escapePipe(str: string): string {
-  return str.replace(/\|/g, "\\|").replace(/\r\n|\r|\n/g, "<br>")
+function escapeCell(str: string, escapeInline: boolean): string {
+  const inline = escapeInline ? str.replace(MARKDOWN_INLINE, "\\$&") : str
+  return inline.replace(/\|/g, "\\|").replace(/\r\n|\r|\n/g, "<br>")
 }
 
 /** Format a cell value as a string for Markdown output */
-function formatCellValue(value: CellValue): string {
+function formatCellValue(value: CellValue, escapeInline: boolean): string {
   if (value === null || value === undefined) return ""
   if (value instanceof Date) {
     // See #364 — an unparseable Date threw a raw RangeError mid-write.
@@ -35,7 +62,7 @@ function formatCellValue(value: CellValue): string {
   }
   if (typeof value === "boolean") return String(value)
   if (typeof value === "number") return String(value)
-  return escapePipe(String(value))
+  return escapeCell(String(value), escapeInline)
 }
 
 /** Truncate a string to maxWidth, adding "..." if truncated */
@@ -99,6 +126,7 @@ export function toMarkdown(sheet: Sheet, options?: MarkdownExportOptions): strin
     hasHeaderRow: options?.hasHeaderRow ?? options?.headerRow ?? true,
     alignment: options?.alignment ?? [],
     maxWidth: options?.maxWidth ?? 50,
+    escapeInline: options?.escapeInline ?? true,
   }
 
   const rows = sheet.rows
@@ -115,7 +143,7 @@ export function toMarkdown(sheet: Sheet, options?: MarkdownExportOptions): strin
   const formatted: string[][] = rows.map((row) => {
     const result: string[] = []
     for (let c = 0; c < numCols; c++) {
-      const raw = formatCellValue(row[c])
+      const raw = formatCellValue(row[c], opts.escapeInline)
       result.push(truncate(raw, opts.maxWidth))
     }
     return result

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -18,6 +18,7 @@ import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
 import { parseXml } from "../xml/parser"
 import { parseRange } from "../cell-utils"
+import { parseUtcDefaultDateTime } from "../_date"
 import { MAX_COL_INDEX, MAX_REPEAT_COUNT, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 
 /**
@@ -450,11 +451,7 @@ function odsFormulaToExcel(formula: string): string {
  * honoured; only an unqualified time is taken to mean UTC.
  */
 export function parseOdsDateTime(text: string): Date | undefined {
-  const trimmed = text.trim()
-  const timeAt = trimmed.indexOf("T")
-  const zoned = timeAt >= 0 && /(?:Z|[+-]\d{2}:?\d{2})$/.test(trimmed.slice(timeAt + 1))
-  const date = new Date(timeAt >= 0 && !zoned ? `${trimmed}Z` : trimmed)
-  return Number.isNaN(date.getTime()) ? undefined : date
+  return parseUtcDefaultDateTime(text)
 }
 
 // ── Cell Value Parsing ──────────────────────────────────────────────

--- a/src/xlsx/doc-props-reader.ts
+++ b/src/xlsx/doc-props-reader.ts
@@ -3,6 +3,7 @@
 
 import type { WorkbookProperties } from "../_types"
 import { parseXml } from "../xml/parser"
+import { parseUtcDefaultDateTime } from "../_date"
 import type { XmlElement } from "../xml/parser"
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -19,11 +20,18 @@ function getChildText(parent: XmlElement, localName: string): string | undefined
   return undefined
 }
 
+/**
+ * Parse a `dcterms:created` / `dcterms:modified` value.
+ *
+ * W3CDTF requires a zone designator on a date-time and hucre's own writer
+ * always emits `Z`, so compliant files were never at risk. A producer
+ * that omits it, though, was read as *local* time — the same workbook
+ * opened in Istanbul and in Tokyo reported timestamps six hours apart.
+ * See #474.
+ */
 function parseW3CDTF(value: string): Date | undefined {
   if (!value) return undefined
-  const d = new Date(value)
-  if (Number.isNaN(d.getTime())) return undefined
-  return d
+  return parseUtcDefaultDateTime(value)
 }
 
 // ── core.xml parsing ────────────────────────────────────────────────

--- a/test/audit-correctness.test.ts
+++ b/test/audit-correctness.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { toMarkdown } from "../src/export/markdown"
+import { formatValue } from "../src/_format"
+import { parseCoreProperties } from "../src/xlsx/doc-props-reader"
+import { parseUtcDefaultDateTime } from "../src/_date"
+import type { Sheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #474 — three of the smaller items from the audit, each real and each
+// too small for its own issue.
+// ═══════════════════════════════════════════════════════════════════════
+
+// ── docProps timestamps ──────────────────────────────────────────────
+//
+// `parseW3CDTF` was `new Date(value)`, which under ECMA-262 reads an
+// unqualified date-time as *local*. W3CDTF requires a zone designator and
+// hucre's own writer always emits `Z`, so compliant files were fine — a
+// non-compliant producer shifted `created` and `modified` by the reader's
+// own offset. This is the #415 shape in a third place, so the three now
+// share one function instead of drifting apart again.
+
+const CORE = (created: string): string =>
+  `<?xml version="1.0" encoding="UTF-8"?>` +
+  `<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"` +
+  ` xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/">` +
+  `<dcterms:created>${created}</dcterms:created></cp:coreProperties>`
+
+describe("docProps timestamps without a zone designator", () => {
+  it("reads a bare date-time as UTC, not as the reader's local time", () => {
+    const props = parseCoreProperties(CORE("2024-01-15T10:30:00"))
+
+    expect(props.created?.toISOString()).toBe("2024-01-15T10:30:00.000Z")
+  })
+
+  it("leaves an explicit zone exactly as the file states it", () => {
+    // The file said +02:00 and means it. Only silence is filled in.
+    expect(parseCoreProperties(CORE("2024-01-15T10:30:00+02:00")).created?.toISOString()).toBe(
+      "2024-01-15T08:30:00.000Z",
+    )
+    expect(parseCoreProperties(CORE("2024-01-15T10:30:00Z")).created?.toISOString()).toBe(
+      "2024-01-15T10:30:00.000Z",
+    )
+  })
+
+  it("still rejects what is not a date at all", () => {
+    expect(parseCoreProperties(CORE("not a date")).created).toBeUndefined()
+    expect(parseUtcDefaultDateTime("")).toBeUndefined()
+  })
+
+  it("round-trips a workbook hucre wrote, which always carries Z", async () => {
+    const created = new Date("2024-03-01T09:00:00Z")
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [["a"]] }],
+      properties: { created },
+    })
+
+    expect((await readXlsx(bytes)).properties?.created?.toISOString()).toBe(created.toISOString())
+  })
+})
+
+// ── Markdown inline escaping ─────────────────────────────────────────
+//
+// `escapePipe` protected the table's structure and nothing else, so a
+// cell reading `*not emphasis*` rendered as emphasis.
+
+function sheet(rows: Sheet["rows"]): Sheet {
+  return { name: "S", rows }
+}
+
+describe("toMarkdown escapes what would change the rendering", () => {
+  it("a cell of *not emphasis* stays those words", () => {
+    const md = toMarkdown(sheet([["text"], ["*not emphasis*"]]))
+
+    expect(md).toContain("\\*not emphasis\\*")
+    expect(md).not.toContain("| *not emphasis* |")
+  })
+
+  it("covers the rest of the inline syntax", () => {
+    const md = toMarkdown(sheet([["v"], ["_a_ `b` [c] <d> e\\f"]]))
+
+    // `>` is deliberately not escaped: a blockquote needs the start of a
+    // line and a table cell is never one, so escaping it would only add
+    // noise. `<` is escaped because raw HTML does work inside a cell.
+    expect(md).toContain("\\_a\\_ \\`b\\` \\[c\\] \\<d> e\\\\f")
+  })
+
+  it("still escapes the structural characters, which is not optional", () => {
+    // Losing a pipe loses the table, so this happens either way.
+    const off = toMarkdown(sheet([["v"], ["a|b\nc"]]), { escapeInline: false })
+
+    expect(off).toContain("a\\|b<br>c")
+  })
+
+  it("leaves inline syntax alone when the caller wants it rendered", () => {
+    const md = toMarkdown(sheet([["v"], ["**bold**"]]), { escapeInline: false })
+
+    expect(md).toContain("| **bold** |")
+  })
+
+  it("does not escape numbers or dates into nonsense", () => {
+    const md = toMarkdown(
+      sheet([
+        ["n", "d"],
+        [1234.5, new Date("2024-01-15T00:00:00Z")],
+      ]),
+    )
+
+    expect(md).toContain("1234.5")
+    expect(md).toContain("2024-01-15")
+    expect(md).not.toContain("\\")
+  })
+})
+
+// ── Locale grouping ──────────────────────────────────────────────────
+//
+// Since #456 the separator comes from Intl for any locale, but the
+// grouping *pattern* was fixed at threes — so hi-IN got the right
+// separator in the wrong places.
+
+describe("formatValue groups the way the locale does", () => {
+  it("matches Intl for the Indian system", () => {
+    // 12,345,678.50 was the old answer. The lakh/crore system puts the
+    // first separator after three digits and every one after that after
+    // two.
+    expect(formatValue(12345678.5, "#,##0.00", { locale: "hi-IN" })).toBe("1,23,45,678.50")
+    expect(formatValue(12345678.5, "#,##0.00", { locale: "en-IN" })).toBe("1,23,45,678.50")
+  })
+
+  it("leaves the three-digit locales exactly where they were", () => {
+    expect(formatValue(12345678.5, "#,##0.00", { locale: "en-US" })).toBe("12,345,678.50")
+    expect(formatValue(12345678.5, "#,##0.00", { locale: "de-DE" })).toBe("12.345.678,50")
+    expect(formatValue(12345678.5, "#,##0.00", { locale: "tr-TR" })).toBe("12.345.678,50")
+  })
+
+  it("agrees with Intl.NumberFormat across all of them", () => {
+    // The check that does not need updating when a locale's data moves.
+    for (const locale of ["en-US", "de-DE", "fr-FR", "tr-TR", "hi-IN", "en-IN", "es-ES"]) {
+      const want = new Intl.NumberFormat(locale, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(12345678.5)
+
+      expect(formatValue(12345678.5, "#,##0.00", { locale }), locale).toBe(want)
+    }
+  })
+
+  it("groups short numbers the same as long ones", () => {
+    // The Indian system's first group is three wide, so anything under a
+    // lakh looks like every other locale.
+    expect(formatValue(1234.5, "#,##0.00", { locale: "hi-IN" })).toBe("1,234.50")
+    expect(formatValue(123456.5, "#,##0.00", { locale: "hi-IN" })).toBe("1,23,456.50")
+  })
+
+  it("does not group when the format did not ask", () => {
+    expect(formatValue(12345678, "0", { locale: "hi-IN" })).toBe("12345678")
+  })
+
+  it("leaves a Special format's literals alone", () => {
+    // `000-00-0000` interleaves literals with placeholders; re-grouping
+    // those digits would be nonsense.
+    expect(formatValue(123456789, "000-00-0000", { locale: "hi-IN" })).toBe("123-45-6789")
+  })
+
+  it("still refuses a locale Intl cannot use", () => {
+    expect(() => formatValue(1, "#,##0", { locale: "not a tag" })).toThrow()
+  })
+})


### PR DESCRIPTION
Refs #474 (three of its items; the issue stays open for the rest).

## `parseW3CDTF` read a bare date-time as local

`new Date("2024-01-15T10:30:00")` is **local** time under ECMA-262. W3CDTF requires a zone designator and hucre's own writer always emits `Z`, so compliant files were never at risk — but a producer that omits it shifted `created` and `modified` by the reader's own offset. The same workbook opened in Istanbul and in Tokyo reported timestamps six hours apart.

This is the #415 shape in a third place (ODS cells, ODS streaming, now docProps), so rather than fix it separately for the third time, all three now call one `parseUtcDefaultDateTime` in `_date.ts`. An explicit `Z` or `+02:00` is still honoured untouched — only silence is filled in.

## `toMarkdown` escaped `|` and nothing else

A cell reading `*not emphasis*` rendered as emphasis. The inline syntax (`\` `` ` `` `*` `_` `[` `]` `<`) is now escaped too.

`escapeInline: false` is there for the opposite case — a column of `**bold**` labels meant to render. Pipes and newlines are escaped either way, because losing those loses the table.

`>` is deliberately **not** escaped: a blockquote needs the start of a line and a table cell is never one, so it would be noise. `_` **is**, despite GFM not treating intraword underscores as emphasis, because telling `_total_` from `sub_total` needs the flanking rules — the escape hatch is the honest answer there.

## `formatValue` grouped in threes regardless of locale

Since #456 the separator came from `Intl` for any locale; the grouping *pattern* did not. Measured before and after:

```
         before              after / Intl
hi-IN    12,345,678.50       1,23,45,678.50
en-IN    12,345,678.50       1,23,45,678.50
en-US    12,345,678.50       12,345,678.50   (unchanged)
de-DE    12.345.678,50       12.345.678,50   (unchanged)
```

The widths are read from `Intl` by formatting a long number and measuring the digit runs, so `en-IN`, `bn-IN`, `ne-NP` and the rest come out right without anyone listing them. `LocaleFormat` gains a `groupSizes` field. A Special format like `000-00-0000` interleaves literals with placeholders and is left alone — re-grouping those digits would be nonsense.

The test asserts agreement with `Intl.NumberFormat` directly across seven locales, so it does not need updating when locale data moves.

## Plus the doc line #474 asked for

`fullCalcOnLoad="1"` is written unconditionally, so Excel discards the cached results hucre just wrote. The practical consequence is now in `docs/PARITY.md`: **`formulaResult` survives a hucre round-trip and does not survive being opened in Excel.**

## Tests

`test/audit-correctness.test.ts` — 16 cases, mutation-checked, 7 fail against `main`.

`pnpm lint`, `pnpm typecheck`, 10001 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)