### PR TITLE
docs(perf): record that building the bytes incrementally does not pay

### DIFF
--- a/src/xlsx/writer.ts
+++ b/src/xlsx/writer.ts
@@ -395,6 +395,21 @@ export async function writeXlsx(options: WriteOptions): Promise<WriteOutput> {
     const drawing = drawingResults[i]
     const comments = commentsResults[i]
 
+    // `result.xml` is one large string — for 100,000 x 12 it is ~42 MB
+    // joined from ~1.3M pieces — and this is the single encode of it.
+    // Building the bytes incrementally instead, so that string never
+    // exists, was proposed in #472 and measured. Every implementable
+    // form of it lost, on identical output bytes:
+    //
+    //   join + one encode (this line)              153-190 ms
+    //   chunked join+encode at ~1 MB                   199 ms
+    //   encodeInto a buffer, one view per piece        439 ms
+    //   encodeInto, five fragments per cell            358 ms
+    //   manual ASCII byte loop, encodeInto fallback    308 ms
+    //
+    // `join` and `TextEncoder.encode` are bulk paths; 1.3M small
+    // JS-level writes do not beat one big one however they are arranged.
+    // The whole step is ~7% of the write, so that is the ceiling anyway.
     zip.add(`xl/worksheets/sheet${i + 1}.xml`, encoder.encode(result.xml))
 
     // Generate worksheet .rels if there are hyperlinks, a drawing, comments, tables, picture, or pivots


### PR DESCRIPTION
Closes nothing; refs #472.

#472 sketches `buf.open("c").attr(...)` appending into one output buffer, so that the large worksheet string is never materialised. I argued against that in the issue thread on weak evidence — I cited the `<row>` experiment, which changed how 100,000 *rows* are emitted, when the proposal targets the 1.3M *cell* pieces. That generalisation was unsound, so I measured the mechanism itself.

## What the write does today

`worksheet-writer.ts` pushes one string per cell, joins per row, joins the rows into `<sheetData>`, joins that into the document; `writer.ts` hands the result to one `encoder.encode`. At 100,000 x 12 that is ~1.3M pieces -> one ~42 MB string -> one encode.

## The measurement

Five variants, all producing the identical 41,388,890 output bytes:

| | |
| --- | --- |
| `join()` then one `encode()` — today | **153–190 ms** |
| chunked join+encode at ~1 MB | 199 ms |
| `encodeInto` a preallocated buffer, one view per piece | 439 ms |
| `encodeInto`, five fragments per cell (the builder’s real shape) | 358 ms |
| manual ASCII byte loop, `encodeInto` fallback | 308 ms |

Every alternative loses, most by 2x or more. `Array.prototype.join` and `TextEncoder.encode` are bulk C++ paths; 1.3M small JS-level writes do not beat one big one however they are arranged.

`encodeInto` *without* a per-piece view measures 101 ms — faster than today — but that is not implementable, since writing at an offset requires a view, and every version that adds the offset back lands at 300–440 ms. Noted in the issue so the one number that looks like a win is not mistaken for one.

The whole step is **~160 ms of a ~2,380 ms write, ~7%**, which is the ceiling for this idea regardless of how it is built.

## What changed

A comment at the encode site in `src/xlsx/writer.ts`. No behaviour change, no test change — this is the same habit as the `colToLetter` memo and the `<row>` fast path: the failed experiment is recorded where the decision would be made, not only in a thread.

`pnpm test` green — 10,357 tests, 210 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)