### PR TITLE
refactor(xlsx): the writer says where the drawing goes — refs #474

### DIFF
--- a/src/xlsx/roundtrip.ts
+++ b/src/xlsx/roundtrip.ts
@@ -1136,7 +1136,7 @@ export async function saveXlsx(
             Target: preservedDrawingTarget,
           }),
         )
-        worksheetXml = injectWorksheetDrawing(worksheetXml, preservedDrawingRId)
+        worksheetXml = insertDrawingElement(worksheetXml, result, preservedDrawingRId)
       }
 
       // Wire up the model-chart drawing (issue #136): emit the drawing
@@ -1150,7 +1150,7 @@ export async function saveXlsx(
             Target: `../drawings/drawing${modelDrawing.drawingNumber}.xml`,
           }),
         )
-        worksheetXml = injectWorksheetDrawing(worksheetXml, modelDrawingRId)
+        worksheetXml = insertDrawingElement(worksheetXml, result, modelDrawingRId)
       }
 
       // Threaded comments (Excel 365). The rId only needs to be unique
@@ -1296,42 +1296,32 @@ const REL_TYPE_SLICER = /\/relationships\/slicer$/
 const REL_TYPE_TIMELINE = /\/relationships\/timeline$/
 
 /**
- * Insert `<drawing r:id="rIdN"/>` into a worksheet body emitted by the
- * worksheet writer. Per OOXML schema (CT_Worksheet) the element must
- * appear after `cellWatches`/`ignoredErrors`/`smartTags` and before
- * `legacyDrawing` / `legacyDrawingHF` / `picture` / `oleObjects` /
- * `controls` / `webPublishItems` / `tableParts` / `extLst`.
+ * Insert `<drawing r:id="rIdN"/>` into a worksheet body the writer just
+ * produced.
  *
- * The writer never emits a `<drawing>` for chart-only sheets, so we
- * splice one into the regenerated XML at the first valid insertion
- * point. Falls back to inserting just before `</worksheet>` when none
- * of the later-position siblings are present.
+ * Per CT_Worksheet the element must appear after
+ * `cellWatches`/`ignoredErrors`/`smartTags` and before `legacyDrawing`,
+ * `picture`, `oleObjects`, `controls`, `webPublishItems`, `tableParts`
+ * and `extLst`. The writer never emits one for a sheet whose drawing is
+ * *preserved* rather than generated, and the body is serialized before
+ * the rId is known — so one has to go in afterwards.
+ *
+ * This used to find the spot by searching the finished string for
+ * thirteen candidate successor tags and inserting before the first
+ * present, falling back to `</worksheet>`. Safe, because the input is
+ * hucre's own output and cell text is escaped — but it was a heuristic
+ * standing in for something the writer knows exactly. It now says so:
+ * `drawingInsertOffset` is the position, and this is one splice. See
+ * #474.
  */
