### PR TITLE
fix(xml): normalize literal line endings, as XML 1.0 requires — closes #493

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,6 +122,22 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
+### Line endings are normalized on the way in
+
+XML 1.0 §2.11 requires a processor to turn a literal CRLF, and a literal
+lone CR, into a single LF before the application sees the content.
+hucre's writer knew this — it escapes a deliberate CR as `&#13;` — and
+the parser did not, so the two disagreed.
+
+Excel writes a multi-line cell with a literal CRLF inside `<t>`, so the
+same authored workbook read as `.xlsx` gave `"line one\r\nline two"` and
+as `.xlsb` — which stores a bare LF — gave `"line one\nline two"`. Fixed
+in #493.
+
+A character reference is not a literal line ending: `&#13;` still comes
+through as CR, which is what makes a deliberate one distinguishable from
+a line break and what keeps hucre's own round trip exact.
+
 ### Cached formula results, whatever their type
 
 `Cell.formulaResult` was assigned in one place — the numeric arm of the

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -40,6 +40,32 @@ const ENTITY_MAP: Record<string, string> = {
   apos: "'",
 }
 
+// ── End-of-line normalization ─────────────────────────────────────
+
+/**
+ * Normalize literal line endings, as XML 1.0 §2.11 requires.
+ *
+ * A processor must turn a literal CRLF, and a literal lone CR, into a
+ * single LF *before* the application sees the content. hucre's writer has
+ * always known this — it escapes CR as `&#13;` precisely so a deliberate
+ * one survives — and the parser did not, so the two disagreed.
+ *
+ * Excel writes a multi-line cell with a literal CRLF inside `<t>`, so
+ * `readXlsx` returned `"line one\r\nline two"` where the same authored
+ * workbook saved as XLSB (which stores a bare LF) gave
+ * `"line one\nline two"`. One cell, two containers, two strings. See
+ * #493.
+ *
+ * This runs on the raw source text, before entity decoding, which is the
+ * order the spec gives and the reason it is a separate pass: `&#13;` is a
+ * *character reference*, not a literal line ending, and must come through
+ * as CR untouched.
+ */
+function normalizeEol(text: string): string {
+  if (text.indexOf("\r") === -1) return text
+  return text.replace(/\r\n?/g, "\n")
+}
+
 // ── Entity Decoding ───────────────────────────────────────────────
 
 function decodeEntities(text: string): string {
@@ -111,13 +137,13 @@ function parseAttrs(raw: string): Record<string, string> {
       i++ // skip opening quote
       const valStart = i
       while (i < len && raw.charCodeAt(i) !== quote) i++
-      attrs[name] = decodeEntities(raw.slice(valStart, i))
+      attrs[name] = decodeEntities(normalizeEol(raw.slice(valStart, i)))
       i++ // skip closing quote
     } else {
       // Unquoted value (technically not valid XML, but handle gracefully)
       const valStart = i
       while (i < len && !isWhitespace(raw.charCodeAt(i))) i++
-      attrs[name] = decodeEntities(raw.slice(valStart, i))
+      attrs[name] = decodeEntities(normalizeEol(raw.slice(valStart, i)))
     }
   }
 
@@ -256,7 +282,7 @@ export function parseSax(xml: string, handlers: SaxHandlers): void {
     while (i < len && input.charCodeAt(i) !== 60 /* < */) i++
     const rawText = input.slice(textStart, i)
     if (rawText) {
-      const decoded = decodeEntities(rawText)
+      const decoded = decodeEntities(normalizeEol(rawText))
       handlers.onText?.(decoded)
     }
   }
@@ -477,7 +503,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
       if (len - textStart > SAX_TEXT_FLUSH_CHARS) {
         const cut = safeTextSplit(buf, textStart, len)
         if (cut > textStart) {
-          handlers.onText?.(decodeEntities(buf.slice(textStart, cut)))
+          handlers.onText?.(decodeEntities(normalizeEol(buf.slice(textStart, cut))))
           return buf.slice(cut)
         }
       }
@@ -486,7 +512,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
 
     const rawText = buf.slice(textStart, i)
     if (rawText) {
-      const decoded = decodeEntities(rawText)
+      const decoded = decodeEntities(normalizeEol(rawText))
       handlers.onText?.(decoded)
     }
   }

--- a/test/fixtures/excel-strings.xlsx.golden.json
+++ b/test/fixtures/excel-strings.xlsx.golden.json
@@ -30,14 +30,5 @@
   ],
   "dateSystem": "1900",
   "hasAuthor": false,
-  "warnings": [],
-  "knownDefects": [
-    {
-      "issue": "#493",
-      "path": "sheets.0.rows.7.0",
-      "expected": "line one\nline two",
-      "actual": "line one\r\nline two",
-      "why": "an embedded newline comes back as CRLF from xlsx and LF from xlsb, for the same authored cell"
-    }
-  ]
+  "warnings": []
 }

