### PR TITLE
fix(read): a part over the string ceiling gets a typed error — closes #503

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,6 +122,25 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
+### The buffered readers have a size ceiling
+
+One JavaScript string cannot hold an arbitrarily large part. V8's limit
+is 536,870,888 characters — about 512 MB — so a worksheet above it cannot
+be turned into a string at all, and `readXlsx`, `readXlsb` and `readOds`
+fail before any parsing begins. Instrument logs at Excel's row limit
+reach it: three files in a corpus of ~600 were 56–99 MB compressed and
+607 MB expanded. See #503.
+
+That used to surface as a raw `Error: Cannot create a string longer than
+0x1fffffe8 characters` — not a `ParseError`, naming no part, saying
+nothing about spreadsheets. It is now a `ParseError` that names the part,
+the size, the bound, and `streamXlsxRows`; and it says the workbook is
+not damaged, because everything else a reader throws means the file is
+wrong and this one means it is large.
+
+**`streamXlsxRows` has no such ceiling** — it reads those same files in
+about 30 seconds at a flat 944 MB, because it never holds the part whole.
+
 ### A sparse sheet has a way out
 
 `Sheet.rows` being a dense rectangle means a read costs the bounding box

--- a/src/_decode.ts
+++ b/src/_decode.ts
@@ -1,0 +1,66 @@
+// ── Decoding a package part ─────────────────────────────────────────
+//
+// One JavaScript string cannot hold an arbitrarily large part. V8's
+// ceiling is 0x1fffffe8 = 536,870,888 characters, about 512 MB, and a
+// worksheet above it cannot be turned into a string at all — the
+// buffered readers die before any parsing begins, with
+//
+//   Error: Cannot create a string longer than 0x1fffffe8 characters
+//
+// which is not a `ParseError`, names no part, and arrives after however
+// long the decompression took. Instrument logs at Excel's row limit
+// reach it: three files in a corpus of ~600 were 56–99 MB compressed and
+// 607 MB expanded. See #503.
+//
+// This is not "hucre cannot read big files" — `streamXlsxRows` reads
+// exactly those files, in 30s at a flat 944 MB. It is that the buffered
+// reader had a hard ceiling it did not know about and reported hitting
+// it in the least useful way available.
+
+import { ParseError } from "./errors"
+
+/**
+ * The largest string this runtime will build, as far as we can tell.
+ *
+ * V8's limit and the number in the error it throws. Other engines differ
+ * — JavaScriptCore's is larger — which is why the check is a `catch`
+ * rather than a comparison: a guess about the ceiling would refuse files
+ * a runtime could actually handle.
+ */
+export const MAX_STRING_LENGTH = 0x1fffffe8
+
+/**
+ * The message for a part too large to become a string.
+ *
+ * Separated from the decode so it can be tested: reproducing the
+ * condition needs a part over 512 MB, which is larger than this
+ * repository, so the message and the decision are what a test can reach.
+ * It follows the `maxTotalCells` error — name the bound, the
+ * measurement, and the way out.
+ */
+export function tooLargeToDecode(path: string, byteLength: number): ParseError {
+  return new ParseError(
+    `Part "${path}" is ${byteLength.toLocaleString("en-US")} bytes, over the ` +
+      `${MAX_STRING_LENGTH.toLocaleString("en-US")}-character maximum string length ` +
+      `this runtime supports, so it cannot be read into memory whole.\n` +
+      `  - streamXlsxRows(input) reads a worksheet of any size, a row at a time.\n` +
+      `  - The workbook is not damaged; this is a limit of the buffered reader.`,
+  )
+}
+
+/**
+ * Decode a package part as UTF-8, or say why it cannot be.
+ *
+ * `path` is only used for the message, so a caller that has not resolved
+ * one can pass whatever it knows.
+ */
+export function decodePart(data: Uint8Array, path: string): string {
+  try {
+    return new TextDecoder("utf-8").decode(data)
+  } catch (error) {
+    // A RangeError here is the string-length ceiling. Anything else is
+    // not ours to reinterpret.
+    if (error instanceof RangeError) throw tooLargeToDecode(path, data.length)
+    throw error
+  }
+}

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -16,6 +16,7 @@ import type {
 import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
 import { ZipReader } from "../zip/reader"
+import { decodePart } from "../_decode"
 import { parseXml } from "../xml/parser"
 import { parseRange } from "../cell-utils"
 import { parseUtcDefaultDateTime } from "../_date"
@@ -35,8 +36,8 @@ import type { XmlElement } from "../xml/parser"
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
-function decodeUtf8(data: Uint8Array): string {
-  return new TextDecoder("utf-8").decode(data)
+function decodeUtf8(data: Uint8Array, path = "(unknown)"): string {
+  return decodePart(data, path)
 }
 
 function findChild(el: XmlElement, localName: string): XmlElement | undefined {
@@ -919,13 +920,13 @@ export async function readOds(input: ReadInput, options?: ReadOptions): Promise<
   if (!zip.has("content.xml")) {
     throw new ParseError("Invalid ODS: missing content.xml")
   }
-  const contentXml = decodeUtf8(await zip.extract("content.xml"))
+  const contentXml = decodeUtf8(await zip.extract("content.xml"), "content.xml")
   const sheets = parseContentXml(contentXml, options)
 
   // 4. Parse meta.xml (optional)
   let properties: WorkbookProperties | undefined
   if (zip.has("meta.xml")) {
-    const metaXml = decodeUtf8(await zip.extract("meta.xml"))
+    const metaXml = decodeUtf8(await zip.extract("meta.xml"), "meta.xml")
     const metaProps = parseMetaXml(metaXml)
     if (Object.keys(metaProps).length > 0) {
       properties = { ...metaProps }

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -21,6 +21,7 @@ import type {
   TimelineCache,
   ChartAnchor,
 } from "../_types"
+import { decodePart } from "../_decode"
 import { parsePersons, parseThreadedComments } from "./threaded-comments-reader"
 import { parseExternalLink } from "./external-link-reader"
 import { assembleCellImages, parseCellImages, REL_CELL_IMAGES } from "./cell-images-reader"
@@ -67,8 +68,8 @@ export function matchesRelType(rel: string, type: string): boolean {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function decodeUtf8(data: Uint8Array): string {
-  return new TextDecoder("utf-8").decode(data)
+function decodeUtf8(data: Uint8Array, path = "(unknown)"): string {
+  return decodePart(data, path)
 }
 
 /**
@@ -142,14 +143,17 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (!zip.has("[Content_Types].xml")) {
     throw new ParseError("Invalid XLSX: missing [Content_Types].xml")
   }
-  const contentTypesXml = decodeUtf8(await zip.extract("[Content_Types].xml"))
+  const contentTypesXml = decodeUtf8(
+    await zip.extract("[Content_Types].xml"),
+    "[Content_Types].xml",
+  )
   parseContentTypes(contentTypesXml) // Validate, not strictly needed for reading
 
   // 3. Parse _rels/.rels to find the workbook path
   if (!zip.has("_rels/.rels")) {
     throw new ParseError("Invalid XLSX: missing _rels/.rels")
   }
-  const rootRelsXml = decodeUtf8(await zip.extract("_rels/.rels"))
+  const rootRelsXml = decodeUtf8(await zip.extract("_rels/.rels"), "_rels/.rels")
   const rootRels = parseRelationships(rootRelsXml)
   const workbookRel = rootRels.find((r) => matchesRelType(r.type, "officeDocument"))
   if (!workbookRel) {
@@ -168,7 +172,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
 
   let workbookRels: Relationship[] = []
   if (zip.has(workbookRelsPath)) {
-    const wbRelsXml = decodeUtf8(await zip.extract(workbookRelsPath))
+    const wbRelsXml = decodeUtf8(await zip.extract(workbookRelsPath), workbookRelsPath)
     workbookRels = parseRelationships(wbRelsXml)
   }
 
@@ -176,7 +180,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (!zip.has(workbookPath)) {
     throw new ParseError(`Invalid XLSX: missing workbook at ${workbookPath}`)
   }
-  const workbookXml = decodeUtf8(await zip.extract(workbookPath))
+  const workbookXml = decodeUtf8(await zip.extract(workbookPath), workbookPath)
   const {
     sheets: sheetInfos,
     dateSystem,
@@ -192,7 +196,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (ssRel) {
     const ssPath = resolvePath(workbookDir, ssRel.target)
     if (zip.has(ssPath)) {
-      const ssXml = decodeUtf8(await zip.extract(ssPath))
+      const ssXml = decodeUtf8(await zip.extract(ssPath), ssPath)
       sharedStrings = parseSharedStrings(ssXml)
     }
   }
@@ -203,7 +207,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (stylesRel) {
     const stylesPath = resolvePath(workbookDir, stylesRel.target)
     if (zip.has(stylesPath)) {
-      const stylesXml = decodeUtf8(await zip.extract(stylesPath))
+      const stylesXml = decodeUtf8(await zip.extract(stylesPath), stylesPath)
       parsedStyles = parseStyles(stylesXml)
     }
   }
@@ -212,7 +216,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   let themeColors: string[] | undefined
   const themePath = workbookDir ? `${workbookDir}/theme/theme1.xml` : "theme/theme1.xml"
   if (zip.has(themePath)) {
-    const themeXml = decodeUtf8(await zip.extract(themePath))
+    const themeXml = decodeUtf8(await zip.extract(themePath), themePath)
     themeColors = parseThemeColors(themeXml)
   }
 
@@ -223,7 +227,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (personsRel) {
     const personsPath = resolvePath(workbookDir, personsRel.target)
     if (zip.has(personsPath)) {
-      const personsXml = decodeUtf8(await zip.extract(personsPath))
+      const personsXml = decodeUtf8(await zip.extract(personsPath), personsPath)
       persons = parsePersons(personsXml)
     }
   }
@@ -239,10 +243,10 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   for (const rel of externalLinkRels) {
     const linkPath = resolvePath(workbookDir, rel.target)
     if (!zip.has(linkPath)) continue
-    const linkXml = decodeUtf8(await zip.extract(linkPath))
+    const linkXml = decodeUtf8(await zip.extract(linkPath), linkPath)
     const linkRelsPath = relsPathFor(linkPath)
     const linkRelsXml = zip.has(linkRelsPath)
-      ? decodeUtf8(await zip.extract(linkRelsPath))
+      ? decodeUtf8(await zip.extract(linkRelsPath), linkRelsPath)
       : undefined
     externalLinks.push(parseExternalLink(linkXml, linkRelsXml))
   }
@@ -257,7 +261,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (cellImagesRel) {
     const cellImagesPath = resolvePath(workbookDir, cellImagesRel.target)
     if (zip.has(cellImagesPath)) {
-      const ciXml = decodeUtf8(await zip.extract(cellImagesPath))
+      const ciXml = decodeUtf8(await zip.extract(cellImagesPath), cellImagesPath)
       const refs = parseCellImages(ciXml)
 
       // Resolve each embed rId against the sibling _rels file and
@@ -266,7 +270,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       const ciDir = dirname(cellImagesPath)
       const media = new Map<string, { data: Uint8Array; type: SheetImage["type"] }>()
       if (zip.has(ciRelsPath)) {
-        const ciRelsXml = decodeUtf8(await zip.extract(ciRelsPath))
+        const ciRelsXml = decodeUtf8(await zip.extract(ciRelsPath), ciRelsPath)
         for (const rel of parseRelationships(ciRelsXml)) {
           if (!matchesRelType(rel.type, "image")) continue
           const mediaPath = resolvePath(ciDir, rel.target)
@@ -295,14 +299,14 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     if (!rel) continue
     const cachePath = resolvePath(workbookDir, rel.target)
     if (!zip.has(cachePath)) continue
-    const cacheXml = decodeUtf8(await zip.extract(cachePath))
+    const cacheXml = decodeUtf8(await zip.extract(cachePath), cachePath)
     const cache = parsePivotCacheDefinition(cacheXml)
     if (!cache) continue
     cache.cacheId = ref.cacheId
     // Detect a sibling pivotCacheRecords part via the cache's _rels.
     const cacheRelsPath = relsPathFor(cachePath)
     if (zip.has(cacheRelsPath)) {
-      const cacheRelsXml = decodeUtf8(await zip.extract(cacheRelsPath))
+      const cacheRelsXml = decodeUtf8(await zip.extract(cacheRelsPath), cacheRelsPath)
       const cacheRels = parseRelationships(cacheRelsXml)
       if (cacheRels.some((r) => matchesRelType(r.type, "pivotCacheRecords"))) {
         cache.hasRecords = true
@@ -328,7 +332,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   for (const rel of slicerCacheRels) {
     const cachePath = resolvePath(workbookDir, rel.target)
     if (!zip.has(cachePath)) continue
-    const cacheXml = decodeUtf8(await zip.extract(cachePath))
+    const cacheXml = decodeUtf8(await zip.extract(cachePath), cachePath)
     const cache = parseSlicerCache(cacheXml)
     if (cache) slicerCaches.push(cache)
   }
@@ -342,7 +346,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   for (const rel of timelineCacheRels) {
     const cachePath = resolvePath(workbookDir, rel.target)
     if (!zip.has(cachePath)) continue
-    const cacheXml = decodeUtf8(await zip.extract(cachePath))
+    const cacheXml = decodeUtf8(await zip.extract(cachePath), cachePath)
     const cache = parseTimelineCache(cacheXml)
     if (cache) timelineCaches.push(cache)
   }
@@ -356,7 +360,9 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   if (metadataRel) {
     const metadataPath = resolvePath(workbookDir, metadataRel.target)
     if (zip.has(metadataPath)) {
-      dynamicArrayCm = parseDynamicArrayCellMetadata(decodeUtf8(await zip.extract(metadataPath)))
+      dynamicArrayCm = parseDynamicArrayCellMetadata(
+        decodeUtf8(await zip.extract(metadataPath), metadataPath),
+      )
     }
   }
 
@@ -413,7 +419,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
     const wsRelsPath = relsPathFor(wsPath)
     let worksheetRels: Relationship[] | undefined
     if (zip.has(wsRelsPath)) {
-      const wsRelsXml = decodeUtf8(await zip.extract(wsRelsPath))
+      const wsRelsXml = decodeUtf8(await zip.extract(wsRelsPath), wsRelsPath)
       worksheetRels = parseRelationships(wsRelsXml)
     }
 
@@ -432,7 +438,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       onWarning: options?.onWarning,
     }
 
-    const wsXml = decodeUtf8(await zip.extract(wsPath))
+    const wsXml = decodeUtf8(await zip.extract(wsPath), wsPath)
     const sheet = parseWorksheet(wsXml, info.name, worksheetCtx)
     if (info.state === "hidden") sheet.hidden = true
     if (info.state === "veryHidden") sheet.veryHidden = true
@@ -458,7 +464,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
           const charts: import("../_types").Chart[] = []
           for (const chartRef of drawing.chartRefs) {
             if (!zip.has(chartRef.path)) continue
-            const chartXml = decodeUtf8(await zip.extract(chartRef.path))
+            const chartXml = decodeUtf8(await zip.extract(chartRef.path), chartRef.path)
             const chart = parseChart(chartXml)
             if (!chart) continue
             if (chartRef.anchor) chart.anchor = chartRef.anchor
@@ -477,7 +483,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       if (commentsRel) {
         const commentsPath = resolvePath(wsDir, commentsRel.target)
         if (zip.has(commentsPath)) {
-          const commentsXml = decodeUtf8(await zip.extract(commentsPath))
+          const commentsXml = decodeUtf8(await zip.extract(commentsPath), commentsPath)
           const commentsMap = parseComments(commentsXml)
 
           // Attach comments to cell objects
@@ -510,7 +516,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       if (threadedRel) {
         const tcPath = resolvePath(wsDir, threadedRel.target)
         if (zip.has(tcPath)) {
-          const tcXml = decodeUtf8(await zip.extract(tcPath))
+          const tcXml = decodeUtf8(await zip.extract(tcPath), tcPath)
           const threaded = parseThreadedComments(tcXml)
           if (threaded.length > 0) sheet.threadedComments = threaded
         }
@@ -525,7 +531,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
         for (const tableRel of tableRels) {
           const tablePath = resolvePath(wsDir, tableRel.target)
           if (zip.has(tablePath)) {
-            const tableXml = decodeUtf8(await zip.extract(tablePath))
+            const tableXml = decodeUtf8(await zip.extract(tablePath), tablePath)
             const tableDef = parseTableXml(tableXml)
             if (tableDef) {
               tables.push(tableDef)
@@ -560,7 +566,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
         for (const ptRel of pivotTableRels) {
           const ptPath = resolvePath(wsDir, ptRel.target)
           if (!zip.has(ptPath)) continue
-          const ptXml = decodeUtf8(await zip.extract(ptPath))
+          const ptXml = decodeUtf8(await zip.extract(ptPath), ptPath)
           const pivot = parsePivotTable(ptXml)
           if (!pivot) continue
           // Resolve the pivot's owning cache via its sibling _rels —
@@ -569,7 +575,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
           // stay tolerant of caches living anywhere under xl/.
           const ptRelsPath = relsPathFor(ptPath)
           if (zip.has(ptRelsPath)) {
-            const ptRelsXml = decodeUtf8(await zip.extract(ptRelsPath))
+            const ptRelsXml = decodeUtf8(await zip.extract(ptRelsPath), ptRelsPath)
             const ptInternalRels = parseRelationships(ptRelsXml)
             const cacheRel = ptInternalRels.find((r) =>
               matchesRelType(r.type, "pivotCacheDefinition"),
@@ -605,7 +611,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
         for (const rel of slicerRels) {
           const path = resolvePath(wsDir, rel.target)
           if (!zip.has(path)) continue
-          const slicerXml = decodeUtf8(await zip.extract(path))
+          const slicerXml = decodeUtf8(await zip.extract(path), path)
           for (const s of parseSlicers(slicerXml)) slicers.push(s)
         }
         if (slicers.length > 0) sheet.slicers = slicers
@@ -618,7 +624,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
         for (const rel of timelineRels) {
           const path = resolvePath(wsDir, rel.target)
           if (!zip.has(path)) continue
-          const tlXml = decodeUtf8(await zip.extract(path))
+          const tlXml = decodeUtf8(await zip.extract(path), path)
           for (const t of parseTimelines(tlXml)) timelines.push(t)
         }
         if (timelines.length > 0) sheet.timelines = timelines
@@ -632,7 +638,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   let properties: import("../_types").WorkbookProperties | undefined
 
   if (zip.has("docProps/core.xml")) {
-    const coreXml = decodeUtf8(await zip.extract("docProps/core.xml"))
+    const coreXml = decodeUtf8(await zip.extract("docProps/core.xml"), "docProps/core.xml")
     const coreProps = parseCoreProperties(coreXml)
     if (Object.keys(coreProps).length > 0) {
       properties = { ...coreProps }
@@ -640,7 +646,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   }
 
   if (zip.has("docProps/app.xml")) {
-    const appXml = decodeUtf8(await zip.extract("docProps/app.xml"))
+    const appXml = decodeUtf8(await zip.extract("docProps/app.xml"), "docProps/app.xml")
     const appProps = parseAppProperties(appXml)
     if (Object.keys(appProps).length > 0) {
       properties = { ...properties, ...appProps }
@@ -648,7 +654,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
   }
 
   if (zip.has("docProps/custom.xml")) {
-    const customXml = decodeUtf8(await zip.extract("docProps/custom.xml"))
+    const customXml = decodeUtf8(await zip.extract("docProps/custom.xml"), "docProps/custom.xml")
     const customProps = parseCustomProperties(customXml)
     if (Object.keys(customProps).length > 0) {
       if (!properties) properties = {}
@@ -807,7 +813,7 @@ async function extractSheetDrawing(
 ): Promise<DrawingExtraction> {
   if (!zip.has(drawingPath)) return { images: [], textBoxes: [], chartRefs: [] }
 
-  const drawingXml = decodeUtf8(await zip.extract(drawingPath))
+  const drawingXml = decodeUtf8(await zip.extract(drawingPath), drawingPath)
 
   // Parse drawing relationships. Same fix as the worksheet path — the
   // hand-rolled slice dropped the first character for a root-level
@@ -821,7 +827,7 @@ async function extractSheetDrawing(
   // graphicFrame walk below can map each chart reference to a file.
   const chartRelMap = new Map<string, string>()
   if (zip.has(drawRelsPath)) {
-    const drawRelsXml = decodeUtf8(await zip.extract(drawRelsPath))
+    const drawRelsXml = decodeUtf8(await zip.extract(drawRelsPath), drawRelsPath)
     const drawRels = parseRelationships(drawRelsXml)
     for (const rel of drawRels) {
       if (matchesRelType(rel.type, "image")) {

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -10,6 +10,7 @@ import { EncryptedFileError, ParseError, ZipError } from "../../errors"
 import { isOle2Container, readInputToUint8Array } from "../../_input"
 import { decryptAgile } from "../crypto/agile"
 import { ZipReader } from "../../zip/reader"
+import { decodePart } from "../../_decode"
 import { parseRelationships } from "../relationships"
 import { matchesRelType } from "../reader"
 import { densify } from "../../xls/reader"
@@ -59,8 +60,8 @@ const ERROR_TEXT: Record<number, string> = {
 
 const decoder = new TextDecoder("utf-8")
 
-function decodeUtf8(d: Uint8Array): string {
-  return decoder.decode(d)
+function decodeUtf8(d: Uint8Array, path = "(unknown)"): string {
+  return decodePart(d, path)
 }
 
 function dirname(path: string): string {
@@ -109,7 +110,7 @@ export async function readXlsb(
   // conventional path).
   let workbookPath = "xl/workbook.bin"
   if (zip.has("_rels/.rels")) {
-    const rootRels = parseRelationships(decodeUtf8(await zip.extract("_rels/.rels")))
+    const rootRels = parseRelationships(decodeUtf8(await zip.extract("_rels/.rels"), "_rels/.rels"))
     const wbRel = rootRels.find((r) => matchesRelType(r.type, REL_WORKBOOK))
     if (wbRel) workbookPath = wbRel.target.startsWith("/") ? wbRel.target.slice(1) : wbRel.target
   }
@@ -155,7 +156,7 @@ async function parseXlsbParts(
   let sharedStringsPath: string | undefined
   let stylesPath: string | undefined
   if (zip.has(wbRelsPath)) {
-    for (const rel of parseRelationships(decodeUtf8(await zip.extract(wbRelsPath)))) {
+    for (const rel of parseRelationships(decodeUtf8(await zip.extract(wbRelsPath), wbRelsPath))) {
       const target = resolvePath(workbookDir, rel.target)
       if (matchesRelType(rel.type, REL_WORKSHEET)) relMap.set(rel.id, target)
       else if (matchesRelType(rel.type, REL_SHARED_STRINGS)) sharedStringsPath = target

--- a/test/huge-part-error.test.ts
+++ b/test/huge-part-error.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { decodePart, tooLargeToDecode, MAX_STRING_LENGTH } from "../src/_decode"
+import { ParseError, HucreError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #503 — a worksheet part over V8's 512 MB string ceiling made the
+// buffered readers die with
+//
+//   Error: Cannot create a string longer than 0x1fffffe8 characters
+//
+// which is not a `ParseError`, names no part, says nothing about
+// spreadsheets, and arrives after however long the decompression took.
+// Three files in a corpus of ~600 hit it — instrument logs at Excel's
+// row limit, 56–99 MB compressed and 607 MB expanded.
+//
+// It is not "hucre cannot read big files": `streamXlsxRows` reads exactly
+// those files, in ~30s at a flat 944 MB. The buffered reader had a hard
+// ceiling it did not know about.
+//
+// The trigger is not reproducible here and that is worth stating rather
+// than working around: it needs a part larger than this repository.
+// Faking the decode failure would test the wrapper rather than the
+// condition, so what is tested is what has logic in it — the decision
+// and the message.
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("the error a part over the ceiling produces", () => {
+  const error = tooLargeToDecode("xl/worksheets/sheet1.xml", 607_505_144)
+
+  it("is one of ours, so a caller catching HucreError sees it", () => {
+    expect(error).toBeInstanceOf(ParseError)
+    expect(error).toBeInstanceOf(HucreError)
+  })
+
+  it("names the part", () => {
+    expect(error.message).toContain("xl/worksheets/sheet1.xml")
+  })
+
+  it("names the measurement and the bound, as the maxTotalCells error does", () => {
+    expect(error.message).toContain("607,505,144")
+    expect(error.message).toContain(MAX_STRING_LENGTH.toLocaleString("en-US"))
+  })
+
+  it("names the way out", () => {
+    expect(error.message).toContain("streamXlsxRows")
+  })
+
+  it("says the workbook is not damaged, because it is not", () => {
+    // Everything else that throws from a reader means the file is wrong.
+    // This one means the file is large, and a caller deciding whether to
+    // retry or to reject needs to know which.
+    expect(error.message).toContain("not damaged")
+  })
+})
+
+describe("decodePart", () => {
+  it("decodes ordinary bytes unchanged", () => {
+    expect(decodePart(new TextEncoder().encode("hello şehir"), "x.xml")).toBe("hello şehir")
+  })
+
+  it("passes through an error that is not the ceiling", () => {
+    // A RangeError is the ceiling; anything else is not ours to
+    // reinterpret, and swallowing it would hide a real bug.
+    const notBytes = { byteLength: 1, length: 1 } as unknown as Uint8Array
+
+    expect(() => decodePart(notBytes, "x.xml")).toThrow()
+    expect(() => decodePart(notBytes, "x.xml")).not.toThrow(ParseError)
+  })
+
+  it("reports the ceiling as the number V8 actually uses", () => {
+    // 0x1fffffe8. Hard-coded here so a change to the constant is a
+    // decision rather than a typo.
+    expect(MAX_STRING_LENGTH).toBe(536_870_888)
+  })
+})


### PR DESCRIPTION
Closes #503.

## Before / after

```
Error: Cannot create a string longer than 0x1fffffe8 characters
```

becomes

```
ParseError: Part "xl/worksheets/sheet1.xml" is 607,505,144 bytes, over the
536,870,888-character maximum string length this runtime supports, so it
cannot be read into memory whole.
  - streamXlsxRows(input) reads a worksheet of any size, a row at a time.
  - The workbook is not damaged; this is a limit of the buffered reader.
```

That last line is there on purpose. Everything else a reader throws means the file is *wrong*; this one means it is *large*, and a caller deciding whether to retry differently or reject the upload needs to know which.

Applied to `readOds` and `readXlsb` as well — you asked for those to be checked, and both had the same shape.

## A `catch`, not a size comparison

The obvious implementation is `if (data.length > MAX) throw`, and it is wrong twice over:

- Byte length is an **upper bound** on character count, so a 600 MB part of multi-byte text may be well under 512 M characters. Comparing would refuse files the runtime can handle.
- JavaScriptCore's ceiling is **higher** than V8's, so a hard-coded guess is wrong in the other direction on Bun and Safari.

Catching the `RangeError` asks the runtime instead of guessing at it. A non-`RangeError` is rethrown untouched, since swallowing it would hide a real bug — there is a test for that.

## On testing it

You called this one not fixture-able and I agree — reproducing it needs a part larger than the repository. Faking the decode failure would test the wrapper rather than the condition, so what `test/huge-part-error.test.ts` covers is the part with logic in it: the decision and the message, built from the same 607,505,144 figure you measured.

The ceiling itself is now in `docs/PARITY.md`, with `streamXlsxRows` and your measurement — ~30s at a flat 944 MB for the same file — as the answer. That seemed worth more than a test that could not fail for the right reason.

`pnpm lint`, `pnpm typecheck`, 10294 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
