### PR TITLE
feat: streaming writers for ODS and NDJSON — refs #467

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,39 @@ for (let i = 0; i < 100_000; i++) {
 const buffer = await writer.finish()
 ```
 
+#### Across the formats
+
+```ts
+import { writeOdsStream } from "hucre/ods"
+import { writeNdjsonStream } from "hucre/json"
+
+return new Response(writeOdsStream(rowCursor, { name: "Export" }), {
+  headers: { "content-type": "application/vnd.oasis.opendocument.spreadsheet" },
+})
+
+return new Response(writeNdjsonStream(rowCursor), {
+  headers: { "content-type": "application/x-ndjson" },
+})
+```
+
+|        | whole read | whole write | stream read | stream write | incremental writer |
+| ------ | :--------: | :---------: | :---------: | :----------: | :----------------: |
+| XLSX   |     ✔      |      ✔      |      ✔      |  ✔ (multi)   |         ✔          |
+| CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
+| NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
+| ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
+| XML    |     ✔      |      ✔      |      —      |      —       |         —          |
+
+`writeOdsStream` carries **values, not formatting**, and that follows from
+the format: ODF puts `<office:automatic-styles>` before the body, so a
+style first seen on row 900,000 has nowhere to be declared — the same
+shape as the shared-string table, which the XLSX streaming writer answers
+with inline strings and ODF has no equivalent for. Column widths and a
+header row are carried, because `columns` is known before the first row.
+`writeOds` remains the path for a document that needs styling.
+
+XML is the remaining gap, on both sides.
+
 #### Which writer to use
 
 |             | `writeXlsxStream()`                          | `XlsxStreamWriter`                |

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ export type {
 // ── ODS ────────────────────────────────────────────────────────────
 export { readOds } from "./ods/reader"
 export { writeOds } from "./ods/writer"
+export { writeOdsStream } from "./ods/stream-writer"
+export type { OdsWriteRow, OdsWriteCell, OdsStreamWriteOptions } from "./ods/stream-writer"
 export { streamOdsRows } from "./ods/stream"
 export { readOdsObjects, writeOdsObjects } from "./ods/objects"
 export type { OdsObjectsReadOptions, OdsObjectsResult, OdsObjectsWriteOptions } from "./ods/objects"
@@ -83,6 +85,7 @@ export {
   NdjsonStreamWriter,
   streamNdjsonRows,
   readNdjsonStream,
+  writeNdjsonStream,
   // Exported from hucre/json but not from the root, so the two surfaces
   // disagreed about what the JSON API is.
   flattenValue,
@@ -98,6 +101,7 @@ export type {
   JsonWriteOptions,
   WorkbookToJsonOptions,
   NdjsonStreamReadOptions,
+  NdjsonStreamRow,
   NdjsonStreamWriterOptions,
   FlattenOptions,
   UnflattenedRow,

--- a/src/json.ts
+++ b/src/json.ts
@@ -12,8 +12,17 @@ export type {
 export { writeJson, writeNdjson, workbookToJson } from "./json/writer"
 export type { JsonWriteOptions, WorkbookToJsonOptions } from "./json/writer"
 
-export { NdjsonStreamWriter, streamNdjsonRows, readNdjsonStream } from "./json/stream"
-export type { NdjsonStreamReadOptions, NdjsonStreamWriterOptions } from "./json/stream"
+export {
+  NdjsonStreamWriter,
+  streamNdjsonRows,
+  readNdjsonStream,
+  writeNdjsonStream,
+} from "./json/stream"
+export type {
+  NdjsonStreamReadOptions,
+  NdjsonStreamWriterOptions,
+  NdjsonStreamRow,
+} from "./json/stream"
 
 export { flattenValue, collectHeaders } from "./json/flatten"
 export type { FlattenOptions } from "./json/flatten"

--- a/src/json/stream.ts
+++ b/src/json/stream.ts
@@ -262,3 +262,100 @@ function tryParseLine(
  * in a future major.
  */
 export const readNdjsonStream: typeof streamNdjsonRows = streamNdjsonRows
+
+// ── True Streaming NDJSON Writer ─────────────────────────────────────
+
+/** A streamed row: an object, or positional values read through `columns`. */
+export type NdjsonStreamRow = Record<string, CellValue> | CellValue[]
+
+/**
+ * Write NDJSON as a byte stream, pulling rows from `rows` only as the
+ * consumer reads.
+ *
+ * `NdjsonStreamWriter.toStream()` already streamed live, but it is a
+ * class the caller has to drive — and `writeXlsxStream` /
+ * `writeCsvStream` are the shape that reads naturally at a `Response`
+ * boundary. NDJSON, of all formats, should not be the one that lacks it.
+ * See #467.
+ *
+ * ```ts
+ * return new Response(writeNdjsonStream(rowCursor), {
+ *   headers: { "content-type": "application/x-ndjson" },
+ * })
+ * ```
+ *
+ * Peak memory is independent of the row count: each row is serialized,
+ * encoded and enqueued on its own, and nothing is retained.
+ *
+ * Positional rows need `columns`, for the same reason
+ * {@link NdjsonStreamWriter.addRow} does — NDJSON rows are objects, so
+ * values with no key names describe nothing.
+ */
+export function writeNdjsonStream(
+  rows: AsyncIterable<NdjsonStreamRow> | Iterable<NdjsonStreamRow>,
+  options?: NdjsonStreamWriterOptions,
+): ReadableStream<Uint8Array> {
+  const chunks = ndjsonStreamChunks(rows, options)
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await chunks.next()
+        if (done) {
+          controller.close()
+          return
+        }
+        controller.enqueue(value)
+      } catch (err) {
+        controller.error(err)
+      }
+    },
+    async cancel(reason) {
+      await chunks.return?.(reason)
+    },
+  })
+}
+
+/** Serialize rows into ~64 KB encoded chunks, pulling lazily. */
+async function* ndjsonStreamChunks(
+  rows: AsyncIterable<NdjsonStreamRow> | Iterable<NdjsonStreamRow>,
+  options?: NdjsonStreamWriterOptions,
+): AsyncGenerator<Uint8Array> {
+  const columns = options?.columns
+  const unflatten = options?.unflatten ?? false
+
+  // Batching is what keeps this from being one syscall-sized write per
+  // row; the same 64 KB the CSV writer uses.
+  const CHUNK_BYTES = 64 * 1024
+  let pending: string[] = []
+  let pendingBytes = 0
+
+  for await (const row of rows) {
+    let object: Record<string, CellValue>
+    if (Array.isArray(row)) {
+      if (!columns) {
+        throw new InvalidArgumentError(
+          "writeNdjsonStream needs `columns` for positional rows — NDJSON rows " +
+            "are objects, so values with no key names describe nothing. Pass " +
+            "`{ columns: [...] }` or yield objects.",
+        )
+      }
+      object = {}
+      for (let i = 0; i < columns.length; i++) object[columns[i]!] = row[i] ?? null
+    } else {
+      object = row
+    }
+
+    const line = `${JSON.stringify(unflatten ? unflattenRow(object) : object)}\n`
+    pending.push(line)
+    pendingBytes += line.length
+
+    if (pendingBytes >= CHUNK_BYTES) {
+      yield TEXT_ENCODER.encode(pending.join(""))
+      pending = []
+      pendingBytes = 0
+    }
+  }
+
+  if (pending.length > 0) yield TEXT_ENCODER.encode(pending.join(""))
+}

--- a/src/ods.ts
+++ b/src/ods.ts
@@ -3,6 +3,8 @@
 
 export { readOds } from "./ods/reader"
 export { writeOds } from "./ods/writer"
+export { writeOdsStream } from "./ods/stream-writer"
+export type { OdsWriteRow, OdsWriteCell, OdsStreamWriteOptions } from "./ods/stream-writer"
 export { streamOdsRows } from "./ods/stream"
 export type { OdsStreamRow } from "./ods/stream"
 export { readOdsObjects, writeOdsObjects } from "./ods/objects"

--- a/src/ods/stream-writer.ts
+++ b/src/ods/stream-writer.ts
@@ -1,0 +1,245 @@
+// ── True Streaming ODS Writer ───────────────────────────────────────
+//
+// ODS was the one that stood out. It has a streaming *reader* and had no
+// streaming writer at all, so the format with the second-best support in
+// the library could not produce a large file without holding the whole
+// thing in memory. The ZIP layer already streams and `zipStream` is
+// format-agnostic; what was missing was a row serializer that can be
+// driven incrementally, the shape `RowSerializer` has for XLSX. See #467.
+//
+// What this deliberately does not do is styles. ODF puts
+// `<office:automatic-styles>` *before* the body, so a style discovered
+// while serializing row 900,000 has nowhere to go — the same shape as the
+// shared-string table the XLSX streaming writer answers with inline
+// strings, and ODF has no inline equivalent. Column widths are the
+// exception and are carried, because `columns` is known before the first
+// row. Everything else is values, which is what a million-row export is.
+
+import type { CellValue, WorkbookProperties } from "../_types"
+import { zipStream, type ZipStreamEntry } from "../zip/stream-writer"
+import { xmlEscape } from "../xml/writer"
+import { validateSheetNames } from "../_validate"
+
+import {
+  MIMETYPE,
+  writeManifestXml,
+  writeMetaXml,
+  writeSettingsXml,
+  writeStylesXml,
+  formatOdsDateValue,
+  formatNumberDisplay,
+  excelFormulaToOds,
+} from "./writer"
+
+const encoder = /* @__PURE__ */ new TextEncoder()
+
+/** A streamed row: positional values, each optionally carrying a formula. */
+export type OdsWriteCell = CellValue | { value?: CellValue; formula?: string }
+export type OdsWriteRow = OdsWriteCell[]
+
+export interface OdsStreamWriteOptions {
+  /** Sheet name. Excel's limits apply — LibreOffice enforces them too. */
+  name?: string
+  /**
+   * Column widths in characters, and the header row to emit before the
+   * data. Known before the first row, which is why these can be carried
+   * when per-cell styles cannot.
+   */
+  columns?: Array<{ header?: string; width?: number }>
+  /** Document properties written to `meta.xml`. */
+  properties?: WorkbookProperties
+  /**
+   * Emit ZIP64 records, lifting the 4 GiB ceiling. Handed straight to
+   * `zipStream`; see its note on why this is an up-front choice.
+   */
+  zip64?: boolean
+}
+
+/**
+ * Write an ODS document as a byte stream, pulling rows from `rows` only
+ * as the consumer reads.
+ *
+ * ```ts
+ * return new Response(writeOdsStream(rowCursor, { name: "Export" }), {
+ *   headers: {
+ *     "content-type": "application/vnd.oasis.opendocument.spreadsheet",
+ *   },
+ * })
+ * ```
+ *
+ * Peak memory is independent of the row count: each row is serialized,
+ * encoded and enqueued on its own, and nothing is retained.
+ *
+ * **Values, not formatting.** `<office:automatic-styles>` precedes the
+ * body in ODF, so a style first seen on row 900,000 has nowhere to be
+ * declared. Column widths and a header row are carried because they are
+ * known up front; per-cell styles are not, and `writeOds` remains the
+ * path for a document that needs them. See #467.
+ */
+export function writeOdsStream(
+  rows: AsyncIterable<OdsWriteRow> | Iterable<OdsWriteRow>,
+  options?: OdsStreamWriteOptions,
+): ReadableStream<Uint8Array> {
+  const name = options?.name ?? "Sheet1"
+  validateSheetNames([{ name }])
+
+  const entries: ZipStreamEntry[] = [
+    // mimetype MUST be first and MUST be stored uncompressed — the one
+    // rule an ODF consumer checks before anything else.
+    { path: "mimetype", data: encoder.encode(MIMETYPE), compress: false },
+    { path: "META-INF/manifest.xml", data: encoder.encode(writeManifestXml()) },
+    { path: "styles.xml", data: encoder.encode(writeStylesXml()) },
+    { path: "meta.xml", data: encoder.encode(writeMetaXml(options?.properties)) },
+    { path: "settings.xml", data: encoder.encode(writeSettingsXml()) },
+    { path: "content.xml", data: contentChunks(rows, name, options?.columns) },
+  ]
+
+  return zipStream(entries, { zip64: options?.zip64 })
+}
+
+const CONTENT_HEAD =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+  '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"' +
+  ' xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"' +
+  ' xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"' +
+  ' xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"' +
+  ' xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"' +
+  ' xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"' +
+  ' xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2"' +
+  ' office:version="1.2">'
+
+/** Serialize content.xml into ~64 KB encoded chunks, pulling lazily. */
+async function* contentChunks(
+  rows: AsyncIterable<OdsWriteRow> | Iterable<OdsWriteRow>,
+  name: string,
+  columns?: Array<{ header?: string; width?: number }>,
+): AsyncGenerator<Uint8Array> {
+  const CHUNK_BYTES = 64 * 1024
+  let pending: string[] = []
+  let pendingBytes = 0
+
+  const push = function* (text: string): Generator<Uint8Array> {
+    pending.push(text)
+    pendingBytes += text.length
+    if (pendingBytes >= CHUNK_BYTES) {
+      yield encoder.encode(pending.join(""))
+      pending = []
+      pendingBytes = 0
+    }
+  }
+
+  yield* push(CONTENT_HEAD)
+  yield* push(automaticStyles(columns))
+  yield* push(`<office:body><office:spreadsheet><table:table table:name="${xmlEscape(name)}">`)
+
+  // Column declarations, which have to precede every row.
+  const colCount = columns?.length ?? 0
+  for (let i = 0; i < colCount; i++) {
+    const width = columns![i]!.width
+    yield* push(
+      width === undefined
+        ? "<table:table-column/>"
+        : `<table:table-column table:style-name="co${i + 1}"/>`,
+    )
+  }
+
+  if (columns?.some((c) => c.header !== undefined)) {
+    yield* push(serializeRow(columns.map((c) => c.header ?? null)))
+  }
+
+  for await (const row of rows) {
+    yield* push(serializeRow(row))
+  }
+
+  yield* push("</table:table></office:spreadsheet></office:body></office:document-content>")
+
+  if (pending.length > 0) yield encoder.encode(pending.join(""))
+}
+
+/**
+ * The style block, emitted before the body because ODF requires it there.
+ *
+ * Only column widths land here — they are the one thing known before the
+ * first row arrives.
+ */
+function automaticStyles(columns?: Array<{ header?: string; width?: number }>): string {
+  const parts: string[] = []
+  columns?.forEach((col, i) => {
+    if (col.width === undefined) return
+    // ODF column widths are a physical measure; the same 7px-per-character
+    // approximation the buffered writer uses, at 96 DPI.
+    const inches = (col.width * 7 + 5) / 96
+    parts.push(
+      `<style:style style:name="co${i + 1}" style:family="table-column">` +
+        `<style:table-column-properties style:column-width="${inches.toFixed(4)}in"/>` +
+        "</style:style>",
+    )
+  })
+  return `<office:automatic-styles>${parts.join("")}</office:automatic-styles>`
+}
+
+/** One `<table:table-row>`, values only. */
+function serializeRow(row: OdsWriteRow): string {
+  const cells: string[] = []
+  for (const cell of row) {
+    cells.push(
+      cell !== null && typeof cell === "object" && !(cell instanceof Date) && !Array.isArray(cell)
+        ? serializeCell(
+            (cell as { value?: CellValue }).value ?? null,
+            (cell as { formula?: string }).formula,
+          )
+        : serializeCell(cell as CellValue),
+    )
+  }
+  return `<table:table-row>${cells.join("")}</table:table-row>`
+}
+
+/**
+ * One `<table:table-cell>`.
+ *
+ * The value encoding matches `cellToOds` exactly, including its two
+ * refusals: a non-finite number and an unparseable Date both produce an
+ * empty cell rather than `office:value="NaN"`, which LibreOffice reads as
+ * garbage and which used to make a corrupt file (#364).
+ */
+function serializeCell(value: CellValue, formula?: string): string {
+  const attrs = formula ? ` table:formula="${xmlEscape(excelFormulaToOds(formula))}"` : ""
+
+  if (value === null || value === undefined) {
+    return attrs ? `<table:table-cell${attrs}/>` : "<table:table-cell/>"
+  }
+
+  if (typeof value === "string") {
+    return (
+      `<table:table-cell${attrs} office:value-type="string">` +
+      `<text:p>${xmlEscape(value)}</text:p></table:table-cell>`
+    )
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return `<table:table-cell${attrs}></table:table-cell>`
+    return (
+      `<table:table-cell${attrs} office:value-type="float" office:value="${value}">` +
+      `<text:p>${xmlEscape(formatNumberDisplay(value))}</text:p></table:table-cell>`
+    )
+  }
+
+  if (typeof value === "boolean") {
+    return (
+      `<table:table-cell${attrs} office:value-type="boolean" ` +
+      `office:boolean-value="${value ? "true" : "false"}">` +
+      `<text:p>${value ? "TRUE" : "FALSE"}</text:p></table:table-cell>`
+    )
+  }
+
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return `<table:table-cell${attrs}></table:table-cell>`
+    const iso = formatOdsDateValue(value)
+    return (
+      `<table:table-cell${attrs} office:value-type="date" office:date-value="${iso}">` +
+      `<text:p>${iso}</text:p></table:table-cell>`
+    )
+  }
+
+  return `<table:table-cell${attrs}/>`
+}

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -35,7 +35,7 @@ const NS_DC = "http://purl.org/dc/elements/1.1/"
 const NS_XLINK = "http://www.w3.org/1999/xlink"
 const NS_OF = "urn:oasis:names:tc:opendocument:xmlns:of:1.2"
 
-const MIMETYPE = "application/vnd.oasis.opendocument.spreadsheet"
+export const MIMETYPE = "application/vnd.oasis.opendocument.spreadsheet"
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -44,7 +44,7 @@ const MIMETYPE = "application/vnd.oasis.opendocument.spreadsheet"
  * - Integers (including floats with no fractional part like 12.0) → "12"
  * - Floats → reasonable decimal places, no floating-point artifacts
  */
-function formatNumberDisplay(value: number): string {
+export function formatNumberDisplay(value: number): string {
   if (Number.isInteger(value)) return String(value)
   // Use toPrecision(15) to avoid floating-point artifacts (JS has ~17 significant digits),
   // then parseFloat to strip trailing zeros
@@ -55,7 +55,7 @@ function formatOdsDate(date: Date): string {
   return date.toISOString().replace(/\.\d{3}Z$/, "Z")
 }
 
-function formatOdsDateValue(date: Date): string {
+export function formatOdsDateValue(date: Date): string {
   // ODS date values use ISO 8601 without time zone: YYYY-MM-DDTHH:MM:SS
   // Must use UTC methods to avoid local timezone offset corruption
   const y = date.getUTCFullYear()
@@ -665,7 +665,7 @@ function odsSheetLocator(sheet: string | undefined): string {
  * Convert an Excel-style formula to ODS formula syntax.
  * ODS formulas use `of:=` prefix and `[.A1]` cell references.
  */
-function excelFormulaToOds(formula: string): string {
+export function excelFormulaToOds(formula: string): string {
   // Convert cell references like A1, $A$1, A1:B2 to ODS [.A1] notation,
   // handling ranges (A1:B2 → [.A1:.B2]) and cross-sheet references
   // (Sheet2!A1 → [$Sheet2.A1]) while leaving function names (LOG10),
@@ -1139,7 +1139,7 @@ function writeContentXml(options: WriteOptions): string {
 
 // ── meta.xml ────────────────────────────────────────────────────────
 
-function writeMetaXml(props?: WorkbookProperties): string {
+export function writeMetaXml(props?: WorkbookProperties): string {
   const children: string[] = []
 
   if (props?.title) {
@@ -1182,7 +1182,7 @@ function writeMetaXml(props?: WorkbookProperties): string {
 
 // ── styles.xml ──────────────────────────────────────────────────────
 
-function writeStylesXml(): string {
+export function writeStylesXml(): string {
   // ODS spec requires these child elements even if empty:
   // office:font-face-decls, office:styles, office:automatic-styles, office:master-styles
   const children: string[] = []
@@ -1209,7 +1209,7 @@ function writeStylesXml(): string {
 
 // ── settings.xml ─────────────────────────────────────────────────────
 
-function writeSettingsXml(): string {
+export function writeSettingsXml(): string {
   const NS_CONFIG = "urn:oasis:names:tc:opendocument:xmlns:config:1.0"
 
   return xmlDocument(
@@ -1225,7 +1225,7 @@ function writeSettingsXml(): string {
 
 // ── manifest.xml ────────────────────────────────────────────────────
 
-function writeManifestXml(): string {
+export function writeManifestXml(): string {
   const NS_MANIFEST = "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"
 
   const entries: string[] = []

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -34,6 +34,7 @@ exports[`export surface snapshot > hucre/json 1`] = `
   "workbookToJson",
   "writeJson",
   "writeNdjson",
+  "writeNdjsonStream",
 ]
 `;
 
@@ -46,6 +47,7 @@ exports[`export surface snapshot > hucre/ods 1`] = `
   "toWriteSheet",
   "writeOds",
   "writeOdsObjects",
