### PR TITLE
fix(xlsx): a chart sheet no longer makes the whole workbook unreadable — closes #499

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,6 +122,26 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
+### Not every tab is a worksheet
+
+`xl/workbook.xml`'s `<sheets>` lists every tab whatever its kind — chart
+sheets, dialog sheets and macro sheets included — and the _relationship
+type_ is what tells them apart. A chart sheet used to make the whole
+workbook unreadable: its rId was not in the worksheet map, so the lookup
+missed and the reader threw, taking every ordinary worksheet beside it
+down too. On one corpus of real instrument-exported files that was 52
+failures out of 538. See #499.
+
+A non-worksheet tab now reads as an empty `Sheet` carrying
+`kind: "chartsheet"` (or `"dialogsheet"`). It is kept rather than skipped
+so `sheets: [2]` still selects Excel's third tab — renumbering would be a
+quieter kind of wrong. `kind` is **read-only**: hucre writes worksheets,
+and `toWriteOptions` reports it as a drop.
+
+`streamXlsxRows` on a non-worksheet tab yields nothing rather than
+throwing. A missing worksheet _part_ is still a `ParseError`, because
+that is damage rather than a different kind of tab.
+
 ### Ranges: two spellings, one meaning
 
 Ranges are A1 strings on `DataValidation.range`, `ConditionalRule.range`,

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -858,9 +858,32 @@ export interface RowDef {
 
 // ── Sheet ──────────────────────────────────────────────────────────
 
+/**
+ * What kind of sheet a tab holds.
+ *
+ * `xl/workbook.xml`'s `<sheets>` lists every tab whatever its kind —
+ * ECMA-376 `CT_Sheet` covers worksheets, chart sheets, dialog sheets and
+ * macro sheets alike, and the *relationship type* is what tells them
+ * apart. Only a worksheet has cells.
+ */
+export type SheetKind = "worksheet" | "chartsheet" | "dialogsheet" | "macrosheet"
+
 export interface Sheet {
   name: string
   rows: CellValue[][]
+  /**
+   * The kind of tab this is. Absent means `"worksheet"`, which is what
+   * all but a handful of sheets are.
+   *
+   * A workbook containing a chart sheet used to fail to read *entirely*
+   * — the chart sheet's relationship is not a `worksheet` one, so the
+   * lookup missed and the reader threw, taking every ordinary worksheet
+   * beside it down too. Non-worksheet tabs are now read as empty sheets
+   * so the indices still line up with Excel's tab bar, and this field is
+   * what tells you one apart from a worksheet that happens to be empty.
+   * Read-only: hucre cannot author a chart sheet. See #499.
+   */
+  kind?: SheetKind
   /** Detailed cell data (keyed by "row,col" e.g. "0,2") */
   cells?: Map<string, Cell>
   columns?: ColumnDef[]

--- a/src/sheet-ops.ts
+++ b/src/sheet-ops.ts
@@ -947,6 +947,7 @@ export function cloneSheet(sheet: Sheet, newName: string): Sheet {
   const rows = sheet.rows.map((row) => [...row])
 
   const cloned: Sheet = { name: newName, rows }
+  if (sheet.kind !== undefined) cloned.kind = sheet.kind
 
   // Deep copy cells Map
   if (sheet.cells && sheet.cells.size > 0) {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -73,6 +73,7 @@ export interface SerializedSheet {
   headerFooter?: Sheet["headerFooter"]
   view?: Sheet["view"]
   hidden?: Sheet["hidden"]
+  kind?: Sheet["kind"]
   veryHidden?: Sheet["veryHidden"]
   tables?: Sheet["tables"]
   a11y?: Sheet["a11y"]
@@ -222,6 +223,7 @@ function serializeSheet(sheet: Sheet): SerializedSheet {
   // caller set and it should survive the trip. `cloneSheet` already did
   // this; this copy did not.
   if (sheet.hidden !== undefined) out.hidden = sheet.hidden
+  if (sheet.kind !== undefined) out.kind = sheet.kind
   if (sheet.veryHidden !== undefined) out.veryHidden = sheet.veryHidden
   if (sheet.tables) out.tables = sheet.tables
   if (sheet.a11y) out.a11y = sheet.a11y
@@ -408,6 +410,7 @@ function deserializeSheet(ss: SerializedSheet): Sheet {
   if (ss.headerFooter) sheet.headerFooter = ss.headerFooter
   if (ss.view) sheet.view = ss.view
   if (ss.hidden !== undefined) sheet.hidden = ss.hidden
+  if (ss.kind !== undefined) sheet.kind = ss.kind
   if (ss.veryHidden !== undefined) sheet.veryHidden = ss.veryHidden
   if (ss.tables) sheet.tables = ss.tables
   if (ss.a11y) sheet.a11y = ss.a11y

--- a/src/write-model.ts
+++ b/src/write-model.ts
@@ -42,6 +42,7 @@ const NO_AUTHORING_API =
 
 /** Sheet fields with no `WriteSheet` counterpart at all. */
 const SHEET_DROPS: Record<string, string> = {
+  kind: "hucre writes worksheets. A chart sheet or dialog sheet is read as an empty sheet so the tab indices line up, and writing one back is not something the writer can do.",
   slicers: NO_AUTHORING_API,
   timelines: NO_AUTHORING_API,
   threadedComments: NO_AUTHORING_API,

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -3,6 +3,7 @@
 
 import type {
   Sheet,
+  SheetKind,
   Workbook,
   ReadOptions,
   ReadInput,
@@ -361,9 +362,19 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
 
   // 8. Build a map of rId → sheet relationship for worksheet paths
   const sheetRelMap = new Map<string, string>()
+  // …and one for the tabs that are not worksheets. `<sheets>` lists
+  // every tab whatever its kind and the relationship type is what tells
+  // them apart, so a chart sheet's rId simply never entered the map
+  // above — and the lookup below threw, taking every ordinary worksheet
+  // in the book down with it. See #499.
+  const nonWorksheetKinds = new Map<string, SheetKind>()
   for (const rel of workbookRels) {
     if (matchesRelType(rel.type, "worksheet")) {
       sheetRelMap.set(rel.id, resolvePath(workbookDir, rel.target))
+    } else if (matchesRelType(rel.type, "chartsheet")) {
+      nonWorksheetKinds.set(rel.id, "chartsheet")
+    } else if (matchesRelType(rel.type, "dialogsheet")) {
+      nonWorksheetKinds.set(rel.id, "dialogsheet")
     }
   }
 
@@ -375,6 +386,19 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
 
   const sheets = []
   for (const info of sheetsToRead) {
+    // A tab that is not a worksheet has no cells to read. It becomes an
+    // empty sheet rather than being skipped, so `sheets: [2]` still
+    // selects what Excel's third tab is — renumbering would be a quieter
+    // kind of wrong.
+    const kind = nonWorksheetKinds.get(info.rId)
+    if (kind !== undefined) {
+      const placeholder: Sheet = { name: info.name, rows: [], kind }
+      if (info.state === "hidden") placeholder.hidden = true
+      if (info.state === "veryHidden") placeholder.veryHidden = true
+      sheets.push(placeholder)
+      continue
+    }
+
     const wsPath = sheetRelMap.get(info.rId)
     if (!wsPath || !zip.has(wsPath)) {
       throw new ParseError(`Invalid XLSX: missing worksheet file for sheet "${info.name}"`)

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -684,9 +684,15 @@ function resolveFromParts(
   if (!targetSheet) return null
 
   const sheetRelMap = new Map<string, string>()
+  // A tab that is not a worksheet has no rows. Recognising it here is
+  // what separates "nothing to stream" from "the part is missing", which
+  // is real damage and still throws. See #499.
+  const nonWorksheetRIds = new Set<string>()
   for (const rel of workbookRels) {
     if (matchesRelType(rel.type, REL_WORKSHEET)) {
       sheetRelMap.set(rel.id, resolvePath(workbookDir, rel.target))
+    } else if (matchesRelType(rel.type, "chartsheet") || matchesRelType(rel.type, "dialogsheet")) {
+      nonWorksheetRIds.add(rel.id)
     }
   }
   const wsPath = sheetRelMap.get(targetSheet.rId)
@@ -899,9 +905,15 @@ export async function* streamXlsxRows(
 
   // 8. Build rId → worksheet path map
   const sheetRelMap = new Map<string, string>()
+  // A tab that is not a worksheet has no rows. Recognising it here is
+  // what separates "nothing to stream" from "the part is missing", which
+  // is real damage and still throws. See #499.
+  const nonWorksheetRIds = new Set<string>()
   for (const rel of workbookRels) {
     if (matchesRelType(rel.type, REL_WORKSHEET)) {
       sheetRelMap.set(rel.id, resolvePath(workbookDir, rel.target))
+    } else if (matchesRelType(rel.type, "chartsheet") || matchesRelType(rel.type, "dialogsheet")) {
+      nonWorksheetRIds.add(rel.id)
     }
   }
 
@@ -910,6 +922,8 @@ export async function* streamXlsxRows(
   if (!targetSheet) {
     return // No matching sheet — yield nothing
   }
+
+  if (nonWorksheetRIds.has(targetSheet.rId)) return
 
   const wsPath = sheetRelMap.get(targetSheet.rId)
   if (!wsPath || !zip.has(wsPath)) {

--- a/test/clone-sheet-coverage.test.ts
+++ b/test/clone-sheet-coverage.test.ts
@@ -43,6 +43,7 @@ const FULL_CELL: Required<Cell> = {
 /** Every field of `Sheet`, same reason. */
 const FULL_SHEET: Required<Sheet> = {
   name: "Full",
+  kind: "worksheet",
   rows: [
     ["a", 1],
     ["b", 2],

--- a/test/real-files.test.ts
+++ b/test/real-files.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { readFileSync } from "node:fs"
-import { read, readXls, readXlsb, readXlsx } from "../src/index"
+import { read, readXls, readXlsb, readXlsx, streamXlsxRows } from "../src/index"
 import type { Cell, CellStyle, ReadOptions, Sheet, Workbook } from "../src/_types"
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -383,23 +383,44 @@ describe("workbooks written by Excel, not by this test suite", () => {
 
   // A chart sheet — a chart on its own tab — is not a worksheet, and
   // xl/workbook.xml's <sheets> lists it anyway; the relationship type is
-  // what separates the kinds. It gets its own block rather than a golden
-  // model because today the read throws, so there is no model to compare.
+  // what separates the kinds.
   //
-  // This one is not hypothetical: it is the single largest failure in a
+  // This one was not hypothetical: it was the single largest failure in a
   // corpus of real instrument-exported workbooks, 52 files out of 538.
+  // Fixed in #499 — the block below is what it does now.
   describe("excel-chartsheet.xlsx", () => {
-    it.fails("#499 — a workbook containing a chart sheet can be read at all", async () => {
+    it("#499 — the workbook reads, and the worksheet beside it survives", async () => {
       const wb = await readXlsx(bytes("excel-chartsheet.xlsx"))
-      // The chart sheet carries no cells, so whatever it is represented
-      // as, the ordinary worksheet next to it has to survive.
+
       expect(wb.sheets.some((s) => s.rows.length > 0)).toBe(true)
     })
 
-    it("fails the way #499 describes, and not some other way", async () => {
-      await expect(readXlsx(bytes("excel-chartsheet.xlsx"))).rejects.toThrow(
-        /missing worksheet file for sheet/,
-      )
+    it("keeps the chart sheet as a tab, so the indices are Excel's", async () => {
+      // Skipping it would renumber every sheet after it, which is a
+      // quieter kind of wrong than throwing.
+      const wb = await readXlsx(bytes("excel-chartsheet.xlsx"))
+
+      expect(wb.sheets).toHaveLength(2)
+      expect(wb.sheets.map((s) => s.kind)).toEqual(["chartsheet", undefined])
+      expect(wb.sheets[0]?.rows).toEqual([])
+    })
+
+    it("streams the worksheet by name", async () => {
+      const rows: unknown[][] = []
+      for await (const row of streamXlsxRows(bytes("excel-chartsheet.xlsx"), { sheet: 1 })) {
+        rows.push(row.values)
+      }
+
+      expect(rows.length).toBeGreaterThan(0)
+    })
+
+    it("streams a chart sheet as nothing, rather than throwing", async () => {
+      const rows: unknown[][] = []
+      for await (const row of streamXlsxRows(bytes("excel-chartsheet.xlsx"), { sheet: 0 })) {
+        rows.push(row.values)
+      }
+
+      expect(rows).toEqual([])
     })
   })
 


### PR DESCRIPTION
Closes #499. Found by the corpus merged in #500.

## The bug

`xl/workbook.xml`'s `<sheets>` lists every tab whatever its kind — `CT_Sheet` covers worksheets, chart sheets, dialog sheets and macro sheets alike — and the **relationship type** is what tells them apart. The reader built its rId → path map from `worksheet` relationships only:

```ts
if (matchesRelType(rel.type, "worksheet")) sheetRelMap.set(rel.id, ...)
```

so a chart sheet's rId was never in it, the lookup missed, and it threw:

```
Invalid XLSX: missing worksheet file for sheet "Chart1"
```

Not for the chart sheet — for the **workbook**. Every ordinary worksheet beside it went down too. On the corpus of real instrument-exported files behind the issue that was **52 failures out of 538**.

## The fix, and the design call

A non-worksheet tab reads as an empty `Sheet` carrying `kind: "chartsheet"` / `"dialogsheet"`.

**Kept rather than skipped**, which is the decision the issue flagged. Skipping renumbers every sheet after it, so `sheets: [2]` would quietly select a different tab than the one Excel shows — a worse failure than the one being fixed, because it produces a plausible answer instead of an error.

`kind` is read-only. hucre writes worksheets; `toWriteOptions` reports it as a drop with that reason.

`streamXlsxRows` gets the same distinction: a non-worksheet target yields nothing, a missing worksheet **part** is still a `ParseError`. That line matters — the whole bug was failing to tell "a different kind of tab" from "damage".

## The registers earned their keep

Adding `kind` to `Sheet` broke `tsc` in three places, which is exactly what they exist for: the `Required<Sheet>` fixture, the `SHEET_DROPS` exhaustiveness check, and then `cloneSheet` and the worker serializer each needing their copy. Nothing here was found by hand.

## Tests

The corpus test carried this as `it.fails("#499 …")` with its issue number. It is now four passing assertions — the workbook reads, the tab count and kinds are Excel's, the worksheet streams by index, and a chart sheet streams as nothing — and the "fails the way #499 describes" companion is deleted.

Mutation-checked: 3 fail against `main`.

`pnpm lint`, `pnpm typecheck`, 10235 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)