### PR TITLE
fix(xlsx): an ISO date cell is a Date in the streaming reader too

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -539,6 +539,13 @@ The streaming readers _do_ agree: `streamXlsxRows` and `streamOdsRows`
 both skip an entirely empty row and keep the true index on `StreamRow`,
 so a gap in the indexes is the signal.
 
+They do **not** agree on how many sheets they walk. `streamXlsxRows`
+yields one sheet — the first, unless `sheet` names another —
+while `streamOdsRows` walks every sheet in the document and tags each row
+with `sheetIndex`. So the same loop over a three-sheet workbook gives you
+one sheet of it as `.xlsx` and all three as `.ods`, silently. Pass
+`sheet` when you mean one, and read `row.sheetIndex` when you mean all.
+
 ### `streamXmlRows` gives you a row's own keys, not a rectangle
 
 XML rows are objects rather than arrays, and the two XML readers differ

--- a/src/xlsx/stream-reader.ts
+++ b/src/xlsx/stream-reader.ts
@@ -19,7 +19,7 @@ import { parseContentTypes } from "./content-types"
 import { parseRelationships } from "./relationships"
 import { parseSharedStrings } from "./shared-strings"
 import { parseStyles, isDateStyle } from "./styles"
-import { parseCellRef } from "./worksheet"
+import { parseCellRef, parseIsoCellDate } from "./worksheet"
 import { serialToDate } from "../_date"
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -581,6 +581,22 @@ function resolveStreamCellValue(
     case "e": {
       // Error
       return valueText
+    }
+    case "d": {
+      // ISO 8601 date (ECMA-376 §18.18.11 ST_CellType), which openpyxl
+      // writes whenever `iso_dates=True`. Without this it fell to the
+      // `n` arm, where `Number("2024-03-17")` is NaN and the text came
+      // back as a string — while `readXlsx` returned a `Date` for the
+      // same cell. See #496.
+      //
+      // The value is an instant, not an offset from an epoch, so the
+      // 1904 system does not apply to it.
+      const parsed = parseIsoCellDate(valueText)
+      if (parsed) return parsed
+      // A bare time (`13:45:30`, openpyxl's `datetime.time`) has no day
+      // to anchor it; left as text rather than guessed onto an epoch,
+      // which is what the buffered reader does too.
+      return valueText === "" ? null : valueText
     }
     case "n":
     default: {

--- a/src/xlsx/worksheet.ts
+++ b/src/xlsx/worksheet.ts
@@ -2322,8 +2322,14 @@ function parseColorAttrs(attrs: Record<string, string>): Color {
  * docProps readers do it: every format hucre reads records an absolute
  * moment, and local time would make the same file mean different things
  * on different machines. See #415, #474.
+ *
+ * Exported for `stream-reader.ts`, which needs the same answer. #496
+ * added the `t="d"` case here and not there, so the streaming reader
+ * returned the raw text where this returned a `Date` — one fix, two
+ * implementations, and only one of them got it. Sharing the parser is
+ * what stops the two drifting on the next shape someone accepts.
  */
-function parseIsoCellDate(text: string): Date | undefined {
+export function parseIsoCellDate(text: string): Date | undefined {
   const trimmed = text.trim()
   if (
     !/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/.test(trimmed)

--- a/test/xlsx-stream-parity.test.ts
+++ b/test/xlsx-stream-parity.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest"
+import { readFileSync, readdirSync } from "node:fs"
+import { readXlsx } from "../src/xlsx/reader"
+import { streamXlsxRows } from "../src/xlsx/stream-reader"
+import type { CellValue } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// XLSX has two readers and they had never been compared. The ODS pair
+// were, and that comparison found #525; the XLSX pair had only spot
+// checks — a chartsheet here, a row count there — and no sweep.
+//
+// It found the same class of bug. #496 taught the *buffered* reader
+// openpyxl's `t="d"` cells, the ISO 8601 date form of ST_CellType, and
+// left the streaming reader on the `n` path where `Number("2024-03-17")`
+// is NaN and the value falls through as a string:
+//
+//     readXlsx         Date 2024-03-17T00:00:00.000Z
+//     streamXlsxRows   "2024-03-17"
+//
+// One fix, two implementations, and only one of them got it.
+//
+// Two documented differences the comparison has to allow for, both in
+// `docs/PARITY.md`:
+//
+//   - `readXlsx` pads every row to the sheet's bounding box; the stream
+//     yields the row as the file had it. Compared on the trimmed form.
+//   - the stream skips an entirely empty row and keeps the true index,
+//     so rows are matched by `index`, not by position.
+//
+// And one that was *not* documented until this test found it: this reads
+// one sheet, where `streamOdsRows` reads them all. See below.
+// ═══════════════════════════════════════════════════════════════════════
+
+const norm = (v: CellValue): unknown => (v instanceof Date ? `D:${v.toISOString()}` : v)
+
+/** `readXlsx` pads to the bounding box; the stream does not. */
+function trim(row: CellValue[]): unknown[] {
+  const out = [...row]
+  while (out.length > 0 && out[out.length - 1] === null) out.pop()
+  return out.map(norm)
+}
+
+function corpus(): string[] {
+  const out: string[] = []
+  for (const dir of ["test/fixtures", "test/fixtures/third-party"]) {
+    for (const file of readdirSync(dir)) {
+      if (file.endsWith(".xlsx")) out.push(`${dir}/${file}`)
+    }
+  }
+  return out.sort()
+}
+
+describe("the two XLSX readers agree, on files hucre did not write", () => {
+  it("row for row, across the whole corpus", async () => {
+    const diffs: string[] = []
+
+    for (const path of corpus()) {
+      const bytes = new Uint8Array(readFileSync(path))
+
+      let sheets
+      try {
+        sheets = (await readXlsx(bytes)).sheets
+      } catch {
+        // Over a documented limit — `excel-sparse.xlsx` is the one, and
+        // `test/sparse-read.test.ts` owns that case.
+        continue
+      }
+
+      // Sheet 0 only: see the test below for why that is not a shortcut.
+      const first = sheets[0]
+      if (!first) continue
+
+      const seen = new Set<number>()
+      for await (const row of streamXlsxRows(bytes)) {
+        const want = first.rows[row.index]
+        const streamed = JSON.stringify(trim(row.values ?? []))
+        const buffered = JSON.stringify(trim(want ?? []))
+
+        if (streamed !== buffered && diffs.length < 8) {
+          diffs.push(`${path} row ${row.index}\n  stream ${streamed}\n  buffer ${buffered}`)
+        }
+        seen.add(row.index)
+      }
+
+      // Anything the stream left out has to have been empty.
+      first.rows.forEach((values: CellValue[], index: number) => {
+        if (seen.has(index)) return
+        if (values.some((v) => v !== null && v !== "") && diffs.length < 8) {
+          diffs.push(
+            `${path} row ${index} skipped but not empty: ${JSON.stringify(values.map(norm))}`,
+          )
+        }
+      })
+    }
+
+    expect(diffs).toEqual([])
+  })
+})
+
+describe("an ISO date cell is a Date in both readers", () => {
+  // openpyxl writes `t="d"` whenever `iso_dates=True`. It is the one
+  // member of ST_CellType that carries a date rather than a serial, and
+  // the streaming reader had no case for it.
+  const FIXTURE = "test/fixtures/openpyxl-isodates.xlsx"
+
+  async function streamed(): Promise<CellValue[][]> {
+    const rows: CellValue[][] = []
+    for await (const row of streamXlsxRows(new Uint8Array(readFileSync(FIXTURE)))) {
+      rows[row.index] = row.values
+    }
+    return rows
+  }
+
+  it("a plain date", async () => {
+    const rows = await streamed()
+
+    expect(rows[0]![1]).toBeInstanceOf(Date)
+    expect((rows[0]![1] as Date).toISOString()).toBe("2024-03-17T00:00:00.000Z")
+  })
+
+  it("a date-time, read as UTC when it names no zone", async () => {
+    const rows = await streamed()
+
+    expect((rows[1]![1] as Date).toISOString()).toBe("2024-03-17T13:45:30.000Z")
+  })
+
+  it("matching the buffered reader exactly", async () => {
+    const buffered = (await readXlsx(new Uint8Array(readFileSync(FIXTURE)))).sheets[0]!.rows
+    const rows = await streamed()
+
+    for (let i = 0; i < buffered.length; i++) {
+      expect(trim(rows[i] ?? []), `row ${i}`).toEqual(trim(buffered[i]!))
+    }
+  })
+})
+
+describe("the sheet each streaming reader walks", () => {
+  it("streamXlsxRows reads one sheet, and `sheet` chooses it", async () => {
+    // Not a defect, but not obvious either, and it differs from
+    // `streamOdsRows`, which walks every sheet in the document. A caller
+    // moving between the two formats loses sheets silently otherwise.
+    const bytes = new Uint8Array(readFileSync("test/fixtures/third-party/multi-sheet.xlsx"))
+
+    const fromDefault: CellValue[][] = []
+    for await (const row of streamXlsxRows(bytes)) fromDefault.push(row.values)
+
+    const fromSecond: CellValue[][] = []
+    for await (const row of streamXlsxRows(bytes, { sheet: 1 })) fromSecond.push(row.values)
+
+    const wb = await readXlsx(bytes)
+    expect(wb.sheets.length).toBeGreaterThan(1)
+    expect(trim(fromDefault[0]!)).toEqual(trim(wb.sheets[0]!.rows[0]!))
+    expect(trim(fromSecond[0]!)).toEqual(trim(wb.sheets[1]!.rows[0]!))
+    expect(trim(fromDefault[0]!)).not.toEqual(trim(fromSecond[0]!))
+  })
+})

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -27,6 +27,7 @@
     "test/ods-third-party.test.ts",
     "test/worksheet-stream-chunks.test.ts",
     "test/xlsb-short-records.test.ts",
+    "test/xlsx-stream-parity.test.ts",
     "test/write-model.test.ts",
     "test/builder-coverage.test.ts"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,7 @@
     "test/ods-third-party.test.ts",
     "test/worksheet-stream-chunks.test.ts",
     "test/xlsb-short-records.test.ts",
+    "test/xlsx-stream-parity.test.ts",
     "test/builder-coverage.test.ts"
   ]
 }


### PR DESCRIPTION
XLSX has two readers and **they had never been compared**. The ODS pair were, and that comparison found #525; the XLSX pair had spot checks — a chartsheet here, a row count there — and no sweep.

Sweeping them found the same class of bug, and it is mine.

## The defect

#496 taught the **buffered** reader openpyxl's `t="d"` cells — the ISO 8601 date form of `ST_CellType` — and left the streaming reader on the `n` path, where `Number("2024-03-17")` is NaN and the text falls through as a string:

```
readXlsx         Date 2024-03-17T00:00:00.000Z
streamXlsxRows   "2024-03-17"
```

One fix, two implementations, and only one of them got it. openpyxl writes this whenever `iso_dates=True`, so it is not an exotic shape.

`parseIsoCellDate` is now **exported and shared** rather than copied, so the two cannot drift on the next spelling someone accepts. A bare time (`13:45:30`, openpyxl's `datetime.time`) is left as text in both — it has no day to anchor it, and guessing one onto an epoch is worse than leaving it.

## The sweep is kept

It compares every `.xlsx` in the corpus — Excel, openpyxl, ExcelJS — row by row, allowing for the two differences `docs/PARITY.md` already documents: the buffered reader pads rows to the bounding box, and the stream skips empty rows while keeping the true index (so rows are matched by `index`, not position).

## And one thing that was nowhere written down

`streamXlsxRows` walks **one** sheet — the first, unless `sheet` names another. `streamOdsRows` walks **every** sheet and tags each row with `sheetIndex`.

So the same loop over a three-sheet workbook gives you one sheet of it as `.xlsx` and all three as `.ods`, silently. Not a defect on either side, but a trap for anyone moving between the two formats. Now stated in `PARITY.md` and pinned by a test, next to the sentence that used to say only that the streaming readers *do* agree.

Four tests fail with the new `case "d"` removed and pass with it — checked by editing the file in place rather than by stashing.

`pnpm test` green — 10,535 tests, 227 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
