### PR TITLE
fix(xlsx): stop offering `sparse` where it cannot work, and name the ceiling

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -171,6 +171,27 @@ different problem with a different answer.
 `Sheet.rows` — `sheetToObjects`, `readObjects`, the writers — sees an
 empty sheet; `cells` is the whole answer.
 
+**`sparse` has a ceiling of its own: 16,777,216 filled cells.** `cells`
+is a `Map`, and V8 caps a `Map` at 2^24 entries. That is not a bound
+hucre chose and it cannot raise it without `Sheet.cells` ceasing to be a
+`Map`, which would break every caller using it as one.
+
+It matters because the two ways a sheet can be over the bounding-box
+limit want different answers, and only one of them is `sparse`:
+
+| the sheet is…             | example                    | use              |
+| ------------------------- | -------------------------- | ---------------- |
+| a large box, mostly empty | 82k values over 305M slots | `sparse: true`   |
+| genuinely dense and large | 28.4M filled of 30.2M      | `streamXlsxRows` |
+
+For the second, the cell count that blew the box limit is the same count
+that blows the `Map`, so `sparse` cannot work by construction. The
+oversize error now says which case it is looking at and stops offering
+`sparse` when the filled count is already past what a `Map` holds; going
+over anyway is a `ParseError` naming the sheet, not a raw
+`RangeError: Map maximum size exceeded`. `streamXlsxRows` has no such
+bound. See #527.
+
 ### A style-only cell does not widen the sheet
 
 Excel writes a self-closing `<c r="WVF45" s="3"/>` for every position

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -50,6 +50,31 @@ export const MAX_COL_INDEX = 16_383
 export const MAX_TOTAL_CELLS = 20_000_000
 
 /**
+ * How many entries `Sheet.cells` can hold.
+ *
+ * Not a policy — a `Map` in V8 caps at 2^24 entries and throws
+ * `RangeError: Map maximum size exceeded` on the one after. Verified:
+ * the 16,777,216th `set` succeeds and the next throws, a real
+ * `RangeError` with no `code`.
+ *
+ * It matters because `sparse: true` is one of the escapes the
+ * {@link MAX_TOTAL_CELLS} error offers, and `cells` is the only place a
+ * sparse read puts anything. For a sheet over the bounding-box limit
+ * because its box is large and mostly empty, that advice is right. For
+ * one over it because the sheet is genuinely dense — 916,449 x 33 at 94%
+ * filled, from a real corpus — the cell count that blew the box limit is
+ * the same count that blows this one, so the advice led somewhere that
+ * could not work.
+ *
+ * hucre cannot raise this bound without replacing `Sheet.cells` with
+ * something that is not a `Map`, which is a breaking change to a public
+ * field. What it can do is not recommend a path that is already too
+ * small, and fail as a `ParseError` naming the sheet rather than as a
+ * raw `RangeError`. See #527.
+ */
+export const MAX_CELL_MAP_ENTRIES = 16_777_216
+
+/**
  * Cap on any `String.repeat` count taken from file content.
  *
  * ODS expresses runs of spaces as `<text:s text:c="N"/>` and decimal

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -35,8 +35,74 @@ import { cloneCellStyle } from "../_style"
 import { PAPER_SIZE_REVERSE } from "./worksheet-writer"
 import { serialToDate } from "../_date"
 import { parseSax, decodeOoxmlEscapes } from "../xml/parser"
-import { MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
+import { MAX_CELL_MAP_ENTRIES, MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 import { ParseError } from "../errors"
+
+/**
+ * The message for a sheet whose bounding box is over the limit.
+ *
+ * Pure, and exported, because the branch that matters cannot be reached
+ * from a test workbook: telling a caller *not* to try `sparse` needs a
+ * sheet with more than 16.7 million filled cells, which is a couple of
+ * gigabytes to build for one string.
+ *
+ * The advice is the point. A sparse sheet — 82k values over a 305M-slot
+ * box, 0.03% filled — wants `sparse: true`, and a dense one cannot use
+ * it: the cell count that blew the box limit is the same count that
+ * blows the `Map` behind `cells`. The message used to offer it either
+ * way. See #501, #527.
+ */
+export function oversizeSheetMessage(
+  name: string,
+  rowCount: number,
+  colCount: number,
+  totalCells: number,
+  cellCount: number,
+  cellLimit: number,
+): string {
+  const density = totalCells > 0 ? (100 * cellCount) / totalCells : 100
+  const sparseWouldFit = cellCount <= MAX_CELL_MAP_ENTRIES
+
+  return (
+    `Sheet "${name}" spans ${rowCount} rows x ${colCount} columns ` +
+    `(${totalCells} cells, ${density.toFixed(2)}% of them filled), ` +
+    `over the ${cellLimit} limit.\n` +
+    `  - streamXlsxRows(input) reads it a row at a time, whatever the box.\n` +
+    (sparseWouldFit
+      ? `  - readXlsx(input, { sparse: true }) returns the cells and no grid.\n`
+      : `  - \`sparse: true\` cannot help here: ${cellCount} filled cells is past ` +
+        `the ${MAX_CELL_MAP_ENTRIES} a Map can hold.\n`) +
+    `  - \`range\` or \`maxRows\` bound the area, if you know where the data is.\n` +
+    `  - \`maxTotalCells\` raises the bound, if the sheet really is this large.`
+  )
+}
+
+/**
+ * Refuse the cell that would overflow `Sheet.cells`.
+ *
+ * V8 caps a `Map` at 2^24 entries and answers the next `set` with a raw
+ * `RangeError: Map maximum size exceeded` — not a `HucreError`, naming
+ * no sheet, saying nothing about spreadsheets. Checking the size first
+ * costs one comparison per cell and turns that into a `ParseError` that
+ * names where to go instead.
+ *
+ * `has` is only consulted at the boundary, so the common path is the
+ * comparison alone.
+ */
+export function assertCellMapCapacity(
+  cells: Map<string, Cell>,
+  key: string,
+  sheetName: string | undefined,
+): void {
+  if (cells.size < MAX_CELL_MAP_ENTRIES || cells.has(key)) return
+
+  throw new ParseError(
+    `Sheet "${sheetName ?? "?"}" has more than ${MAX_CELL_MAP_ENTRIES} filled cells, ` +
+      `which is the most \`Sheet.cells\` can hold — a Map caps at 2^24 entries.\n` +
+      `  - streamXlsxRows(input) reads it a row at a time and has no such bound.\n` +
+      `The file is not damaged; it is larger than this model.`,
+  )
+}
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -1206,15 +1272,8 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
       //
       // `streamXlsxRows` reads exactly this file today, one row at a
       // time, and the message never mentioned it. See #501.
