### PR TITLE
feat(read): three more onWarning sites — refs #474

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -323,6 +323,19 @@ Each warning carries a `code`, a sentence, and the sheet and cell it came
 from. Nothing changes when the option is omitted, and a file hucre wrote
 produces none.
 
+| code                       | what silently went missing                                    |
+| -------------------------- | ------------------------------------------------------------- |
+| `unresolved-shared-string` | a cell's text; reads as empty                                 |
+| `unresolved-style`         | a cell's format; reads unstyled                               |
+| `unresolved-dxf`           | a conditional rule's formatting; the rule keeps its condition |
+| `unresolved-hyperlink`     | a link's target; reads as an empty target                     |
+| `unusable-paper-size`      | the sheet's paper size; reads as unset                        |
+
+Each is a place where leniency produces something _indistinguishable from
+correct_ — an empty cell, an unstyled cell, a rule that paints nothing, a
+link that goes nowhere. Where a reader drops something that is visibly
+absent instead, there is no warning, because none is needed.
+
 Structural damage still throws: a missing `xl/workbook.xml`, or a
 worksheet part a sheet declares and the archive does not contain, is a
 `ParseError`. The difference is whether the answer would be _short_ or

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1421,7 +1421,12 @@ export interface Workbook {
 /** What a reader had to drop, and where. */
 export interface ReadWarning {
   /** What kind of problem this is, for programmatic handling. */
-  code: "unresolved-shared-string" | "unresolved-style" | "unresolved-dxf"
+  code:
+    | "unresolved-shared-string"
+    | "unresolved-style"
+    | "unresolved-dxf"
+    | "unresolved-hyperlink"
+    | "unusable-paper-size"
   /** A sentence a person can act on. */
   message: string
   /** The sheet it happened in, when the reader knows. */

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -714,7 +714,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
           // Merge, don't replace: <printOptions> is written before
           // <pageSetup> in a worksheet, so assigning here dropped
           // whatever it had already contributed. See #360.
-          pageSetup = { ...pageSetup, ...parsePageSetupAttrs(attrs) }
+          pageSetup = { ...pageSetup, ...parsePageSetupAttrs(attrs, ctx) }
           break
         case "printOptions":
           // <printOptions> was never parsed, so showGridLines and
@@ -1020,6 +1020,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
               isCfvos,
               isAttrs,
               ctx.styles?.dxfs,
+              ctx,
             )
             if (cfRule) {
               conditionalRules.push(cfRule)
@@ -1208,6 +1209,19 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
       const target = relMap.get(hl.rId)
       if (target) {
         hyperlink.target = target
+      } else {
+        // The cell keeps a hyperlink with an empty target, which reads as
+        // a link that goes nowhere rather than as a missing relationship.
+        // See #474.
+        ctx.onWarning?.({
+          code: "unresolved-hyperlink",
+          message:
+            `Cell ${hl.ref} links through ${hl.rId}, which the sheet's ` +
+            "relationships do not define. Read with an empty target.",
+          sheet: ctx.sheetName,
+          row: pos.row,
+          col: pos.col,
+        })
       }
     }
 
@@ -1484,6 +1498,7 @@ function buildConditionalRule(
   isCfvos: Array<{ type: string; value?: string }>,
   isAttrsObj: Record<string, string>,
   dxfs: CellStyle[] | undefined,
+  ctx?: WorksheetContext,
 ): ConditionalRule | null {
   const typeStr = attrs["type"]
   if (!typeStr || !VALID_CF_TYPES.has(typeStr)) return null
@@ -1513,6 +1528,19 @@ function buildConditionalRule(
     // at the same dxfId, following the same contract as a resolved cell
     // style; see resolveStyle in ./styles.ts.
     if (dxf && Object.keys(dxf).length > 0) rule.style = dxf
+    // A rule whose formatting silently vanished still applies — it just
+    // paints nothing, which looks like the rule not working rather than
+    // like a damaged file. See #474.
+    else if (!dxf) {
+      ctx?.onWarning?.({
+        code: "unresolved-dxf",
+        message:
+          `Conditional rule on ${sqref} asks for differential format ${dxfId}, ` +
+          `which the file does not have (${dxfs.length} present). The rule keeps ` +
+          "its condition and loses its formatting.",
+        sheet: ctx.sheetName,
+      })
+    }
   }
 
   // stopIfTrue
@@ -1916,13 +1944,25 @@ function applyPrintOptionsAttrs(
   return ps
 }
 
-function parsePageSetupAttrs(attrs: Record<string, string>): PageSetup {
+function parsePageSetupAttrs(attrs: Record<string, string>, ctx?: WorksheetContext): PageSetup {
   const ps: PageSetup = {}
 
   if (attrs["paperSize"]) {
     const num = Number(attrs["paperSize"])
     // A code with no name round-trips as the number rather than vanishing.
     if (Number.isInteger(num) && num > 0) ps.paperSize = PAPER_SIZE_REVERSE[num] ?? num
+    else {
+      // Anything else is not a paper size, so the sheet comes back
+      // claiming the default one. Reported, because the printed output
+      // then differs from the file and nothing else says why. See #474.
+      ctx?.onWarning?.({
+        code: "unusable-paper-size",
+        message:
+          `Page setup names paper size "${attrs["paperSize"]}", which is not a ` +
+          "positive integer code. Dropped; the sheet reads with no paper size set.",
+        sheet: ctx.sheetName,
+      })
+    }
   }
 
   if (attrs["orientation"] === "landscape" || attrs["orientation"] === "portrait") {

--- a/test/read-warnings.test.ts
+++ b/test/read-warnings.test.ts
@@ -119,3 +119,142 @@ describe("a clean file says nothing", () => {
     expect(without.sheets[0]!.rows).toEqual(withSink.sheets[0]!.rows)
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════
+// #474 — `onWarning` was wired at the two sites measured as silent. Three
+// more follow the same shape, each with a test rather than a speculative
+// call. One of them, `unresolved-dxf`, was already in the `ReadWarning`
+// union and emitted from nowhere.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("a conditional rule's formatting that resolves to nothing", () => {
+  async function ruled(): Promise<Uint8Array> {
+    return writeXlsx({
+      sheets: [
+        {
+          name: "Data",
+          rows: [[1], [2]],
+          conditionalRules: [
+            {
+              type: "cellIs",
+              priority: 1,
+              range: "A1:A2",
+              operator: "greaterThan",
+              formula: "1",
+              style: { fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } } },
+            },
+          ],
+        },
+      ],
+    })
+  }
+
+  it("names the dxfId and says what the rule keeps", async () => {
+    const bytes = await damage(await ruled(), SHEET, (xml) =>
+      xml.replace(/dxfId="\d+"/, 'dxfId="42"'),
+    )
+
+    const warnings: ReadWarning[] = []
+    const wb = await readXlsx(bytes, { readStyles: true, onWarning: (w) => warnings.push(w) })
+
+    // Still lenient: the rule survives without its formatting, because a
+    // rule that paints nothing is closer to the file than no rule at all.
+    expect(wb.sheets[0]!.conditionalRules).toHaveLength(1)
+    expect(wb.sheets[0]!.conditionalRules![0]!.style).toBeUndefined()
+
+    const dxf = warnings.find((w) => w.code === "unresolved-dxf")
+    expect(dxf).toBeDefined()
+    expect(dxf!.message).toContain("42")
+    expect(dxf!.message).toContain("A1:A2")
+    expect(dxf!.sheet).toBe("Data")
+  })
+
+  it("says nothing when the rule's format is there", async () => {
+    const warnings: ReadWarning[] = []
+    await readXlsx(await ruled(), { readStyles: true, onWarning: (w) => warnings.push(w) })
+
+    expect(warnings.filter((w) => w.code === "unresolved-dxf")).toEqual([])
+  })
+})
+
+describe("a hyperlink pointing at a relationship that is not there", () => {
+  async function linked(): Promise<Uint8Array> {
+    return writeXlsx({
+      sheets: [
+        {
+          name: "Data",
+          rows: [["click"]],
+          cells: new Map([
+            ["0,0", { value: "click", hyperlink: { target: "https://example.com" } }],
+          ]),
+        },
+      ],
+    })
+  }
+
+  it("names the cell and the rId", async () => {
+    // Drop the relationship, keep the reference — a real shape, since the
+    // two live in different parts of the package.
+    const bytes = await damage(await linked(), "xl/worksheets/_rels/sheet1.xml.rels", (xml) =>
+      xml.replace(/<Relationship [^>]*hyperlink[^>]*\/>/, ""),
+    )
+
+    const warnings: ReadWarning[] = []
+    const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+
+    // Lenient: an empty target, not an exception.
+    expect(wb.sheets[0]!.cells?.get("0,0")?.hyperlink?.target).toBe("")
+
+    const warning = warnings.find((w) => w.code === "unresolved-hyperlink")
+    expect(warning).toBeDefined()
+    expect(warning!.message).toContain("A1")
+    expect(warning!.row).toBe(0)
+    expect(warning!.col).toBe(0)
+    expect(warning!.sheet).toBe("Data")
+  })
+
+  it("says nothing about a link that resolves", async () => {
+    const warnings: ReadWarning[] = []
+    await readXlsx(await linked(), { onWarning: (w) => warnings.push(w) })
+
+    expect(warnings.filter((w) => w.code === "unresolved-hyperlink")).toEqual([])
+  })
+})
+
+describe("a paper size that is not a usable code", () => {
+  async function printed(): Promise<Uint8Array> {
+    return writeXlsx({
+      sheets: [{ name: "Data", rows: [["a"]], pageSetup: { paperSize: "a4" } }],
+    })
+  }
+
+  it("names what the file said", async () => {
+    const bytes = await damage(await printed(), SHEET, (xml) =>
+      xml.replace(/paperSize="\d+"/, 'paperSize="0"'),
+    )
+
+    const warnings: ReadWarning[] = []
+    const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+
+    expect(wb.sheets[0]!.pageSetup?.paperSize).toBeUndefined()
+
+    const warning = warnings.find((w) => w.code === "unusable-paper-size")
+    expect(warning).toBeDefined()
+    expect(warning!.message).toContain('"0"')
+    expect(warning!.sheet).toBe("Data")
+  })
+
+  it("says nothing about a code with no name, which is still a size", async () => {
+    // 999 has no name in hucre's table; it round-trips as the number
+    // rather than vanishing, so there is nothing to report.
+    const bytes = await damage(await printed(), SHEET, (xml) =>
+      xml.replace(/paperSize="\d+"/, 'paperSize="999"'),
+    )
+
+    const warnings: ReadWarning[] = []
+    const wb = await readXlsx(bytes, { onWarning: (w) => warnings.push(w) })
+
+    expect(wb.sheets[0]!.pageSetup?.paperSize).toBe(999)
+    expect(warnings.filter((w) => w.code === "unusable-paper-size")).toEqual([])
+  })
+})


### PR DESCRIPTION
Refs #474 (its diagnostics item) — and this closes the last of that issue's code items.

`onWarning` (#462) was wired at the two places measured as silent. The issue named three more and asked that each come with a test rather than a speculative call.

| code | what silently went missing |
| --- | --- |
| `unresolved-dxf` | a conditional rule's formatting; the rule keeps its condition |
| `unresolved-hyperlink` | a link's target; reads as an empty target |
| `unusable-paper-size` | the sheet's paper size; reads as unset |

**`unresolved-dxf` was already in the `ReadWarning` union and emitted from nowhere** — a code no caller could ever receive. A rule that loses its format still applies and paints nothing, which reads as the rule not working rather than as a damaged file.

**`unresolved-hyperlink`** is a real shape rather than a contrived one: the reference and the relationship live in different parts of the package, so losing one and keeping the other is what actually happens. The test drops the `<Relationship>` and leaves the `r:id`.

**`unusable-paper-size`** fires on a `paperSize` that is not a positive integer code. A code with no *name* is deliberately **not** warned about — `999` round-trips as the number rather than vanishing, so nothing was lost. There is a test for that distinction.

## The dividing line

Now written into `docs/PARITY.md` next to the full code table: these are the places where leniency produces something **indistinguishable from correct** — an empty cell, an unstyled cell, a rule that paints nothing, a link that goes nowhere. Where a reader drops something visibly absent instead, no warning is needed. That is the test for whether the next site belongs.

## Tests

Six cases added to `test/read-warnings.test.ts` — for each code, one that it fires with the right cell/sheet/detail, and one that it stays quiet on an undamaged file. Mutation-checked: 3 fail against `main`.

`pnpm lint`, `pnpm typecheck`, 10044 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
