### PR TITLE
fix(sheet-ops): a reference pushed off the grid is #REF!, on both axes

### DIFF
--- a/src/_refs.ts
+++ b/src/_refs.ts
@@ -12,6 +12,7 @@
 // anything but the ODS writer.
 
 import { colToLetter, letterToCol, replaceA1Ranges, type A1RangeMatch } from "./cell-utils"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "./limits"
 
 /** What moved, from where, by how much. */
 export interface RefShift {
@@ -69,9 +70,16 @@ const REF_ERROR = "#REF!"
  * formula is *copied*, not when the grid moves underneath it, and Excel
  * shifts `$A$5` on an insert exactly as it shifts `A5`.
  */
-function shiftCoordinate(value: number, shift: RefShift): number | null {
+function shiftCoordinate(value: number, shift: RefShift, max: number): number | null {
   if (shift.delta > 0) {
-    return value >= shift.at ? value + shift.delta : value
+    if (value < shift.at) return value
+    // An insert can push a reference past the last row or column, and
+    // then it has nowhere to point — the same state a deletion leaves it
+    // in, so it gets the same `null`. Without this the row axis produced
+    // `A1048577`, a row that cannot exist, and the column axis threw out
+    // of `colToLetter` and took the whole `insertColumns` with it.
+    const moved = value + shift.delta
+    return moved > max ? null : moved
   }
   const removed = -shift.delta
   if (value >= shift.at + removed) return value - removed
@@ -138,8 +146,10 @@ function shiftMatch(match: A1RangeMatch, shift: RefShift): string {
   const start = parseRef(match.ref1)
   if (!start) return rebuild(match)
 
+  const max = shift.axis === "row" ? MAX_ROW_INDEX : MAX_COL_INDEX
+
   if (match.ref2 === undefined) {
-    const moved = shiftCoordinate(coordinateOf(start, shift.axis), shift)
+    const moved = shiftCoordinate(coordinateOf(start, shift.axis), shift, max)
     if (moved === null) return REF_ERROR
     return `${qualifierOf(match)}${formatRef(withCoordinate(start, shift.axis, moved))}`
   }
@@ -157,11 +167,19 @@ function shiftMatch(match: A1RangeMatch, shift: RefShift): string {
     if (startAt >= shift.at && endAt < shift.at + removed) return REF_ERROR
   }
 
+  const rawStart = shiftCoordinate(startAt, shift, max)
+  const rawEnd = shiftCoordinate(endAt, shift, max)
+
+  // An insert that pushes the *start* off the end leaves nothing to point
+  // at. One that pushes only the end off clips the range there, which is
+  // the same shape as a deletion clipping it.
+  if (shift.delta > 0 && rawStart === null) return REF_ERROR
+
   // Clamp each endpoint into the surviving grid rather than letting it
   // become #REF!: a range clipped by a deletion shrinks, which is what
   // Excel does and what the caller means.
-  const movedStart = shiftCoordinate(startAt, shift) ?? shift.at
-  const movedEnd = shiftCoordinate(endAt, shift) ?? Math.max(shift.at - 1, 0)
+  const movedStart = rawStart ?? shift.at
+  const movedEnd = rawEnd ?? (shift.delta > 0 ? max : Math.max(shift.at - 1, 0))
 
   const lo = Math.min(movedStart, movedEnd)
   const hi = Math.max(movedStart, movedEnd)

--- a/test/shift-off-grid.test.ts
+++ b/test/shift-off-grid.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest"
+import { shiftFormula } from "../src/_refs"
+import { insertColumns, insertRows } from "../src/sheet-ops"
+import { MAX_COL_INDEX, MAX_ROW_INDEX } from "../src/limits"
+import type { Sheet } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// An insert that pushes a reference past the last row or column had two
+// different wrong answers, one per axis:
+//
+//   A1048576  + insert row   ->  A1048577   a row that cannot exist
+//   XFD1      + insert col   ->  throws InvalidArgumentError
+//
+// The throw is the worse of the two. It comes out of `colToLetter`, which
+// is right to refuse column 16384, but it comes out through
+// `insertColumns` — so inserting a column anywhere in a sheet that has
+// one formula mentioning column XFD failed the whole operation with a
+// message about column indexes.
+//
+// Excel's answer for both is `#REF!`: the reference had somewhere to
+// point and no longer does, which is the same thing a deletion does to
+// it, and `shiftCoordinate` already returned `null` for that.
+// ═══════════════════════════════════════════════════════════════════════
+
+const LAST_ROW = MAX_ROW_INDEX + 1 // 1-based, as a formula writes it
+const LAST_COL = "XFD"
+
+const ROW_INSERT = { axis: "row", at: 0, delta: 1 } as const
+const COL_INSERT = { axis: "col", at: 0, delta: 1 } as const
+
+describe("a reference pushed off the grid becomes #REF!", () => {
+  it("on the row axis", () => {
+    expect(shiftFormula(`A${LAST_ROW}`, ROW_INSERT)).toBe("#REF!")
+  })
+
+  it("on the column axis, where it used to throw", () => {
+    expect(shiftFormula(`${LAST_COL}1`, COL_INSERT)).toBe("#REF!")
+  })
+
+  it("and the row below the last one still moves normally", () => {
+    expect(shiftFormula(`A${LAST_ROW - 1}`, ROW_INSERT)).toBe(`A${LAST_ROW}`)
+  })
+
+  it("as does the column before the last", () => {
+    expect(shiftFormula("XFC1", COL_INSERT)).toBe(`${LAST_COL}1`)
+  })
+
+  it("by more than one, too", () => {
+    expect(shiftFormula(`A${LAST_ROW - 1}`, { axis: "row", at: 0, delta: 5 })).toBe("#REF!")
+  })
+})
+
+describe("a range clipped by the edge keeps what fits", () => {
+  it("when only its end falls off", () => {
+    // The range still has somewhere to start, so it stops at the edge
+    // rather than vanishing.
+    expect(shiftFormula(`SUM(A1:A${LAST_ROW})`, ROW_INSERT)).toBe(`SUM(A2:A${LAST_ROW})`)
+  })
+
+  it("and becomes #REF! when its start does too", () => {
+    // The range token is what becomes `#REF!`; the call around it stays,
+    // which is both what Excel shows and what a deletion already did.
+    expect(shiftFormula(`SUM(A${LAST_ROW}:A${LAST_ROW})`, ROW_INSERT)).toBe("SUM(#REF!)")
+  })
+
+  it("the same on columns", () => {
+    expect(shiftFormula(`SUM(A1:${LAST_COL}1)`, COL_INSERT)).toBe(`SUM(B1:${LAST_COL}1)`)
+    expect(shiftFormula(`SUM(${LAST_COL}1:${LAST_COL}1)`, COL_INSERT)).toBe("SUM(#REF!)")
+  })
+
+  it("which is exactly what a deletion swallowing a range gives", () => {
+    // The pair, so the two paths cannot drift.
+    expect(shiftFormula("SUM(A3:A3)", { axis: "row", at: 2, delta: -1 })).toBe("SUM(#REF!)")
+  })
+})
+
+describe("through the operations a caller runs", () => {
+  it("insertColumns no longer fails the whole sheet", () => {
+    const sheet: Sheet = {
+      name: "S",
+      rows: [["a"]],
+      cells: new Map([["0,0", { value: 1, type: "formula", formula: `${LAST_COL}1` }]]),
+    }
+
+    expect(() => insertColumns(sheet, 0, 1)).not.toThrow()
+    expect(sheet.cells!.get("0,1")?.formula).toBe("#REF!")
+  })
+
+  it("insertRows leaves a valid reference behind, not an impossible one", () => {
+    const sheet: Sheet = {
+      name: "S",
+      rows: [["a"]],
+      cells: new Map([["0,0", { value: 1, type: "formula", formula: `A${LAST_ROW}` }]]),
+    }
+
+    insertRows(sheet, 0, 1)
+
+    expect(sheet.cells!.get("1,0")?.formula).toBe("#REF!")
+  })
+})
+
+describe("deletion is unchanged", () => {
+  it("still gives #REF! for what it removed", () => {
+    expect(shiftFormula("A3", { axis: "row", at: 2, delta: -1 })).toBe("#REF!")
+  })
+
+  it("and still clips a range rather than dropping it", () => {
+    expect(shiftFormula("SUM(A1:A5)", { axis: "row", at: 2, delta: -1 })).toBe("SUM(A1:A4)")
+  })
+
+  it("the bounds themselves are what they always were", () => {
+    expect(MAX_ROW_INDEX).toBe(1_048_575)
+    expect(MAX_COL_INDEX).toBe(16_383)
+  })
+})


### PR DESCRIPTION
An insert that pushed a reference past the last row or column had **two different wrong answers, one per axis**:

```
A1048576  + insert row   →   A1048577      a row that cannot exist
XFD1      + insert col   →   throws InvalidArgumentError
```

The throw is the worse of the two. It comes out of `colToLetter`, which is right to refuse column 16384 — but it came out through `insertColumns`. So **inserting a column anywhere in a sheet holding one formula that mentions column XFD failed the entire operation**, with a message about column indexes and nothing about the formula that caused it.

## The fix

Excel's answer for both is `#REF!` — and that is the same state a *deletion* leaves a reference in. `shiftCoordinate` already returned `null` for that case and the caller already turned `null` into `#REF!`, so the overflow just needed to return `null` too.

For ranges:

| | |
| --- | --- |
| insert pushes the **start** off the end | `#REF!` — nothing left to point at |
| insert pushes only the **end** off | clipped at the edge |

The second is the shape a deletion clipping a range already had, and there is a test pairing the two cases so they cannot drift apart.

## Testing

Eight tests fail against main's `src` and pass with it (`git stash -q -- src`, confirmed) — two of them driven through `insertRows` / `insertColumns` rather than the helper, since the throw only mattered because it escaped that far.

The bounds themselves are asserted (`MAX_ROW_INDEX` 1,048,575 and `MAX_COL_INDEX` 16,383), and the deletion path is pinned unchanged.

One correction from writing these: `SUM(A1048576:A1048576)` becomes `SUM(#REF!)`, not `#REF!` — the range token is what fails, the call around it stays. That is what Excel shows and what deletion already did; my first expectation was wrong, not the code.

`pnpm test` green — 10,502 tests, 223 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
