### PR TITLE
fix(ods): a letter inside a quoted literal is text, not a date token

### DIFF
--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -467,10 +467,22 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
     return { kind: "currency", children, attrs: { "number:automatic-order": "true" } }
   }
 
-  const time = isTimeFormat(section)
-  const date = isDateFormat(section)
+  // Quoted literals are text, not tokens. In `#,##0" days"` the `d` and
+  // `y` are letters in a word; in `"Sales"#,##0` the `s` is. Read as
+  // tokens they made the whole code a date or time format, and
+  // `buildDateChildren` then emitted every `#` and `0` as
+  // `<number:text>` — so `"Sales"#,##0` came back as
+  // `"Sales""#","#""#""0"`, a format with no placeholder left in it.
+  //
+  // `isPercentageFormat` above already strips them, and the colour tags
+  // stripped further up are the same problem found earlier: `[White]`
+  // was being read as a time format for the `h` in "White".
+  const tokens = section.replace(/"[^"]*"/g, "").replace(/\\./g, "")
+
+  const time = isTimeFormat(tokens)
+  const date = isDateFormat(tokens)
   // Bracketed-hour durations like `[HH]:MM` are pure time; check time first.
-  const isElapsed = /\[[hHmMsS]+\]/.test(section)
+  const isElapsed = /\[[hHmMsS]+\]/.test(tokens)
   if (isElapsed || (time && !date)) {
     const def: OdsNumFmtDef = {
       kind: "time",

--- a/test/ods-literal-number-format.test.ts
+++ b/test/ods-literal-number-format.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { writeXlsx } from "../src/xlsx/writer"
+import { readXlsx } from "../src/xlsx/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// A number format whose *literal text* happened to contain h, s, d or y
+// was read as a date or time format, and the digits were destroyed with
+// it:
+//
+//   "Sales"#,##0   ->   "Sales""#","#""#""0"
+//
+// Every `#` and `0` came back as quoted literal text, so the number had
+// no placeholder left to land in.
+//
+// The classifiers looked for those letters in the whole format code. In
+// `#,##0" days"` the `d` and `y` are letters in a word, not tokens —
+// `isPercentageFormat` right next to them already stripped quoted
+// literals for exactly this reason, and the comment in `isDateFormat`
+// says colour tags are stripped because `[White]` was mistaken for a time
+// format by the `h` in "White". Quoted literals are the same problem and
+// were the case nobody had.
+//
+// XLSX was never affected: it writes the format code verbatim.
+// ═══════════════════════════════════════════════════════════════════════
+
+async function odsNumFmt(numFmt: string): Promise<string | undefined> {
+  const cells = new Map([["0,0", { value: 1234.5, style: { numFmt } as CellStyle }]])
+  const bytes = await writeOds({ sheets: [{ name: "S", rows: [[1234.5]], cells }] })
+  return (await readOds(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")?.style?.numFmt
+}
+
+async function xlsxNumFmt(numFmt: string): Promise<string | undefined> {
+  const cells = new Map([["0,0", { value: 1234.5, style: { numFmt } as CellStyle }]])
+  const bytes = await writeXlsx({ sheets: [{ name: "S", rows: [[1234.5]], cells }] })
+  return (await readXlsx(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")?.style?.numFmt
+}
+
+describe("letters inside a quoted literal are text, not tokens", () => {
+  const CASES = [
+    '"Sales"#,##0',
+    '"Hours"0.0',
+    '"Yes"0',
+    '"Days"0',
+    '"Month"0',
+    '"Sum: "#,##0.00',
+    '#,##0" hrs"',
+    '#,##0" days"',
+    '0" units"',
+    '"Total"#,##0;"Loss"#,##0',
+  ]
+
+  it("round-trip through ODS unchanged", async () => {
+    for (const numFmt of CASES) {
+      expect(await odsNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+
+  it("and XLSX carries them too, as it always did", async () => {
+    for (const numFmt of CASES) {
+      expect(await xlsxNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+
+  it("a colour tag in front of one does not bring the problem back", async () => {
+    // `[Red]` is dropped, which is what stopped `[White]` being read as a
+    // time format. The literal after it still has to survive.
+    expect(await odsNumFmt('[Red]"Sales"#,##0')).toBe('"Sales"#,##0')
+  })
+})
+
+describe("real date and time formats still are ones", () => {
+  it("the plain ones", async () => {
+    for (const numFmt of ["yyyy-mm-dd", "dd/mm/yyyy", "hh:mm:ss", "hh:mm", "mmm-yy"]) {
+      expect(await odsNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+
+  it("and one with a literal in the middle of it", async () => {
+    // The tokens outside the quotes are what makes this a date, and they
+    // still are. This is the case a fix that stripped too much breaks.
+    const back = await odsNumFmt('dd" of "mmmm')
+
+    expect(back).toContain("dd")
+    expect(back).toContain("mmmm")
+    expect(back).toContain(" of ")
+  })
+
+  it("an elapsed-time format is still elapsed", async () => {
+    expect(await odsNumFmt("[hh]:mm")).toBe("[hh]:mm")
+  })
+})
+
+describe("the plain formats around them are unchanged", () => {
+  it("still round-trip", async () => {
+    for (const numFmt of ["0.00", "#,##0", "#,##0.00", "0%", "0.00%", '"$"#,##0.00', "0.00E+00"]) {
+      expect(await odsNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+})


### PR DESCRIPTION
A number format whose **literal text** happened to contain `h`, `s`, `d` or `y` was written to ODS as a date or time format — and the digits went with it:

```
"Sales"#,##0   →   "Sales""#","#""#""0"
```

Every `#` and `0` came back as quoted literal text, so the number had no placeholder left to land in. The cell shows the format string instead of the value, in LibreOffice as much as on re-read.

Ordinary formats hit this:

| written | came back as |
| --- | --- |
| `#,##0" days"` | `"#","#""#""0"" days"` |
| `"Hours"0.0` | `"Hours""0"."0"` |
| `0" units"` | `"0"" units"` |
| `"Total"#,##0;"Loss"#,##0` | second section mangled |

## Cause

`isDateFormat` and `isTimeFormat` looked for those letters across the whole code. In `#,##0" days"` the `d` and `y` are letters in a word, not tokens.

Quoted literals are now stripped before the classification — which is exactly what `isPercentageFormat`, sitting immediately below them, already did for the same reason: *"Strip quoted literals so a literal % inside a string does not trigger"*.

And the colour tags stripped further up are the same bug found once before. The comment there records that `[White]0.00` was being read as a time format for the `h` in "White". Quoted literals were the case nobody had.

## Scope of the fix

The literals are stripped for the **test** only. `detectCurrencySymbol` reads them to find a symbol and `buildDateChildren` emits them, so both still see the whole code.

Real date formats are unaffected, including `dd" of "mmmm` — where the tokens *outside* the quotes are what makes it a date. That is the case a fix that stripped too much would break, and it has a test, as do `[hh]:mm` and the plain date and time codes.

XLSX was never affected; it writes the code verbatim. There is a test saying so, which is also what would notice if this were ever applied there.

Two tests fail against main's `src` and pass with it (`git stash -q -- src`, confirmed).

`pnpm test` green — 10,450 tests, 218 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
