### PR TITLE
test: a fuzzer, a corpus, and property tests — closes #473

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -323,13 +323,14 @@ Each warning carries a `code`, a sentence, and the sheet and cell it came
 from. Nothing changes when the option is omitted, and a file hucre wrote
 produces none.
 
-| code                       | what silently went missing                                    |
-| -------------------------- | ------------------------------------------------------------- |
-| `unresolved-shared-string` | a cell's text; reads as empty                                 |
-| `unresolved-style`         | a cell's format; reads unstyled                               |
-| `unresolved-dxf`           | a conditional rule's formatting; the rule keeps its condition |
-| `unresolved-hyperlink`     | a link's target; reads as an empty target                     |
-| `unusable-paper-size`      | the sheet's paper size; reads as unset                        |
+| code                       | what silently went missing                                     |
+| -------------------------- | -------------------------------------------------------------- |
+| `unresolved-shared-string` | a cell's text; reads as empty                                  |
+| `unresolved-style`         | a cell's format; reads unstyled                                |
+| `unresolved-dxf`           | a conditional rule's formatting; the rule keeps its condition  |
+| `unresolved-hyperlink`     | a link's target; reads as an empty target                      |
+| `unusable-paper-size`      | the sheet's paper size; reads as unset                         |
+| `malformed-cell-ref`       | one cell whose `r` is not a reference; the sheet is still read |
 
 Each is a place where leniency produces something _indistinguishable from
 correct_ — an empty cell, an unstyled cell, a rule that paints nothing, a
@@ -410,6 +411,24 @@ Symmetric: delimiter (including tab auto-detection), quote character, line
 separator, header handling, `skipHeaderRow`, type inference, leading-zero
 preservation, comment lines, and formula-injection escaping — which now
 has an inverse in `unescapeFormulae`.
