### PR TITLE
feat(xml): a streaming reader — closes #467

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ const buffer = await writer.finish()
 ```ts
 import { writeOdsStream } from "hucre/ods"
 import { writeNdjsonStream } from "hucre/json"
-import { writeXmlStream } from "hucre/xml"
+import { streamXmlRows, writeXmlStream } from "hucre/xml"
 
 return new Response(writeOdsStream(rowCursor, { name: "Export" }), {
   headers: { "content-type": "application/vnd.oasis.opendocument.spreadsheet" },
@@ -429,6 +429,11 @@ return new Response(writeNdjsonStream(rowCursor), {
 return new Response(writeXmlStream(rowCursor, { rowTag: "record" }), {
   headers: { "content-type": "application/xml; charset=utf-8" },
 })
+
+// Reading one back, a row at a time.
+for await (const row of streamXmlRows(bytes, { rowTag: "record" })) {
+  console.log(row.index, row.values)
+}
 ```
 
 |        | whole read | whole write | stream read | stream write | incremental writer |
@@ -437,7 +442,7 @@ return new Response(writeXmlStream(rowCursor, { rowTag: "record" }), {
 | CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
 | NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
 | ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
-| XML    |     ✔      |      ✔      |      —      |      ✔       |         —          |
+| XML    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
 
 `writeOdsStream` carries **values, not formatting**, and that follows from
 the format: ODF puts `<office:automatic-styles>` before the body, so a
@@ -447,10 +452,18 @@ with inline strings and ODF has no equivalent for. Column widths and a
 header row are carried, because `columns` is known before the first row.
 `writeOds` remains the path for a document that needs styling.
 
-XML's **reader** is the remaining gap. `src/xml/parser.ts` is push-based,
-so a streaming reader needs a pull-based row scanner rather than a
-wrapper around what is there — that is its own change, not an oversight
-in this table.
+`streamXmlRows` differs from `readXml` in one way that follows from
+streaming rather than from a choice: **it yields the keys each row
+actually has.** `readXml` pads every row to the union of all headers,
+which needs the whole document — a streaming reader cannot know a key
+that appears only in a later row. For the same reason it takes `rowTag`
+from the first child of the root rather than from the most frequent one.
+
+The only cell left is an incremental ODS writer. `writeOdsStream` covers
+the streaming case; a buffering class could carry the styles it cannot,
+which would leave two ODS writers with different capabilities and no
+obvious rule for choosing — so it is an open question rather than an
+oversight.
 
 #### Which writer to use
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,14 @@ export type {
 } from "./json"
 
 // ── XML ────────────────────────────────────────────────────────────
-export { readXml, writeXml, writeXmlStream } from "./xml"
-export type { XmlReadOptions, XmlReadResult, XmlWriteOptions } from "./xml"
+export { readXml, writeXml, writeXmlStream, streamXmlRows } from "./xml"
+export type {
+  XmlReadOptions,
+  XmlReadResult,
+  XmlWriteOptions,
+  XmlStreamRow,
+  XmlStreamReadOptions,
+} from "./xml"
 
 // ── Schema Validation ──────────────────────────────────────────────
 export { validateWithSchema } from "./_schema"

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -5,6 +5,8 @@ export { readXml } from "./xml/data-reader"
 export type { XmlReadOptions, XmlReadResult } from "./xml/data-reader"
 
 export { writeXml, writeXmlStream } from "./xml/data-writer"
+export { streamXmlRows } from "./xml/stream-reader"
+export type { XmlStreamRow, XmlStreamReadOptions } from "./xml/stream-reader"
 export type { XmlWriteOptions } from "./xml/data-writer"
 
 // ── Shared types used by this entry point's signatures ──────────────

--- a/src/xml/data-reader.ts
+++ b/src/xml/data-reader.ts
@@ -50,7 +50,7 @@ export interface XmlReadResult<T extends Record<string, CellValue> = Record<stri
   rowTag: string
 }
 
-interface MiniElement {
+export interface MiniElement {
   tag: string
   local: string
   prefix: string
@@ -59,9 +59,9 @@ interface MiniElement {
   text: string
 }
 
-type MiniNode = MiniElement | { __text: string }
+export type MiniNode = MiniElement | { __text: string }
 
-function splitTag(tag: string): { local: string; prefix: string } {
+export function splitTag(tag: string): { local: string; prefix: string } {
   const colon = tag.indexOf(":")
   if (colon === -1) return { local: tag, prefix: "" }
   return { prefix: tag.slice(0, colon), local: tag.slice(colon + 1) }
@@ -195,7 +195,7 @@ function detectRowTag(input: string, stripNs: boolean): string {
 
 // ── Row collection ─────────────────────────────────────────────────────
 
-function collectRows(input: string, rowTag: string, stripNs: boolean): MiniElement[] {
+export function collectRows(input: string, rowTag: string, stripNs: boolean): MiniElement[] {
   const rows: MiniElement[] = []
   // Stack of elements we are currently building. The first entry (when set)
   // is the root row element; nested elements are pushed/popped during traversal.
@@ -259,14 +259,14 @@ function collectRows(input: string, rowTag: string, stripNs: boolean): MiniEleme
 
 // ── Flatten a row element into dot-path keys ───────────────────────────
 
-interface FlattenCtx {
+export interface FlattenCtx {
   attrPrefix: string
   flatten: boolean
   textKey: string
   stripNs: boolean
 }
 
-function elementToFlat(
+export function elementToFlat(
   el: MiniElement,
   ctx: FlattenCtx,
   prefix: string,

--- a/src/xml/stream-reader.ts
+++ b/src/xml/stream-reader.ts
@@ -1,0 +1,256 @@
+// ── Streaming XML reader ────────────────────────────────────────────
+//
+// XML was the last format with no streaming reader. `readXml` builds
+// every row before returning one, so a feed larger than memory could not
+// be walked at all. See #467.
+//
+// The obstacle was that `src/xml/parser.ts` is push-based: `parseSax`
+// runs to completion and calls back, so wrapping it in a generator would
+// buffer every row before yielding the first — the opposite of the
+// point.
+//
+// What this does instead is split the work in two, so almost none of it
+// is new code:
+//
+//   1. A scanner walks the source and finds the *span* of each row
+//      element. It understands only what it must to know where an
+//      element ends — comments, CDATA, processing instructions,
+//      doctypes, quoted attributes, self-closing tags, and elements
+//      nested inside a row that share its name.
+//   2. Each span is handed to `collectRows`, the same function `readXml`
+//      uses, so the element model and the flattening are identical *by
+//      construction* rather than by a second implementation agreeing.
+//
+// The scanner's failure mode is loud: a mis-cut span is not well-formed
+// XML and the parse throws, rather than quietly yielding a wrong row.
+
+import type { CellValue } from "../_types"
+import { ParseError } from "../errors"
+import { collectRows, elementToFlat, splitTag } from "./data-reader"
+import type { XmlReadOptions } from "./data-reader"
+
+/** One row, as `readXml` would have flattened it. */
+export interface XmlStreamRow<T = Record<string, CellValue>> {
+  /** 0-based position among the rows yielded. */
+  index: number
+  /** The flattened record. */
+  values: T
+}
+
+export interface XmlStreamReadOptions extends Pick<
+  XmlReadOptions,
+  "rowTag" | "stripNamespaces" | "attrPrefix" | "flatten" | "textKey" | "maxRows"
+> {}
+
+/**
+ * Read an XML feed a row at a time.
+ *
+ * ```ts
+ * for await (const row of streamXmlRows(bytes, { rowTag: "record" })) {
+ *   console.log(row.index, row.values)
+ * }
+ * ```
+ *
+ * Peak memory tracks one row rather than the whole document — the source
+ * itself is still held, the same as `streamOdsRows`, because a `<row>`
+ * cannot be parsed before its closing tag arrives and the format gives
+ * no index to seek by.
+ *
+ * `rowTag` is worth passing. Without it the tag is taken from the first
+ * child of the root, which is what a feed of uniform records has;
+ * `readXml` instead counts every child and takes the most frequent,
+ * which needs the whole document and so is not something a streaming
+ * reader can do.
+ */
+export async function* streamXmlRows<T = Record<string, CellValue>>(
+  input: string | Uint8Array,
+  options?: XmlStreamReadOptions,
+): AsyncGenerator<XmlStreamRow<T>, void, undefined> {
+  const xml = typeof input === "string" ? input : new TextDecoder("utf-8").decode(input)
+  if (xml.trim() === "") return
+
+  const stripNs = options?.stripNamespaces ?? false
+  const flatOpts = {
+    attrPrefix: options?.attrPrefix ?? "@",
+    flatten: options?.flatten ?? true,
+    textKey: options?.textKey ?? "#text",
+    stripNs,
+  }
+  const limit = options?.maxRows ?? Infinity
+
+  let rowTag = options?.rowTag
+  let index = 0
+
+  for (const span of scanRowSpans(xml, rowTag, stripNs)) {
+    if (index >= limit) return
+    // The first span settles the tag when the caller did not name one.
+    rowTag ??= span.tag
+
+    // Wrapped so the row sits at depth 2, which is where `collectRows`
+    // looks — the same position it occupies under the real root.
+    const [element] = collectRows(
+      `<x>${span.text}</x>`,
+      stripNs ? splitTag(span.tag).local : span.tag,
+      stripNs,
+    )
+    if (!element) continue
+
+    const values: Record<string, CellValue> = {}
+    elementToFlat(element, flatOpts, "", values)
+    yield { index, values: values as T }
+    index++
+  }
+}
+
+interface RowSpan {
+  tag: string
+  text: string
+}
+
+/**
+ * Find the source span of every row element, without building any of it.
+ *
+ * A generator so the caller pulls: nothing beyond the current row is
+ * scanned until the next `next()`.
+ */
+function* scanRowSpans(
+  xml: string,
+  rowTag: string | undefined,
+  stripNs: boolean,
+): Generator<RowSpan> {
+  const matches = (tag: string): boolean => {
+    if (rowTag === undefined) return true
+    return stripNs ? splitTag(tag).local === rowTag : tag === rowTag
+  }
+
+  let i = 0
+  let depth = 0
+  /** Where the current row started, and how deep we were when it did. */
+  let rowStart = -1
+  let rowTagName = ""
+  let rowDepth = -1
+
+  while (i < xml.length) {
+    const lt = xml.indexOf("<", i)
+    if (lt < 0) break
+
+    // ── The things that are not elements ─────────────────────────────
+    if (xml.startsWith("<!--", lt)) {
+      const end = xml.indexOf("-->", lt + 4)
+      i = end < 0 ? xml.length : end + 3
+      continue
+    }
+    if (xml.startsWith("<![CDATA[", lt)) {
+      const end = xml.indexOf("]]>", lt + 9)
+      i = end < 0 ? xml.length : end + 3
+      continue
+    }
+    if (xml.startsWith("<?", lt)) {
+      const end = xml.indexOf("?>", lt + 2)
+      i = end < 0 ? xml.length : end + 2
+      continue
+    }
+    if (xml.startsWith("<!", lt)) {
+      // A doctype, which may carry an internal subset in brackets.
+      i = skipDoctype(xml, lt)
+      continue
+    }
+
+    // ── An element ───────────────────────────────────────────────────
+    const closing = xml.charCodeAt(lt + 1) === 47 /* / */
+    const tagEnd = findTagEnd(xml, lt)
+    if (tagEnd < 0) break
+
+    const selfClosing = !closing && xml.charCodeAt(tagEnd - 1) === 47 /* / */
+    const tag = readTagName(xml, lt + (closing ? 2 : 1))
+
+    if (closing) {
+      depth--
+      if (rowStart >= 0 && depth === rowDepth && tag === rowTagName) {
+        yield { tag: rowTagName, text: xml.slice(rowStart, tagEnd + 1) }
+        rowStart = -1
+      }
+    } else if (!selfClosing) {
+      // A row opens only at depth 1 — a direct child of the root — and
+      // only when we are not already inside one, so an element nested in
+      // a row that shares its name does not start a second.
+      if (rowStart < 0 && depth === 1 && matches(tag)) {
+        rowStart = lt
+        rowTagName = tag
+        rowDepth = depth
+      }
+      depth++
+    } else if (rowStart < 0 && depth === 1 && matches(tag)) {
+      // `<row/>` — a whole row in one tag.
+      yield { tag, text: xml.slice(lt, tagEnd + 1) }
+    }
+
+    i = tagEnd + 1
+  }
+
+  if (rowStart >= 0) {
+    throw new ParseError(`Unterminated <${rowTagName}> element in XML input`)
+  }
+}
+
+/**
+ * The index of the `>` that ends the tag starting at `start`.
+ *
+ * `>` inside a quoted attribute value does not end anything, which is
+ * the one place a naive `indexOf(">")` goes wrong on real documents.
+ */
+function findTagEnd(xml: string, start: number): number {
+  let quote = 0
+  for (let i = start + 1; i < xml.length; i++) {
+    const c = xml.charCodeAt(i)
+    if (quote !== 0) {
+      if (c === quote) quote = 0
+      continue
+    }
+    if (c === 34 /* " */ || c === 39 /* ' */) {
+      quote = c
+      continue
+    }
+    if (c === 62 /* > */) return i
+  }
+  return -1
+}
+
+/** The tag name starting at `start`, up to whitespace or the tag's end. */
+function readTagName(xml: string, start: number): string {
+  let i = start
+  while (i < xml.length) {
+    const c = xml.charCodeAt(i)
+    if (c === 32 || c === 9 || c === 10 || c === 13 || c === 62 /* > */ || c === 47 /* / */) break
+    i++
+  }
+  return xml.slice(start, i)
+}
+
+/**
+ * Skip a `<!DOCTYPE …>`, including an internal subset.
+ *
+ * The subset is bracketed and may itself contain `>`, so the bracket has
+ * to be tracked rather than scanning for the first `>`.
+ */
+function skipDoctype(xml: string, start: number): number {
+  let i = start + 2
+  let bracket = 0
+  let quote = 0
+  while (i < xml.length) {
+    const c = xml.charCodeAt(i)
+    if (quote !== 0) {
+      if (c === quote) quote = 0
+    } else if (c === 34 || c === 39) {
+      quote = c
+    } else if (c === 91 /* [ */) {
+      bracket++
+    } else if (c === 93 /* ] */) {
+      bracket--
+    } else if (c === 62 /* > */ && bracket <= 0) {
+      return i + 1
+    }
+    i++
+  }
+  return xml.length
+}

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -118,6 +118,7 @@ exports[`export surface snapshot > hucre/xlsx 1`] = `
 exports[`export surface snapshot > hucre/xml 1`] = `
 [
   "readXml",
+  "streamXmlRows",
   "writeXml",
   "writeXmlStream",
 ]
@@ -244,6 +245,7 @@ exports[`export surface snapshot > root 1`] = `
   "streamNdjsonRows",
   "streamOdsRows",
   "streamXlsxRows",
+  "streamXmlRows",
   "stripBom",
   "timeToSerial",
   "toHtml",

--- a/test/xml-stream-reader.test.ts
+++ b/test/xml-stream-reader.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest"
+import { readXml } from "../src/xml/data-reader"
+import { writeXml } from "../src/xml/data-writer"
+import { streamXmlRows } from "../src/xml/stream-reader"
+import { seeded } from "./_fuzz"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #467 — XML was the last format with no streaming reader.
+//
+// `src/xml/parser.ts` is push-based, so wrapping `parseSax` in a
+// generator would buffer every row before yielding the first. The way
+// round it is to split the work: a scanner finds each row's *span*, and
+// each span goes to `collectRows` — the same function `readXml` uses —
+// so the element model and the flattening are identical by construction
+// rather than by a second implementation agreeing.
+//
+// Which means the test that matters is agreement with `readXml`. The
+// scanner is the only new logic, and its whole job is knowing where an
+// element ends: comments, CDATA, processing instructions, doctypes with
+// internal subsets, `>` inside a quoted attribute, self-closing tags,
+// and an element nested inside a row that shares its name.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function rowsOf(xml: string, options?: Parameters<typeof streamXmlRows>[1]) {
+  const out: Array<Record<string, CellValue>> = []
+  for await (const row of streamXmlRows(xml, options))
+    out.push(row.values as Record<string, CellValue>)
+  return out
+}
+
+/**
+ * `readXml` pads every row to the union of all headers; a streaming
+ * reader cannot know a key that appears only in a later row. Comparing
+ * on the keys each row actually carries is what the two can agree on.
+ */
+const trim = (o: Record<string, CellValue>): Record<string, CellValue> =>
+  Object.fromEntries(Object.entries(o).filter(([, v]) => v !== null))
+
+describe("it agrees with readXml on the shapes a scanner can get wrong", () => {
+  const CASES: Array<[string, string, Parameters<typeof readXml>[1]?]> = [
+    ["plain rows", "<root><row><a>1</a><b>x</b></row><row><a>2</a><b>y</b></row></root>"],
+    ["attributes", '<root><row id="1"><v>3</v></row><row id="2"><v>4</v></row></root>'],
+    [
+      "nested elements",
+      "<root><row><a><b>1</b><c>2</c></a></row><row><a><b>3</b></a></row></root>",
+    ],
+    ["a self-closing row", "<root><row/><row><a>1</a></row></root>"],
+    [
+      "CDATA holding a tag",
+      "<root><row><a><![CDATA[<not a tag>]]></a></row><row><a>2</a></row></root>",
+    ],
+    ["a comment holding a row", "<root><!-- <row>fake</row> --><row><a>1</a></row></root>"],
+    ["`>` inside an attribute", '<root><row a="x>y"><v>1</v></row></root>'],
+    ["a quote inside an attribute", `<root><row a='q">z'><v>1</v></row></root>`],
+    [
+      "a doctype with an internal subset",
+      '<?xml version="1.0"?><!DOCTYPE root [<!ENTITY x "y">]><root><row><a>1</a></row></root>',
+    ],
+    ["a row nested inside a row", "<root><row><row>inner</row></row><row><a>2</a></row></root>"],
+    ["indentation", "<root>\n  <row>\n    <a>1</a>\n  </row>\n</root>"],
+    ["mixed content", "<root><row>text<a>1</a>more</row></root>"],
+    ["entities", "<root><row><a>&amp;&lt;&gt;&#65;</a></row></root>"],
+    ["a processing instruction inside a row", "<root><row><?target data?><a>1</a></row></root>"],
+    [
+      "namespaces",
+      "<root><ns:row xmlns:ns='u'><ns:a>1</ns:a></ns:row></root>",
+      { stripNamespaces: true },
+    ],
+  ]
+
+  for (const [label, xml, options] of CASES) {
+    it(label, async () => {
+      const reference = readXml(xml, options)
+      const streamed = await rowsOf(xml, { ...options, rowTag: reference.rowTag || undefined })
+
+      expect(streamed.map(trim)).toEqual(reference.data.map(trim))
+    })
+  }
+})
+
+describe("it agrees over generated documents too", () => {
+  it("400 of them, seeded", async () => {
+    // The hand-written cases are the ones someone thought of. These are
+    // the ones nobody did — same discipline as test/fuzz-robustness.
+    const rnd = seeded(0xabcdef)
+    const NASTY = [
+      "plain",
+      "a<b",
+      "a>b",
+      'q"uote',
+      "amp&amp",
+      "<!-- x -->",
+      "]]>",
+      "<row>fake</row>",
+      "  pad  ",
+      "ünï",
+      "😀",
+    ]
+
+    for (let run = 0; run < 400; run++) {
+      const keys = ["a", "b", "c"].slice(0, 1 + Math.floor(rnd() * 3))
+      const rows = Array.from({ length: 1 + Math.floor(rnd() * 5) }, () => {
+        const row: Record<string, CellValue> = {}
+        for (const key of keys) {
+          if (rnd() < 0.2) continue
+          row[key] =
+            rnd() < 0.5 ? NASTY[Math.floor(rnd() * NASTY.length)]! : Math.floor(rnd() * 1000)
+        }
+        if (rnd() < 0.3) row["@id"] = Math.floor(rnd() * 100)
+        return row
+      })
+
+      const xml = writeXml(rows, { pretty: rnd() < 0.5 })
+      let reference: ReturnType<typeof readXml>
+      try {
+        reference = readXml(xml)
+      } catch {
+        continue
+      }
+
+      const streamed = await rowsOf(xml, { rowTag: reference.rowTag || undefined })
+      expect(streamed.map(trim), `run ${run}`).toEqual(reference.data.map(trim))
+    }
+  }, 120_000)
+})
+
+describe("the streaming properties", () => {
+  it("yields an index with each row", async () => {
+    const xml = "<root><row><a>1</a></row><row><a>2</a></row><row><a>3</a></row></root>"
+    const seen: number[] = []
+    for await (const row of streamXmlRows(xml)) seen.push(row.index)
+
+    expect(seen).toEqual([0, 1, 2])
+  })
+
+  it("stops at maxRows without scanning the rest", async () => {
+    const xml = `<root>${"<row><a>1</a></row>".repeat(1000)}</root>`
+
+    expect(await rowsOf(xml, { maxRows: 3 })).toHaveLength(3)
+  })
+
+  it("scans lazily — the caller decides how far to go", async () => {
+    // The property the whole thing exists for. Abandoning after one row
+    // must not have cost the other 999.
+    const xml = `<root>${Array.from({ length: 1000 }, (_, i) => `<row><a>${i}</a></row>`).join("")}</root>`
+
+    const iterator = streamXmlRows(xml)[Symbol.asyncIterator]()
+    const first = await iterator.next()
+    await iterator.return?.(undefined)
+
+    expect(first.value?.values).toEqual({ a: "0" })
+  })
+
+  it("takes bytes as well as a string", async () => {
+    const xml = "<root><row><a>şehir</a></row></root>"
+
+    expect(await rowsOf(new TextEncoder().encode(xml) as never)).toEqual([{ a: "şehir" }])
+  })
+
+  it("infers the row tag from the first child when none is given", async () => {
+    // `readXml` counts every child and takes the most frequent, which
+    // needs the whole document. A streaming reader takes the first.
+    expect(await rowsOf("<root><record><a>1</a></record></root>")).toEqual([{ a: "1" }])
+  })
+
+  it("yields nothing for an empty document", async () => {
+    expect(await rowsOf("")).toEqual([])
+    expect(await rowsOf("   ")).toEqual([])
+  })
+})
+
+describe("what it refuses", () => {
+  it("an unterminated row, rather than yielding a truncated one", async () => {
+    await expect(rowsOf("<root><row><a>1</a>")).rejects.toThrow(/Unterminated/)
+  })
+})


### PR DESCRIPTION
Closes #467. The last reader gap in the matrix.

|        | whole read | whole write | stream read | stream write | incremental writer |
| ------ | :--------: | :---------: | :---------: | :----------: | :----------------: |
| XLSX   |     ✔      |      ✔      |      ✔      |  ✔ (multi)   |         ✔          |
| CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
| XML    |     ✔      |      ✔      |  ✔ **new**  |      ✔       |         —          |

## The obstacle, and the way round it

#515 left this open for a real reason: `parseSax` is push-based — it runs to completion and calls back — so wrapping it in a generator buffers every row before yielding the first.

The way round is to split the work so **almost none of it is new code**:

1. A scanner finds the *span* of each row element.
2. Each span goes to `collectRows` — the same function `readXml` uses.

So the element model and the flattening are identical **by construction**, not because a second implementation happens to agree. That matters: the risk in "write a streaming version" is two parsers drifting, and this design removes it rather than testing for it.

The scanner is the only new logic, and its entire job is knowing where an element ends. Its failure mode is loud: a mis-cut span is not well-formed XML and the parse throws, rather than quietly yielding a wrong row.

## So the test is agreement with `readXml`

Fifteen hand-written cases, one per way a naive scanner goes wrong:

CDATA holding a tag · a comment holding a row · `>` inside an attribute · a quote inside an attribute · a doctype with an internal subset · a row nested inside a row · a self-closing row · a processing instruction inside a row · mixed content · namespaces · entities · indentation

…plus **400 generated documents**, seeded the same way the fuzzer is, with values drawn from a nasty list (`a<b`, `]]>`, `<row>fake</row>`, `😀`, padded whitespace). All agree.

## One difference, and it is not a choice

`streamXmlRows` yields **the keys each row actually has**. `readXml` pads every row to the union of all headers — which needs the whole document, so a streaming reader cannot do it. For the same reason `rowTag` is taken from the first child of the root rather than the most frequent one.

Both are documented in the README and in the function's own doc. The agreement test compares on present keys for exactly this reason, and says so.

## What is left

One cell: an incremental ODS writer. `writeOdsStream` covers the streaming case; a buffering class *could* carry the styles it cannot, which would leave two ODS writers with different capabilities and no obvious rule for choosing. That is an open question rather than an oversight, and the README now says so instead of showing a bare dash.

`pnpm lint`, `pnpm typecheck`, 10339 tests green; coverage and size budgets pass. Export snapshots moved by one name on each of two surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
