### PR TITLE
feat: read() and the CLI reach the formats the library has — closes #469

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,8 +1181,14 @@ Auto-detect format and work with simple helpers:
 ```ts
 import { read, write, readObjects, writeObjects } from "hucre"
 
-// Auto-detect XLSX vs ODS
+// Auto-detect. Containers by their magic bytes — XLSX, XLSB, XLS, ODS —
+// and the text formats by their opening: CSV, JSON, NDJSON, XML, HTML.
 const wb = await read(buffer)
+
+// Write any of nine. Default xlsx; always returns bytes, so nothing
+// downstream has to branch on the format.
+const bytes = await write({ sheets, format: "ndjson" })
+// "xlsx" | "ods" | "csv" | "tsv" | "json" | "ndjson" | "xml" | "html" | "markdown"
 
 // Quick: file → objects, plus the headers they were keyed by. Same
 // { data, headers } shape — and the same options — as readXlsxObjects /
@@ -1198,22 +1204,50 @@ const { data: products, headers } = await readObjects<{ name: string; price: num
 const xlsx = await writeObjects(products, { sheetName: "Products" })
 ```
 
+Detection **decides rather than guesses**: every text format announces
+itself in its first non-whitespace character or two, which is a far
+weaker claim than the delimiter auto-detection `parseCsv` already makes.
+CSV is the fallback, because "text that is not any of the others" is what
+CSV is. Bytes that are not text at all still get the same
+`UnsupportedFormatError` as before — a NUL in the first few KB is where
+that line is drawn.
+
+The text formats are single-sheet by nature: `write()` takes the first
+sheet for those, and carries values rather than formatting. The
+record-shaped ones (`json`, `ndjson`, `xml`) read row 0 as field names,
+which is the convention `read()` inverts on the way back in.
+
 ### CLI
 
 ```bash
 npx hucre convert input.xlsx output.csv
 npx hucre convert input.csv output.xlsx
 npx hucre convert legacy.xls output.xlsx # .xls / .xlsb read as input
+npx hucre convert data.csv report.md     # .json .ndjson .xml .html .md too
+
+# stdin and stdout, the usual `-`
+cat data.csv | npx hucre convert - out.xlsx
+npx hucre convert in.xlsx - --to csv
+cat data.csv | npx hucre convert - - --to md
+
 npx hucre inspect file.xlsx
 npx hucre inspect file.xlsx --sheet 0
 npx hucre validate data.xlsx --schema schema.json
 ```
 
-Input: `.xlsx`, `.ods`, `.csv`, `.tsv`, `.xls`, `.xlsb`. Output: the first
-four — `.xls` and `.xlsb` are read-only formats, and naming one as the
-output says so. `convert` carries cell values and sheet names only; from a
-legacy binary input that is all there is (see the notes on each format
-above).
+Input: `.xlsx`, `.ods`, `.csv`, `.tsv`, `.json`, `.ndjson`/`.jsonl`,
+`.xml`, `.html`, `.xls`, `.xlsb`. Output: the same minus `.xls` and
+`.xlsb`, which are read-only formats — naming one as the output says so —
+plus `.md`, which is write-only, because there is no `fromMarkdown` and
+there will not be.
+
+`-` reads stdin or writes stdout. From a pipe there is no extension to go
+on, so the input format comes from the content and the output format from
+`--to`; guessing a binary default would spray a ZIP into a terminal.
+Progress messages go to stderr whenever stdout is the file.
+
+`convert` carries cell values and sheet names only; from a legacy binary
+input that is all there is (see the notes on each format above).
 
 ### Sheet Operations
 

