### PR TITLE
refactor(chart): one walk instead of 43 — closes #466

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import { readXml, writeXml } from "hucre/xml" // Tabular XML
 |                         | hucre                | SheetJS CE    | ExcelJS   | xlsx-js-style |
 | ----------------------- | -------------------- | ------------- | --------- | ------------- |
 | **Dependencies**        | 0                    | 0\*           | 9         | 0\*           |
-| **Bundle (gzip)**       | 4–127 KB<sup>†</sup> | ~300 KB       | ~500 KB   | ~300 KB       |
+| **Bundle (gzip)**       | 4–129 KB<sup>†</sup> | ~300 KB       | ~500 KB   | ~300 KB       |
 | **ESM native**          | Yes                  | Partial       | No (CJS)  | Partial       |
 | **TypeScript**          | Native               | Bolted-on     | Bolted-on | Bolted-on     |
 | **Edge runtime**        | Yes                  | No            | No        | No            |
@@ -87,7 +87,7 @@ import { readXml, writeXml } from "hucre/xml" // Tabular XML
 single number. Minified + gzipped, bundled with rolldown against `dist/`:
 `{ parseCsv, writeCsv }` from `hucre/csv` = **3.7 KB**, `{ readXlsx }` from
 `hucre/xlsx` = **34 KB**, `{ readXlsx, writeXlsx }` = **68 KB**, the entire
-library (`export * from "hucre"`) = **127 KB**.
+library (`export * from "hucre"`) = **129 KB**.
 
 These four are measured by `pnpm size` and pinned in
 `scripts/size-budget.json`, so CI fails when one grows past its budget.

