### PR TITLE
fix(xlsx): read ISO-8601 date cells as dates — closes #496

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,6 +122,22 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
+### ISO-8601 date cells
+
+`ST_CellType` (§18.18.11) has seven members and the reader's switch had
+six: `d`, "cell containing a date in the ISO 8601 format", fell through
+to the numeric branch and came back as a **string**. openpyxl writes it
+whenever `iso_dates=True`, so the same day under the same number format
+read as a `Date` when stored as a serial and as text when stored as ISO.
+Fixed in #496.
+
+The parse is deliberately strict — `new Date(text)` accepts a great deal
+that is not ISO 8601 — and two cases stay text on purpose: a bare time
+(`13:45:30`, which openpyxl writes for a `datetime.time`) has no day to
+anchor it, and anything that is not an ISO date is left as the file wrote
+it. An unqualified time is read as UTC, and `date1904` is **not** applied:
+the value is an instant, not an offset from an epoch.
+
 ### Not every tab is a worksheet
 
 `xl/workbook.xml`'s `<sheets>` lists every tab whatever its kind — chart

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -1748,6 +1748,37 @@ function processCell(
       cellType = "error"
       break
     }
+    case "d": {
+      // ISO 8601 date (ECMA-376 Part 1, §18.18.11 ST_CellType). Every
+      // other member of that enumeration had a case; this one fell
+      // through to `n`, where `Number("2024-03-17")` is NaN and the
+      // value landed in the "shouldn't happen, but be safe" arm as a
+      // *string*. It does happen: openpyxl writes it whenever
+      // `iso_dates=True`. See #496.
+      //
+      // The value is an instant, not an offset from an epoch, so
+      // `date1904` must NOT be applied — unlike the serial path below,
+      // where the same day is 1,462 days apart between the two systems.
+      const parsed = parseIsoCellDate(valueText)
+      if (parsed) {
+        value = parsed
+        cellType = "date"
+      } else if (valueText !== "") {
+        // A bare time (`13:45:30`, which openpyxl emits for a
+        // `datetime.time`) is not an ISO 8601 date-time and has no day
+        // to anchor it. Left as text rather than guessed onto an epoch.
+        value = valueText
+        cellType = "string"
+      } else {
+        value = null
+        cellType = "empty"
+      }
+      if (formula) {
+        formulaResult = value
+        cellType = "formula"
+      }
+      break
+    }
     case "n":
     default: {
       // Number (explicit or implied)
@@ -2083,4 +2114,32 @@ function parseColorAttrs(attrs: Record<string, string>): Color {
     color.indexed = Number(attrs["indexed"])
   }
   return color
+}
+
+/**
+ * Parse the value of a `t="d"` cell — an ISO 8601 date or date-time.
+ *
+ * Deliberately strict. `new Date(text)` accepts a great deal that is not
+ * ISO 8601 and answers `Invalid Date` for the rest, so a loose parse here
+ * would turn arbitrary cell text into dates. The shapes accepted are the
+ * ones ECMA-376 §18.18.11 describes and that producers actually write:
+ * `YYYY-MM-DD`, optionally with a time, optionally with a zone.
+ *
+ * An unqualified time is read as UTC, for the same reason the ODS and
+ * docProps readers do it: every format hucre reads records an absolute
+ * moment, and local time would make the same file mean different things
+ * on different machines. See #415, #474.
+ */
+function parseIsoCellDate(text: string): Date | undefined {
+  const trimmed = text.trim()
+  if (
+    !/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/.test(trimmed)
+  ) {
+    return undefined
+  }
+  const zoned = /(?:Z|[+-]\d{2}:?\d{2})$/.test(trimmed)
+  const hasTime = /[T ]\d{2}:/.test(trimmed)
+  const normalized = trimmed.replace(" ", "T")
+  const date = new Date(hasTime && !zoned ? `${normalized}Z` : normalized)
+  return Number.isNaN(date.getTime()) ? undefined : date
 }

--- a/test/fixtures/openpyxl-isodates.xlsx.golden.json
+++ b/test/fixtures/openpyxl-isodates.xlsx.golden.json
@@ -28,21 +28,5 @@
   ],
   "dateSystem": "1900",
   "hasAuthor": false,