+
+Two things a `writeCsv` → `parseCsv` round-trip does not carry, both
+facts about the format rather than defects. Property testing found them
+(#473); they are here so nobody has to find them again.
+
+**A final row holding a single empty cell is lost.** It renders as
+nothing after the preceding line's terminator, and a file ending in a
+terminator is universally read as having no record after it. RFC 4180
+leaves the trailing CRLF optional and says nothing about the ambiguity.
+A trailing row of _two_ empty cells survives — it renders as a bare
+delimiter — and so does an empty row anywhere but the end.
+
+**Delimiter auto-detection is a guess, and a file can defeat it.**
+`[["with,comma"], ["with\ttab"]]` written with the default comma quotes
+its one comma, so the only unquoted separator character left in the file
+is a tab — and `parseCsv` is right to read it as tab-separated. Pass
+`delimiter` when you know it; there is no reading of those bytes that
+recovers the intent.
 
 **Encoding is read, not guessed.** The readers take bytes and honour a
 byte-order mark — UTF-8, UTF-16LE, UTF-16BE — and fall back to UTF-8.

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1427,6 +1427,7 @@ export interface ReadWarning {
     | "unresolved-dxf"
     | "unresolved-hyperlink"
     | "unusable-paper-size"
+    | "malformed-cell-ref"
   /** A sentence a person can act on. */
   message: string
   /** The sheet it happened in, when the reader knows. */

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -1633,21 +1633,35 @@ function processCell(
   if (!pos) return
   const { row, col } = pos
 
-  // Guard against malicious / corrupt cell references that would
-  // otherwise allocate billions of null slots and OOM the process.
-  if (
-    !Number.isInteger(row) ||
-    !Number.isInteger(col) ||
-    row < 0 ||
-    col < 0 ||
-    row > MAX_ROW_INDEX ||
-    col > MAX_COL_INDEX
-  ) {
+  // Two different failures, treated differently on purpose — the same
+  // distinction `clampColumnBound` draws a few lines down.
+  //
+  // A reference *past the grid* (`AAAAAA1`, row 2,000,000) is a resource
+  // claim: honouring it would allocate billions of null slots and OOM
+  // the process, and there is no partial answer that is not a fabricated
+  // one. That throws, and always has.
+  //
+  // A reference that is *not a reference* (`B` with no row, `A0`) claims
+  // nothing. It used to throw too, so one malformed `r` attribute cost
+  // the whole sheet where every other content damage costs one cell.
+  // It now drops the cell and says so. See #473.
+  if (row > MAX_ROW_INDEX || col > MAX_COL_INDEX) {
     throw new ParseError(
       `Cell reference "${ref}" is outside the supported sheet bounds (max row ${
         MAX_ROW_INDEX + 1
       }, max col ${MAX_COL_INDEX + 1})`,
     )
+  }
+  if (!Number.isInteger(row) || !Number.isInteger(col) || row < 0 || col < 0) {
+    ctx.onWarning?.({
+      code: "malformed-cell-ref",
+      message:
+        `Cell reference "${ref}" is not a cell reference — a column needs a ` +
+        "row number and rows are 1-based. The cell is dropped; the rest of " +
+        "the sheet is read.",
+      sheet: ctx.sheetName,
+    })
+    return
   }
 
   // Ensure row array exists

--- a/src/zip/deflate.ts
+++ b/src/zip/deflate.ts
@@ -51,7 +51,7 @@ class BitReader {
   readBits(n: number): number {
     while (this.bitCount < n) {
       if (this.pos >= this.data.length) {
-        throw new Error("Unexpected end of DEFLATE data")
+        throw new ZipError("Unexpected end of DEFLATE data")
       }
       this.bitBuf |= this.data[this.pos++] << this.bitCount
       this.bitCount += 8
@@ -70,7 +70,7 @@ class BitReader {
 
   readByte(): number {
     if (this.pos >= this.data.length) {
-      throw new Error("Unexpected end of DEFLATE data")
+      throw new ZipError("Unexpected end of DEFLATE data")
     }
     return this.data[this.pos++]
   }
@@ -145,7 +145,7 @@ function decodeSymbol(reader: BitReader, tree: HuffmanTree): number {
     code <<= 1
   }
 
-  throw new Error("Invalid Huffman code")
+  throw new ZipError("Invalid Huffman code")
 }
 
 // ── Fixed Huffman Tables (RFC 1951 Section 3.2.6) ───────────────────
@@ -329,7 +329,7 @@ export function inflate(data: Uint8Array, maxBytes: number = MAX_DECOMPRESSED_BY
 
       inflateBlock(litLenTree, distTree)
     } else {
-      throw new Error(`Invalid DEFLATE block type: ${btype}`)
+      throw new ZipError(`Invalid DEFLATE block type: ${btype}`)
     }
   } while (bfinal === 0)
 

--- a/test/_fuzz.ts
+++ b/test/_fuzz.ts
@@ -1,0 +1,123 @@
+// ── Deterministic fuzzing helpers ───────────────────────────────────
+//
+// `src/limits.ts` and `SECURITY.md` describe a library that expects
+// hostile files, and every bound in them is tested — with a hand-written
+// case that reaches exactly that bound. The interesting failures are the
+// ones nobody thought of. See #473.
+//
+// Everything here is seeded. A fuzzer that finds a failure you cannot
+// reproduce has told you something useless, and one that runs different
+// cases every CI run makes a red build a coin toss. The seed is in the
+// test; change it deliberately to search elsewhere.
+
+/**
+ * mulberry32 — a small, fast, well-distributed PRNG.
+ *
+ * `Math.random()` cannot be seeded, and a fuzzer without a seed cannot
+ * hand you back the case that broke.
+ */
+export function seeded(seed: number): () => number {
+  let a = seed
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** One mutated input, with a label that says how to rebuild it. */
+export interface Mutation {
+  label: string
+  bytes: Uint8Array
+}
+
+/**
+ * Byte-level mutations of a valid file.
+ *
+ * Four kinds, because they break different layers: a flipped bit usually
+ * lands in compressed data, a truncation usually kills the central
+ * directory, a random byte can do either, and a scatter reaches several
+ * at once.
+ */
+export function* byteMutations(
+  source: Uint8Array,
+  count: number,
+  seed: number,
+): Generator<Mutation> {
+  const rnd = seeded(seed)
+  for (let i = 0; i < count; i++) {
+    const copy = new Uint8Array(source)
+    const at = Math.floor(rnd() * Math.max(1, copy.length))
+    switch (i % 4) {
+      case 0:
+        copy[at] ^= 1 << Math.floor(rnd() * 8)
+        yield { label: `flip@${at}`, bytes: copy }
+        break
+      case 1:
+        yield { label: `truncate@${at}`, bytes: copy.subarray(0, at) }
+        break
+      case 2:
+        copy[at] = Math.floor(rnd() * 256)
+        yield { label: `set@${at}`, bytes: copy }
+        break
+      default: {
+        const n = 1 + Math.floor(rnd() * 8)
+        for (let k = 0; k < n; k++) {
+          copy[Math.floor(rnd() * copy.length)] = Math.floor(rnd() * 256)
+        }
+        yield { label: `scatter${n}`, bytes: copy }
+        break
+      }
+    }
+  }
+}
+
+/**
+ * Text mutations of one XML part, applied inside an otherwise valid
+ * package.
+ *
+ * Byte mutations mostly break the DEFLATE stream, which exercises one
+ * layer over and over. These reach the parsers: a `<c>` whose `r` is
+ * `"A"` with no row, a part that ends mid-element, a `count` of
+ * 999999999999, a reference past the last legal cell.
+ */
+export const XML_MUTATORS: Array<[string, (xml: string, rnd: () => number) => string]> = [
+  ["truncate", (x, rnd) => x.slice(0, Math.floor(rnd() * x.length))],
+  [
+    "drop-a-close-tag",
+    (x, rnd) => {
+      const all = [...x.matchAll(/<\/[\w:]+>/g)]
+      if (all.length === 0) return x
+      const pick = all[Math.floor(rnd() * all.length)]!
+      return x.slice(0, pick.index) + x.slice(pick.index! + pick[0].length)
+    },
+  ],
+  ["ref-without-row", (x) => x.replace(/ r="[A-Z]+\d+"/g, ' r="A"')],
+  ["ref-past-the-grid", (x) => x.replace(/ r="[A-Z]+\d+"/g, ' r="XFD1048577"')],
+  ["negative-numbers", (x) => x.replace(/="(\d+)"/g, '="-$1"')],
+  ["huge-numbers", (x) => x.replace(/="(\d+)"/g, '="999999999999"')],
+  ["not-a-number", (x) => x.replace(/="(\d+)"/g, '="NaN"')],
+  ["every-attribute-empty", (x) => x.replace(/="[^"]*"/g, '=""')],
+  [
+    "unknown-element",
+    (x, rnd) => {
+      const all = [...x.matchAll(/<([\w:]+)[ >]/g)]
+      if (all.length < 2) return x
+      const pick = all[Math.floor(rnd() * all.length)]!
+      return `${x.slice(0, pick.index)}<zzz ${x.slice(pick.index! + pick[0].length)}`
+    },
+  ],
+  ["no-xml-declaration", (x) => x.replace(/<\?xml[^>]*\?>/, "")],
+  [
+    "entity-expansion",
+    (x) =>
+      x.replace(
+        "<sheetData>",
+        '<!DOCTYPE t [<!ENTITY a "aaaaaaaaaa"><!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">' +
+          '<!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;"><!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">]>' +
+          "<sheetData>",
+      ),
+  ],
+]

--- a/test/corpus-malformed.test.ts
+++ b/test/corpus-malformed.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import { HucreError, ParseError, ZipError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #473 — a corpus of deliberately-broken files, each with one assertion:
+// *this throws a typed error*, or *this returns a partial result*.
+//
+// Built in code rather than committed as binaries. A directory of opaque
+// .xlsx files tells a reader nothing about what is wrong with each one,
+// and cannot be adjusted when a part's layout changes. Every entry below
+// says how it is broken in the line that breaks it.
+//
+// This is where the known cases belong — they were scattered through
+// `edge-cases*.test.ts` — and the boundary it draws is the one that
+// matters: **short is fine, wrong is not.** A file missing a shared
+// string reads as empty; a file missing `xl/workbook.xml` is not a
+// workbook and says so.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+async function clean(): Promise<Uint8Array> {
+  return writeXlsx({
+    sheets: [
+      {
+        name: "Data",
+        rows: [
+          ["name", "qty"],
+          ["Widget", 3],
+        ],
+      },
+    ],
+  })
+}
+
+/** Rebuild the archive with parts rewritten, replaced or removed. */
+async function rebuild(
+  bytes: Uint8Array,
+  edits: Record<string, ((xml: string) => string) | null>,
+): Promise<Uint8Array> {
+  const all = await new ZipReader(bytes).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    const edit = edits[name]
+    if (edit === null) continue // removed
+    zw.add(name, edit ? enc.encode(edit(dec.decode(data))) : data)
+  }
+  return zw.build()
+}
+
+// ── Not a workbook at all ────────────────────────────────────────────
+
+describe("structural damage throws, because the answer would be wrong", () => {
+  it("empty input", async () => {
+    await expect(readXlsx(new Uint8Array(0))).rejects.toThrow(HucreError)
+  })
+
+  it("not a ZIP", async () => {
+    await expect(readXlsx(enc.encode("this is just text, at some length"))).rejects.toThrow(
+      HucreError,
+    )
+  })
+
+  it("a ZIP with no end-of-central-directory record", async () => {
+    const bytes = await clean()
+    await expect(readXlsx(bytes.subarray(0, bytes.length - 40))).rejects.toThrow(ZipError)
+  })
+
+  it("a valid ZIP that is not a workbook", async () => {
+    const zw = new ZipWriter()
+    zw.add("hello.txt", enc.encode("hi"))
+
+    await expect(readXlsx(await zw.build())).rejects.toThrow(HucreError)
+  })
+
+  it("no xl/workbook.xml", async () => {
+    await expect(
+      readXlsx(await rebuild(await clean(), { "xl/workbook.xml": null })),
+    ).rejects.toThrow(HucreError)
+  })
+
+  it("a worksheet part the workbook declares and the archive does not have", async () => {
+    await expect(
+      readXlsx(await rebuild(await clean(), { "xl/worksheets/sheet1.xml": null })),
+    ).rejects.toThrow(HucreError)
+  })
+
+  it("workbook.xml that is not XML", async () => {
+    await expect(
+      readXlsx(await rebuild(await clean(), { "xl/workbook.xml": () => "<<<<not xml" })),
+    ).rejects.toThrow(HucreError)
+  })
+
+  it("corrupt compressed data", async () => {
+    // The case the fuzzer found: this used to throw a bare `Error`, so a
+    // caller catching HucreError missed it. See #473.
+    const bytes = await clean()
+    const copy = new Uint8Array(bytes)
+    // Byte 87 is inside the first entry's DEFLATE stream.
+    copy[87] ^= 0xff
+
+    await expect(readXlsx(copy)).rejects.toThrow(HucreError)
+  })
+})
+
+// ── Damaged but readable ─────────────────────────────────────────────
+
+describe("content damage reads short, because a partial answer is useful", () => {
+  it("a cell pointing at a shared string that is not there", async () => {
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) => x.replace("<v>0</v>", "<v>9999</v>"),
+      }),
+    )
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBeNull()
+    expect(wb.sheets[0]!.rows[1]![1]).toBe(3)
+  })
+
+  it("no sharedStrings.xml at all", async () => {
+    const wb = await readXlsx(await rebuild(await clean(), { "xl/sharedStrings.xml": null }))
+
+    // Numbers live in the sheet and survive; text lived in the part that
+    // is gone.
+    expect(wb.sheets[0]!.rows[1]![1]).toBe(3)
+  })
+
+  it("no styles.xml", async () => {
+    const wb = await readXlsx(await rebuild(await clean(), { "xl/styles.xml": null }), {
+      readStyles: true,
+    })
+
+    expect(wb.sheets[0]!.rows[1]![1]).toBe(3)
+  })
+
+  it("a cell reference with no row number", async () => {
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) => x.replace(/ r="B2"/, ' r="B"'),
+      }),
+    )
+
+    expect(wb.sheets).toHaveLength(1)
+  })
+
+  it("a dimension that lies about the sheet's size", async () => {
+    // `A1:XFD1048576` is 17 billion slots. The reader uses the cells it
+    // finds, not the claim.
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) =>
+          x.replace(/<dimension ref="[^"]*"\/>/, '<dimension ref="A1:XFD1048576"/>'),
+      }),
+    )
+
+    expect(wb.sheets[0]!.rows.length).toBeLessThan(10)
+  })
+
+  it("sheetData that ends mid-element", async () => {
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) => x.replace("</sheetData>", ""),
+      }),
+    )
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("name")
+  })
+
+  it("an unknown element in the middle of the sheet", async () => {
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) =>
+          x.replace("<sheetData>", "<sheetData><wat><nested/></wat>"),
+      }),
+    )
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("name")
+  })
+
+  it("a style index past the end of the table", async () => {
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) => x.replace(/ s="\d+"/g, ' s="9999"'),
+      }),
+      { readStyles: true },
+    )
+
+    expect(wb.sheets[0]!.rows[1]![1]).toBe(3)
+    expect(wb.sheets[0]!.cells?.get("1,1")?.style).toBeUndefined()
+  })
+
+  it("a merge range whose end is before its start", async () => {
+    const wb = await readXlsx(
+      await rebuild(await clean(), {
+        "xl/worksheets/sheet1.xml": (x) =>
+          x.replace(
+            "<sheetData>",
+            '<mergeCells count="1"><mergeCell ref="D4:A1"/></mergeCells><sheetData>',
+          ),
+      }),
+    )
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("name")
+  })
+})
+
+// ── The line between them ────────────────────────────────────────────
+
+describe("the boundary is short-versus-wrong", () => {
+  it("a missing part that only holds content reads short", async () => {
+    // Nothing here throws, and that is the decision: half a sheet is
+    // usually more useful than an exception.
+    const wb = await readXlsx(await rebuild(await clean(), { "xl/sharedStrings.xml": null }))
+
+    expect(wb.sheets).toHaveLength(1)
+  })
+
+  it("a missing part that holds structure throws", async () => {
+    // Without workbook.xml there is no sheet list, so a "partial" answer
+    // would be a fabricated one.
+    await expect(
+      readXlsx(await rebuild(await clean(), { "xl/workbook.xml": null })),
+    ).rejects.toThrow(ParseError)
+  })
+})