-function injectWorksheetDrawing(worksheetXml: string, rId: string): string {
-  if (worksheetXml.includes("<drawing ")) return worksheetXml // already present
-  const tag = `<drawing r:id="${rId}"/>`
-  const candidates = [
-    "<legacyDrawing ",
-    "<legacyDrawingHF ",
-    "<picture ",
-    "<oleObjects ",
-    "<oleObjects>",
-    "<controls ",
-    "<controls>",
-    "<webPublishItems ",
-    "<webPublishItems>",
-    "<tableParts ",
-    "<tableParts>",
-    "<extLst ",
-    "<extLst>",
-  ]
-  for (const c of candidates) {
-    const idx = worksheetXml.indexOf(c)
-    if (idx >= 0) return worksheetXml.slice(0, idx) + tag + worksheetXml.slice(idx)
-  }
-  const closeIdx = worksheetXml.lastIndexOf("</worksheet>")
-  if (closeIdx < 0) return worksheetXml
-  return worksheetXml.slice(0, closeIdx) + tag + worksheetXml.slice(closeIdx)
+function insertDrawingElement(worksheetXml: string, result: WorksheetResult, rId: string): string {
+  // A sheet that already has its own drawing is not this function's
+  // business; the caller's guards mean it should never arrive here.
+  if (worksheetXml.includes("<drawing ")) return worksheetXml
+
+  const at = result.drawingInsertOffset
+  if (at < 0 || at > worksheetXml.length) return worksheetXml
+  return `${worksheetXml.slice(0, at)}<drawing r:id="${rId}"/>${worksheetXml.slice(at)}`
 }
 
 /**

--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -41,6 +41,16 @@ export interface HyperlinkRelationship {
 
 export interface WorksheetResult {
   xml: string
+  /**
+   * Character offset in {@link xml} where a `<drawing>` element belongs.
+   *
+   * The roundtrip has to insert one for a drawing it preserves rather
+   * than generates, and the worksheet body is serialized before the rId
+   * is known. This is the writer saying where, exactly, instead of the
+   * caller searching the finished string for a tag to sit in front of.
+   * See #474.
+   */
+  drawingInsertOffset: number
   hyperlinkRelationships: HyperlinkRelationship[]
   /** The rId used for the drawing reference (if sheet has images) */
   drawingRId: string | null
@@ -636,6 +646,12 @@ export function writeWorksheetXml(
   const hasImages = sheet.images && sheet.images.length > 0
   const hasTextBoxes = sheet.textBoxes && sheet.textBoxes.length > 0
   const hasCharts = sheet.charts && sheet.charts.length > 0
+  // Where a `<drawing>` element belongs in CT_Worksheet's element order.
+  // Recorded even when this writer emits none, because the roundtrip has
+  // to put one here for a drawing it is *preserving* rather than
+  // generating — and it used to find the spot by searching the finished
+  // string for thirteen candidate successor tags. See #474.
+  const drawingSlot = parts.length
   if (hasImages || hasTextBoxes || hasCharts) {
     // Drawing rId comes after all hyperlink rIds
     drawingRId = `rId${nextRId}`
@@ -706,8 +722,11 @@ export function writeWorksheetXml(
     }
   }
 
+  const xml = xmlDocument("worksheet", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts)
+
   return {
-    xml: xmlDocument("worksheet", { xmlns: NS_SPREADSHEET, "xmlns:r": NS_R }, parts),
+    xml,
+    drawingInsertOffset: offsetOfPart(xml, parts, drawingSlot),
     hyperlinkRelationships,
     drawingRId,
     legacyDrawingRId,
@@ -1713,4 +1732,23 @@ function serializeSparklines(sparklines: Sparkline[]): string {
   )
 
   return xmlElement("extLst", undefined, [extEl])
+}
+
+/**
+ * Character offset in a rendered document at which `parts[index]` starts.
+ *
+ * `xmlDocument` prepends a declaration and the root open tag, then joins
+ * the parts in order — so the offset is that prefix plus the lengths of
+ * everything before `index`. Derived from the rendered string rather than
+ * assumed, so a change to how the prologue is written cannot silently
+ * move it.
+ */
+function offsetOfPart(xml: string, parts: string[], index: number): number {
+  const body = parts.join("")
+  const bodyStart = body.length === 0 ? xml.lastIndexOf("</worksheet>") : xml.indexOf(body)
+  if (bodyStart < 0) return xml.lastIndexOf("</worksheet>")
+
+  let offset = bodyStart
+  for (let i = 0; i < index; i++) offset += parts[i]!.length
+  return offset
 }

--- a/test/drawing-insert-position.test.ts
+++ b/test/drawing-insert-position.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeWorksheetXml, createSharedStrings } from "../src/xlsx/worksheet-writer"
+import { createStylesCollector } from "../src/xlsx/styles-writer"
+import { openXlsx, saveXlsx } from "../src/xlsx/roundtrip"
+import { getCharts } from "../src/xlsx/chart-helpers"
+import { ZipReader } from "../src/zip/reader"
+import type { SheetChart, WriteSheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #474 — a preserved chart drawing needs a `<drawing r:id>` in the
+// regenerated worksheet, and the body is serialized before the rId is
+// known, so one has to go in afterwards. That was done by searching the
+// finished string for thirteen candidate successor tags and inserting
+// before the first one present.
+//
+// Safe, because the input is hucre's own output and cell text is escaped
+// — but a heuristic standing in for something the writer knows exactly.
+// The writer now reports the offset; this pins where it lands.
+// ═══════════════════════════════════════════════════════════════════════
+
+const decoder = new TextDecoder("utf-8")
+
+async function sheetXml(bytes: Uint8Array, n = 1): Promise<string> {
+  return decoder.decode(await new ZipReader(bytes).extract(`xl/worksheets/sheet${n}.xml`))
+}
+
+const CHART: SheetChart = {
+  type: "column",
+  title: "Revenue",
+  series: [{ name: "R", values: "B2:B5", categories: "A2:A5" }],
+  anchor: { from: { row: 7, col: 0 }, to: { row: 21, col: 7 } },
+}
+
+function base(): WriteSheet {
+  return {
+    name: "Data",
+    rows: [
+      ["Quarter", "Revenue"],
+      ["Q1", 12000],
+      ["Q2", 15500],
+      ["Q3", 14000],
+      ["Q4", 17800],
+    ],
+    charts: [CHART],
+  }
+}
+
+/** Index of an element in the worksheet body, or -1. */
+function at(xml: string, tag: string): number {
+  return xml.indexOf(`<${tag}`)
+}
+
+describe("the inserted <drawing> sits where CT_Worksheet says", () => {
+  it("goes after the elements that precede it", async () => {
+    // pageMargins, pageSetup, rowBreaks and colBreaks all come before
+    // `drawing` in the schema's sequence.
+    const sheet = base()
+    sheet.pageSetup = { orientation: "landscape", margins: { top: 1 } }
+    sheet.rowBreaks = [2]
+    sheet.colBreaks = [1]
+
+    const xml = await sheetXml(await saveXlsx(await openXlsx(await writeXlsx({ sheets: [sheet] }))))
+    const drawing = at(xml, "drawing ")
+
+    expect(drawing).toBeGreaterThan(0)
+    expect(drawing).toBeGreaterThan(at(xml, "pageMargins"))
+    expect(drawing).toBeGreaterThan(at(xml, "pageSetup"))
+    expect(drawing).toBeGreaterThan(at(xml, "rowBreaks"))
+    expect(drawing).toBeGreaterThan(at(xml, "colBreaks"))
+  })
+
+  it("goes before the elements that follow it", async () => {
+    // `tableParts` is the case the old search existed for: it is one of
+    // the thirteen, and a drawing after it is schema-invalid.
+    const sheet = base()
+    sheet.tables = [
+      {
+        name: "T1",
+        displayName: "T1",
+        range: "A1:B5",
+        columns: [{ name: "Quarter" }, { name: "Revenue" }],
+      },
+    ]
+
+    const xml = await sheetXml(await saveXlsx(await openXlsx(await writeXlsx({ sheets: [sheet] }))))
+
+    expect(at(xml, "drawing ")).toBeGreaterThan(0)
+    expect(at(xml, "drawing ")).toBeLessThan(at(xml, "tableParts"))
+  })
+
+  it("lands correctly on a sheet with none of the trailing siblings", async () => {
+    // The old code's fallback path: nothing to insert before, so the
+    // element goes last. Still has to be inside <worksheet>.
+    const xml = await sheetXml(
+      await saveXlsx(await openXlsx(await writeXlsx({ sheets: [base()] }))),
+    )
+
+    expect(at(xml, "drawing ")).toBeGreaterThan(0)
+    expect(at(xml, "drawing ")).toBeLessThan(xml.indexOf("</worksheet>"))
+    expect(at(xml, "drawing ")).toBeGreaterThan(at(xml, "sheetData"))
+  })
+
+  it("emits exactly one", async () => {
+    const xml = await sheetXml(
+      await saveXlsx(await openXlsx(await writeXlsx({ sheets: [base()] }))),
+    )
+
+    expect(xml.match(/<drawing /g)).toHaveLength(1)
+  })
+})
+
+describe("the reference resolves to a real part", () => {
+  it("the rId names a drawing relationship that exists", async () => {
+    const saved = await saveXlsx(await openXlsx(await writeXlsx({ sheets: [base()] })))
+
+    const xml = await sheetXml(saved)
+    const rId = /<drawing r:id="(rId\d+)"/.exec(xml)?.[1]
+    expect(rId).toBeDefined()
+
+    const rels = decoder.decode(
+      await new ZipReader(saved).extract("xl/worksheets/_rels/sheet1.xml.rels"),
+    )
+    const target = new RegExp(`Id="${rId}"[^>]*Target="([^"]+)"`).exec(rels)?.[1]
+    expect(target).toBeDefined()
+
+    const entries = new ZipReader(saved).entries()
+    expect(entries).toContain(`xl/${target!.replace(/^\.\.\//, "")}`)
+  })
+
+  it("and the chart still reads back", async () => {
+    // The point of the insertion in the first place.
+    const charts = getCharts(
+      await openXlsx(await saveXlsx(await openXlsx(await writeXlsx({ sheets: [base()] })))),
+    )
+
+    expect(charts).toHaveLength(1)
+    expect(charts[0].chart.title).toBe("Revenue")
+  })
+})
+
+// ── The contract itself ──────────────────────────────────────────────
+//
+// The tests above pass against the old string search too — this is a
+// refactor, and both put the element in a schema-valid place. What is
+// new is that the position is *reported* rather than rediscovered, so
+// that is what this asserts directly.
+
+describe("drawingInsertOffset is where the writer's own <drawing> goes", () => {
+  it("points exactly at the element on a sheet that has one", () => {
+    // A sheet with an image makes the writer emit its own `<drawing>`.
+    // The reported offset has to be that element's index — same slot,
+    // filled rather than empty.
+    const result = writeWorksheetXml(
+      {
+        name: "S",
+        rows: [["a"]],
+        images: [
+          {
+            data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]),
+            type: "png",
+            anchor: { from: { row: 0, col: 2 } },
+          },
+        ],
+      },
+      createStylesCollector(),
+      createSharedStrings(),
+    )
+
+    expect(result.drawingRId).not.toBeNull()
+    expect(result.drawingInsertOffset).toBe(result.xml.indexOf("<drawing "))
+  })
+
+  it("points at the gap where one would go on a sheet that has none", () => {
+    const result = writeWorksheetXml(
+      { name: "S", rows: [["a"]] },
+      createStylesCollector(),
+      createSharedStrings(),
+    )
+
+    expect(result.drawingRId).toBeNull()
+    expect(result.drawingInsertOffset).toBeGreaterThan(result.xml.indexOf("<sheetData"))
+    expect(result.drawingInsertOffset).toBeLessThanOrEqual(result.xml.indexOf("</worksheet>"))
+
+    // And splicing there produces a body whose drawing is in sequence.
+    const spliced =
+      result.xml.slice(0, result.drawingInsertOffset) +
+      '<drawing r:id="rId1"/>' +
+      result.xml.slice(result.drawingInsertOffset)
+
+    expect(spliced.indexOf("<drawing ")).toBeGreaterThan(spliced.indexOf("<sheetData"))
+    expect(spliced.indexOf("<drawing ")).toBeLessThan(spliced.indexOf("</worksheet>"))
+  })
+})


