### PR TITLE
fix(read): a worksheet part over the string ceiling now reads — closes #503

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -122,24 +122,56 @@ would otherwise show `1E-07` — but only when that form is the same
 number, which it was not for the smallest values (`Number.MIN_VALUE` used
 to come out as `0.0`).
 
-### The buffered readers have a size ceiling
+### The string ceiling, and where it still is
 
 One JavaScript string cannot hold an arbitrarily large part. V8's limit
-is 536,870,888 characters — about 512 MB — so a worksheet above it cannot
-be turned into a string at all, and `readXlsx`, `readXlsb` and `readOds`
-fail before any parsing begins. Instrument logs at Excel's row limit
-reach it: three files in a corpus of ~600 were 56–99 MB compressed and
-607 MB expanded. See #503.
+is 536,870,888 characters — about 512 MB — so a part above it cannot be
+turned into a string at all, however much memory the machine has.
+Instrument logs at Excel's row limit reach it: in a corpus of ~600, 14
+workbooks had a worksheet part between 588 MB and 1.13 GB. See #503.
 
-That used to surface as a raw `Error: Cannot create a string longer than
-0x1fffffe8 characters` — not a `ParseError`, naming no part, saying
-nothing about spreadsheets. It is now a `ParseError` that names the part,
-the size, the bound, and `streamXlsxRows`; and it says the workbook is
-not damaged, because everything else a reader throws means the file is
-wrong and this one means it is large.
+**`readXlsx` reads a worksheet part of any size.** When the part is over
+the ceiling it is parsed from the ZIP entry's stream instead of from a
+string, by the same SAX handlers the buffered parse uses — so the `Sheet`
+is the same `Sheet`, and no option selects between them. Which path runs
+is decided from the size the ZIP declares, before anything is
+decompressed; when the ZIP declares no size, the buffered read runs and
+the ceiling error it raises is the signal to retry as a stream.
 
-**`streamXlsxRows` has no such ceiling** — it reads those same files in
-about 30 seconds at a flat 944 MB, because it never holds the part whole.
+Two things this does not do:
+
+- **The other buffered readers still have the ceiling.** `readXlsb` and
+  `readOds` are unchanged, as is every non-worksheet part of an
+  XLSX — `sharedStrings.xml`, `styles.xml`, a drawing. Those still fail
+  with the `ParseError` from #514: it names the part, the size, the
+  bound, and `streamXlsxRows`, and it says the workbook is not damaged,
+  because everything else a reader throws means the file is wrong and
+  this one means it is large. (None of the ~600 has a non-worksheet part
+  anywhere near the ceiling; a workbook with a 512 MB shared-string
+  table would still fail.)
+- **It does not lift the cell bound.** A part over the ceiling is
+  usually also a sheet with a very large bounding box, so clearing the
+  ceiling often lands on `maxTotalCells` instead — of the 14, ten read
+  and four hit that limit. See the next section.
+
+Two trades worth knowing:
+
+- The streaming ZIP path has no whole entry to check, so a worksheet read
+  this way is **not CRC-32 verified**. That is the same trade
+  `streamXlsxRows` has always made. It is bounded on the way in — a
+  declared size the compressed body could not have produced (DEFLATE tops
+  out at 1032:1) is not believed, so a small entry cannot claim to be
+  enormous and skip the checksum that way.
+- A truncated part is still an error. The row streamers have no error
+  contract for one — they drop the unfinished construct and let the
+  caller notice the missing rows — but the worksheet reader asks the
+  streaming parser for `strict`, so a part that ends mid-tag throws the
+  `XmlError` the buffered parser throws rather than returning a short
+  `Sheet`.
+
+**`streamXlsxRows` still has no ceiling either** and remains the lower-cost
+answer when you only need to walk the rows: it never builds a `Workbook`,
+so it is bounded by the row you are on rather than by the sheet.
 
 ### A sparse sheet has a way out
 

--- a/scripts/size-budget.json
+++ b/scripts/size-budget.json
@@ -4,23 +4,23 @@
     "gzip": 4038
   },
   "readXlsx (hucre/xlsx)": {
-    "min": 133188,
-    "gzip": 36967
+    "min": 138926,
+    "gzip": 39085
   },
   "read+write xlsx (hucre/xlsx)": {
-    "min": 266018,
-    "gzip": 72846
+    "min": 271860,
+    "gzip": 75215
   },
   "everything (hucre)": {
-    "min": 489277,
-    "gzip": 138764
+    "min": 500939,
+    "gzip": 142754
   },
   "writeXlsx (hucre)": {
-    "min": 137695,
-    "gzip": 39254
+    "min": 137825,
+    "gzip": 39445
   },
   "readOds (hucre/ods)": {
-    "min": 26941,
-    "gzip": 9438
+    "min": 28240,
+    "gzip": 9953
   }
 }