--- a/test/fuzz-robustness.test.ts
+++ b/test/fuzz-robustness.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeOds } from "../src/ods/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { readOds } from "../src/ods/reader"
+import { openXlsx } from "../src/xlsx/roundtrip"
+import { parseCsv } from "../src/csv/reader"
+import { read } from "../src/defter"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import { HucreError } from "../src/errors"
+import { byteMutations, seeded, XML_MUTATORS } from "./_fuzz"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #473 — every bound in `src/limits.ts` is tested with a hand-written
+// case that reaches exactly that bound. The interesting failures are the
+// ones nobody thought of: a byte flipped in a ZIP central directory, a
+// `<c>` whose `r` is `"A"` with no row, a part that ends mid-element.
+//
+// The bar is the one limits.ts already states — "a typed error instead of
+// killing the process" — so that is what these assert, and nothing more.
+// A fuzzer that pinned the *value* a corrupt file reads back would be
+// asserting an accident.
+//
+// Two rules for everything here:
+//   - Seeded. A failure you cannot reproduce has told you nothing, and a
+//     suite that runs different cases each time makes a red build a coin
+//     toss.
+//   - Bounded. A few hundred cases is seconds, which is what keeps this
+//     in CI rather than in a nightly nobody reads.
+//
+// This found one thing on its first run: corrupt DEFLATE data threw a
+// bare `Error`, so a caller doing `catch (e) { if (e instanceof
+// HucreError) }` — the documented contract — missed it entirely.
+// ═══════════════════════════════════════════════════════════════════════
+
+const SEED = 0xc0ffee
+const ITERATIONS = 240
+
+async function fixtureXlsx(): Promise<Uint8Array> {
+  return writeXlsx({
+    sheets: [
+      {
+        name: "S",
+        rows: [
+          ["a", 1, true],
+          ["b", 2.5, null],
+          ["c", "text", new Date("2024-01-15T00:00:00Z")],
+        ],
+        merges: [{ startRow: 0, startCol: 0, endRow: 0, endCol: 1 }],
+        conditionalRules: [
+          { type: "cellIs", priority: 1, range: "A1:B2", operator: "greaterThan", formula: "1" },
+        ],
+      },
+    ],
+  })
+}
+
+/**
+ * The whole contract, in one function.
+ *
+ * Succeeding is fine — leniency is the documented default. Throwing is
+ * fine, as long as it is a `HucreError`. Anything else is the bug: a raw
+ * `TypeError` or `RangeError` is the library falling over rather than
+ * refusing.
+ */
+async function mustBeTypedOrFine(run: () => Promise<unknown>, label: string): Promise<void> {
+  try {
+    await run()
+  } catch (error) {
+    expect(
+      error instanceof HucreError,
+      `${label} threw ${(error as Error)?.constructor?.name}: ${(error as Error)?.message}`,
+    ).toBe(true)
+  }
+}
+
+describe("byte-level corruption never escapes the error hierarchy", () => {
+  it("readXlsx", async () => {
+    const base = await fixtureXlsx()
+    for (const { label, bytes } of byteMutations(base, ITERATIONS, SEED)) {
+      await mustBeTypedOrFine(() => readXlsx(bytes), `readXlsx ${label}`)
+    }
+  })
+
+  it("openXlsx, which keeps far more of the package", async () => {
+    const base = await fixtureXlsx()
+    for (const { label, bytes } of byteMutations(base, ITERATIONS, SEED)) {
+      await mustBeTypedOrFine(() => openXlsx(bytes), `openXlsx ${label}`)
+    }
+  })
+
+  it("readOds", async () => {
+    const base = await writeOds({
+      sheets: [
+        {
+          name: "S",
+          rows: [
+            ["a", 1],
+            ["b", 2],
+          ],
+        },
+      ],
+    })
+    for (const { label, bytes } of byteMutations(base, ITERATIONS, SEED)) {
+      await mustBeTypedOrFine(() => readOds(bytes), `readOds ${label}`)
+    }
+  })
+
+  it("read(), which has to sniff before it can dispatch", async () => {
+    const base = await fixtureXlsx()
+    for (const { label, bytes } of byteMutations(base, ITERATIONS, SEED)) {
+      await mustBeTypedOrFine(() => read(bytes), `read ${label}`)
+    }
+  })
+
+  it("parseCsv, where every byte sequence is arguably valid", async () => {
+    const base = new TextEncoder().encode('name,qty\n"a""b",1\nc,2\n')
+    for (const { label, bytes } of byteMutations(base, ITERATIONS, SEED)) {
+      await mustBeTypedOrFine(async () => parseCsv(bytes), `parseCsv ${label}`)
+    }
+  })
+})
+
+describe("structure-aware corruption reaches the parsers, not just the ZIP", () => {
+  /** Rebuild a valid archive with one part replaced. */
+  async function repackage(
+    all: Map<string, Uint8Array>,
+    path: string,
+    xml: string,
+  ): Promise<Uint8Array> {
+    const zw = new ZipWriter()
+    for (const [name, data] of all) {
+      zw.add(name, name === path ? new TextEncoder().encode(xml) : data)
+    }
+    return zw.build()
+  }
+
+  it("every XML part, every mutator, still typed", async () => {
+    // Byte mutations mostly break the DEFLATE stream, which exercises one
+    // layer over and over. These arrive at the parsers intact-but-wrong,
+    // which is where the interesting failures live.
+    const base = await fixtureXlsx()
+    const all = await new ZipReader(base).extractAll()
+    const parts = [...all.keys()].filter((p) => p.endsWith(".xml") || p.endsWith(".rels"))
+    const rnd = seeded(SEED)
+
+    expect(parts.length).toBeGreaterThan(4)
+
+    for (const part of parts) {
+      const original = new TextDecoder().decode(all.get(part)!)
+      for (const [label, mutate] of XML_MUTATORS) {
+        const mutated = mutate(original, rnd)
+        if (mutated === original) continue
+        const bytes = await repackage(all, part, mutated)
+
+        await mustBeTypedOrFine(() => readXlsx(bytes), `readXlsx ${part} ${label}`)
+        await mustBeTypedOrFine(() => openXlsx(bytes), `openXlsx ${part} ${label}`)
+      }
+    }
+  }, 60_000)
+})
+
+describe("corruption is refused promptly", () => {
+  it("no mutation takes materially longer than the clean file", async () => {
+    // The failure mode `limits.ts` exists to prevent is not a wrong
+    // answer, it is a process that never comes back. A quadratic parse or
+    // an unbounded allocation shows up here as a wall-clock outlier.
+    const base = await fixtureXlsx()
+
+    const t0 = performance.now()
+    await readXlsx(base)
+    const clean = performance.now() - t0
+
+    let worst = 0
+    for (const { bytes } of byteMutations(base, 120, SEED)) {
+      const start = performance.now()
+      try {
+        await readXlsx(bytes)
+      } catch {
+        // The point is the clock, not the outcome.
+      }
+      worst = Math.max(worst, performance.now() - start)
+    }
+
+    // Generous on purpose: this is a hang detector, not a benchmark, and
+    // a tight bound here would fail on a loaded CI runner rather than on
+    // a real regression.
+    expect(worst).toBeLessThan(Math.max(2000, clean * 200))
+  }, 60_000)
+})