-      const density = totalCells > 0 ? (100 * cellCount) / totalCells : 100
       throw new ParseError(
-        `Sheet "${name}" spans ${maxRow + 1} rows x ${colCount} columns ` +
-          `(${totalCells} cells, ${density.toFixed(2)}% of them filled), ` +
-          `over the ${cellLimit} limit.\n` +
-          `  - streamXlsxRows(input) reads it a row at a time, whatever the box.\n` +
-          `  - readXlsx(input, { sparse: true }) returns the cells and no grid.\n` +
-          `  - \`range\` or \`maxRows\` bound the area, if you know where the data is.\n` +
-          `  - \`maxTotalCells\` raises the bound, if the sheet really is this large.`,
+        oversizeSheetMessage(name, maxRow + 1, colCount, totalCells, cellCount, cellLimit),
       )
     }
     for (let r = 0; r <= maxRow; r++) {
@@ -1248,6 +1307,9 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
         value: (rows[pos.row] && rows[pos.row][pos.col]) ?? null,
         type: "string",
       }
+      // Far fewer hyperlinks than cells in any real file, but this is
+      // the other place `cells` grows and the check is one comparison.
+      assertCellMapCapacity(cells, key, name)
       cells.set(key, cell)
     }
 
@@ -1965,7 +2027,9 @@ function processCell(
         })
       }
     }
-    cells.set(`${row},${col}`, cell)
+    const cellKey = `${row},${col}`
+    assertCellMapCapacity(cells, cellKey, ctx.sheetName)
+    cells.set(cellKey, cell)
   }
 }
 