--- a/test/xml-eol-normalization.test.ts
+++ b/test/xml-eol-normalization.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+import { parseXml } from "../src/xml/parser"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #493 — XML 1.0 §2.11 requires a processor to turn a literal CRLF, and
+// a literal lone CR, into a single LF before the application sees the
+// content. hucre's writer knew this and the parser did not, so the two
+// disagreed with each other.
+//
+// Excel writes a multi-line cell with a literal CRLF inside `<t>`, so
+// `readXlsx` returned "line one\r\nline two" where the same authored
+// workbook saved as XLSB — which stores a bare LF — gave
+// "line one\nline two". One cell, two containers, two strings.
+//
+// Nothing caught it because every multi-line-string test in the suite
+// builds its own XML with `\n`, so the reader had never been shown what
+// Excel actually emits.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+const textOf = (xml: string): string => {
+  const el = parseXml(xml)
+  return el.children.filter((c): c is string => typeof c === "string").join("")
+}
+
+describe("literal line endings in text", () => {
+  it("CRLF becomes LF", () => {
+    expect(textOf("<t>line one\r\nline two</t>")).toBe("line one\nline two")
+  })
+
+  it("a lone CR becomes LF", () => {
+    expect(textOf("<t>line one\rline two</t>")).toBe("line one\nline two")
+  })
+
+  it("an LF is left alone", () => {
+    expect(textOf("<t>line one\nline two</t>")).toBe("line one\nline two")
+  })
+
+  it("a run of them normalizes to a run of LFs", () => {
+    expect(textOf("<t>a\r\n\r\nb\r\rc</t>")).toBe("a\n\nb\n\nc")
+  })
+})
+
+describe("a character reference is not a literal line ending", () => {
+  it("&#13; survives as CR", () => {
+    // This is why normalization runs on the raw source *before* entity
+    // decoding, and why it is a separate pass rather than a step inside
+    // the decoder. hucre's own writer escapes CR as `&#13;` precisely so
+    // a deliberate one can be told apart from a line break.
+    expect(textOf("<t>a&#13;b</t>")).toBe("a\rb")
+  })
+
+  it("&#13;&#10; survives as CRLF", () => {
+    expect(textOf("<t>a&#13;&#10;b</t>")).toBe("a\r\nb")
+  })
+
+  it("&#xD; survives too", () => {
+    expect(textOf("<t>a&#xD;b</t>")).toBe("a\rb")
+  })
+})
+
+describe("attribute values get the same treatment", () => {
+  it("a literal CRLF in an attribute normalizes", () => {
+    expect(parseXml('<c v="a\r\nb"/>').attrs.v).toBe("a\nb")
+  })
+
+  it("and a character reference in one does not", () => {
+    expect(parseXml('<c v="a&#13;b"/>').attrs.v).toBe("a\rb")
+  })
+})
+
+describe("through the readers", () => {
+  /** Put a raw shared string into a workbook, bytes and all. */
+  async function withSharedString(inner: string): Promise<Uint8Array> {
+    const base = await writeXlsx({ sheets: [{ name: "S", rows: [["placeholder"]] }] })
+    const all = await new ZipReader(base).extractAll()
+    const zw = new ZipWriter()
+    for (const [name, data] of all) {
+      zw.add(
+        name,
+        name === "xl/sharedStrings.xml"
+          ? enc.encode(dec.decode(data).replace(/<si>.*<\/si>/, `<si><t>${inner}</t></si>`))
+          : data,
+      )
+    }
+    return zw.build()
+  }
+
+  it("a cell Excel wrote with a literal CRLF reads as LF", async () => {
+    const wb = await readXlsx(await withSharedString("line one\r\nline two"))
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("line one\nline two")
+  })
+
+  it("a deliberate CR still round-trips through hucre's own writer", async () => {
+    // The writer escapes it; the parser must not then eat it.
+    const wb = await readXlsx(
+      await writeXlsx({ sheets: [{ name: "S", rows: [["a\rb", "c\r\nd", "e\nf"]] }] }),
+    )
+
+    expect(wb.sheets[0]!.rows[0]).toEqual(["a\rb", "c\r\nd", "e\nf"])
+  })
+})


### PR DESCRIPTION
Closes #493. Found by the corpus.

## The bug

XML 1.0 §2.11 requires a processor to turn a literal CRLF, and a literal lone CR, into a single LF **before** the application sees the content.

hucre's writer has always known this — it escapes a deliberate CR as `&#13;` for exactly this reason. The parser did not. So the two disagreed with each other, and the corpus made it visible: `excel-strings.xlsx` and `excel-strings.xlsb` are the *same authored workbook* saved twice by the same Excel.

| container | bytes in `<t>` | before | after |
| --- | --- | --- | --- |
| `.xlsx` | `… 0d 0a …` literal CRLF | `"line one\r\nline two"` | `"line one\nline two"` |
| `.xlsb` | bare LF | `"line one\nline two"` | unchanged |

One authored cell, two containers, two different strings out.

## Why it runs where it runs

The normalization happens on the **raw source, before entity decoding**. That is the order the spec gives, and it is the reason this is a separate pass rather than a step inside the decoder:

```
<t>a&#13;b</t>   →  "a\rb"     a character reference is not a line ending
<t>a\r\nb</t>    →  "a\nb"     a literal one is
```

That distinction is what keeps a deliberate carriage return tellable from a line break — and what keeps hucre's own round trip exact, since its writer escapes them. There is a test for each direction.

Applied to attribute values as well as text: §2.11 is about the document, not about one production.

## Why nothing caught it

Every multi-line-string test in the suite builds its own XML with `\n`, so the parser had never been shown what Excel actually emits. Exactly the class #464 predicted.

## Tests

`test/xml-eol-normalization.test.ts` — 11 cases, mutation-checked, 5 fail against `main`. The corpus carried this as `it.fails` with the issue number; that entry and its `knownDefects` record are retired.

`pnpm lint`, `pnpm typecheck`, 10254 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