--- a/test/property-roundtrip.test.ts
+++ b/test/property-roundtrip.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest"
+import { writeCsv } from "../src/csv/writer"
+import { parseCsv } from "../src/csv/reader"
+import { writeNdjson } from "../src/json/writer"
+import { parseNdjson } from "../src/json/reader"
+import {
+  cellRef,
+  parseCellRef,
+  colToLetter,
+  letterToCol,
+  rangeRef,
+  parseRange,
+} from "../src/cell-utils"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../src/limits"
+import { seeded } from "./_fuzz"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #473 part 3 — property tests for the parsers that have an inverse.
+//
+// The issue named `fast-check` as the usual choice and noted it would be
+// the repo's first test dependency beyond vitest. It is not added here:
+// these properties are about the *inverse*, not about shrinking a
+// counterexample out of a rich generator space, and a seeded loop over
+// hand-built generators covers them without spending the zero-dependency
+// claim. `fast-check` remains the right answer if the properties ever get
+// harder than this — the door is not closed, it just is not open yet.
+//
+// Seeded for the same reason as the fuzzer: a failing property that
+// cannot be reproduced has told you nothing.
+// ═══════════════════════════════════════════════════════════════════════
+
+const SEED = 0x5eed
+const RUNS = 200
+
+/** Strings chosen to sit on the boundaries a CSV writer has to handle. */
+const AWKWARD = [
+  "",
+  " ",
+  "  leading and trailing  ",
+  "with,comma",
+  'with"quote',
+  '"fully quoted"',
+  "with\nnewline",
+  "with\r\ncrlf",
+  "with\ttab",
+  "şehir",
+  "😀 astral",
+  "-",
+  "=SUM(A1)",
+  "0007",
+  "null",
+  "undefined",
+  "NaN",
+  "true",
+]
+
+function randomCell(rnd: () => number): CellValue {
+  const kind = Math.floor(rnd() * 10)
+  if (kind < 4) return AWKWARD[Math.floor(rnd() * AWKWARD.length)]!
+  if (kind < 6) return Math.floor(rnd() * 2_000_000) - 1_000_000
+  if (kind < 7) return (rnd() - 0.5) * 1e6
+  if (kind < 8) return rnd() < 0.5
+  if (kind < 9) return null
+  return `text ${Math.floor(rnd() * 1000)}`
+}
+
+function randomGrid(rnd: () => number): CellValue[][] {
+  const cols = 1 + Math.floor(rnd() * 6)
+  const rows = 1 + Math.floor(rnd() * 8)
+  return Array.from({ length: rows }, () => Array.from({ length: cols }, () => randomCell(rnd)))
+}
+
+/** What CSV can carry: every value comes back as a string. */
+function asText(value: CellValue): string {
+  if (value === null || value === undefined) return ""
+  if (value instanceof Date) return value.toISOString()
+  return String(value)
+}
+
+/**
+ * The one row CSV cannot round-trip, dropped from the expectation.
+ *
+ * A final row holding a single empty cell renders as nothing after the
+ * preceding line's terminator, and a file that ends in a terminator is
+ * universally read as having no record after it. RFC 4180 leaves the
+ * trailing CRLF optional and says nothing about this, so there is no
+ * spelling that distinguishes the two — every mainstream parser reads it
+ * the way hucre does.
+ *
+ * A trailing row of *two* empty cells survives, because it renders as a
+ * bare delimiter. So does an empty row anywhere but the end. The property
+ * found this; it is a fact about the format, not a defect, and it is
+ * narrowed here rather than papered over.
+ */
+function withoutUnrepresentableTail(grid: string[][]): string[][] {
+  const last = grid[grid.length - 1]
+  return last?.length === 1 && last[0] === "" ? grid.slice(0, -1) : grid
+}
+
+describe("parseCsv(writeCsv(rows)) preserves the text of every cell", () => {
+  // The delimiter is named on both sides. A reader that has to *guess* it
+  // is answering a different question, and gets its own test below —
+  // where the property found a case worth knowing about.
+  for (const delimiter of [",", "\t", ";", "|"]) {
+    it(`over ${RUNS} generated grids, delimiter ${JSON.stringify(delimiter)}`, () => {
+      const rnd = seeded(SEED)
+
+      for (let run = 0; run < RUNS; run++) {
+        const grid = randomGrid(rnd)
+        const back = parseCsv(writeCsv(grid, { delimiter }), { delimiter })
+
+        // CSV is a text format with no types: the property is that the
+        // *text* survives, not that the values do. Anything less would be
+        // asserting an accident of type inference.
+        const want = withoutUnrepresentableTail(grid.map((row) => row.map(asText)))
+        expect(back, `run ${run} seed ${SEED} delimiter ${JSON.stringify(delimiter)}`).toEqual(want)
+      }
+    })
+  }
+})
+
+describe("auto-detection is a guess, and the property says where it misses", () => {
+  it("a file whose only unquoted separator is a tab reads as tab-separated", () => {
+    // Found by the property, at seed 0x5eed run 15. Written with the
+    // default comma, this grid quotes its one comma — so the only
+    // unquoted separator character left in the file is a tab, and the
+    // sniffer is right to call it tab-separated. There is no reading of
+    // those bytes that recovers the intent.
+    const grid = [["with,comma"], ["with\ttab"]]
+    const csv = writeCsv(grid)
+
+    expect(csv).toContain('"with,comma"')
+    expect(parseCsv(csv)).toEqual([["with,comma"], ["with", "tab"]])
+
+    // Naming the delimiter is the answer, and it is exact.
+    expect(parseCsv(csv, { delimiter: "," })).toEqual(grid)
+  })
+
+  it("detection is right whenever the file has unquoted delimiters to count", () => {
+    const grid = [
+      ["a", "b"],
+      ["c\td", "e"],
+    ]
+
+    expect(parseCsv(writeCsv(grid))).toEqual(grid)
+  })
+})
+
+describe("the one row CSV cannot carry", () => {
+  it("a final row of one empty cell is indistinguishable from the terminator", () => {
+    expect(writeCsv([["a"], [""]])).toBe("a\r\n")
+    expect(parseCsv("a\r\n")).toEqual([["a"]])
+  })
+
+  it("but two empty cells survive, because they render as a delimiter", () => {
+    expect(parseCsv(writeCsv([["a"], ["", ""]]))).toEqual([["a"], ["", ""]])
+  })
+
+  it("and an empty row anywhere but the end survives", () => {
+    expect(parseCsv(writeCsv([["a"], [""], ["b"]]))).toEqual([["a"], [""], ["b"]])
+  })
+})
+
+describe("parseNdjson(writeNdjson(records)) preserves the values", () => {
+  it("over 200 generated record sets", () => {
+    // JSON does carry types, so this is the stronger property: the values
+    // themselves come back, not just their text.
+    const rnd = seeded(SEED)
+
+    for (let run = 0; run < RUNS; run++) {
+      const keys = ["a", "b", "c"].slice(0, 1 + Math.floor(rnd() * 3))
+      const records = Array.from({ length: 1 + Math.floor(rnd() * 6) }, () => {
+        const record: Record<string, CellValue> = {}
+        for (const key of keys) {
+          const value = randomCell(rnd)
+          // A Date serialises to a string and comes back as one; that is
+          // JSON, not a defect, and is out of this property's scope.
+          record[key] = value instanceof Date ? value.toISOString() : value
+        }
+        return record
+      })
+
+      expect(parseNdjson(writeNdjson(records)).data, `run ${run} seed ${SEED}`).toEqual(records)
+    }
+  })
+})
+
+describe("the A1 reference helpers are inverses", () => {
+  it("parseCellRef(cellRef(row, col)) === { row, col }", () => {
+    const rnd = seeded(SEED)
+
+    for (let run = 0; run < RUNS * 5; run++) {
+      const row = Math.floor(rnd() * (MAX_ROW_INDEX + 1))
+      const col = Math.floor(rnd() * (MAX_COL_INDEX + 1))
+
+      expect(parseCellRef(cellRef(row, col)), `row ${row} col ${col}`).toEqual({ row, col })
+    }
+  })
+
+  it("letterToCol(colToLetter(col)) === col, across the whole grid", () => {
+    // Every column, not a sample: 16,384 is small enough to be exhaustive,
+    // and exhaustive beats random when it is affordable.
+    for (let col = 0; col <= MAX_COL_INDEX; col++) {
+      expect(letterToCol(colToLetter(col)), `col ${col}`).toBe(col)
+    }
+  })
+
+  it("the boundaries specifically", () => {
+    expect(cellRef(0, 0)).toBe("A1")
+    expect(cellRef(MAX_ROW_INDEX, MAX_COL_INDEX)).toBe("XFD1048576")
+    expect(parseCellRef("XFD1048576")).toEqual({ row: MAX_ROW_INDEX, col: MAX_COL_INDEX })
+  })
+
+  it("parseRange(rangeRef(...)) is the identity", () => {
+    const rnd = seeded(SEED)
+
+    for (let run = 0; run < RUNS; run++) {
+      const startRow = Math.floor(rnd() * 10_000)
+      const startCol = Math.floor(rnd() * 1000)
+      const endRow = startRow + Math.floor(rnd() * 100)
+      const endCol = startCol + Math.floor(rnd() * 50)
+
+      expect(parseRange(rangeRef(startRow, startCol, endRow, endCol))).toEqual({
+        startRow,
+        startCol,
+        endRow,
+        endCol,
+      })
+    }
+  })
+})


