### PR TITLE
chore: pin coverage and bundle size, and one sturdy type reader — refs #474

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,27 @@ jobs:
       - name: Verify packaged artifact
         run: node scripts/verify-package.mjs
 
+  budgets:
+    # Two numbers that were true and enforced by nothing: 98.8% coverage,
+    # and a bundle size the README only ever compared *against* a
+    # competitor without publishing. Either can slide a release at a time
+    # until someone notices. One job, no matrix — these do not vary by
+    # runtime. See #474.
+    runs-on: ubuntu-latest
+    name: coverage + size
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Coverage thresholds
+        run: pnpm coverage
+      - name: Bundle-size budget
+        run: pnpm size
+
   timezone:
     # Everything above runs in UTC, which is where a whole class of date bug
     # hides: #415 was silent in CI for exactly that reason, and the CSV

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import { readXml, writeXml } from "hucre/xml" // Tabular XML
 |                         | hucre                | SheetJS CE    | ExcelJS   | xlsx-js-style |
 | ----------------------- | -------------------- | ------------- | --------- | ------------- |
 | **Dependencies**        | 0                    | 0\*           | 9         | 0\*           |
-| **Bundle (gzip)**       | 2–114 KB<sup>†</sup> | ~300 KB       | ~500 KB   | ~300 KB       |
+| **Bundle (gzip)**       | 4–127 KB<sup>†</sup> | ~300 KB       | ~500 KB   | ~300 KB       |
 | **ESM native**          | Yes                  | Partial       | No (CJS)  | Partial       |
 | **TypeScript**          | Native               | Bolted-on     | Bolted-on | Bolted-on     |
 | **Edge runtime**        | Yes                  | No            | No        | No            |
@@ -85,9 +85,15 @@ import { readXml, writeXml } from "hucre/xml" // Tabular XML
 
 † Depends on what you import — hucre is fully tree-shakeable, so there is no
 single number. Minified + gzipped, bundled with rolldown against `dist/`:
-`{ parseCsv, writeCsv }` from `hucre/csv` = **2.3 KB**, `{ readXlsx }` from
-`hucre/xlsx` = **32 KB**, `{ readXlsx, writeXlsx }` = **64 KB**, the entire
-library (`export * from "hucre"`) = **114 KB**.
+`{ parseCsv, writeCsv }` from `hucre/csv` = **3.7 KB**, `{ readXlsx }` from
+`hucre/xlsx` = **34 KB**, `{ readXlsx, writeXlsx }` = **68 KB**, the entire
+library (`export * from "hucre"`) = **127 KB**.
+
+These four are measured by `pnpm size` and pinned in
+`scripts/size-budget.json`, so CI fails when one grows past its budget.
+They are in the README because they had already drifted once — the
+previous figures (2.3 / 32 / 64 / 114 KB) were true when written and were
+enforced by nothing.
 
 ‡ `cellIs`, `expression`, `colorScale`, `dataBar`, `iconSet`, `containsText`,
 `notContainsText`, `beginsWith`, `endsWith`, `containsBlanks`,

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "bench": "node bench/index.mjs",
     "build": "obuild",
     "verify:package": "pnpm build && node scripts/verify-package.mjs",
+    "coverage": "vitest run --coverage",
+    "size": "pnpm build && node scripts/size.mjs",
+    "size:update": "pnpm build && node scripts/size.mjs --update",
     "dev": "vitest",
     "lint": "oxlint . && oxfmt --check .",
     "lint:fix": "oxlint . --fix && oxfmt .",
@@ -93,6 +96,7 @@
     "obuild": "^0.4.38",
     "oxfmt": "^0.61.0",
     "oxlint": "^1.76.0",
+    "rolldown": "^1.2.3",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,21 +32,24 @@ importers:
       oxlint:
         specifier: ^1.76.0
         version: 1.76.0
