### PR TITLE
feat(xlsx): a sparse sheet has a way out — closes #501

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,6 +122,36 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
+### A sparse sheet has a way out
+
+`Sheet.rows` being a dense rectangle means a read costs the bounding box
+rather than the cell count. That is right for almost every sheet and
+wrong for a sparse one: a real workbook with 82,000 values scattered over
+a 305,612,208-slot box — 0.03% filled — could not be read at all, and
+none of the three options the error named would have helped. Raising
+`maxTotalCells` trades a clean error for a multi-gigabyte allocation,
+`range` needs you to already know where the data is, and `maxRows` bounds
+rows when the problem is columns. See #501.
+
+Two answers, and the error now names both:
+
+- **`streamXlsxRows`** already read that file, a row at a time, and the
+  message never said so. It is the better answer when you only need to
+  walk the rows once.
+- **`readXlsx(input, { sparse: true })`** returns `cells` keyed
+  `"row,col"` and leaves `rows` empty. Memory tracks the values rather
+  than the box, the bounding-box limit does not apply because nothing
+  dense is built, and you get a `Workbook` — which is what streaming
+  cannot give you.
+
+The error also reports how full the box actually is, which is what turns
+"your sheet is too large" into "your sheet is mostly nothing" — a
+different problem with a different answer.
+
+`sparse` is XLSX-only and off by default. With it on, anything that reads
+`Sheet.rows` — `sheetToObjects`, `readObjects`, the writers — sees an
+empty sheet; `cells` is the whole answer.
+
 ### A style-only cell does not widen the sheet
 
 Excel writes a self-closing `<c r="WVF45" s="3"/>` for every position

--- a/src/_types.ts
+++ b/src/_types.ts
@@ -1565,6 +1565,30 @@ export interface ReadOptions {
    */
   maxInputBytes?: number
   /**
+   * Return cells without materializing the grid. Default: false.
+   *
+   * `Sheet.rows` is a dense rectangle, so the cost of a read is the
+   * bounding box rather than the cell count — which is right for almost
+   * every sheet and wrong for a sparse one. A real workbook with 82,000
+   * values scattered over a 305,612,208-slot box (0.03% filled) could
+   * not be read at all: raising {@link maxTotalCells} trades a clean
+   * error for a multi-gigabyte allocation, `range` needs you to already
+   * know where the data is, and `maxRows` bounds rows when the problem
+   * is columns. See #501.
+   *
+   * With this set, `rows` comes back empty and every cell that carries
+   * something is in {@link Sheet.cells}, keyed `"row,col"`. Memory then
+   * tracks the values rather than the box, and the bounding-box limit
+   * does not apply because nothing dense is built.
+   *
+   * `streamXlsxRows` is the other answer and the better one when you
+   * only need to walk the rows once; this is for random access, or for
+   * when you want a `Workbook`.
+   *
+   * XLSX only.
+   */
+  sparse?: boolean
+  /**
    * Maximum number of cells a single sheet may be normalized into —
    * `rows` is a dense rectangle, so this bounds the bounding box rather
    * than the cell count. Default: 20,000,000 ({@link MAX_TOTAL_CELLS}).

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -426,6 +426,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       maxRows: options?.maxRows,
       range: options?.range,
       maxTotalCells: options?.maxTotalCells,
+      sparse: options?.sparse,
       dynamicArrayCm,
       sheetName: info.name,
       onWarning: options?.onWarning,

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -53,6 +53,8 @@ export interface WorksheetContext {
   range?: string
   /** Bounding-box ceiling; see ReadOptions.maxTotalCells. Default {@link MAX_TOTAL_CELLS}. */
   maxTotalCells?: number
+  /** Skip the dense grid and return cells only; see ReadOptions.sparse. */
+  sparse?: boolean
   /** Name of the sheet being parsed, so a warning can say where it was. */
   sheetName?: string
   /** Where a dropped reference is reported; see ReadOptions.onWarning. */
@@ -164,6 +166,8 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   const merges: MergeRange[] = []
   let maxCol = -1
   let maxRow = -1
+  /** Cells that carried something — the numerator of the fill factor. */
+  let cellCount = 0
   let hasCells = false
 
   // Range filter — parse once, use in cell processing
@@ -959,6 +963,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
                 if (effCol > maxCol) maxCol = effCol
                 if (effRow > maxRow) maxRow = effRow
                 hasCells = true
+                cellCount++
               }
             }
             inCell = false
