### PR TITLE
fix(xlsx): an empty inline string is a value, not a blank cell

### DIFF
--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -934,6 +934,17 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
               inlineRichText.length > 0 ||
               cellFormulaText !== "" ||
               cellType === "e" ||
+              // An empty *inline* string is still a string. The producer
+              // wrote `t="inlineStr"` and an `<is>` to say so, which is
+              // not the contentless `<c r="WVF45" s="3"/>` this guard is
+              // for. Deciding from the collected text alone made the two
+              // spellings of one value disagree: a shared string carries
+              // its index here, non-empty even when the string is empty,
+              // so `""` survived that way and vanished the other.
+              //
+              // It reached hucre's own writers, because
+              // `writeXlsxStream` defaults to inline strings.
+              cellType === "inlineStr" ||
               (ctx.readStyles && cellStyleIndex >= 0) ||
               (ctx.styles && cellStyleIndex >= 0
                 ? (ctx.styles.cellXfs[cellStyleIndex]?.hasCheckboxFeature ?? false)

--- a/test/empty-inline-string.test.ts
+++ b/test/empty-inline-string.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { writeXlsxStream, XlsxStreamWriter } from "../src/xlsx/stream-writer"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+
+// ═══════════════════════════════════════════════════════════════════════
+// An empty string read back as `null`, but only when it had been written
+// as an *inline* string:
+//
+//   <c t="s"><v>1</v></c>            shared, entry 1 is ""   →  ""
+//   <c t="inlineStr"><is><t/></is></c>                       →  null
+//
+// Both are a producer saying "this cell holds the empty string". The
+// asymmetry was accidental: #492 skips a cell that carries no
+// information, and it decided that from the *text* it had collected —
+// which for a shared string is the index `"1"`, non-empty, and for an
+// inline string is the string itself, empty.
+//
+// #492 is about `<c r="WVF45" s="3"/>`: self-closing, no `t`, no
+// content, written by Excel for every position formatting ever touched.
+// A cell that declares `t="inlineStr"` and carries an `<is>` is not that.
+// The producer wrote an element to say so.
+//
+// It matters because `writeXlsxStream` defaults to inline strings, so
+// hucre's own three XLSX writers disagreed with each other on the same
+// input — found by a property test comparing them.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+/** A workbook whose sheet body is exactly the rows given. */
+async function sheetWith(rowsXml: string): Promise<Uint8Array> {
+  const base = await writeXlsx({ sheets: [{ name: "S", rows: [["seed"]] }] })
+  const all = await new ZipReader(base).extractAll()
+  const zw = new ZipWriter()
+  for (const [name, data] of all) {
+    zw.add(
+      name,
+      name === "xl/worksheets/sheet1.xml"
+        ? enc.encode(
+            dec
+              .decode(data)
+              .replace(/<sheetData>.*<\/sheetData>/, `<sheetData>${rowsXml}</sheetData>`),
+          )
+        : data,
+    )
+  }
+  return zw.build()
+}
+
+describe("an empty inline string is a value", () => {
+  it('reads as "", not null', async () => {
+    const bytes = await sheetWith(
+      '<row r="1">' +
+        '<c r="A1" t="inlineStr"><is><t>a</t></is></c>' +
+        '<c r="B1" t="inlineStr"><is><t/></is></c>' +
+        '<c r="C1" t="inlineStr"><is><t>c</t></is></c>' +
+        "</row>",
+    )
+
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]).toEqual(["a", "", "c"])
+  })
+
+  it("the same as the shared-string spelling of it always did", async () => {
+    // The two spellings of one value have to agree; this is the pair.
+    const inline = await sheetWith('<row r="1"><c r="A1" t="inlineStr"><is><t/></is></c></row>')
+    const shared = await writeXlsx({ sheets: [{ name: "S", rows: [[""]] }] })
+
+    expect((await readXlsx(inline)).sheets[0]!.rows[0]![0]).toBe(
+      (await readXlsx(shared)).sheets[0]!.rows[0]![0],
+    )
+  })
+
+  it("including an <is> with no <t> at all", async () => {
+    const bytes = await sheetWith(
+      '<row r="1"><c r="A1" t="inlineStr"><is/></c><c r="B1" t="inlineStr"><is><t>b</t></is></c></row>',
+    )
+
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]).toEqual(["", "b"])
+  })
+})
+
+describe("hucre's three XLSX writers agree with each other", () => {
+  // The property test that found this compared them on random grids;
+  // this is the reduced case, kept because the agreement is the point.
+  const ROWS = [["a", "", "c"]]
+
+  it("on an empty string in the middle of a row", async () => {
+    const incremental = new XlsxStreamWriter({ name: "S" })
+    for (const row of ROWS) incremental.addRow(row)
+
+    const variants = [
+      await writeXlsx({ sheets: [{ name: "S", rows: ROWS }] }),
+      await drain(writeXlsxStream(ROWS, { name: "S" })),
+      await drain(writeXlsxStream(ROWS, { name: "S", inlineStrings: true })),
+      await incremental.finish(),
+    ]
+
+    for (const bytes of variants) {
+      expect((await readXlsx(bytes)).sheets[0]!.rows[0]).toEqual(["a", "", "c"])
+    }
+  })
+
+  it("and writeXlsxStream really is writing the inline spelling", async () => {
+    // Otherwise the test above could pass for the wrong reason.
+    const bytes = await drain(writeXlsxStream(ROWS, { name: "S" }))
+    const xml = dec.decode(await new ZipReader(bytes).extract("xl/worksheets/sheet1.xml"))
+
+    expect(xml).toContain('t="inlineStr"')
+    expect(xml).toContain("<t/>")
+  })
+})
+
+describe("the #492 cells are still skipped", () => {
+  it("a self-closing style-only cell carries nothing", async () => {
+    // The guard this fix relaxes exists for these. A cell with no `t`
+    // and no content is not a producer saying "empty string" — it is
+    // Excel remembering that someone once formatted the position.
+    const bytes = await sheetWith(
+      '<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c><c r="WVF1" s="3"/></row>',
+    )
+
+    expect((await readXlsx(bytes)).sheets[0]!.rows[0]).toEqual(["a"])
+  })
+
+  it("but is kept when its style is being read", async () => {
+    const bytes = await sheetWith(
+      '<row r="1"><c r="A1" t="inlineStr"><is><t>a</t></is></c><c r="D1" s="0"/></row>',
+    )
+    const rows = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.rows
+
+    expect(rows[0]).toHaveLength(4)
+  })
+})

