### PR TITLE
feat(xlsx): resolve indexed colours against the palette, including an overridden one

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -452,6 +452,19 @@ the workbook-level caches, and has no write counterpart because
 
 Three cases where a field is carried but a particular _value_ is not.
 
+**An indexed colour outside the palette keeps its index and no RGB.**
+A colour may name a palette index rather than an RGB. hucre resolves those
+against the file's `<indexedColors>` when it overrides the palette and
+against the ECMA-376 §18.8.27 defaults otherwise, so `ColorSpec` carries
+both the `indexed` it was given and the `rgb` it stands for.
+
+Two indices are not colours: 64 is the system foreground and 65 the system
+background, and the specification gives neither an ARGB. Those keep the
+index and get no `rgb`, because the colour depends on the reader's own
+theme and inventing one would be answering a question the file did not
+ask. The same is true of any index past the end of the palette — Excel
+writes 81 for tooltip text.
+
 **A cell whose text is literally `_x0041_` reads back as `A` — in XLSX.**
 OOXML uses `_xHHHH_` to encode characters XML cannot hold, and hucre
 decodes it on read. Excel disambiguates by escaping a leading underscore

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -10,7 +10,7 @@ Corpus: 35 workbooks under `test/fixtures`, 280 distinct element names, 169 dist
 
 ## SpreadsheetML (ECMA-376 Part 1)
 
-360 complex types. **33** names appear in the corpus and are _nowhere_ in `src/`; 5 appear in the corpus and occur in `src/` only inside a longer string, which usually means a writer emits them in a template; 625 the source switches on directly; 510 it knows but the corpus does not use; 919 are in neither.
+360 complex types. **31** names appear in the corpus and are _nowhere_ in `src/`; 5 appear in the corpus and occur in `src/` only inside a longer string, which usually means a writer emits them in a template; 627 the source switches on directly; 510 it knows but the corpus does not use; 919 are in neither.
 
 ### Not yet looked at
 
@@ -20,36 +20,34 @@ signal this report exists for.
 
 ### Looked at, and left
 