-  "warnings": [],
-  "knownDefects": [
-    {
-      "issue": "#496",
-      "path": "sheets.0.rows.0.1",
-      "expected": "D:2024-03-17T00:00:00.000Z",
-      "actual": "2024-03-17",
-      "why": "an ISO-8601 date cell (t=\"d\") comes back as a string, while B4 — the same day as a serial under the same number format — comes back as a Date"
-    },
-    {
-      "issue": "#496",
-      "path": "sheets.0.rows.1.1",
-      "expected": "D:2024-03-17T13:45:30.000Z",
-      "actual": "2024-03-17T13:45:30",
-      "why": "an ISO-8601 date-time cell (t=\"d\") comes back as a string"
-    }
-  ]
+  "warnings": []
 }

--- a/test/iso-date-cells.test.ts
+++ b/test/iso-date-cells.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #496 — ECMA-376 §18.18.11 `ST_CellType` has seven members and the
+// reader's switch had six. `d` — "Cell containing a date in the ISO 8601
+// format" — fell through to `n`, where `Number("2024-03-17")` is NaN, and
+// landed in the arm commented "shouldn't happen, but be safe". It does
+// happen: openpyxl writes it whenever `iso_dates=True`.
+//
+// So the same day, under the same number format, came back as a `Date`
+// when stored as a serial and as a **string** when stored as ISO text.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+/** A workbook whose A1 is a raw `<c>` element of our choosing. */
+async function withCell(cellXml: string): Promise<Uint8Array> {
+  const base = await writeXlsx({ sheets: [{ name: "S", rows: [[1]] }] })
+  const all = await new ZipReader(base).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    zw.add(
+      name,
+      name === "xl/worksheets/sheet1.xml"
+        ? enc.encode(
+            dec
+              .decode(data)
+              .replace(
+                /<sheetData>.*<\/sheetData>/,
+                `<sheetData><row r="1">${cellXml}</row></sheetData>`,
+              ),
+          )
+        : data,
+    )
+  }
+  return zw.build()
+}
+
+async function valueOf(cellXml: string): Promise<unknown> {
+  return (await readXlsx(await withCell(cellXml))).sheets[0]!.rows[0]![0]
+}
+
+describe('t="d" cells read as dates', () => {
+  it("a plain ISO date", async () => {
+    const value = await valueOf('<c r="A1" t="d"><v>2024-03-17</v></c>')
+
+    expect(value).toBeInstanceOf(Date)
+    expect((value as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+  })
+
+  it("an ISO date-time, read as UTC when it names no zone", async () => {
+    // Same reason as the ODS and docProps readers: every format hucre
+    // reads records an absolute moment, and local time would make one
+    // file mean different things on different machines. See #415, #474.
+    const value = await valueOf('<c r="A1" t="d"><v>2024-03-17T13:45:30</v></c>')
+
+    expect((value as Date).toISOString()).toBe("2024-03-17T13:45:30.000Z")
+  })
+
+  it("honours a zone the cell does name", async () => {
+    expect(
+      (
+        (await valueOf('<c r="A1" t="d"><v>2024-03-17T13:45:30+02:00</v></c>')) as Date
+      ).toISOString(),
+    ).toBe("2024-03-17T11:45:30.000Z")
+    expect(
+      ((await valueOf('<c r="A1" t="d"><v>2024-03-17T13:45:30Z</v></c>')) as Date).toISOString(),
+    ).toBe("2024-03-17T13:45:30.000Z")
+  })
+
+  it("takes fractional seconds", async () => {
+    expect(
+      (
+        (await valueOf('<c r="A1" t="d"><v>2024-03-17T13:45:30.250Z</v></c>')) as Date
+      ).toISOString(),
+    ).toBe("2024-03-17T13:45:30.250Z")
+  })
+
+  it("does not apply the 1904 epoch to it", async () => {
+    // The value is an instant, not an offset from an epoch. The serial
+    // path shifts by 1,462 days between the two systems; this one must
+    // not move at all.
+    const bytes = await withCell('<c r="A1" t="d"><v>2024-03-17</v></c>')
+    const all = await new ZipReader(bytes).extractAll()
+    const zw = new ZipWriter()
+    for (const [name, data] of all) {
+      zw.add(
+        name,
+        name === "xl/workbook.xml"
+          ? enc.encode(dec.decode(data).replace("<workbookPr", '<workbookPr date1904="1"'))
+          : data,
+      )
+    }
+    const wb = await readXlsx(await zw.build())
+
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+  })
+})
+
+describe("what stays text, and why", () => {
+  it("a bare time has no day to anchor it", async () => {
+    // openpyxl writes this for a `datetime.time`. Guessing it onto an
+    // epoch would invent a date the file does not contain.
+    expect(await valueOf('<c r="A1" t="d"><v>13:45:30</v></c>')).toBe("13:45:30")
+  })
+
+  it("anything that is not an ISO date is left alone", async () => {
+    // `new Date(text)` accepts a great deal that is not ISO 8601, so a
+    // loose parse here would turn arbitrary cell text into dates.
+    for (const text of ["March 17 2024", "17/03/2024", "2024", "not a date", "2024-13-45"]) {
+      expect(await valueOf(`<c r="A1" t="d"><v>${text}</v></c>`), text).toBe(text)
+    }
+  })
+
+  it('an empty t="d" cell is empty, not Invalid Date', async () => {
+    expect(await valueOf('<c r="A1" t="d"><v></v></c>')).toBeNull()
+  })
+})
+
+describe("the rest of ST_CellType still behaves", () => {
+  it("a serial under a date format is still a Date, and still epoch-aware", async () => {
+    const wb = await readXlsx(
+      await writeXlsx({
+        sheets: [
+          {
+            name: "S",
+            rows: [[new Date("2024-03-17T00:00:00Z")]],
+          },
+        ],
+      }),
+    )
+
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+  })
+
+  it("a plain number is still a number", async () => {
+    expect(await valueOf('<c r="A1"><v>42</v></c>')).toBe(42)
+  })
+
+  it("an error cell is still an error", async () => {
+    expect(await valueOf('<c r="A1" t="e"><v>#DIV/0!</v></c>')).toBe("#DIV/0!")
+  })
+})


### PR DESCRIPTION
Closes #496. Found by the openpyxl half of the corpus (#498).

## The bug

`ST_CellType` (ECMA-376 §18.18.11) has seven members. The reader's switch had six — `d`, *"cell containing a date in the ISO 8601 format"*, was missing — so it fell through to the `n` branch, where `Number("2024-03-17")` is `NaN`, and landed in the arm commented *"Non-numeric value text (shouldn't happen, but be safe)"*.

The comment was accurate about expectations and wrong about the format. openpyxl writes `t="d"` whenever `iso_dates=True`.

The fixture carries its own control, which is what makes it undeniable — B1 and B4 are **the same day under the same number format**:

| cell | serialization | before | after |
| --- | --- | --- | --- |
| B1 | `<c t="d"><v>2024-03-17</v></c>` | `"2024-03-17"` (string) | `Date` |
| B2 | `<c t="d"><v>2024-03-17T13:45:30</v></c>` | string | `Date` |
| B4 | `<c><v>45368</v></c>` under `yyyy-mm-dd` | `Date` | `Date` |

## The two decisions the issue asked about

**`date1904` is not applied.** The value is an instant, not an offset from an epoch. The serial path shifts by 1,462 days between the two systems; this one must not move at all. There is a test that reads the same cell out of a `date1904="1"` workbook and expects the same instant.

**A bare time stays text.** openpyxl writes `13:45:30` for a `datetime.time`, and it has no day to anchor it — putting it on an epoch would invent a date the file does not contain.

## Strict on purpose

`new Date(text)` accepts a great deal that is not ISO 8601, so a loose parse would turn arbitrary cell text into dates. `March 17 2024`, `17/03/2024`, `2024`, `2024-13-45` all stay as the file wrote them. An unqualified time reads as UTC — the same rule the ODS and docProps readers already follow (#415, #474).

## Tests

`test/iso-date-cells.test.ts` — 11 cases, mutation-checked, 6 fail against `main`. The corpus carried this as two `it.fails` entries with the issue number; those and their `knownDefects` records are retired here, so the fixture's golden now asserts the dates directly.

`pnpm lint`, `pnpm typecheck`, 10241 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