--- a/src/_decode.ts
+++ b/src/_decode.ts
@@ -30,6 +30,29 @@ import { ParseError } from "./errors"
 export const MAX_STRING_LENGTH = 0x1fffffe8
 
 /**
+ * The error a part over the string ceiling produces.
+ *
+ * A caller that can do something about the ceiling — the worksheet
+ * reader, which parses the part as a stream instead (#503) — has to
+ * recognise this one error among all the `ParseError`s a decode can
+ * raise. Matching its message would be the same mistake #516 was: the
+ * text is for people, and a reworded sentence would silently turn the
+ * recovery off. A class cannot be reworded, and it is how every other
+ * distinguishable condition in this library is told apart — see
+ * `errors.ts`.
+ *
+ * Unexported, and a `ParseError` first: nothing outside needs to name it
+ * yet, and every existing `catch (e) { e instanceof ParseError }` keeps
+ * working.
+ */
+class PartTooLargeError extends ParseError {}
+
+/** Whether `error` is the "part is over the string ceiling" `ParseError`. */
+export function isPartTooLargeToDecode(error: unknown): boolean {
+  return error instanceof PartTooLargeError
+}
+
+/**
  * The message for a part too large to become a string.
  *
  * Separated from the decode so it can be tested: reproducing the
@@ -39,7 +62,7 @@ export const MAX_STRING_LENGTH = 0x1fffffe8
  * measurement, and the way out.
  */
 export function tooLargeToDecode(path: string, byteLength: number): ParseError {
-  return new ParseError(
+  return new PartTooLargeError(
     `Part "${path}" is ${byteLength.toLocaleString("en-US")} bytes, over the ` +
       `${MAX_STRING_LENGTH.toLocaleString("en-US")}-character maximum string length ` +
       `this runtime supports, so it cannot be read into memory whole.\n` +

--- a/src/xlsx/reader.ts
+++ b/src/xlsx/reader.ts
@@ -21,7 +21,7 @@ import type {
   TimelineCache,
   ChartAnchor,
 } from "../_types"
-import { decodePart } from "../_decode"
+import { decodePart, isPartTooLargeToDecode, MAX_STRING_LENGTH } from "../_decode"
 import { parsePersons, parseThreadedComments } from "./threaded-comments-reader"
 import { parseExternalLink } from "./external-link-reader"
 import { assembleCellImages, parseCellImages, REL_CELL_IMAGES } from "./cell-images-reader"
@@ -37,7 +37,8 @@ import { parseContentTypes } from "./content-types"
 import { parseRelationships } from "./relationships"
 import { parseSharedStrings } from "./shared-strings"
 import { parseStyles } from "./styles"
-import { parseWorksheet } from "./worksheet"
+import { parseWorksheet, parseWorksheetStream } from "./worksheet"
+import type { WorksheetContext } from "./worksheet"
 import { parseDynamicArrayCellMetadata } from "./metadata"
 import type { ParsedStyles } from "./styles"
 import type { SharedString } from "./shared-strings"
@@ -70,6 +71,60 @@ export function matchesRelType(rel: string, type: string): boolean {
 
 function decodeUtf8(data: Uint8Array, path = "(unknown)"): string {
   return decodePart(data, path)
+}
+
+/**
+ * Read one worksheet part into a `Sheet`, whatever size it is.
+ *
+ * A worksheet over V8's 0x1fffffe8-character ceiling cannot be turned
+ * into a string at all, so buffering it and parsing the string — what
+ * this did until #503 — could not work however much memory the machine
+ * had. `readXlsx` threw on eleven of the twelve workbooks over 100 MB in
+ * a corpus of ~600 instrument exports; the largest worksheet part in it
+ * is 589 MB.
+ *
+ * The part is parsed from the ZIP entry's stream instead, by the same
+ * handlers the buffered parse uses (`parseWorksheetStream`), so there is
+ * no second model-building path to keep in step.
+ *
+ * Which path is taken is not the caller's business — the ceiling is an
+ * implementation limit of a decoder, not a property of the workbook, and
+ * an option to work around it would only make every caller who meets one
+ * of these files handle it themselves. So it is decided here:
+ *
+ *  - The declared size settles it before anything is decompressed. It is
+ *    a *byte* count against a *character* ceiling, so a multibyte part
+ *    can be sent to the streaming path that the buffered one would have
+ *    managed. That costs nothing: same handlers, same `Sheet`.
+ *  - When the ZIP declares no size, the buffered path runs and the
+ *    ceiling error it raises is the signal to retry as a stream. That
+ *    pays for the decompression twice, which is why it is the fallback
+ *    and not the rule.
+ *
+ * One difference is worth knowing about: the streaming ZIP path does not
+ * verify CRC-32 (it has no whole entry to check), so a part read this way
+ * is not checked for corruption the way a buffered one is. That is the
+ * same trade `streamXlsxRows` has always made.
+ */
+async function readWorksheet(
+  zip: ZipReader,
+  wsPath: string,
+  name: string,
+  ctx: WorksheetContext,
+): Promise<Sheet> {
+  const declared = zip.declaredSize(wsPath)
+  if (declared === undefined || declared <= MAX_STRING_LENGTH) {
+    try {
+      return parseWorksheet(decodeUtf8(await zip.extract(wsPath), wsPath), name, ctx)
+    } catch (error) {
+      // Only `tooLargeToDecode` produces this one, so a `ParseError` the
+      // handlers raised — a malformed ref, the cell bound — is rethrown
+      // rather than retried. Retrying it would parse the part twice to
+      // arrive at the same error.
+      if (!isPartTooLargeToDecode(error)) throw error
+    }
+  }
+  return parseWorksheetStream(zip.extractStream(wsPath), name, ctx)
 }
 
 /**
@@ -438,8 +493,7 @@ export async function readXlsx(input: ReadInput, options?: ReadOptions): Promise
       onWarning: options?.onWarning,
     }
 
-    const wsXml = decodeUtf8(await zip.extract(wsPath), wsPath)
-    const sheet = parseWorksheet(wsXml, info.name, worksheetCtx)
+    const sheet = await readWorksheet(zip, wsPath, info.name, worksheetCtx)
     if (info.state === "hidden") sheet.hidden = true
     if (info.state === "veryHidden") sheet.veryHidden = true
 

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -34,7 +34,7 @@ import { resolveStyle, isDateStyle } from "./styles"
 import { cloneCellStyle } from "../_style"
 import { PAPER_SIZE_REVERSE } from "./worksheet-writer"
 import { serialToDate } from "../_date"
-import { parseSax, decodeOoxmlEscapes } from "../xml/parser"
+import { parseSax, parseSaxStream, decodeOoxmlEscapes, type SaxHandlers } from "../xml/parser"
 import { MAX_CELL_MAP_ENTRIES, MAX_COL_INDEX, MAX_ROW_INDEX, MAX_TOTAL_CELLS } from "../limits"
 import { ParseError } from "../errors"
 
@@ -223,10 +223,22 @@ function parseRangeRef(ref: string): MergeRange {
 // ── SAX-based Worksheet Parser ───────────────────────────────────────
 
 /**
- * Parse a worksheet XML into a Sheet using SAX parsing for performance.
- * This avoids building a full DOM tree for large worksheets.
+ * The SAX handlers for one worksheet, and the finalisation that turns
+ * what they collected into a {@link Sheet}.
+ *
+ * Split out so the buffered and the streaming reader drive the *same*
+ * handler set rather than two copies of it. A worksheet part over the
+ * string ceiling has to be parsed a chunk at a time (#503), and a second
+ * implementation of these 850 lines would be a second set of answers for
+ * every field of the model — the two would drift on the first field
+ * added to one and forgotten in the other, which is the failure mode
+ * `CONTRIBUTING.md` calls the registers. There is exactly one
+ * implementation; only the driver differs.
  */
-export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext): Sheet {
+function worksheetParser(
+  name: string,
+  ctx: WorksheetContext,
+): { handlers: SaxHandlers; finish: () => Sheet } {
   const rows: CellValue[][] = []
   const cells = new Map<string, Cell>()
   const merges: MergeRange[] = []
@@ -392,7 +404,7 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
   let currentRunFont: FontStyle | undefined
   let _fontPropTag = ""
 
-  parseSax(xml, {
+  const handlers: SaxHandlers = {
     onOpenTag(tag, attrs) {
       const local = tag.includes(":") ? tag.slice(tag.indexOf(":") + 1) : tag
 
@@ -1249,186 +1261,227 @@ export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext)
           break
       }
     },
-  })
+  }
 
-  // Ensure all rows have consistent length. Not in sparse mode: there is
-  // no grid, which is the whole point, and the bounding-box limit below
-  // has nothing to guard.
-  if (hasCells && !ctx.sparse) {
-    const colCount = maxCol + 1
-    // The cost of a sheet is its bounding box, not its cell count — the
-    // loop below fills every slot in it. Two in-bounds cells at opposite
-    // corners describe 1.7e10 slots, which V8 answers with an OOM the
-    // caller cannot catch, so the product is checked before allocating.
-    const totalCells = (maxRow + 1) * colCount
-    const cellLimit = ctx.maxTotalCells ?? MAX_TOTAL_CELLS
-    if (totalCells > cellLimit) {
-      // The options this used to name were the wrong three for the case
-      // that actually hits it. A *sparse* sheet — 82k values scattered
-      // over a 305M-slot box, 0.03% fill — is not large, so raising
-      // `maxTotalCells` trades a clean error for a multi-gigabyte
-      // allocation; `range` needs the caller to already know where the
-      // data is; and `maxRows` bounds rows when the problem is columns.
-      //
-      // `streamXlsxRows` reads exactly this file today, one row at a
-      // time, and the message never mentioned it. See #501.
-      throw new ParseError(
-        oversizeSheetMessage(name, maxRow + 1, colCount, totalCells, cellCount, cellLimit),
-      )
-    }
-    for (let r = 0; r <= maxRow; r++) {
-      if (!rows[r]) {
-        rows[r] = Array.from({ length: colCount }, () => null) as CellValue[]
-      } else {
-        while (rows[r].length < colCount) {
-          rows[r].push(null)
+  function finish(): Sheet {
+    // Ensure all rows have consistent length. Not in sparse mode: there is
+    // no grid, which is the whole point, and the bounding-box limit below
+    // has nothing to guard.
+    if (hasCells && !ctx.sparse) {
+      const colCount = maxCol + 1
+      // The cost of a sheet is its bounding box, not its cell count — the
+      // loop below fills every slot in it. Two in-bounds cells at opposite
+      // corners describe 1.7e10 slots, which V8 answers with an OOM the
+      // caller cannot catch, so the product is checked before allocating.
+      const totalCells = (maxRow + 1) * colCount
+      const cellLimit = ctx.maxTotalCells ?? MAX_TOTAL_CELLS
+      if (totalCells > cellLimit) {
+        // The options this used to name were the wrong three for the case
+        // that actually hits it. A *sparse* sheet — 82k values scattered
+        // over a 305M-slot box, 0.03% fill — is not large, so raising
+        // `maxTotalCells` trades a clean error for a multi-gigabyte
+        // allocation; `range` needs the caller to already know where the
+        // data is; and `maxRows` bounds rows when the problem is columns.
+        //
+        // `streamXlsxRows` reads exactly this file today, one row at a
+        // time, and the message never mentioned it. See #501.
+        throw new ParseError(
+          oversizeSheetMessage(name, maxRow + 1, colCount, totalCells, cellCount, cellLimit),
+        )
+      }
+      for (let r = 0; r <= maxRow; r++) {
+        if (!rows[r]) {
+          rows[r] = Array.from({ length: colCount }, () => null) as CellValue[]
+        } else {
+          while (rows[r].length < colCount) {
+            rows[r].push(null)
+          }
         }
       }
     }
-  }
 
-  // ── Resolve hyperlinks ──
-  // Build a map of rId → target URL from worksheet relationships
-  const relMap = new Map<string, string>()
-  if (ctx.worksheetRels) {
-    for (const rel of ctx.worksheetRels) {
-      relMap.set(rel.id, rel.target)
-    }
-  }
-
-  for (const hl of rawHyperlinks) {
-    const pos = parseCellRef(hl.ref)
-    const key = `${pos.row},${pos.col}`
-
-    // Get or create cell in the cells map
-    let cell = cells.get(key)
-    if (!cell) {
-      cell = {
-        value: (rows[pos.row] && rows[pos.row][pos.col]) ?? null,
-        type: "string",
-      }
-      // Far fewer hyperlinks than cells in any real file, but this is
-      // the other place `cells` grows and the check is one comparison.
-      assertCellMapCapacity(cells, key, name)
-      cells.set(key, cell)
-    }
-
-    const hyperlink: Hyperlink = { target: "" }
-
-    if (hl.location) {
-      // Internal hyperlink
-      hyperlink.location = hl.location
-      hyperlink.target = hl.location
-    } else if (hl.rId) {
-      // External hyperlink — resolve from relationships
-      const target = relMap.get(hl.rId)
-      if (target) {
-        hyperlink.target = target
-      } else {
-        // The cell keeps a hyperlink with an empty target, which reads as
-        // a link that goes nowhere rather than as a missing relationship.
-        // See #474.
-        ctx.onWarning?.({
-          code: "unresolved-hyperlink",
-          message:
-            `Cell ${hl.ref} links through ${hl.rId}, which the sheet's ` +
-            "relationships do not define. Read with an empty target.",
-          sheet: ctx.sheetName,
-          row: pos.row,
-          col: pos.col,
-        })
+    // ── Resolve hyperlinks ──
+    // Build a map of rId → target URL from worksheet relationships
+    const relMap = new Map<string, string>()
+    if (ctx.worksheetRels) {
+      for (const rel of ctx.worksheetRels) {
+        relMap.set(rel.id, rel.target)
       }
     }
 
-    if (hl.tooltip) hyperlink.tooltip = hl.tooltip
-    if (hl.display) hyperlink.display = hl.display
+    for (const hl of rawHyperlinks) {
+      const pos = parseCellRef(hl.ref)
+      const key = `${pos.row},${pos.col}`
 
-    cell.hyperlink = hyperlink
-  }
+      // Get or create cell in the cells map
+      let cell = cells.get(key)
+      if (!cell) {
+        cell = {
+          value: (rows[pos.row] && rows[pos.row][pos.col]) ?? null,
+          type: "string",
+        }
+        // Far fewer hyperlinks than cells in any real file, but this is
+        // the other place `cells` grows and the check is one comparison.
+        assertCellMapCapacity(cells, key, name)
+        cells.set(key, cell)
+      }
 
-  const sheet: Sheet = {
-    name,
-    rows,
-  }
+      const hyperlink: Hyperlink = { target: "" }
 
-  if (cells.size > 0) {
-    sheet.cells = cells
-  }
-  // Attach column definitions (width, hidden, outlineLevel, collapsed)
-  if (defaultRowHeight !== undefined) sheet.defaultRowHeight = defaultRowHeight
-  if (defaultColWidth !== undefined) sheet.defaultColWidth = defaultColWidth
+      if (hl.location) {
+        // Internal hyperlink
+        hyperlink.location = hl.location
+        hyperlink.target = hl.location
+      } else if (hl.rId) {
+        // External hyperlink — resolve from relationships
+        const target = relMap.get(hl.rId)
+        if (target) {
+          hyperlink.target = target
+        } else {
+          // The cell keeps a hyperlink with an empty target, which reads as
+          // a link that goes nowhere rather than as a missing relationship.
+          // See #474.
+          ctx.onWarning?.({
+            code: "unresolved-hyperlink",
+            message:
+              `Cell ${hl.ref} links through ${hl.rId}, which the sheet's ` +
+              "relationships do not define. Read with an empty target.",
+            sheet: ctx.sheetName,
+            row: pos.row,
+            col: pos.col,
+          })
+        }
+      }
 
-  if (columnDefs.some((c) => Object.keys(c).length > 0)) {
-    sheet.columns = columnDefs
-  }
-  if (merges.length > 0) {
-    sheet.merges = merges
-  }
-  if (dataValidations.length > 0) {
-    sheet.dataValidations = dataValidations
-  }
-  if (conditionalRules.length > 0) {
-    sheet.conditionalRules = conditionalRules
-  }
-  if (autoFilter) {
-    sheet.autoFilter = autoFilter
-  }
-  if (freezePane) {
-    sheet.freezePane = freezePane
-  }
-  if (splitPane) {
-    sheet.splitPane = splitPane
-  }
-  if (sheetProtection) {
-    sheet.protection = sheetProtection
-  }
+      if (hl.tooltip) hyperlink.tooltip = hl.tooltip
+      if (hl.display) hyperlink.display = hl.display
 
-  // Attach sheet view settings
-  if (sheetView && Object.keys(sheetView).length > 0) {
-    sheet.view = sheetView
-  }
-
-  // Attach page setup (merge margins into pageSetup if present)
-  if (pageSetup || pageMargins || fitToPageFlag) {
-    const ps: PageSetup = pageSetup ?? {}
-    if (pageMargins) {
-      ps.margins = pageMargins
+      cell.hyperlink = hyperlink
     }
-    if (fitToPageFlag) {
-      ps.fitToPage = true
+
+    const sheet: Sheet = {
+      name,
+      rows,
     }
-    sheet.pageSetup = ps
+
+    if (cells.size > 0) {
+      sheet.cells = cells
+    }
+    // Attach column definitions (width, hidden, outlineLevel, collapsed)
+    if (defaultRowHeight !== undefined) sheet.defaultRowHeight = defaultRowHeight
+    if (defaultColWidth !== undefined) sheet.defaultColWidth = defaultColWidth
+
+    if (columnDefs.some((c) => Object.keys(c).length > 0)) {
+      sheet.columns = columnDefs
+    }
+    if (merges.length > 0) {
+      sheet.merges = merges
+    }
+    if (dataValidations.length > 0) {
+      sheet.dataValidations = dataValidations
+    }
+    if (conditionalRules.length > 0) {
+      sheet.conditionalRules = conditionalRules
+    }
+    if (autoFilter) {
+      sheet.autoFilter = autoFilter
+    }
+    if (freezePane) {
+      sheet.freezePane = freezePane
+    }
+    if (splitPane) {
+      sheet.splitPane = splitPane
+    }
+    if (sheetProtection) {
+      sheet.protection = sheetProtection
+    }
+
+    // Attach sheet view settings
+    if (sheetView && Object.keys(sheetView).length > 0) {
+      sheet.view = sheetView
+    }
+
+    // Attach page setup (merge margins into pageSetup if present)
+    if (pageSetup || pageMargins || fitToPageFlag) {
+      const ps: PageSetup = pageSetup ?? {}
+      if (pageMargins) {
+        ps.margins = pageMargins
+      }
+      if (fitToPageFlag) {
+        ps.fitToPage = true
+      }
+      sheet.pageSetup = ps
+    }
+
+    // Attach header/footer
+    if (headerFooter && Object.keys(headerFooter).length > 0) {
+      sheet.headerFooter = headerFooter
+    }
+
+    // Attach page breaks
+    if (rowBreaks.length > 0) {
+      sheet.rowBreaks = rowBreaks.sort((a, b) => a - b)
+    }
+    if (colBreaks.length > 0) {
+      sheet.colBreaks = colBreaks.sort((a, b) => a - b)
+    }
+
+    // Attach row definitions (height, hidden, outlineLevel)
+    if (rowDefs.size > 0) {
+      sheet.rowDefs = rowDefs
+    }
+
+    // Attach sparklines
+    if (sparklines.length > 0) {
+      sheet.sparklines = sparklines
+    }
+
+    // Attach outline properties
+    if (outlineProperties) {
+      sheet.outlineProperties = outlineProperties
+    }
+
+    return sheet
   }
 
-  // Attach header/footer
-  if (headerFooter && Object.keys(headerFooter).length > 0) {
-    sheet.headerFooter = headerFooter
-  }
+  return { handlers, finish }
+}
 
-  // Attach page breaks
-  if (rowBreaks.length > 0) {
-    sheet.rowBreaks = rowBreaks.sort((a, b) => a - b)
-  }
-  if (colBreaks.length > 0) {
-    sheet.colBreaks = colBreaks.sort((a, b) => a - b)
-  }
+/**
+ * Parse a worksheet XML into a Sheet using SAX parsing for performance.
+ * This avoids building a full DOM tree for large worksheets.
+ */
+export function parseWorksheet(xml: string, name: string, ctx: WorksheetContext): Sheet {
+  const { handlers, finish } = worksheetParser(name, ctx)
+  parseSax(xml, handlers)
+  return finish()
+}
 
-  // Attach row definitions (height, hidden, outlineLevel)
-  if (rowDefs.size > 0) {
-    sheet.rowDefs = rowDefs
-  }
-
-  // Attach sparklines
-  if (sparklines.length > 0) {
-    sheet.sparklines = sparklines
-  }
-
-  // Attach outline properties
-  if (outlineProperties) {
-    sheet.outlineProperties = outlineProperties
-  }
-
-  return sheet
+/**
+ * Parse a worksheet from a stream of its bytes, for a part that cannot
+ * become a string at all.
+ *
+ * V8 stops at 0x1fffffe8 characters, so `xl/worksheets/sheet2.xml` at
+ * 589 MB is unrepresentable however much memory the machine has — the
+ * buffered reader could decompress it and still not parse it. See #503.
+ *
+ * The result is the same `Sheet` {@link parseWorksheet} builds, because
+ * it is the same handlers and the same finalisation; only the driver
+ * differs. `parseSaxStream` holds back a tag or an entity split across a
+ * chunk boundary, and every text handler accumulates with `+=`, so a run
+ * arriving in pieces is assembled exactly as one arriving whole.
+ */
+export async function parseWorksheetStream(
+  stream: ReadableStream<Uint8Array>,
+  name: string,
+  ctx: WorksheetContext,
+): Promise<Sheet> {
+  const { handlers, finish } = worksheetParser(name, ctx)
+  // `strict` so a truncated part is an error here, as it is for the
+  // buffered driver. See `endOfInput` in the parser for why it is not
+  // the default.
+  await parseSaxStream(stream, handlers, { strict: true })
+  return finish()
 }
 
 // ── Sheet Protection Parser ─────────────────────────────────────────

--- a/src/xml/parser.ts
+++ b/src/xml/parser.ts
@@ -298,7 +298,9 @@ export function parseSax(xml: string, handlers: SaxHandlers): void {
 export async function parseSaxStream(
   stream: ReadableStream<Uint8Array>,
   handlers: SaxHandlers,
+  options?: { strict?: boolean },
 ): Promise<void> {
+  const strict = options?.strict ?? false
   const reader = stream.getReader()
   const decoder = new TextDecoder("utf-8")
   let buf = ""
@@ -319,13 +321,13 @@ export async function parseSaxStream(
         bomStripped = true
       }
 
-      buf = processSaxBuffer(buf, handlers, false)
+      buf = processSaxBuffer(buf, handlers, false, strict)
     }
 
     // Flush remaining decoder state
     buf += decoder.decode()
     if (buf.length > 0) {
-      processSaxBuffer(buf, handlers, true)
+      processSaxBuffer(buf, handlers, true, strict)
     }
   } finally {
     try {
@@ -376,8 +378,39 @@ function safeTextSplit(buf: string, from: number, to: number): number {
     cut = amp
   }
   const last = cut > from ? buf.charCodeAt(cut - 1) : 0
-  if (last >= 0xd800 && last <= 0xdbff) cut-- // don't orphan a high surrogate
+  if (last >= 0xd800 && last <= 0xdbff)
+    cut-- // don't orphan a high surrogate
+  // A CRLF must not be cut in half either. `normalizeEol` runs per piece
+  // and rewrites a lone CR to LF, so a cut between the CR and its LF
+  // turns one line ending into two — a spurious blank line in a cell,
+  // on the streaming driver only, and only in a text run long enough to
+  // be flushed. Holding the CR back costs one character.
+  else if (last === 13 /* \r */) cut--
   return cut > from ? cut : from
+}
+
+/**
+ * What to do with a construct the buffer ends in the middle of.
+ *
+ * Mid-stream it is simply incomplete: hand it back and wait for the next
+ * chunk. At the end of the input there is no next chunk, so it is the
+ * same malformed document `parseSax` refuses — but only a caller that
+ * asked for `strict` is told so.
+ *
+ * The split exists because the two callers want different things. The
+ * row streamers have never had an error contract for a truncated
+ * document; they drop the unfinished construct and let the caller notice
+ * the missing rows, and changing that would change what
+ * `streamXlsxRows` does for everyone. The worksheet reader cannot afford
+ * it: since #503 it parses a part over the string ceiling with the same
+ * handlers as the buffered parse, so if it stayed lenient a truncated
+ * 589 MB worksheet would return a short `Sheet` with no error while the
+ * identical part under the ceiling threw. Two drivers over one handler
+ * set have to agree about failure as well as about success.
+ */
+function endOfInput(reject: boolean, buf: string, i: number, message: string): string {
+  if (reject) throw new XmlError(message)
+  return buf.slice(i)
 }
 
 /**
@@ -385,7 +418,12 @@ function safeTextSplit(buf: string, from: number, to: number): number {
  * Returns the unprocessed remainder (incomplete tag/text at chunk boundary).
  * When `final` is true, all remaining content must be processable.
  */
-function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): string {
+function processSaxBuffer(
+  buf: string,
+  handlers: SaxHandlers,
+  final: boolean,
+  strict: boolean,
+): string {
   let i = 0
   const len = buf.length
 
@@ -403,7 +441,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
         if (buf.slice(i, i + 4) === "<!--") {
           const end = buf.indexOf("-->", i + 4)
           if (end === -1) {
-            return final ? "" : buf.slice(i)
+            return endOfInput(final && strict, buf, i, "Unterminated comment")
           }
           i = end + 3
           continue
@@ -411,7 +449,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
         if (buf.slice(i, i + 9) === "<![CDATA[") {
           const end = buf.indexOf("]]>", i + 9)
           if (end === -1) {
-            return final ? "" : buf.slice(i)
+            return endOfInput(final && strict, buf, i, "Unterminated CDATA section")
           }
           const text = buf.slice(i + 9, end)
           handlers.onCData?.(text)
@@ -426,7 +464,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
         // DOCTYPE or other declaration — skip
         const end = buf.indexOf(">", i + 2)
         if (end === -1) {
-          return final ? "" : buf.slice(i)
+          return endOfInput(final && strict, buf, i, "Unterminated declaration")
         }
         i = end + 1
         continue
@@ -436,7 +474,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
         // Processing instruction: <?...?>
         const end = buf.indexOf("?>", i + 2)
         if (end === -1) {
-          return final ? "" : buf.slice(i)
+          return endOfInput(final && strict, buf, i, "Unterminated processing instruction")
         }
         i = end + 2
         continue
@@ -446,7 +484,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
         // Closing tag: </tagName>
         const end = buf.indexOf(">", i + 2)
         if (end === -1) {
-          return final ? "" : buf.slice(i)
+          return endOfInput(final && strict, buf, i, "Unterminated closing tag")
         }
         const tag = buf.slice(i + 2, end).trim()
         handlers.onCloseTag?.(tag)
@@ -470,7 +508,7 @@ function processSaxBuffer(buf: string, handlers: SaxHandlers, final: boolean): s
       }
       if (j >= len) {
         // Tag not complete in this chunk
-        return final ? "" : buf.slice(i)
+        return endOfInput(final && strict, buf, i, "Unterminated opening tag")
       }
 
       const selfClosing = buf.charCodeAt(j - 1) === 47 /* / */

--- a/src/zip/byte-limit.ts
+++ b/src/zip/byte-limit.ts
@@ -33,3 +33,38 @@ export function byteLimitStream(maxBytes: number): TransformStream<Uint8Array, U
     },
   })
 }
+
+/**
+ * How much of an already-in-memory entry one chunk of its stream holds.
+ *
+ * `DecompressionStream` hands back pieces of its own accord, but the two
+ * paths that do not decompress — a STORE entry, and the fallback inflate
+ * that returns a whole buffer — had nothing to divide and enqueued the
+ * entry in one go. A consumer that accumulates what it is given then
+ * gets the entire entry as one chunk: `parseSaxStream` does
+ * `buf += decoder.decode(chunk)`, so a 589 MB stored worksheet rebuilt
+ * the 512 MB string the streaming path exists to avoid, and the reader
+ * for the files in #503 would have failed on exactly the ones it was
+ * added for. Nothing here is copied — each chunk is a `subarray` view.
+ *
+ * 1 MiB is small enough to keep any one string far from the ceiling and
+ * large enough that the per-chunk overhead does not show up in a
+ * measurement.
+ */
+export const STREAM_CHUNK_BYTES: number = 1024 * 1024
+
+/** Emit an in-memory buffer as a stream of {@link STREAM_CHUNK_BYTES} pieces. */
+export function chunkedStream(data: Uint8Array): ReadableStream<Uint8Array> {
+  let offset = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= data.length) {
+        controller.close()
+        return
+      }
+      const end = Math.min(offset + STREAM_CHUNK_BYTES, data.length)
+      controller.enqueue(data.subarray(offset, end))
+      offset = end
+    },
+  })
+}

--- a/src/zip/reader.ts
+++ b/src/zip/reader.ts
@@ -4,7 +4,7 @@
 
 import { ZipError } from "../errors"
 import { MAX_DECOMPRESSED_BYTES } from "../limits"
-import { byteLimitStream } from "./byte-limit"
+import { byteLimitStream, chunkedStream } from "./byte-limit"
 import { crc32, inflate } from "./deflate"
 import { canInflateRaw } from "./capability"
 
@@ -21,6 +21,14 @@ const SIG_ZIP64_EOCD_LOCATOR = 0x07064b50
 const ZIP64_SENTINEL = 0xffffffff
 /** 0xFFFF marker for the 16-bit entry-count fields. */
 const ZIP64_SENTINEL_16 = 0xffff
+/**
+ * The most DEFLATE can expand a byte by — 1032:1, the format's ceiling
+ * for a maximum-length match emitted from a minimum-length code. Used to
+ * tell a declared uncompressed size that the compressed body could have
+ * produced from one it could not.
+ */
+const MAX_DEFLATE_RATIO = 1032
+
 /** Header id of the ZIP64 extended information extra field. */
 const ZIP64_EXTRA_ID = 0x0001
 
@@ -133,6 +141,44 @@ export class ZipReader {
   /** Check if an entry exists */
   has(path: string): boolean {
     return this.entryMap.has(path)
+  }
+
+  /**
+   * What the central directory says an entry expands to, or `undefined`
+   * when it does not say.
+   *
+   * Lets a reader choose how to parse a part *before* paying to
+   * decompress it — a worksheet past the string ceiling has to be parsed
+   * as a stream, and finding that out by buffering it first costs the
+   * decompression twice and the peak memory of a buffer that gets thrown
+   * away. See #503.
+   *
+   * Zero means "not declared": it is what a producer writing a data
+   * descriptor leaves behind, and it is not a small entry, so it may not
+   * be reported as one — the caller is told nothing and falls back to
+   * finding out the slow way. A ZIP64 size needs no handling here;
+   * `readCentralDir` has already resolved the sentinel from the extra
+   * field, or thrown.
+   *
+   * A size the compressed body could not possibly produce is also not
+   * declared. Nothing verifies this field, and the answer decides whether
+   * a part is read whole — CRC-32 checked — or as a stream, which has no
+   * whole entry to check. Without the plausibility test a 40 KB worksheet
+   * whose central directory claims 600 MB would take the streaming route
+   * and skip the checksum, so a corrupt entry could buy its way out of
+   * verification by lying about its size. DEFLATE cannot exceed 1032:1,
+   * and a stored entry expands not at all, so a claim past that is the
+   * archive contradicting itself and is not trusted.
+   */
+  declaredSize(path: string): number | undefined {
+    const entry = this.entryMap.get(path)
+    if (!entry?.uncompressedSize) return undefined
+    const most =
+      entry.compressionMethod === 0
+        ? entry.compressedSize
+        : entry.compressedSize * MAX_DEFLATE_RATIO
+    if (entry.compressedSize > 0 && entry.uncompressedSize > most) return undefined
+    return entry.uncompressedSize
   }
 
   /** Extract a single file by path */
@@ -507,13 +553,8 @@ export class ZipReader {
     const compressedData = this.data.subarray(dataStart, dataStart + compressedSize)
 
     if (entry.compressionMethod === 0) {
-      // STORE — return raw data as a stream
-      return new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(compressedData)
-          controller.close()
-        },
-      })
+      // STORE — no decompression, but still emitted in pieces
+      return chunkedStream(compressedData)
     }
 
     if (entry.compressionMethod === 8) {
@@ -550,13 +591,7 @@ export class ZipReader {
       }
 
       // Fallback: inflate synchronously and emit as stream
-      const inflated = inflate(compressedData, declaredCap)
-      return new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(inflated)
-          controller.close()
-        },
-      })
+      return chunkedStream(inflate(compressedData, declaredCap))
     }
 
     throw new ZipError(

--- a/src/zip/stream-reader.ts
+++ b/src/zip/stream-reader.ts
@@ -16,7 +16,7 @@
 // recover the bytes consumed so far via {@link ZipStreamReader.drainToBuffer}
 // and fall back to the random-access {@link ZipReader}.
 
-import { byteLimitStream } from "./byte-limit"
+import { byteLimitStream, STREAM_CHUNK_BYTES } from "./byte-limit"
 import { inflate } from "./deflate"
 import { ParseError, ZipError } from "../errors"
 import { MAX_DECOMPRESSED_BYTES, MAX_INPUT_BYTES } from "../limits"
@@ -227,6 +227,12 @@ export class ZipStreamReader {
       ).pipeThrough(byteLimitStream(cap))
     }
     // No DecompressionStream — buffer the compressed body and inflate once.
+    // The result is handed on in pieces rather than as one enqueue: a
+    // consumer that accumulates what it is given (`parseSaxStream` does
+    // `buf += decoder.decode(chunk)`) would otherwise rebuild the very
+    // string the streaming path exists to avoid, and this is the branch
+    // the Deno/browser/Workers claims rest on. Same reason as the twin
+    // paths in `reader.ts`. See #503.
     return new ReadableStream<Uint8Array>({
       async start(controller) {
         const chunks: Uint8Array[] = []
@@ -236,7 +242,12 @@ export class ZipStreamReader {
           if (done) break
           if (value) chunks.push(value)
         }
-        controller.enqueue(inflate(concat(chunks), cap))
+        const inflated = inflate(concat(chunks), cap)
+        for (let at = 0; at < inflated.length; at += STREAM_CHUNK_BYTES) {
+          controller.enqueue(
+            inflated.subarray(at, Math.min(at + STREAM_CHUNK_BYTES, inflated.length)),
+          )
+        }
         controller.close()
       },
     })

--- a/test/huge-worksheet.test.ts
+++ b/test/huge-worksheet.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest"
+import { readXlsx } from "../src/xlsx/reader"
+import { parseWorksheet, parseWorksheetStream, type WorksheetContext } from "../src/xlsx/worksheet"
+import { MAX_STRING_LENGTH } from "../src/_decode"
+import { SAX_TEXT_FLUSH_CHARS } from "../src/xml/parser"
+import { XmlError } from "../src/errors"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// #503 — a worksheet part over V8's 0x1fffffe8-character ceiling cannot
+// become a string, so the buffered reader could not parse it however much
+// memory the machine had. #514 and #518 made that legible (a `ParseError`
+// naming the part and the bound); neither made the file load. This is the
+// capability: the part is parsed from the ZIP entry's stream instead.
+//
+// Two things need testing, and they are different things.
+//
+//  1. That a part past the ceiling reads at all. Nothing smaller
+//     reproduces it — the trigger is a buffer over 512 MB, which is
+//     larger than this repository, so the part is built rather than
+//     committed (`test/huge-part-error.test.ts` set the precedent: a
+//     large *buffer* is affordable, a large *fixture* is not).
+//
+//  2. That the streaming driver and the buffered one agree. They share
+//     one handler set by construction, so the risk is not a missing
+//     field, it is the chunk boundary: a tag, an entity or a text run
+//     split across two chunks. That is what the byte-at-a-time case
+//     below is for.
+// ═══════════════════════════════════════════════════════════════════════
+
+const ctx: WorksheetContext = {
+  sharedStrings: [{ text: "shared one" }, { text: "shared two" }],
+  styles: null,
+  readStyles: false,
+  dateSystem: "1900",
+}
+
+/**
+ * A worksheet exercising the handlers that carry text across calls —
+ * values, formulas, inline strings and their runs, data validations,
+ * conditional-formatting formulas, header/footer — plus the elements the
+ * finalisation reads. Every one of these accumulates with `+=`, which is
+ * exactly what a split run depends on.
+ */
+const RICH_SHEET = `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetPr><tabColor rgb="FFFF0000"/></sheetPr>
+  <sheetViews><sheetView showGridLines="0" zoomScale="125" tabSelected="1"><pane xSplit="1" ySplit="2" topLeftCell="B3" state="frozen"/></sheetView></sheetViews>
+  <cols><col min="1" max="3" width="18.5" customWidth="1"/><col min="4" max="4" hidden="1"/></cols>
+  <sheetData>
+    <row r="1" ht="24" customHeight="1">
+      <c r="A1" t="inlineStr"><is><r><rPr><b/><sz val="12"/></rPr><t>bold run </t></r><r><t>and a plain one &amp; an entity</t></r></is></c>
+      <c r="B1" t="s"><v>0</v></c>
+      <c r="C1"><f>SUM(A2:A3)</f><v>7</v></c>
+    </row>
+    <row r="2">
+      <c r="A2"><v>3</v></c>
+      <c r="B2" t="str"><f t="shared" si="0" ref="B2:B3">A2*2</f><v>6</v></c>
+      <c r="C2" t="b"><v>1</v></c>
+    </row>
+    <row r="3">
+      <c r="A3"><v>4</v></c>
+      <c r="B3" t="inlineStr"><is><t xml:space="preserve">  spaced  </t></is></c>
+      <c r="C3" t="e"><v>#DIV/0!</v></c>
+    </row>
+  </sheetData>
+  <autoFilter ref="A1:C3"/>
+  <mergeCells count="1"><mergeCell ref="A1:B1"/></mergeCells>
+  <conditionalFormatting sqref="A2:A3"><cfRule type="cellIs" operator="greaterThan" dxfId="0" priority="1"><formula>2</formula></cfRule></conditionalFormatting>
+  <dataValidations count="1"><dataValidation type="list" sqref="C2:C3" allowBlank="1"><formula1>"yes,no"</formula1></dataValidation></dataValidations>
+  <pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3"/>
+  <pageSetup orientation="landscape" paperSize="9"/>
+  <headerFooter><oddHeader>&amp;LLeft&amp;CCentre</oddHeader><oddFooter>&amp;RPage &amp;P</oddFooter></headerFooter>
+  <rowBreaks count="1"><brk id="2" max="16383" man="1"/></rowBreaks>
+</worksheet>`
+
+/** The bytes of `xml`, handed out `chunk` at a time. */
+function streamOf(xml: string, chunk: number): ReadableStream<Uint8Array> {
+  const bytes = new TextEncoder().encode(xml)
+  let offset = 0
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= bytes.length) {
+        controller.close()
+        return
+      }
+      const end = Math.min(offset + chunk, bytes.length)
+      controller.enqueue(bytes.subarray(offset, end))
+      offset = end
+    },
+  })
+}
+
+describe("the streaming worksheet driver agrees with the buffered one", () => {
+  const buffered = parseWorksheet(RICH_SHEET, "Sheet1", ctx)
+
+  it("produces the same Sheet when the part arrives whole", async () => {
+    const streamed = await parseWorksheetStream(streamOf(RICH_SHEET, 1 << 20), "Sheet1", ctx)
+
+    expect(streamed).toEqual(buffered)
+  })
+
+  it("produces the same Sheet when every byte is its own chunk", async () => {
+    // The worst boundary case there is: every tag, every attribute value,
+    // every entity and every text run is split. If `parseSaxStream`'s
+    // hold-back were wrong anywhere, this is where it shows — and a
+    // chunking bug that only bit on a 589 MB file would otherwise need a
+    // 589 MB file to find.
+    const streamed = await parseWorksheetStream(streamOf(RICH_SHEET, 1), "Sheet1", ctx)
+
+    expect(streamed).toEqual(buffered)
+  })
+
+  it("agrees on a sheet read sparsely, where there is no grid to compare", async () => {
+    const sparseCtx = { ...ctx, sparse: true }
+
+    expect(await parseWorksheetStream(streamOf(RICH_SHEET, 7), "S", sparseCtx)).toEqual(
+      parseWorksheet(RICH_SHEET, "S", sparseCtx),
+    )
+  })
+})
+
+describe("the two drivers agree about failure, not only about success", () => {
+  // Sharing the handlers makes the two drivers agree on what a good
+  // document means. It does not, on its own, make them agree on what a
+  // bad one means — and until #503 gave the buffered parser a streaming
+  // twin, only one of them had an opinion. `processSaxBuffer` returned
+  // the unfinished remainder and stopped; `parseSax` threw. A worksheet
+  // truncated by a crashed producer therefore parsed to a short `Sheet`
+  // with no error on exactly the files that can only be read streaming.
+  const TRUNCATED: Array<[string, string]> = [
+    ["an opening tag", `<worksheet><sheetData><row r="1"><c r="A1" t="inl`],
+    ["a closing tag", `<worksheet><sheetData><row r="1"></row></sheetDa`],
+    ["a comment", `<worksheet><sheetData></sheetData><!-- unfinished`],
+    ["a CDATA section", `<worksheet><sheetData><row r="1"><c r="A1"><![CDATA[x`],
+    ["a processing instruction", `<worksheet><sheetData></sheetData><?mso-application`],
+  ]
+
+  for (const [what, xml] of TRUNCATED) {
+    it(`rejects a document ending inside ${what}, as the buffered parser does`, async () => {
+      expect(() => parseWorksheet(xml, "S", ctx)).toThrow(XmlError)
+
+      await expect(parseWorksheetStream(streamOf(xml, 8), "S", ctx)).rejects.toThrow(XmlError)
+    })
+  }
+})
+
+describe("a text run flushed mid-CRLF", () => {
+  // `parseSaxStream` flushes a text run that has outgrown
+  // SAX_TEXT_FLUSH_CHARS rather than carrying it across another chunk,
+  // and `normalizeEol` runs on each piece it emits. The cut lands at the
+  // chunk boundary, so a boundary falling between a CR and its LF split
+  // one line ending into two: the first piece ended "\r" and normalised
+  // to "\n", the second began "\n", and the handler's `+=` accumulated
+  // both. A cell gained a blank line it never had.
+  //
+  // Reaching it needs a run over 256 KiB *and* a boundary on the CRLF,
+  // which is why the byte-at-a-time case above cannot find it — that one
+  // splits everything, but never lets a run grow long enough to flush.
+  const PREFIX = `<worksheet><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>`
+
+  for (const run of [SAX_TEXT_FLUSH_CHARS + 1, SAX_TEXT_FLUSH_CHARS * 2]) {
+    it(`keeps one newline when the break falls on the CRLF of a ${run}-char run`, async () => {
+      const value = "a".repeat(run) + "\r\n" + "b".repeat(1024)
+      const xml = `${PREFIX}${value}</t></is></c></row></sheetData></worksheet>`
+      // All ASCII, so a character index is a byte index: end the first
+      // chunk immediately after the CR.
+      const chunk = PREFIX.length + run + 1
+
+      const streamed = await parseWorksheetStream(streamOf(xml, chunk), "S", ctx)
+
+      expect(streamed.rows[0]![0]).toBe(parseWorksheet(xml, "S", ctx).rows[0]![0])
+      expect(String(streamed.rows[0]![0])).not.toContain("\n\n")
+    })
+  }
+})
+
+// ── Building a workbook whose worksheet part is over the ceiling ──────
+
+const CONTENT_TYPES = `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+<Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>`
+
+const ROOT_RELS = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`
+
+const WORKBOOK = `<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<sheets><sheet name="Huge" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`
+
+const WORKBOOK_RELS = `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`
+
+const HUGE_HEAD = `<?xml version="1.0" encoding="UTF-8"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>first</t></is></c><c r="B1"><v>1</v></c></row>`
+const HUGE_TAIL = `<row r="2"><c r="A2" t="inlineStr"><is><t>last</t></is></c><c r="B2"><v>2</v></c></row></sheetData></worksheet>`
+
+/** An entry whose bytes are written straight into the archive buffer. */
+interface Entry {
+  name: string
+  size: number
+  fill: (out: Uint8Array) => void
+  /**
+   * What to write as the entry's uncompressed size, when that should not
+   * be the truth. `0` models a central directory that declares nothing,
+   * which is what `readWorksheet`'s fallback branches on — not a full
+   * data-descriptor archive: bit 3 of the general-purpose flag stays
+   * clear and no descriptor is appended, so the `hasDataDescriptor`
+   * recovery paths in `extractEntry`/`extractEntryStream` are not what
+   * this exercises.
+   */
+  declares?: number
+}
+
+function textEntry(name: string, text: string): Entry {
+  const bytes = new TextEncoder().encode(text)
+  return { name, size: bytes.length, fill: (out) => out.set(bytes) }
+}
+
+/**
+ * A STORE-only ZIP, assembled in one allocation.
+ *
+ * Written here rather than with `ZipWriter` for two reasons the test
+ * depends on: the entry is not compressed, so the archive can be built
+ * without spending a minute deflating half a gigabyte, and each entry is
+ * filled in place, so the half-gigabyte part exists once rather than
+ * twice. CRC-32 is left at zero — the readers skip verification for a
+ * zero CRC, and computing one over 537 MB would be the slowest thing in
+ * this file by far.
+ */
+function storeZip(entries: Entry[]): { bytes: Uint8Array; declare: (size: number) => void } {
+  const nameBytes = entries.map((e) => new TextEncoder().encode(e.name))
+  const localSize = entries.reduce((n, e, i) => n + 30 + nameBytes[i]!.length + e.size, 0)
+  const centralSize = entries.reduce((n, _e, i) => n + 46 + nameBytes[i]!.length, 0)
+  const out = new Uint8Array(localSize + centralSize + 22)
+  const view = new DataView(out.buffer)
+
+  const offsets: number[] = []
+  const sizeFieldOffsets: number[] = []
+  const centralSizeOffsets: number[] = []
+  let pos = 0
+  for (const [i, entry] of entries.entries()) {
+    const name = nameBytes[i]!
+    offsets.push(pos)
+    view.setUint32(pos, 0x04034b50, true)
+    view.setUint16(pos + 4, 20, true)
+    view.setUint32(pos + 14, 0, true) // CRC-32 — see above
+    view.setUint32(pos + 18, entry.size, true)
+    sizeFieldOffsets.push(pos + 22)
+    view.setUint32(pos + 22, entry.declares ?? entry.size, true)
+    view.setUint16(pos + 26, name.length, true)
+    out.set(name, pos + 30)
+    entry.fill(out.subarray(pos + 30 + name.length, pos + 30 + name.length + entry.size))
+    pos += 30 + name.length + entry.size
+  }
+
+  const centralStart = pos
+  for (const [i, entry] of entries.entries()) {
+    const name = nameBytes[i]!
+    view.setUint32(pos, 0x02014b50, true)
+    view.setUint16(pos + 4, 20, true)
+    view.setUint16(pos + 6, 20, true)
+    view.setUint32(pos + 16, 0, true) // CRC-32
+    view.setUint32(pos + 20, entry.size, true)
+    centralSizeOffsets.push(pos + 24)
+    view.setUint32(pos + 24, entry.declares ?? entry.size, true)
+    view.setUint16(pos + 28, name.length, true)
+    view.setUint32(pos + 42, offsets[i]!, true)
+    out.set(name, pos + 46)
+    pos += 46 + name.length
+  }
+
+  const lastLocal = sizeFieldOffsets[sizeFieldOffsets.length - 1]!
+  const lastCentral = centralSizeOffsets[centralSizeOffsets.length - 1]!
+
+  view.setUint32(pos, 0x06054b50, true)
+  view.setUint16(pos + 8, entries.length, true)
+  view.setUint16(pos + 10, entries.length, true)
+  view.setUint32(pos + 12, pos - centralStart, true)
+  view.setUint32(pos + 16, centralStart, true)
+
+  return {
+    bytes: out,
+    // Rewrite the final entry's declared uncompressed size in place. The
+    // half-gigabyte body is the expensive part of this fixture and it is
+    // identical either way, so the two cases share one archive rather
+    // than building it twice: two live 537 MB buffers in a suite that
+    // runs test files in parallel starves the time budgets of unrelated
+    // tests, which is a flaky suite for no gain.
+    declare(size: number) {
+      view.setUint32(lastLocal, size, true)
+      view.setUint32(lastCentral, size, true)
+    },
+  }
+}
+
+/**
+ * A workbook of two rows with half a gigabyte of ignorable whitespace
+ * between them, so the worksheet part is past the ceiling and nothing
+ * else about it is expensive.
+ *
+ * Built once and shared: see `declare` on the return of `storeZip`.
+ */
+function hugeWorkbook(): { bytes: Uint8Array; declare: (size: number) => void; size: number } {
+  const padding = MAX_STRING_LENGTH + 1024 - HUGE_HEAD.length - HUGE_TAIL.length
+  const head = new TextEncoder().encode(HUGE_HEAD)
+  const tail = new TextEncoder().encode(HUGE_TAIL)
+  const size = head.length + padding + tail.length
+
+  const zip = storeZip([
+    textEntry("[Content_Types].xml", CONTENT_TYPES),
+    textEntry("_rels/.rels", ROOT_RELS),
+    textEntry("xl/workbook.xml", WORKBOOK),
+    textEntry("xl/_rels/workbook.xml.rels", WORKBOOK_RELS),
+    {
+      name: "xl/worksheets/sheet1.xml",
+      size,
+      fill: (out) => {
+        out.fill(0x20)
+        out.set(head, 0)
+        out.set(tail, out.length - tail.length)
+      },
+    },
+  ])
+
+  return { ...zip, size }
+}
+
+describe("a workbook whose worksheet part is past the string ceiling", () => {
+  // Before this change both cases threw the #514 `ParseError` naming the
+  // part and the bound, and the eleven files in #503 stayed unreadable.
+  const expected = [
+    ["first", 1],
+    ["last", 2],
+  ]
+  const huge = hugeWorkbook()
+
+  it("reads, instead of reporting that it cannot be read", async () => {
+    // The ZIP declares the size, so the streaming path is chosen before
+    // anything is decompressed.
+    huge.declare(huge.size)
+
+    const wb = await readXlsx(huge.bytes)
+
+    expect(wb.sheets).toHaveLength(1)
+    expect(wb.sheets[0]!.name).toBe("Huge")
+    expect(wb.sheets[0]!.rows).toEqual(expected)
+  }, 120_000)
+
+  it("reads when the ZIP declares no size and the ceiling is met head-on", async () => {
+    // With no size in the central directory there is nothing to decide
+    // on up front: the buffered read runs, fails at the ceiling, and that
+    // error is the signal to retry as a stream. The slow path, and the
+    // one that has to work for a file whose ZIP is less forthcoming than
+    // Excel's.
+    huge.declare(0)
+
+    const wb = await readXlsx(huge.bytes)
+
+    expect(wb.sheets[0]!.rows).toEqual(expected)
+  }, 120_000)
+})
+
+describe("a declared size the compressed body could not have produced", () => {
+  // The declared size decides whether a part is read whole — and so
+  // CRC-32 checked — or streamed, which has no whole entry to check.
+  // Nothing verifies the field, so a small entry claiming to be enormous
+  // would take the streaming route and skip the checksum: corruption
+  // buying its way out of verification by lying about its size. A STORE
+  // entry expands not at all, so the claim is refused and the buffered,
+  // verified path runs.
+  const tiny = `<worksheet><sheetData><row r="1"><c r="A1"><v>1</v></c></row></sheetData></worksheet>`
+
+  const { bytes: zip } = storeZip([
+    textEntry("[Content_Types].xml", CONTENT_TYPES),
+    textEntry("_rels/.rels", ROOT_RELS),
+    textEntry("xl/workbook.xml", WORKBOOK),
+    textEntry("xl/_rels/workbook.xml.rels", WORKBOOK_RELS),
+    { ...textEntry("xl/worksheets/sheet1.xml", tiny), declares: MAX_STRING_LENGTH + 1 },
+  ])
+
+  it("is not reported as a declared size", () => {
+    expect(new ZipReader(zip).declaredSize("xl/worksheets/sheet1.xml")).toBeUndefined()
+  })
+
+  it("still reads, by the buffered path it was trying to escape", async () => {
+    expect((await readXlsx(zip)).sheets[0]!.rows).toEqual([[1]])
+  })
+})


### PR DESCRIPTION
## Scope

**Fixed:** `readXlsx` reads a workbook whose *worksheet* part is over V8's
0x1fffffe8-character string ceiling. Ten of the fourteen such workbooks in a
~600-file corpus now import; the other four clear the ceiling and land on
`maxTotalCells`, with numbers below.

**Not fixed, deliberately:** `readXlsb` and `readOds` still have the ceiling, and
so does every non-worksheet part of an XLSX — `sharedStrings.xml`, `styles.xml`, a
drawing. Those still throw the #514 `ParseError`. I scanned all ~600 central
directories: no non-worksheet part in the corpus is anywhere near the ceiling, so
this is untriggered here rather than tested-and-working. A workbook with a 512 MB
shared-string table would still fail.

#514 and #518 made the failure legible. Neither made a file load. This is the
capability fix.

Rebased onto `main` after #528-#531 landed. #530 is the fix for #527, which came
out of measuring this branch — so the four workbooks below that land on
`maxTotalCells` now get the error that describes their case, and the `Map`
ceiling they hit is `main`'s bound rather than something this PR has to explain.

## The change

`parseWorksheet`'s handlers were already SAX handlers — only their *driver*
needed the string.

- `src/xlsx/worksheet.ts` — the handlers and the finalisation are split into
  `worksheetParser(name, ctx)`, returning `{ handlers, finish }`. `parseWorksheet`
  drives them with `parseSax` over a string; the new `parseWorksheetStream` drives
  the *same* object with `parseSaxStream` over a `ReadableStream`. The diff is
  large but almost entirely re-indentation — `git diff -w` is small.
- `src/xlsx/reader.ts:71` — `readWorksheet()` chooses the driver.
- `src/zip/reader.ts` — `declaredSize(path)` exposes the central directory's
  uncompressed size (0 and the ZIP64 sentinel both report `undefined`, since
  neither means "small").
- `src/_decode.ts` — `isPartTooLargeToDecode()`, identity-based.
- `src/zip/reader.ts` — `extractEntryStream` now emits STORE and
  fallback-inflate entries in 1 MiB chunks (see "incidental fix").

`parseWorksheetStream` is intentionally **not** exported from `src/index.ts`. It is
an internal seam; `streamXlsxRows` remains the public streaming API.

## Decision 1 — automatic, no option

Both drivers run the same handler set and the same finalisation, so they cannot
disagree about a field of the model; a second model builder would be a second set
of answers for every field, which is the divergence `CONTRIBUTING.md` calls the
registers. With that established, automatic is safe, and the ceiling stops being
something a caller has to know about — which is the point.

Which driver runs is decided from the ZIP's declared uncompressed size, before
anything is decompressed. When the ZIP declares no size (a streaming producer
writes zero), the buffered read runs and the ceiling error it raises is the signal
to retry as a stream — the slow path, since it pays for the decompression twice.
That error is recognised by object identity, not by matching its message; matching
the text would be exactly the mistake #516 was.

The size gate compares *bytes* against a *character* ceiling, so a multibyte part
can be sent to the streaming path that the buffered one would have managed. That
costs nothing — same handlers, same `Sheet`.

**Two divergences closed rather than documented.** A multi-agent correctness
review of this branch found both; each has a test that fails without its fix.

- `parseSaxStream` *dropped* an unfinished construct at exactly the six places
  `parseSax` throws `XmlError`, so a worksheet truncated by a crashed producer
  would have read as a short `Sheet` with no error — silent data loss on
  precisely the files this PR is for. It now takes a `strict` option.
  `parseWorksheetStream` asks for it; the row streamers do not, so
  `streamXlsxRows` keeps the lenient contract
  `test/coverage-xml-parser.test.ts` pins. Making it the default would have
  changed that public behaviour for everyone, which is not this PR's to change.
- A CRLF split across a text-flush boundary normalised to *two* newlines
  (`normalizeEol` runs per emitted piece, and `safeTextSplit` guarded entities
  and surrogate pairs but not CR/LF). Only reachable in a run over 256 KiB with
  the chunk boundary on the CRLF, so no ordinary sheet shows it.

**On CRC-32.** The streaming ZIP path has no whole entry to check, so a
worksheet read that way is not CRC-32 verified — the same trade
`streamXlsxRows` has always made. It is bounded on the way in: a declared size
the compressed body could not have produced is not believed (DEFLATE tops out at
1032:1, a stored entry does not expand), so a 40 KB entry cannot claim 600 MB,
take the streaming route and skip the checksum. `docs/PARITY.md` says all of
this.

## Decision 2 — measured: ten read, four land on the cell bound

One process per workbook, `--max-old-space-size=8192`, timeout 15 min, concurrency
1. Files are labelled `F1`–`F14`; nothing from them is reproduced here. "before" is
`origin/main` at 05a7358 — time and RSS to *reach the error*, i.e. work spent to
fail.

| file | part bytes | before | after | rows x cols | before RSS | after RSS |
| --- | ---: | --- | --- | ---: | ---: | ---: |
| F1 | 588,490,362 | ParseError 6.1s | reads 32.7s | 546,462 x 62 | 2,890 MB | 1,586 MB |
| F2 | 588,490,362 | ParseError 5.7s | reads 30.2s | 546,462 x 62 | 2,891 MB | 1,585 MB |
| F3 | 588,939,986 | ParseError 4.1s | reads 33.9s | 800,001 x 15 | 2,011 MB | 1,808 MB |
| F4 | 588,951,686 | ParseError 4.2s | reads 24.6s | 800,001 x 15 | 1,981 MB | 1,227 MB |
| F5 | 589,208,551 | ParseError 4.1s | reads 38.2s | 800,001 x 15 | 2,015 MB | 2,036 MB |
| F6 | 589,255,109 | ParseError 3.9s | reads 36.7s | 800,001 x 15 | 2,013 MB | 2,029 MB |
| F7 | 607,505,144 | ParseError 4.0s | reads 25.5s | 1,048,557 x 13 | 2,266 MB | 749 MB |
| F8 | 787,192,563 | ParseError 6.0s | reads 115.1s | 501,982 x 35 | 2,644 MB | 2,040 MB |
| F9 | 860,154,420 | ParseError 7.4s | reads 75.0s | 458,225 x 41 | 3,648 MB | 1,239 MB |
| F10 | 880,986,535 | ParseError 6.1s | reads 76.2s | 566,155 x 35 | 2,944 MB | 2,286 MB |
| F11 | 886,914,347 | ParseError 6.4s | `maxTotalCells` 52.9s | — | 2,969 MB | 789 MB |
| F12 | 895,198,503 | ParseError 6.3s | `maxTotalCells` 90.9s | — | 3,008 MB | 811 MB |
| F13 | 900,010,877 | ParseError 6.0s | `maxTotalCells` 79.6s | — | 3,024 MB | 814 MB |
| F14 | 1,131,823,668 | ParseError 12.1s | `maxTotalCells` 131.2s | — | 5,323 MB | 2,630 MB |

Peak RSS is **lower after the change in twelve of the fourteen** — often much
lower (F7 2,266 → 749 MB, F9 3,648 → 1,239 MB, F14 5,323 → 2,630 MB) — and that
is while doing the whole parse the "before" never started. F5 and F6 are the
exceptions and are a wash: 2,015 → 2,036 MB and 2,013 → 2,029 MB, under 1%.
Buffering a 589 MB–1.13 GB part into a `Uint8Array` and then asking
`TextDecoder` for a string of it generally cost more than parsing the part a
chunk at a time costs.

"after" is the final branch; "before" is `origin/main` at 05a7358, where the
ceiling error is unchanged by #528–#531. Wall times are as measured, one process
each, on files served over OneDrive under WSL2, and **cold-read variance
dominates them**: F1 and F2 are byte-identical and differ run to run, and F8
measured 38 s and 115 s on two runs of the same build. Read the times as an order
of magnitude, not a benchmark; the RSS figures are stable.

The four that land on the cell bound, from the error itself:

| file | bounding box | filled |
| --- | --- | ---: |
| F11 | 579,151 × 35 = 20,270,285 | 96.25% |
| F12 | 637,888 × 35 = 22,326,080 | 88.14% |
| F13 | 658,025 × 35 = 23,030,875 | 85.70% |
| F14 | 916,449 × 33 = 30,242,817 | 93.95% |

Against `MAX_TOTAL_CELLS` = 20,000,000. Since #530 the error tells these four
apart from the sparse case and stops offering them `sparse`, e.g. F14:

```
  - streamXlsxRows(input) reads it a row at a time, whatever the box.
  - `sparse: true` cannot help here: 28412273 filled cells is past the 16777216 a Map can hold.