@@ -1169,8 +1174,10 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
     },
   })
 
-  // Ensure all rows have consistent length
-  if (hasCells) {
+  // Ensure all rows have consistent length. Not in sparse mode: there is
+  // no grid, which is the whole point, and the bounding-box limit below
+  // has nothing to guard.
+  if (hasCells && !ctx.sparse) {
     const colCount = maxCol + 1
     // The cost of a sheet is its bounding box, not its cell count — the
     // loop below fills every slot in it. Two in-bounds cells at opposite
@@ -1179,11 +1186,24 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
     const totalCells = (maxRow + 1) * colCount
     const cellLimit = ctx.maxTotalCells ?? MAX_TOTAL_CELLS
     if (totalCells > cellLimit) {
+      // The options this used to name were the wrong three for the case
+      // that actually hits it. A *sparse* sheet — 82k values scattered
+      // over a 305M-slot box, 0.03% fill — is not large, so raising
+      // `maxTotalCells` trades a clean error for a multi-gigabyte
+      // allocation; `range` needs the caller to already know where the
+      // data is; and `maxRows` bounds rows when the problem is columns.
+      //
+      // `streamXlsxRows` reads exactly this file today, one row at a
+      // time, and the message never mentioned it. See #501.
+      const density = totalCells > 0 ? (100 * cellCount) / totalCells : 100
       throw new ParseError(
         `Sheet "${name}" spans ${maxRow + 1} rows x ${colCount} columns ` +
-          `(${totalCells} cells), over the ${cellLimit} limit. ` +
-          `Use the \`range\` or \`maxRows\` read option to bound the area read, ` +
-          `or raise \`maxTotalCells\` if the sheet really is this large.`,
+          `(${totalCells} cells, ${density.toFixed(2)}% of them filled), ` +
+          `over the ${cellLimit} limit.\n` +
+          `  - streamXlsxRows(input) reads it a row at a time, whatever the box.\n` +
+          `  - readXlsx(input, { sparse: true }) returns the cells and no grid.\n` +
+          `  - \`range\` or \`maxRows\` bound the area, if you know where the data is.\n` +
+          `  - \`maxTotalCells\` raises the bound, if the sheet really is this large.`,
       )
     }
     for (let r = 0; r <= maxRow; r++) {
@@ -1686,12 +1706,16 @@ function processCell(
     return
   }
 
-  // Ensure row array exists
-  while (rows.length <= row) {
-    rows.push([])
-  }
-  while (rows[row].length <= col) {
-    rows[row].push(null)
+  // Ensure row array exists. Skipped in sparse mode — allocating the row
+  // out to the cell's column is the cost being avoided, and it is paid
+  // here rather than in the densify pass at the end. See #501.
+  if (!ctx.sparse) {
+    while (rows.length <= row) {
+      rows.push([])
+    }
+    while (rows[row].length <= col) {
+      rows[row].push(null)
+    }
   }
 
   let value: CellValue = null
@@ -1850,8 +1874,10 @@ function processCell(
     }
   }
 
-  // Set the value in the rows array
-  rows[row][col] = value
+  // Set the value in the rows array. In sparse mode there is no grid to
+  // set it in: the whole point is that the bounding box is not paid for.
+  // See #501.
+  if (!ctx.sparse) rows[row][col] = value
 
   // Detect Excel 2024 checkbox feature on this cell's xf — independent of
   // readStyles so the flag round-trips even without full style hydration.
@@ -1860,8 +1886,10 @@ function processCell(
       ? (ctx.styles.cellXfs[styleIndex]?.hasCheckboxFeature ?? false)
       : false
 
-  // Build Cell object if there's detail beyond the raw value
+  // Build Cell object if there's detail beyond the raw value — or always,
+  // in sparse mode, where `cells` is the only place a value can live.
   const hasDetails =
+    ctx.sparse ||
     formula !== undefined ||
     richText !== undefined ||
     (ctx.readStyles && ctx.styles && styleIndex >= 0) ||

--- a/test/sparse-read.test.ts
+++ b/test/sparse-read.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { streamXlsxRows } from "../src/xlsx/stream-reader"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import { ParseError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #501 — `Sheet.rows` is a dense rectangle, so a read costs the bounding
+// box rather than the cell count. That is right for almost every sheet
+// and wrong for a sparse one: a real workbook with 82,000 values
+// scattered over a 305,612,208-slot box — 0.03% filled — could not be
+// read at all, and none of the three options the error named would help.
+//
+// Raising `maxTotalCells` trades a clean error for a multi-gigabyte
+// allocation; `range` needs the caller to already know where the data
+// is; `maxRows` bounds rows when the problem is columns.
+//
+// Two things fix that. `streamXlsxRows` already read the file and the
+// message never said so, and `sparse: true` returns the cells with no
+// grid at all.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+function colName(index: number): string {
+  let n = index + 1
+  let out = ""
+  while (n > 0) {
+    const rem = (n - 1) % 26
+    out = String.fromCharCode(65 + rem) + out
+    n = Math.floor((n - rem) / 26)
+  }
+  return out
+}
+
+/**
+ * A sheet shaped like the one in the issue: values scattered across
+ * `cols` columns spread over a box `width` wide.
+ *
+ * The real file had 507 used columns; these use fewer, because what
+ * makes it unreadable is the *box* — 2,000 x 15,312 is 30.6M slots
+ * whatever fills it — and a million-value fixture costs the suite ten
+ * seconds to prove the same thing.
+ */
+async function sparseSheet(rowCount: number, cols: number, width: number): Promise<Uint8Array> {
+  const used = Array.from({ length: cols }, (_, i) => Math.round((i * (width - 1)) / (cols - 1)))
+  const rows: string[] = []
+  for (let r = 1; r <= rowCount; r++) {
+    rows.push(
+      `<row r="${r}">` +
+        used.map((c) => `<c r="${colName(c)}${r}"><v>${(r * c) % 97}</v></c>`).join("") +
+        "</row>",
+    )
+  }
+  const base = await writeXlsx({ sheets: [{ name: "Sparse", rows: [["seed"]] }] })
+  const all = await new ZipReader(base).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    zw.add(
+      name,
+      name === "xl/worksheets/sheet1.xml"
+        ? enc.encode(
+            dec
+              .decode(data)
+              .replace(
+                /<dimension ref="[^"]*"\/>/,
+                `<dimension ref="A1:${colName(width - 1)}${rowCount}"/>`,
+              )
+              .replace(/<sheetData>.*<\/sheetData>/, `<sheetData>${rows.join("")}</sheetData>`),
+          )
+        : data,
+    )
+  }
+  return zw.build()
+}
+
+describe("the error names the options that actually work", () => {
+  it("points at streamXlsxRows and sparse, not only at the three that do not help", async () => {
+    const bytes = await sparseSheet(2000, 24, 15312)
+
+    await expect(readXlsx(bytes)).rejects.toThrow(ParseError)
+    await expect(readXlsx(bytes)).rejects.toThrow(/streamXlsxRows/)
+    await expect(readXlsx(bytes)).rejects.toThrow(/sparse: true/)
+  }, 120_000)
+
+  it("says how empty the box actually is", async () => {
+    // The number that turns "your sheet is too large" into "your sheet
+    // is mostly nothing", which is a different problem with a different
+    // answer.
+    await expect(readXlsx(await sparseSheet(2000, 24, 15312))).rejects.toThrow(/% of them filled/)
+  }, 120_000)
+})
+
+describe("sparse: true reads what the grid cannot hold", () => {
+  it("returns every value, keyed by position", async () => {
+    const wb = await readXlsx(await sparseSheet(2000, 24, 15312), { sparse: true })
+    const sheet = wb.sheets[0]!
+
+    expect(sheet.cells?.size).toBe(2000 * 24)
+    expect(sheet.cells?.get("0,0")?.value).toBe(0)
+    expect(sheet.cells?.get("1999,15311")?.value).toBe(70)
+  }, 120_000)
+
+  it("leaves rows empty, because the grid is what it is avoiding", async () => {
+    const wb = await readXlsx(await sparseSheet(2000, 24, 15312), { sparse: true })
+
+    expect(wb.sheets[0]!.rows).toEqual([])
+  }, 120_000)
+
+  it("streamXlsxRows reads the same file too, a row at a time", async () => {
+    // The option that already worked and was never mentioned.
+    let count = 0
+    for await (const _row of streamXlsxRows(await sparseSheet(200, 24, 15312))) count++
+
+    expect(count).toBe(200)
+  }, 120_000)
+})
+
+describe("sparse agrees with dense on a sheet both can read", () => {
+  const GRID = [
+    ["name", "qty", "when"],
+    ["Widget", 3, null],
+    [null, null, "x"],
+  ]
+
+  it("same values at the same positions", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: GRID }] })
+
+    const dense = (await readXlsx(bytes)).sheets[0]!
+    const sparse = (await readXlsx(bytes, { sparse: true })).sheets[0]!
+
+    for (let r = 0; r < GRID.length; r++) {
+      for (let c = 0; c < 3; c++) {
+        const fromDense = dense.rows[r]?.[c] ?? null
+        const fromSparse = sparse.cells?.get(`${r},${c}`)?.value ?? null
+        expect(fromSparse, `${r},${c}`).toEqual(fromDense)
+      }
+    }
+  })
+
+  it("carries styles when asked, the same as dense does", async () => {
+    const bytes = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [["a"]],
+          cells: new Map([["0,0", { value: "a", style: { font: { bold: true } } }]]),
+        },
+      ],
+    })
+
+    const sparse = (await readXlsx(bytes, { sparse: true, readStyles: true })).sheets[0]!
+
+    expect(sparse.cells?.get("0,0")?.style?.font?.bold).toBe(true)
+  })
+
+  it("keeps formulas and their cached results", async () => {
+    const bytes = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [[1, 2, null]],
+          cells: new Map([["0,2", { value: 3, formula: "A1+B1", formulaResult: 3 }]]),
+        },
+      ],
+    })
+
+    const cell = (await readXlsx(bytes, { sparse: true })).sheets[0]!.cells?.get("0,2")
+
+    expect(cell?.formula).toBe("A1+B1")
+    expect(cell?.formulaResult).toBe(3)
+  })
+
+  it("is off by default, so nothing changes for anyone", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: GRID }] })
+    const wb = await readXlsx(bytes)
+
+    expect(wb.sheets[0]!.rows).toHaveLength(3)
+    expect(wb.sheets[0]!.rows[0]).toEqual(["name", "qty", "when"])
+  })
+})


