### PR TITLE
fix(ods): carry fractional seconds, and finish the number-format list

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -461,13 +461,21 @@ tab colour, hidden sheets, and `time` cells (which read back as the raw
 ISO duration string).
 
 Number format is carried, but not every Excel code has an ODF spelling.
-Three that do not survive intact, measured rather than assumed:
+These do not survive intact. Every row was measured through the round
+trip rather than reasoned about:
 
-| code            | comes back as | why                                                                                              |
-| --------------- | ------------- | ------------------------------------------------------------------------------------------------ |
-| `0.00_);(0.00)` | `0.00;(0.00)` | `_)` reserves the width of a character. ODF has no equivalent, so the padding is dropped         |
-| `@`             | _(General)_   | the text format has no data style to write; a cell already carrying a string is unaffected       |
-| `##0.0E+0`      | `0.0E+0`      | engineering notation steps the integer part in threes, which ODF spells with `exponent-interval` |
+| code              | comes back as | why                                                                                              |
+| ----------------- | ------------- | ------------------------------------------------------------------------------------------------ |
+| `0.00_);(0.00)`   | `0.00;(0.00)` | `_)` reserves the width of a character. ODF has no equivalent, so the padding is dropped         |
+| `@`               | _(General)_   | the text format has no data style to write; a cell already carrying a string is unaffected       |
+| `##0.0E+0`        | `0.0E+0`      | engineering notation steps the integer part in threes, which ODF spells with `exponent-interval` |
+| `#`, `#.##`       | `0`, `0.00`   | `#` is an optional digit and `0` a mandatory one. ODF counts digits, so the distinction goes     |
+| `[mm]:ss`, `[ss]` | `mm:ss`, `ss` | the elapsed marker survives on hours (`[hh]:mm`) but not on minutes or seconds alone             |
+| `0.00;[Red]-0.00` | `0.00;-0.00`  | colour tags are dropped on purpose — it is what stops `[White]0.00` being read as a time format  |
+| `0.00;;`          | `0.00`        | empty trailing sections have nothing to write                                                    |
+
+`General` returning no `numFmt` is not in that list: General _is_ the
+absence of a data style, so there is nothing lost.
 
 Ordinary scientific formats — `0.00E+00` and its widths — do round-trip,
 through `<number:scientific-number>`. They did not until it was written:

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -274,6 +274,12 @@ function serializeDataStyleChildren(
       out += child.attrs["number:style"] === "long" ? "mm" : "m"
     } else if (local === "seconds") {
       out += child.attrs["number:style"] === "long" ? "ss" : "s"
+      // `number:decimal-places` on seconds is Excel's `ss.0` / `ss.00`.
+      const places = Math.min(
+        parseInt(child.attrs["number:decimal-places"] ?? "0", 10) || 0,
+        MAX_REPEAT_COUNT,
+      )
+      if (places > 0) out += `.${"0".repeat(places)}`
     } else if (local === "am-pm") {
       out += "AM/PM"
     }

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -319,11 +319,27 @@ function buildDateChildren(code: string): string[] {
     } else if (lower === "h") {
       out.push(xmlSelfClose("number:hours"))
       lastWasHours = true
-    } else if (lower === "ss") {
-      out.push(xmlSelfClose("number:seconds", { "number:style": "long" }))
-      lastWasHours = false
-    } else if (lower === "s") {
-      out.push(xmlSelfClose("number:seconds"))
+    } else if (lower === "ss" || lower === "s") {
+      // Excel spells fractional seconds by writing the places after the
+      // token — `ss.0`, `ss.00`. ODF puts the count on the element. The
+      // tokeniser hands `.` and each `0` over separately, so they are
+      // consumed here; left alone they fell through to the literal-text
+      // branch and `hh:mm:ss.0` came back as `hh:mm:ss."0"`, a format
+      // that displays the digit rather than the fraction.
+      const attrs: Record<string, string> = {}
+      if (lower === "ss") attrs["number:style"] = "long"
+
+      if (tokens[i + 1] === ".") {
+        let j = i + 2
+        while (tokens[j] === "0") j++
+        const places = j - (i + 2)
+        if (places > 0) {
+          attrs["number:decimal-places"] = String(places)
+          i = j - 1
+        }
+      }
+
+      out.push(xmlSelfClose("number:seconds", attrs))
       lastWasHours = false
     } else if (lower === "am/pm") {
       out.push(xmlSelfClose("number:am-pm"))

--- a/test/ods-fractional-seconds.test.ts
+++ b/test/ods-fractional-seconds.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// `hh:mm:ss.0` came back as `hh:mm:ss."0"` — the fractional part became
+// literal text, so the cell displayed the digit rather than a fraction of
+// a second.
+//
+// Excel spells the precision by writing the places after the token;
+// ODF puts the count on the element as `number:decimal-places`. The
+// tokeniser hands `.` and each `0` over separately, and nothing consumed
+// them, so they reached the literal-text branch.
+//
+// Timing and instrument exports use these. Found by a sweep of number
+// formats through the ODS round trip.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function odsNumFmt(numFmt: string): Promise<string | undefined> {
+  const cells = new Map([["0,0", { value: 0.5, style: { numFmt } as CellStyle }]])
+  const bytes = await writeOds({ sheets: [{ name: "S", rows: [[0.5]], cells }] })
+  return (await readOds(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")?.style?.numFmt
+}
+
+async function contentXml(numFmt: string): Promise<string> {
+  const cells = new Map([["0,0", { value: 0.5, style: { numFmt } as CellStyle }]])
+  const bytes = await writeOds({ sheets: [{ name: "S", rows: [[0.5]], cells }] })
+  return dec.decode(await new ZipReader(bytes).extract("content.xml"))
+}
+
+describe("fractional seconds survive", () => {
+  it("round-trip at each precision", async () => {
+    for (const numFmt of ["hh:mm:ss.0", "hh:mm:ss.00", "hh:mm:ss.000", "mm:ss.0", "ss.00"]) {
+      expect(await odsNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+
+  it("as decimal-places on the element, not as literal text", async () => {
+    // What LibreOffice reads. A cell showing the digit `0` after the
+    // seconds is wrong there too, so the round trip alone is not enough.
+    const xml = await contentXml("hh:mm:ss.00")
+
+    expect(xml).toContain('number:decimal-places="2"')
+    expect(xml).not.toContain("<number:text>0</number:text>")
+  })
+
+  it("and the seconds element keeps its own style", async () => {
+    // `ss` is two-digit, `s` is not — the precision must not overwrite it.
+    expect(await odsNumFmt("hh:mm:s.0")).toBe("hh:mm:s.0")
+    expect(await odsNumFmt("hh:mm:ss.0")).toBe("hh:mm:ss.0")
+  })
+})
+
+describe("seconds without a fraction are untouched", () => {
+  it("the ordinary time formats", async () => {
+    for (const numFmt of ["hh:mm:ss", "mm:ss", "hh:mm", "h:mm AM/PM", "[hh]:mm"]) {
+      expect(await odsNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+
+  it("a trailing dot with no digits is left alone", async () => {
+    // The consumer only fires on `.` followed by at least one `0`.
+    const back = await odsNumFmt("hh:mm:ss.")
+
+    expect(back).toContain("ss")
+  })
+
+  it("and a date is still a date", async () => {
+    for (const numFmt of ["yyyy-mm-dd", "yyyy-mm-dd hh:mm:ss", "mmm"]) {
+      expect(await odsNumFmt(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+})

--- a/test/ods-scientific-format.test.ts
+++ b/test/ods-scientific-format.test.ts
@@ -132,6 +132,32 @@ describe("the number-format codes ODS still cannot carry", () => {
     expect((await styleOf("@"))?.numFmt).toBeUndefined()
   })
 
+  it("makes an optional digit a mandatory one", async () => {
+    // `#` means "a digit if there is one" and `0` means "always a digit".
+    // ODF counts digits, so `#.##` displays 1234.50 where Excel showed
+    // 1234.5.
+    expect((await styleOf("#"))?.numFmt).toBe("0")
+    expect((await styleOf("#.##"))?.numFmt).toBe("0.00")
+  })
+
+  it("keeps the elapsed marker on hours but not on minutes or seconds", async () => {
+    expect((await styleOf("[hh]:mm"))?.numFmt).toBe("[hh]:mm")
+    expect((await styleOf("[mm]:ss"))?.numFmt).toBe("mm:ss")
+    expect((await styleOf("[ss]"))?.numFmt).toBe("ss")
+  })
+
+  it("drops a colour tag, which is what keeps [White] out of the time branch", async () => {
+    expect((await styleOf("0.00;[Red]-0.00"))?.numFmt).toBe("0.00;-0.00")
+  })
+
+  it("drops empty trailing sections", async () => {
+    expect((await styleOf("0.00;;"))?.numFmt).toBe("0.00")
+  })
+
+  it("and General is no loss — it is the absence of a data style", async () => {
+    expect((await styleOf("General"))?.numFmt).toBeUndefined()
+  })
+
   it("flattens engineering notation to plain scientific", async () => {
     // `##0.0E+0` steps the integer part in threes. ODF spells that with
     // `number:exponent-interval`, which the writer does not emit, so the


### PR DESCRIPTION
`hh:mm:ss.0` came back as `hh:mm:ss."0"` — the fractional part became **literal text**, so the cell displayed the digit rather than a fraction of a second. Timing and instrument exports use these formats.

Excel spells the precision by writing the places after the token; ODF puts the count on the element as `number:decimal-places`. The tokeniser hands `.` and each `0` over separately, and nothing consumed them, so they reached the literal-text branch.

The seconds branch now takes them and the reader turns them back. `ss` stays two-digit and `s` stays one — the precision must not overwrite the style, and there is a test for that pair. A trailing `.` with no digits is left alone.

The test asserts on the emitted `number:decimal-places`, not only the round trip: a cell showing a literal `0` after the seconds is wrong in LibreOffice too.

## Finishing the list

This came out of a sweep of number formats through the ODS round trip. Everything else it found was a **loss rather than a defect** — no ODF spelling exists — but `PARITY.md` listed only three of them, and the page's own rule is that a loss not on it is a bug. It now lists all seven, each measured rather than reasoned about, and each pinned by a test:

| code | comes back as | why |
| --- | --- | --- |
| `#`, `#.##` | `0`, `0.00` | `#` is an optional digit and `0` a mandatory one; ODF counts digits |
| `[mm]:ss`, `[ss]` | `mm:ss`, `ss` | the elapsed marker survives on hours (`[hh]:mm`) but not on minutes or seconds alone |
| `0.00;[Red]-0.00` | `0.00;-0.00` | colour tags are dropped on purpose — it is what stops `[White]0.00` being read as a time format |
| `0.00;;` | `0.00` | empty trailing sections have nothing to write |

`General` returning no `numFmt` is called out as explicitly **not** a loss: General *is* the absence of a data style.

Three tests fail against main's `src` and pass with it (`git stash -q -- src`, confirmed).

`pnpm test` green — 10,469 tests, 220 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
