### PR TITLE
fix(read): recognise the string ceiling however the runtime reports it

### DIFF
--- a/src/_decode.ts
+++ b/src/_decode.ts
@@ -58,9 +58,25 @@ export function decodePart(data: Uint8Array, path: string): string {
   try {
     return new TextDecoder("utf-8").decode(data)
   } catch (error) {
-    // A RangeError here is the string-length ceiling. Anything else is
-    // not ours to reinterpret.
-    if (error instanceof RangeError) throw tooLargeToDecode(path, data.length)
+    // The ceiling does not announce itself the same way twice. V8 raises
+    // `RangeError` for a plain string operation, but Node's TextDecoder
+    // goes through its own encoding layer and throws a *plain* `Error`
+    // carrying `code: "ERR_STRING_TOO_LONG"` — so guarding on RangeError
+    // alone converted nothing on the one runtime this was reported
+    // against, and every file in #503 kept getting the raw V8 error. See
+    // #516.
+    //
+    // The length test is the backstop for whatever the next engine does.
+    // It is only consulted once the decode has already failed, so it
+    // cannot refuse a part a roomier engine would have decoded — it just
+    // stops the classification depending on which wrapper a runtime
+    // happened to choose. A short part that fails is still a genuine
+    // decode error and is passed through untouched.
+    const isCeiling =
+      error instanceof RangeError ||
+      (error as { code?: string } | null)?.code === "ERR_STRING_TOO_LONG" ||
+      data.length > MAX_STRING_LENGTH
+    if (isCeiling) throw tooLargeToDecode(path, data.length)
     throw error
   }
 }

--- a/test/huge-part-error.test.ts
+++ b/test/huge-part-error.test.ts
@@ -67,6 +67,25 @@ describe("decodePart", () => {
     expect(() => decodePart(notBytes, "x.xml")).not.toThrow(ParseError)
   })
 