```

which is the right answer, and it is the one that works:

- **`streamXlsxRows` works** on all four — 579,151 / 637,888 / 658,025 / 916,449
  rows in 40 / 53 / 46 / 53 s at 510 / 521 / 527 MB / 2.1 GB peak RSS. Those row
  counts match the bounding boxes the cell-limit error reports exactly, which is
  a useful cross-check that the streaming worksheet parse sees the same data.
- **`sparse: true` does not**, which is what #527 was about and what #530 fixed:
  all four have 19–28 M filled cells against a `Map` cap of 16,777,216.

So all fourteen now either import or fail with an error that names an escape that
actually works. That is the whole of what this PR set out to change.

## Incidental fix, needed for this to work at all

`extractEntryStream` emitted a STORE entry (and the fallback inflate's output) as
a *single* `enqueue`. `parseSaxStream` does `buf += decoder.decode(chunk)`, so a
589 MB stored worksheet would have rebuilt the very 512 MB string the streaming
path exists to avoid — the new reader would have failed on the files it was added
for. Both paths now emit 1 MiB chunks; nothing is copied, each chunk is a
`subarray` view. `DecompressionStream` already chunked, so the deflate path
(every file above) is unchanged.

The review caught that `ZipStreamReader.entryStream` had the identical
one-chunk pattern in its no-`DecompressionStream` fallback — the branch the
Deno/browser/Workers claims rest on — so `streamXlsxRows` would still have died
on these files there. `chunkedStream` and its chunk size moved to
`src/zip/byte-limit.ts` and both readers now use it, rather than one being fixed
and its twin left behind.

## Bundle size

`readXlsx` grows **+2.7 KB minified / +1.0 KB gzipped (+2.8%)**, because it now
contains the streaming parser and the streaming ZIP path — `parseWorksheetStream`
reaches `parseSaxStream`, and the size gate reaches `extractStream`. Both were
already in the package; they were not in this entry point's graph.

`readOds` grows +0.3 KB / +0.2 KB (+2.2%) without gaining a feature: the CRLF
guard and the truncation contract live in `xml/parser.ts` and the chunked
emission in `zip/byte-limit.ts`, both shared. `csv` and `writeXlsx` are unchanged;
`everything` is +0.4%.

Re-baselined in its own commit with `node scripts/size.mjs --update`, as the
budget check asks. That command rewrites every budget to measurement + 5%, so the
scenarios that did not move are re-stated at the same headroom rather than left
alone — only `readXlsx` and `readOds` actually needed it.

## Tests

`test/huge-worksheet.test.ts`, 14 cases, ~3 s, fully in memory — no fixture, no
disk read, so no `tsconfig.cli.json` registration.

- **Fails before, passes after:** a workbook whose worksheet part is
  `MAX_STRING_LENGTH + 1024` bytes — two real rows with ignorable whitespace
  between them, in a hand-built STORE-only ZIP so nothing is spent deflating half
  a gigabyte. Re-verified against the final branch with the fix disabled: both
  cases throw the #514 `ParseError`. `test/huge-part-error.test.ts` set the
  precedent that a large *buffer* is affordable where a large *fixture* is not.
- **The undeclared-size path** has its own case: the ZIP writes zero for the
  uncompressed size, so the buffered read runs, hits the ceiling, and the retry
  is what has to work. The two cases **share one archive**, patching the declared
  size in place — two live 537 MB buffers made unrelated tests in other files
  miss their time budgets, which is a flaky suite for no gain. The file went from
  27 s to 3 s.
- **Divergence guard:** a worksheet exercising every handler that accumulates
  text across calls, parsed both ways and compared with `toEqual` — whole, and
  again with **every byte its own chunk**, plus the same in `sparse` mode.
- **Failure parity:** five documents ending mid-construct (opening tag, closing
  tag, comment, CDATA, PI), each asserted to throw `XmlError` on *both* drivers.
- **The CRLF flush cut:** a run over `SAX_TEXT_FLUSH_CHARS` with the chunk
  boundary placed exactly between the CR and the LF. Fails without the guard.
- **A lying declared size** is not believed, and the entry still reads by the
  buffered path it was trying to escape.

## Checks

- `corepack pnpm test` — green, twice in a row. 217 files, 10,442 tests.
- `corepack pnpm coverage` — 98.68 / 96.63 / 98.8 / 99.1 against 98.5 / 96 / 98 / 99.
- `test/real-files.test.ts` — passes. It has **zero** `it.fails` markers on current
  `main` (#501's was retired by #513); zero before this change, zero after.
- `docs/PARITY.md` updated in this PR: what reads and what still does not, the
  CRC-32 trade and its bound, and the truncation contract.

What I did not check: any runtime other than Node 24, and any workbook outside
this corpus. The no-`DecompressionStream` fallback fix is reasoned, not measured
— I have no runtime here that lacks `deflate-raw`.

Nothing from the corpus is reproduced anywhere in this PR — the harness reports
counts, byte sizes and part names only, and quoted literals in error messages are
redacted.
