### PR TITLE
fix(xlsx): keep a cached formula result whatever its type — closes #497

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,6 +122,26 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
+### Cached formula results, whatever their type
+
+`Cell.formulaResult` was assigned in one place — the numeric arm of the
+cell-type switch — so a cached result survived only when it happened to
+be a number. A formula whose result is a string, an error or a boolean
+lost it.
+
+That was a round-trip loss rather than a missing field: the _writer_ has
+always been able to write those back, so `readXlsx` → `writeXlsx` emitted
+`<f>` with no `<v>`, and anything opening the result without
+recalculating saw an empty cell where Excel showed `#DIV/0!`. Fixed in
+#497.
+
+One behaviour changed with it. A formula cell now reports
+`type: "formula"` whatever its cached result is; it used to report
+`"error"` on the way in and `"formula"` on the way back out, and both
+cannot be right. `value` still holds the error token, so spotting an
+error by its value is unaffected, and a _hard-coded_ error cell — one
+with no formula — still reports `"error"`.
+
 ### ISO-8601 date cells
 
 `ST_CellType` (§18.18.11) has seven members and the reader's switch had

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -1719,9 +1719,14 @@ function processCell(
       break
     }
     case "str": {
-      // Inline formula string result
+      // Inline formula string result. `formulaResult` used to be set in
+      // the numeric arm alone, so a cached result survived only when it
+      // happened to be a number — and `readXlsx` → `writeXlsx` dropped
+      // the rest, emitting `<f>` with no `<v>`. The writer has always
+      // been able to write them back. See #497.
       value = decodeOoxmlEscapes(valueText)
       cellType = formula ? "formula" : "string"
+      if (formula) formulaResult = value
       break
     }
     case "inlineStr": {
@@ -1739,13 +1744,23 @@ function processCell(
     case "b": {
       // Boolean
       value = valueText === "1" || valueText.toLowerCase() === "true"
-      cellType = "boolean"
+      cellType = formula ? "formula" : "boolean"
+      if (formula) formulaResult = value
       break
     }
     case "e": {
-      // Error
+      // Error.
+      //
+      // A cell carrying a formula reports `type: "formula"` here, as the
+      // numeric and string arms do. It used to report `"error"` on the
+      // way in and `"formula"` on the way back out, which cannot both be
+      // right — and the round trip is the side with a second opinion.
+      // `value` still holds the error token either way, so spotting an
+      // error by its value is unaffected; a *hard-coded* error cell,
+      // which carries no formula, still reports `"error"`. See #497.
       value = valueText
-      cellType = "error"
+      cellType = formula ? "formula" : "error"
+      if (formula) formulaResult = value
       break
     }
     case "d": {

--- a/test/fixtures/excel-basic.xlsx.golden.json
+++ b/test/fixtures/excel-basic.xlsx.golden.json
@@ -32,21 +32,5 @@
   ],
   "dateSystem": "1900",
   "hasAuthor": false,
-  "warnings": [],
-  "knownDefects": [
-    {
-      "issue": "#497",
-      "path": "sheets.0.formulas.B5",
-      "expected": "1/0 => \"#DIV/0!\"",
-      "actual": "1/0 => null",
-      "why": "a formula whose cached result is an error loses that result; only numeric results survive"
-    },
-    {
-      "issue": "#497",
-      "path": "sheets.0.formulas.C5",
-      "expected": "\"x\" & \"y\" => \"xy\"",
-      "actual": "\"x\" & \"y\" => null",
-      "why": "a formula whose cached result is a string loses that result, and writeXlsx then emits <f> with no <v>"
-    }
-  ]
+  "warnings": []
 }

--- a/test/formula-result-types.test.ts
+++ b/test/formula-result-types.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #497 — `Cell.formulaResult` was assigned in exactly one place: the
+// numeric arm of the cell-type switch. A formula whose cached result is
+// a string, an error or a boolean set `value` and left `formulaResult`
+// undefined, so the cached result survived only when it happened to be a
+// number.
+//
+// Not a missing field — a round-trip loss. The *writer* has always been
+// able to write string and boolean results back, so `readXlsx` →
+// `writeXlsx` emitted `<f>` with no `<v>`, and anything opening the
+// result without recalculating saw an empty cell where Excel showed
+// `#DIV/0!` or `xy`.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+/** A workbook whose first row is raw `<c>` elements of our choosing. */
+async function withCells(cellsXml: string): Promise<Uint8Array> {
+  const base = await writeXlsx({ sheets: [{ name: "S", rows: [[1]] }] })
+  const all = await new ZipReader(base).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    zw.add(
+      name,
+      name === "xl/worksheets/sheet1.xml"
+        ? enc.encode(
+            dec
+              .decode(data)
+              .replace(
+                /<sheetData>.*<\/sheetData>/,
+                `<sheetData><row r="1">${cellsXml}</row></sheetData>`,
+              ),
+          )
+        : data,
+    )
+  }
+  return zw.build()
+}
+
+const NUMBER = '<c r="A1"><f>B1*2</f><v>24</v></c>'
+const TEXT = '<c r="B1" t="str"><f>"x" &amp; "y"</f><v>xy</v></c>'
+const ERROR = '<c r="C1" t="e"><f>1/0</f><v>#DIV/0!</v></c>'
+const BOOLEAN = '<c r="D1" t="b"><f>1=1</f><v>1</v></c>'
+
+async function cellsOf(xml: string) {
+  const wb = await readXlsx(await withCells(xml), { readStyles: true })
+  return wb.sheets[0]!.cells!
+}
+
+describe("a cached formula result survives whatever its type", () => {
+  it("number, string, error and boolean all arrive", async () => {
+    const cells = await cellsOf(`${NUMBER}${TEXT}${ERROR}${BOOLEAN}`)
+
+    expect(cells.get("0,0")?.formulaResult).toBe(24)
+    expect(cells.get("0,1")?.formulaResult).toBe("xy")
+    expect(cells.get("0,2")?.formulaResult).toBe("#DIV/0!")
+    expect(cells.get("0,3")?.formulaResult).toBe(true)
+  })
+
+  it("the formula text arrives with it", async () => {
+    const cells = await cellsOf(`${NUMBER}${TEXT}${ERROR}${BOOLEAN}`)
+
+    expect(cells.get("0,1")?.formula).toBe('"x" & "y"')
+    expect(cells.get("0,2")?.formula).toBe("1/0")
+  })
+})
+
+describe("the round trip that was losing them", () => {
+  it("readXlsx -> writeXlsx keeps every cached result", async () => {
+    // This is the whole issue: the writer could always write these back,
+    // so the loss was one-sided and silent.
+    const first = await readXlsx(await withCells(`${NUMBER}${TEXT}${ERROR}${BOOLEAN}`), {
+      readStyles: true,
+    })
+
+    const rewritten = await writeXlsx({
+      sheets: first.sheets.map((s) => ({ name: s.name, rows: s.rows, cells: s.cells })),
+    })
+    const second = (await readXlsx(rewritten, { readStyles: true })).sheets[0]!.cells!
+
+    expect(second.get("0,0")?.formulaResult).toBe(24)
+    expect(second.get("0,1")?.formulaResult).toBe("xy")
+    expect(second.get("0,2")?.formulaResult).toBe("#DIV/0!")
+    expect(second.get("0,3")?.formulaResult).toBe(true)
+  })
+
+  it("so the rewritten file has a <v> under every <f>", async () => {
+    const first = await readXlsx(await withCells(`${TEXT}${ERROR}`), { readStyles: true })
+    const rewritten = await writeXlsx({
+      sheets: first.sheets.map((s) => ({ name: s.name, rows: s.rows, cells: s.cells })),
+    })
+
+    const sheetXml = dec.decode(await new ZipReader(rewritten).extract("xl/worksheets/sheet1.xml"))
+
+    // An `<f>` with no `<v>` is what anything that does not recalculate
+    // reads as an empty cell.
+    expect(sheetXml).not.toMatch(/<f>[^<]*<\/f><\/c>/)
+    expect(sheetXml).toContain("xy")
+    expect(sheetXml).toContain("#DIV/0!")
+  })
+})
+
+describe("the type a formula cell reports", () => {
+  it("is `formula`, whatever the cached result is", async () => {
+    // It used to report `error` on the way in and `formula` on the way
+    // back out. Both cannot be right, and the round trip is the side
+    // with a second opinion.
+    const cells = await cellsOf(`${NUMBER}${TEXT}${ERROR}${BOOLEAN}`)
+
+    expect(cells.get("0,0")?.type).toBe("formula")
+    expect(cells.get("0,1")?.type).toBe("formula")
+    expect(cells.get("0,2")?.type).toBe("formula")
+    expect(cells.get("0,3")?.type).toBe("formula")
+  })
+
+  it("but a hard-coded error is still an error, not a formula", async () => {
+    // Excel writes these for a literal error value. Nothing about them
+    // changed, and spotting an error by its value works either way.
+    const cells = await cellsOf('<c r="A1" t="e"><v>#REF!</v></c>')
+
+    expect(cells.get("0,0")?.type).toBe("error")
+    expect(cells.get("0,0")?.formula).toBeUndefined()
+  })
+
+  it("and a plain boolean is still a boolean", async () => {
+    // No style, no formula, no comment — so there is no `cells` entry to
+    // hold a type. The value is the assertion.
+    const wb = await readXlsx(await withCells('<c r="A1" t="b"><v>1</v></c>'))
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe(true)
+    expect(wb.sheets[0]!.cells?.get("0,0")).toBeUndefined()
+  })
+})
+
+describe("the value stays where callers look for it", () => {
+  it("rows carry the cached result, not the formula text", async () => {
+    const wb = await readXlsx(await withCells(`${NUMBER}${TEXT}${ERROR}${BOOLEAN}`))
+
+    expect(wb.sheets[0]!.rows[0]).toEqual([24, "xy", "#DIV/0!", true])
+  })
+})


