### PR TITLE
docs(perf): record that the row fast path does not pay — refs #472

### DIFF
--- a/src/xlsx/worksheet-writer.ts
+++ b/src/xlsx/worksheet-writer.ts
@@ -543,6 +543,12 @@ export function writeWorksheetXml(
     }
 
     if (hasAnyCells || hasRowDef) {
+      // Emitting `<row r="N">` directly for the common no-rowDef case was
+      // tried and measured: over ten alternating benchmark pairs it won
+      // six and moved the mean 1.8%, which is inside this machine's noise
+      // floor. The cell fast path below it pays because there are 1.2M
+      // cells to a sheet's 100k rows — a twelfth of the allocations is a
+      // twelfth of the prize. See #472.
       const rowAttrs = rowAttributes(r, rowDef)
       if (hasAnyCells) {
         rowElements.push(xmlElement("row", rowAttrs, cellElements))


### PR DESCRIPTION
Refs #472. A measurement and a comment, no behaviour change.

## What I tried

After #491 and #517, `xmlElement` is still the largest non-GC item in the write profile:

```
sampled 2442 ms; on-CPU 1586 ms
   402  25.4%  (garbage collector)
   186  11.8%  xmlElement
   141   8.9%  add            (shared strings)
   128   8.1%  serializeCell
   111   7.0%  crc32Update
```

`registerXf` has dropped out of the top ten entirely, which is #517 having done its job. With cells already emitted directly, the remaining `xmlElement` calls are mostly the `<row>` elements — one per row, and the common row's only attribute is `r`. So: emit `<row r="N">…</row>` directly and skip the attrs object and the `serializeAttrs` walk.

## What it measured

Ten alternating pairs:

```
-14%  -7%  +1%  +16%      (first batch of four)
fast mean=2226ms  main mean=2266ms  fast wins 4 of 6  delta=1.8%
```

**6 of 10 wins, mean 1.8%** — inside this machine's noise floor, where individual pairs swing ±16%. Not merged.

## Why, and it is countable

```
cells : 1,200,000  -> the change that paid (#491, ~17%)
rows  :   100,000  -> this one, 12x fewer allocations
```

A twelfth of the allocations is a twelfth of the prize, and a twelfth of 17% is not something this benchmark can resolve. That also sets expectations for the builder the issue sketches: with the per-cell work already done, what is left of `xmlElement` is spread across a hundred thousand rows and a handful of structural elements, not the two million cells that made the first change worth it.

The comment sits where the decision would be made, the same as the one `colToLetter` carries for its memo — so the next person reading that line finds the number rather than repeating the experiment.

`pnpm lint`, `pnpm typecheck`, 10357 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
