### PR TITLE
fix(ods): write a carriage return as &#13;, not Excel's _x000D_

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -392,12 +392,21 @@ the workbook-level caches, and has no write counterpart because
 
 Three cases where a field is carried but a particular _value_ is not.
 
-**A cell whose text is literally `_x0041_` reads back as `A`.** OOXML uses
-`_xHHHH_` to encode characters XML cannot hold, and hucre decodes it on
-read. Excel disambiguates by escaping a leading underscore as `_x005F_`;
-hucre deliberately does not, because doing so would mangle the far more
-common case of ordinary text that happens to contain an underscore. The
-ambiguity is accepted, and now written down.
+**A cell whose text is literally `_x0041_` reads back as `A` — in XLSX.**
+OOXML uses `_xHHHH_` to encode characters XML cannot hold, and hucre
+decodes it on read. Excel disambiguates by escaping a leading underscore
+as `_x005F_`; hucre deliberately does not, because doing so would mangle
+the far more common case of ordinary text that happens to contain an
+underscore. The ambiguity is accepted, and now written down.
+
+It is an OOXML convention and the loss is OOXML's alone. ODF has no
+`_xHHHH_`, so the same string round-trips through ODS unchanged. The ODS
+writer used to borrow the spelling for carriage returns, which meant
+`"a\r\nb"` came back as `"a_x000D_\nb"` — and LibreOffice showed those
+seven characters too, since to anything but Excel that is all they are.
+ODS now writes `&#13;`, which is what XML gives you for this: a character
+reference is not subject to the end-of-line normalisation of §2.11, so it
+survives any conforming parse.
 
 **Serial 60 collapses onto 59.** Serial 60 in the 1900 system is the
 Lotus 1-2-3 phantom 29 February 1900, a date that does not exist. It has

--- a/src/ods/stream-writer.ts
+++ b/src/ods/stream-writer.ts
@@ -17,7 +17,7 @@
 
 import type { CellValue, WorkbookProperties } from "../_types"
 import { zipStream, type ZipStreamEntry } from "../zip/stream-writer"