### PR DESCRIPTION
Closes #473. All three parts, and each of them found something.

## 1. The fuzzer — and it found a real gap on its first run

Byte-level mutation (flip, truncate, overwrite, scatter) plus XML-level mutation applied inside an otherwise valid package: a `<c>` whose `r` is `"A"` with no row, a part ending mid-element, `count="999999999999"`, `="NaN"`, a reference past the last legal cell, an entity-expansion attempt.

It asserts **only** the bar `limits.ts` already states — *a typed error instead of killing the process*. A fuzzer that pinned the value a corrupt file reads back would be asserting an accident.

First run, before any fixing:

```
non-HucreError escapes: 73
   xlsx flip@87:  Error: Unexpected end of DEFLATE data
   xlsx set@3033: Error: Invalid Huffman code
   ...
by kind: {"Error": 73}
```

**Corrupt DEFLATE data threw a bare `Error`.** `ZipError` was already imported in `zip/deflate.ts`; four throws had simply been missed. So a caller doing `catch (e) { if (e instanceof HucreError) }` — the documented contract — missed every corrupt-compression failure. After the fix, 0 escapes across ~3,600 mutations over six readers.

Seeded, because a failure you cannot reproduce has told you nothing and a suite that runs different cases each time makes a red build a coin toss. Bounded: the whole file runs in ~2 seconds, which is what keeps it in CI rather than in a nightly nobody reads. There is also a wall-clock check, because the failure `limits.ts` exists to prevent is not a wrong answer but a process that never comes back.