### PR DESCRIPTION
Closes #501.

## The first finding: the file was already readable

`streamXlsxRows` reads exactly this shape **today**. Measured on a 30.6M-slot reproduction (2,000 × 15,312, 507 used columns, 4.8 MB):

```
readXlsx          ParseError: … 30624000 cells, over the 20000000 limit
streamXlsxRows    OK  rows=2000  widest=15312  2319 ms
```

So the error message was the first bug. It named three options and, as you set out, none of them helps — and it omitted the one that does.

It now reads:

```
Sheet "Sparse" spans 2000 rows x 15312 columns (30624000 cells, 3.31% of them filled),
over the 20000000 limit.
  - streamXlsxRows(input) reads it a row at a time, whatever the box.
  - readXlsx(input, { sparse: true }) returns the cells and no grid.
  - `range` or `maxRows` bound the area, if you know where the data is.
  - `maxTotalCells` raises the bound, if the sheet really is this large.
```

The fill factor is there deliberately: it turns *"your sheet is too large"* into *"your sheet is mostly nothing"*, which is a different problem with a different answer, and the old message actively pointed away from it.

## The second: `sparse: true`

`rows` comes back empty; every cell carrying something is in `cells`, keyed `"row,col"`. Memory tracks the values rather than the box, and the bounding-box limit has nothing to guard because nothing dense is built.