-import { xmlEscape } from "../xml/writer"
+import { xmlEscapeAttr } from "../xml/writer"
 import { validateSheetNames } from "../_validate"
 
 import {
@@ -29,6 +29,7 @@ import {
   formatOdsDateValue,
   formatNumberDisplay,
   excelFormulaToOds,
+  odsEscape,
 } from "./writer"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
@@ -130,7 +131,7 @@ async function* contentChunks(
 
   yield* push(CONTENT_HEAD)
   yield* push(automaticStyles(columns))
-  yield* push(`<office:body><office:spreadsheet><table:table table:name="${xmlEscape(name)}">`)
+  yield* push(`<office:body><office:spreadsheet><table:table table:name="${xmlEscapeAttr(name)}">`)
 
   // Column declarations, which have to precede every row.
   const colCount = columns?.length ?? 0
@@ -203,7 +204,7 @@ function serializeRow(row: OdsWriteRow): string {
  * garbage and which used to make a corrupt file (#364).
  */
 function serializeCell(value: CellValue, formula?: string): string {
-  const attrs = formula ? ` table:formula="${xmlEscape(excelFormulaToOds(formula))}"` : ""
+  const attrs = formula ? ` table:formula="${xmlEscapeAttr(excelFormulaToOds(formula))}"` : ""
 
   if (value === null || value === undefined) {
     return attrs ? `<table:table-cell${attrs}/>` : "<table:table-cell/>"
@@ -212,7 +213,7 @@ function serializeCell(value: CellValue, formula?: string): string {
   if (typeof value === "string") {
     return (
       `<table:table-cell${attrs} office:value-type="string">` +
-      `<text:p>${xmlEscape(value)}</text:p></table:table-cell>`
+      `<text:p>${odsEscape(value)}</text:p></table:table-cell>`
     )
   }
 
@@ -220,7 +221,7 @@ function serializeCell(value: CellValue, formula?: string): string {
     if (!Number.isFinite(value)) return `<table:table-cell${attrs}></table:table-cell>`
     return (
       `<table:table-cell${attrs} office:value-type="float" office:value="${value}">` +
-      `<text:p>${xmlEscape(formatNumberDisplay(value))}</text:p></table:table-cell>`
+      `<text:p>${odsEscape(formatNumberDisplay(value))}</text:p></table:table-cell>`
     )
   }
 

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -16,10 +16,26 @@ import type {
 import { ZipWriter } from "../zip/writer"
 import { validateSheetNames } from "../_validate"
 import { unwrapCellValue } from "../xlsx/hyperlink"
-import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape } from "../xml/writer"
+import { xmlDocument, xmlElement, xmlSelfClose, xmlEscape as escapeXmlText } from "../xml/writer"
 import { replaceA1Ranges, toRanges } from "../cell-utils"
 
 const encoder = /* @__PURE__ */ new TextEncoder()
+
+/**
+ * Escape text content for an ODF document.
+ *
+ * The whole of this file — and the two streaming ODS writers, which
+ * import this — goes through here rather than calling `xmlEscape`
+ * directly, so that the carriage-return spelling is decided once.
+ *
+ * ODF has no `_xHHHH_` convention. Sharing the XLSX escaper meant a
+ * string with a CR in it was written as `_x000D_` and read back with the
+ * escape still in it — and LibreOffice showed the same seven characters,
+ * because to anything that is not Excel that is all they are.
+ */
+export function odsEscape(text: string): string {
+  return escapeXmlText(text, "charRef")
+}
 
 // ── ODS Namespaces ──────────────────────────────────────────────────
 
@@ -270,12 +286,12 @@ function buildDateChildren(code: string): string[] {
       out.push(xmlSelfClose("number:am-pm"))
       lastWasHours = false
     } else if (tok.startsWith('"') && tok.endsWith('"')) {
-      out.push(xmlElement("number:text", undefined, xmlEscape(tok.slice(1, -1))))
+      out.push(xmlElement("number:text", undefined, odsEscape(tok.slice(1, -1))))
     } else if (tok.startsWith("\\") && tok.length === 2) {
-      out.push(xmlElement("number:text", undefined, xmlEscape(tok.slice(1))))
+      out.push(xmlElement("number:text", undefined, odsEscape(tok.slice(1))))
     } else {
       // Literal separator (`-`, `/`, `:`, `.`, ` `, etc.)
-      out.push(xmlElement("number:text", undefined, xmlEscape(tok)))
+      out.push(xmlElement("number:text", undefined, odsEscape(tok)))
     }
   }
 
@@ -395,7 +411,7 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   if (currency) {
     const decimals = decimalsFromCode(section)
     const grouping = hasGrouping(section)
-    const symbol = xmlElement("number:currency-symbol", undefined, xmlEscape(currency))
+    const symbol = xmlElement("number:currency-symbol", undefined, odsEscape(currency))
     const number = buildNumberChild(decimals, grouping)
     // Detect symbol position: leading vs trailing
     const beforeNum = /^[^0#]*(\$|\[\$|"[$€£¥₺₽₹])/.test(section)
@@ -424,7 +440,7 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   // Plain number
   const { prefix, suffix } = numberLiterals(section)
   const children: string[] = []
-  if (prefix) children.push(xmlElement("number:text", undefined, xmlEscape(prefix)))
+  if (prefix) children.push(xmlElement("number:text", undefined, odsEscape(prefix)))
   // A section with no `#`/`0` at all is pure literal text — Excel's third
   // section is often `"-"` for zero — and gets no <number:number> child.
   if (/[#0?]/.test(section)) {
@@ -432,7 +448,7 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   } else if (children.length === 0) {
     return undefined
   }
-  if (suffix) children.push(xmlElement("number:text", undefined, xmlEscape(suffix)))
+  if (suffix) children.push(xmlElement("number:text", undefined, odsEscape(suffix)))
   return { kind: "number", children }
 }
 
@@ -699,7 +715,7 @@ export interface CellContext {
 function richTextSpans(runs: RichTextRun[], collector: StyleCollector): string {
   let out = ""
   for (const run of runs) {
-    const text = xmlEscape(run.text)
+    const text = odsEscape(run.text)
     const styleName = run.font ? getOrCreateTextStyleName(collector, run.font) : ""
     out += styleName ? xmlElement("text:span", { "text:style-name": styleName }, text) : text
   }
@@ -726,9 +742,9 @@ function cellTextP(
   const runs = ctx?.cellOverride?.richText
   const hyperlink = ctx?.cellOverride?.hyperlink
 
-  let content = runs && runs.length > 0 ? richTextSpans(runs, collector) : xmlEscape(display)
+  let content = runs && runs.length > 0 ? richTextSpans(runs, collector) : odsEscape(display)
   if (hyperlink) {
-    const anchor = hyperlink.display !== undefined ? xmlEscape(hyperlink.display) : content
+    const anchor = hyperlink.display !== undefined ? odsEscape(hyperlink.display) : content
     content = xmlElement(
       "text:a",
       { "xlink:href": hyperlink.target, "xlink:type": "simple" },
@@ -1143,19 +1159,19 @@ export function writeMetaXml(props?: WorkbookProperties): string {
   const children: string[] = []
 
   if (props?.title) {
-    children.push(xmlElement("dc:title", undefined, xmlEscape(props.title)))
+    children.push(xmlElement("dc:title", undefined, odsEscape(props.title)))
   }
   if (props?.subject) {
-    children.push(xmlElement("dc:subject", undefined, xmlEscape(props.subject)))
+    children.push(xmlElement("dc:subject", undefined, odsEscape(props.subject)))
   }
   if (props?.creator) {
-    children.push(xmlElement("meta:initial-creator", undefined, xmlEscape(props.creator)))
+    children.push(xmlElement("meta:initial-creator", undefined, odsEscape(props.creator)))
   }
   if (props?.description) {
-    children.push(xmlElement("dc:description", undefined, xmlEscape(props.description)))
+    children.push(xmlElement("dc:description", undefined, odsEscape(props.description)))
   }
   if (props?.keywords) {
-    children.push(xmlElement("meta:keyword", undefined, xmlEscape(props.keywords)))
+    children.push(xmlElement("meta:keyword", undefined, odsEscape(props.keywords)))
   }
   if (props?.created) {
     children.push(xmlElement("meta:creation-date", undefined, formatOdsDate(props.created)))

--- a/src/xml/writer.ts
+++ b/src/xml/writer.ts
@@ -30,8 +30,30 @@ function isIllegalXmlChar(code: number): boolean {
   )
 }
 
+/**
+ * How a carriage return is spelled in text content.
+ *
+ * A literal CR does not survive a parse: XML 1.0 §2.11 folds CR and CRLF
+ * to LF before the application ever sees them, so carrying one takes an
+ * escape. There are two, and they belong to different formats:
+ *
+ * - `"ooxml"` — `_x000D_`, Excel's convention. Correct for XLSX, where
+ *   the reader decodes it back. **Meaningless in any other format**: to
+ *   a consumer that does not know the convention it is seven literal
+ *   characters, which is what LibreOffice showed when the ODS writer
+ *   inherited this spelling.
+ * - `"charRef"` — `&#13;`, which is simply XML. A character reference is
+ *   not subject to §2.11 (that covers literal CR in the source), so it
+ *   survives a conforming parse anywhere.
+ *
+ * `"charRef"` is the right answer for everything except OOXML, and is
+ * only not the default because XLSX is the larger caller and Excel
+ * expects its own spelling.
+ */
+export type CrSpelling = "ooxml" | "charRef"
+
 /** Escape text content for safe embedding in XML */
-export function xmlEscape(text: string): string {
+export function xmlEscape(text: string, cr: CrSpelling = "ooxml"): string {
   let result = ""
   let last = 0
 
@@ -49,7 +71,7 @@ export function xmlEscape(text: string): string {
         replacement = "&gt;"
         break
       case 13: // CR — encode so it round-trips through XML newline normalization
-        replacement = xEscape(13)
+        replacement = cr === "charRef" ? "&#13;" : xEscape(13)
         break
       default:
         // Strip/encode XML-1.0-illegal control chars so output is always

--- a/test/ods-escaping.test.ts
+++ b/test/ods-escaping.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { writeOdsStream } from "../src/ods/stream-writer"
+import { OdsStreamWriter } from "../src/ods/incremental-writer"
+import { streamOdsRows } from "../src/ods/stream"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// A string containing a carriage return, written to ODS, came back with
+// a literal `_x000D_` in it:
+//
+//   in   "with\r\ncrlf"
+//   out  "with_x000D_\ncrlf"
+//
+// `_xHHHH_` is **Excel's** convention, from OOXML. XLSX needs it (a
+// literal CR in an XML text node is normalised to LF by XML 1.0 §2.11,
+// so an escape is the only way to carry one) and the XLSX reader decodes
+// it back, so that pair is self-consistent.
+//
+// ODF has no such convention. The ODS writer shared `xmlEscape` with the
+// XLSX writer and inherited the spelling; nothing on the ODS side decodes
+// it. The damage is not confined to hucre either — LibreOffice shows the
+// literal `_x000D_` too, because to it that is just seven characters.
+//
+// The fix is the spelling XML gives you for exactly this: `&#13;`. A
+// character reference is not subject to end-of-line normalisation
+// (§2.11 covers literal CR in the source), so it survives — and the ODS
+// readers already handled it, which is what #493 sorted out when it put
+// `normalizeEol` before `decodeEntities`.
+//
+// Found by a property test over random grids, comparing what went into
+// each writer with what came back out of its reader.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+const VALUES = ["with\r\ncrlf", "bare\rcr", "lf\nonly", "trailing\r", "\rleading"]
+const ROWS: CellValue[][] = VALUES.map((v) => [v])
+
+async function contentXml(bytes: Uint8Array): Promise<string> {
+  return dec.decode(await new ZipReader(bytes).extract("content.xml"))
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+describe("a carriage return survives the ODS round trip", () => {
+  it("through writeOds and readOds", async () => {
+    const back = (await readOds(await writeOds({ sheets: [{ name: "S", rows: ROWS }] }))).sheets[0]!
+
+    expect(back.rows.map((r) => r[0])).toEqual(VALUES)
+  })
+
+  it("and through the streaming reader, which shares nothing with it", async () => {
+    const bytes = await writeOds({ sheets: [{ name: "S", rows: ROWS }] })
+    const streamed: CellValue[] = []
+    for await (const row of streamOdsRows(bytes)) streamed.push(row.values[0]!)
+
+    expect(streamed).toEqual(VALUES)
+  })
+
+  it("out of writeOdsStream", async () => {
+    const bytes = await drain(
+      writeOdsStream(
+        ROWS.map((r) => r),
+        { name: "S" },
+      ),
+    )
+    const back = (await readOds(bytes)).sheets[0]!
+
+    expect(back.rows.map((r) => r[0])).toEqual(VALUES)
+  })
+
+  it("out of OdsStreamWriter", async () => {
+    const writer = new OdsStreamWriter({ name: "S" })
+    for (const row of ROWS) writer.addRow(row)
+    const back = (await readOds(await writer.finish())).sheets[0]!
+
+    expect(back.rows.map((r) => r[0])).toEqual(VALUES)
+  })
+})
+
+describe("what is actually in the file", () => {
+  it("is a character reference, not Excel's escape", async () => {
+    // The assertion that matters to every *other* consumer. A reader
+    // that decoded `_x000D_` would make hucre's round trip pass while
+    // LibreOffice still showed seven literal characters.
+    const xml = await contentXml(await writeOds({ sheets: [{ name: "S", rows: ROWS }] }))
+
+    expect(xml).toContain("&#13;")
+    expect(xml).not.toContain("_x000D_")
+  })
+
+  it("from every ODS writer", async () => {
+    const streamed = await contentXml(
+      await drain(
+        writeOdsStream(
+          ROWS.map((r) => r),
+          { name: "S" },
+        ),
+      ),
+    )
+    const writer = new OdsStreamWriter({ name: "S" })
+    for (const row of ROWS) writer.addRow(row)
+    const incremental = await contentXml(await writer.finish())
+
+    for (const xml of [streamed, incremental]) {
+      expect(xml).toContain("&#13;")
+      expect(xml).not.toContain("_x000D_")
+    }
+  })
+})
+
+describe("an attribute is escaped as an attribute", () => {
+  // The second half of the same mistake. `writeOdsStream` builds its
+  // opening tag by hand and reached for the *text* escaper for values
+  // that sit inside quotes. `xmlEscape` does not escape `"` — it has no
+  // reason to — so a sheet name containing one closed the attribute
+  // early:
+  //
+  //   <table:table table:name="say "hi"">
+  //
+  // which is not well-formed. The name came back as `say ` — truncated
+  // silently, with no error anywhere. `writeOds` was never affected,
+  // because it goes through `xmlElement`, which escapes attributes
+  // properly; only the hand-built tag was wrong.
+  const AWKWARD_NAME = 'say "hi" & <that>'
+
+  it("survives a sheet name full of markup characters", async () => {
+    const bytes = await drain(writeOdsStream([["a"]], { name: AWKWARD_NAME }))
+    const wb = await readOds(bytes)
+
+    expect(wb.sheets.map((s) => s.name)).toEqual([AWKWARD_NAME])
+  })
+
+  it("the same name the buffered writer already handled", async () => {
+    // Pinning the agreement, since the two took different routes to it.
+    const buffered = await writeOds({ sheets: [{ name: AWKWARD_NAME, rows: [["a"]] }] })
+
+    expect((await readOds(buffered)).sheets[0]!.name).toBe(AWKWARD_NAME)
+  })
+
+  it("and a formula with a quote in a string literal", async () => {
+    // `table:formula` is the other hand-built attribute in that file.
+    const bytes = await drain(
+      writeOdsStream([[{ value: "x", formula: 'IF(A1="q",1,2)' }]], { name: "S" }),
+    )
+
+    expect(await contentXml(bytes)).toContain("&quot;")
+  })
+})
+
+describe("XLSX keeps the convention that is right for it", () => {
+  it("still writes _x000D_ and still reads it back", async () => {
+    // OOXML's escape is correct here and Excel expects it. This is the
+    // line that notices if the ODS fix is applied too widely.
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] })
+    const sheet = dec.decode(await new ZipReader(bytes).extract("xl/sharedStrings.xml"))
+
+    expect(sheet).toContain("_x000D_")
+    expect((await readXlsx(bytes)).sheets[0]!.rows.map((r) => r[0])).toEqual(VALUES)
+  })
+})

--- a/test/property-roundtrip.test.ts
+++ b/test/property-roundtrip.test.ts
@@ -12,6 +12,10 @@ import {
   parseRange,
 } from "../src/cell-utils"
 import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../src/limits"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
 import { seeded } from "./_fuzz"
 import type { CellValue } from "../src/_types"
 
@@ -228,5 +232,111 @@ describe("the A1 reference helpers are inverses", () => {
         endCol,
       })
     }
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// The binary formats had no property test. Everything above is a parser
+// with a *string* inverse; `writeXlsx`/`readXlsx` and `writeOds`/
+// `readOds` are inverses too, and nobody had pointed random values at
+// them.
+//
+// Doing so found two defects in the ODS writer on the first run — a
+// carriage return written as Excel's `_x000D_`, and, chasing that, a
+// sheet name escaped with the text escaper inside an attribute. Both are
+// pinned properly in test/ods-escaping.test.ts; this is the thing that
+// noticed, kept so it can notice the next one.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** Values chosen to sit where a spreadsheet writer has to make a choice. */
+const AWKWARD_CELLS: CellValue[] = [
+  ...AWKWARD,
+  "with\rbare cr",
+  "trailing\r",
+  "<xml>&amp;</xml>",
+  "]]>",
+  "a".repeat(300),
+  0,
+  -12.5,
+  1e21,
+  1e-7,
+  Number.MAX_SAFE_INTEGER,
+  0.1 + 0.2,
+  true,
+  false,
+  null,
+]
+
+function randomBinaryCell(rnd: () => number): CellValue {
+  if (rnd() < 0.12) {
+    return new Date(
+      Date.UTC(1900 + Math.floor(rnd() * 200), Math.floor(rnd() * 12), 1 + Math.floor(rnd() * 28)),
+    )
+  }
+  return AWKWARD_CELLS[Math.floor(rnd() * AWKWARD_CELLS.length)]!
+}
+
+/**
+ * Trailing empties are trimmed on read, so the comparison is on the
+ * trimmed form — the readers do not promise to hand back a row's shape,
+ * only its values. `docs/PARITY.md` says so.
+ */
+function trimTrailing(row: CellValue[]): unknown[] {
+  const out = [...row]
+  while (out.length > 0 && (out[out.length - 1] === null || out[out.length - 1] === "")) out.pop()
+  return out.map((v) => (v instanceof Date ? `D:${v.toISOString()}` : v))
+}
+
+describe("write then read is the identity, for the binary formats", () => {
+  const cases = [
+    ["xlsx", writeXlsx, readXlsx],
+    ["ods", writeOds, readOds],
+  ] as const
+
+  for (const [label, write, read] of cases) {
+    it(`${label} carries every value it was given`, async () => {
+      const rnd = seeded(SEED)
+
+      for (let run = 0; run < 60; run++) {
+        const rows: CellValue[][] = Array.from({ length: 1 + Math.floor(rnd() * 5) }, () =>
+          Array.from({ length: 1 + Math.floor(rnd() * 5) }, () => randomBinaryCell(rnd)),
+        )
+
+        const bytes = await (write as typeof writeXlsx)({ sheets: [{ name: "S", rows }] })
+        const back = (await (read as typeof readXlsx)(bytes)).sheets[0]!.rows
+
+        for (let i = 0; i < rows.length; i++) {
+          expect(trimTrailing(back[i] ?? []), `${label} run ${run} row ${i}`).toEqual(
+            trimTrailing(rows[i]!),
+          )
+        }
+      }
+    })
+  }
+})
+
+describe("the one value the generator above deliberately leaves out", () => {
+  // `docs/PARITY.md` records that a cell whose text is literally
+  // `_x0041_` reads back as `A`: OOXML uses `_xHHHH_` for characters XML
+  // cannot hold, hucre decodes it on read, and it does not re-escape a
+  // leading underscore on write because that would mangle the far more
+  // common ordinary text containing one. The ambiguity is accepted.
+  //
+  // It is accepted **for XLSX**. ODS never had the convention, and since
+  // the CR fix does not write it either, the same string survives there.
+  // Feeding it to the property test above would have looked like a bug
+  // in one format and a pass in the other, so it is stated here instead.
+  const LITERAL = "_x000D_ already"
+
+  it("xlsx decodes it, as documented", async () => {
+    const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[LITERAL]] }] })
+
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]![0]).toBe("\r already")
+  })
+
+  it("ods carries it through unchanged", async () => {
+    const bytes = await writeOds({ sheets: [{ name: "S", rows: [[LITERAL]] }] })
+
+    expect((await readOds(bytes)).sheets[0]!.rows[0]![0]).toBe(LITERAL)
   })
 })


### PR DESCRIPTION
Two defects, one root cause: the ODS writers reached for an escaper that belongs to another format.

## 1. A carriage return round-tripped as seven literal characters

```
in   "with\r\ncrlf"
out  "with_x000D_\ncrlf"
```

`_xHHHH_` is **OOXML’s** convention. XLSX needs it — a literal CR in an XML text node is folded to LF by XML 1.0 §2.11, so an escape is the only way to carry one — and the XLSX reader decodes it back, so that pair is self-consistent.

ODF has no such convention, and nothing on the ODS side decodes it. **The damage is not confined to hucre**: LibreOffice shows the same seven characters, because to anything that is not Excel that is all they are. So this was producing wrong files, not merely failing its own round trip.

ODS now writes `&#13;` — what XML gives you for exactly this. A character reference is not subject to §2.11 (which covers *literal* CR in the source), so it survives any conforming parse. Both ODS readers already handled it: that is what #493 sorted out when it put `normalizeEol` before `decodeEntities`.

All four ODS writers are covered — `writeOds`, `writeOdsStream`, `OdsStreamWriter`, and the shared cell serializer — and the test asserts on the bytes (`&#13;` present, `_x000D_` absent), not only on the round trip. A reader-side hack would have made hucre agree with itself while LibreOffice still showed the escape.

## 2. A sheet name containing a quote was silently truncated

Chasing the first defect turned up the same mistake pointing the other way. `writeOdsStream` builds its opening tag by hand and used the *text* escaper for values that sit inside quotes. `xmlEscape` does not escape `"` — it has no reason to:

```xml
<table:table table:name="say "hi"">
```

Not well-formed. The name came back as `say ` — truncated, no error anywhere. `writeOds` was never affected, because it goes through `xmlElement`, which escapes attributes properly; only the hand-built tag was wrong. Same for `table:formula`, the other hand-built attribute in that file.

## How they were found

A property test over random grids, comparing what went into each writer with what came back out of its reader. **The binary formats had none** — every property test in the repo was over a parser with a *string* inverse (`writeCsv`/`parseCsv`, NDJSON, the cell-utils pairs), and nobody had pointed random values at `writeXlsx`/`readXlsx` or `writeOds`/`readOds`. It found both defects on the first run, and it is kept so it can find the next one.

It also flushed out a false positive worth stating: a cell whose text is literally `_x000D_` does not survive XLSX, because the reader decodes it. That is documented in `docs/PARITY.md` and deliberate. But the doc did not say the loss is **OOXML’s alone** — ODS carries that string unchanged — so PARITY now scopes it, and there is a test pinning both halves.

## Shape of the fix

`xmlEscape` takes the carriage-return spelling as a parameter, defaulting to OOXML so XLSX is untouched. Every ODS call site goes through a single `odsEscape`, so the choice is made once rather than remembered at fifteen call sites.

Eight tests fail against main’s `src` and pass with it (`git stash -q -- src`, confirmed). The two that pass either way are the buffered-writer name and the XLSX convention — both correctly unaffected.

`pnpm test` green — 10,390 tests, 212 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)