### PR TITLE
feat(ods): an incremental writer — closes #467

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ for await (const row of streamXmlRows(bytes, { rowTag: "record" })) {
 | XLSX   |     ✔      |      ✔      |      ✔      |  ✔ (multi)   |         ✔          |
 | CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
 | NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
-| ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
+| ODS    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
 | XML    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |
 
 `writeOdsStream` carries **values, not formatting**, and that follows from
@@ -459,11 +459,16 @@ which needs the whole document — a streaming reader cannot know a key
 that appears only in a later row. For the same reason it takes `rowTag`
 from the first child of the root rather than from the most frequent one.
 
-The only cell left is an incremental ODS writer. `writeOdsStream` covers
-the streaming case; a buffering class could carry the styles it cannot,
-which would leave two ODS writers with different capabilities and no
-obvious rule for choosing — so it is an open question rather than an
-oversight.
+ODS now has both writers, and the rule for choosing is the same one XLSX
+already has: `writeOdsStream` for constant memory and values only,
+`OdsStreamWriter` when you want the styles and can afford to buffer.
+
+That difference is the format's, not a gap: ODF puts
+`<office:automatic-styles>` **before** the body, so a style first seen on
+row 900,000 has nowhere to be declared once the body has gone out. A
+buffering writer holds the rows until `finish()` and writes the style
+block from everything it saw, which is exactly what buys it per-cell
+styles and column widths.
 
 #### Which writer to use
 
@@ -511,9 +516,9 @@ Run `pnpm bench` to see both on your own machine.
 
 #### One surface across the incremental writers
 
-`XlsxStreamWriter`, `CsvStreamWriter`, and `NdjsonStreamWriter` all
-implement `SpreadsheetStreamWriter`, so a format-agnostic export helper
-can be written once:
+`XlsxStreamWriter`, `CsvStreamWriter`, `NdjsonStreamWriter` and
+`OdsStreamWriter` all implement `SpreadsheetStreamWriter`, so a
+format-agnostic export helper can be written once:
 
 | Method            | Behaviour                                                         |
 | ----------------- | ----------------------------------------------------------------- |

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,12 @@ export type {
 export { readOds } from "./ods/reader"
 export { writeOds } from "./ods/writer"
 export { writeOdsStream } from "./ods/stream-writer"
+export { OdsStreamWriter } from "./ods/incremental-writer"
+export type {
+  OdsStreamWriterOptions,
+  OdsStyledCell,
+  OdsIncrementalCell,
+} from "./ods/incremental-writer"
 export type { OdsWriteRow, OdsWriteCell, OdsStreamWriteOptions } from "./ods/stream-writer"
 export { streamOdsRows } from "./ods/stream"
 export { readOdsObjects, writeOdsObjects } from "./ods/objects"

--- a/src/ods.ts
+++ b/src/ods.ts
@@ -4,6 +4,12 @@
 export { readOds } from "./ods/reader"
 export { writeOds } from "./ods/writer"
 export { writeOdsStream } from "./ods/stream-writer"
+export { OdsStreamWriter } from "./ods/incremental-writer"
+export type {
+  OdsStreamWriterOptions,
+  OdsStyledCell,
+  OdsIncrementalCell,
+} from "./ods/incremental-writer"
 export type { OdsWriteRow, OdsWriteCell, OdsStreamWriteOptions } from "./ods/stream-writer"
 export { streamOdsRows } from "./ods/stream"
 export type { OdsStreamRow } from "./ods/stream"

--- a/src/ods/incremental-writer.ts
+++ b/src/ods/incremental-writer.ts
@@ -1,0 +1,264 @@
+// ── Incremental ODS Writer ──────────────────────────────────────────
+//
+// The last empty cell in the streaming matrix. `writeOdsStream` covers
+// the constant-memory case and carries values only, because ODF puts
+// `<office:automatic-styles>` *before* the body: a style first seen on
+// row 900,000 has nowhere to be declared once the body has gone out.
+//
+// A buffering writer does not have that problem. It holds the serialized
+// rows until `finish()`, so the style block can be written from
+// everything it saw. That is the trade this class exists to make, and it
+// is the same one XLSX already offers: `writeXlsxStream` for constant
+// memory, `XlsxStreamWriter` for a buffer you can style. See #467.
+
+import type { CellValue, CellStyle, WorkbookProperties } from "../_types"
+import { validateSheetNames } from "../_validate"
+import { xmlElement, xmlSelfClose } from "../xml/writer"
+import { ZipWriter } from "../zip/writer"
+import {
+  MIMETYPE,
+  cellToOds,
+  createStyleCollector,
+  getOrCreateStyleName,
+  writeManifestXml,
+  writeMetaXml,
+  writeSettingsXml,
+  writeStylesXml,
+} from "./writer"
+import type { CellContext } from "./writer"
+
+const encoder = /* @__PURE__ */ new TextEncoder()
+
+/** A cell that brings its own formatting, or just a value. */
+export type OdsStyledCell = { value?: CellValue; style?: CellStyle; formula?: string }
+export type OdsIncrementalCell = CellValue | OdsStyledCell
+
+export interface OdsStreamWriterOptions {
+  /** Sheet name. Excel's limits apply — LibreOffice enforces them too. */
+  name?: string
+  /**
+   * Column definitions. `header` writes a first row; `width` and `style`
+   * are carried, unlike in `writeOdsStream` where the body has already
+   * gone out by the time a style is known.
+   */
+  columns?: Array<{ header?: string; key?: string; width?: number; style?: CellStyle }>
+  /** Document properties written to `meta.xml`. */
+  properties?: WorkbookProperties
+}
+
+/**
+ * Incremental ODS writer.
+ *
+ * Rows are serialized to XML as they arrive — no workbook object model
+ * is built — but every serialized row is retained until {@link finish}
+ * assembles the archive, so peak memory scales with the data. For
+ * constant-memory output use `writeOdsStream` instead, and accept that
+ * it carries values only.
+ *
+ * ```ts
+ * const writer = new OdsStreamWriter({
+ *   name: "Report",
+ *   columns: [{ header: "Name", width: 20 }, { header: "Qty" }],
+ * })
+ * writer.addRow(["Widget", { value: 3, style: { font: { bold: true } } }])
+ * const bytes = await writer.finish()
+ * ```
+ *
+ * Implements the same `addRow` / `addObject` / `finish` / `toStream`
+ * vocabulary as the other incremental writers, so a format-agnostic
+ * helper written against `SpreadsheetStreamWriter` takes it unchanged.
+ */
+export class OdsStreamWriter {
+  private sheetName: string
+  private columns: OdsStreamWriterOptions["columns"]
+  private properties: WorkbookProperties | undefined
+  private collector = createStyleCollector()
+  private rowFragments: string[] = []
+  private maxCols = 0
+  private done = false
+
+  constructor(options?: OdsStreamWriterOptions) {
+    this.sheetName = options?.name ?? "Sheet1"
+    validateSheetNames([{ name: this.sheetName }])
+    this.columns = options?.columns
+    this.properties = options?.properties
+
+    // A header row is written immediately, the same as XlsxStreamWriter
+    // does, so `addRow` starts at the first data row either way.
+    const headers = this.columns?.map((c) => c.header)
+    if (headers?.some((h) => h !== undefined)) {
+      this.addRow(headers.map((h) => h ?? null))
+    }
+  }
+
+  /** Append a row of positional values, each optionally styled. */
+  addRow(values: OdsIncrementalCell[]): void {
+    if (this.done) {
+      throw new Error("Cannot write to OdsStreamWriter after finish()")
+    }
+    if (values.length > this.maxCols) this.maxCols = values.length
+
+    const cells: string[] = []
+    for (let i = 0; i < values.length; i++) {
+      const raw = values[i]
+      const styled = isStyled(raw) ? raw : undefined
+      const value = styled ? (styled.value ?? null) : (raw as CellValue)
+
+      // A cell's own style wins over its column's, which is the same
+      // precedence XlsxStreamWriter uses.
+      const style = styled?.style ?? this.columns?.[i]?.style
+      const ctx: CellContext = {}
+      if (style) {
+        const name = getOrCreateStyleName(this.collector, style)
+        if (name) ctx.styleName = name
+      }
+      if (styled?.formula !== undefined) {
+        ctx.cellOverride = { formula: styled.formula }
+      }
+
+      cells.push(cellToOds(value, ctx, this.collector))
+    }
+
+    this.rowFragments.push(`<table:table-row>${cells.join("")}</table:table-row>`)
+  }
+
+  /**
+   * Append a row from an object, projected through the column order.
+   *
+   * Needs `columns` with `key` accessors, for the same reason
+   * `XlsxStreamWriter.addObject` does: an object's values have no
+   * position without one.
+   */
+  addObject(item: Record<string, CellValue>): void {
+    if (!this.columns) {
+      throw new Error("addObject requires columns with key accessors")
+    }
+    this.addRow(this.columns.map((c) => (c.key ? (item[c.key] ?? null) : null)))
+  }
+
+  /** Finalize and return the ODS document. */
+  async finish(): Promise<Uint8Array> {
+    this.done = true
+
+    const zip = new ZipWriter()
+    // mimetype MUST be first and MUST be stored uncompressed.
+    zip.add("mimetype", encoder.encode(MIMETYPE), { compress: false })
+    zip.add("META-INF/manifest.xml", encoder.encode(writeManifestXml()))
+    zip.add("content.xml", encoder.encode(this.contentXml()))
+    zip.add("meta.xml", encoder.encode(writeMetaXml(this.properties)))
+    zip.add("styles.xml", encoder.encode(writeStylesXml()))
+    zip.add("settings.xml", encoder.encode(writeSettingsXml()))
+    return zip.build()
+  }
+
+  /**
+   * Emit the finished document as a `ReadableStream<Uint8Array>`.
+   *
+   * Like `XlsxStreamWriter.toStream()`, this does **not** bound memory —
+   * everything is buffered until `finish()` and the stream hands you the
+   * result. `writeOdsStream` is the constant-memory path.
+   */
+  toStream(): ReadableStream<Uint8Array> {
+    const finish = (): Promise<Uint8Array> => this.finish()
+    return new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        controller.enqueue(await finish())
+        controller.close()
+      },
+    })
+  }
+
+  /**
+   * Assemble content.xml.
+   *
+   * The order is the point: the style block is built *here*, from
+   * everything the rows produced, and ODF requires it before the body.
+   * Data styles come before the cell styles that reference them.
+   */
+  private contentXml(): string {
+    const columnElements: string[] = []
+    const count = Math.max(this.maxCols, this.columns?.length ?? 0)
+    for (let i = 0; i < count; i++) {
+      const width = this.columns?.[i]?.width
+      columnElements.push(
+        width === undefined
+          ? xmlSelfClose("table:table-column")
+          : xmlSelfClose("table:table-column", {
+              "table:style-name": this.columnStyleName(i, width),
+            }),
+      )
+    }
+
+    const table = xmlElement("table:table", { "table:name": this.sheetName }, [
+      ...columnElements,
+      ...this.rowFragments,
+    ])
+    const body = xmlElement(
+      "office:body",
+      undefined,
+      xmlElement("office:spreadsheet", undefined, table),
+    )
+
+    const styleParts = [
+      ...this.collector.dataStyleElements.values(),
+      ...this.collector.styleElements.values(),
+      ...this.collector.textStyleElements.values(),
+      ...this.columnStyles.values(),
+    ]
+
+    return xmlDocumentContent([
+      xmlSelfClose("office:scripts"),
+      xmlElement("office:font-face-decls", undefined, ""),
+      xmlElement("office:automatic-styles", undefined, styleParts.length > 0 ? styleParts : ""),
+      body,
+    ])
+  }
+
+  private columnStyles = new Map<string, string>()
+
+  /** A `<style:style>` for one column's width, made once per column. */
+  private columnStyleName(index: number, width: number): string {
+    const name = `co${index + 1}`
+    if (!this.columnStyles.has(name)) {
+      // ODF column widths are a physical measure; the same
+      // 7px-per-character approximation the buffered writer uses.
+      const inches = (width * 7 + 5) / 96
+      this.columnStyles.set(
+        name,
+        `<style:style style:name="${name}" style:family="table-column">` +
+          `<style:table-column-properties style:column-width="${inches.toFixed(4)}in"/>` +
+          "</style:style>",
+      )
+    }
+    return name
+  }
+}
+
+function isStyled(value: OdsIncrementalCell): value is OdsStyledCell {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !(value instanceof Date) &&
+    !Array.isArray(value) &&
+    ("value" in value || "style" in value || "formula" in value)
+  )
+}
+
+/** The `office:document-content` shell, with the namespaces ODF wants. */
+function xmlDocumentContent(children: string[]): string {
+  return (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+    '<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"' +
+    ' xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"' +
+    ' xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"' +
+    ' xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"' +
+    ' xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"' +
+    ' xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0"' +
+    ' xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"' +
+    ' xmlns:xlink="http://www.w3.org/1999/xlink"' +
+    ' xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2"' +
+    ' office:version="1.2">' +
+    children.join("") +
+    "</office:document-content>"
+  )
+}

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -492,7 +492,7 @@ function generateStyleElement(name: string, style: CellStyle, dataStyleName?: st
 
 // ── Style Collector ────────────────────────────────────────────────
 
-interface StyleCollector {
+export interface StyleCollector {
   /** Map from style key → style name (e.g. "ce1") */
   styleMap: Map<string, string>
   /** Map from style name → XML element string */
@@ -513,7 +513,7 @@ interface StyleCollector {
   textStyleCounter: number
 }
 
-function createStyleCollector(): StyleCollector {
+export function createStyleCollector(): StyleCollector {
   return {
     styleMap: new Map(),
     styleElements: new Map(),
@@ -629,7 +629,7 @@ function hasVisualProps(style: CellStyle): boolean {
   )
 }
 
-function getOrCreateStyleName(collector: StyleCollector, style: CellStyle): string {
+export function getOrCreateStyleName(collector: StyleCollector, style: CellStyle): string {
   const key = styleKey(style)
   if (!key) return "" // No style properties
 
@@ -685,7 +685,7 @@ export function excelFormulaToOds(formula: string): string {
 
 // ── Cell Serialization ──────────────────────────────────────────────
 
-interface CellContext {
+export interface CellContext {
   /** Cell override from sheet.cells */
   cellOverride?: Partial<Cell>
   /** Style name to apply (from style collector) */
@@ -738,7 +738,7 @@ function cellTextP(
   return xmlElement("text:p", undefined, content)
 }
 
-function cellToOds(
+export function cellToOds(
   value: CellValue,
   ctx: CellContext | undefined,
   collector: StyleCollector,

--- a/test/__snapshots__/exports.test.ts.snap
+++ b/test/__snapshots__/exports.test.ts.snap
@@ -40,6 +40,7 @@ exports[`export surface snapshot > hucre/json 1`] = `
 
 exports[`export surface snapshot > hucre/ods 1`] = `
 [
+  "OdsStreamWriter",
   "readOds",
   "readOdsObjects",
   "streamOdsRows",
@@ -141,6 +142,7 @@ exports[`export surface snapshot > root 1`] = `
   "MAX_SPIN_COUNT",
   "MAX_TOTAL_CELLS",
   "NdjsonStreamWriter",
+  "OdsStreamWriter",
   "ParseError",
   "REL_CELL_IMAGES",
   "SheetBuilder",

--- a/test/ods-incremental-writer.test.ts
+++ b/test/ods-incremental-writer.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest"
+import { OdsStreamWriter } from "../src/ods/incremental-writer"
+import { writeOdsStream } from "../src/ods/stream-writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellValue, SpreadsheetStreamWriter } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #467's last empty cell. `writeOdsStream` covers the constant-memory
+// case and carries values only, because ODF puts
+// `<office:automatic-styles>` before the body — a style first seen on row
+// 900,000 has nowhere to be declared once the body has gone out.
+//
+// A buffering writer does not have that problem: it holds the serialized
+// rows until `finish()`, so the style block is written from everything it
+// saw. That is the trade, and it is the same one XLSX already offers —
+// `writeXlsxStream` for constant memory, `XlsxStreamWriter` for a buffer
+// you can style.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+describe("it writes a document ODS readers accept", () => {
+  it("values of every type, in order", async () => {
+    const w = new OdsStreamWriter({ name: "Report" })
+    w.addRow(["Widget", 3, true, new Date("2024-03-17T00:00:00Z")])
+    w.addRow(["Gadget", -7.5, false, null])
+
+    const wb = await readOds(await w.finish())
+    const sheet = wb.sheets[0]!
+
+    expect(sheet.name).toBe("Report")
+    expect(sheet.rows[0]![0]).toBe("Widget")
+    expect(sheet.rows[0]![1]).toBe(3)
+    expect(sheet.rows[0]![2]).toBe(true)
+    expect(sheet.rows[0]![3]).toBeInstanceOf(Date)
+    expect(sheet.rows[1]![1]).toBe(-7.5)
+  })
+
+  it("a valid ODF package, mimetype first and stored", async () => {
+    const w = new OdsStreamWriter()
+    w.addRow(["a"])
+    const bytes = await w.finish()
+
+    const entries = new ZipReader(bytes).entries()
+    expect(entries[0]).toBe("mimetype")
+    for (const part of ["META-INF/manifest.xml", "content.xml", "styles.xml", "meta.xml"]) {
+      expect(entries, part).toContain(part)
+    }
+  })
+})
+
+describe("the thing writeOdsStream cannot do", () => {
+  const styled = async (): Promise<Uint8Array> => {
+    const w = new OdsStreamWriter({ name: "S" })
+    w.addRow([
+      { value: "bold", style: { font: { bold: true } } },
+      { value: 1234.5, style: { numFmt: "#,##0.00" } },
+      {
+        value: "filled",
+        style: { fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } } },
+      },
+    ])
+    return w.finish()
+  }
+
+  it("carries per-cell styles", async () => {
+    const sheet = (await readOds(await styled(), { readStyles: true })).sheets[0]!
+
+    expect(sheet.cells?.get("0,0")?.style?.font?.bold).toBe(true)
+    expect(sheet.cells?.get("0,1")?.style?.numFmt).toBe("#,##0.00")
+
+    const fill = sheet.cells?.get("0,2")?.style?.fill
+    expect(fill?.type === "pattern" ? fill.fgColor?.rgb : undefined).toBe("FFFF00")
+  })
+
+  it("which the streaming writer does not, and that is the trade", async () => {
+    // Not a defect in `writeOdsStream` — the style block has already been
+    // written by the time row 1 is serialized. This test exists so the
+    // difference between the two is pinned rather than folklore.
+    const streamed = await drain(writeOdsStream([["bold"]], { name: "S" }))
+    const sheet = (await readOds(streamed, { readStyles: true })).sheets[0]!
+
+    expect(sheet.rows[0]![0]).toBe("bold")
+    expect(sheet.cells?.get("0,0")?.style?.font?.bold).toBeUndefined()
+  })
+
+  it("and column widths, which it also cannot", async () => {
+    const w = new OdsStreamWriter({ name: "S", columns: [{ width: 30 }, {}] })
+    w.addRow(["a", "b"])
+    const content = new TextDecoder().decode(
+      await new ZipReader(await w.finish()).extract("content.xml"),
+    )
+
+    expect(content).toContain("style:column-width")
+  })
+})
+
+describe("the shared vocabulary", () => {
+  it("satisfies SpreadsheetStreamWriter", async () => {
+    // The assignment is the assertion — this file fails `tsc` before it
+    // fails vitest if the class drifts from the other three.
+    const writer: SpreadsheetStreamWriter = new OdsStreamWriter({
+      name: "S",
+      columns: [{ header: "Name", key: "name" }],
+    })
+
+    writer.addObject({ name: "Widget" })
+    const bytes = await writer.finish()
+
+    expect(bytes).toBeInstanceOf(Uint8Array)
+  })
+
+  it("writes a header row from columns, like the others do", async () => {
+    const w = new OdsStreamWriter({
+      name: "S",
+      columns: [
+        { header: "Name", key: "name" },
+        { header: "Qty", key: "qty" },
+      ],
+    })
+    w.addObject({ name: "Widget", qty: 3 })
+
+    const rows = (await readOds(await w.finish())).sheets[0]!.rows
+    expect(rows[0]).toEqual(["Name", "Qty"])
+    expect(rows[1]).toEqual(["Widget", 3])
+  })
+
+  it("addObject needs keys, and says so rather than guessing", async () => {
+    const w = new OdsStreamWriter({ name: "S" })
+
+    expect(() => w.addObject({ a: 1 })).toThrow(/columns/)
+  })
+
+  it("toStream hands back the finished document", async () => {
+    const w = new OdsStreamWriter({ name: "S" })
+    w.addRow(["a", 1])
+
+    const wb = await readOds(await drain(w.toStream()))
+    expect(wb.sheets[0]!.rows[0]).toEqual(["a", 1])
+  })
+
+  it("refuses writes after finish", async () => {
+    const w = new OdsStreamWriter({ name: "S" })
+    w.addRow(["a"])
+    await w.finish()
+
+    expect(() => w.addRow(["b"])).toThrow(/after finish/)
+  })
+})
+
+describe("details that are easy to get wrong", () => {
+  it("a cell's own style beats its column's", async () => {
+    const w = new OdsStreamWriter({
+      name: "S",
+      columns: [{ style: { font: { italic: true } } }],
+    })
+    w.addRow([{ value: "x", style: { font: { bold: true } } }])
+
+    const style = (await readOds(await w.finish(), { readStyles: true })).sheets[0]!.cells?.get(
+      "0,0",
+    )?.style
+
+    expect(style?.font?.bold).toBe(true)
+    expect(style?.font?.italic).toBeUndefined()
+  })
+
+  it("a column style applies where the cell has none", async () => {
+    const w = new OdsStreamWriter({ name: "S", columns: [{ style: { font: { italic: true } } }] })
+    w.addRow(["x"])
+
+    const style = (await readOds(await w.finish(), { readStyles: true })).sheets[0]!.cells?.get(
+      "0,0",
+    )?.style
+
+    expect(style?.font?.italic).toBe(true)
+  })
+
+  it("carries a formula", async () => {
+    const w = new OdsStreamWriter({ name: "S" })
+    w.addRow([1, 2, { formula: "SUM(A1:B1)" }])
+
+    const content = new TextDecoder().decode(
+      await new ZipReader(await w.finish()).extract("content.xml"),
+    )
+    expect(content).toContain("table:formula")
+  })
+
+  it("reuses one style record for a repeated style", async () => {
+    // The collector is shared across rows, which is what makes this a
+    // writer rather than a document builder.
+    const style = { font: { bold: true } }
+    const w = new OdsStreamWriter({ name: "S" })
+    for (let i = 0; i < 50; i++) w.addRow([{ value: i, style }])
+
+    const content = new TextDecoder().decode(
+      await new ZipReader(await w.finish()).extract("content.xml"),
+    )
+    expect((content.match(/style:family="table-cell"/g) ?? []).length).toBe(1)
+  })
+
+  it("escapes what would otherwise break the XML", async () => {
+    const w = new OdsStreamWriter({ name: "A&B" })
+    w.addRow(['<a & "b">'])
+
+    const wb = await readOds(await w.finish())
+    expect(wb.sheets[0]!.name).toBe("A&B")
+    expect(wb.sheets[0]!.rows[0]![0]).toBe('<a & "b">')
+  })
+
+  it("still refuses a sheet name Excel would", () => {
+    expect(() => new OdsStreamWriter({ name: "a/b" })).toThrow()
+  })
+
+  it("takes rows of differing length", async () => {
+    const w = new OdsStreamWriter({ name: "S" })
+    w.addRow(["a"])
+    w.addRow(["b", "c", "d"])
+
+    const rows = (await readOds(await w.finish())).sheets[0]!.rows
+    expect(rows[0]![0]).toBe("a")
+    expect(rows[1]).toEqual(["b", "c", "d"])
+  })
+})
+
+describe("it agrees with writeOds on values", () => {
+  it("the same rows produce the same values", async () => {
+    const rows: CellValue[][] = [
+      ["name", "qty"],
+      ["Widget", 3],
+      ["Gadget", -7.5],
+    ]
+
+    const { writeOds } = await import("../src/ods/writer")
+    const buffered = (await readOds(await writeOds({ sheets: [{ name: "S", rows }] }))).sheets[0]!
+
+    const w = new OdsStreamWriter({ name: "S" })
+    for (const row of rows) w.addRow(row)
+    const incremental = (await readOds(await w.finish())).sheets[0]!
+
+    expect(incremental.rows).toEqual(buffered.rows)
+  })
+})

--- a/test/stream-writer-interface.test.ts
+++ b/test/stream-writer-interface.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 import { XlsxStreamWriter } from "../src/xlsx/stream-writer"
 import { CsvStreamWriter } from "../src/csv/stream"
 import { NdjsonStreamWriter } from "../src/json/stream"
+import { OdsStreamWriter } from "../src/ods/incremental-writer"
+import { readOds } from "../src/ods/reader"
 import { readXlsx } from "../src/xlsx/reader"
 import { parseCsv } from "../src/csv/reader"
 import type { CellValue, SpreadsheetStreamWriter } from "../src/_types"
@@ -54,6 +56,16 @@ function writers(): Array<[string, SpreadsheetStreamWriter]> {
     ["XlsxStreamWriter", new XlsxStreamWriter({ name: "Sheet1", columns: COLUMN_DEFS })],
     ["CsvStreamWriter", new CsvStreamWriter({ columns: KEYS, headers: ["Name", "Qty"] })],
     ["NdjsonStreamWriter", new NdjsonStreamWriter({ columns: KEYS })],
+    [
+      "OdsStreamWriter",
+      new OdsStreamWriter({
+        name: "S",
+        columns: [
+          { header: "Name", key: "name" },
+          { header: "Qty", key: "qty" },
+        ],
+      }),
+    ],
   ]
 }
 
@@ -90,6 +102,15 @@ describe("the three writers satisfy one interface", () => {
       ["Name", "Qty"],
       ["Widget", "3"],
       ["Gadget", "7"],
+    ])
+
+    // ODS: bytes, and a document that reads back.
+    const odsBytes = out.get("OdsStreamWriter")
+    expect(odsBytes).toBeInstanceOf(Uint8Array)
+    expect((await readOds(odsBytes as Uint8Array)).sheets[0]!.rows).toEqual([
+      ["Name", "Qty"],
+      ["Widget", 3],
+      ["Gadget", 7],
     ])
 
     // NDJSON: one object per line.


### PR DESCRIPTION
Closes #467. The last empty cell in the matrix.

|        | whole read | whole write | stream read | stream write | incremental writer |
| ------ | :--------: | :---------: | :---------: | :----------: | :----------------: |
| XLSX   |     ✔      |      ✔      |      ✔      |  ✔ (multi)   |         ✔          |
| CSV    |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| NDJSON |     ✔      |      ✔      |      ✔      |      ✔       |         ✔          |
| ODS    |     ✔      |      ✔      |      ✔      |      ✔       |   ✔ **new**        |
| XML    |     ✔      |      ✔      |      ✔      |      ✔       |         —          |

## I was wrong to call this a design question

I twice left this open saying a buffering ODS writer *could* carry styles `writeOdsStream` cannot, and that this would leave "two ODS writers with different capabilities and no obvious rule for choosing".

XLSX already ships exactly that pair, with a "Which writer to use" table explaining it. The precedent settles the question I was hesitating over, and the rule is the same one:

| | `writeOdsStream` | `OdsStreamWriter` |
| --- | --- | --- |
| Output | `ReadableStream<Uint8Array>` | `Promise<Uint8Array>` |
| Peak memory | flat | O(data) |
| Styles | — | ✔ |
| Column widths | — | ✔ |

## Why the difference exists at all

ODF puts `<office:automatic-styles>` **before** the body, so a style first seen on row 900,000 has nowhere to be declared once the body has gone out. A buffering writer holds the serialized rows until `finish()` and writes the style block from everything it saw — which is precisely what buys it per-cell styles, column widths and formulas.

That is the format's constraint, not a gap, and the test suite pins it rather than leaving it as folklore: the same styled row keeps its bold through `OdsStreamWriter` and does not through `writeOdsStream`.

## Built from what is already there

Rows serialize on arrival through `cellToOds` and a shared style collector — the same pair `writeOds` uses — so the cell model is the existing one rather than a second opinion. A repeated style produces **one** `<style:style>` however many rows use it, which is what makes this a writer rather than a document builder. There is a test asserting exactly that over 50 rows.

## #468's register now covers four writers

`OdsStreamWriter` implements `SpreadsheetStreamWriter`, and the format-agnostic helper in `test/stream-writer-interface.test.ts` runs against it unchanged — no `instanceof`, no per-format branch — with its output read back through `readOds`. That is the type doing the job it was added for: the fourth writer was held to the interface from the start rather than discovered to have drifted later.

## Tests

`test/ods-incremental-writer.test.ts` — 18 cases, plus the interface register extended from three writers to four.

`pnpm lint`, `pnpm typecheck`, 10357 tests green; coverage and size budgets pass. Export snapshots moved by one name on each of two surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
