### PR TITLE
feat(xml): a streaming writer — refs #467

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ const buffer = await writer.finish()
 ```ts
 import { writeOdsStream } from "hucre/ods"
 import { writeNdjsonStream } from "hucre/json"
+import { writeXmlStream } from "hucre/xml"
 
 return new Response(writeOdsStream(rowCursor, { name: "Export" }), {
   headers: { "content-type": "application/vnd.oasis.opendocument.spreadsheet" },
@@ -423,6 +424,10 @@ return new Response(writeOdsStream(rowCursor, { name: "Export" }), {
 
 return new Response(writeNdjsonStream(rowCursor), {
   headers: { "content-type": "application/x-ndjson" },
+})
+
+return new Response(writeXmlStream(rowCursor, { rowTag: "record" }), {
+  headers: { "content-type": "application/xml; charset=utf-8" },
 })
 ```
 
@@ -432,7 +437,7 @@ return new Response(writeNdjsonStream(rowCursor), {
 | CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
 | NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
 | ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
-| XML    |     ✔      |      ✔      |      —      |      —       |         —          |
+| XML    |     ✔      |      ✔      |      —      |      ✔       |         —          |
 
 `writeOdsStream` carries **values, not formatting**, and that follows from
 the format: ODF puts `<office:automatic-styles>` before the body, so a
@@ -442,7 +447,10 @@ with inline strings and ODF has no equivalent for. Column widths and a
 header row are carried, because `columns` is known before the first row.
 `writeOds` remains the path for a document that needs styling.
 
-XML is the remaining gap, on both sides.
+XML's **reader** is the remaining gap. `src/xml/parser.ts` is push-based,
+so a streaming reader needs a pull-based row scanner rather than a
+wrapper around what is there — that is its own change, not an oversight
+in this table.
 
 #### Which writer to use
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ export type {
 } from "./json"
 
 // ── XML ────────────────────────────────────────────────────────────
-export { readXml, writeXml } from "./xml"
+export { readXml, writeXml, writeXmlStream } from "./xml"
 export type { XmlReadOptions, XmlReadResult, XmlWriteOptions } from "./xml"
 
 // ── Schema Validation ──────────────────────────────────────────────

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -4,7 +4,7 @@
 export { readXml } from "./xml/data-reader"
 export type { XmlReadOptions, XmlReadResult } from "./xml/data-reader"
 
-export { writeXml } from "./xml/data-writer"
+export { writeXml, writeXmlStream } from "./xml/data-writer"
 export type { XmlWriteOptions } from "./xml/data-writer"
 
 // ── Shared types used by this entry point's signatures ──────────────

--- a/src/xml/data-writer.ts
+++ b/src/xml/data-writer.ts
@@ -207,3 +207,109 @@ function renderElement(
 
   return `<${tag}${attrStr}>${sep}${inner.join("")}${pad(depth)}</${tag}>`
 }
+
+// ── True Streaming XML Writer ────────────────────────────────────────
+
+const TEXT_ENCODER = /* @__PURE__ */ new TextEncoder()
+
+/**
+ * Write an XML document as a byte stream, pulling rows from `rows` only
+ * as the consumer reads.
+ *
+ * XML was the one format with no streaming on either side, which made it
+ * the odd one out of five. See #467.
+ *
+ * ```ts
+ * return new Response(writeXmlStream(rowCursor, { rowTag: "record" }), {
+ *   headers: { "content-type": "application/xml; charset=utf-8" },
+ * })
+ * ```
+ *
+ * Peak memory is independent of the row count: each row is rendered,
+ * encoded and enqueued on its own, and nothing is retained. The
+ * declaration and the root element are written around them, so the
+ * result is the same document {@link writeXml} produces from the same
+ * rows — there is a test asserting exactly that.
+ *
+ * The *reader* is still not streaming: `src/xml/parser.ts` is push-based,
+ * so a streaming reader needs a pull-based row scanner rather than a
+ * wrapper around what is there. That is its own change.
+ */
+export function writeXmlStream(
+  rows: AsyncIterable<Record<string, CellValue>> | Iterable<Record<string, CellValue>>,
+  options?: XmlWriteOptions,
+): ReadableStream<Uint8Array> {
+  const chunks = xmlStreamChunks(rows, options)
+
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await chunks.next()
+        if (done) {
+          controller.close()
+          return
+        }
+        controller.enqueue(value)
+      } catch (err) {
+        controller.error(err)
+      }
+    },
+    async cancel(reason) {
+      await chunks.return?.(reason)
+    },
+  })
+}
+
+/** Render rows into ~64 KB encoded chunks, pulling lazily. */
+async function* xmlStreamChunks(
+  rows: AsyncIterable<Record<string, CellValue>> | Iterable<Record<string, CellValue>>,
+  options?: XmlWriteOptions,
+): AsyncGenerator<Uint8Array> {
+  const rootTag = options?.rootTag ?? "root"
+  const rowTag = options?.rowTag ?? "row"
+  const attrPrefix = options?.attrPrefix ?? "@"
+  const textKey = options?.textKey ?? "#text"
+  const declaration = options?.declaration ?? true
+  const pretty = options?.pretty ?? false
+  const indent = options?.indent ?? "  "
+
+  // Validated up front, so a bad tag fails before any bytes go out
+  // rather than half way through a response.
+  validateName(rootTag, "rootTag")
+  validateName(rowTag, "rowTag")
+
+  const sep = pretty ? "\n" : ""
+  const pad = pretty ? indent : ""
+
+  const CHUNK_BYTES = 64 * 1024
+  let pending: string[] = []
+  let pendingBytes = 0
+
+  const push = function* (text: string): Generator<Uint8Array> {
+    pending.push(text)
+    pendingBytes += text.length
+    if (pendingBytes >= CHUNK_BYTES) {
+      yield TEXT_ENCODER.encode(pending.join(""))
+      pending = []
+      pendingBytes = 0
+    }
+  }
+
+  if (declaration) {
+    yield* push('<?xml version="1.0" encoding="UTF-8"?>')
+    if (pretty) yield* push("\n")
+  }
+  yield* push(`<${rootTag}>`)
+  yield* push(sep)
+
+  for await (const row of rows) {
+    yield* push(pad)
+    yield* push(renderElement(rowTag, buildTree(row, attrPrefix, textKey), pretty, indent, 1))
+    yield* push(sep)
+  }
+
+  yield* push(`</${rootTag}>`)
+  if (pretty) yield* push("\n")
+
+  if (pending.length > 0) yield TEXT_ENCODER.encode(pending.join(""))
+}

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -119,6 +119,7 @@ exports[`export surface snapshot > hucre/xml 1`] = `
 [
   "readXml",
   "writeXml",
+  "writeXmlStream",
 ]
 `;
 