Same reproduction:

```
readXlsx({ sparse: true })   1642 ms   1,014,000 cells
                             A1 = 0    (1999,15311) = 70
```

Three places had to stop paying for the box, not one: the row allocation inside `processCell`, the value write itself, and the densify pass at the end. Skipping only the last would have left the 15,312-slot rows behind.

## Why both, rather than either

Streaming is the better answer when you only need to walk the rows once, and it is listed first for that reason. `sparse` is for random access, or for when you actually need a `Workbook` — which streaming cannot give you.

Off by default, XLSX-only. With it on, anything that reads `Sheet.rows` — `sheetToObjects`, `readObjects`, the writers — sees an empty sheet, and `cells` is the whole answer. That is in `docs/PARITY.md` rather than left to be discovered.

## Tests

`test/sparse-read.test.ts` — 9 cases, mutation-checked, 5 fail against `main`. They include the agreement check that matters: on a sheet both modes can read, sparse and dense return the same value at every position, and styles and formulas survive either way.

The fixtures use 24 used columns rather than 507. What makes the sheet unreadable is the **box** — 2,000 × 15,312 is 30.6M slots whatever fills it — and a million-value fixture cost the suite ten seconds to prove the same thing.

`pnpm lint`, `pnpm typecheck`, 10286 tests green; coverage and size budgets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