--- a/src/_sniff.ts
+++ b/src/_sniff.ts
@@ -1,0 +1,128 @@
+// ── Text-format detection ───────────────────────────────────────────
+//
+// `read()` dispatched on container bytes — the ZIP shape for XLSX/ODS,
+// the OLE2 shape for XLS and encrypted packages — and gave up on
+// anything else. A CSV file read off disk is a `Uint8Array` like any
+// other, so `read(bytes)` on one answered
+//
+//   UnsupportedFormatError: Unsupported format: unknown (not a ZIP archive)
+//
+// which is a correct error for a function that cannot do the job, under a
+// README heading that says **Unified API**. See #469.
+//
+// What this does is decide, not guess. Every format here announces itself
+// in its first non-whitespace character or two, which is a far weaker
+// claim than the delimiter auto-detection the CSV reader already makes.
+// CSV is the fallback rather than a positive match, because "text that is
+// not any of the others" is what CSV actually is.
+
+import { detectBom } from "./csv/encoding"
+
+/** A text format `read()` can dispatch to. */
+export type TextFormat = "json" | "ndjson" | "xml" | "html" | "csv"
+
+/** How many bytes are enough to decide. */
+const PREFIX_BYTES = 4096
+
+/**
+ * Decide which text format some bytes hold, or `null` when they are not
+ * text at all.
+ *
+ * `null` is the important return: it means the caller should keep its
+ * existing "this is not a spreadsheet" error rather than handing binary
+ * rubbish to the CSV parser, which would cheerfully make a sheet of it.
+ */
+export function detectTextFormat(data: Uint8Array): TextFormat | null {
+  const bom = detectBom(data)
+  const body = bom ? data.subarray(bom.length) : data
+
+  // A NUL byte in the first few KB means binary. UTF-16 is the exception
+  // — it is full of them by construction — and the mark is what says so.
+  const prefix = body.subarray(0, PREFIX_BYTES)
+  const utf16 = bom?.encoding === "utf-16le" || bom?.encoding === "utf-16be"
+  if (!utf16 && prefix.includes(0)) return null
+
+  const label = bom?.encoding ?? "utf-8"
+  let head: string
+  try {
+    head = new TextDecoder(label, { fatal: false }).decode(prefix)
+  } catch {
+    return null
+  }
+
+  const trimmed = head.trimStart()
+  if (trimmed.length === 0) return null
+
+  const first = trimmed[0]!
+
+  if (first === "<") return sniffMarkup(trimmed)
+  if (first === "{" || first === "[") return sniffJson(data, bom?.length ?? 0, label, first)
+
+  // Not a positive match for anything else — which is what CSV is.
+  return "csv"
+}
+
+/**
+ * XML or HTML.
+ *
+ * Both open with `<`. HTML announces itself with a doctype, an `<html>`
+ * root, or — for the fragment case `fromHtml` exists to handle — a bare
+ * `<table>`. Anything else with an XML declaration or a plain tag is XML.
+ */
+function sniffMarkup(trimmed: string): TextFormat {
+  const lower = trimmed.slice(0, 512).toLowerCase()
+
+  // A declaration or a processing instruction settles it before any tag.
+  // XHTML is the ambiguous case and is treated as XML: it parses as XML
+  // by definition, which is the more conservative of the two answers.
+  if (lower.startsWith("<?xml")) return "xml"
+
+  if (
+    lower.startsWith("<!doctype html") ||
+    lower.startsWith("<html") ||
+    lower.startsWith("<table") ||
+    lower.startsWith("<!--")
+  ) {
+    return "html"
+  }
+
+  return "xml"
+}
+
+/**
+ * JSON or NDJSON.
+ *
+ * `[` is JSON: an NDJSON file whose first line is an array is legal and
+ * essentially unheard of, and reading it as JSON gives the same rows.
+ *
+ * `{` is decided by trying. If the whole document parses, it is JSON. If
+ * it does not but the first two lines each do, it is NDJSON — which is
+ * exactly the shape that makes the whole fail to parse.
+ */
+function sniffJson(data: Uint8Array, bomLength: number, label: string, first: string): TextFormat {
+  if (first === "[") return "json"
+
+  let text: string
+  try {
+    text = new TextDecoder(label, { fatal: false }).decode(data.subarray(bomLength))
+  } catch {
+    return "json"
+  }
+
+  try {
+    JSON.parse(text)
+    return "json"
+  } catch {
+    // Not one document. Two lines that each parse is what NDJSON is.
+    const lines = text.split("\n").filter((l) => l.trim().length > 0)
+    if (lines.length < 2) return "json"
+    for (const line of lines.slice(0, 2)) {
+      try {
+        JSON.parse(line)
+      } catch {
+        return "json"
+      }
+    }
+    return "ndjson"
+  }
+}

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -21,6 +21,7 @@ import { writeOds } from "../ods/writer"
 import { parseCsv } from "../csv/reader"
 import { writeCsv } from "../csv/writer"
 import { validateWithSchema } from "../_schema"
+import { read, write } from "../defter"
 import type { Workbook, CellValue, WriteOptions, SchemaDefinition } from "../_types"
 
 // ── Errors ──────────────────────────────────────────────────────────
