### PR TITLE
perf(xlsx): share the derived date style — refs #472

### DIFF
--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -238,6 +238,28 @@ function toHyperlink(hv: HyperlinkValue): Hyperlink {
 const DEFAULT_DATE_FORMAT = "yyyy-mm-dd"
 
 /**
+ * The style a bare `Date` gets, as one object rather than one per cell.
+ *
+ * `serializeCell` used to build `{ ...style, numFmt: DEFAULT_DATE_FORMAT }`
+ * fresh for every date cell, which defeated the xf identity cache #435
+ * added: measured on the 100,000 x 12 benchmark, `registerXf` was called
+ * 400,000 times — exactly the date-cell count — with **zero** identity
+ * hits, to produce one xf. Every one of those paid for an object, a
+ * seven-element key array, a join and a Map lookup.
+ *
+ * Sharing one frozen object makes the cache hit on the second date cell
+ * and every one after it. See #472.
+ */
+const BARE_DATE_STYLE: CellStyle = Object.freeze({ numFmt: DEFAULT_DATE_FORMAT })
+
+/**
+ * Derived date styles for cells that *do* carry a style, keyed by that
+ * style's identity — same reasoning, one step further out. A `WeakMap`
+ * so a style object the caller drops does not keep an entry alive.
+ */
+const DATE_STYLE_CACHE = /* @__PURE__ */ new WeakMap<CellStyle, CellStyle>()
+
+/**
  * Known Excel error value strings.
  *
  * The first eight are the ST_CellType `e` values ECMA-376 enumerates.
@@ -912,11 +934,22 @@ export function serializeCell(
   let styleIdx = 0
   let effectiveStyle = style
 
-  // If value is Date and no numFmt specified, add default date format
+  // If value is Date and no numFmt specified, add default date format.
+  // Both branches reuse one object per distinct input so the xf identity
+  // cache can hit; building a fresh one per cell is what made this the
+  // hottest thing in the writer. See #472.
   if (value instanceof Date && (!effectiveStyle || !effectiveStyle.numFmt)) {
-    effectiveStyle = {
-      ...effectiveStyle,
-      numFmt: DEFAULT_DATE_FORMAT,
+    if (!effectiveStyle) {
+      effectiveStyle = BARE_DATE_STYLE
+    } else {
+      const cached = DATE_STYLE_CACHE.get(effectiveStyle)
+      if (cached) {
+        effectiveStyle = cached
+      } else {
+        const derived: CellStyle = { ...effectiveStyle, numFmt: DEFAULT_DATE_FORMAT }
+        DATE_STYLE_CACHE.set(effectiveStyle, derived)
+        effectiveStyle = derived
+      }
     }
   }
 

--- a/test/date-style-sharing.test.ts
+++ b/test/date-style-sharing.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #472 — a `Date` with no explicit number format gets one, and the
+// writer built `{ ...style, numFmt: "yyyy-mm-dd" }` fresh for every such
+// cell. That defeated the xf identity cache #435 added: measured on the
+// 100,000 x 12 benchmark, `registerXf` was called 400,000 times — exactly
+// the date-cell count — with **zero** identity hits, to produce one xf.
+//
+// Sharing one object per distinct input makes the cache hit on the second
+// date cell and every one after: 399,999 of 400,000. What follows is the
+// behaviour that must not change for it.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function stylesXml(bytes: Uint8Array): Promise<string> {
+  return dec.decode(await new ZipReader(bytes).extract("xl/styles.xml"))
+}
+
+const DAY = new Date("2024-03-17T00:00:00Z")
+
+describe("a bare date still gets its format", () => {
+  it("reads back as a Date", async () => {
+    const wb = await readXlsx(await writeXlsx({ sheets: [{ name: "S", rows: [[DAY]] }] }))
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBeInstanceOf(Date)
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+  })
+
+  it("and many of them share one format record", async () => {
+    // The point of the change, visible in the file: 500 date cells must
+    // not produce 500 xfs.
+    const rows = Array.from({ length: 500 }, () => [DAY, DAY, DAY])
+    const xml = await stylesXml(await writeXlsx({ sheets: [{ name: "S", rows }] }))
+
+    const xfCount = (xml.match(/<xf /g) ?? []).length
+    expect(xfCount).toBeLessThan(5)
+    expect((xml.match(/yyyy-mm-dd/g) ?? []).length).toBe(1)
+  })
+})
+
+describe("a styled date keeps its own style", () => {
+  it("the style survives alongside the added format", async () => {
+    const style: CellStyle = { font: { bold: true } }
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[DAY]], cells: new Map([["0,0", { value: DAY, style }]]) }],
+    })
+
+    const cell = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")
+
+    expect(cell?.style?.font?.bold).toBe(true)
+    expect(cell?.style?.numFmt).toBe("yyyy-mm-dd")
+  })
+
+  it("two different styles do not collapse into one", async () => {
+    // The risk of caching by identity: a shared derived object must be
+    // shared only among cells that started from the same style.
+    const bold: CellStyle = { font: { bold: true } }
+    const italic: CellStyle = { font: { italic: true } }
+    const bytes = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [[DAY, DAY]],
+          cells: new Map([
+            ["0,0", { value: DAY, style: bold }],
+            ["0,1", { value: DAY, style: italic }],
+          ]),
+        },
+      ],
+    })
+
+    const cells = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.cells!
+
+    expect(cells.get("0,0")?.style?.font?.bold).toBe(true)
+    expect(cells.get("0,0")?.style?.font?.italic).toBeUndefined()
+    expect(cells.get("0,1")?.style?.font?.italic).toBe(true)
+    expect(cells.get("0,1")?.style?.font?.bold).toBeUndefined()
+  })
+
+  it("an explicit numFmt on a date is not overwritten", async () => {
+    const style: CellStyle = { numFmt: "dd/mm/yyyy" }
+    const bytes = await writeXlsx({
+      sheets: [{ name: "S", rows: [[DAY]], cells: new Map([["0,0", { value: DAY, style }]]) }],
+    })
+
+    const cell = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")
+
+    expect(cell?.style?.numFmt).toBe("dd/mm/yyyy")
+  })
+
+  it("does not mutate the caller's style object", async () => {
+    // The shared object is frozen, but the caller's is not — and adding
+    // the format to theirs would be a surprising side effect.
+    const style: CellStyle = { font: { bold: true } }
+    await writeXlsx({
+      sheets: [{ name: "S", rows: [[DAY]], cells: new Map([["0,0", { value: DAY, style }]]) }],
+    })
+
+    expect(style).toEqual({ font: { bold: true } })
+    expect(style.numFmt).toBeUndefined()
+  })
+})
+
+describe("the sheet still writes what it always did", () => {
+  it("dates mixed with everything else", async () => {
+    const rows = [
+      ["text", 42, DAY, true],
+      [null, -1.5, new Date("2020-01-01T00:00:00Z"), false],
+    ]
+    const wb = await readXlsx(await writeXlsx({ sheets: [{ name: "S", rows }] }))
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("text")
+    expect(wb.sheets[0]!.rows[0]![1]).toBe(42)
+    expect((wb.sheets[0]!.rows[0]![2] as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+    expect(wb.sheets[0]!.rows[0]![3]).toBe(true)
+    expect((wb.sheets[0]!.rows[1]![2] as Date).toISOString()).toBe("2020-01-01T00:00:00.000Z")
+  })
+
+  it("under the 1904 date system", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[DAY]] }], dateSystem: "1904" })
+    const wb = await readXlsx(bytes)
+
+    expect((wb.sheets[0]!.rows[0]![0] as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+  })
+})


### PR DESCRIPTION
Refs #472. The follow-up the last profile pointed at.

#491 left `registerXf` as the top remaining target at 9% of on-CPU time. I instrumented it before touching anything, and the reason is not the hashing:

```
before   400,000 calls   0 identity hits
after    400,000 calls   399,999 identity hits
```

400,000 is **exactly the date-cell count** in the benchmark, and `registerXf` is called for nothing else there — an unstyled cell never reaches it. So every date cell was paying for an object, a seven-element key array, a `join`, and a `Map` lookup, to produce **one** xf.

## Why the cache could never fire

A `Date` with no number format gets one, and the writer built it fresh each time:

```ts
effectiveStyle = { ...effectiveStyle, numFmt: DEFAULT_DATE_FORMAT }
```

A fresh object cannot hit an identity cache. So #435's optimisation — the whole point of which is to short-circuit repeated styles — could never fire on the most common styled cell in a spreadsheet.

Bare dates now share one frozen object. A date that *does* carry a style gets its derived style memoised against that style's identity in a `WeakMap`. Same contract as the existing xf identity cache, and the same one the `readStyles` docs already state: a style's parts are shared, not copied.

## Measured, in alternating pairs

```
mixed benchmark (1 of 3 columns dates)    ~11% median, 6 of 7 pairs
date-heavy (11 of 12 columns dates)       ~35%, 3 of 3
```

The spread between those is the honest headline: **the gain scales with how many dates a sheet has**, and one pair of the mixed run came out a wash. A log export is mostly timestamps and gets the 35%; a text-heavy sheet gets very little. I would not quote the 35% on its own.

## About the tests

`test/date-style-sharing.test.ts` — 8 cases, and they **pass against `main` too**. That is correct and worth stating: this is a pure optimisation, so they guard the behaviour that must not change rather than prove the change. The measurement above is the proof.

Two of them are the ones that earn their place — the risks this shape of caching actually carries:

- two different source styles must not collapse into one derived style
- the caller's own style object must not quietly gain a `numFmt` it never asked for

`pnpm lint`, `pnpm typecheck`, 10315 tests green; coverage and size budgets pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
