### PR TITLE
fix(image): decode base64 with atob, the Web API, and refuse invalid input

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -1,20 +1,38 @@
 import type { SheetImage } from "./_types"
+import { InvalidArgumentError } from "./errors"
 
 /**
- * Decode a base64 string to a Uint8Array.
- * Works in both Node.js (via Buffer) and browsers (via atob).
+ * Decode a base64 string to a `Uint8Array`.
+ *
+ * `atob` is a Web API and is in every runtime this library claims —
+ * Node 24, Deno, Bun, browsers, Workers. This used to prefer
+ * `globalThis.Buffer` when it was there, reached through an `any` cast,
+ * which was the one place in `src/` outside the CLI that touched a Node
+ * API. `tsconfig.json` sets `"types": []` so that reaching for one is a
+ * compile error; the cast is what got past it. See CLAUDE.md.
+ *
+ * The two do not agree on invalid input, and that is worth having. Given
+ * `"YWJj###"`, `Buffer.from(…, "base64")` silently returns the three
+ * bytes it could read; `atob` throws. For an image that means a workbook
+ * carrying a truncated or garbage PNG, which Excel refuses to open with
+ * no hint as to why — a failure a long way from the bad string that
+ * caused it. Failing here instead, and saying so, is the better trade.
  */
 function base64ToUint8Array(base64: string): Uint8Array {
   // Strip data URI prefix if present (e.g. "data:image/png;base64,...")
   const clean = base64.includes(",") ? base64.slice(base64.indexOf(",") + 1) : base64
 
-  if (typeof globalThis !== "undefined" && "Buffer" in globalThis) {
-    // Node.js
-    return new Uint8Array((globalThis as any).Buffer.from(clean, "base64"))
+  let binary: string
+  try {
+    binary = atob(clean)
+  } catch {
+    throw new InvalidArgumentError(
+      "Image data is not valid base64. It decoded to nothing a runtime would accept — " +
+        "check for a truncated string, a URL-safe alphabet (`-` and `_` rather than `+` and `/`), " +
+        "or bytes that were never encoded at all.",
+    )
   }
 
-  // Browser
-  const binary = atob(clean)
   const bytes = new Uint8Array(binary.length)
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i)

--- a/test/image-base64.test.ts
+++ b/test/image-base64.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { imageFromBase64 } from "../src/image"
+import { InvalidArgumentError } from "../src/errors"
+
+// ═══════════════════════════════════════════════════════════════════════
+// `src/image.ts` was the least-covered file in the library at 45%, and
+// for a reason worth fixing rather than papering over: it had two decode
+// paths, `globalThis.Buffer` when it was there and `atob` otherwise, so
+// the tests only ever ran one of them.
+//
+// It was also the single place in `src/` outside the CLI that reached for
+// a Node API. CLAUDE.md: "src/ outside the CLI uses Web APIs only", and
+// `tsconfig.json` sets `"types": []` so that reaching for one is a
+// compile error. An `any` cast got past it.
+//
+// `atob` is a Web API and is in every runtime this library claims. One
+// path now, and it is the portable one.
+//
+// The two disagree on invalid input, which is the part worth keeping.
+// Given "YWJj###", `Buffer.from(…, "base64")` silently returns the three
+// bytes it managed; `atob` throws. Silence there means a workbook
+// carrying a garbage PNG that Excel refuses to open, a long way from the
+// bad string that caused it.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** A 1x1 transparent PNG. */
+const PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+const ANCHOR = { type: "oneCell", from: { row: 0, col: 0 } } as const
+
+describe("valid base64 decodes to the bytes it encoded", () => {
+  it("a real PNG, header and all", () => {
+    const image = imageFromBase64(PNG, "png", ANCHOR)
+
+    // The PNG signature: 89 50 4E 47 0D 0A 1A 0A.
+    expect([...image.data.slice(0, 8)]).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+    expect(image.type).toBe("png")
+  })
+
+  it("through a data URI prefix", () => {
+    const bare = imageFromBase64(PNG, "png", ANCHOR)
+    const prefixed = imageFromBase64(`data:image/png;base64,${PNG}`, "png", ANCHOR)
+
+    expect(prefixed.data).toEqual(bare.data)
+  })
+
+  it("every byte value, not just the printable ones", () => {
+    // 0..255 encoded. A decoder that goes through a string has to keep
+    // each charCode as a byte; this is what notices if it does not.
+    const all = Uint8Array.from({ length: 256 }, (_, i) => i)
+    let binary = ""
+    for (const b of all) binary += String.fromCharCode(b)
+    const b64 = btoa(binary)
+
+    expect([...imageFromBase64(b64, "png", ANCHOR).data]).toEqual([...all])
+  })
+
+  it("an empty string is empty, not an error", () => {
+    expect(imageFromBase64("", "png", ANCHOR).data).toHaveLength(0)
+  })
+
+  it("unpadded and whitespace-broken input, which atob forgives", () => {
+    // `atob` strips ASCII whitespace and tolerates missing padding, so a
+    // base64 blob wrapped across lines still decodes.
+    expect([...imageFromBase64("YQ", "png", ANCHOR).data]).toEqual([0x61])
+    expect([...imageFromBase64("YWJj\ndGVzdA==", "png", ANCHOR).data]).toEqual([
+      0x61, 0x62, 0x63, 0x74, 0x65, 0x73, 0x74,
+    ])
+  })
+})
+
+describe("invalid base64 says so, rather than making bytes up", () => {
+  it("throws InvalidArgumentError, not a DOMException", () => {
+    // The runtime's own error is an `InvalidCharacterError` naming
+    // nothing about images or spreadsheets.
+    expect(() => imageFromBase64("not!valid!base64", "png", ANCHOR)).toThrow(InvalidArgumentError)
+  })
+
+  it("and the message names what to look for", () => {
+    expect(() => imageFromBase64("YWJj###", "png", ANCHOR)).toThrow(/not valid base64/)
+    expect(() => imageFromBase64("YWJj###", "png", ANCHOR)).toThrow(/URL-safe alphabet/)
+  })
+
+  it("including a URL-safe alphabet, which is the likely mistake", () => {
+    // base64url swaps `+/` for `-_`. `Buffer.from` accepts it silently
+    // and produces different bytes; this refuses it by name.
+    expect(() => imageFromBase64("a-b_c-d_", "png", ANCHOR)).toThrow(InvalidArgumentError)
+  })
+
+  it("and over-padding, which used to decode to something", () => {
+    expect(() => imageFromBase64("YQ===", "png", ANCHOR)).toThrow(InvalidArgumentError)
+  })
+})


### PR DESCRIPTION
`src/image.ts` was **the one place in `src/` outside the CLI that reached for a Node API**:

```ts
if (typeof globalThis !== "undefined" && "Buffer" in globalThis) {
  return new Uint8Array((globalThis as any).Buffer.from(clean, "base64"))
}
```

CLAUDE.md is explicit — *"`src/` outside the CLI uses Web APIs only — no `node:` imports, no `process`, no `Buffer`"* — and `tsconfig.json` sets `"types": []` so that reaching for one is a compile error rather than something that quietly works on your machine. The `any` cast is what got past it.

It was also **the least-covered file in the library, at 45%**, for the same reason: two decode paths, and the tests only ever ran the Node one. The portable path was the untested path, which is exactly the wrong way round for a library whose Deno, Bun, browser and Workers claims depend on it.

## The replacement

`atob` is a Web API and is in every runtime this library claims. Verified identical to `Buffer.from(…, "base64")` on valid input before switching — a real PNG, empty, unpadded (`YQ`), whitespace-broken across lines, and all 256 byte values:

```
tiny png     SAME      empty        SAME      no padding   SAME
one pad      SAME      whitespace   SAME      all bytes    SAME
```

## Where they differ, and why that is the point

Invalid input:

| input | `Buffer.from` | `atob` |
| --- | --- | --- |
| `YWJj###` | `[97, 98, 99]` | throws |
| `not!valid!base64` | `[158, 139, 111, …]` | throws |
| `YQ===` | `[97]` | throws |

Silence there means a workbook carrying a truncated or invented PNG, which Excel refuses to open with no hint as to why — a failure a long way from the bad string that caused it.

It now throws an `InvalidArgumentError` naming the likely causes: truncation, a URL-safe alphabet (`-`/`_` rather than `+`/`/`, which `Buffer.from` accepts silently and decodes *differently*), or bytes that were never encoded. The runtime's own `InvalidCharacterError` mentions neither images nor spreadsheets.

This is a behaviour change for callers passing malformed base64: they used to get a corrupt image and now get an error at the call that caused it.

Four tests fail against main's `src` and pass with it (`git stash -q -- src`, confirmed). One decode path now, and it is covered — `image.ts` has left the bottom of the coverage table entirely.

`pnpm test` green — 10,478 tests, 221 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