@@ -39,7 +40,17 @@ export class CliError extends Error {
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-export type Format = "xlsx" | "ods" | "csv" | "xls" | "xlsb"
+export type Format =
+  | "xlsx"
+  | "ods"
+  | "csv"
+  | "xls"
+  | "xlsb"
+  | "json"
+  | "ndjson"
+  | "xml"
+  | "html"
+  | "markdown"
 
 /** The formats hucre can write; `.xls` and `.xlsb` are read-only. */
 export type WritableFormat = Exclude<Format, "xls" | "xlsb">
@@ -49,8 +60,22 @@ const DELIMITERS: Record<string, string> = { ".csv": ",", ".tsv": "\t" }
 
 const READ_ONLY_FORMATS = new Set<Format>(["xls", "xlsb"])
 
-const SUPPORTED = ".xlsx, .ods, .csv, .tsv (read-only: .xls, .xlsb)"
+/**
+ * The stdin/stdout convention. `hucre convert - out.xlsx` reads the
+ * pipe; `hucre convert in.csv -` writes to it. Most of what a CLI is for
+ * was unreachable without this. See #469.
+ */
+export const STDIO = "-"
 
+const SUPPORTED =
+  ".xlsx, .ods, .csv, .tsv, .json, .ndjson, .jsonl, .xml, .html, .md " + "(read-only: .xls, .xlsb)"
+
+/**
+ * Map a file extension to a format.
+ *
+ * JSON, NDJSON, XML, HTML and Markdown all had readers and/or writers in
+ * the library and none was reachable from the terminal. See #469.
+ */
 export function detectFormatFromExtension(filePath: string): Format {
   const ext = extname(filePath).toLowerCase()
   switch (ext) {
@@ -69,6 +94,19 @@ export function detectFormatFromExtension(filePath: string): Format {
       return "xls"
     case ".xlsb":
       return "xlsb"
+    case ".json":
+      return "json"
+    case ".ndjson":
+    case ".jsonl":
+      return "ndjson"
+    case ".xml":
+      return "xml"
+    case ".html":
+    case ".htm":
+      return "html"
+    case ".md":
+    case ".markdown":
+      return "markdown"
     default:
       throw new CliError(`Unsupported file extension: ${ext || "(none)"}. Supported: ${SUPPORTED}`)
   }
@@ -87,7 +125,7 @@ export function detectOutputFormat(filePath: string): WritableFormat {
     throw new CliError(
       `Cannot write .${format}: it is a read-only format in hucre — ` +
         "readable as input, but there is no writer for it. " +
-        "Write .xlsx, .ods, .csv or .tsv instead.",
+        `Write one of: ${SUPPORTED.replace(/ \(read-only.*$/, "")}.`,
     )
   }
   return format as WritableFormat
@@ -104,7 +142,22 @@ export function delimiterForExtension(filePath: string): string {
   return DELIMITERS[extname(filePath).toLowerCase()] ?? ","
 }
 
+/**
+ * Read every byte from stdin.
+ *
+ * `readFileSync(0)` is the whole of it — the pipe is a file descriptor
+ * and Node reads it to EOF. See #469.
+ */
+export function readStdin(): Uint8Array {
+  return new Uint8Array(readFileSync(0))
+}
+
 export async function readFile(filePath: string, encoding?: string): Promise<Workbook> {
+  // From a pipe there is no extension to go on, so the content decides —
+  // which is what `read()` is for, and it now covers the text formats
+  // too (#469).
+  if (filePath === STDIO) return read(readStdin())
+
   const format = detectFormatFromExtension(filePath)
   const data = readFileSync(filePath)
   const input = new Uint8Array(data)
@@ -133,6 +186,19 @@ export async function readFile(filePath: string, encoding?: string): Promise<Wor
         sheets: [{ name: "Sheet1", rows }],
       }
     }
+    // The remaining text formats have no extension-specific handling the
+    // library does not already do — `read()` sniffs the same bytes and
+    // dispatches to the same reader.
+    case "json":
+    case "ndjson":
+    case "xml":
+    case "html":
+      return read(input)
+    case "markdown":
+      throw new CliError(
+        "Markdown is output only in hucre — there is no `fromMarkdown`, " +
+          "and there will not be. Use .csv or .json to bring data back in.",
+      )
   }
 }
 
@@ -168,54 +234,97 @@ export const convertCommand = defineCommand({
         "Character encoding of a CSV/TSV input (e.g. windows-1254). " +
         "Default: the file's byte-order mark, or utf-8.",
     },
+    to: {
+      type: "string",
+      description:
+        "Output format when writing to stdout (`-`), which has no " +
+        "extension to read. E.g. `--to csv`.",
+    },
   },
   async run({ args }) {
     const inputPath = args.input as string
     const outputPath = args.output as string
-    const outputFormat = detectOutputFormat(outputPath)
+    // Writing to a pipe has no extension either, and guessing would be
+    // worse than asking: `--to` names the format. See #469.
+    const outputFormat =
+      outputPath === STDIO
+        ? stdoutFormat(args.to as string | undefined)
+        : detectOutputFormat(outputPath)
 
-    consola.start(`Reading ${inputPath}...`)
-    const workbook = await readFile(inputPath, args.encoding as string | undefined)
-    consola.success(`Read ${workbook.sheets.length} sheet(s)`)
-
-    consola.start(`Writing ${outputPath}...`)
-
-    if (outputFormat === "csv") {
-      // CSV: use first sheet only
-      const sheet = workbook.sheets[0]
-      if (!sheet) {
-        throw new CliError("No sheets found in input file")
-      }
-      // Every row goes through writeCsv, including the first. It used to
-      // be pulled out as `headers` and stringified separately, so a Date
-      // in row 0 came out ISO while the same Date in row 1 came out in
-      // writeCsv's format — one column, two formats, decided by which
-      // row the value happened to land in.
-      const csv = writeCsv(sheet.rows, { delimiter: delimiterForExtension(outputPath) })
-      writeFileSync(outputPath, csv, "utf-8")
-    } else {
-      // XLSX or ODS
-      const writeOptions: WriteOptions = {
-        sheets: workbook.sheets.map((sheet) => ({
-          name: sheet.name,
-          rows: sheet.rows,
-        })),
-        properties: workbook.properties,
-      }
-
-      let output: Uint8Array
-      if (outputFormat === "ods") {
-        output = await writeOds(writeOptions)
-      } else {
-        output = await writeXlsx(writeOptions)
-      }
-
-      writeFileSync(outputPath, output)
+    // Progress goes to stderr, always — with `-` as the output, stdout is
+    // the file, and a "Reading..." line in it would corrupt the result.
+    const toStdout = outputPath === STDIO
+    const say = (fn: (m: string) => void, message: string): void => {
+      if (!toStdout) fn(message)
     }
 
-    consola.success(`Written to ${outputPath}`)
+    say(consola.start, `Reading ${inputPath === STDIO ? "stdin" : inputPath}...`)
+    const workbook = await readFile(inputPath, args.encoding as string | undefined)
+    say(consola.success, `Read ${workbook.sheets.length} sheet(s)`)
+
+    say(consola.start, `Writing ${outputPath}...`)
+
+    const output = await renderWorkbook(workbook, outputFormat, outputPath)
+    if (toStdout) writeFileSync(1, output)
+    else writeFileSync(outputPath, output)
+
+    say(consola.success, `Written to ${outputPath}`)
   },
 })