### PR DESCRIPTION
Closes #497. Found by the corpus.

## The bug

`Cell.formulaResult` was assigned in exactly one place — the numeric arm of the cell-type switch. The `str`, `e` and `b` arms set `value` and left it undefined, so a cached result survived only when it happened to be a number.

**This is a round-trip loss, not a missing field.** The writer has always been able to write string and boolean results back, so the loss was one-sided and silent:

```
read from Excel        E2 formulaResult=24    B5 undefined      C5 undefined
after write+read       E2 formulaResult=24    B5 null           C5 null
```

The rewritten file has `<f>` with no `<v>`, so anything that opens it without recalculating — hucre included — sees an empty cell where Excel showed `#DIV/0!` and `xy`.

## `b` had it too

The issue named `str` and `e`. The boolean arm had the same hole and is fixed with them — a formula with a cached boolean result is as ordinary as the others, and leaving it would have been fixing the reported symptom rather than the bug.

## The type question, answered

The issue flagged that a formula-with-error-result reports `type: "error"` in and `"formula"` out, and that both cannot be right.

Resolved toward `"formula"`, because the round trip is the side with a second opinion — the writer already treats it that way, and the numeric and string arms already reported `"formula"`. Two things are unchanged and tested:

- `value` still holds the error token, so spotting an error by its value works exactly as before.
- A **hard-coded** error cell (`<c t="e"><v>#REF!</v></c>`, no formula) still reports `"error"`.

## Tests

`test/formula-result-types.test.ts` — 8 cases, mutation-checked, 4 fail against `main`. One asserts the thing that actually bit: after a round trip the sheet XML contains no `<f>…</f></c>` with no `<v>` between them.

The corpus carried this as two `it.fails` entries; those and their `knownDefects` records are retired, so `excel-basic.xlsx`'s golden now asserts the cached results directly.

`pnpm lint`, `pnpm typecheck`, 10250 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