+  "writeOdsStream",
 ]
 `;
 
@@ -260,9 +262,11 @@ exports[`export surface snapshot > root 1`] = `
   "writeCsvStream",
   "writeJson",
   "writeNdjson",
+  "writeNdjsonStream",
   "writeObjects",
   "writeOds",
   "writeOdsObjects",
+  "writeOdsStream",
   "writeTsv",
   "writeTsvObjects",
   "writeXlsx",

--- a/test/streaming-holes.test.ts
+++ b/test/streaming-holes.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest"
+import { writeOdsStream } from "../src/ods/stream-writer"
+import { writeNdjsonStream } from "../src/json/stream"
+import { readOds } from "../src/ods/reader"
+import { streamOdsRows } from "../src/ods/stream"
+import { parseNdjson } from "../src/json/reader"
+import { ZipReader } from "../src/zip/reader"
+import { InvalidArgumentError } from "../src/errors"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #467 — constant-memory streaming is one of the library's headline
+// properties and it was uneven. ODS was the one that stood out: a
+// streaming *reader* and no streaming writer at all, so the format with
+// the second-best support could not produce a large file without holding
+// the whole thing in memory. NDJSON had the class but not the
+// `write*Stream(rows, options)` shape that reads naturally at a
+// `Response` boundary.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0)
+  const out = new Uint8Array(total)
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+const text = (b: Uint8Array): string => new TextDecoder().decode(b)
+
+describe("writeOdsStream produces a file hucre's own reader accepts", () => {
+  const ROWS: CellValue[][] = [
+    ["Widget", 3, true, new Date("2024-01-15T00:00:00Z")],
+    ["Gadget", 7.5, false, null],
+  ]
+
+  it("round-trips values of every type", async () => {
+    const bytes = await drain(writeOdsStream(ROWS, { name: "Export" }))
+    const wb = await readOds(bytes)
+
+    expect(wb.sheets[0]!.name).toBe("Export")
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("Widget")
+    expect(wb.sheets[0]!.rows[0]![1]).toBe(3)
+    expect(wb.sheets[0]!.rows[0]![2]).toBe(true)
+    expect(wb.sheets[0]!.rows[0]![3]).toBeInstanceOf(Date)
+    expect(wb.sheets[0]!.rows[1]![1]).toBe(7.5)
+    // A trailing null is not written, so the row comes back short — the
+    // same thing `writeOds` + `readOds` do, which is the bar here.
+    expect(wb.sheets[0]!.rows[1]).toHaveLength(3)
+  })
+
+  it("is a valid ODF package, mimetype first and stored", async () => {
+    // The one rule an ODF consumer checks before anything else.
+    const bytes = await drain(writeOdsStream(ROWS))
+    const entries = new ZipReader(bytes).entries()
+
+    expect(entries[0]).toBe("mimetype")
+    expect(text(await new ZipReader(bytes).extract("mimetype"))).toBe(
+      "application/vnd.oasis.opendocument.spreadsheet",
+    )
+    for (const part of ["META-INF/manifest.xml", "content.xml", "styles.xml", "meta.xml"]) {
+      expect(entries, part).toContain(part)
+    }
+  })
+
+  it("the streaming reader reads what the streaming writer wrote", async () => {
+    const bytes = await drain(writeOdsStream(ROWS, { name: "Export" }))
+    const rows: CellValue[][] = []
+    for await (const row of streamOdsRows(bytes)) rows.push(row.values)
+
+    expect(rows[0]![0]).toBe("Widget")
+    expect(rows[1]![0]).toBe("Gadget")
+  })
+
+  it("carries column widths and a header row, which are known up front", async () => {
+    const bytes = await drain(
+      writeOdsStream(ROWS, {
+        columns: [
+          { header: "name", width: 20 },
+          { header: "qty", width: 10 },
+          { header: "ok" },
+          { header: "when" },
+        ],
+      }),
+    )
+
+    const content = text(await new ZipReader(bytes).extract("content.xml"))
+    expect(content).toContain("style:column-width")
+    expect((await readOds(bytes)).sheets[0]!.rows[0]).toEqual(["name", "qty", "ok", "when"])
+  })
+
+  it("writes a formula when a cell carries one", async () => {
+    const bytes = await drain(writeOdsStream([[1, 2, { formula: "SUM(A1:B1)" }]]))
+    const content = text(await new ZipReader(bytes).extract("content.xml"))
+
+    expect(content).toContain("table:formula")
+  })
+
+  it("refuses NaN and an unparseable Date the same way writeOds does", async () => {
+    // `office:value="NaN"` makes LibreOffice read garbage — a corrupt
+    // file rather than an error. See #364.
+    const bytes = await drain(writeOdsStream([[Number.NaN, new Date("nonsense")]]))
+    const content = text(await new ZipReader(bytes).extract("content.xml"))
+
+    expect(content).not.toContain("NaN")
+  })
+
+  it("escapes what would otherwise break the XML", async () => {
+    const bytes = await drain(writeOdsStream([['<a & "b">']], { name: "A&B" }))
+    const wb = await readOds(bytes)
+
+    expect(wb.sheets[0]!.name).toBe("A&B")
+    expect(wb.sheets[0]!.rows[0]![0]).toBe('<a & "b">')
+  })
+
+  it("pulls rows lazily rather than draining the source first", async () => {
+    // The property the whole thing exists for. If the generator ran to
+    // completion before the first chunk, this would count to 5000 before
+    // a single byte came out.
+    let produced = 0
+    function* rows(): Generator<CellValue[]> {
+      for (let i = 0; i < 5000; i++) {
+        produced++
+        yield [`row ${i}`, i]
+      }
+    }
+
+    const reader = writeOdsStream(rows()).getReader()
+    await reader.read()
+    const afterFirstChunk = produced
+    await reader.cancel()
+
+    expect(afterFirstChunk).toBeLessThan(5000)
+  })
+
+  it("takes an async source", async () => {
+    async function* rows(): AsyncGenerator<CellValue[]> {
+      yield ["a", 1]
+      yield ["b", 2]
+    }
+
+    const wb = await readOds(await drain(writeOdsStream(rows())))
+    expect(wb.sheets[0]!.rows).toHaveLength(2)
+  })
+
+  it("still refuses a sheet name Excel would", async () => {
+    expect(() => writeOdsStream([], { name: "a/b" })).toThrow()
+  })
+})
+
+describe("writeNdjsonStream", () => {
+  it("writes one JSON object per line", async () => {
+    const out = text(
+      await drain(
+        writeNdjsonStream([
+          { name: "Widget", qty: 3 },
+          { name: "Gadget", qty: 7 },
+        ]),
+      ),
+    )
+
+    expect(out.trim().split("\n")).toHaveLength(2)
+    expect(parseNdjson(out).data).toEqual([
+      { name: "Widget", qty: 3 },
+      { name: "Gadget", qty: 7 },
+    ])
+  })
+
+  it("takes positional rows through columns", async () => {
+    const out = text(
+      await drain(
+        writeNdjsonStream(
+          [
+            ["Widget", 3],
+            ["Gadget", 7],
+          ],
+          { columns: ["name", "qty"] },
+        ),
+      ),
+    )
+
+    expect(parseNdjson(out).data[0]).toEqual({ name: "Widget", qty: 3 })
+  })
+
+  it("says why rather than guessing when positional rows have no columns", async () => {
+    // NDJSON rows are objects; values with no key names describe nothing.
+    // Same contract as NdjsonStreamWriter.addRow.
+    await expect(drain(writeNdjsonStream([["a", 1]]))).rejects.toThrow(InvalidArgumentError)
+  })
+
+  it("unflattens dot paths when asked", async () => {
+    const out = text(await drain(writeNdjsonStream([{ "a.b": 1 }], { unflatten: true })))
+
+    expect(JSON.parse(out.trim())).toEqual({ a: { b: 1 } })
+  })
+
+  it("pulls rows lazily", async () => {
+    // Rows big enough that the 64 KB chunk boundary lands well before the
+    // source is exhausted — otherwise the first chunk is the only chunk,
+    // and this would prove nothing.
+    let produced = 0
+    const filler = "x".repeat(200)
+    function* rows(): Generator<Record<string, CellValue>> {
+      for (let i = 0; i < 5000; i++) {
+        produced++
+        yield { i, filler }
+      }
+    }
+
+    const reader = writeNdjsonStream(rows()).getReader()
+    await reader.read()
+    const afterFirstChunk = produced
+    await reader.cancel()
+
+    expect(afterFirstChunk).toBeLessThan(5000)
+  })
+
+  it("takes an async source", async () => {
+    async function* rows(): AsyncGenerator<Record<string, CellValue>> {
+      yield { a: 1 }
+      yield { a: 2 }
+    }
+
+    expect(parseNdjson(text(await drain(writeNdjsonStream(rows())))).data).toHaveLength(2)
+  })
+
+  it("emits nothing for no rows, rather than a stray newline", async () => {
+    expect(text(await drain(writeNdjsonStream([])))).toBe("")
+  })
+})