+      rolldown:
+        specifier: ^1.2.3
+        version: 1.2.3
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
 
   web:
     devDependencies:
       nitro:
         specifier: latest
-        version: 3.0.260610-beta(jiti@2.7.0)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 3.0.260610-beta(jiti@2.7.0)(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
       vite:
         specifier: latest
-        version: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
+        version: 8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
 
 packages:
 
@@ -99,6 +102,9 @@ packages:
 
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
+
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
 
   '@oxfmt/binding-android-arm-eabi@0.61.0':
     resolution: {integrity: sha512-BaS+1OVvg9sr+Xav0+KdWedQRcAzrdoEcwMZeqoc2F6ieC1s/t5eM35YQoRPQ7vAqkZ+p3tbQb1r9I9mrV5oGA==}
@@ -353,8 +359,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.2.1':
     resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -365,8 +383,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.2.1':
     resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -377,8 +407,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.2.1':
     resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -391,8 +434,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -405,8 +462,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.2.1':
     resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -419,8 +490,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.2.1':
     resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -435,8 +519,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.2.1':
     resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1174,6 +1270,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
@@ -1321,8 +1422,8 @@ packages:
     resolution: {integrity: sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg==}
     engines: {node: '>=18.12.0'}
 
-  vite@8.2.0:
-    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1475,6 +1576,8 @@ snapshots:
 
   '@oxc-project/types@0.142.0': {}
 
+  '@oxc-project/types@0.143.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.61.0':
     optional: true
 
@@ -1596,37 +1699,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.2.1':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.2.1':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.2.1':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.2.1':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.2.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.2.1':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.2.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.2.1':
@@ -1639,7 +1778,13 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.2.1':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.2.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -1736,7 +1881,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -1747,13 +1892,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2042,7 +2187,7 @@ snapshots:
 
   nf3@0.3.23: {}
 
-  nitro@3.0.260610-beta(jiti@2.7.0)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
+  nitro@3.0.260610-beta(jiti@2.7.0)(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
@@ -2060,7 +2205,7 @@ snapshots:
       unstorage: 2.0.0-alpha.7(db0@0.3.4)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       jiti: 2.7.0
-      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -2103,8 +2248,8 @@ snapshots:
       exsolve: 1.1.1
       magic-string: 0.30.21
       pathe: 2.0.3
-      rolldown: 1.2.1
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.1)(typescript@7.0.2)
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.3)(typescript@7.0.2)
       tinyglobby: 0.2.17
     transitivePeerDependencies:
       - '@typescript/native-preview'
@@ -2201,12 +2346,12 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.27.14(rolldown@1.2.1)(typescript@7.0.2):
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.3)(typescript@7.0.2):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
-      rolldown: 1.2.1
+      rolldown: 1.2.3
       yuku-ast: 0.8.3
       yuku-codegen: 0.8.3
       yuku-parser: 0.8.3
@@ -2235,6 +2380,26 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.2.1
       '@rolldown/binding-win32-arm64-msvc': 1.2.1
       '@rolldown/binding-win32-x64-msvc': 1.2.1
+
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
 
   rou3@0.8.1: {}
 
@@ -2319,7 +2484,7 @@ snapshots:
 
   verkit@0.3.1: {}
 
