### PR TITLE
fix(sheet-ops): a quoted sheet name survives inserting a row

### DIFF
--- a/src/_refs.ts
+++ b/src/_refs.ts
@@ -101,18 +101,37 @@ export function shiftFormula(formula: string, shift: RefShift): string {
   return replaceA1Ranges(formula, (match) => shiftMatch(match, shift))
 }
 
+/**
+ * The qualifier, exactly as the formula spelled it.
+ *
+ * `replaceA1Ranges` strips the `!` and a leading `$` and hands back the
+ * rest verbatim — so a name needing quotes still carries them, which is
+ * what makes it a legal qualifier. This used to re-quote it, escaping the
+ * quotes already there, and turned a reference to `My Sheet` into one
+ * Excel rejects.
+ */
 function qualifierOf(match: A1RangeMatch): string {
-  return match.sheet1 === undefined ? "" : `${quoteSheet(match.sheet1)}!`
+  return match.sheet1 === undefined ? "" : `${match.sheet1}!`
 }
 
-function quoteSheet(name: string): string {
-  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `'${name.replace(/'/g, "''")}'`
+/**
+ * The sheet *name* a qualifier denotes, with Excel's quoting removed.
+ *
+ * Only for comparing against {@link RefShift.sheetName}, which is a name
+ * rather than a qualifier. A quoted qualifier never equalled the bare
+ * name, so a formula pointing at its own sheet that way was taken for a
+ * foreign one and left unshifted while the rows moved under it.
+ */
+function unquoteSheet(name: string): string {
+  return name.length >= 2 && name.startsWith("'") && name.endsWith("'")
+    ? name.slice(1, -1).replace(/''/g, "'")
+    : name
 }
 
 function shiftMatch(match: A1RangeMatch, shift: RefShift): string {
   // A reference into another sheet is not affected by this sheet's rows
   // moving. An unqualified one is local by definition.
-  if (match.sheet1 !== undefined && match.sheet1 !== shift.sheetName) {
+  if (match.sheet1 !== undefined && unquoteSheet(match.sheet1) !== shift.sheetName) {
     return rebuild(match)
   }
 
@@ -156,7 +175,7 @@ function shiftMatch(match: A1RangeMatch, shift: RefShift): string {
 function rebuild(match: A1RangeMatch): string {
   const head = `${qualifierOf(match)}${match.ref1}`
   if (match.ref2 === undefined) return head
-  const tail = match.sheet2 === undefined ? match.ref2 : `${quoteSheet(match.sheet2)}!${match.ref2}`
+  const tail = match.sheet2 === undefined ? match.ref2 : `${match.sheet2}!${match.ref2}`
   return `${head}:${tail}`
 }
 

--- a/test/shift-quoted-sheet.test.ts
+++ b/test/shift-quoted-sheet.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+import { shiftFormula } from "../src/_refs"
+import { insertRows } from "../src/sheet-ops"
+import type { Sheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// Inserting a row corrupted every formula that named a sheet in quotes:
+//
+//   'My Sheet'!A3   ->   '''My Sheet'''!A3
+//
+// `replaceA1Ranges` hands back the qualifier as it appeared in the
+// formula — quotes included, since that is what makes `My Sheet` a legal
+// qualifier — and `_refs.ts` then ran it through a `quoteSheet` that
+// assumed a bare name and escaped the quotes it found. Excel rejects the
+// result.
+//
+// The same mismatch caused a second failure, quieter than the first. The
+// shift only applies to references on the sheet that moved, decided by
+// `match.sheet1 !== shift.sheetName` — and `'My Sheet'` never equals
+// `My Sheet`, so a formula pointing at its *own* sheet by a quoted name
+// was left unshifted while `S!A3` on a sheet named `S` shifted correctly.
+// The rows moved underneath it and the reference did not follow.
+//
+// The ODS formula writer reads the same qualifier and wants the quotes —
+// `$'My Sheet'.A1` is correct ODF and round-trips today — so the fix is
+// here rather than in the shared matcher.
+// ═══════════════════════════════════════════════════════════════════════
+
+const INSERT_AT_2 = { axis: "row", at: 2, delta: 1 } as const
+
+describe("a quoted sheet name survives a shift", () => {
+  it("unchanged when it names another sheet", () => {
+    expect(shiftFormula("'My Sheet'!A3", { ...INSERT_AT_2, sheetName: "S" })).toBe("'My Sheet'!A3")
+  })
+
+  it("in a range, and in a function call", () => {
+    expect(shiftFormula("SUM('My Sheet'!A3:A5)", { ...INSERT_AT_2, sheetName: "S" })).toBe(
+      "SUM('My Sheet'!A3:A5)",
+    )
+  })
+
+  it("with an escaped apostrophe in the name", () => {
+    // Excel writes a literal `'` in a sheet name as `''`. Re-escaping it
+    // turned `'Bob''s Data'` into `'''Bob''''s Data'''`.
+    expect(shiftFormula("'Bob''s Data'!A3", { ...INSERT_AT_2, sheetName: "S" })).toBe(
+      "'Bob''s Data'!A3",
+    )
+  })
+
+  it("and an unquoted one is still left alone", () => {
+    expect(shiftFormula("Sheet2!A3", { ...INSERT_AT_2, sheetName: "S" })).toBe("Sheet2!A3")
+  })
+})
+
+describe("a reference to the moving sheet shifts, quoted or not", () => {
+  it("unquoted, as it always did", () => {
+    expect(shiftFormula("S!A3", { ...INSERT_AT_2, sheetName: "S" })).toBe("S!A4")
+  })
+
+  it("quoted, which it did not", () => {
+    // The quiet half: `'My Sheet'` never equalled `My Sheet`, so this was
+    // treated as a foreign sheet and left where it was.
+    expect(shiftFormula("'My Sheet'!A3", { ...INSERT_AT_2, sheetName: "My Sheet" })).toBe(
+      "'My Sheet'!A4",
+    )
+  })
+
+  it("quoted, with an escaped apostrophe", () => {
+    expect(shiftFormula("'Bob''s Data'!A3", { ...INSERT_AT_2, sheetName: "Bob's Data" })).toBe(
+      "'Bob''s Data'!A4",
+    )
+  })
+
+  it("quoted, in a range", () => {
+    expect(shiftFormula("SUM('My Sheet'!A3:A5)", { ...INSERT_AT_2, sheetName: "My Sheet" })).toBe(
+      "SUM('My Sheet'!A4:A6)",
+    )
+  })
+
+  it("and a local reference is unaffected by any of this", () => {
+    expect(shiftFormula("A3", { ...INSERT_AT_2, sheetName: "My Sheet" })).toBe("A4")
+    expect(shiftFormula("SUM(A1:A5)", { ...INSERT_AT_2, sheetName: "My Sheet" })).toBe("SUM(A1:A6)")
+  })
+})
+
+describe("through the operation a caller actually runs", () => {
+  it("insertRows leaves a foreign quoted reference intact", () => {
+    const sheet: Sheet = {
+      name: "S",
+      rows: [["a"], ["b"], ["c"]],
+      cells: new Map([["2,0", { value: 1, type: "formula", formula: "'My Sheet'!A3" }]]),
+    }
+
+    insertRows(sheet, 0, 1)
+
+    expect(sheet.cells!.get("3,0")?.formula).toBe("'My Sheet'!A3")
+  })
+})


### PR DESCRIPTION
Inserting a row corrupted every formula that named a sheet in quotes:

```
'My Sheet'!A3   →   '''My Sheet'''!A3
```

Excel rejects that — and it happened on an insert that had nothing to do with `My Sheet`. `'Bob''s Data'!A3`, where the name legitimately contains an apostrophe, came back as `'''Bob''''s Data'''!A3`.

## Cause

`replaceA1Ranges` hands back the qualifier **as the formula spelled it**, quotes included — that is what makes a name with a space in it a legal qualifier. `_refs.ts` then ran it through a `quoteSheet` that assumed a bare name and escaped the quotes already there.

## The quieter half

The same mismatch caused a second failure that produces no visibly broken output. A shift applies only to references on the sheet that moved, decided by comparing the qualifier against `shift.sheetName` — and a quoted qualifier never equals a bare name:

| formula | sheet that moved | before | after |
| --- | --- | --- | --- |
| `S!A3` | `S` | `S!A4` ✓ | `S!A4` |
| `'My Sheet'!A3` | `My Sheet` | `A3`, unshifted | `'My Sheet'!A4` |

So a formula pointing at its **own** sheet by a quoted name was taken for a foreign one and left where it was, while the rows moved underneath it. Silent wrong answers rather than a rejected file.

Both come from one place. The qualifier is echoed back verbatim now, and unquoted only for the name comparison.

## Why here and not in the shared matcher

The ODS formula writer reads the same qualifier and **wants** the quotes: it emits `$'My Sheet'.A1`, which is correct ODF and round-trips today. Verified before changing anything — making `normalizeQualifier` unquote would have fixed this and broken that.

Seven tests fail against main's `src` and pass with it (`git stash -q -- src`, confirmed), including one driven through `insertRows` rather than the helper, since that is what a caller actually runs.

`pnpm test` green — 10,488 tests, 222 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