### PR DESCRIPTION
Refs #467. Two of its three holes; XML is left open and the README now says so.

|        | whole read | whole write | stream read | stream write | incremental writer |
| ------ | :--------: | :---------: | :---------: | :----------: | :----------------: |
| XLSX   |     ✔      |      ✔      |      ✔      |  ✔ (multi)   |         ✔          |
| CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| NDJSON |     ✔      |      ✔      |      ✔      |   ✔ **new**  |         ✔          |
| ODS    |     ✔      |      ✔      |      ✔      |   ✔ **new**  |         —          |
| XML    |     ✔      |      ✔      |      —      |      —       |         —          |

## `writeOdsStream`

The one the issue said stood out: ODS had a streaming *reader* and no streaming writer at all, so the format with the second-best support in the library could not produce a large file without holding the whole thing in memory.

`zipStream` was already format-agnostic, so the missing piece was a row serializer that can be driven incrementally — the shape `RowSerializer` has for XLSX.

**It carries values, not formatting, and that follows from the format rather than from effort.** ODF puts `<office:automatic-styles>` *before* the body, so a style first seen on row 900,000 has nowhere to be declared. It is the same shape as the shared-string table, which the XLSX streaming writer answers with inline strings — and ODF has no inline equivalent. Column widths and a header row **are** carried, because `columns` is known before the first row. `writeOds` remains the path for a document that needs styling.