+
+/**
+ * Resolve the format for `-` output. There is no extension to read, and
+ * defaulting to a binary format would spray a ZIP into a terminal.
+ */
+function stdoutFormat(to: string | undefined): WritableFormat {
+  if (!to) {
+    throw new CliError(
+      "Writing to stdout needs `--to` to say which format " +
+        "(e.g. `--to csv`), because there is no extension to read.",
+    )
+  }
+  // `.x` so the same table decides, and the same error names the same
+  // supported list.
+  const format = detectFormatFromExtension(`out.${to.toLowerCase()}`)
+  if (READ_ONLY_FORMATS.has(format)) {
+    throw new CliError(`Cannot write ${to}: it is a read-only format in hucre.`)
+  }
+  return format as WritableFormat
+}
+
+/**
+ * Render a workbook to the bytes of one format.
+ *
+ * CSV keeps its own path because the delimiter comes from the output
+ * *extension* rather than the format — `.tsv` is tab-separated, and a
+ * file named `.tsv` full of commas lies about itself (#365). Everything
+ * else goes through the library's own `write()`, which is the function
+ * that is supposed to know how to do this.
+ */
+async function renderWorkbook(
+  workbook: Workbook,
+  format: WritableFormat,
+  outputPath: string,
+): Promise<Uint8Array> {
+  const encoder = new TextEncoder()
+
+  if (format === "csv") {
+    const sheet = workbook.sheets[0]
+    if (!sheet) throw new CliError("No sheets found in input file")
+    // Every row goes through writeCsv, including the first. It used to
+    // be pulled out as `headers` and stringified separately, so a Date
+    // in row 0 came out ISO while the same Date in row 1 came out in
+    // writeCsv's format — one column, two formats, decided by which
+    // row the value happened to land in.
+    return encoder.encode(writeCsv(sheet.rows, { delimiter: delimiterForExtension(outputPath) }))
+  }
+
+  const writeOptions: WriteOptions = {
+    sheets: workbook.sheets.map((sheet) => ({ name: sheet.name, rows: sheet.rows })),
+    properties: workbook.properties,
+  }
+  return write({ ...writeOptions, format })
+}
 
 // ── Inspect Command ─────────────────────────────────────────────────
 

--- a/src/defter.ts
+++ b/src/defter.ts
@@ -26,6 +26,17 @@ import { readOds } from "./ods/reader"
 import { writeOds } from "./ods/writer"
 import { EncryptedFileError, UnsupportedFormatError } from "./errors"
 import { isOle2Container, readInputToUint8Array } from "./_input"
+import { detectTextFormat, type TextFormat } from "./_sniff"
+import { parseCsv } from "./csv/reader"
+import { writeCsv } from "./csv/writer"
+import { writeTsv } from "./export/tsv"
+import { jsonToWorkbook, parseNdjson } from "./json/reader"
+import { writeJson, writeNdjson } from "./json/writer"
+import { readXml } from "./xml/data-reader"
+import { writeXml } from "./xml/data-writer"
+import { fromHtml } from "./export/html-import"
+import { toHtml } from "./export/html"
+import { toMarkdown } from "./export/markdown"
 
 // ── Format Detection ────────────────────────────────────────────────
 
@@ -116,6 +127,14 @@ export async function read(input: ReadInput, options?: ReadOptions): Promise<Wor
     }
   }
 