--- a/test/sparse-map-ceiling.test.ts
+++ b/test/sparse-map-ceiling.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+import { assertCellMapCapacity, oversizeSheetMessage } from "../src/xlsx/worksheet"
+import { readXlsx } from "../src/xlsx/reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { ZipReader } from "../src/zip/reader"
+import { ZipWriter } from "../src/zip/writer"
+import { ParseError } from "../src/errors"
+import { MAX_CELL_MAP_ENTRIES } from "../src/limits"
+import type { Cell } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #527 — `sparse: true` is one of the escapes the `maxTotalCells` error
+// offers, and `Sheet.cells` is the only place a sparse read puts
+// anything. A `Map` in V8 caps at 2^24 entries, so the sparse path has a
+// ceiling of its own: a raw `RangeError: Map maximum size exceeded`,
+// naming no sheet and saying nothing about spreadsheets.
+//
+// The two cases the old message could not tell apart:
+//
+//   large box, mostly empty   82k values over 305M slots   sparse works
+//   genuinely dense           28.4M filled of 30.2M        sparse cannot
+//
+// For the second, the cell count that blew the bounding-box limit is the
+// same count that blows the Map — so the advice pointed at the one path
+// guaranteed not to work. Four workbooks in a ~600-file corpus are that
+// shape, and `streamXlsxRows` reads all four.
+//
+// Raising the ceiling means `Sheet.cells` stops being a `Map`, which is
+// a breaking change to a public field. This does the other thing: stops
+// recommending a path already too small, and fails as a `ParseError`.
+//
+// Both pieces are exported and tested directly. Reaching either branch
+// through a real workbook needs 16.7 million filled cells — a couple of
+// gigabytes to build for one string — which is not a thing to put in a
+// suite that runs on every push.
+// ═══════════════════════════════════════════════════════════════════════
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+describe("the advice depends on which kind of large the sheet is", () => {
+  it("offers sparse for a big, mostly empty box", () => {
+    // #501's file: 82,000 values over 305,612,208 slots.
+    const message = oversizeSheetMessage("Data", 18_654, 16_384, 305_612_208, 82_000, 20_000_000)
+
+    expect(message).toContain("readXlsx(input, { sparse: true })")
+    expect(message).toContain("streamXlsxRows")
+    expect(message).toContain("0.03% of them filled")
+  })
+
+  it("does not offer it for a dense sheet that would not fit", () => {
+    // #527's fourth file: 916,449 x 33, 93.95% filled.
+    const message = oversizeSheetMessage("Log", 916_449, 33, 30_242_817, 28_413_226, 20_000_000)
+
+    // Not the *recommendation* — the message still names the option, to
+    // say why it is not one.
+    expect(message).not.toContain("readXlsx(input, { sparse: true })")
+    expect(message).toContain("cannot help here")
+    expect(message).toContain("28413226 filled cells")
+    expect(message).toContain(String(MAX_CELL_MAP_ENTRIES))
+    // The escape that does work is still named, and named first.
+    expect(message).toContain("streamXlsxRows")
+  })
+
+  it("switches exactly at the Map bound, not near it", () => {
+    const fits = oversizeSheetMessage("S", 2, 2, 30_000_000, MAX_CELL_MAP_ENTRIES, 20_000_000)
+    const over = oversizeSheetMessage("S", 2, 2, 30_000_000, MAX_CELL_MAP_ENTRIES + 1, 20_000_000)
+
+    expect(fits).toContain("readXlsx(input, { sparse: true })")
+    expect(over).not.toContain("readXlsx(input, { sparse: true })")
+  })
+
+  it("keeps naming range, maxRows and maxTotalCells either way", () => {
+    for (const cellCount of [1, MAX_CELL_MAP_ENTRIES + 1]) {
+      const message = oversizeSheetMessage("S", 2, 2, 30_000_000, cellCount, 20_000_000)
+
+      expect(message).toContain("`range` or `maxRows`")
+      expect(message).toContain("`maxTotalCells`")
+      expect(message).toContain('Sheet "S"')
+    }
+  })
+})
+
+describe("the overflow itself is a typed error", () => {
+  /** A Map that reports itself full without holding 16.7M entries. */
+  function fullMap(size: number, present?: string): Map<string, Cell> {
+    const map = new Map<string, Cell>()
+    Object.defineProperty(map, "size", { value: size })
+    if (present) map.set(present, { value: null, type: "string" })
+    return map
+  }
+
+  it("throws ParseError, not RangeError, at the bound", () => {
+    // V8's own is a real `RangeError` with message "Map maximum size
+    // exceeded" and no `code` — checked directly, because the last time
+    // a ceiling was guarded here the error type was assumed and the
+    // guard never fired. See #516.
+    const cells = fullMap(MAX_CELL_MAP_ENTRIES)
+
+    expect(() => assertCellMapCapacity(cells, "0,0", "Log")).toThrow(ParseError)
+    expect(() => assertCellMapCapacity(cells, "0,0", "Log")).toThrow(/Sheet "Log"/)
+    expect(() => assertCellMapCapacity(cells, "0,0", "Log")).toThrow(/streamXlsxRows/)
+    expect(() => assertCellMapCapacity(cells, "0,0", "Log")).toThrow(/not damaged/)
+  })
+
+  it("allows the last entry that fits", () => {
+    const cells = fullMap(MAX_CELL_MAP_ENTRIES - 1)
+
+    expect(() => assertCellMapCapacity(cells, "0,0", "Log")).not.toThrow()
+  })
+
+  it("allows overwriting a key already present when full", () => {
+    // `set` on an existing key does not grow the Map, so refusing it
+    // would reject a cell the Map can hold.
+    const cells = fullMap(MAX_CELL_MAP_ENTRIES, "5,5")
+
+    expect(() => assertCellMapCapacity(cells, "5,5", "Log")).not.toThrow()
+  })
+
+  it("names the sheet even when there is no name", () => {
+    const cells = fullMap(MAX_CELL_MAP_ENTRIES)
+
+    expect(() => assertCellMapCapacity(cells, "0,0", undefined)).toThrow(ParseError)
+  })
+})
+
+describe("ordinary sheets are untouched", () => {
+  it("a sparse read still returns its cells", async () => {
+    const base = await writeXlsx({
+      sheets: [
+        {
+          name: "S",
+          rows: [
+            ["a", "b"],
+            [1, 2],
+          ],
+        },
+      ],
+    })
+    const wb = await readXlsx(base, { sparse: true })
+
+    expect(wb.sheets[0]!.cells?.get("0,0")?.value).toBe("a")
+    expect(wb.sheets[0]!.cells?.get("1,1")?.value).toBe(2)
+  })
+
+  it("and the oversize error still fires on a big box", async () => {
+    // Two cells at opposite corners: a large box, two filled cells, so
+    // the message should recommend `sparse` — the case it is for.
+    const base = await writeXlsx({ sheets: [{ name: "S", rows: [["seed"]] }] })
+    const all = await new ZipReader(base).extractAll()
+    const zw = new ZipWriter()
+    for (const [path, data] of all) {
+      zw.add(
+        path,
+        path === "xl/worksheets/sheet1.xml"
+          ? enc.encode(
+              dec
+                .decode(data)
+                .replace(
+                  /<sheetData>.*<\/sheetData>/,
+                  '<sheetData><row r="1"><c r="A1" t="str"><v>a</v></c></row>' +
+                    '<row r="1048576"><c r="XFD1048576" t="str"><v>z</v></c></row></sheetData>',
+                ),
+            )
+          : data,
+      )
+    }
+
+    await expect(readXlsx(await zw.build())).rejects.toThrow(/sparse: true/)
+  })
+})