The value encoding matches `cellToOds` exactly, including its two refusals: a non-finite number and an unparseable `Date` both produce an empty cell rather than `office:value="NaN"`, which LibreOffice reads as garbage and which used to make a corrupt file (#364). There is a test.

Verified end to end: the file round-trips through `readOds`, through `streamOdsRows`, and has `mimetype` first and stored — the one rule an ODF consumer checks before anything else.

## `writeNdjsonStream`

NDJSON had `NdjsonStreamWriter.toStream()`, a class the caller has to drive, but not `writeNdjsonStream(rows, options)` — the shape both XLSX and CSV expose and the one that reads naturally at a `Response` boundary.

Positional rows still need `columns`, for the same reason `addRow` does: NDJSON rows are objects, so values with no key names describe nothing. It says that rather than guessing.

## Tests

`test/streaming-holes.test.ts` — 17 cases, mutation-checked, 16 fail against `main`.

Both writers have a laziness test that *proves* the property rather than asserting it: count how many rows the source produced before the first chunk came out. My first attempt at the NDJSON one proved nothing — 5000 tiny rows fit inside a single 64 KB chunk, so the generator was exhausted either way. It now uses rows big enough to cross the boundary early.

`pnpm lint`, `pnpm typecheck`, 10090 tests green; coverage and size budgets pass. The export snapshots moved by two names each, additions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