-  vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -2332,10 +2497,10 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2352,7 +2517,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.0(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.2.1(@types/node@26.1.2)(jiti@2.7.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.2

--- a/scripts/size-budget.json
+++ b/scripts/size-budget.json
@@ -1,0 +1,26 @@
+{
+  "csv (hucre/csv)": {
+    "min": 10197,
+    "gzip": 4016
+  },
+  "readXlsx (hucre/xlsx)": {
+    "min": 137436,
+    "gzip": 36958
+  },
+  "read+write xlsx (hucre/xlsx)": {
+    "min": 269990,
+    "gzip": 72852
+  },
+  "everything (hucre)": {
+    "min": 487341,
+    "gzip": 136931
+  },
+  "writeXlsx (hucre)": {
+    "min": 137445,
+    "gzip": 39162
+  },
+  "readOds (hucre/ods)": {
+    "min": 26941,
+    "gzip": 9438
+  }
+}

--- a/scripts/size.mjs
+++ b/scripts/size.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// ── Bundle-size budget ──────────────────────────────────────────────
+//
+// The README compares hucre against a competitor's ~300 KB without ever
+// publishing hucre's own number, and nothing anywhere pinned it — so a
+// regression that doubled what a caller pulls in would ship silently.
+// See #474.
+//
+// What this measures is what a caller actually gets: a synthetic entry
+// importing one API from one entry point, bundled and minified, so the
+// tree shaking counts. That is a different — and much smaller — number
+// than the size of `dist/`, which holds every format.
+//
+// Run: node scripts/size.mjs          check against the budgets below
+//      node scripts/size.mjs --update rewrite the budgets from measurement
+
+import { gzipSync } from "node:zlib"
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { rolldown } from "rolldown"
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url))
+const budgetPath = join(repoRoot, "scripts", "size-budget.json")
+
+/**
+ * One entry per thing worth pinning. `from` is the published subpath so
+ * the numbers describe what a caller imports, not what `src/` contains.
+ */
+const SCENARIOS = [
+  // The four the README's bundle-size footnote publishes. Pinning
+  // exactly these is the point: the footnote had already drifted — it
+  // claimed 114 KB for the whole library, which measures 127.
+  { name: "csv (hucre/csv)", from: "hucre/csv", named: ["parseCsv", "writeCsv"] },
+  { name: "readXlsx (hucre/xlsx)", from: "hucre/xlsx", named: ["readXlsx"] },
+  { name: "read+write xlsx (hucre/xlsx)", from: "hucre/xlsx", named: ["readXlsx", "writeXlsx"] },
+  { name: "everything (hucre)", from: "hucre", named: null },
+  // Worth watching besides.
+  { name: "writeXlsx (hucre)", from: "hucre", named: ["writeXlsx"] },
+  { name: "readOds (hucre/ods)", from: "hucre/ods", named: ["readOds"] },
+]
+
+/** Map a published subpath to the built file it resolves to. */
+function resolveEntry(subpath) {
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"))
+  const key = subpath === "hucre" ? "." : `./${subpath.slice("hucre/".length)}`
+  const target = pkg.exports[key]?.default
+  if (!target) throw new Error(`package.json#exports has no entry for ${subpath}`)
+  return join(repoRoot, target)
+}
+
+async function measure(scenario, workDir) {
+  const entryFile = resolveEntry(scenario.from)
+  const source = scenario.named
+    ? `import { ${scenario.named.join(", ")} } from ${JSON.stringify(entryFile)}\n` +
+      `console.log(${scenario.named.join(", ")})\n`
+    : `import * as all from ${JSON.stringify(entryFile)}\nconsole.log(all)\n`
+
+  const input = join(workDir, `${scenario.name.replace(/\W+/g, "-")}.mjs`)
+  writeFileSync(input, source)
+
+  const bundle = await rolldown({ input, logLevel: "silent" })
+  const { output } = await bundle.write({
+    dir: join(workDir, "out"),
+    format: "esm",
+    minify: true,
+  })
+  await bundle.close()
+
+  const code = output
+    .filter((c) => c.type === "chunk")
+    .map((c) => c.code)
+    .join("")
+  const bytes = Buffer.from(code, "utf8")
+  return { min: bytes.length, gzip: gzipSync(bytes, { level: 9 }).length }
+}
+
+const update = process.argv.includes("--update")
+const workDir = mkdtempSync(join(tmpdir(), "hucre-size-"))
+let failures = 0
+
+try {
+  const budgets = update ? {} : JSON.parse(readFileSync(budgetPath, "utf8"))
+  const measured = {}
+
+  console.log("\n  scenario                        minified      gzipped")
+  console.log("  " + "-".repeat(58))
+
+  for (const scenario of SCENARIOS) {
+    const { min, gzip } = await measure(scenario, workDir)
+    measured[scenario.name] = { min, gzip }
+
+    const budget = budgets[scenario.name]
+    const over = budget && (min > budget.min || gzip > budget.gzip)
+    if (over) failures++
+
+    const mark = update ? " " : over ? "!" : " "
+    console.log(
+      `${mark} ${scenario.name.padEnd(30)} ${kb(min).padStart(9)} ${kb(gzip).padStart(12)}` +
+        (over ? `   over ${kb(budget.min)} / ${kb(budget.gzip)}` : ""),
+    )
+  }
+
+  if (update) {
+    writeFileSync(budgetPath, `${JSON.stringify(withHeadroom(measured), null, 2)}\n`)
+    console.log(`\n  budgets written to scripts/size-budget.json (+5% headroom)\n`)
+  } else if (failures > 0) {
+    console.log(
+      `\n  ${failures} scenario(s) over budget. If the growth is intended, ` +
+        `run \`node scripts/size.mjs --update\` and say why in the commit.\n`,
+    )
+    process.exitCode = 1
+  } else {
+    console.log("\n  all within budget\n")
+  }
+} finally {
+  rmSync(workDir, { recursive: true, force: true })
+}
+
+/**
+ * Budgets carry 5% headroom over the measurement that set them.
+ *
+ * A budget pinned to the exact byte fails on a comment, which teaches
+ * people to run `--update` reflexively and stops the check meaning
+ * anything. 5% is loose enough to absorb ordinary edits and tight enough
+ * that pulling in a new subsystem is still caught.
+ */
+function withHeadroom(measured) {
+  const out = {}
+  for (const [name, { min, gzip }] of Object.entries(measured)) {
+    out[name] = { min: Math.ceil(min * 1.05), gzip: Math.ceil(gzip * 1.05) }
+  }
+  return out
+}
+
+function kb(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`
+}

--- a/test/_reflect.ts
+++ b/test/_reflect.ts
@@ -1,0 +1,179 @@
+// ── Reading the type model at run time ──────────────────────────────
+//
+// Several tests derive their expectations from `src/_types.ts` rather
+// than transcribing them, so a field added to the model breaks the test
+// that should have covered it. Types are erased at run time, so the
+// source is what there is to read.
+//
+// This used to be three copies of
+// `new RegExp('export interface ' + name + ' \\{([\\s\\S]*?)\\n\\}')`,
+// which has two failure modes worth naming (#474):
+//
+//   1. `[\s\S]*?\n\}` stops at the first `}` in column 0. A JSDoc block
+//      holding a code example, or any nested type closed at column 0,
+//      truncates the interface silently — and a *shorter* field list
+//      makes a derive-from-source test pass, not fail.
+//   2. It cannot match `export interface Foo extends Bar {` at all, and
+//      it never followed `extends`, so inherited fields were invisible.
+//      That is not hypothetical: during the audit behind #439 a finding
+//      was filed against `JsonReadOptions` for a missing `typeInference`
+//      that was there all along, on the interface it extends.
+//
+// So: strip comments, count braces, follow `extends`.
+
+import { readFileSync } from "node:fs"
+
+/**
+ * Files searched for a declaration, in order.
+ *
+ * `_types.ts` holds the model, but `extends` shows up in the per-format
+ * option types — and following it is the whole point, so the reader has
+ * to be able to see them.
+ */
+const SOURCES = [
+  "../src/_types.ts",
+  "../src/json/reader.ts",
+  "../src/json/flatten.ts",
+  "../src/csv/reader.ts",
+]
+
+const cache = new Map<string, string>()
+
+function sources(): string[] {
+  return SOURCES.map((path) => {
+    let text = cache.get(path)
+    if (text === undefined) {
+      text = stripComments(readFileSync(new URL(path, import.meta.url), "utf-8"))
+      cache.set(path, text)
+    }
+    return text
+  })
+}
+
+/**
+ * Remove block and line comments, keeping every newline so line-anchored
+ * matching still lines up with the original.
+ *
+ * Done before brace counting, so a `}` inside a JSDoc example cannot end
+ * an interface early, and before field matching, so a commented-out field
+ * is not collected as a real one.
+ */
+function stripComments(text: string): string {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, " "))
+    .replace(/\/\/[^\n]*/g, (m) => " ".repeat(m.length))
+}
+
+/** The declaration head and body of one interface, comments removed. */
+function declarationOf(iface: string): { extends: string[]; body: string } {
+  let text: string | undefined
+  let head: RegExpExecArray | null = null
+  for (const candidate of sources()) {
+    head = new RegExp(`export interface ${iface}\\b([^{]*)\\{`).exec(candidate)
+    if (head) {
+      text = candidate
+      break
+    }
+  }
+  if (!head || text === undefined) {
+    throw new Error(`interface ${iface} not found — did it get renamed?`)
+  }
+
+  // Brace-count from the opening brace to its match. `[\s\S]*?\n\}` was
+  // the shortcut here and it is the one that truncates.
+  const open = head.index + head[0].length
+  let depth = 1
+  let i = open
+  for (; i < text.length && depth > 0; i++) {
+    if (text[i] === "{") depth++
+    else if (text[i] === "}") depth--
+  }
+  if (depth !== 0) throw new Error(`interface ${iface} has no closing brace`)
+
+  const heritage = head[1]!.trim()
+  const bases = heritage.startsWith("extends")
+    ? heritage
+        .slice("extends".length)
+        .split(",")
+        // `extends Foo<Bar>` — the base's own name is what we can look up.
+        .map((b) => b.trim().replace(/<.*$/, ""))
+        .filter(Boolean)
+    : []
+
+  return { extends: bases, body: text.slice(open, i - 1) }
+}
+
+/**
+ * Field names declared directly on an interface — not on anything it
+ * extends, and not on nested object types inside it.
+ *
+ * Depth tracking is what excludes the nested ones: a field of an inline
+ * `{ ... }` type sits at depth 1 or deeper and is not part of this
+ * interface's own surface.
+ */
+export function ownFieldsOf(iface: string): string[] {
+  const { body } = declarationOf(iface)
+  const fields: string[] = []
+  let depth = 0
+  let atLineStart = true
+
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i]!
+    if (ch === "{" || ch === "(" || ch === "[") depth++
+    else if (ch === "}" || ch === ")" || ch === "]") depth--
+    else if (ch === "\n") {
+      atLineStart = true
+      continue
+    }
+
+    if (!atLineStart || depth !== 0) {
+      if (ch !== " ") atLineStart = false
+      continue
+    }
+    if (ch === " ") continue
+
+    // First non-space on a line at depth 0 — the only place a field of
+    // this interface can be declared.
+    atLineStart = false
+    const rest = body.slice(i)
+    const match = /^(?:readonly\s+)?(\w+)\s*\??\s*:/.exec(rest)
+    if (match) fields.push(match[1]!)
+  }
+
+  return fields
+}
+
+/**
+ * Every field an interface has, including those it inherits.
+ *
+ * A base that is not itself declared in `_types.ts` — a TypeScript
+ * built-in, or a type imported from elsewhere — contributes nothing
+ * rather than throwing, because it is not part of hucre's model and no
+ * test derives expectations from it.
+ */
+export function fieldsOf(iface: string): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  const visit = (name: string, guard: Set<string>): void => {
+    if (guard.has(name)) return
+    guard.add(name)
+
+    let decl: { extends: string[]; body: string }
+    try {
+      decl = declarationOf(name)
+    } catch {
+      return
+    }
+    for (const base of decl.extends) visit(base, guard)
+    for (const field of ownFieldsOf(name)) {
+      if (!seen.has(field)) {
+        seen.add(field)
+        out.push(field)
+      }
+    }
+  }
+
+  visit(iface, new Set())
+  return out
+}

--- a/test/builder-coverage.test.ts
+++ b/test/builder-coverage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { fieldsOf } from "./_reflect"
 import { readFileSync } from "node:fs"
 import { WorkbookBuilder } from "../src/builder"
 import { readXlsx } from "../src/xlsx/reader"
@@ -15,14 +16,6 @@ import { readXlsx } from "../src/xlsx/reader"
 // The named methods below cover what a builder is for; `set` covers the
 // rest, so the class cannot fall behind the type again.
 // ═══════════════════════════════════════════════════════════════════════
-
-/** Field names of an interface, read out of the source — see write-model.test.ts. */
-function fieldsOf(iface: string): string[] {
-  const source = readFileSync(new URL("../src/_types.ts", import.meta.url), "utf-8")
-  const body = new RegExp(`export interface ${iface} \\{([\\s\\S]*?)\\n\\}`).exec(source)
-  if (!body) throw new Error(`interface ${iface} not found — did it get renamed?`)
-  return [...body[1]!.matchAll(/^ {2}([a-zA-Z0-9]+)\??:/gm)].map((m) => m[1]!)
-}
 
 describe("the builder can express the whole model", () => {
   it("reaches every WriteSheet field", async () => {

--- a/test/parity-statement.test.ts
+++ b/test/parity-statement.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { fieldsOf } from "./_reflect"
 import { readFileSync } from "node:fs"
 import type { Sheet, WriteOptions, WriteSheet, Workbook } from "../src/_types"
 
@@ -17,19 +18,6 @@ import type { Sheet, WriteOptions, WriteSheet, Workbook } from "../src/_types"
 
 const parity = (): string => readFileSync(new URL("../docs/PARITY.md", import.meta.url), "utf-8")
 const readme = (): string => readFileSync(new URL("../README.md", import.meta.url), "utf-8")
-
-/**
- * Field names of an interface, read out of the source.
- *
- * Types are erased at run time, so the alternative is transcribing the
- * lists by hand — which is exactly the drift this file exists to catch.
- */
-function fieldsOf(iface: string): string[] {
-  const source = readFileSync(new URL("../src/_types.ts", import.meta.url), "utf-8")
-  const body = new RegExp(`export interface ${iface} \\{([\\s\\S]*?)\\n\\}`).exec(source)
-  if (!body) throw new Error(`interface ${iface} not found — did it get renamed?`)
-  return [...body[1].matchAll(/^ {2}(\w+)\??:/gm)].map((m) => m[1])
-}
 
 const writeFields = new Set([...fieldsOf("WriteOptions"), ...fieldsOf("WriteSheet")])
 const readFields = new Set([...fieldsOf("Workbook"), ...fieldsOf("Sheet")])

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { fieldsOf, ownFieldsOf } from "./_reflect"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #474 — four tests derive their expectations from `src/_types.ts` by
+// regex, and a derive-from-source test that reads *less* than it should
+// passes rather than fails. That is the dangerous direction, so the
+// reader itself is worth testing.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("reading an interface's own fields", () => {
+  it("finds the ones a hand-check confirms", () => {
+    const fields = ownFieldsOf("MergeRange")
+
+    expect(fields).toEqual(["startRow", "startCol", "endRow", "endCol"])
+  })
+
+  it("does not stop at a nested type's closing brace", () => {
+    // `PageMargins` is small and flat; `PageSetup` holds `margins?:
+    // PageMargins` plus a dozen fields after it, and several of its doc
+    // comments carry braces. Truncation here would be silent.
+    const fields = ownFieldsOf("PageSetup")
+
+    expect(fields).toContain("paperSize") // first
+    expect(fields).toContain("margins") // middle
+    expect(fields).toContain("usePrinterDefaults") // last
+  })
+
+  it("does not collect a nested object type's fields as the parent's", () => {
+    // `SheetImage.anchor` is an inline `{ from: ...; to?: ... }`. Its
+    // `from` and `to` belong to that type, not to SheetImage.
+    const fields = ownFieldsOf("SheetImage")
+
+    expect(fields).toContain("anchor")
+    expect(fields).not.toContain("from")
+    expect(fields).not.toContain("to")
+  })
+
+  it("does not collect a commented-out field", () => {
+    // Comments are stripped before matching, so a field someone parked
+    // behind `//` is not counted as shipped.
+    expect(ownFieldsOf("ReadOptions")).not.toContain("headerRow")
+  })
+})
+
+describe("following extends", () => {
+  it("includes an inherited field", () => {
+    // The audit behind #439 filed a finding against `JsonReadOptions` for
+    // a missing `typeInference` that was there all along, on the
+    // interface it extends. A reader that cannot see `extends` is how
+    // that mistake gets made twice.
+    expect(ownFieldsOf("JsonReadOptions")).not.toContain("typeInference")
+    expect(fieldsOf("JsonReadOptions")).toContain("typeInference")
+  })
+
+  it("keeps the interface's own fields as well", () => {
+    const own = ownFieldsOf("JsonReadOptions")
+    const all = fieldsOf("JsonReadOptions")
+
+    expect(own.length).toBeGreaterThan(0)
+    for (const field of own) expect(all, field).toContain(field)
+    expect(all.length).toBeGreaterThan(own.length)
+  })
+
+  it("reports each field once even when a base repeats it", () => {
+    const all = fieldsOf("JsonReadOptions")
+
+    expect(new Set(all).size).toBe(all.length)
+  })
+})
+
+describe("when the model moves under it", () => {
+  it("says so rather than returning nothing", () => {
+    expect(() => ownFieldsOf("NoSuchInterfaceAnywhere")).toThrow(/not found/)
+  })
+})

