### PR TITLE
fix(read): the string-ceiling guard never fired on Node — closes #516

### DIFF
--- a/src/_decode.ts
+++ b/src/_decode.ts
@@ -49,6 +49,31 @@ export function tooLargeToDecode(path: string, byteLength: number): ParseError {
 }
 
 /**
+ * Is this the string-length ceiling, and not some other failure?
+ *
+ * Three signals, because no one of them holds everywhere:
+ *
+ * - **Node throws a plain `Error`** carrying `code: "ERR_STRING_TOO_LONG"`.
+ *   `TextDecoder.decode` goes through Node's internal encoding layer,
+ *   which wraps V8's failure rather than passing it through. The first
+ *   version of this checked `instanceof RangeError` — which is what a
+ *   plain string concatenation throws — so on Node the guard never fired
+ *   and the raw error reached the caller exactly as before. See #516.
+ * - **Other engines throw a `RangeError`**, so that stays.
+ * - **The byte length is a necessary condition either way.** A string
+ *   cannot exceed {@link MAX_STRING_LENGTH} characters unless the buffer
+ *   exceeds it in bytes, since UTF-8 uses at least one byte per
+ *   character. So a failure on a buffer that large is this failure,
+ *   whatever the engine chose to call it — which is the backstop that
+ *   does not depend on guessing at engine internals.
+ */
+function isStringLengthCeiling(error: unknown, byteLength: number): boolean {
+  if (error instanceof RangeError) return true
+  if ((error as { code?: unknown } | null)?.code === "ERR_STRING_TOO_LONG") return true
+  return byteLength > MAX_STRING_LENGTH
+}
+
+/**
  * Decode a package part as UTF-8, or say why it cannot be.
  *
  * `path` is only used for the message, so a caller that has not resolved
@@ -58,9 +83,8 @@ export function decodePart(data: Uint8Array, path: string): string {
   try {
     return new TextDecoder("utf-8").decode(data)
   } catch (error) {
-    // A RangeError here is the string-length ceiling. Anything else is
-    // not ours to reinterpret.
-    if (error instanceof RangeError) throw tooLargeToDecode(path, data.length)
+    // Anything that is not the ceiling is not ours to reinterpret.
+    if (isStringLengthCeiling(error, data.length)) throw tooLargeToDecode(path, data.length)
     throw error
   }
 }

--- a/test/huge-part-error.test.ts
+++ b/test/huge-part-error.test.ts
@@ -17,11 +17,18 @@ import { ParseError, HucreError } from "../src/errors"
 // those files, in ~30s at a flat 944 MB. The buffered reader had a hard
 // ceiling it did not know about.
 //
-// The trigger is not reproducible here and that is worth stating rather
-// than working around: it needs a part larger than this repository.
-// Faking the decode failure would test the wrapper rather than the
-// condition, so what is tested is what has logic in it — the decision
-// and the message.
+// The first version of this file said the trigger was not reproducible —
+// that it needed a part larger than the repository — and tested only the
+// message factory. That was wrong, and the gap it left was a real bug:
+// the guard tested `instanceof RangeError`, Node throws a plain `Error`
+// with `code: "ERR_STRING_TOO_LONG"`, so on Node the conversion never
+// happened and the raw error reached the caller exactly as before (#516).
+//
+// The condition needs a large *buffer*, not a large *file*. One
+// allocation of MAX_STRING_LENGTH + 1 bytes reproduces it in about a
+// second, and that test is below. A test that could not fail for the
+// right reason is worth less than the paragraph explaining why it does
+// not exist.
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("the error a part over the ceiling produces", () => {
@@ -66,6 +73,23 @@ describe("decodePart", () => {
     expect(() => decodePart(notBytes, "x.xml")).toThrow()
     expect(() => decodePart(notBytes, "x.xml")).not.toThrow(ParseError)
   })
+
+  it("turns the real ceiling into a ParseError", () => {
+    // The test that was missing. ~537 MB, outside the JS heap, about a
+    // second — and it is the only thing here that exercises the `catch`
+    // rather than the message it builds.
+    const tooBig = new Uint8Array(MAX_STRING_LENGTH + 1)
+
+    expect(() => decodePart(tooBig, "xl/worksheets/sheet1.xml")).toThrow(ParseError)
+    expect(() => decodePart(tooBig, "xl/worksheets/sheet1.xml")).toThrow(/streamXlsxRows/)
+  }, 60_000)
+
+  it("recognises it whatever the engine calls the error", () => {
+    // Node throws `Error` + `code: "ERR_STRING_TOO_LONG"`; other engines
+    // throw `RangeError`. The byte length is the backstop that does not
+    // depend on guessing which.
+    expect(() => decodePart(new Uint8Array(MAX_STRING_LENGTH + 1), "p.xml")).toThrow(ParseError)
+  }, 60_000)
 
   it("reports the ceiling as the number V8 actually uses", () => {
     // 0x1fffffe8. Hard-coded here so a change to the constant is a


### PR DESCRIPTION
Closes #516. You are right on both counts, and the second one is the more useful correction.

## The guard tested the wrong type

Verified here rather than taken on trust:

```
ctor       : Error
RangeError : false
code       : ERR_STRING_TOO_LONG
message    : Cannot create a string longer than 0x1fffffe8 characters
```

`TextDecoder.decode` goes through Node's internal encoding layer, which wraps V8's failure rather than passing it through. My `RangeError` assumption came from plain string concatenation, which *does* throw one — so the fix for #503 shipped doing nothing on the runtime it was written for.

Three signals now, since no single one holds everywhere:

- Node's `code === "ERR_STRING_TOO_LONG"`
- other engines' `RangeError`
- **the byte length**, as the backstop that does not depend on guessing at engine internals: a string cannot exceed the ceiling in characters unless the buffer exceeds it in bytes, because UTF-8 uses at least one byte per character. So a failure on a buffer that large *is* this failure, whatever the engine chose to call it.

I kept the `catch` rather than switching to an up-front comparison, for the reason you agreed with — but the length now serves as evidence inside the catch instead of as a gate before it, which gets the engine-independence without the false positives.

## The claim about testing it was wrong

This is the part worth naming. #514 said:

> reproducing the condition needs a part over 512 MB, which is larger than this repository

and tested only the message factory. The condition needs a large **buffer**, not a large **file** — as you point out, one `new Uint8Array(MAX_STRING_LENGTH + 1)` reproduces it in about a second, outside the JS heap, with no fixture.

So the untested branch was the one with the bug in it, and the comment explaining why it could not be tested was doing the work of hiding that. Your framing is exact: it is the closed loop of #464 reappearing *inside* the fix for a bug that only breaking the loop had found.

The test is now there. It fails against `b723e80` and passes here, and it is the only case in the file that exercises the `catch` rather than the message it builds.

```
× turns the real ceiling into a ParseError
  AssertionError: expected error to be instance of ParseError
```

`pnpm lint`, `pnpm typecheck`, 10317 tests green; the new case adds ~1.2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
