### PR TITLE
fix(csv): stop expanding a number into a different number — refs #474

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -97,6 +97,31 @@ and does not survive being opened in Excel.** Set it when something other
 than Excel will read the file — a second tool, a diff, hucre itself — and
 do not rely on it as the number a person will see.
 
+### Numbers are written at full precision, not Excel's 15 digits
+
+`1e21` is written `1e+21` and `0.1 + 0.2` is written
+`0.30000000000000004` — seventeen significant digits, where Excel writes
+`1E+21` and caps its _display_ at fifteen. Both spellings are conformant
+`xsd:double`; the lexical space is `[Ee](\+|-)?[0-9]+`, so a lowercase
+`e` is correct rather than merely tolerated.
+
+The precision is the part that matters. `String(value)` is the only
+spelling that round-trips a double exactly, and every extreme does:
+`1e-7`, `1e300`, `Number.MIN_VALUE`, `Number.EPSILON`,
+`Number.MAX_SAFE_INTEGER`. Rounding to fifteen digits to look more like a
+file Excel wrote would turn `0.1 + 0.2` into `0.3` — a number the caller
+did not write. A library for moving data faithfully should not make that
+trade, and `test/number-serialisation.test.ts` pins it so the change
+cannot land quietly.
+
+The one loss is negative zero: `String(-0)` is `"0"`, and Excel has no
+signed zero either, so the sign goes.
+
+CSV has the same guarantee. It prefers the plain decimal form where Excel
+would otherwise show `1E-07` — but only when that form is the same
+number, which it was not for the smallest values (`Number.MIN_VALUE` used
+to come out as `0.0`).
+
 ### Ranges: two spellings, one meaning
 
 Ranges are A1 strings on `DataValidation.range`, `ConditionalRule.range`,

--- a/src/csv/writer.ts
+++ b/src/csv/writer.ts
@@ -218,15 +218,35 @@ function quoteField(value: string, opts: NormalizedWriteOptions): string {
   return opts.quote + escaped + opts.quote
 }
 
+/**
+ * Render a number for CSV.
+ *
+ * Excel shows a value written in exponent notation as `1E-07`, so the
+ * plain decimal form is preferred where there is one — but only when it
+ * is *the same number*. The expansion used to be unconditional, and
+ * `toFixed(20)` caps at twenty decimal places:
+ *
+ *   Number.EPSILON  →  "0.00000000000000022204"   (five digits kept)
+ *   Number.MIN_VALUE →  "0.0"                      (all of them lost)
+ *
+ * So the smallest values a caller could put in a cell came back as zero.
+ * A prettier rendering is not worth a different number. See #474.
+ */
 function formatNumber(n: number): string {
-  // Avoid scientific notation for large integers
+  if (!Number.isFinite(n)) return String(n)
+
+  // Large integers: `1e+21` reads as text in some importers.
   if (Number.isInteger(n) && Math.abs(n) >= 1e15) {
-    return n.toFixed(0)
+    const plain = n.toFixed(0)
+    if (Number(plain) === n) return plain
   }
-  // For very small numbers that would use scientific notation
+
+  // Small magnitudes, where JS switches to exponent notation at 1e-7.
   if (Math.abs(n) > 0 && Math.abs(n) < 1e-6) {
-    return n.toFixed(20).replace(/0+$/, "").replace(/\.$/, ".0")
+    const plain = n.toFixed(20).replace(/0+$/, "").replace(/\.$/, ".0")
+    if (Number(plain) === n) return plain
   }
+
   return String(n)
 }
 