+  // Not a container. Every text format the library reads announces
+  // itself in its first non-whitespace character or two, so `read()` no
+  // longer stops at the ZIP boundary. See #469.
+  if (data.length < 4 || data[0] !== 0x50 || data[1] !== 0x4b) {
+    const text = detectTextFormat(data)
+    if (text !== null) return readTextFormat(data, text)
+  }
+
   const format = detectFormat(data)
 
   if (format === "ods") {
@@ -132,16 +151,111 @@ export async function read(input: ReadInput, options?: ReadOptions): Promise<Wor
 }
 
 /**
+ * Turn a detected text format into a workbook.
+ *
+ * Each of these readers already exists and is exported; what was missing
+ * was `read()` knowing to call one. The tabular readers hand back
+ * `{ data, headers }`, so the header row is put back at the top — a
+ * workbook is a grid, and dropping the names would lose them.
+ */
+function readTextFormat(data: Uint8Array, format: TextFormat): Workbook {
+  switch (format) {
+    case "csv":
+      return { sheets: [{ name: "Sheet1", rows: parseCsv(data) }] }
+    case "json":
+      return jsonToWorkbook(data)
+    case "ndjson": {
+      const { data: rows, headers } = parseNdjson(data)
+      return { sheets: [{ name: "Sheet1", rows: withHeaderRow(rows, headers) }] }
+    }
+    case "xml": {
+      const { data: rows, headers } = readXml(data)
+      return { sheets: [{ name: "Sheet1", rows: withHeaderRow(rows, headers) }] }
+    }
+    case "html":
+      return { sheets: [fromHtml(new TextDecoder("utf-8").decode(data))] }
+  }
+}
+
+/** Put the header names back at row 0, the way a grid holds them. */
+function withHeaderRow(rows: Array<Record<string, CellValue>>, headers: string[]): CellValue[][] {
+  return [headers, ...rows.map((row) => headers.map((h) => row[h] ?? null))]
+}
+
+/** Every format {@link write} can produce. */
+export type WriteFormat =
+  | "xlsx"
+  | "ods"
+  | "csv"
+  | "tsv"
+  | "json"
+  | "ndjson"
+  | "xml"
+  | "html"
+  | "markdown"
+
+/**
  * Write a workbook to the specified format.
+ *
+ * The union used to be `"xlsx" | "ods"` while the library could write
+ * nine things, so the one function meant to be format-agnostic covered
+ * two of them. See #469.
+ *
+ * The text formats are single-sheet by nature and take the first sheet;
+ * they also carry values and not formatting, which is the same trade
+ * `hucre convert` documents. The return is always bytes, so a caller can
+ * hand the result to `Response` or `writeFile` without branching.
  */
 export async function write(
-  options: WriteOptions & { format?: "xlsx" | "ods" },
+  options: WriteOptions & { format?: WriteFormat },
 ): Promise<WriteOutput> {
   const format = options.format ?? "xlsx"
-  if (format === "ods") {
-    return writeOds(options)
+  if (format === "xlsx") return writeXlsx(options)
+  if (format === "ods") return writeOds(options)
+
+  const sheet = options.sheets[0]
+  if (!sheet) {
+    throw new UnsupportedFormatError(`${format} needs a sheet to write, and the workbook has none.`)
   }
-  return writeXlsx(options)
+  const rows = sheet.rows ?? []
+
+  const encoder = new TextEncoder()
+  switch (format) {
+    case "csv":
+      return encoder.encode(writeCsv(rows))
+    case "tsv":
+      return encoder.encode(writeTsv(rows))
+    case "json":
+      return encoder.encode(writeJson(rowsToRecords(rows)))
+    case "ndjson":
+      return encoder.encode(writeNdjson(rowsToRecords(rows)))
+    case "xml":
+      return encoder.encode(writeXml(rowsToRecords(rows)))
+    case "html":
+      return encoder.encode(toHtml({ name: sheet.name, rows }))
+    case "markdown":
+      return encoder.encode(toMarkdown({ name: sheet.name, rows }))
+  }
+}
+
+/**
+ * Read the first row as field names and project the rest against it.
+ *
+ * The record-shaped writers need names; a `WriteSheet` is a grid. This is
+ * the same convention `writeCsvObjects` and the CLI use, and the same one
+ * {@link withHeaderRow} inverts on the way in.
+ */
+function rowsToRecords(rows: CellValue[][]): Array<Record<string, CellValue>> {
+  const [header, ...body] = rows
+  if (!header) return []
+  const names = header.map((h, i) => (h === null || h === undefined ? `column${i + 1}` : String(h)))
+  return body.map((row) => {
+    const out: Record<string, CellValue> = {}
+    names.forEach((name, i) => {
+      out[name] = row[i] ?? null
+    })
+    return out
+  })
 }
 
 /**

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -560,3 +560,115 @@ describe("formatCellValue", () => {
     expect(formatCellValue("x")).toBe("x")
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════
+// #469 — JSON, NDJSON, XML, HTML and Markdown all had readers and/or
+// writers in the library and none was reachable from the terminal. Nor
+// was stdin or stdout, which is most of what a CLI is for.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("convert reaches the formats the library has", () => {
+  async function csvFile(name = "in.csv"): Promise<string> {
+    const p = path(name)
+    writeFileSync(p, "name,qty\nWidget,3\nGadget,7\n", "utf-8")
+    return p
+  }
+
+  it("writes JSON", async () => {
+    const out = path("out.json")
+    await run(convertCommand, { input: await csvFile(), output: out })
+
+    expect(JSON.parse(readFileSync(out, "utf-8"))).toEqual([
+      { name: "Widget", qty: "3" },
+      { name: "Gadget", qty: "7" },
+    ])
+  })
+
+  it("writes NDJSON, one object per line", async () => {
+    const out = path("out.ndjson")
+    await run(convertCommand, { input: await csvFile(), output: out })
+
+    const lines = readFileSync(out, "utf-8").trim().split("\n")
+    expect(lines).toHaveLength(2)
+    expect(JSON.parse(lines[0]!)).toEqual({ name: "Widget", qty: "3" })
+  })
+
+  it("takes .jsonl as a name for the same thing", () => {
+    expect(detectFormatFromExtension("a.jsonl")).toBe("ndjson")
+    expect(detectFormatFromExtension("a.ndjson")).toBe("ndjson")
+  })
+
+  it("writes XML, HTML and Markdown", async () => {
+    for (const [ext, needle] of [
+      ["xml", "<name>"],
+      ["html", "<table"],
+      ["md", "| name"],
+    ] as const) {
+      const out = path(`out.${ext}`)
+      await run(convertCommand, { input: await csvFile(), output: out })
+
+      expect(readFileSync(out, "utf-8"), ext).toContain(needle)
+    }
+  })
+
+  it("reads JSON back into a spreadsheet", async () => {
+    const src = path("in.json")
+    writeFileSync(src, JSON.stringify([{ name: "Widget", qty: 3 }]), "utf-8")
+
+    const out = path("out.xlsx")
+    await run(convertCommand, { input: src, output: out })
+
+    const wb = await readXlsx(new Uint8Array(readFileSync(out)))
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["name", "qty"],
+      ["Widget", 3],
+    ])
+  })
+
+  it("refuses to read Markdown, because there is no reader", async () => {
+    // Output only, and saying so is better than a confusing parse error.
+    const src = path("in.md")
+    writeFileSync(src, "| a |\n| - |\n| 1 |\n", "utf-8")
+
+    await expect(run(convertCommand, { input: src, output: path("o.csv") })).rejects.toThrow(
+      /output only/,
+    )
+  })
+})
+
+describe("convert names the formats it cannot write", () => {
+  it("lists the writable ones when asked for a read-only format", () => {
+    expect(() => detectOutputFormat("a.xls")).toThrow(/read-only/)
+    expect(() => detectOutputFormat("a.xls")).toThrow(/\.json/)
+  })
+
+  it("still rejects an extension that is nothing", () => {
+    expect(() => detectFormatFromExtension("a.pdf")).toThrow(CliError)
+  })
+})
+
+describe("the stdin/stdout convention", () => {
+  it("asks for --to when writing to a pipe, rather than guessing", async () => {
+    // There is no extension to read, and defaulting to a binary format
+    // would spray a ZIP into a terminal.
+    const src = path("in.csv")
+    writeFileSync(src, "a,b\n1,2\n", "utf-8")
+
+    await expect(run(convertCommand, { input: src, output: "-" })).rejects.toThrow(/--to/)
+  })
+
+  it("resolves --to through the same table as an extension", async () => {
+    const src = path("in.csv")
+    writeFileSync(src, "a,b\n1,2\n", "utf-8")
+
+    // A format that does not exist fails the same way a bad extension does.
+    await expect(run(convertCommand, { input: src, output: "-", to: "pdf" })).rejects.toThrow(
+      CliError,
+    )
+
+    // And a read-only one is named as read-only, not as unknown.
+    await expect(run(convertCommand, { input: src, output: "-", to: "xls" })).rejects.toThrow(
+      /read-only/,
+    )
+  })
+})

--- a/test/unified-text-formats.test.ts
+++ b/test/unified-text-formats.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest"
+import { read, write } from "../src/defter"
+import { detectTextFormat } from "../src/_sniff"
+import { writeXlsx } from "../src/xlsx/writer"
+import { parseCsv } from "../src/csv/reader"
+import { UnsupportedFormatError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #469 — the library reads and/or writes nine formats. The two functions
+// that exist to be format-agnostic covered four and two of them.
+//
+// `read(csvBytes)` answered "Unsupported format: unknown (not a ZIP
+// archive)" — a correct error for a function that cannot do the job,
+// under a README heading that says **Unified API**. A CSV file read off
+// disk is a `Uint8Array` like any other.
+//
+// The detection decides rather than guesses: every format here announces
+// itself in its first non-whitespace character or two, which is a far
+// weaker claim than the delimiter auto-detection the CSV reader already
+// makes. CSV is the fallback, because "text that is not any of the
+// others" is what CSV actually is.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s)
+const dec = (b: Uint8Array): string => new TextDecoder().decode(b)
+
+const CSV = "name,qty\nWidget,3\nGadget,7\n"
+const JSON_ARRAY = '[{"name":"Widget","qty":3},{"name":"Gadget","qty":7}]'
+const NDJSON = '{"name":"Widget","qty":3}\n{"name":"Gadget","qty":7}\n'
+const XML = '<?xml version="1.0"?><rows><row><name>Widget</name><qty>3</qty></row></rows>'
+const HTML = "<table><tr><th>name</th></tr><tr><td>Widget</td></tr></table>"
+
+describe("detectTextFormat", () => {
+  it("names each format from its opening", () => {
+    expect(detectTextFormat(enc(CSV))).toBe("csv")
+    expect(detectTextFormat(enc(JSON_ARRAY))).toBe("json")
+    expect(detectTextFormat(enc(NDJSON))).toBe("ndjson")
+    expect(detectTextFormat(enc(XML))).toBe("xml")
+    expect(detectTextFormat(enc(HTML))).toBe("html")
+  })
+
+  it("tells one JSON document from many", () => {
+    // Both open with `{`. A whole document that parses is JSON; one that
+    // does not, whose lines each do, is NDJSON — which is exactly the
+    // shape that makes the whole fail.
+    expect(detectTextFormat(enc('{"a":1}'))).toBe("json")
+    expect(detectTextFormat(enc('{"a":1}\n{"a":2}'))).toBe("ndjson")
+
+    // A pretty-printed object spans lines and is still one document.
+    expect(detectTextFormat(enc('{\n  "a": 1\n}'))).toBe("json")
+  })
+
+  it("tells HTML from XML", () => {
+    expect(detectTextFormat(enc("<!DOCTYPE html><html><body></body></html>"))).toBe("html")
+    expect(detectTextFormat(enc("<html>"))).toBe("html")
+    expect(detectTextFormat(enc("<table><tr><td>a</td></tr></table>"))).toBe("html")
+    expect(detectTextFormat(enc('<?xml version="1.0"?><a/>'))).toBe("xml")
+    expect(detectTextFormat(enc("<rows><row/></rows>"))).toBe("xml")
+  })
+
+  it("skips a byte-order mark before deciding", () => {
+    const bom = (s: string): Uint8Array => new Uint8Array([0xef, 0xbb, 0xbf, ...enc(s)])
+
+    expect(detectTextFormat(bom(CSV))).toBe("csv")
+    expect(detectTextFormat(bom(JSON_ARRAY))).toBe("json")
+  })
+
+  it("says nothing about bytes that are not text", () => {
+    // The important return. Without it, binary rubbish would reach the
+    // CSV parser, which would cheerfully make a sheet of it.
+    expect(detectTextFormat(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]))).toBeNull()
+    expect(detectTextFormat(new Uint8Array([]))).toBeNull()
+    expect(detectTextFormat(enc("   \n  "))).toBeNull()
+  })
+})
+
+describe("read() dispatches to the text formats", () => {
+  it("CSV", async () => {
+    const wb = await read(enc(CSV))
+
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["name", "qty"],
+      ["Widget", "3"],
+      ["Gadget", "7"],
+    ])
+  })
+
+  it("JSON", async () => {
+    const wb = await read(enc(JSON_ARRAY))
+
+    expect(wb.sheets[0]!.rows[0]).toEqual(["name", "qty"])
+    expect(wb.sheets[0]!.rows[1]).toEqual(["Widget", 3])
+  })
+
+  it("NDJSON, with the header row put back", async () => {
+    // A workbook is a grid. The record readers hand back
+    // `{ data, headers }`, and dropping the names would lose them.
+    const wb = await read(enc(NDJSON))
+
+    expect(wb.sheets[0]!.rows).toEqual([
+      ["name", "qty"],
+      ["Widget", 3],
+      ["Gadget", 7],
+    ])
+  })
+
+  it("XML", async () => {
+    const wb = await read(enc(XML))
+
+    expect(wb.sheets[0]!.rows[0]).toEqual(["name", "qty"])
+    expect(wb.sheets[0]!.rows[1]![0]).toBe("Widget")
+  })
+
+  it("HTML", async () => {
+    const wb = await read(enc(HTML))
+
+    expect(wb.sheets[0]!.rows).toEqual([["name"], ["Widget"]])
+  })
+
+  it("still reads the container formats it always did", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [["a", 1]] }] })
+
+    expect((await read(bytes)).sheets[0]!.rows).toEqual([["a", 1]])
+  })
+
+  it("still refuses bytes that are not a spreadsheet at all", async () => {
+    await expect(read(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))).rejects.toThrow(
+      UnsupportedFormatError,
+    )
+  })
+})
+
+describe("write() covers what the library can write", () => {
+  const sheets = [
+    {
+      name: "S",
+      rows: [
+        ["name", "qty"],
+        ["Widget", 3],
+      ],
+    },
+  ]
+
+  it("the text formats each produce their own shape", async () => {
+    expect(dec(await write({ sheets, format: "csv" }))).toContain("name,qty")
+    expect(dec(await write({ sheets, format: "tsv" }))).toContain("name\tqty")
+    expect(dec(await write({ sheets, format: "json" }))).toContain('"name"')
+    expect(
+      dec(await write({ sheets, format: "ndjson" }))
+        .trim()
+        .split("\n"),
+    ).toHaveLength(1)
+    expect(dec(await write({ sheets, format: "xml" }))).toContain("<name>")
+    expect(dec(await write({ sheets, format: "html" }))).toContain("<table")
+    expect(dec(await write({ sheets, format: "markdown" }))).toContain("| name")
+  })
+
+  it("returns bytes for every format, so the caller does not branch", async () => {
+    for (const format of ["xlsx", "ods", "csv", "json", "html"] as const) {
+      expect(await write({ sheets, format }), format).toBeInstanceOf(Uint8Array)
+    }
+  })
+
+  it("still defaults to xlsx", async () => {
+    const bytes = await write({ sheets })
+
+    expect((await read(bytes)).sheets[0]!.rows[1]).toEqual(["Widget", 3])
+  })
+
+  it("round-trips through the text formats it can read back", async () => {
+    for (const format of ["csv", "json", "ndjson", "xml"] as const) {
+      const wb = await read(await write({ sheets, format }))
+
+      expect(wb.sheets[0]!.rows[0], format).toEqual(["name", "qty"])
+      expect(String(wb.sheets[0]!.rows[1]![0]), format).toBe("Widget")
+    }
+  })
+
+  it("says so rather than crashing on a workbook with no sheets", async () => {
+    await expect(write({ sheets: [], format: "csv" })).rejects.toThrow(UnsupportedFormatError)
+  })
+})
+
+describe("the header-row convention is the same in both directions", () => {
+  it("a grid written and read back keeps its names", async () => {
+    const sheets = [
+      {
+        name: "S",
+        rows: [
+          ["a", "b"],
+          [1, 2],
+        ],
+      },
+    ]
+    const csv = dec(await write({ sheets, format: "csv" }))
+
+    expect(parseCsv(csv)[0]).toEqual(["a", "b"])
+  })
+
+  it("an unnamed first-row cell gets a positional name rather than being dropped", async () => {
+    const sheets = [
+      {
+        name: "S",
+        rows: [
+          ["a", null],
+          [1, 2],
+        ],
+      },
+    ]
+
+    expect(dec(await write({ sheets, format: "json" }))).toContain("column2")
+  })
+})


### PR DESCRIPTION
Closes #469.

The library reads and/or writes nine formats. The two entry points that exist to be format-agnostic covered four and two of them.

## `read()`

`read(csvBytes)` answered `UnsupportedFormatError: Unsupported format: unknown (not a ZIP archive)` — a correct error for a function that cannot do the job, and a strange one for a CSV file read off disk, which is a `Uint8Array` like any other. The doc comment blamed a signature that had already changed: *"CSV uses parseCsv separately since it's string input"*, when `ReadInput` has been bytes for a while.

`src/_sniff.ts` **decides rather than guesses**. Every text format announces itself in its first non-whitespace character or two — a far weaker claim than the delimiter auto-detection `parseCsv` already makes:

```
csv        -> [["name","qty"],["Widget","3"]]
json       -> [["name","qty"],["Widget",3]]
ndjson     -> [["name","qty"],["Widget",3],["Gadget",7]]
xml        -> [["name","qty"],["Widget","3"]]
html       -> [["name"],["Widget"]]
bom csv    -> [["a","b"],["1","2"]]
binary     -> ERROR (good): Unsupported format: unknown (not a ZIP archive)
```

Three decisions worth naming:

- **JSON vs NDJSON** both open with `{`, so that one is settled by *trying*. A whole document that parses is JSON; one that does not, whose lines each do, is NDJSON — which is exactly the shape that makes the whole fail. A pretty-printed object spans lines and is still one document; there is a test.
- **CSV is the fallback, not a positive match.** "Text that is not any of the others" is what CSV actually is.
- **Not-text returns `null`**, and the caller keeps its existing error. A NUL byte in the first few KB is where that line is drawn (UTF-16 excepted, since the mark says so). Without it, binary rubbish would reach the CSV parser, which would cheerfully make a sheet of it.

## `write()`

The union goes from `"xlsx" | "ods"` to all nine, and always returns bytes so nothing downstream has to branch on the format.

The text formats are single-sheet by nature and take the first sheet; the record-shaped ones (`json`, `ndjson`, `xml`) read row 0 as field names — the convention `read()` inverts on the way back in, so a round-trip through any of them keeps its headers.

## The CLI

Same formats, plus `-` for stdin and stdout. Verified against the built binary:

```
$ cat d.csv | hucre convert - - --to md
| name   | qty |
| ------ | --- |
| Widget | 3   |
| Gadget | 7   |

$ hucre convert d.csv -
 ERROR  Writing to stdout needs --to to say which format (e.g. --to csv),
        because there is no extension to read.
```

From a pipe there is no extension, so the input format comes from the content and the output from `--to`. Guessing a binary default would spray a ZIP into a terminal, so it asks instead. **Progress goes to stderr whenever stdout is the file** — a "Reading..." line in stdout would corrupt the result.

Markdown is refused as *input* with a sentence saying why, rather than a confusing parse error: it is output only, and there is no `fromMarkdown`.

## Tests

`test/unified-text-formats.test.ts` (19 cases) and 11 more in `test/cli.test.ts`. Mutation-checked: 9 of the 19 fail against `main`.

The stdin/stdout **byte** paths are verified by hand against `dist/cli.mjs` (shown above) rather than in vitest, where fd 0 and 1 belong to the test runner; the format-resolution and error paths, which is where the logic is, do have tests.

`pnpm lint`, `pnpm typecheck`, 10073 tests green; coverage and size budgets both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