### PR DESCRIPTION
Refs #474 (the `injectWorksheetDrawing` item).

## What it did

`injectWorksheetDrawing` put `<drawing r:id>` into a regenerated worksheet by searching the finished string for thirteen candidate successor tags and inserting before the first one present:

```ts
const candidates = [
  "<legacyDrawing ", "<legacyDrawingHF ", "<picture ", "<oleObjects ", "<oleObjects>",
  "<controls ", "<controls>", "<webPublishItems ", "<webPublishItems>",
  "<tableParts ", "<tableParts>", "<extLst ", "<extLst>",
]
```
…falling back to just before `</worksheet>` when none were present.

The audit called this safe and it is: the input is hucre's own output and cell text is escaped, so nothing hostile reaches the search. But it is a heuristic standing in for something the writer knows exactly, and it rediscovers on every save a position the writer had in hand.

## What it does now

`WorksheetResult` carries `drawingInsertOffset` — the character offset where a `<drawing>` belongs, recorded as the writer assembles its parts. The insertion is one splice at a known index.

The offset is resolved against the *rendered* string rather than assumed, so a change to how `xmlDocument` writes the prologue cannot silently move it.

## Why not the obvious alternative

The natural fix is to pass a `drawingRId` into the writer so no insertion is needed at all. That does not work without a substantial reorder: the worksheet body is serialized before `sheetPreservedDrawingTargets` and `modelChartDrawings` are computed, and `worksheetResults` is consumed at five points in between. Moving the serialization loop past them is a large change to the most delicate function in the codebase, to fix something the issue itself classifies as safe. Reporting the offset gets the fragility out without that risk.

## Tests — and what they do and do not prove

`test/drawing-insert-position.test.ts`, 8 cases. Being straight about the split:

- **Six pass against `main` too.** They assert the element lands after `pageMargins`/`pageSetup`/`rowBreaks`/`colBreaks` and before `tableParts`, that exactly one is emitted, and that the rId resolves to a part that exists. Both implementations put it in a schema-valid place — this is a refactor, so that is the correct outcome. What these add is that the position is pinned rather than incidental.
- **Two fail against `main`**, and they are the ones asserting the new contract: on a sheet whose drawing the writer emits itself, `drawingInsertOffset` equals that element's own index — same slot, filled rather than empty; and on a sheet with none, splicing at the reported offset yields a body in schema sequence.

`pnpm lint`, `pnpm typecheck`, 10031 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