--- a/test/number-serialisation.test.ts
+++ b/test/number-serialisation.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeCsv } from "../src/csv/writer"
+import { parseCsv } from "../src/csv/reader"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #474 asked whether numbers should keep being written with
+// `String(value)` — so `1e21` becomes `1e+21` and `0.1 + 0.2` becomes
+// `0.30000000000000004` (17 significant digits), where Excel writes
+// `1E+21` and caps its *display* at 15.
+//
+// The decision is to keep it, and this file is why: `String(value)` is
+// the only spelling that round-trips a double exactly. Truncating to 15
+// significant digits would lose data that a caller put in the cell on
+// purpose, to make the file look more like one Excel wrote. A library
+// whose job is moving data faithfully should not make that trade.
+//
+// Both spellings are valid `xsd:double` — the lexical space is
+// `[Ee](\+|-)?[0-9]+`, so lowercase `e` is conformant, not tolerated.
+//
+// These tests exist so the 15-digit "fix" cannot land quietly later.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** The values where a naive round-trip goes wrong. */
+const EXTREMES = [
+  1e21, // where JS switches to exponent notation
+  1e-7, // where it switches at the small end
+  0.1 + 0.2, // 17 significant digits, and famously not 0.3
+  1 / 3,
+  1e300,
+  5e-324, // Number.MIN_VALUE — one subnormal bit
+  -1e21,
+  Number.MAX_SAFE_INTEGER,
+  Number.MIN_SAFE_INTEGER,
+  Number.EPSILON,
+]
+
+const decoder = new TextDecoder("utf-8")
+
+describe("XLSX numbers survive exactly", () => {
+  it("every extreme comes back bit-identical", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [EXTREMES] }] })
+    const back = (await readXlsx(bytes)).sheets[0]!.rows[0]!
+
+    for (let i = 0; i < EXTREMES.length; i++) {
+      // Object.is, not toBe: -0 and NaN would otherwise pass wrongly.
+      expect(Object.is(back[i], EXTREMES[i]), `${EXTREMES[i]} came back as ${back[i]}`).toBe(true)
+    }
+  })
+
+  it("writes the digits JS produces, exponent and all", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[1e21, 0.1 + 0.2]] }] })
+    const xml = decoder.decode(await new ZipReader(bytes).extract("xl/worksheets/sheet1.xml"))
+
+    // Both are conformant xsd:double. `1E+21` would be equally valid and
+    // no more correct; `1000000000000000000000` and `0.3` would be
+    // neither, the second because it is a different number.
+    expect(xml).toContain("<v>1e+21</v>")
+    expect(xml).toContain("<v>0.30000000000000004</v>")
+  })
+
+  it("does not round to 15 significant digits", async () => {
+    // The change #474 raised. 0.1 + 0.2 at 15 digits is 0.3 — a value
+    // the caller did not write.
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[0.1 + 0.2]] }] })
+
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]![0]).not.toBe(0.3)
+  })
+
+  it("does not keep the sign of negative zero, and that is the one loss", async () => {
+    // `String(-0)` is `"0"`, so the sign goes. Excel has no signed zero
+    // either — writing `<v>-0</v>` would be hucre inventing a distinction
+    // the format does not carry. Recorded here so it is a known answer
+    // rather than a surprise.
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[-0]] }] })
+    const back = (await readXlsx(bytes)).sheets[0]!.rows[0]!
+
+    expect(back[0]).toBe(0)
+    expect(Object.is(back[0], -0)).toBe(false)
+  })
+})
+
+describe("CSV numbers survive exactly too", () => {
+  it("every extreme comes back bit-identical", () => {
+    const rows = parseCsv(writeCsv([EXTREMES]), { typeInference: true })
+
+    for (let i = 0; i < EXTREMES.length; i++) {
+      expect(
+        Object.is(rows[0]![i], EXTREMES[i]),
+        `${EXTREMES[i]} came back as ${rows[0]![i]}`,
+      ).toBe(true)
+    }
+  })
+
+  it("still prefers the plain form where it is the same number", () => {
+    // The point of expanding at all: Excel shows a value written as
+    // `1E-07` in exponent notation, and `0.0000001` is both prettier and
+    // exactly equal.
+    expect(writeCsv([[1e-7]]).trim()).toBe("0.0000001")
+    expect(writeCsv([[1e16]]).trim()).toBe("10000000000000000")
+  })
+
+  it("stops expanding when the plain form is a different number", () => {
+    // `toFixed(20)` caps at twenty decimal places. Number.MIN_VALUE came
+    // out as "0.0" and Number.EPSILON kept five digits of seventeen.
+    expect(writeCsv([[Number.MIN_VALUE]]).trim()).toBe("5e-324")
+    expect(writeCsv([[Number.EPSILON]]).trim()).toBe("2.220446049250313e-16")
+  })
+})


### PR DESCRIPTION
Refs #474 (its number-serialisation item).

## The question, and the decision

The issue observed that both writers use `String(value)`, so `1e21` becomes `1e+21` and `0.1 + 0.2` becomes `0.30000000000000004` (17 significant digits), where Excel writes `1E+21` and caps at 15 — "worth deciding rather than inheriting whatever V8 does."

**Decided: keep it.** `String(value)` is the only spelling that round-trips a double exactly. Measured end-to-end through `writeXlsx` → `readXlsx`:

```
1e+21                    -> 1e+21                    EXACT
1e-7                     -> 1e-7                     EXACT
0.30000000000000004      -> 0.30000000000000004      EXACT
1e+300                   -> 1e+300                   EXACT
5e-324                   -> 5e-324                   EXACT
9007199254740991         -> 9007199254740991         EXACT
```

Rounding to 15 significant digits would turn `0.1 + 0.2` into `0.3` — a number the caller did not write — to make the file look more like one Excel wrote. Excel's 15 digits is a *display* convention, not a storage rule. And both spellings are conformant `xsd:double` anyway: the lexical space is `[Ee](\+|-)?[0-9]+`, so lowercase `e` is correct rather than merely tolerated.

## What measuring it turned up

**The CSV writer does not do this, and loses data.** `formatNumber` expands small magnitudes with `toFixed(20)` so Excel does not display `1E-07` — but `toFixed(20)` caps at twenty decimal places:

```
Number.EPSILON    →  "0.00000000000000022204"    five digits of seventeen
Number.MIN_VALUE  →  "0.0"                        all of them
```

So the smallest values a caller could put in a cell came back as **zero**. Round-tripped through `writeCsv` → `parseCsv`, `5e-324` read back as `0`.

The expansion is now conditional on the plain form parsing back to the *same number*. That keeps the intent exactly where it was harmless — `1e-7` still writes `0.0000001`, `1e16` still writes `10000000000000000` — and drops it where it was destructive.

## One loss, recorded rather than fixed

Negative zero. `String(-0)` is `"0"`, and Excel has no signed zero either, so emitting `<v>-0</v>` would be hucre inventing a distinction the format does not carry. There is a test asserting the current answer so it is known rather than surprising.

## Tests

`test/number-serialisation.test.ts` — 7 cases across XLSX and CSV, mutation-checked, 2 fail against `main` (both the CSV precision ones; the XLSX cases pass on both, which is the point — they exist so the 15-digit "fix" cannot land quietly later).

`pnpm lint`, `pnpm typecheck`, 10030 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