@@ -274,5 +275,6 @@ exports[`export surface snapshot > root 1`] = `
   "writeXlsxStream",
   "writeXlsxStreamSheets",
   "writeXml",
+  "writeXmlStream",
 ]
 `;

--- a/test/xml-stream-writer.test.ts
+++ b/test/xml-stream-writer.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+import { writeXml, writeXmlStream } from "../src/xml/data-writer"
+import { readXml } from "../src/xml/data-reader"
+import { ParseError } from "../src/errors"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #467 — XML was the one format with no streaming on either side, which
+// made it the odd one out of five.
+//
+// The writer streams cleanly: a prologue, one rendered element per row,
+// a closer. The *reader* does not, and this does not pretend otherwise —
+// `src/xml/parser.ts` is push-based, so a streaming reader needs a
+// pull-based row scanner rather than a wrapper around what is there.
+// That is its own change, and the matrix still shows the gap.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0)
+  const out = new Uint8Array(total)
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return new TextDecoder().decode(out)
+}
+
+const ROWS: Array<Record<string, CellValue>> = [
+  { name: "Widget", qty: 3, ok: true },
+  { name: "Gadget", qty: 7, ok: false },
+]
+
+describe("writeXmlStream produces the same document writeXml does", () => {
+  it("byte for byte, on the same rows", async () => {
+    // The assertion that makes this a streaming *version* rather than a
+    // second implementation with its own opinions.
+    expect(await drain(writeXmlStream(ROWS))).toBe(writeXml(ROWS))
+  })
+
+  it("with every option that changes the shape", async () => {
+    for (const options of [
+      { rootTag: "records", rowTag: "record" },
+      { declaration: false },
+      { pretty: true },
+      { pretty: true, indent: "    " },
+      { attrPrefix: "$", textKey: "_" },
+    ]) {
+      expect(await drain(writeXmlStream(ROWS, options)), JSON.stringify(options)).toBe(
+        writeXml(ROWS, options),
+      )
+    }
+  })
+
+  it("on no rows at all", async () => {
+    expect(await drain(writeXmlStream([]))).toBe(writeXml([]))
+  })
+
+  it("with attributes and mixed content", async () => {
+    const rows = [{ "@id": 1, "#text": "hello", nested: "x" }]
+
+    expect(await drain(writeXmlStream(rows))).toBe(writeXml(rows))
+  })
+
+  it("escaping whatever needs it", async () => {
+    const rows = [{ text: '<a & "b">', "@attr": "q'uote" }]
+
+    expect(await drain(writeXmlStream(rows))).toBe(writeXml(rows))
+  })
+})
+
+describe("it reads back", () => {
+  it("through readXml, with the values intact", async () => {
+    const { data, headers } = readXml(await drain(writeXmlStream(ROWS)))
+
+    // XML carries no types, so values come back as text — the same as
+    // `readXml` of a `writeXml` document, which is the comparison that
+    // matters here.
+    expect(headers).toEqual(["name", "qty", "ok"])
+    expect(data[0]).toEqual({ name: "Widget", qty: "3", ok: "true" })
+    expect(data[1]!.name).toBe("Gadget")
+    expect(data).toEqual(readXml(writeXml(ROWS)).data)
+  })
+})
+
+describe("the streaming properties", () => {
+  it("pulls rows lazily rather than draining the source first", async () => {
+    // Rows big enough that the 64 KB chunk boundary lands well before
+    // the source is exhausted; otherwise the first chunk is the only
+    // chunk and this would prove nothing.
+    let produced = 0
+    const filler = "x".repeat(200)
+    function* rows(): Generator<Record<string, CellValue>> {
+      for (let i = 0; i < 5000; i++) {
+        produced++
+        yield { i, filler }
+      }
+    }
+
+    const reader = writeXmlStream(rows()).getReader()
+    await reader.read()
+    const afterFirstChunk = produced
+    await reader.cancel()
+
+    expect(afterFirstChunk).toBeLessThan(5000)
+  })
+
+  it("takes an async source", async () => {
+    async function* rows(): AsyncGenerator<Record<string, CellValue>> {
+      yield { a: 1 }
+      yield { a: 2 }
+    }
+
+    expect(readXml(await drain(writeXmlStream(rows()))).data).toHaveLength(2)
+  })
+
+  it("rejects a bad tag before any bytes go out", async () => {
+    // Half a response is worse than no response: validate up front.
+    await expect(drain(writeXmlStream(ROWS, { rowTag: "not a tag" }))).rejects.toThrow(ParseError)
+    await expect(drain(writeXmlStream(ROWS, { rootTag: "1bad" }))).rejects.toThrow(ParseError)
+  })
+})