--- a/scripts/size-budget.json
+++ b/scripts/size-budget.json
@@ -1,23 +1,23 @@
 {
   "csv (hucre/csv)": {
-    "min": 10197,
-    "gzip": 4016
+    "min": 10315,
+    "gzip": 4038
   },
   "readXlsx (hucre/xlsx)": {
-    "min": 137436,
-    "gzip": 36958
+    "min": 133188,
+    "gzip": 36967
   },
   "read+write xlsx (hucre/xlsx)": {
-    "min": 269990,
-    "gzip": 72852
+    "min": 266018,
+    "gzip": 72846
   },
   "everything (hucre)": {
-    "min": 487341,
-    "gzip": 136931
+    "min": 489277,
+    "gzip": 138764
   },
   "writeXlsx (hucre)": {
-    "min": 137445,
-    "gzip": 39162
+    "min": 137695,
+    "gzip": 39254
   },
   "readOds (hucre/ods)": {
     "min": 26941,

--- a/src/xlsx/chart/axis.ts
+++ b/src/xlsx/chart/axis.ts
@@ -83,6 +83,7 @@ import {
 } from "./title"
 import type { SheetChart } from "../../_types"
 import { normalizeLegendLayout } from "./legend"
+import { resolveTitleDefRPr, resolveTxPrDefRPr } from "./text"
 
 const TITLE_FONT_SZ_PER_POINT = FONT_SZ_PER_POINT
 const TITLE_FONT_SIZE_MIN_PT = FONT_SIZE_MIN_PT
@@ -876,13 +877,7 @@ export function parseAxisLabelRotation(axis: XmlElement): number | undefined {
  * {@link SheetChart.axes}.x.labelFontSize.
  */
 export function parseAxisLabelFontSize(axis: XmlElement): number | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.sz
   if (typeof raw !== "string") return undefined
@@ -927,13 +922,7 @@ export function parseAxisLabelFontSize(axis: XmlElement): number | undefined {
  * {@link SheetChart.axes}.x.labelBold.
  */
 export function parseAxisLabelBold(axis: XmlElement): boolean | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const parsed = parseBoolAttr(defRPr.attrs.b)
   // The OOXML default `false` collapses to `undefined` so absence and
@@ -963,13 +952,7 @@ export function parseAxisLabelBold(axis: XmlElement): boolean | undefined {
  * {@link SheetChart.axes}.x.labelItalic.
  */
 export function parseAxisLabelItalic(axis: XmlElement): boolean | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const parsed = parseBoolAttr(defRPr.attrs.i)
   // The OOXML default `false` collapses to `undefined` so absence and
@@ -1009,13 +992,7 @@ export function parseAxisLabelItalic(axis: XmlElement): boolean | undefined {
  * fill cannot leak in.
  */
 export function parseAxisLabelColor(axis: XmlElement): ChartColor | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const solidFill = findChild(defRPr, "solidFill")
   if (!solidFill) return undefined
@@ -1061,13 +1038,7 @@ export function parseAxisLabelColor(axis: XmlElement): ChartColor | undefined {
  * {@link SheetChart.axes}.x.labelUnderline.
  */
 export function parseAxisLabelUnderline(axis: XmlElement): boolean | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.u
   // Only the UI-default `"sng"` surfaces as `true`. The OOXML
@@ -1115,13 +1086,7 @@ export function parseAxisLabelUnderline(axis: XmlElement): boolean | undefined {
  * {@link SheetChart.axes}.x.labelStrike.
  */
 export function parseAxisLabelStrike(axis: XmlElement): boolean | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.strike
   // Only the UI-default `"sngStrike"` surfaces as `true`. The OOXML
@@ -1164,13 +1129,7 @@ export function parseAxisLabelStrike(axis: XmlElement): boolean | undefined {
  * `<c:title><c:tx><c:rich>` body cannot leak in.
  */
 export function parseAxisLabelFontFamily(axis: XmlElement): string | undefined {
-  const txPr = findChild(axis, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(axis)
   if (!defRPr) return undefined
   const latin = findChild(defRPr, "latin")
   if (!latin) return undefined
@@ -1536,21 +1495,7 @@ export function parseAxisTitleRotation(axis: XmlElement): number | undefined {
  * the writer-side {@link SheetChart.axes}.x.axisTitleFontSize.
  */
 export function parseAxisTitleFontSize(axis: XmlElement): number | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph font size. The reader walks the canonical chain
-  // and bails on the first missing link so a malformed `<c:rich>`
-  // surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.sz
   if (typeof raw !== "string") return undefined
@@ -1596,21 +1541,7 @@ export function parseAxisTitleFontSize(axis: XmlElement): number | undefined {
  * writer-side {@link SheetChart.axes}.x.axisTitleBold.
  */
 export function parseAxisTitleBold(axis: XmlElement): boolean | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph bold flag. The reader walks the canonical chain
-  // and bails on the first missing link so a malformed `<c:rich>`
-  // surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const parsed = parseBoolAttr(defRPr.attrs.b)
   // The OOXML default `false` collapses to `undefined` so absence and
@@ -1648,21 +1579,7 @@ export function parseAxisTitleBold(axis: XmlElement): boolean | undefined {
  * writer-side {@link SheetChart.axes}.x.axisTitleItalic.
  */
 export function parseAxisTitleItalic(axis: XmlElement): boolean | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph italic flag. The reader walks the canonical chain
-  // and bails on the first missing link so a malformed `<c:rich>`
-  // surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const parsed = parseBoolAttr(defRPr.attrs.i)
   // The OOXML default `false` collapses to `undefined` so absence and
@@ -1709,22 +1626,7 @@ export function parseAxisTitleItalic(axis: XmlElement): boolean | undefined {
  * writer-side {@link SheetChart.axes}.x.axisTitleColor.
  */
 export function parseAxisTitleColor(axis: XmlElement): ChartColor | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr>` is the OOXML path
-  // Excel writes for the default-paragraph font color. The reader walks
-  // the canonical chain and bails on the first missing link so a
-  // malformed `<c:rich>` surfaces as absence rather than a fabricated
-  // value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const solidFill = findChild(defRPr, "solidFill")
   if (!solidFill) return undefined
@@ -1772,21 +1674,7 @@ export function parseAxisTitleColor(axis: XmlElement): ChartColor | undefined {
  * writer-side {@link SheetChart.axes}.x.axisTitleStrike.
  */
 export function parseAxisTitleStrike(axis: XmlElement): boolean | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph strikethrough flag. The reader walks the
-  // canonical chain and bails on the first missing link so a malformed
-  // `<c:rich>` surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.strike
   // Only the UI-default `"sngStrike"` surfaces as `true`. The OOXML
@@ -1839,21 +1727,7 @@ export function parseAxisTitleStrike(axis: XmlElement): boolean | undefined {
  * the writer-side {@link SheetChart.axes}.x.axisTitleUnderline.
  */
 export function parseAxisTitleUnderline(axis: XmlElement): boolean | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph underline flag. The reader walks the canonical
-  // chain and bails on the first missing link so a malformed
-  // `<c:rich>` surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.u
   // Only the UI-default `"sng"` surfaces as `true`. The OOXML
@@ -1901,22 +1775,7 @@ export function parseAxisTitleUnderline(axis: XmlElement): boolean | undefined {
  * writer-side {@link SheetChart.axes}.x.axisTitleFontFamily.
  */
 export function parseAxisTitleFontFamily(axis: XmlElement): string | undefined {
-  const title = findChild(axis, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr><a:latin>` is the OOXML path Excel writes
-  // for the default-paragraph typeface. The reader walks the
-  // canonical chain and bails on the first missing link so a
-  // malformed `<c:rich>` surfaces as absence rather than a fabricated
-  // value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(axis)
   if (!defRPr) return undefined
   const latin = findChild(defRPr, "latin")
   if (!latin) return undefined
@@ -2107,7 +1966,7 @@ export function parseAxisTitleFillColor(axis: XmlElement): ChartColor | undefine
  * {@link parseTitleBorderColor} so a parsed value slots straight
  * into the writer-side {@link SheetChart.axes.x.axisTitleBorderColor}.
  */
-export function parseAxisTitleBorderColor(axis: XmlElement): ChartColor | undefined {
+function parseAxisTitleBorderColor(axis: XmlElement): ChartColor | undefined {
   const title = findChild(axis, "title")
   if (!title) return undefined
   return parseSpPrBorderColor(title)
@@ -2129,7 +1988,7 @@ export function parseAxisTitleBorderColor(axis: XmlElement): ChartColor | undefi
  * and {@link parseAxisTitleBorderDash}: all three readers walk
  * disjoint slots of the shared `<a:ln>` element.
  */
-export function parseAxisTitleBorderWidth(axis: XmlElement): number | undefined {
+function parseAxisTitleBorderWidth(axis: XmlElement): number | undefined {
   const title = findChild(axis, "title")
   if (!title) return undefined
   return parseBorderWidthFromSpPr(title)
@@ -2143,7 +2002,7 @@ export function parseAxisTitleBorderWidth(axis: XmlElement): number | undefined 
  * is missing at any link, when the attribute is absent / unrecognized,
  * or when it matches the OOXML default `"solid"`.
  */
-export function parseAxisTitleBorderDash(axis: XmlElement): ChartBorderDash | undefined {
+function parseAxisTitleBorderDash(axis: XmlElement): ChartBorderDash | undefined {
   const title = findChild(axis, "title")
   if (!title) return undefined
   return parseBorderDashFromSpPr(title)
@@ -2154,7 +2013,7 @@ export function parseAxisTitleBorderDash(axis: XmlElement): ChartBorderDash | un
  * scoped to an axis element. Returns the {@link ChartLineCap} or
  * `undefined` for absence / OOXML default `"flat"`.
  */
-export function parseAxisTitleBorderCap(axis: XmlElement): ChartLineCap | undefined {
+function parseAxisTitleBorderCap(axis: XmlElement): ChartLineCap | undefined {
   const title = findChild(axis, "title")
   if (!title) return undefined
   return parseBorderCapFromSpPr(title)
@@ -2165,7 +2024,7 @@ export function parseAxisTitleBorderCap(axis: XmlElement): ChartLineCap | undefi
  * scoped to an axis element. Returns the {@link ChartLineCompound} or
  * `undefined` for absence / OOXML default `"sng"`.
  */
-export function parseAxisTitleBorderCompound(axis: XmlElement): ChartLineCompound | undefined {
+function parseAxisTitleBorderCompound(axis: XmlElement): ChartLineCompound | undefined {
   const title = findChild(axis, "title")
   if (!title) return undefined
   return parseBorderCompoundFromSpPr(title)
@@ -2882,9 +2741,7 @@ export function normalizeAxisGridlines(
  * before the optional `<c:title>`. Excel's strict-validator rejects
  * any other position.
  */
-export function buildAxisGridlines(
-  gridlines: { major: boolean; minor: boolean } | undefined,
-): string[] {
+function buildAxisGridlines(gridlines: { major: boolean; minor: boolean } | undefined): string[] {
   if (!gridlines) return []
   const out: string[] = []
   if (gridlines.major) out.push(xmlElement("c:majorGridlines", undefined, []))
@@ -3226,7 +3083,7 @@ export function normalizeAxisLabelFontFamily(value: string | undefined): string 
  * with no custom color matches Excel's reference serialization (the
  * tick labels inherit the theme text color in that case).
  */
-export function buildAxisTxPr(
+function buildAxisTxPr(
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
   bold: boolean | undefined,
@@ -3356,7 +3213,7 @@ export function normalizeAxisCrosses(
  * (which always pins `<c:crosses val="autoZero"/>` on every axis) is
  * preserved on freshly-drawn charts.
  */
-export function buildAxisCrosses(resolved: ResolvedAxisCrosses): string {
+function buildAxisCrosses(resolved: ResolvedAxisCrosses): string {
   switch (resolved.kind) {
     case "numeric":
       return xmlSelfClose("c:crossesAt", { val: resolved.value })
@@ -3375,7 +3232,7 @@ export function buildAxisCrosses(resolved: ResolvedAxisCrosses): string {
  *
  * Returns the children to splice in after `<c:orientation>`.
  */
-export function buildAxisScalingExtras(scale: ChartAxisScale | undefined): {
+function buildAxisScalingExtras(scale: ChartAxisScale | undefined): {
   before: string[]
   after: string[]
 } {
@@ -3398,10 +3255,7 @@ export function buildAxisScalingExtras(scale: ChartAxisScale | undefined): {
  * `"minMax"` (the OOXML default) for a forward axis, `"maxMin"` when
  * the caller pinned `reverse: true` to flip the plotting order.
  */
-export function buildAxisScaling(
-  scale: ChartAxisScale | undefined,
-  reverse: boolean = false,
-): string {
+function buildAxisScaling(scale: ChartAxisScale | undefined, reverse: boolean = false): string {
   const { before, after } = buildAxisScalingExtras(scale)
   const children: string[] = [
     ...before,
@@ -3416,7 +3270,7 @@ export function buildAxisScaling(
  * sit later in the axis-element child sequence (after `<c:numFmt>`,
  * before `<c:crossAx>` per CT_CatAx / CT_ValAx).
  */
-export function buildAxisTickUnits(scale: ChartAxisScale | undefined): string[] {
+function buildAxisTickUnits(scale: ChartAxisScale | undefined): string[] {
   if (!scale) return []
   const out: string[] = []
   if (scale.majorUnit !== undefined) {
@@ -3567,7 +3421,7 @@ export function normalizeAxisCrossBetween(
  * Returns an empty array when the axis declares no number format — the
  * writer then leaves Excel's default linked behaviour untouched.
  */
-export function buildAxisNumFmt(numFmt: ChartAxisNumberFormat | undefined): string[] {
+function buildAxisNumFmt(numFmt: ChartAxisNumberFormat | undefined): string[] {
   if (!numFmt) return []
   const sourceLinked = numFmt.sourceLinked === true ? 1 : 0
   return [xmlSelfClose("c:numFmt", { formatCode: numFmt.formatCode, sourceLinked })]
@@ -3609,7 +3463,7 @@ export function normalizeTickLblPos(
  * `tickLblPos="nextTo"`) match Excel's reference serialization, so
  * absence and the default round-trip identically through the reader.
  */
-export function buildAxisTickRendering(
+function buildAxisTickRendering(
   majorTickMark: ChartAxisTickMark | undefined,
   minorTickMark: ChartAxisTickMark | undefined,
   tickLblPos: ChartAxisTickLabelPosition | undefined,
@@ -3636,7 +3490,7 @@ export function buildAxisTickRendering(
  * {@link normalizeAxisSkip} having already collapsed `1` and out-of-
  * range inputs to `undefined`).
  */
-export function buildAxisSkips(
+function buildAxisSkips(
   tickLblSkip: number | undefined,
   tickMarkSkip: number | undefined,
 ): string[] {
@@ -4001,7 +3855,7 @@ export function buildScatterAxes(opts: AxisRenderOptions): string[] {
  * matches Excel's reference serialization byte-for-byte (the title
  * inherits the theme text color in that case).
  */
-export function buildAxisTitle(
+function buildAxisTitle(
   label: string,
   rotationDeg: number | undefined,
   fontSizePt: number | undefined,
@@ -5456,7 +5310,7 @@ export function applyTickLblPosOverride(
  * collapses to `undefined` so absence and the default round-trip
  * identically — symmetric with the parser-side default-collapse.
  */
-export function applyLabelRotationOverride(
+function applyLabelRotationOverride(
   source: number | undefined,
   override: number | null | undefined,
 ): number | undefined {
@@ -5475,7 +5329,7 @@ export function applyLabelRotationOverride(
  * collapses to absence — symmetric with the writer-side
  * {@link normalizeAxisLabelRotation} contract.
  */
-export function clampLabelRotationDeg(value: number): number | undefined {
+function clampLabelRotationDeg(value: number): number | undefined {
   let degrees = Math.round(value)
   if (degrees < -90) degrees = -90
   else if (degrees > 90) degrees = 90
@@ -5682,7 +5536,7 @@ export function applyLabelFontFamilyOverride(
  * collapses to `undefined` so the cloned chart drops the field
  * rather than carry a value the writer would silently elide.
  */
-export function normalizeLabelFontFamily(value: string | undefined): string | undefined {
+function normalizeLabelFontFamily(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
   if (trimmed.length === 0) return undefined
@@ -5701,7 +5555,7 @@ export function normalizeLabelFontFamily(value: string | undefined): string | un
  * cloned shape never carries a rotation that the writer would silently
  * elide.
  */
-export function applyAxisTitleRotationOverride(
+function applyAxisTitleRotationOverride(
   source: number | undefined,
   override: number | null | undefined,
 ): number | undefined {
@@ -5729,7 +5583,7 @@ export function applyAxisTitleRotationOverride(
  * scopes the size emission to `<c:title>`, which is omitted when the
  * axis renders no title).
  */
-export function applyAxisTitleFontSizeOverride(
+function applyAxisTitleFontSizeOverride(
   source: number | undefined,
   override: number | null | undefined,
 ): number | undefined {
@@ -5810,7 +5664,7 @@ export function applyAxisTitleItalicOverride(
  * scopes the fill emission to `<c:title>`, which is omitted when
  * the axis renders no title).
  */
-export function applyAxisTitleColorOverride(
+function applyAxisTitleColorOverride(
   source: ChartColor | undefined,
   override: ChartColor | null | undefined,
 ): ChartColor | undefined {
@@ -5843,7 +5697,7 @@ export function applyAxisTitleColorOverride(
  * scopes the fill emission to `<c:title>`, which is omitted when
  * the axis renders no title).
  */
-export function applyAxisTitleFillColorOverride(
+function applyAxisTitleFillColorOverride(
   source: ChartColor | undefined,
   override: ChartColor | null | undefined,
 ): ChartColor | undefined {
@@ -5883,7 +5737,7 @@ export function applyAxisTitleFillColorOverride(
  * scopes the stroke emission to `<c:title>`, which is omitted when
  * the axis renders no title).
  */
-export function applyAxisTitleBorderColorOverride(
+function applyAxisTitleBorderColorOverride(
   source: ChartColor | undefined,
   override: ChartColor | null | undefined,
 ): ChartColor | undefined {
@@ -5961,7 +5815,7 @@ export function applyAxisTitleUnderlineOverride(
  * writer scopes the element emission to `<c:title>`, which is omitted
  * when the axis renders no title).
  */
-export function applyAxisTitleFontFamilyOverride(
+function applyAxisTitleFontFamilyOverride(
   source: string | undefined,
   override: string | null | undefined,
 ): string | undefined {
@@ -5979,7 +5833,7 @@ export function applyAxisTitleFontFamilyOverride(
  * caller) collapses to `undefined` so the cloned chart drops the
  * field rather than carry a value the writer would silently elide.
  */
-export function normalizeAxisTitleFontFamilyClone(value: string | undefined): string | undefined {
+function normalizeAxisTitleFontFamilyClone(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
   if (trimmed.length === 0) return undefined
@@ -6053,7 +5907,7 @@ export function applyAxisTitleOverlayOverride(
  * `<c:layout>` emission to `<c:title>`, which is omitted when the axis
  * renders no title).
  */
-export function resolveAxisTitleLayout(
+function resolveAxisTitleLayout(
   sourceValue: ChartManualLayout | undefined,
   override: ChartManualLayout | null | undefined,
 ): ChartManualLayout | undefined {
@@ -6075,7 +5929,7 @@ export function resolveAxisTitleLayout(
  * orientation, so the dropped state is indistinguishable from a literal
  * `false`.
  */
-export function applyReverseOverride(
+function applyReverseOverride(
   source: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {

--- a/src/xlsx/chart/chartSpace.ts
+++ b/src/xlsx/chart/chartSpace.ts
@@ -243,9 +243,7 @@ export function resolveCloneProtection(
  * the field rather than carry a value the writer would silently elide
  * back to absence.
  */
-export function normalizeClonePlotAreaFillColor(
-  value: ChartColor | undefined,
-): ChartColor | undefined {
+function normalizeClonePlotAreaFillColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeChartColor(value)
 }
 
@@ -261,9 +259,7 @@ export function normalizeClonePlotAreaFillColor(
  * would silently elide back to absence. Mirrors
  * {@link normalizeClonePlotAreaFillColor} — same hex grammar.
  */
-export function normalizeClonePlotAreaBorderColor(
-  value: ChartColor | undefined,
-): ChartColor | undefined {
+function normalizeClonePlotAreaBorderColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeChartColor(value)
 }
 
@@ -279,9 +275,7 @@ export function normalizeClonePlotAreaBorderColor(
  * so the cloned chart drops the field rather than carry a value the
  * writer would silently elide back to absence.
  */
-export function normalizeCloneChartSpaceFillColor(
-  value: ChartColor | undefined,
-): ChartColor | undefined {
+function normalizeCloneChartSpaceFillColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeChartColor(value)
 }
 
@@ -328,7 +322,7 @@ export function resolveCloneChartSpaceFillColor(
  * so the cloned chart drops the field rather than carry a value the
  * writer would silently elide back to absence.
  */
-export function normalizeCloneChartSpaceBorderColor(
+function normalizeCloneChartSpaceBorderColor(
   value: ChartColor | undefined,
 ): ChartColor | undefined {
   return normalizeChartColor(value)

--- a/src/xlsx/chart/dataLabels.ts
+++ b/src/xlsx/chart/dataLabels.ts
@@ -42,7 +42,7 @@ import {
   parseSpPrFill,
 } from "./shape"
 import { elementText, findChild, readBoolAttr } from "./util"
-import { FONT_SIZE_MAX_PT, FONT_SIZE_MIN_PT, FONT_SZ_PER_POINT } from "./text"
+import { FONT_SIZE_MAX_PT, FONT_SIZE_MIN_PT, FONT_SZ_PER_POINT, resolveTxPrDefRPr } from "./text"
 import { normalizeTitleColor, normalizeTitleFontSize } from "./title"
 import type { SheetChart } from "../../_types"
 
@@ -314,13 +314,7 @@ export function parseDataLabels(el: XmlElement): ChartDataLabelsInfo | undefined
  * writer's emit path.
  */
 export function parseDataLabelsFontSize(dLbls: XmlElement): number | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.sz
   if (typeof raw !== "string") return undefined
@@ -359,13 +353,7 @@ export function parseDataLabelsFontSize(dLbls: XmlElement): number | undefined {
  * writer's emit path.
  */
 export function parseDataLabelsFontColor(dLbls: XmlElement): ChartColor | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const solidFill = findChild(defRPr, "solidFill")
   if (!solidFill) return undefined
@@ -391,13 +379,7 @@ export function parseDataLabelsFontColor(dLbls: XmlElement): ChartColor | undefi
  * emit path.
  */
 export function parseDataLabelsBold(dLbls: XmlElement): boolean | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.b
   if (raw === "1" || raw === "true") return true
@@ -419,13 +401,7 @@ export function parseDataLabelsBold(dLbls: XmlElement): boolean | undefined {
  * emit path.
  */
 export function parseDataLabelsItalic(dLbls: XmlElement): boolean | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.i
   if (raw === "1" || raw === "true") return true
@@ -451,13 +427,7 @@ export function parseDataLabelsItalic(dLbls: XmlElement): boolean | undefined {
  * back into the writer's emit path.
  */
 export function parseDataLabelsUnderline(dLbls: XmlElement): boolean | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.u
   if (raw === "sng") return true
@@ -483,13 +453,7 @@ export function parseDataLabelsUnderline(dLbls: XmlElement): boolean | undefined
  * straight back into the writer's emit path.
  */
 export function parseDataLabelsStrikethrough(dLbls: XmlElement): boolean | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.strike
   if (raw === "sngStrike") return true
@@ -518,13 +482,7 @@ export function parseDataLabelsStrikethrough(dLbls: XmlElement): boolean | undef
  * value slots straight back into the writer's emit path.
  */
 export function parseDataLabelsFontFamily(dLbls: XmlElement): string | undefined {
-  const txPr = findChild(dLbls, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dLbls)
   if (!defRPr) return undefined
   const latin = findChild(defRPr, "latin")
   if (!latin) return undefined
@@ -561,7 +519,7 @@ export function parseDataLabelsFontFamily(dLbls: XmlElement): string | undefined
  * {@link parseLegendFillColor} so a parsed value slots straight into
  * the writer-side {@link ChartDataLabels.fillColor}.
  */
-export function parseDataLabelsFillColor(dLbls: XmlElement): ChartColor | undefined {
+function parseDataLabelsFillColor(dLbls: XmlElement): ChartColor | undefined {
   return parseSpPrFill(dLbls)
 }
 
@@ -599,7 +557,7 @@ export function parseDataLabelsFillColor(dLbls: XmlElement): ChartColor | undefi
  * (`<a:ln><a:solidFill>`) child rather than the fill (`<a:solidFill>`)
  * child.
  */
-export function parseDataLabelsBorderColor(dLbls: XmlElement): ChartColor | undefined {
+function parseDataLabelsBorderColor(dLbls: XmlElement): ChartColor | undefined {
   return parseSpPrBorderColor(dLbls)
 }
 
@@ -617,7 +575,7 @@ export function parseDataLabelsBorderColor(dLbls: XmlElement): ChartColor | unde
  * surfaces `true`. Mirrors how the axis-side numFmt parser shapes its
  * output.
  */
-export function parseDataLabelsNumberFormat(el: XmlElement): ChartAxisNumberFormat | undefined {
+function parseDataLabelsNumberFormat(el: XmlElement): ChartAxisNumberFormat | undefined {
   const numFmt = findChild(el, "numFmt")
   if (!numFmt) return undefined
   const formatCode = numFmt.attrs.formatCode
@@ -818,7 +776,7 @@ export function buildDataLabelsBody(dl: ChartDataLabels, chartType: WriteChartKi
  * survives, every other shape (`undefined` / `false` / non-boolean)
  * collapses so the writer's `val` attribute defaults to `0`.
  */
-export function resolveDataLabelsNumberFormat(
+function resolveDataLabelsNumberFormat(
   value: ChartAxisNumberFormat | undefined,
 ): ChartAxisNumberFormat | undefined {
   if (!value) return undefined
@@ -841,7 +799,7 @@ export function resolveDataLabelsNumberFormat(
  * rounding (Excel's UI step is 0.5pt), and the same OOXML conversion
  * (100ths of a point at emit time).
  */
-export function resolveDataLabelsFontSize(value: number | undefined): number | undefined {
+function resolveDataLabelsFontSize(value: number | undefined): number | undefined {
   return normalizeTitleFontSize(value)
 }
 
@@ -856,7 +814,7 @@ export function resolveDataLabelsFontSize(value: number | undefined): number | u
  * accept-with-or-without-`#` grammar matches the chart-title /
  * axis-title / axis tick-label / legend color resolvers exactly.
  */
-export function resolveDataLabelsFontColor(value: ChartColor | undefined): ChartColor | undefined {
+function resolveDataLabelsFontColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -870,7 +828,7 @@ export function resolveDataLabelsFontColor(value: ChartColor | undefined): Chart
  * only literal `true` / `false` pass through; non-boolean tokens
  * (typed escapes from an untyped caller) collapse to `undefined`.
  */
-export function resolveDataLabelsBold(value: boolean | undefined): boolean | undefined {
+function resolveDataLabelsBold(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -886,7 +844,7 @@ export function resolveDataLabelsBold(value: boolean | undefined): boolean | und
  * only literal `true` / `false` pass through; non-boolean tokens
  * (typed escapes from an untyped caller) collapse to `undefined`.
  */
-export function resolveDataLabelsItalic(value: boolean | undefined): boolean | undefined {
+function resolveDataLabelsItalic(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -905,7 +863,7 @@ export function resolveDataLabelsItalic(value: boolean | undefined): boolean | u
  * UI variant — single underline) and `false` into `u="none"` at emit
  * time.
  */
-export function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undefined {
+function resolveDataLabelsUnderline(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -943,7 +901,7 @@ export function resolveDataLabelsStrikethrough(value: boolean | undefined): bool
  * exactly so a single configuration call threads cleanly through
  * every typography slot Excel exposes.
  */
-export function resolveDataLabelsFontFamily(value: string | undefined): string | undefined {
+function resolveDataLabelsFontFamily(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
   if (trimmed.length === 0) return undefined
@@ -965,7 +923,7 @@ export function resolveDataLabelsFontFamily(value: string | undefined): string |
  * resolvers feed disjoint slots so a caller can pin both without
  * conflict.
  */
-export function resolveDataLabelsFillColor(value: ChartColor | undefined): ChartColor | undefined {
+function resolveDataLabelsFillColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -987,9 +945,7 @@ export function resolveDataLabelsFillColor(value: ChartColor | undefined): Chart
  * grammar, same `<a:ln>` slot on the `CT_ShapeProperties` schema —
  * but lands on `<c:dLbls>`'s own `<c:spPr>` block.
  */
-export function resolveDataLabelsBorderColor(
-  value: ChartColor | undefined,
-): ChartColor | undefined {
+function resolveDataLabelsBorderColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -1024,7 +980,7 @@ export function resolveDataLabelsBorderColor(
  * the background and outline of each label box, while the legend /
  * data-table variants paint a different chart-frame element.
  */
-export function buildDataLabelsSpPr(
+function buildDataLabelsSpPr(
   fillRgbHex: ChartColor | undefined,
   borderRgbHex: ChartColor | undefined,
   borderWidthPt: number | undefined,
@@ -1115,7 +1071,7 @@ export function buildDataLabelsSpPr(
  * canonical default-paragraph slot every other typography reader
  * expects.
  */
-export function buildDataLabelsTxPr(
+function buildDataLabelsTxPr(
   fontSizePt: number | undefined,
   rgbHex: ChartColor | undefined,
   bold: boolean | undefined,

--- a/src/xlsx/chart/dataTable.ts
+++ b/src/xlsx/chart/dataTable.ts
@@ -37,7 +37,7 @@ import {
   parseSpPrFill,
 } from "./shape"
 import { findChild } from "./util"
-import { FONT_SIZE_MAX_PT, FONT_SIZE_MIN_PT, FONT_SZ_PER_POINT } from "./text"
+import { FONT_SIZE_MAX_PT, FONT_SIZE_MIN_PT, FONT_SZ_PER_POINT, resolveTxPrDefRPr } from "./text"
 import { normalizeTitleColor, normalizeTitleFontSize } from "./title"
 
 const TITLE_FONT_SZ_PER_POINT = FONT_SZ_PER_POINT
@@ -128,13 +128,7 @@ export function parseDataTable(plotArea: XmlElement): ChartDataTable | undefined
  * writer's emit path.
  */
 export function parseDataTableBold(dTable: XmlElement): boolean | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.b
   if (typeof raw !== "string") return undefined
@@ -168,13 +162,7 @@ export function parseDataTableBold(dTable: XmlElement): boolean | undefined {
  * back into the writer's emit path.
  */
 export function parseDataTableItalic(dTable: XmlElement): boolean | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.i
   if (typeof raw !== "string") return undefined
@@ -216,13 +204,7 @@ export function parseDataTableItalic(dTable: XmlElement): boolean | undefined {
  * writer's emit path.
  */
 export function parseDataTableUnderline(dTable: XmlElement): boolean | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.u
   if (raw === "sng") return true
@@ -249,13 +231,7 @@ export function parseDataTableUnderline(dTable: XmlElement): boolean | undefined
  * slots straight back into the writer's emit path.
  */
 export function parseDataTableStrikethrough(dTable: XmlElement): boolean | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.strike
   if (raw === "sngStrike") return true
@@ -284,13 +260,7 @@ export function parseDataTableStrikethrough(dTable: XmlElement): boolean | undef
  * so a parsed value slots straight back into the writer's emit path.
  */
 export function parseDataTableFontFamily(dTable: XmlElement): string | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const latin = findChild(defRPr, "latin")
   if (!latin) return undefined
@@ -401,13 +371,7 @@ export function parseDataTableBorderColor(dTable: XmlElement): ChartColor | unde
  * writer's emit path.
  */
 export function parseDataTableFontColor(dTable: XmlElement): ChartColor | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const solidFill = findChild(defRPr, "solidFill")
   if (!solidFill) return undefined
@@ -434,13 +398,7 @@ export function parseDataTableFontColor(dTable: XmlElement): ChartColor | undefi
  * the writer's emit path.
  */
 export function parseDataTableFontSize(dTable: XmlElement): number | undefined {
-  const txPr = findChild(dTable, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(dTable)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.sz
   if (typeof raw !== "string") return undefined
@@ -591,7 +549,7 @@ export function resolveDataTable(chart: SheetChart):
  * (Excel's UI step is 0.5pt), and the same OOXML conversion (100ths of
  * a point at emit time).
  */
-export function resolveDataTableFontSize(value: number | undefined): number | undefined {
+function resolveDataTableFontSize(value: number | undefined): number | undefined {
   return normalizeTitleFontSize(value)
 }
 
@@ -607,7 +565,7 @@ export function resolveDataTableFontSize(value: number | undefined): number | un
  * axis-title / axis tick-label / legend / data-label color resolvers
  * exactly.
  */
-export function resolveDataTableFontColor(value: ChartColor | undefined): ChartColor | undefined {
+function resolveDataTableFontColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -622,7 +580,7 @@ export function resolveDataTableFontColor(value: ChartColor | undefined): ChartC
  * tokens (typed escapes from an untyped caller) collapse to
  * `undefined`.
  */
-export function resolveDataTableBold(value: boolean | undefined): boolean | undefined {
+function resolveDataTableBold(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -639,7 +597,7 @@ export function resolveDataTableBold(value: boolean | undefined): boolean | unde
  * `false` pass through; non-boolean tokens (typed escapes from an
  * untyped caller) collapse to `undefined`.
  */
-export function resolveDataTableItalic(value: boolean | undefined): boolean | undefined {
+function resolveDataTableItalic(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -658,7 +616,7 @@ export function resolveDataTableItalic(value: boolean | undefined): boolean | un
  * `u="sng"` (Excel's UI variant — single underline) and `false` into
  * `u="none"` at emit time.
  */
-export function resolveDataTableUnderline(value: boolean | undefined): boolean | undefined {
+function resolveDataTableUnderline(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -679,7 +637,7 @@ export function resolveDataTableUnderline(value: boolean | undefined): boolean |
  * mirroring how `resolveTitleStrike` / `resolveLegendStrikethrough` /
  * `resolveDataLabelsStrikethrough` land on their `<a:defRPr>` slots.
  */
-export function resolveDataTableStrikethrough(value: boolean | undefined): boolean | undefined {
+function resolveDataTableStrikethrough(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   return undefined
 }
@@ -696,7 +654,7 @@ export function resolveDataTableStrikethrough(value: boolean | undefined): boole
  * resolvers exactly so a single configuration call threads cleanly
  * through every typography slot Excel exposes.
  */
-export function resolveDataTableFontFamily(value: string | undefined): string | undefined {
+function resolveDataTableFontFamily(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
   if (trimmed.length === 0) return undefined
@@ -718,7 +676,7 @@ export function resolveDataTableFontFamily(value: string | undefined): string | 
  * (ECMA-376 Part 1, §21.2.2.54), distinct from the `<c:txPr>` block
  * that carries {@link ChartDataTable.fontColor}.
  */
-export function resolveDataTableFillColor(value: ChartColor | undefined): ChartColor | undefined {
+function resolveDataTableFillColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -740,7 +698,7 @@ export function resolveDataTableFillColor(value: ChartColor | undefined): ChartC
  * slot on the `CT_ShapeProperties` schema — but lands on `<c:dTable>`'s
  * own `<c:spPr>` block.
  */
-export function resolveDataTableBorderColor(value: ChartColor | undefined): ChartColor | undefined {
+function resolveDataTableBorderColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -914,7 +872,7 @@ export function buildDataTableSpPr(
  * canonical default-paragraph slot every other typography reader
  * expects.
  */
-export function buildDataTableTxPr(
+function buildDataTableTxPr(
   fontSizePt: number | undefined,
   rgbHex: ChartColor | undefined,
   bold: boolean | undefined,

--- a/src/xlsx/chart/legend.ts
+++ b/src/xlsx/chart/legend.ts
@@ -47,7 +47,7 @@ import {
   parseManualLayout,
 } from "./layout"
 import { childElements, findChild, readBoolVal } from "./util"
-import { FONT_SIZE_MAX_PT, FONT_SIZE_MIN_PT, FONT_SZ_PER_POINT } from "./text"
+import { FONT_SIZE_MAX_PT, FONT_SIZE_MIN_PT, FONT_SZ_PER_POINT, resolveTxPrDefRPr } from "./text"
 import { normalizeTitleColor, normalizeTitleFontSize } from "./title"
 
 // ── Legend types (writer-side) ────────────────────────────────────
@@ -207,69 +207,59 @@ export function parseLegendEntries(chartEl: XmlElement): ChartLegendEntry[] | un
     const deleteFlag = deleteEl !== undefined ? readBoolVal(deleteEl.attrs.val) === true : false
     const entry: ChartLegendEntry = { idx, delete: deleteFlag }
 
-    // Walk `<c:legendEntry><c:txPr><a:p><a:pPr><a:defRPr ...>` for the
-    // per-entry typography overrides. Mirror the same path the
-    // chart-level legend font-size / bold / italic readers use.
-    const txPr = findChild(child, "txPr")
-    if (txPr) {
-      const p = findChild(txPr, "p")
-      if (p) {
-        const pPr = findChild(p, "pPr")
-        if (pPr) {
-          const defRPr = findChild(pPr, "defRPr")
-          if (defRPr) {
-            const sz = defRPr.attrs.sz
-            if (typeof sz === "string") {
-              const trimmed = sz.trim()
-              if (trimmed.length > 0) {
-                const parsed = Number.parseInt(trimmed, 10)
-                if (Number.isFinite(parsed)) {
-                  const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2)
-                  const points = halfSteps / 2
-                  if (points >= TITLE_FONT_SIZE_MIN_PT && points <= TITLE_FONT_SIZE_MAX_PT) {
-                    entry.fontSize = points
-                  }
-                }
-              }
-            }
-            const b = defRPr.attrs.b
-            if (typeof b === "string") {
-              const v = readBoolVal(b)
-              if (v === true) entry.bold = true
-            }
-            const i = defRPr.attrs.i
-            if (typeof i === "string") {
-              const v = readBoolVal(i)
-              if (v === true) entry.italic = true
-            }
-            const u = defRPr.attrs.u
-            if (typeof u === "string" && u === "sng") entry.underline = true
-            const strike = defRPr.attrs.strike
-            if (typeof strike === "string" && strike === "sngStrike") entry.strikethrough = true
-
-            // Font color
-            const solidFill = findChild(defRPr, "solidFill")
-            if (solidFill) {
-              const srgb = findChild(solidFill, "srgbClr")
-              if (srgb) {
-                const v = srgb.attrs.val
-                if (typeof v === "string") {
-                  const hex = v.replace(/^#/, "").toUpperCase()
-                  if (/^[0-9A-F]{6}$/.test(hex)) entry.color = hex
-                }
-              }
-            }
-
-            // Font family
-            const latin = findChild(defRPr, "latin")
-            if (latin) {
-              const tf = latin.attrs.typeface
-              if (typeof tf === "string") {
-                const trimmed = tf.trim()
-                if (trimmed.length > 0) entry.fontFamily = trimmed
-              }
+    // Per-entry typography overrides, on the same path the chart-level
+    // legend readers use — `<c:legendEntry>` is just another host.
+    const defRPr = resolveTxPrDefRPr(child)
+    if (defRPr) {
+      const sz = defRPr.attrs.sz
+      if (typeof sz === "string") {
+        const trimmed = sz.trim()
+        if (trimmed.length > 0) {
+          const parsed = Number.parseInt(trimmed, 10)
+          if (Number.isFinite(parsed)) {
+            const halfSteps = Math.round((parsed / TITLE_FONT_SZ_PER_POINT) * 2)
+            const points = halfSteps / 2
+            if (points >= TITLE_FONT_SIZE_MIN_PT && points <= TITLE_FONT_SIZE_MAX_PT) {
+              entry.fontSize = points
             }
           }
+        }
+      }
+      const b = defRPr.attrs.b
+      if (typeof b === "string") {
+        const v = readBoolVal(b)
+        if (v === true) entry.bold = true
+      }
+      const i = defRPr.attrs.i
+      if (typeof i === "string") {
+        const v = readBoolVal(i)
+        if (v === true) entry.italic = true
+      }
+      const u = defRPr.attrs.u
+      if (typeof u === "string" && u === "sng") entry.underline = true
+      const strike = defRPr.attrs.strike
+      if (typeof strike === "string" && strike === "sngStrike") entry.strikethrough = true
+
+      // Font color
+      const solidFill = findChild(defRPr, "solidFill")
+      if (solidFill) {
+        const srgb = findChild(solidFill, "srgbClr")
+        if (srgb) {
+          const v = srgb.attrs.val
+          if (typeof v === "string") {
+            const hex = v.replace(/^#/, "").toUpperCase()
+            if (/^[0-9A-F]{6}$/.test(hex)) entry.color = hex
+          }
+        }
+      }
+
+      // Font family
+      const latin = findChild(defRPr, "latin")
+      if (latin) {
+        const tf = latin.attrs.typeface
+        if (typeof tf === "string") {
+          const trimmed = tf.trim()
+          if (trimmed.length > 0) entry.fontFamily = trimmed
         }
       }
     }
@@ -306,13 +296,7 @@ export function parseLegendEntries(chartEl: XmlElement): ChartLegendEntry[] | un
 export function parseLegendFontSize(chartEl: XmlElement): number | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.sz
   if (typeof raw !== "string") return undefined
@@ -357,13 +341,7 @@ export function parseLegendFontSize(chartEl: XmlElement): number | undefined {
 export function parseLegendBold(chartEl: XmlElement): boolean | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.b
   // OOXML `xsd:boolean` accepts `"1"` / `"true"` (truthy) and `"0"` /
@@ -396,13 +374,7 @@ export function parseLegendBold(chartEl: XmlElement): boolean | undefined {
 export function parseLegendItalic(chartEl: XmlElement): boolean | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.i
   if (raw === "1" || raw === "true") return true
@@ -432,13 +404,7 @@ export function parseLegendItalic(chartEl: XmlElement): boolean | undefined {
 export function parseLegendUnderline(chartEl: XmlElement): boolean | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.u
   if (raw === "sng") return true
@@ -469,13 +435,7 @@ export function parseLegendUnderline(chartEl: XmlElement): boolean | undefined {
 export function parseLegendStrikethrough(chartEl: XmlElement): boolean | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.strike
   if (raw === "sngStrike") return true
@@ -508,13 +468,7 @@ export function parseLegendStrikethrough(chartEl: XmlElement): boolean | undefin
 export function parseLegendFontColor(chartEl: XmlElement): ChartColor | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const solidFill = findChild(defRPr, "solidFill")
   if (!solidFill) return undefined
@@ -549,13 +503,7 @@ export function parseLegendFontColor(chartEl: XmlElement): ChartColor | undefine
 export function parseLegendFontFamily(chartEl: XmlElement): string | undefined {
   const legend = findChild(chartEl, "legend")
   if (!legend) return undefined
-  const txPr = findChild(legend, "txPr")
-  if (!txPr) return undefined
-  const p = findChild(txPr, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTxPrDefRPr(legend)
   if (!defRPr) return undefined
   const latin = findChild(defRPr, "latin")
   if (!latin) return undefined
@@ -990,7 +938,7 @@ export function buildLegendSpPr(
  * default explicitly, which is functionally identical to absence but
  * lets a clone target override an upstream `1` from a templated chart.
  */
-export function buildLegendTxPr(
+function buildLegendTxPr(
   fontSizePt: number | undefined,
   bold: boolean | undefined,
   italic: boolean | undefined,
@@ -1212,7 +1160,7 @@ export function resolveLegendFontColor(chart: SheetChart): ChartColor | undefine
  * the theme typeface (Excel's reference behavior for a fresh legend
  * without a custom font picked).
  */
-export function normalizeLegendFontFamily(value: string | undefined): string | undefined {
+function normalizeLegendFontFamily(value: string | undefined): string | undefined {
   if (typeof value !== "string") return undefined
   const trimmed = value.trim()
   if (trimmed.length === 0) return undefined
@@ -1456,7 +1404,7 @@ export function resolveLegendBorderDash(chart: SheetChart): ChartBorderDash | un
  * the field rather than carry a value the writer would silently elide
  * back to absence.
  */
-export function normalizeLegendBold(value: boolean | undefined): boolean | undefined {
+function normalizeLegendBold(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -1468,7 +1416,7 @@ export function normalizeLegendBold(value: boolean | undefined): boolean | undef
  * literally, every other token (typed escape from an untyped caller)
  * collapses to `undefined`.
  */
-export function normalizeLegendItalic(value: boolean | undefined): boolean | undefined {
+function normalizeLegendItalic(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -1479,7 +1427,7 @@ export function normalizeLegendItalic(value: boolean | undefined): boolean | und
  * Mirrors the writer's `resolveLegendUnderline` — `true` / `false`
  * pass through literally, every other token collapses to `undefined`.
  */
-export function normalizeLegendUnderline(value: boolean | undefined): boolean | undefined {
+function normalizeLegendUnderline(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -1499,7 +1447,7 @@ export function normalizeLegendUnderline(value: boolean | undefined): boolean | 
  * writer's `<a:defRPr>` slot does the `false` collapse to attribute
  * omission.
  */
-export function normalizeLegendStrikethrough(value: boolean | undefined): boolean | undefined {
+function normalizeLegendStrikethrough(value: boolean | undefined): boolean | undefined {
   if (value === true) return true
   if (value === false) return false
   return undefined
@@ -1531,7 +1479,7 @@ export function normalizeLegendLayout(
  * collapse to `undefined` so the cloned chart drops the field rather
  * than carry a value the writer would silently elide back to absence.
  */
-export function normalizeLegendBorderWidth(value: number | undefined): number | undefined {
+function normalizeLegendBorderWidth(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined
   // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
   const snapped = Math.round(value * 4) / 4

--- a/src/xlsx/chart/plotArea.ts
+++ b/src/xlsx/chart/plotArea.ts
@@ -1187,7 +1187,7 @@ export function buildPlotAreaSpPr(chart: SheetChart): string | undefined {
  * the chart-level {@link normalizeTitleColor} so the two share the same
  * sRGB grammar.
  */
-export function normalizePlotAreaFillColor(value: ChartColor | undefined): ChartColor | undefined {
+function normalizePlotAreaFillColor(value: ChartColor | undefined): ChartColor | undefined {
   return normalizeTitleColor(value)
 }
 
@@ -1215,7 +1215,7 @@ export function normalizePlotAreaBorderColor(
   return normalizeTitleColor(value)
 }
 
-export function buildBarChart(chart: SheetChart, sheetName: string): string {
+function buildBarChart(chart: SheetChart, sheetName: string): string {
   const grouping = chart.barGrouping ?? "clustered"
   const barDir = chart.type === "bar" ? "bar" : "col"
   const isStacked = grouping === "percentStacked" || grouping === "stacked"
@@ -1298,7 +1298,7 @@ export function buildBarChart(chart: SheetChart, sheetName: string): string {
  * the bar width with no natural wrap-around (a `600` group spacing is
  * not the same as `100`).
  */
-export function clampGapWidth(value: number | undefined): number | undefined {
+function clampGapWidth(value: number | undefined): number | undefined {
   if (value === undefined || !Number.isFinite(value)) return undefined
   const rounded = Math.round(value)
   if (rounded < 0) return 0
@@ -1317,7 +1317,7 @@ export function clampGapWidth(value: number | undefined): number | undefined {
  * series fully separated and series fully overlapped — wrapping makes
  * no physical sense).
  */
-export function clampOverlap(value: number | undefined): number | undefined {
+function clampOverlap(value: number | undefined): number | undefined {
   if (value === undefined || !Number.isFinite(value)) return undefined
   const rounded = Math.round(value)
   if (rounded < -100) return -100
@@ -1325,7 +1325,7 @@ export function clampOverlap(value: number | undefined): number | undefined {
   return rounded
 }
 
-export function buildLineChart(chart: SheetChart, sheetName: string): string {
+function buildLineChart(chart: SheetChart, sheetName: string): string {
   const grouping = chart.lineGrouping ?? "standard"
   const children: string[] = [
     xmlSelfClose("c:grouping", { val: grouping }),
@@ -1409,7 +1409,7 @@ export function buildLineChart(chart: SheetChart, sheetName: string): string {
  * fresh toggle. A richer model — per-bar styling — can layer on top
  * in a follow-up if needed.
  */
-export function buildUpDownBars(gapWidth: number | undefined): string {
+function buildUpDownBars(gapWidth: number | undefined): string {
   const resolved = clampUpDownBarsGapWidth(gapWidth) ?? 150
   return xmlElement("c:upDownBars", undefined, [xmlSelfClose("c:gapWidth", { val: resolved })])
 }
@@ -1430,14 +1430,14 @@ export function buildUpDownBars(gapWidth: number | undefined): string {
  * silently rewriting an `800` to `500` would mislead the caller about
  * what Excel ends up rendering.
  */
-export function clampUpDownBarsGapWidth(value: number | undefined): number | undefined {
+function clampUpDownBarsGapWidth(value: number | undefined): number | undefined {
   if (value === undefined || !Number.isFinite(value)) return undefined
   const rounded = Math.round(value)
   if (rounded < 0 || rounded > 500) return undefined
   return rounded
 }
 
-export function buildAreaChart(chart: SheetChart, sheetName: string): string {
+function buildAreaChart(chart: SheetChart, sheetName: string): string {
   const grouping = chart.areaGrouping ?? "standard"
   const children: string[] = [
     xmlSelfClose("c:grouping", { val: grouping }),
@@ -1506,7 +1506,7 @@ export function buildPieChart(chart: SheetChart, sheetName: string): string {
   return xmlElement("c:pieChart", undefined, children)
 }
 
-export function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
+function buildDoughnutChart(chart: SheetChart, sheetName: string): string {
   const children: string[] = [
     xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
   ]
@@ -1577,7 +1577,7 @@ export function clampHoleSize(value: number | undefined): number {
   return rounded
 }
 
-export function buildScatterChart(chart: SheetChart, sheetName: string): string {
+function buildScatterChart(chart: SheetChart, sheetName: string): string {
   const children: string[] = [
     xmlSelfClose("c:scatterStyle", { val: resolveScatterStyle(chart) }),
     xmlSelfClose("c:varyColors", { val: resolveVaryColors(chart) ? 1 : 0 }),
@@ -1625,7 +1625,7 @@ export function buildScatterChart(chart: SheetChart, sheetName: string): string 
  * value (matching Excel's reference output) keeps the rendered intent
  * unambiguous on roundtrip.
  */
-export function resolveVaryColors(chart: SheetChart): boolean {
+function resolveVaryColors(chart: SheetChart): boolean {
   if (typeof chart.varyColors === "boolean") return chart.varyColors
   return VARY_COLORS_DEFAULT_TRUE_TYPES.has(chart.type)
 }
@@ -1642,7 +1642,7 @@ export function resolveVaryColors(chart: SheetChart): boolean {
  * OOXML schema lists it as required there — omitting it would produce
  * an invalid chart document Excel refuses to open.
  */
-export function resolveScatterStyle(chart: SheetChart): ChartScatterStyle {
+function resolveScatterStyle(chart: SheetChart): ChartScatterStyle {
   const raw = chart.scatterStyle
   if (raw && SCATTER_STYLE_VALUES.has(raw)) return raw
   return "lineMarker"
@@ -1829,7 +1829,7 @@ export function resolveClonePlotAreaBorderColor(
  * collapse to `undefined` so the cloned chart drops the field rather
  * than carry a value the writer would silently elide back to absence.
  */
-export function normalizeClonePlotAreaBorderWidth(value: number | undefined): number | undefined {
+function normalizeClonePlotAreaBorderWidth(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined
   // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
   const snapped = Math.round(value * 4) / 4

--- a/src/xlsx/chart/series.ts
+++ b/src/xlsx/chart/series.ts
@@ -195,7 +195,7 @@ export interface SeriesOptions {
  * present. Bare ranges like `B2:B10` are auto-qualified with the
  * owning sheet's name.
  */
-export function qualifyRef(ref: string, sheetName: string): string {
+function qualifyRef(ref: string, sheetName: string): string {
   if (ref.includes("!")) return ref
   return `${quoteSheetName(sheetName)}!${ref}`
 }
@@ -205,7 +205,7 @@ export function qualifyRef(ref: string, sheetName: string): string {
  * unsafe in a 3D reference (whitespace, punctuation, etc.). Single
  * quotes inside the name are doubled per the OOXML spec.
  */
-export function quoteSheetName(name: string): string {
+function quoteSheetName(name: string): string {
   if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) return name
   return `'${name.replace(/'/g, "''")}'`
 }
@@ -338,7 +338,7 @@ export function parseSeries(ser: XmlElement, kind: ChartKind, index: number): Ch
  * writer's elision logic, so collapsing them keeps the parsed shape
  * minimal.
  */
-export function parseSmooth(ser: XmlElement): boolean | undefined {
+function parseSmooth(ser: XmlElement): boolean | undefined {
   const el = findChild(ser, "smooth")
   if (!el) return undefined
   const v = readBoolAttr(el)
@@ -353,7 +353,7 @@ export function parseSmooth(ser: XmlElement): boolean | undefined {
  * `false` round-trip identically through the writer's elision logic,
  * so collapsing them keeps the parsed shape minimal.
  */
-export function parseInvertIfNegative(ser: XmlElement): boolean | undefined {
+function parseInvertIfNegative(ser: XmlElement): boolean | undefined {
   const el = findChild(ser, "invertIfNegative")
   if (!el) return undefined
   const v = readBoolAttr(el)
@@ -372,7 +372,7 @@ export function parseInvertIfNegative(ser: XmlElement): boolean | undefined {
  * minimal. Non-integer input rounds to the nearest integer for parity
  * with the writer (Excel's UI accepts integer percentages only).
  */
-export function parseExplosion(ser: XmlElement): number | undefined {
+function parseExplosion(ser: XmlElement): number | undefined {
   const el = findChild(ser, "explosion")
   if (!el) return undefined
   const raw = el.attrs.val
@@ -600,7 +600,7 @@ export function parseSeriesStroke(ser: XmlElement): ChartLineStroke | undefined 
  * input) so the writer can elide the element entirely; absence and `0`
  * round-trip identically through the parser's collapse logic.
  */
-export function clampExplosion(value: number | undefined): number | undefined {
+function clampExplosion(value: number | undefined): number | undefined {
   if (value === undefined || !Number.isFinite(value)) return undefined
   const rounded = Math.round(value)
   if (rounded <= 0) return undefined
@@ -777,9 +777,7 @@ export function buildSeries(
  * `undefined` for unrecognized values so the writer can elide
  * `<a:prstDash>` rather than emit a token Excel will reject.
  */
-export function normalizeDashStyle(
-  value: ChartLineDashStyle | undefined,
-): ChartLineDashStyle | undefined {
+function normalizeDashStyle(value: ChartLineDashStyle | undefined): ChartLineDashStyle | undefined {
   if (value === undefined) return undefined
   return VALID_DASH_STYLES.has(value) ? value : undefined
 }
@@ -883,7 +881,7 @@ export function buildSeriesSpPr(
  * Returns `undefined` for non-finite values so the writer can elide
  * `<c:size>` (Excel falls back to its series-rotation default).
  */
-export function clampMarkerSize(value: number | undefined): number | undefined {
+function clampMarkerSize(value: number | undefined): number | undefined {
   if (value === undefined || !Number.isFinite(value)) return undefined
   const rounded = Math.round(value)
   if (rounded < MARKER_SIZE_MIN) return MARKER_SIZE_MIN
@@ -896,7 +894,7 @@ export function clampMarkerSize(value: number | undefined): number | undefined {
  * Returns `undefined` for unrecognized values so the writer can elide
  * `<c:symbol>` rather than emit a token Excel will reject.
  */
-export function normalizeMarkerSymbol(
+function normalizeMarkerSymbol(
   value: ChartMarkerSymbol | undefined,
 ): ChartMarkerSymbol | undefined {
   if (value === undefined) return undefined
@@ -957,7 +955,7 @@ export function buildSeriesMarker(marker: ChartMarker | undefined): string | und
  * so the writer can elide the element rather than emit a bare
  * `<a:ln/>` that Excel paints with the inherited default.
  */
-export function resolveStroke(
+function resolveStroke(
   sourceStroke: ChartLineStroke | undefined,
   override: ChartLineStroke | null | undefined,
 ): ChartLineStroke | undefined {
@@ -969,7 +967,7 @@ export function resolveStroke(
   return cloneStroke(override)
 }
 
-export function cloneStroke(source: ChartLineStroke): ChartLineStroke | undefined {
+function cloneStroke(source: ChartLineStroke): ChartLineStroke | undefined {
   const out: ChartLineStroke = {}
   if (source.dash !== undefined) out.dash = source.dash
   if (typeof source.width === "number" && Number.isFinite(source.width)) out.width = source.width
@@ -991,7 +989,7 @@ export function cloneStroke(source: ChartLineStroke): ChartLineStroke | undefine
  * to `undefined` so absence and the OOXML default round-trip identically
  * (the writer emits straight segments either way).
  */
-export function resolveSmooth(
+function resolveSmooth(
   sourceSmooth: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {
@@ -1014,7 +1012,7 @@ export function resolveSmooth(
  * to `undefined` so absence and the OOXML default round-trip identically
  * (the writer omits `<c:invertIfNegative>` either way).
  */
-export function resolveInvertIfNegative(
+function resolveInvertIfNegative(
   sourceFlag: boolean | undefined,
   override: boolean | null | undefined,
 ): boolean | undefined {
@@ -1040,7 +1038,7 @@ export function resolveInvertIfNegative(
  * applies the final `0..400` clamp at emit time so a parsed-then-cloned
  * value remains visible on the resulting `SheetChart` object.
  */
-export function resolveExplosion(
+function resolveExplosion(
   sourceValue: number | undefined,
   override: number | null | undefined,
 ): number | undefined {
@@ -1068,7 +1066,7 @@ export function resolveExplosion(
  * `undefined` so the writer can elide the element rather than emit a
  * bare `<c:marker/>` that Excel paints with the inherited default.
  */
-export function resolveMarker(
+function resolveMarker(
   sourceMarker: ChartMarker | undefined,
   override: ChartMarker | null | undefined,
 ): ChartMarker | undefined {

--- a/src/xlsx/chart/shape.ts
+++ b/src/xlsx/chart/shape.ts
@@ -235,7 +235,7 @@ export function parseBorderCompoundFromSpPr(parent: XmlElement): ChartLineCompou
  * Recognized values of {@link ChartThemeColorName} — the OOXML
  * `ST_SchemeColorVal` enum on `<a:schemeClr val="..."/>`.
  */
-export const VALID_THEME_COLOR_NAMES: ReadonlySet<ChartThemeColorName> = new Set([
+const VALID_THEME_COLOR_NAMES: ReadonlySet<ChartThemeColorName> = new Set([
   "bg1",
   "tx1",
   "bg2",
@@ -385,13 +385,6 @@ export function buildColorElement(value: ChartColor): string {
     return xmlSelfClose("a:schemeClr", { val: value.theme })
   }
   return xmlElement("a:schemeClr", { val: value.theme }, children)
-}
-
-/**
- * Build a `<a:solidFill>` block wrapping the supplied color reference.
- */
-export function buildSolidFill(value: ChartColor): string {
-  return xmlElement("a:solidFill", undefined, [buildColorElement(value)])
 }
 
 /**

--- a/src/xlsx/chart/text.ts
+++ b/src/xlsx/chart/text.ts
@@ -39,6 +39,60 @@ function findChild(el: XmlElement, localName: string): XmlElement | undefined {
   return undefined
 }
 
+// ── The walk ──────────────────────────────────────────────────────
+//
+// Both hosts end at the same `<a:defRPr>`; they differ only in how you
+// get there. Written out at each call site, that walk appeared 43 times
+// across five files — axis.ts alone had 14 — so reading one axis
+// re-walked the same subtree once per attribute, and adding a property
+// meant another copy of it. See #466.
+
+/**
+ * `host` → `<c:txPr>` → `<a:p>` → `<a:pPr>` → `<a:defRPr>`.
+ *
+ * The text-properties body: what the legend, axis tick labels,
+ * data-labels and data-table hosts use. Scoped to the host's *own*
+ * `<c:txPr>`, so a `<a:defRPr>` inside a sibling `<c:title><c:tx>
+ * <c:rich>` cannot leak in — which is why this is a walk and not a
+ * recursive search.
+ *
+ * Returns `undefined` at the first missing link, so a malformed chain
+ * surfaces as absence rather than a fabricated value.
+ */
+export function resolveTxPrDefRPr(host: XmlElement): XmlElement | undefined {
+  const txPr = findChild(host, "txPr")
+  if (!txPr) return undefined
+  return resolveParagraphDefRPr(txPr)
+}
+
+/**
+ * `host` → `<c:title>` → `<c:tx>` → `<c:rich>` → `<a:p>` → `<a:pPr>` →
+ * `<a:defRPr>`.
+ *
+ * The rich-text body: what the chart title and axis titles use. Takes
+ * the element that *owns* the title — `<c:chart>` for the chart title,
+ * the axis element for an axis title — because that is where both
+ * callers start.
+ */
+export function resolveTitleDefRPr(host: XmlElement): XmlElement | undefined {
+  const title = findChild(host, "title")
+  if (!title) return undefined
+  const tx = findChild(title, "tx")
+  if (!tx) return undefined
+  const rich = findChild(tx, "rich")
+  if (!rich) return undefined
+  return resolveParagraphDefRPr(rich)
+}
+
+/** The shared tail: `<a:p>` → `<a:pPr>` → `<a:defRPr>`. */
+function resolveParagraphDefRPr(body: XmlElement): XmlElement | undefined {
+  const p = findChild(body, "p")
+  if (!p) return undefined
+  const pPr = findChild(p, "pPr")
+  if (!pPr) return undefined
+  return findChild(pPr, "defRPr")
+}
+
 // ── Rotation constants ────────────────────────────────────────────
 
 /**

--- a/src/xlsx/chart/title.ts
+++ b/src/xlsx/chart/title.ts
@@ -65,6 +65,7 @@ import {
   ROTATION_MIN_DEG,
   TXPR_ROT_PER_DEGREE,
 } from "./text"
+import { resolveTitleDefRPr } from "./text"
 
 // ── Constants (chart-title scope) ──────────────────────────────────
 
@@ -246,21 +247,7 @@ export function parseTitleRotation(chartEl: XmlElement): number | undefined {
  * data-labels block) cannot leak in.
  */
 export function parseTitleFontSize(chartEl: XmlElement): number | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph font size. The reader walks the canonical chain
-  // and bails on the first missing link so a malformed `<c:rich>`
-  // surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.sz
   if (typeof raw !== "string") return undefined
@@ -301,21 +288,7 @@ export function parseTitleFontSize(chartEl: XmlElement): number | undefined {
  * data-labels block) cannot leak in.
  */
 export function parseTitleBold(chartEl: XmlElement): boolean | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph bold flag. The reader walks the canonical chain
-  // and bails on the first missing link so a malformed `<c:rich>`
-  // surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const parsed = parseBoolAttr(defRPr.attrs.b)
   // The OOXML default `false` collapses to `undefined` so absence and
@@ -348,21 +321,7 @@ export function parseTitleBold(chartEl: XmlElement): boolean | undefined {
  * data-labels block) cannot leak in.
  */
 export function parseTitleItalic(chartEl: XmlElement): boolean | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph italic flag. The reader walks the canonical chain
-  // and bails on the first missing link so a malformed `<c:rich>`
-  // surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const parsed = parseBoolAttr(defRPr.attrs.i)
   // The OOXML default `false` collapses to `undefined` so absence and
@@ -399,22 +358,7 @@ export function parseTitleItalic(chartEl: XmlElement): boolean | undefined {
  * a data-labels block) cannot leak in.
  */
 export function parseTitleColor(chartEl: XmlElement): ChartColor | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr><a:solidFill><a:srgbClr>` (or `<a:schemeClr>`)
-  // is the OOXML path Excel writes for the default-paragraph font color.
-  // The reader walks the canonical chain and bails on the first missing
-  // link so a malformed `<c:rich>` surfaces as absence rather than a
-  // fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const solidFill = findChild(defRPr, "solidFill")
   if (!solidFill) return undefined
@@ -614,22 +558,7 @@ export function parseTitleBorderCompound(chartEl: XmlElement): ChartLineCompound
  * leak in.
  */
 export function parseTitleStrike(chartEl: XmlElement): boolean | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph strikethrough flag. The reader walks the
-  // canonical chain and bails on the first missing link so a
-  // malformed `<c:rich>` surfaces as absence rather than a fabricated
-  // value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.strike
   // Only the UI-default `"sngStrike"` surfaces as `true`. The OOXML
@@ -673,21 +602,7 @@ export function parseTitleStrike(chartEl: XmlElement): boolean | undefined {
  * leak in.
  */
 export function parseTitleUnderline(chartEl: XmlElement): boolean | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr>` is the OOXML path Excel writes for the
-  // default-paragraph underline flag. The reader walks the canonical
-  // chain and bails on the first missing link so a malformed
-  // `<c:rich>` surfaces as absence rather than a fabricated value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const raw = defRPr.attrs.u
   // Only the UI-default `"sng"` surfaces as `true`. The OOXML
@@ -727,22 +642,7 @@ export function parseTitleUnderline(chartEl: XmlElement): boolean | undefined {
  * leak in.
  */
 export function parseTitleFontFamily(chartEl: XmlElement): string | undefined {
-  const title = findChild(chartEl, "title")
-  if (!title) return undefined
-  const tx = findChild(title, "tx")
-  if (!tx) return undefined
-  const rich = findChild(tx, "rich")
-  if (!rich) return undefined
-  // `<a:p><a:pPr><a:defRPr><a:latin>` is the OOXML path Excel writes
-  // for the default-paragraph typeface. The reader walks the
-  // canonical chain and bails on the first missing link so a
-  // malformed `<c:rich>` surfaces as absence rather than a fabricated
-  // value.
-  const p = findChild(rich, "p")
-  if (!p) return undefined
-  const pPr = findChild(p, "pPr")
-  if (!pPr) return undefined
-  const defRPr = findChild(pPr, "defRPr")
+  const defRPr = resolveTitleDefRPr(chartEl)
   if (!defRPr) return undefined
   const latin = findChild(defRPr, "latin")
   if (!latin) return undefined
@@ -1799,7 +1699,7 @@ export function resolveCloneTitleBorderColor(
  * collapse to `undefined` so the cloned chart drops the field rather
  * than carry a value the writer would silently elide back to absence.
  */
-export function normalizeTitleBorderWidth(value: number | undefined): number | undefined {
+function normalizeTitleBorderWidth(value: number | undefined): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined
   // Snap to the 0.25 pt grid Excel's UI exposes (Math.round(x * 4) / 4).
   const snapped = Math.round(value * 4) / 4

--- a/test/chart-text-walk.test.ts
+++ b/test/chart-text-walk.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import { parseXml } from "../src/xml/parser"
+import { resolveTitleDefRPr, resolveTxPrDefRPr } from "../src/xlsx/chart/text"
+import {
+  parseAxisLabelBold,
+  parseAxisLabelFontSize,
+  parseAxisTitleBold,
+  parseAxisTitleFontSize,
+} from "../src/xlsx/chart/axis"
+import type { XmlElement } from "../src/xml/parser"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #466 — `<c:txPr><a:p><a:pPr><a:defRPr>` was written out at the call
+// site 43 times across five files; axis.ts alone had 14, so reading one
+// axis re-walked the same subtree once per attribute and adding a
+// property meant another copy of the walk.
+//
+// The interesting part is not that it was repeated but what each copy
+// had to restate: the walk is *scoped*, not a search. A `<a:defRPr>`
+// inside the axis's `<c:title><c:tx><c:rich>` must not reach the
+// tick-label readers, and vice versa. That invariant now lives in one
+// place, so it is worth testing there.
+// ═══════════════════════════════════════════════════════════════════════
+
+const el = (xml: string): XmlElement => parseXml(xml)
+
+/** An axis with typography on the tick labels, the title, or both. */
+function axis(opts: { label?: string; title?: string }): XmlElement {
+  const txPr = opts.label
+    ? `<c:txPr><a:p><a:pPr><a:defRPr ${opts.label}/></a:pPr></a:p></c:txPr>`
+    : ""
+  const title = opts.title
+    ? `<c:title><c:tx><c:rich><a:p><a:pPr><a:defRPr ${opts.title}/></a:pPr></a:p></c:rich></c:tx></c:title>`
+    : ""
+  return el(`<c:catAx xmlns:c="c" xmlns:a="a">${title}${txPr}</c:catAx>`)
+}
+
+describe("the two walks land on the right defRPr", () => {
+  it("each finds its own host's", () => {
+    const both = axis({ label: 'sz="1000"', title: 'sz="2000"' })
+
+    expect(resolveTxPrDefRPr(both)?.attrs.sz).toBe("1000")
+    expect(resolveTitleDefRPr(both)?.attrs.sz).toBe("2000")
+  })
+
+  it("neither reaches into the other, which is the whole point", () => {
+    // A search would find the wrong one here; a walk cannot.
+    expect(resolveTxPrDefRPr(axis({ title: 'sz="2000"' }))).toBeUndefined()
+    expect(resolveTitleDefRPr(axis({ label: 'sz="1000"' }))).toBeUndefined()
+  })
+
+  it("stops at the first missing link rather than guessing", () => {
+    // A malformed chain surfaces as absence, not a fabricated value.
+    expect(resolveTxPrDefRPr(el('<c:catAx xmlns:c="c"/>'))).toBeUndefined()
+    expect(
+      resolveTxPrDefRPr(el('<c:catAx xmlns:c="c" xmlns:a="a"><c:txPr/></c:catAx>')),
+    ).toBeUndefined()
+    expect(
+      resolveTxPrDefRPr(el('<c:catAx xmlns:c="c" xmlns:a="a"><c:txPr><a:p/></c:txPr></c:catAx>')),
+    ).toBeUndefined()
+  })
+})
+
+describe("the readers built on it keep their scoping", () => {
+  it("tick-label readers do not see the title's typography", () => {
+    const titleOnly = axis({ title: 'sz="2000" b="1"' })
+
+    expect(parseAxisLabelFontSize(titleOnly)).toBeUndefined()
+    expect(parseAxisLabelBold(titleOnly)).toBeUndefined()
+    expect(parseAxisTitleFontSize(titleOnly)).toBe(20)
+    expect(parseAxisTitleBold(titleOnly)).toBe(true)
+  })
+
+  it("title readers do not see the tick labels'", () => {
+    const labelOnly = axis({ label: 'sz="1000" b="1"' })
+
+    expect(parseAxisTitleFontSize(labelOnly)).toBeUndefined()
+    expect(parseAxisTitleBold(labelOnly)).toBeUndefined()
+    expect(parseAxisLabelFontSize(labelOnly)).toBe(10)
+    expect(parseAxisLabelBold(labelOnly)).toBe(true)
+  })
+
+  it("both read their own when both are present", () => {
+    const both = axis({ label: 'sz="1000"', title: 'sz="2000"' })
+
+    expect(parseAxisLabelFontSize(both)).toBe(10)
+    expect(parseAxisTitleFontSize(both)).toBe(20)
+  })
+})


### PR DESCRIPTION
Closes #466.

## The walk

`<c:txPr><a:p><a:pPr><a:defRPr>` was written out at the call site 43 times across five files. Reading one axis re-walked the same subtree once per attribute, and adding a property meant another copy of the walk plus another copy of the comment explaining it.

| file | walks | now |
| --- | ---: | ---: |
| `axis.ts` | 14 | 0 |
| `legend.ts` | 8 | 0 |
| `title.ts` | 7 | 0 |
| `dataLabels.ts` | 7 | 0 |
| `dataTable.ts` | 7 | 0 |

Two helpers in `chart/text.ts` cover both host shapes — `resolveTxPrDefRPr` (the text-properties body: legend, tick labels, data labels, data table) and `resolveTitleDefRPr` (the rich-text body: chart title, axis titles).

**The interesting part is not that the walk was repeated but what each copy had to restate.** It is a *scoped* walk, not a search: a `<a:defRPr>` inside an axis's `<c:title><c:tx><c:rich>` must not reach the tick-label readers, and vice versa. Forty-three copies each said so in a comment and none of them could be tested as a property. It now lives in one place, and `test/chart-text-walk.test.ts` pins it — including the case a naive search would get wrong, an axis carrying typography on both.

## `buildSolidFill`

Exported and referenced nowhere in `src/` or `test/`. Removed.

## The export-hygiene item, measured

The issue said 93 of 640 exported functions are used only inside their own file. I measured before acting on it, and the number is right but the shape is worth stating:

```
exported but used by no other src file: 226
  ...of which a test imports directly:  127
  ...of which nothing anywhere uses  :   93
```

The 127 are legitimate — these parsers have enough branching that testing them at the unit is the reasonable choice, and `coverage-chart-axis.test.ts` and friends do exactly that. Un-exporting those would have traded real coverage for a hygiene number.

The remaining 93 are all in the chart module and lose their `export`. `tsc` and the export snapshot verify nothing was reachable that mattered.

## The tree-shaking claim, also measured

It holds, and by less than the raw number suggests:

```
                        before      after
readXlsx (hucre/xlsx)   128.5 KB    123.9 KB   minified
                         34.4 KB     34.4 KB   gzipped
```

4.6 KB of minified output gone; **gzipped is unchanged**, because gzip was already deduplicating the repeated names. The win is real for anyone shipping unzipped or measuring parse cost, and not the headline it would be if I quoted only the minified figure.

Budgets re-baselined to lock the improvement in. The README's whole-library figure moved 127 → 129 KB, which is #488's streaming writers, not this.

## Tests

`test/chart-text-walk.test.ts` — 6 cases, mutation-checked, 3 fail against `main`. The other 3 pass on both, and correctly: they assert the scoping property, which was already right and is now expressible.

`pnpm lint`, `pnpm typecheck`, 10096 tests green; coverage and size budgets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