## 2. The corpus — and writing it found an inconsistency

Nineteen deliberately-broken files, **built in code rather than committed as binaries**: a directory of opaque `.xlsx` files tells a reader nothing about what is wrong with each one, and cannot be adjusted when a part's layout changes.

The boundary it draws is the one that matters — **short is fine, wrong is not.** A file missing `sharedStrings.xml` reads short; a file missing `xl/workbook.xml` is not a workbook and says so.

Writing it turned up that **a malformed cell reference took out the whole sheet** where every other content damage costs one cell. Those are now two different failures, on the distinction `clampColumnBound` twenty lines below already draws:

- past the grid (`AAAAAA1`, row 2,000,000) — a resource claim, still throws
- not a reference at all (`B` with no row, `A0`) — claims nothing, so it drops the cell and warns `malformed-cell-ref`

The two existing tests that pin the throwing behaviour both use `AAAAAA1`, so they are unaffected — which is the check that this split is the right one.

## 3. The properties — and they found two facts about CSV

`parseCsv(writeCsv(rows))`, `parseNdjson(writeNdjson(records))`, and the A1 helpers — the last **exhaustively across all 16,384 columns** rather than sampled, because exhaustive beats random when it is affordable.

Two things surfaced, neither a defect, both now written into `docs/PARITY.md`:

- **A final row of one empty cell is lost.** It renders as nothing after the preceding terminator, and a file ending in a terminator is universally read as having no record after it. A trailing row of *two* empty cells survives, because it renders as a bare delimiter.
- **Delimiter auto-detection can be defeated.** `[["with,comma"], ["with\ttab"]]` written with the default comma quotes its one comma, so the only unquoted separator left in the file is a tab — and `parseCsv` is *right* to call it tab-separated. There is no reading of those bytes that recovers the intent.

The property is scoped to name the delimiter on both sides, which is what a caller who cares does; the auto-detection case gets its own test that documents the miss rather than hiding it.

**`fast-check` is deliberately not added.** These properties are about the inverse, not about shrinking a counterexample out of a rich generator space, and a seeded loop covers them without spending the zero-dependency claim. The door is not closed — it just is not open yet.

## Tests

`test/fuzz-robustness.test.ts` (7), `test/corpus-malformed.test.ts` (19), `test/property-roundtrip.test.ts` (14), plus `test/_fuzz.ts`. Mutation-checked: 4 of the fuzz cases fail against `main`, naming the reproducible input (`flip@87`).

`pnpm lint`, `pnpm typecheck`, 10136 tests green; coverage and size budgets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