### PR DESCRIPTION
Closes #527. Reported by @erannave, with the corpus measurements that make the case — this is their option 3, which they identified as the right first step regardless of whether 1 or 2 ever happens. I agree, and for the reason they give: it is the same move #514 made for the string ceiling.

## The collision

`Sheet.cells` is a `Map`, V8 caps a `Map` at 2^24 entries, and the sparse path has nowhere else to put a cell. Verified rather than assumed — the 16,777,216th `set` succeeds and the next throws a real `RangeError`, message `Map maximum size exceeded`, no `code`:

```
size at throw: 16777216 = 2^24
constructor: RangeError    instanceof RangeError: true
```

(Checked directly because the last ceiling guarded here assumed the error type and the guard never fired — #516.)

That collides with the advice. `maxTotalCells` offers `sparse: true` as one of two escapes, and the two ways a sheet can be over that limit want different answers:

| the sheet is… | example | wants |
| --- | --- | --- |
| a large box, mostly empty | 82k values over 305M slots, 0.03% filled | `sparse: true` |
| genuinely dense and large | 28.4M filled of 30.2M, 94% | `streamXlsxRows` |

For the second, **the cell count that blew the box limit is the same count that blows the `Map`** — so the message recommended the one path guaranteed not to work. Four workbooks in the reporter’s ~600-file corpus are that shape, and `streamXlsxRows` reads all four.

## What this does, and does not

Raising the bound means `Sheet.cells` stops being a `Map` — a breaking change to a public field, and the reporter’s options 1 and 2. Not this PR. This does the other thing:

- the oversize message **drops the `sparse` recommendation** when the filled count is already past what a `Map` holds, and says why instead;
- going over anyway is a **`ParseError`** naming the sheet and pointing at `streamXlsxRows`, rather than a raw `RangeError` that names nothing and says nothing about spreadsheets.

So the capability is unchanged and the failure is legible. `streamXlsxRows` remains the answer for that shape and has no such bound.

## Testing

Reaching either branch through a real workbook needs 16.7 million filled cells — a couple of gigabytes to build for one string, which is not something to run on every push. So the message builder is a pure function and the capacity check is a small one, both exported and tested directly, including the boundaries: exactly at the bound, one past it, and overwriting a key already present (which does not grow a `Map`, so refusing it would reject a cell that fits).

The paths that go through a real workbook — an ordinary sparse read, and the oversize error still firing and still recommending `sparse` for the mostly-empty case — are covered end to end.

Eight tests fail against main’s `src` and pass with it.

`PARITY.md` now states the ceiling and which of the two cases each escape is for, since it advertised `sparse` without it.

`pnpm test` green — 10,417 tests, 215 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)