### PR DESCRIPTION
Refs #467. Closes the write half of its last gap; the read half stays open, deliberately.

XML was the one format with no streaming on either side:

|        | whole read | whole write | stream read | stream write | incremental writer |
| ------ | :--------: | :---------: | :---------: | :----------: | :----------------: |
| XLSX   |     ✔      |      ✔      |      ✔      |  ✔ (multi)   |         ✔          |
| CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
| XML    |     ✔      |      ✔      |      —      |   ✔ **new**  |         —          |

## The test that matters

`writeXmlStream` produces **the same document `writeXml` does** — byte for byte, across every option that changes the shape (`rootTag`, `rowTag`, `declaration`, `pretty`, `indent`, `attrPrefix`, `textKey`), on attributes, mixed content, escaping, and no rows at all.

That is what makes it a streaming *version* of the writer rather than a second implementation with its own opinions, which is the failure mode this shape invites — and the one I would have shipped if the test had only checked that the output parses.

## Tags are validated before any bytes go out

Half a response is worse than no response. At a `Response` boundary that is the difference between an error the caller sees and a truncated document they do not.

## The reader stays a gap, and the matrix says so

`src/xml/parser.ts` is push-based: `parseSax` runs to completion and calls back. Wrapping it in a generator would buffer every row before yielding the first, which is the opposite of the point.

A streaming reader needs a **pull-based row scanner** — finding element spans while respecting nesting, CDATA, comments and attribute quoting. That is real parser work with real risk, and bolting a half-version of it onto this change would be worse than leaving the cell empty. The README now explains the gap rather than just showing a dash.

## Tests

`test/xml-stream-writer.test.ts` — 9 cases, mutation-checked, all 9 fail against `main`. Includes the laziness check (count rows produced before the first chunk, with rows big enough to cross the 64 KB boundary — otherwise the first chunk is the only chunk and it proves nothing).

`pnpm lint`, `pnpm typecheck`, 10307 tests green; coverage and size budgets pass. Export snapshots moved by one name on each of two surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
