### PR TITLE
fix(ods): carry a scientific number format, and say what still is not

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -439,6 +439,20 @@ auto-filter, named ranges, tables, images, page setup, sheet protection,
 tab colour, hidden sheets, and `time` cells (which read back as the raw
 ISO duration string).
 
+Number format is carried, but not every Excel code has an ODF spelling.
+Three that do not survive intact, measured rather than assumed:
+
+| code            | comes back as | why                                                                                              |
+| --------------- | ------------- | ------------------------------------------------------------------------------------------------ |
+| `0.00_);(0.00)` | `0.00;(0.00)` | `_)` reserves the width of a character. ODF has no equivalent, so the padding is dropped         |
+| `@`             | _(General)_   | the text format has no data style to write; a cell already carrying a string is unaffected       |
+| `##0.0E+0`      | `0.0E+0`      | engineering notation steps the integer part in threes, which ODF spells with `exponent-interval` |
+
+Ordinary scientific formats — `0.00E+00` and its widths — do round-trip,
+through `<number:scientific-number>`. They did not until it was written:
+the code fell through to the plain-number branch, so `0.00E+00` became
+`0.00` and the file displayed a plain decimal in LibreOffice too.
+
 The reader opens `content.xml` and `meta.xml`. It does not open
 `styles.xml` or `settings.xml`, which is where LibreOffice keeps named and
 default cell styles and all page setup — so a LibreOffice-authored file

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -224,6 +224,28 @@ function serializeDataStyleChildren(
       const grouping = child.attrs["number:grouping"] === "true"
       const integerPart = grouping ? "#,##0" : "0"
       out += decimals > 0 ? `${integerPart}.${"0".repeat(decimals)}` : integerPart
+    } else if (local === "scientific-number") {
+      // `<number:scientific-number number:decimal-places="2"
+      //  number:min-integer-digits="1" number:min-exponent-digits="2"/>`
+      // is Excel's `0.00E+00`. The sign is always written: ODF has no
+      // attribute for a bare `E00`, and Excel's own scientific formats
+      // all carry one.
+      const decimals = Math.min(
+        parseInt(child.attrs["number:decimal-places"] ?? "0", 10) || 0,
+        MAX_REPEAT_COUNT,
+      )
+      const integerDigits = Math.min(
+        parseInt(child.attrs["number:min-integer-digits"] ?? "1", 10) || 1,
+        MAX_REPEAT_COUNT,
+      )
+      const exponentDigits = Math.min(
+        parseInt(child.attrs["number:min-exponent-digits"] ?? "2", 10) || 2,
+        MAX_REPEAT_COUNT,
+      )
+      out +=
+        "0".repeat(integerDigits) +
+        (decimals > 0 ? `.${"0".repeat(decimals)}` : "") +
+        `E+${"0".repeat(exponentDigits)}`
     } else if (local === "currency-symbol") {
       const text = child.children.filter((c: unknown) => typeof c === "string").join("")
       out += `"${text}"`

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -155,6 +155,38 @@ function hasGrouping(code: string): boolean {
   return /#,##0|0,000/.test(code)
 }
 
+/**
+ * A scientific format, and the widths ODF needs to describe it.
+ *
+ * Excel spells it `0.00E+00`: digits, then `E` with a sign, then the
+ * exponent's own digits. ODF has `<number:scientific-number>` for this,
+ * and without it the exponent is simply lost — the code fell through to
+ * the plain-number branch, which reads the decimals and nothing else, so
+ * `0.00E+00` became `0.00` and the file displayed a plain decimal in
+ * LibreOffice as well.
+ *
+ * Quoted literals are stripped first: `"EUR "#,##0.00` has an `E` in it
+ * and is not scientific.
+ */
+function parseScientificFormat(
+  code: string,
+): { decimals: number; integerDigits: number; exponentDigits: number } | undefined {
+  const unquoted = code.replace(/"[^"]*"/g, "").replace(/\\./g, "")
+  const match = unquoted.match(/^([#0]*)(?:\.([0#]+))?[Ee]([+-])([0#]+)$/)
+  if (!match) return undefined
+
+  // `min-integer-digits` counts the mandatory digits — the `0`s. `##0.0E+0`
+  // asks for engineering notation, where the integer part steps in threes;
+  // ODF expresses that with `number:exponent-interval`, which this does not
+  // write, so such a code comes back as `0.0E+0`.
+  const integerDigits = (match[1]?.match(/0/g) ?? []).length
+  return {
+    integerDigits: Math.max(integerDigits, 1),
+    decimals: match[2]?.length ?? 0,
+    exponentDigits: match[4]!.length,
+  }
+}
+
 /** Build a `<number:number>` child for numeric / percentage / currency styles */
 function buildNumberChild(decimals: number, grouping: boolean): string {
   const attrs: Record<string, string> = {
@@ -396,6 +428,22 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   const section = trimmed
     .replace(/\[\$-[^\]]*\]/g, "")
     .replace(/\[(?:black|blue|cyan|green|magenta|red|white|yellow|color\s*\d+)\]/gi, "")
+
+  // Before the currency and date checks: an exponent's `E` is neither,
+  // but the plain-number branch at the bottom would swallow it silently.
+  const scientific = parseScientificFormat(section)
+  if (scientific) {
+    return {
+      kind: "number",
+      children: [
+        xmlSelfClose("number:scientific-number", {
+          "number:decimal-places": String(scientific.decimals),
+          "number:min-integer-digits": String(scientific.integerDigits),
+          "number:min-exponent-digits": String(scientific.exponentDigits),
+        }),
+      ],
+    }
+  }
 
   if (isPercentageFormat(section)) {
     const decimals = decimalsFromCode(section)

--- a/test/ods-scientific-format.test.ts
+++ b/test/ods-scientific-format.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// `docs/PARITY.md` lists number format among the six style facets ODS
+// carries. A scientific one did not survive: `0.00E+00` was written as a
+// plain `<number:number number:decimal-places="2"/>` and read back as
+// `0.00`, the exponent gone.
+//
+// That is not only a round-trip loss. ODF has `<number:scientific-number>`
+// for exactly this, so what hucre wrote *displayed* as a plain decimal in
+// LibreOffice too — 1.2345E+03 shown as 1234.50.
+//
+// Found by a property test over random styles, checking each facet PARITY
+// claims against what came back.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function styleOf(numFmt: string): Promise<CellStyle | undefined> {
+  const bytes = await writeOds({
+    sheets: [
+      {
+        name: "S",
+        rows: [[1234.5]],
+        cells: new Map([["0,0", { value: 1234.5, style: { numFmt } }]]),
+      },
+    ],
+  })
+  return (await readOds(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")?.style
+}
+
+async function contentXml(numFmt: string): Promise<string> {
+  const bytes = await writeOds({
+    sheets: [
+      {
+        name: "S",
+        rows: [[1234.5]],
+        cells: new Map([["0,0", { value: 1234.5, style: { numFmt } }]]),
+      },
+    ],
+  })
+  return dec.decode(await new ZipReader(bytes).extract("content.xml"))
+}
+
+describe("a scientific format survives ODS", () => {
+  it("round-trips the common spellings", async () => {
+    for (const numFmt of ["0.00E+00", "0.000E+00", "0.0E+00", "0E+00"]) {
+      expect((await styleOf(numFmt))?.numFmt, numFmt).toBe(numFmt)
+    }
+  })
+
+  it("as ODF's own element, so LibreOffice shows it too", async () => {
+    // The assertion that matters to every other consumer. Reconstructing
+    // the code on read would fix hucre's round trip and leave the file
+    // still displaying a plain decimal everywhere else.
+    const xml = await contentXml("0.00E+00")
+
+    expect(xml).toContain("<number:scientific-number")
+    expect(xml).toContain('number:min-exponent-digits="2"')
+    expect(xml).toContain('number:decimal-places="2"')
+  })
+
+  it("with the exponent width it was given", async () => {
+    expect(await contentXml("0.0E+0")).toContain('number:min-exponent-digits="1"')
+    expect(await contentXml("0.0E+000")).toContain('number:min-exponent-digits="3"')
+  })
+
+  it("and XLSX still carries it, as it always did", async () => {
+    const bytes = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [[1234.5]],
+          cells: new Map([["0,0", { value: 1234.5, style: { numFmt: "0.00E+00" } }]]),
+        },
+      ],
+    })
+    const back = (await readXlsx(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")
+
+    expect(back?.style?.numFmt).toBe("0.00E+00")
+  })
+})
+
+describe("the formats around it are unchanged", () => {
+  it("plain, grouped, percentage, currency and date still round-trip", async () => {
+    // A scientific check that fires on a bare `E` would catch these, and
+    // `General` has one.
+    for (const numFmt of [
+      "0.00",
+      "#,##0",
+      "#,##0.00",
+      "0%",
+      "0.00%",
+      "yyyy-mm-dd",
+      "hh:mm:ss",
+      '"$"#,##0.00',
+    ]) {
+      expect((await styleOf(numFmt))?.numFmt, numFmt).toBe(numFmt)
+    }
+  })
+
+  it("a literal E in a quoted section is not an exponent", async () => {
+    // `"E"0.00` is the letter E followed by a number, not scientific.
+    const xml = await contentXml('"EUR "#,##0.00')
+
+    expect(xml).not.toContain("<number:scientific-number")
+  })
+})
+
+describe("the number-format codes ODS still cannot carry", () => {
+  // Chasing the scientific gap turned up three more. None has an ODF
+  // spelling, so they are losses rather than defects — but `PARITY.md`
+  // listed number format as carried without saying which codes, and a
+  // documented loss nobody checks is a claim, not a fact. These are the
+  // three the doc now names.
+
+  it("drops the width reserved by _", async () => {
+    // `_)` reserves the width of a `)` so positives line up with
+    // parenthesised negatives. ODF has nothing for it.
+    expect((await styleOf("0.00_);(0.00)"))?.numFmt).toBe("0.00;(0.00)")
+  })
+
+  it("has no data style for the text format", async () => {
+    // A cell already holding a string is unaffected — this only matters
+    // for a number one asked to display as text.
+    expect((await styleOf("@"))?.numFmt).toBeUndefined()
+  })
+
+  it("flattens engineering notation to plain scientific", async () => {
+    // `##0.0E+0` steps the integer part in threes. ODF spells that with
+    // `number:exponent-interval`, which the writer does not emit, so the
+    // exponent survives and the stepping does not.
+    expect((await styleOf("##0.0E+0"))?.numFmt).toBe("0.0E+0")
+  })
+})


### PR DESCRIPTION
`docs/PARITY.md` lists number format among the six style facets ODS carries. A scientific one did not survive.

```
0.00E+00  →  0.00
```

The code fell through to the plain-number branch, which reads the decimals and nothing else, so it was written as `<number:number number:decimal-places="2"/>`.

**This was not only a round-trip loss.** ODF has `<number:scientific-number>` for exactly this, so what hucre wrote displayed as a plain decimal in LibreOffice too — `1.2345E+03` shown as `1234.50`. The test asserts on the emitted element, not just the round trip, because reconstructing the code on read would have fixed hucre’s own loop and left every other consumer with the wrong file.

The writer now emits the element with the decimal, integer and exponent widths the Excel code asked for, and the reader turns it back. Quoted literals are stripped before the check, so `"EUR "#,##0.00` is not mistaken for an exponent — there is a test for that, since a looser check on a bare `E` would have caught it.

## Three more codes, which are losses rather than defects

Chasing this turned up three with no ODF spelling. PARITY said "number format" without qualifying which codes, and a documented loss that nothing checks is a claim rather than a fact. All three are now named in the doc and pinned by tests:

| code | comes back as | why |
| --- | --- | --- |
| `0.00_);(0.00)` | `0.00;(0.00)` | `_)` reserves the width of a character; ODF has no equivalent |
| `@` | *(General)* | the text format has no data style to write. A cell already holding a string is unaffected |
| `##0.0E+0` | `0.0E+0` | engineering notation steps the integer part in threes, which ODF spells with `number:exponent-interval` |

## How it was found

A property test over random styles, checking each facet PARITY claims against what came back. Everything else it flagged for ODS — borders, alignment, font name, underline, strikethrough — is already listed there as *not modelled in either direction*, so those are correct. Number format was the one the doc promised and the code did not deliver.

XLSX lost none of these; there is a test saying so, which is also what would notice if this fix were applied too widely.

Four tests fail against main’s `src` and pass with it (`git stash -q -- src`, confirmed).

`pnpm test` green — 10,407 tests, 214 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)