--- a/test/property-roundtrip.test.ts
+++ b/test/property-roundtrip.test.ts
@@ -14,7 +14,10 @@ import {
 import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../src/limits"
 import { writeXlsx } from "../src/xlsx/writer"
 import { readXlsx } from "../src/xlsx/reader"
+import { writeXlsxStream, XlsxStreamWriter } from "../src/xlsx/stream-writer"
 import { writeOds } from "../src/ods/writer"
+import { writeOdsStream } from "../src/ods/stream-writer"
+import { OdsStreamWriter } from "../src/ods/incremental-writer"
 import { readOds } from "../src/ods/reader"
 import { seeded } from "./_fuzz"
 import type { CellValue } from "../src/_types"
@@ -338,5 +341,70 @@ describe("the one value the generator above deliberately leaves out", () => {
     const bytes = await writeOds({ sheets: [{ name: "S", rows: [[LITERAL]] }] })
 
     expect((await readOds(bytes)).sheets[0]!.rows[0]![0]).toBe(LITERAL)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════
+// Each format has more than one writer, and they are supposed to differ
+// only in how much they hold in memory. Pointing the same random grids
+// at all of them found that they did not: `writeXlsxStream` defaults to
+// inline strings, and an empty inline string read back as `null` where
+// the buffered writer's shared string read back as `""`.
+//
+// The reduced case lives in test/empty-inline-string.test.ts. This is
+// the comparison that noticed.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function drainStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+describe("every writer of a format agrees with every other", () => {
+  it("on the same random grids", async () => {
+    const rnd = seeded(SEED)
+
+    for (let run = 0; run < 25; run++) {
+      const rows: CellValue[][] = Array.from({ length: 1 + Math.floor(rnd() * 4) }, () =>
+        Array.from({ length: 1 + Math.floor(rnd() * 4) }, () => randomBinaryCell(rnd)),
+      )
+
+      const xlsxIncremental = new XlsxStreamWriter({ name: "S" })
+      const odsIncremental = new OdsStreamWriter({ name: "S" })
+      for (const row of rows) {
+        xlsxIncremental.addRow(row)
+        odsIncremental.addRow(row)
+      }
+
+      const variants: Array<[string, Uint8Array, typeof readXlsx]> = [
+        ["xlsx buffered", await writeXlsx({ sheets: [{ name: "S", rows }] }), readXlsx],
+        ["xlsx stream", await drainStream(writeXlsxStream(rows, { name: "S" })), readXlsx],
+        ["xlsx incremental", await xlsxIncremental.finish(), readXlsx],
+        ["ods buffered", await writeOds({ sheets: [{ name: "S", rows }] }), readOds],
+        ["ods stream", await drainStream(writeOdsStream(rows, { name: "S" })), readOds],
+        ["ods incremental", await odsIncremental.finish(), readOds],
+      ]
+
+      for (const [label, bytes, read] of variants) {
+        const back = (await read(bytes)).sheets[0]!.rows
+        for (let i = 0; i < rows.length; i++) {
+          expect(trimTrailing(back[i] ?? []), `${label}, run ${run}, row ${i}`).toEqual(
+            trimTrailing(rows[i]!),
+          )
+        }
+      }
+    }
   })
 })


### PR DESCRIPTION
The two spellings of one value disagreed:

```
<c t="s"><v>1</v></c>               shared, entry 1 is ""   →  ""
<c t="inlineStr"><is><t/></is></c>                          →  null
```

Both are a producer saying *this cell holds the empty string*.

## Why

#492 skips a cell that carries no information, and decided that from the text it had collected. For a shared string that text is the **index** — `"1"`, non-empty even when the string it points at is empty. For an inline string it is the string itself. So `""` survived one way and vanished the other.

#492 is about `<c r="WVF45" s="3"/>`: self-closing, no `t`, no content, which Excel writes for every position formatting was ever applied to — 145,315 of them against 197 values in the workbook that issue came from. A cell that declares `t="inlineStr"` and carries an `<is>` is not that. The producer wrote an element to say so.

Those cells are still skipped, with and without `readStyles`, and there are tests for both halves so the relaxation cannot quietly widen.

## How it was found

A property test pointing the same random grids at **every writer of each format** — extended from the binary round-trip property added in #526. `writeXlsxStream` defaults to inline strings, so hucre's own three XLSX writers disagreed with each other on the same input:

```
buffered      ["a", "",   "c"]
stream        ["a", null, "c"]     ← inline strings
incremental   ["a", "",   "c"]
```

The writers were all correct — `<is><t/></is>` is a valid empty inline string, and the test asserts that `writeXlsxStream` really does emit it, so the agreement cannot pass for the wrong reason. The reader was the one that had to change.

This also affects files hucre did not write: openpyxl and other producers use inline strings, and any of them writing an empty one was read as a blank cell.

Five tests fail against main’s `src` and pass with it (`git stash -q -- src`, confirmed).

`pnpm test` green — 10,398 tests, 213 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)