### PR TITLE
perf(xlsx): emit the hot cell shapes directly — refs #472

### DIFF
--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -84,6 +84,10 @@ const NS_R = "http://schemas.openxmlformats.org/officeDocument/2006/relationship
 
 /** Convert a 0-based column index to an Excel column letter (A, B, ... Z, AA, AB, ...) */
 export function colToLetter(col: number): string {
+  // Memoising this was tried and measured: it is 10 ms of a 2,814 ms
+  // write, 0.36%, and the change did not show above run-to-run noise. A
+  // cache that cannot be measured is complexity for nothing. See #472.
+  //
   // Pure arithmetic on an unchecked number produced references no reader
   // can parse — "@" for -1, a NUL character for NaN, "XFE" one past the
   // last column. See #364.
@@ -855,6 +859,34 @@ function resolveRows(sheet: WriteSheet): Array<Array<ResolvedCell | null>> {
  * had to do exactly that for formula-result typing and the non-finite
  * guard. See #439 §B.
  */
+/**
+ * The cell shapes that make up essentially all of a data sheet, emitted
+ * straight into a string.
+ *
+ * `xmlElement` is the right tool for the document's structure — a hundred
+ * elements built once each — and the wrong one for the two million built
+ * here. Per cell it allocated an attrs object literal, a children array,
+ * a joined string, and then the element; profiling `writeXlsx` at
+ * 100,000 x 12 put `xmlElement` at 16.6% of on-CPU time and the garbage
+ * collector at 20.3%. See #472.
+ *
+ * The attribute order — `r`, then `t`, then `s` — is the order the object
+ * literals produced, and the output is byte-identical. The formula and
+ * rich-text paths still go through `xmlElement`: they are a small
+ * fraction of any real sheet and they are the shapes worth keeping
+ * readable.
+ */
+function simpleCell(ref: string, styleIdx: number, type: string, content: string): string {
+  if (styleIdx === 0) {
+    return type === ""
+      ? `<c r="${ref}"><v>${content}</v></c>`
+      : `<c r="${ref}" t="${type}"><v>${content}</v></c>`
+  }
+  return type === ""
+    ? `<c r="${ref}" s="${styleIdx}"><v>${content}</v></c>`
+    : `<c r="${ref}" t="${type}" s="${styleIdx}"><v>${content}</v></c>`
+}
+
 export function serializeCell(
   row: number,
   col: number,
@@ -980,23 +1012,22 @@ export function serializeCell(
 
   // Error value (e.g. #VALUE!, #REF!, #N/A, #NAME?, #NULL!, #DIV/0!, #NUM!)
   if (typeof value === "string" && EXCEL_ERRORS.has(value)) {
-    const attrs: Record<string, string | number> = { r: ref, t: "e" }
-    if (styleIdx !== 0) attrs["s"] = styleIdx
-    return xmlElement("c", attrs, [xmlElement("v", undefined, value)])
+    return simpleCell(ref, styleIdx, "e", value)
   }
 
   // String value
   if (typeof value === "string") {
     if (inlineStrings) {
       // Inline string: <c t="inlineStr"><is><t>value</t></is></c>
-      const attrs: Record<string, string | number> = { r: ref, t: "inlineStr" }
-      if (styleIdx !== 0) attrs["s"] = styleIdx
-      return xmlElement("c", attrs, [xmlElement("is", undefined, [xmlTextElement(value)])])
+      // `writeXlsxStream` defaults to this path, so it is as hot as the
+      // shared-string one and gets the same treatment. `xmlTextElement`
+      // still decides `xml:space`; only the wrappers are inlined.
+      const inner = `<is>${xmlTextElement(value)}</is>`
+      return styleIdx === 0
+        ? `<c r="${ref}" t="inlineStr">${inner}</c>`
+        : `<c r="${ref}" t="inlineStr" s="${styleIdx}">${inner}</c>`
     }
-    const ssIdx = sharedStrings.add(value)
-    const attrs: Record<string, string | number> = { r: ref, t: "s" }
-    if (styleIdx !== 0) attrs["s"] = styleIdx
-    return xmlElement("c", attrs, [xmlElement("v", undefined, String(ssIdx))])
+    return simpleCell(ref, styleIdx, "s", String(sharedStrings.add(value)))
   }
 
   // Number value
@@ -1008,24 +1039,17 @@ export function serializeCell(
       }
       return null
     }
-    const attrs: Record<string, string | number> = { r: ref }
-    if (styleIdx !== 0) attrs["s"] = styleIdx
-    return xmlElement("c", attrs, [xmlElement("v", undefined, String(value))])
+    return simpleCell(ref, styleIdx, "", String(value))
   }
 
   // Boolean value
   if (typeof value === "boolean") {
-    const attrs: Record<string, string | number> = { r: ref, t: "b" }
-    if (styleIdx !== 0) attrs["s"] = styleIdx
-    return xmlElement("c", attrs, [xmlElement("v", undefined, value ? "1" : "0")])
+    return simpleCell(ref, styleIdx, "b", value ? "1" : "0")
   }
 
   // Date value
   if (value instanceof Date) {
-    const serial = dateToSerial(value, is1904)
-    const attrs: Record<string, string | number> = { r: ref }
-    if (styleIdx !== 0) attrs["s"] = styleIdx
-    return xmlElement("c", attrs, [xmlElement("v", undefined, String(serial))])
+    return simpleCell(ref, styleIdx, "", String(dateToSerial(value, is1904)))
   }
 
   return null


### PR DESCRIPTION
Refs #472. The issue asked for the honest sequence — prototype, run `pnpm bench` before and after, decide from the numbers rather than from the shape of the code. Doing that changed **both** answers it suggested.

## The cheap change it recommended first does not pay

> `cellRef` is called once per cell and rebuilds the column letter every time... a memo of `colToLetter` for the first few thousand columns is a two-line change with a measurable answer.

The answer is measurable, and it is *no*:

```
colToLetter loop x cells               10 ms   0.36% of the write
cellRef (letter + row) x cells         36 ms   1.3%
writeXlsx (whole)                    2814 ms
```

I implemented the memo and measured it in alternating pairs. The run-to-run spread (2859–3115 ms) was larger than any difference it made. A cache that cannot be measured is complexity for nothing, so it is **not in this PR** — a comment in `colToLetter` records the number so nobody has to try it again.

## The structural one does

Profiling `writeXlsx` at 100,000 × 12:

| | before |
| --- | ---: |
| (garbage collector) | 14.8% |
| `xmlElement` | 12.1% |
| `serializeCell` | 9.7% |
| `registerXf` | 8.5% |
| `cellRef` | 0.9% |

`xmlElement` is the right tool for a hundred structural elements built once each, and the wrong one for two million cells — per cell it allocated an attrs object literal, a children array, a joined string, and then the element.

The five shapes that make up essentially all of a data sheet (string, number, boolean, date, error) plus the inline-string shape are now emitted straight into a string. **Formulas and rich text still go through `xmlElement`**: they are a small fraction of any real sheet and they are the shapes worth keeping readable.

## Results

Measured in **strictly alternating pairs**, because the box drifts and absolute numbers moved 20% between sessions:

```
writeXlsx          ~17% faster    388k -> 468k cells/s    7 of 7 pairs
writeXlsxStream    ~25% faster    490k -> 650k cells/s    3 of 3 pairs
XlsxStreamWriter   ~6-13% faster                          3 of 3 pairs
```

`writeXlsxStream` was a **wash** until the inline-string branch was fast-pathed too — it defaults to inline strings, so the first attempt missed its hot path entirely. That is the kind of thing only measuring finds.

Re-profiling confirms where it went: `xmlElement` + `serializeCell` fell from **711 ms to 321 ms** of on-CPU time.

Peak RSS is unchanged at ~750 MB. The allocations removed were short-lived garbage, not retained memory, so this is a throughput change and not a memory one — worth being precise about, since #472 quotes the 758 MB figure.

## Byte-identical

The attribute order is the order the object literals produced (`r`, then `t`, then `s`). All **10,136 tests pass unchanged**, including the ones that compare bytes — which is the real check that this is a rewrite of *how*, not *what*.

## What is left

The profile's next target is `registerXf` at 9%, which is #435's territory. Left for its own measurement rather than folded in here.

`pnpm lint`, `pnpm typecheck`, coverage and size budgets all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