--- a/test/write-model.test.ts
+++ b/test/write-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { fieldsOf } from "./_reflect"
 import { readFileSync } from "node:fs"
 import { toWriteOptions, toWriteSheet, type WriteModelDrop } from "../src/write-model"
 import { writeXlsx } from "../src/xlsx/writer"
@@ -17,18 +18,6 @@ import type { Sheet, Workbook } from "../src/_types"
 // decided which fields to drop. `toWriteOptions` makes the decisions once
 // and makes the loss observable.
 // ═══════════════════════════════════════════════════════════════════════
-
-/**
- * Field names of an interface, read out of the source. Same trick as
- * test/parity-statement.test.ts: types are erased at run time, and
- * transcribing the lists is exactly the drift this guards against.
- */
-function fieldsOf(iface: string): string[] {
-  const source = readFileSync(new URL("../src/_types.ts", import.meta.url), "utf-8")
-  const body = new RegExp(`export interface ${iface} \\{([\\s\\S]*?)\\n\\}`).exec(source)
-  if (!body) throw new Error(`interface ${iface} not found — did it get renamed?`)
-  return [...body[1]!.matchAll(/^ {2}([a-zA-Z0-9]+)\??:/gm)].map((m) => m[1]!)
-}
 
 describe("the drop list stays exhaustive", () => {
   it("names every Sheet field with no WriteSheet counterpart", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,10 @@
     "test/ods-fidelity.test.ts",
     "test/parity-statement.test.ts",
     "test/write-model.test.ts",
+    // Reads src/_types.ts off disk, so it needs `node:fs` — the same
+    // reason the file-reading tests above are here. See #474.
+    "test/_reflect.ts",
+    "test/reflect.test.ts",
     "test/builder-coverage.test.ts"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,25 @@ export default defineConfig({
     // silently collects every worktree's suite as well, and the reported
     // test count is whatever happens to be checked out beside you.
     exclude: ["**/node_modules/**", "**/dist/**", "**/.claude/**"],
+    coverage: {
+      // 98.8% coverage enforced by nothing is a number, not a floor —
+      // it can slide a point a release and nobody notices until it has
+      // slid ten. See #474.
+      //
+      // Set just under the measurement that produced them, so an
+      // ordinary edit does not fail while a subsystem landing untested
+      // does. Raise them when the real figure moves up; that is the
+      // point of a ratchet.
+      thresholds: {
+        statements: 98.5,
+        branches: 96,
+        functions: 98,
+        lines: 99,
+      },
+      // The CLI is verified by running the packaged binary
+      // (scripts/verify-package.mjs), not by the unit suite, so counting
+      // it here would report a floor the suite never defended.
+      exclude: ["src/cli.ts", "src/cli/**"],
+    },
   },
 })


### PR DESCRIPTION
Refs #474 (its three testing-infrastructure items). All the same shape: something true that nothing enforced.

## Coverage

98.8% with no threshold is a number, not a floor — it slides a point a release until it has slid ten. `vitest.config.ts` now sets statements 98.5 / branches 96 / functions 98 / lines 99, just under the measurement that produced them.

`src/cli` is excluded, because the packaged binary is verified by `scripts/verify-package.mjs` and not by the unit suite — counting it would report a floor the suite never defended.

Verified as enforcement, not decoration: raising statements to 99.9 produces `ERROR: Coverage for statements (98.77%) does not meet global threshold (99.9%)` and exits non-zero.

## Bundle size

`scripts/size.mjs` bundles a synthetic entry per API with rolldown and checks it against `scripts/size-budget.json`, so the numbers describe what a caller actually pulls in rather than the size of `dist/`:

```
  scenario                        minified      gzipped
  ----------------------------------------------------------
  csv (hucre/csv)                   9.5 KB       3.7 KB
  readXlsx (hucre/xlsx)           127.8 KB      34.4 KB
  read+write xlsx (hucre/xlsx)    251.1 KB      67.8 KB
  everything (hucre)              453.3 KB     127.4 KB
  writeXlsx (hucre)               127.8 KB      36.4 KB
  readOds (hucre/ods)              25.1 KB       8.8 KB
```

Budgets carry **5% headroom**. A budget pinned to the byte fails on a comment, which teaches people to run `--update` reflexively and stops the check meaning anything.

**Measuring it found the README's own figures had already drifted** — which is the argument for pinning them, in one line. It published 2.3 / 32 / 64 / 114 KB gzipped; the truth is 3.7 / 34 / 68 / 127. Corrected, and the four scenarios pinned are exactly the four the README quotes, so they cannot drift apart again.

Adds `rolldown` as a devDependency. It was already in the lockfile transitively via obuild.

## The type reader

Three tests each carried their own copy of `new RegExp('export interface ' + name + ' \{([\s\S]*?)\n\}')`.

**It is not currently wrong.** Measured against every interface those tests use, the new reader returns identical field lists:

```
Sheet          old= 33 new= 33
WriteSheet     old= 31 new= 31
Workbook       old= 14 new= 14
WriteOptions   old= 10 new= 10
ReadOptions    old= 11 new= 11
PageSetup      old= 27 new= 27
```

It is fragile in the *dangerous* direction, though: `[\s\S]*?\n\}` stops at the first `}` in column 0, and a **shorter** field list makes a derive-from-source test pass rather than fail. That is a guard that quietly stops guarding.

`test/_reflect.ts` strips comments, counts braces, and follows `extends`. The last of those is not hypothetical — the audit behind #439 filed a finding against `JsonReadOptions` for a `typeInference` that was there all along, on the interface it extends. There is a test asserting exactly that case.

## CI

Both budgets run in one `coverage + size` job. Neither varies by runtime, so no matrix.

`pnpm lint`, `pnpm typecheck`, 10015 tests green; coverage and size both pass their own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
