### PR TITLE
chore: name the fixture generators for their producers — closes #508

### DIFF
--- a/scripts/fixtures/make-exceljs-fixtures.mjs
+++ b/scripts/fixtures/make-exceljs-fixtures.mjs
@@ -16,7 +16,7 @@
 // once-in-a-while thing:
 //
 //   mkdir -p /tmp/gen && cd /tmp/gen && npm init -y && npm i exceljs
-//   node /path/to/hucre/scripts/make-fixtures.mjs /tmp/gen/node_modules
+//   node /path/to/hucre/scripts/fixtures/make-exceljs-fixtures.mjs /tmp/gen/node_modules
 //
 // Licensing: ExcelJS is MIT, and every value in these files was written
 // here. Nothing is scraped and no third-party document is redistributed.
@@ -28,14 +28,16 @@ import { createRequire } from "node:module"
 
 const modulesDir = process.argv[2]
 if (!modulesDir) {
-  console.error("usage: node scripts/make-fixtures.mjs <path-to-node_modules-with-exceljs>")
+  console.error(
+    "usage: node scripts/fixtures/make-exceljs-fixtures.mjs <path-to-node_modules-with-exceljs>",
+  )
   process.exit(1)
 }
 
 const require = createRequire(join(modulesDir, "index.js"))
 const ExcelJS = require("exceljs")
 
-const outDir = fileURLToPath(new URL("../test/fixtures/third-party", import.meta.url))
+const outDir = fileURLToPath(new URL("../../test/fixtures/third-party", import.meta.url))
 mkdirSync(outDir, { recursive: true })
 
 /** Written to disk and asserted against in test/third-party-fixtures.test.ts. */

--- a/test/fixtures/third-party/README.md
+++ b/test/fixtures/third-party/README.md
@@ -22,7 +22,7 @@ someone with those tools; this needed only `npm i exceljs`.
 ## Licensing
 
 ExcelJS is MIT. Every value inside these files was written in
-`scripts/make-fixtures.mjs` in this repository. Nothing is scraped and no
+`scripts/fixtures/make-exceljs-fixtures.mjs` in this repository. Nothing is scraped and no
 third-party document is redistributed.
 
 ## Regenerating
@@ -32,7 +32,7 @@ bytes, so neither CI nor a contributor needs it:
 
 ```bash
 mkdir -p /tmp/gen && cd /tmp/gen && npm init -y && npm i exceljs
-node /path/to/hucre/scripts/make-fixtures.mjs /tmp/gen/node_modules
+node /path/to/hucre/scripts/fixtures/make-exceljs-fixtures.mjs /tmp/gen/node_modules
 ```
 
 Regenerating changes the bytes (timestamps, ExcelJS version). The tests


### PR DESCRIPTION
Closes #508. The collision was mine, so this is the rename you suggested:

```
scripts/make-fixtures.mjs  ->  scripts/fixtures/make-exceljs-fixtures.mjs
```

All three generators now sit in `scripts/fixtures/` and say what they generate.

One thing worth mentioning because it would have been a silent breakage: the script resolves its output path relative to itself, so moving it a directory deeper needed `../test/fixtures/third-party` to become `../../`. I ran it to confirm the eleven fixtures landed where they belong, then restored the committed bytes rather than keeping the regenerated ones — the corpus README's own advice about not regenerating casually applies to me too.

## On the larger question

Agreed, and not doing it. Your reasoning is the right reasoning: the eleven ExcelJS golden models exist in the shape they do because a person wrote them, and re-deriving them mechanically into the `real-files` format would quietly undo the exact property #464 was asking for. If the two ever merge it should be by hand, as its own change, and with someone reading each fixture.

The one thing I would add: `real-files.test.ts`'s design is the better of the two — hand-written models plus the `knownDefects` mechanism — and it has now paid for itself four times over (#493, #494, #496, #497 are all merged, each with its `it.fails` flipped to a real assertion). If a fourth producer shows up, that is the one to extend.