-| name                     | kind      | why                                                                                                                                                                                               |
-| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autoFilterDateGrouping` | attribute | view state — not modelled                                                                                                                                                                         |
-| `firstSheet`             | attribute | view state — not modelled                                                                                                                                                                         |
-| `minimized`              | attribute | window geometry — not modelled                                                                                                                                                                    |
-| `showHorizontalScroll`   | attribute | window geometry — not modelled                                                                                                                                                                    |
-| `showSheetTabs`          | attribute | window geometry — not modelled                                                                                                                                                                    |
-| `showVerticalScroll`     | attribute | window geometry — not modelled                                                                                                                                                                    |
-| `tabRatio`               | attribute | window geometry — not modelled                                                                                                                                                                    |
-| `visibility`             | attribute | window visibility — not modelled                                                                                                                                                                  |
-| `tabSelected`            | attribute | view state — not modelled                                                                                                                                                                         |
-| `zoomToFit`              | attribute | view state — not modelled                                                                                                                                                                         |
-| `indexedColors`          | element   | **open** — the legacy palette. `ColorSpec.indexed` carries the _index_ and hucre has no palette to resolve it against, so a file that overrides the palette is dropped silently. Not in PARITY.md |
-| `shapeId`                | attribute | the VML shape a comment or control is drawn as. hucre generates its own on write and does not need the file's on read                                                                             |
-| `appName`                | attribute | writer provenance — not modelled                                                                                                                                                                  |
-| `lastEdited`             | attribute | writer provenance — not modelled                                                                                                                                                                  |
-| `lowestEdited`           | attribute | writer provenance — not modelled                                                                                                                                                                  |
-| `rupBuild`               | attribute | writer provenance — not modelled                                                                                                                                                                  |
-| `rgbColor`               | element   | **open** — an entry of the `indexedColors` palette above                                                                                                                                          |
-| `quotePrefix`            | attribute | **open** — marks a cell forced to text by a leading apostrophe. The value is already a string in the file, so nothing is lost from `rows`; the flag itself is not carried                         |
-| `customFormat`           | attribute | restates that the row has a style, which the style says                                                                                                                                           |
-| `spans`                  | attribute | a hint at which columns a row uses. hucre derives that from the cells themselves, which is the authority — Excel treats a wrong `spans` as advisory too                                           |
-| `activeCell`             | attribute | view state — not modelled                                                                                                                                                                         |
-| `baseColWidth`           | attribute | **open** — the base width column widths are relative to. hucre assumes the 8.43 default; a file that sets another makes every width wrong                                                         |
-| `outlineLevelCol`        | attribute | summary of the per-column outline levels hucre reads                                                                                                                                              |
-| `outlineLevelRow`        | attribute | summary of the per-row outline levels hucre reads                                                                                                                                                 |
-| `fileVersion`            | element   | writer provenance — not modelled                                                                                                                                                                  |
-| `defaultThemeVersion`    | attribute | writer provenance — not modelled                                                                                                                                                                  |
-| `filterPrivacy`          | attribute | privacy flag, no data — not modelled                                                                                                                                                              |
-| `pivotButton`            | attribute | pivot UI affordance — pivots are round-trip only                                                                                                                                                  |
+| name                     | kind      | why                                                                                                                                                                       |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `autoFilterDateGrouping` | attribute | view state — not modelled                                                                                                                                                 |
+| `firstSheet`             | attribute | view state — not modelled                                                                                                                                                 |
+| `minimized`              | attribute | window geometry — not modelled                                                                                                                                            |
+| `showHorizontalScroll`   | attribute | window geometry — not modelled                                                                                                                                            |
+| `showSheetTabs`          | attribute | window geometry — not modelled                                                                                                                                            |
+| `showVerticalScroll`     | attribute | window geometry — not modelled                                                                                                                                            |
+| `tabRatio`               | attribute | window geometry — not modelled                                                                                                                                            |
+| `visibility`             | attribute | window visibility — not modelled                                                                                                                                          |
+| `tabSelected`            | attribute | view state — not modelled                                                                                                                                                 |
+| `zoomToFit`              | attribute | view state — not modelled                                                                                                                                                 |
+| `shapeId`                | attribute | the VML shape a comment or control is drawn as. hucre generates its own on write and does not need the file's on read                                                     |
+| `appName`                | attribute | writer provenance — not modelled                                                                                                                                          |
+| `lastEdited`             | attribute | writer provenance — not modelled                                                                                                                                          |
+| `lowestEdited`           | attribute | writer provenance — not modelled                                                                                                                                          |
+| `rupBuild`               | attribute | writer provenance — not modelled                                                                                                                                          |
+| `quotePrefix`            | attribute | **open** — marks a cell forced to text by a leading apostrophe. The value is already a string in the file, so nothing is lost from `rows`; the flag itself is not carried |
+| `customFormat`           | attribute | restates that the row has a style, which the style says                                                                                                                   |
+| `spans`                  | attribute | a hint at which columns a row uses. hucre derives that from the cells themselves, which is the authority — Excel treats a wrong `spans` as advisory too                   |
+| `activeCell`             | attribute | view state — not modelled                                                                                                                                                 |
+| `baseColWidth`           | attribute | **open** — the base width column widths are relative to. hucre assumes the 8.43 default; a file that sets another makes every width wrong                                 |
+| `outlineLevelCol`        | attribute | summary of the per-column outline levels hucre reads                                                                                                                      |
+| `outlineLevelRow`        | attribute | summary of the per-row outline levels hucre reads                                                                                                                         |
+| `fileVersion`            | element   | writer provenance — not modelled                                                                                                                                          |
+| `defaultThemeVersion`    | attribute | writer provenance — not modelled                                                                                                                                          |
+| `filterPrivacy`          | attribute | privacy flag, no data — not modelled                                                                                                                                      |
+| `pivotButton`            | attribute | pivot UI affordance — pivots are round-trip only                                                                                                                          |
 
 ## OpenDocument (OASIS ODF 1.3)
 

--- a/scripts/spec-coverage.mjs
+++ b/scripts/spec-coverage.mjs
@@ -283,8 +283,8 @@ const REVIEWED = new Map(
     baseColWidth:
       "**open** — the base width column widths are relative to. hucre assumes the 8.43 default; a file that sets another makes every width wrong",
     indexedColors:
-      "**open** — the legacy palette. `ColorSpec.indexed` carries the *index* and hucre has no palette to resolve it against, so a file that overrides the palette is dropped silently. Not in PARITY.md",
-    rgbColor: "**open** — an entry of the `indexedColors` palette above",
+      "read since #546 — the palette a file overrides, applied to every colour that names an index. Indices 64 and 65 stay unresolved: they are the system foreground and background and have no ARGB",
+    rgbColor: "read since #546 — an entry of the `indexedColors` palette above",
   }),
 )
 

--- a/src/xlsx/indexed-palette.ts
+++ b/src/xlsx/indexed-palette.ts
@@ -1,0 +1,98 @@
+// ── The legacy indexed colour palette ────────────────────────────────
+//
+// A colour can name a palette index instead of an RGB — `indexed="2"` —
+// and hucre carried the index and nothing else, because it had no palette
+// to resolve it against. A caller got `{ indexed: 2 }` and no way to know
+// that means red, and a file that *overrode* the palette was dropped
+// entirely: `<indexedColors>` was not read at all, so even a caller with
+// its own copy of the defaults got the wrong answer for those files.
+//
+// Found by `scripts/spec-coverage.mjs`, which crosses the schema with the
+// fixture corpus: `indexedColors` and `rgbColor` are in ECMA-376, and in
+// the corpus, and were nowhere in `src/`.
+//
+// ECMA-376 Part 1 §18.8.27 defines the defaults and says why they are odd:
+// "0-7 are redundant of 8-15 to preserve backwards compatibility". Indices
+// 64 and 65 are the system foreground and background — they have no ARGB
+// in the table and are deliberately absent here, so a colour naming one
+// stays unresolved rather than being given a colour the file did not
+// choose.
+//
+// The values were lifted from the specification text rather than typed
+// from memory, and cross-checked against the `<indexedColors>` block
+// openpyxl writes into `test/fixtures/openpyxl-basic.xlsx` — an
+// independent implementation, agreeing on all 64.
+
+/**
+ * Indices 0-63 of the default palette, as 6-digit RGB.
+ *
+ * The spec writes them ARGB with a `00` alpha, which is not transparency
+ * — `ColorSpec.rgb` is 6 hex digits, so the prefix is dropped here as it
+ * is everywhere else in the reader.
+ */
+export const DEFAULT_INDEXED_PALETTE: readonly string[] = [
+  "000000", // 0
+  "FFFFFF", // 1
+  "FF0000", // 2
+  "00FF00", // 3
+  "0000FF", // 4
+  "FFFF00", // 5
+  "FF00FF", // 6
+  "00FFFF", // 7
+  "000000", // 8
+  "FFFFFF", // 9
+  "FF0000", // 10
+  "00FF00", // 11
+  "0000FF", // 12
+  "FFFF00", // 13
+  "FF00FF", // 14
+  "00FFFF", // 15
+  "800000", // 16
+  "008000", // 17
+  "000080", // 18
+  "808000", // 19
+  "800080", // 20
+  "008080", // 21
+  "C0C0C0", // 22
+  "808080", // 23
+  "9999FF", // 24
+  "993366", // 25
+  "FFFFCC", // 26
+  "CCFFFF", // 27
+  "660066", // 28
+  "FF8080", // 29
+  "0066CC", // 30
+  "CCCCFF", // 31
+  "000080", // 32
+  "FF00FF", // 33
+  "FFFF00", // 34
+  "00FFFF", // 35
+  "800080", // 36
+  "800000", // 37
+  "008080", // 38
+  "0000FF", // 39
+  "00CCFF", // 40
+  "CCFFFF", // 41
+  "CCFFCC", // 42
+  "FFFF99", // 43
+  "99CCFF", // 44
+  "FF99CC", // 45
+  "CC99FF", // 46
+  "FFCC99", // 47
+  "3366FF", // 48
+  "33CCCC", // 49
+  "99CC00", // 50
+  "FFCC00", // 51
+  "FF9900", // 52
+  "FF6600", // 53
+  "666699", // 54
+  "969696", // 55
+  "003366", // 56
+  "339966", // 57
+  "003300", // 58
+  "333300", // 59
+  "993300", // 60
+  "993366", // 61
+  "333399", // 62
+  "333333", // 63
+]

--- a/src/xlsx/styles.ts
+++ b/src/xlsx/styles.ts
@@ -16,6 +16,7 @@ import type {
 } from "../_types"
 import { parseXml } from "../xml/parser"
 import { isBuiltinDateFormatId, isDateFormat } from "../_date"
+import { DEFAULT_INDEXED_PALETTE } from "./indexed-palette"
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -134,7 +135,75 @@ export function parseStyles(xml: string): ParsedStyles {
     }
   }
 
+  // `<colors>` comes *after* the fonts and fills that reference it — the
+  // schema puts it near the end of CT_Stylesheet — so the palette cannot
+  // be applied as those are parsed. Resolving afterwards is what makes
+  // the order irrelevant.
+  const palette = readIndexedPalette(doc)
+  for (const group of [fonts, fills, borders, dxfs]) resolveIndexed(group, palette)
+
   return { numFmts, fonts, fills, borders, cellXfs, dxfs }
+}
+
+// ── Indexed colours ──────────────────────────────────────────────────
+
+/**
+ * The palette this stylesheet uses: its own if it overrides one.
+ *
+ * §18.8.27: "When using the default indexed color palette, the values are
+ * not written out, but instead are implied. When the color palette has
+ * been modified from default, then the entire color palette is written
+ * out." So an absent `<indexedColors>` means the defaults, not none.
+ */
+function readIndexedPalette(doc: XmlElement): readonly string[] {
+  for (const child of doc.children) {
+    if (typeof child === "string") continue
+    if ((child.local || child.tag) !== "colors") continue
+
+    for (const sub of child.children) {
+      if (typeof sub === "string") continue
+      if ((sub.local || sub.tag) !== "indexedColors") continue
+
+      const entries: string[] = []
+      for (const entry of sub.children) {
+        if (typeof entry === "string") continue
+        if ((entry.local || entry.tag) !== "rgbColor") continue
+        const rgb = entry.attrs["rgb"]
+        if (rgb) entries.push(rgb.length === 8 ? rgb.slice(2) : rgb)
+      }
+      if (entries.length > 0) return entries
+    }
+  }
+  return DEFAULT_INDEXED_PALETTE
+}
+
+/**
+ * Give every colour that named an index the RGB it stands for.
+ *
+ * Walks the parsed structures rather than threading a palette through
+ * `parseColor`, because the palette is not known until the whole
+ * stylesheet has been read. `indexed` is a field only `Color` has in this
+ * model, so matching on it is safe; an existing `rgb` always wins,
+ * because the file said the colour outright and the index is only the
+ * legacy spelling of one.
+ */
+function resolveIndexed(value: unknown, palette: readonly string[]): void {
+  if (value === null || typeof value !== "object") return
+  if (Array.isArray(value)) {
+    for (const item of value) resolveIndexed(item, palette)
+    return
+  }
+
+  const record = value as Record<string, unknown>
+  if (typeof record["indexed"] === "number" && typeof record["rgb"] !== "string") {
+    const rgb = palette[record["indexed"] as number]
+    // Indices past the palette — 64 and 65 are the system foreground and
+    // background — have no colour, and inventing one would be worse than
+    // leaving the caller the index it can interpret itself.
+    if (rgb) record["rgb"] = rgb
+  }
+
+  for (const nested of Object.values(record)) resolveIndexed(nested, palette)
 }
 
 // ── Number Formats ───────────────────────────────────────────────────

--- a/test/indexed-color-palette.test.ts
+++ b/test/indexed-color-palette.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest"
+import { readFileSync } from "node:fs"
+import { parseStyles } from "../src/xlsx/styles"
+import { ZipReader } from "../src/zip/reader"
+import { readXlsx } from "../src/xlsx/reader"
+import { DEFAULT_INDEXED_PALETTE } from "../src/xlsx/indexed-palette"
+
+// ═══════════════════════════════════════════════════════════════════════
+// A colour can name a palette index instead of an RGB — `indexed="2"` —
+// and hucre carried the index and nothing else. A caller got
+// `{ indexed: 2 }` with no way to know that means red, and a file that
+// *overrode* the palette was dropped entirely: `<indexedColors>` was
+// never read, so even a caller carrying its own copy of the defaults got
+// the wrong answer for those files.
+//
+// Found by `scripts/spec-coverage.mjs` rather than by anyone noticing:
+// `indexedColors` and `rgbColor` are in ECMA-376, and in the fixture
+// corpus, and were nowhere in `src/`. That is the report's whole purpose
+// and this is the first thing it caught.
+//
+// Indices 64 and 65 are the system foreground and background. They have
+// no ARGB in §18.8.27 and stay unresolved here — giving them a colour the
+// file did not choose would be worse than leaving them.
+// ═══════════════════════════════════════════════════════════════════════
+
+/** A stylesheet with one font colour and an optional palette override. */
+function stylesXml(colorAttrs: string, palette?: string[]): string {
+  const colors = palette
+    ? `<colors><indexedColors>${palette
+        .map((rgb) => `<rgbColor rgb="${rgb}"/>`)
+        .join("")}</indexedColors></colors>`
+    : ""
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+    `<fonts count="1"><font><color ${colorAttrs}/></font></fonts>` +
+    '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>' +
+    '<borders count="1"><border/></borders>' +
+    '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs>' +
+    colors +
+    "</styleSheet>"
+  )
+}
+
+describe("an indexed colour resolves to its palette entry", () => {
+  it("through the default palette", () => {
+    const styles = parseStyles(stylesXml('indexed="2"'))
+
+    expect(styles.fonts[0]!.color?.rgb).toBe("FF0000")
+  })
+
+  it("keeping the index alongside it", () => {
+    // Additive: a caller reading `indexed` still finds it.
+    const styles = parseStyles(stylesXml('indexed="4"'))
+
+    expect(styles.fonts[0]!.color?.indexed).toBe(4)
+    expect(styles.fonts[0]!.color?.rgb).toBe("0000FF")
+  })
+
+  it("and through a palette the file overrides", () => {
+    // The case that was dropped completely. A caller with its own copy of
+    // the defaults still got this wrong, because the override never
+    // reached it.
+    const custom = Array.from({ length: 64 }, (_, i) => (i === 2 ? "00123456" : "00000000"))
+    const styles = parseStyles(stylesXml('indexed="2"', custom))
+
+    expect(styles.fonts[0]!.color?.rgb).toBe("123456")
+  })
+
+  it("in a fill as well as a font", () => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">' +
+      '<fonts count="1"><font/></fonts>' +
+      '<fills count="1"><fill><patternFill patternType="solid">' +
+      '<fgColor indexed="5"/><bgColor indexed="6"/>' +
+      "</patternFill></fill></fills>" +
+      '<borders count="1"><border/></borders>' +
+      '<cellXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellXfs>' +
+      "</styleSheet>"
+
+    const fill = parseStyles(xml).fills[0]!
+
+    expect(fill.type).toBe("pattern")
+    if (fill.type === "pattern") {
+      expect(fill.fgColor?.rgb).toBe("FFFF00")
+      expect(fill.bgColor?.rgb).toBe("FF00FF")
+    }
+  })
+})
+
+describe("the indices that are not colours stay unresolved", () => {
+  it("64 and 65 are the system foreground and background", () => {
+    for (const indexed of [64, 65]) {
+      const color = parseStyles(stylesXml(`indexed="${indexed}"`)).fonts[0]!.color
+
+      expect(color?.indexed, `indexed ${indexed}`).toBe(indexed)
+      expect(color?.rgb, `indexed ${indexed}`).toBeUndefined()
+    }
+  })
+
+  it("and an index past the palette is left alone", () => {
+    const color = parseStyles(stylesXml('indexed="81"')).fonts[0]!.color
+
+    expect(color?.indexed).toBe(81)
+    expect(color?.rgb).toBeUndefined()
+  })
+
+  it("an explicit rgb wins over the index", () => {
+    // Both can be present. The file said the colour outright; the index
+    // is the legacy spelling of it and must not overwrite.
+    const color = parseStyles(stylesXml('rgb="FF00AABB" indexed="2"')).fonts[0]!.color
+
+    expect(color?.rgb).toBe("00AABB")
+  })
+})
+
+describe("the palette itself", () => {
+  it("is the 64 entries §18.8.27 defines", () => {
+    expect(DEFAULT_INDEXED_PALETTE).toHaveLength(64)
+    // The first eight, which the spec notes are redundant of 8-15.
+    expect(DEFAULT_INDEXED_PALETTE.slice(0, 8)).toEqual([
+      "000000",
+      "FFFFFF",
+      "FF0000",
+      "00FF00",
+      "0000FF",
+      "FFFF00",
+      "FF00FF",
+      "00FFFF",
+    ])
+    expect(DEFAULT_INDEXED_PALETTE.slice(8, 16)).toEqual(DEFAULT_INDEXED_PALETTE.slice(0, 8))
+    expect(DEFAULT_INDEXED_PALETTE[63]).toBe("333333")
+  })
+
+  it("matches the one openpyxl writes, independently", async () => {
+    // `openpyxl-basic.xlsx` carries the default palette written out in
+    // full. Two implementations of one table: the values here came from
+    // the specification text, and these came from openpyxl. If they
+    // disagree, one of them is wrong and it is worth knowing which.
+    const zip = new ZipReader(new Uint8Array(readFileSync("test/fixtures/openpyxl-basic.xlsx")))
+    const xml = new TextDecoder().decode(await zip.extract("xl/styles.xml"))
+    const block = xml.match(/<indexedColors>([\s\S]*?)<\/indexedColors>/)
+
+    expect(block, "openpyxl-basic.xlsx should carry an indexedColors block").not.toBeNull()
+
+    const theirs = [...block![1]!.matchAll(/rgb="([0-9A-Fa-f]{8})"/g)].map((m) =>
+      m[1]!.slice(2).toUpperCase(),
+    )
+
+    expect(theirs).toHaveLength(64)
+    expect(theirs).toEqual([...DEFAULT_INDEXED_PALETTE])
+  })
+})
+
+describe("real files keep working", () => {
+  it("excel-styled.xlsx names index 64, which stays a system colour", async () => {
+    // The corpus uses 64 and 81, both outside the palette — so this fix
+    // changes nothing about what those files read back as, which is the
+    // point of the boundary cases above.
+    const bytes = new Uint8Array(readFileSync("test/fixtures/excel-styled.xlsx"))
+    const wb = await readXlsx(bytes, { readStyles: true })
+    const styled = [...(wb.sheets[0]!.cells?.values() ?? [])]
+
+    expect(styled.length).toBeGreaterThan(0)
+    for (const cell of styled) {
+      const color = cell.style?.font?.color
+      if (color?.indexed === 64) expect(color.rgb).toBeUndefined()
+    }
+  })
+})

--- a/test/styles-parser.test.ts
+++ b/test/styles-parser.test.ts
@@ -207,10 +207,14 @@ describe("parseStyles — colors", () => {
   })
 
   it("reads theme 0 and tint 0 rather than treating them as absent", () => {
+    // The point is the zeros: none of them may be dropped as falsy.
+    // `rgb` joins them because index 0 is black in the palette — see
+    // test/indexed-color-palette.test.ts. The index itself still stands.
     expect(font('<color theme="0" tint="0" indexed="0"/>').color).toEqual({
       theme: 0,
       tint: 0,
       indexed: 0,
+      rgb: "000000",
     })
   })
 

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -28,6 +28,7 @@
     "test/worksheet-stream-chunks.test.ts",
     "test/xlsb-short-records.test.ts",
     "test/xlsx-stream-parity.test.ts",
+    "test/indexed-color-palette.test.ts",
     "test/write-model.test.ts",
     "test/builder-coverage.test.ts"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,6 +48,7 @@
     "test/worksheet-stream-chunks.test.ts",
     "test/xlsb-short-records.test.ts",
     "test/xlsx-stream-parity.test.ts",
+    "test/indexed-color-palette.test.ts",
     "test/builder-coverage.test.ts"
   ]
 }


### PR DESCRIPTION
The first thing #544's spec-coverage report found, and it is a real loss.

A colour may name a legacy palette index rather than an RGB — `indexed="2"`. hucre carried the index and **nothing else**, because it had no palette to resolve it against. A caller got `{ indexed: 2 }` and no way to know that means red.

Worse: **a file that overrode the palette was dropped entirely.** `<indexedColors>` was never read, so even a caller carrying its own copy of the defaults got the wrong colour for exactly the files where the defaults are wrong. openpyxl writes that block into every workbook it produces.

## What changes

`ColorSpec` now carries both — the `indexed` it was given and the `rgb` it stands for:

```
<color indexed="2"/>   →   { indexed: 2, rgb: "FF0000" }
```

An explicit `rgb` still wins: the file said the colour outright, and the index is only the legacy spelling of one.

**Indices 64 and 65 stay unresolved.** They are the system foreground and background; §18.8.27 gives neither an ARGB, and the colour depends on the reader's own theme. Inventing one would answer a question the file did not ask. Same for any index past the palette — Excel writes 81 for tooltip text, and the corpus contains both 64 and 81.

Resolution runs after the whole stylesheet is parsed, because the schema puts `<colors>` *after* the fonts and fills that reference it.

## Where the numbers came from

Not from memory. Extracted from the ECMA-376 Part 1 specification text (§18.8.27, the table that also explains why indices 0–7 duplicate 8–15: "to preserve backwards compatibility"), then **cross-checked against the `<indexedColors>` block openpyxl writes** into `test/fixtures/openpyxl-basic.xlsx`.

Two implementations of one table, agreeing on all 64 entries. That check is a test, so if they ever disagree it says so rather than me having to remember to look.

## Documentation

`PARITY.md` now states what remains lost — only the two system indices — since the report's whole finding was that this loss was on no page. The triage entry in `spec-coverage.mjs` moves from **open** to done, so a regeneration does not re-raise it.

One existing expectation in `styles-parser.test.ts` gained an `rgb`. Its subject is that `theme="0" tint="0" indexed="0"` are not dropped as falsy — which still holds — and index 0 is black. The neighbouring case asserting `indexed="64"` stays bare passes untouched, which is the boundary holding.

Four tests fail with the resolution pass removed and pass with it.

`pnpm test` green — 10,545 tests, 228 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