+  it("turns a part past the ceiling into a ParseError — #516", () => {
+    // The first fix for #503 was never exercised against the condition
+    // itself, on the grounds that reproducing it needs a part larger
+    // than this repository. It needs a large *buffer*, not a large
+    // *file*: an ArrayBuffer of this size lives outside the JS heap and
+    // costs about a second, so the branch is reachable after all.
+    //
+    // It mattered. The guard was `error instanceof RangeError`, and on
+    // Node `TextDecoder.decode` throws a plain `Error` carrying
+    // `code: "ERR_STRING_TOO_LONG"` — so the conversion never happened
+    // and every one of the files in #503 still got the raw V8 error.
+    // Zero bytes decode one-to-one, so this lands exactly one character
+    // past the ceiling.
+    const past = new Uint8Array(MAX_STRING_LENGTH + 1)
+
+    expect(() => decodePart(past, "xl/worksheets/sheet1.xml")).toThrow(ParseError)
+    expect(() => decodePart(past, "xl/worksheets/sheet1.xml")).toThrow(/streamXlsxRows/)
+  })
+
   it("reports the ceiling as the number V8 actually uses", () => {
     // 0x1fffffe8. Hard-coded here so a change to the constant is a
     // decision rather than a typo.


### PR DESCRIPTION
Closes #516. Branches from current `main`, single commit.

> **Scope: this makes the failure legible, not the file readable.** After this change `readXlsx` still throws on every workbook above the ceiling — it throws a `ParseError` naming the part, the size, the bound and the way out, instead of a raw V8 `Error`. Nothing that failed to load now loads. Making the buffered reader actually read those files is a separate, larger change; there is a note on what it would take at the bottom.

#514 converted the string-ceiling failure into a typed `ParseError`. On Node the conversion never happens, so #503 is still live for every file it was reported about.

## The guard tests for the wrong type

```ts
if (error instanceof RangeError) throw tooLargeToDecode(path, data.length)
throw error
```

Node's `TextDecoder.decode` does not throw a `RangeError`. It goes through `node:internal/encoding` and throws a plain `Error` carrying `code: "ERR_STRING_TOO_LONG"`:

```js
const big = new Uint8Array(0x1fffffe8 + 1024)
try { new TextDecoder("utf-8").decode(big) } catch (e) {
  e.constructor.name       // "Error"
  e instanceof RangeError  // false
  e.code                   // "ERR_STRING_TOO_LONG"
}
```

The `RangeError` assumption is reasonable — it is what V8 raises for a plain string operation — but it is not what comes back through this path.

## Measured against the files, before and after

The corpus that produced #503, re-read against `b723e80`: **ten workbooks above the ceiling, all ten still failing untyped**, with the stack frame sitting *inside* `decodePart` — being called, declining to convert.

After this change, all ten produce the `ParseError`, and the escape it names works on all ten. Taking the largest as the example (162 MB compressed, `xl/worksheets/sheet2.xml` at 589,208,551 bytes):

| | result |
| --- | --- |
| `readXlsx` | `ParseError` naming the part, the size, the bound and `streamXlsxRows` |
| `streamXlsxRows(bytes, { sheet: 1 })` | **800,001 rows, 30.2s, 259 MB flat** |

One caveat worth stating since the message makes a promise: `streamXlsxRows` defaults to the first sheet, and in these files the first sheet is a small one — the oversized sheet needs `{ sheet: n }`. The promise holds, but it is the caller's job to pick the sheet.

## Why it stays a `catch`

The original comment's reasoning is right and is kept: engines differ, JavaScriptCore's ceiling is higher, and a length comparison up front would refuse files a runtime could actually read. So the shape is unchanged and only the classification widens — `RangeError`, or `ERR_STRING_TOO_LONG`, or a length past `MAX_STRING_LENGTH` as the backstop for whatever the next engine reports.

The length arm is only reached **after** the decode has already thrown, so it cannot refuse anything that would have decoded successfully. A short part that fails is still a genuine decode error and passes through untouched — the existing test for that still passes unchanged.

## The test, and why there wasn't one

Added first, failing before the change, per `CONTRIBUTING.md`.

`test/huge-part-error.test.ts` said the condition was out of reach:

> The trigger is not reproducible here and that is worth stating rather than working around: it needs a part larger than this repository.

That is true of a *file* and not of a *buffer*. `new Uint8Array(MAX_STRING_LENGTH + 1)` is a ~537 MB `ArrayBuffer` allocated outside the JS heap; the test runs in **1.2 s**. Zero bytes decode one-to-one, so it lands exactly one character past the ceiling.

That assumption is the whole reason this shipped untested: the message factory and the happy path were covered, and the `catch` that decides whether to call the factory was the one piece with a decision in it. I have left that reasoning in the test as a comment rather than deleting it, since it is the interesting part.

## Checks

- `pnpm test` — 206 files, 10,294 passed, 1 expected fail (#501's `it.fails`, unrelated).
- The new test fails on `main` with `expected error to be instance of ParseError` and passes here.
- Verified end-to-end against ten real workbooks, not only the unit test.

## What would actually make them readable

Worth writing down, since this PR deliberately does not attempt it.

The ceiling is on a single JavaScript string, not on the data. `src/xlsx/reader.ts` decodes a worksheet part whole and hands the string to `parseWorksheet`, so a 589 MB part cannot be represented no matter how much memory is free. But the pieces for a chunked parse already exist:

- `parseSaxStream` (`src/xml/parser.ts:298`) consumes a `ReadableStream<Uint8Array>`, decodes with `{ stream: true }`, and `processSaxBuffer` already holds back partial tags and entities across chunk boundaries. `buf` stays small because completed constructs are consumed as they arrive.
- `parseWorksheet`'s handlers are already SAX handlers. They are driven by `parseSax` over a full string today, but nothing about them requires the string.
- `streamXlsxRows` proves the path works on exactly these files — it just yields rows instead of building the `Sheet` model.

So the shape of a real fix is: give the buffered worksheet parse a streaming driver, and fall back to it when `decodePart` would exceed the ceiling. That keeps one public API and one model, and removes the ceiling as a user-visible concept.

Two things I would want settled before attempting it:

1. **It may trade one limit for another.** The largest sheet in the corpus is 800,001 rows; at ~25 columns that is 20M cells, which is `MAX_TOTAL_CELLS` exactly. Some of these workbooks would clear the string ceiling and land on the cell bound instead — where `sparse: true` from #513 is now the answer, but that is a second decision for the caller rather than a transparent read.
2. **Whether you want the fallback to be automatic.** Silently switching parsers on a size threshold means two code paths that must agree on every field of the model, which is its own class of bug. An explicit option is duller and safer.

Happy to take it on if you want it, in whichever of those two shapes you prefer.
