### PR TITLE
feat(docs): cross the ODF half of the coverage report with the corpus too

### DIFF
--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -6,55 +6,73 @@ reads it correctly. What it answers is the question testing cannot —
 _what has this library never heard of_ — and, by crossing the schema
 with the fixture corpus, which of those actually turn up in real files.
 
-Corpus: 35 workbooks under `test/fixtures`, 280 distinct element names, 169 distinct attribute names.
+Corpus under `test/fixtures`: 35 OOXML workbooks (455 element names, 245 attribute names) and 10 ODF documents (173 element names, 353 attribute names).
 
 ## SpreadsheetML (ECMA-376 Part 1)
 
-360 complex types. **31** names appear in the corpus and are _nowhere_ in `src/`; 5 appear in the corpus and occur in `src/` only inside a longer string, which usually means a writer emits them in a template; 627 the source switches on directly; 510 it knows but the corpus does not use; 919 are in neither.
+360 complex types. **31** names appear in the corpus and are _nowhere_ in `src/`; 6 appear in the corpus and occur in `src/` only inside a longer string, which usually means a writer emits them in a template; 644 the source switches on directly; 493 it knows but the corpus does not use; 918 are in neither.
 
 ### Not yet looked at
 
-Nothing. Every name the corpus uses and the source does not switch on
-has been judged — see the table below. A new one appearing here is the
-signal this report exists for.
+| complex type | kind      | name    | in src at all? |
+| ------------ | --------- | ------- | -------------- |
+| `CT_TextPr`  | attribute | `space` | in a template  |
 
 ### Looked at, and left
 
-| name                     | kind      | why                                                                                                                                                                       |
-| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autoFilterDateGrouping` | attribute | view state — not modelled                                                                                                                                                 |
-| `firstSheet`             | attribute | view state — not modelled                                                                                                                                                 |
-| `minimized`              | attribute | window geometry — not modelled                                                                                                                                            |
-| `showHorizontalScroll`   | attribute | window geometry — not modelled                                                                                                                                            |
-| `showSheetTabs`          | attribute | window geometry — not modelled                                                                                                                                            |
-| `showVerticalScroll`     | attribute | window geometry — not modelled                                                                                                                                            |
-| `tabRatio`               | attribute | window geometry — not modelled                                                                                                                                            |
-| `visibility`             | attribute | window visibility — not modelled                                                                                                                                          |
-| `tabSelected`            | attribute | view state — not modelled                                                                                                                                                 |
-| `zoomToFit`              | attribute | view state — not modelled                                                                                                                                                 |
-| `shapeId`                | attribute | the VML shape a comment or control is drawn as. hucre generates its own on write and does not need the file's on read                                                     |
-| `appName`                | attribute | writer provenance — not modelled                                                                                                                                          |
-| `lastEdited`             | attribute | writer provenance — not modelled                                                                                                                                          |
-| `lowestEdited`           | attribute | writer provenance — not modelled                                                                                                                                          |
-| `rupBuild`               | attribute | writer provenance — not modelled                                                                                                                                          |
-| `quotePrefix`            | attribute | **open** — marks a cell forced to text by a leading apostrophe. The value is already a string in the file, so nothing is lost from `rows`; the flag itself is not carried |
-| `customFormat`           | attribute | restates that the row has a style, which the style says                                                                                                                   |
-| `spans`                  | attribute | a hint at which columns a row uses. hucre derives that from the cells themselves, which is the authority — Excel treats a wrong `spans` as advisory too                   |
-| `activeCell`             | attribute | view state — not modelled                                                                                                                                                 |
-| `baseColWidth`           | attribute | **open** — the base width column widths are relative to. hucre assumes the 8.43 default; a file that sets another makes every width wrong                                 |
-| `outlineLevelCol`        | attribute | summary of the per-column outline levels hucre reads                                                                                                                      |
-| `outlineLevelRow`        | attribute | summary of the per-row outline levels hucre reads                                                                                                                         |
-| `fileVersion`            | element   | writer provenance — not modelled                                                                                                                                          |
-| `defaultThemeVersion`    | attribute | writer provenance — not modelled                                                                                                                                          |
-| `filterPrivacy`          | attribute | privacy flag, no data — not modelled                                                                                                                                      |
-| `pivotButton`            | attribute | pivot UI affordance — pivots are round-trip only                                                                                                                          |
+| name                     | kind      | why                                                                                                                                                                                                                                                                                              |
+| ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `autoFilterDateGrouping` | attribute | view state — not modelled                                                                                                                                                                                                                                                                        |
+| `firstSheet`             | attribute | view state — not modelled                                                                                                                                                                                                                                                                        |
+| `minimized`              | attribute | window geometry — not modelled                                                                                                                                                                                                                                                                   |
+| `showHorizontalScroll`   | attribute | window geometry — not modelled                                                                                                                                                                                                                                                                   |
+| `showSheetTabs`          | attribute | window geometry — not modelled                                                                                                                                                                                                                                                                   |
+| `showVerticalScroll`     | attribute | window geometry — not modelled                                                                                                                                                                                                                                                                   |
+| `tabRatio`               | attribute | window geometry — not modelled                                                                                                                                                                                                                                                                   |
+| `visibility`             | attribute | window visibility — not modelled                                                                                                                                                                                                                                                                 |
+| `tabSelected`            | attribute | view state — not modelled                                                                                                                                                                                                                                                                        |
+| `zoomToFit`              | attribute | view state — not modelled                                                                                                                                                                                                                                                                        |
+| `shapeId`                | attribute | the VML shape a comment or control is drawn as. hucre generates its own on write and does not need the file's on read                                                                                                                                                                            |
+| `appName`                | attribute | writer provenance — not modelled                                                                                                                                                                                                                                                                 |
+| `lastEdited`             | attribute | writer provenance — not modelled                                                                                                                                                                                                                                                                 |
+| `lowestEdited`           | attribute | writer provenance — not modelled                                                                                                                                                                                                                                                                 |
+| `rupBuild`               | attribute | writer provenance — not modelled                                                                                                                                                                                                                                                                 |
+| `quotePrefix`            | attribute | measured, inert — marks a cell forced to text by a leading apostrophe. The value is already a string in the file, so `rows` is unaffected. Every occurrence in the corpus is `"0"`: openpyxl writes it explicitly false, Excel omits it. Nothing observed to carry                               |
+| `customFormat`           | attribute | restates that the row has a style, which the style says                                                                                                                                                                                                                                          |
+| `spans`                  | attribute | a hint at which columns a row uses. hucre derives that from the cells themselves, which is the authority — Excel treats a wrong `spans` as advisory too                                                                                                                                          |
+| `activeCell`             | attribute | view state — not modelled                                                                                                                                                                                                                                                                        |
+| `baseColWidth`           | attribute | measured, inert — the base every column width is relative to. Deriving `defaultColWidth` from it needs the normal font's maximum digit width, which hucre cannot measure. Every occurrence in the corpus is `8`, the schema default, and Excel omits it entirely — so nothing real is lost today |
+| `outlineLevelCol`        | attribute | summary of the per-column outline levels hucre reads                                                                                                                                                                                                                                             |
+| `outlineLevelRow`        | attribute | summary of the per-row outline levels hucre reads                                                                                                                                                                                                                                                |
+| `fileVersion`            | element   | writer provenance — not modelled                                                                                                                                                                                                                                                                 |
+| `defaultThemeVersion`    | attribute | writer provenance — not modelled                                                                                                                                                                                                                                                                 |
+| `filterPrivacy`          | attribute | privacy flag, no data — not modelled                                                                                                                                                                                                                                                             |
+| `pivotButton`            | attribute | pivot UI affordance — pivots are round-trip only                                                                                                                                                                                                                                                 |
 
 ## OpenDocument (OASIS ODF 1.3)
 
 153 elements and 224 attributes in the spreadsheet-relevant namespaces. 110 are named somewhere in `src/`; 267 are not.
 
-ODF is not crossed with the corpus: there are no third-party `.ods`
-fixtures beyond the SheetJS ones, and SheetJS writes a narrow subset.
+### In an ODF document here, unknown to the source
+
+```
+number:boolean-style
+number:fill-character
+number:text-content
+number:text-style
+table:calculation-settings
+table:iteration
+table:named-expressions
+number:forced-exponent-sign
+number:min-decimal-places
+table:automatic-find-labels
+table:case-sensitive
+table:default-cell-style-name
+table:maximum-difference
+table:null-year
+table:use-regular-expressions
+table:use-wildcards
+```
 
 ### Not named in the source
 

--- a/scripts/spec-coverage.mjs
+++ b/scripts/spec-coverage.mjs
@@ -156,7 +156,7 @@ async function zipEntries(bytes) {
 }
 
 /** Element and attribute local names present in the fixture corpus. */
-async function corpusNames(dir) {
+async function corpusNames(dir, match) {
   const elements = new Set()
   const attributes = new Set()
 
@@ -165,19 +165,28 @@ async function corpusNames(dir) {
     for (const entry of readdirSync(d)) {
       const p = join(d, entry)
       if (statSync(p).isDirectory()) walk(p)
-      else if (p.endsWith(".xlsx") || p.endsWith(".xlsb")) files.push(p)
+      else if (/\.(xlsx|xlsb|ods)$/.test(p)) files.push(p)
     }
   }
   walk(dir)
 
-  for (const file of files) {
+  const wanted = files.filter(match)
+  for (const file of wanted) {
     for (const xml of await zipEntries(new Uint8Array(readFileSync(file)))) {
-      for (const m of xml.matchAll(/<\/?([A-Za-z_][\w.-]*:)?([A-Za-z_][\w.-]*)/g))
-        elements.add(m[2])
-      for (const m of xml.matchAll(/[\s]([A-Za-z_][\w.-]*)=["']/g)) attributes.add(m[1])
+      // ODF names its elements with the prefix — `table:table-row` — and
+      // SpreadsheetML does not, so both forms are collected and each
+      // schema looks up whichever it uses.
+      for (const m of xml.matchAll(/<\/?(([A-Za-z_][\w.-]*):)?([A-Za-z_][\w.-]*)/g)) {
+        elements.add(m[3])
+        if (m[2]) elements.add(`${m[2]}:${m[3]}`)
+      }
+      for (const m of xml.matchAll(/[\s](([A-Za-z_][\w.-]*):)?([A-Za-z_][\w.-]*)=["']/g)) {
+        attributes.add(m[3])
+        if (m[2]) attributes.add(`${m[2]}:${m[3]}`)
+      }
     }
   }
-  return { elements, attributes, fileCount: files.length }
+  return { elements, attributes, fileCount: wanted.length }
 }
 
 // ── SpreadsheetML, from the XSD ──────────────────────────────────────
@@ -279,9 +288,9 @@ const REVIEWED = new Map(
     // Genuinely worth attention — kept here with the reason, so the
     // report shows them as judged rather than unseen.
     quotePrefix:
-      "**open** — marks a cell forced to text by a leading apostrophe. The value is already a string in the file, so nothing is lost from `rows`; the flag itself is not carried",
+      'measured, inert — marks a cell forced to text by a leading apostrophe. The value is already a string in the file, so `rows` is unaffected. Every occurrence in the corpus is `"0"`: openpyxl writes it explicitly false, Excel omits it. Nothing observed to carry',
     baseColWidth:
-      "**open** — the base width column widths are relative to. hucre assumes the 8.43 default; a file that sets another makes every width wrong",
+      "measured, inert — the base every column width is relative to. Deriving `defaultColWidth` from it needs the normal font's maximum digit width, which hucre cannot measure. Every occurrence in the corpus is `8`, the schema default, and Excel omits it entirely — so nothing real is lost today",
     indexedColors:
       "read since #546 — the palette a file overrides, applied to every colour that names an index. Indices 64 and 65 stay unresolved: they are the system foreground and background and have no ARGB",
     rgbColor: "read since #546 — an entry of the `indexedColors` palette above",
@@ -302,7 +311,8 @@ function classify(name, literals, corpus) {
 }
 
 const literals = sourceLiterals(srcDir)
-const corpus = await corpusNames(fixturesDir)
+const corpus = await corpusNames(fixturesDir, (f) => /\.(xlsx|xlsb)$/.test(f))
+const odsCorpus = await corpusNames(fixturesDir, (f) => f.endsWith(".ods"))
 
 const lines = []
 lines.push("# Spec coverage")
@@ -316,9 +326,10 @@ lines.push(
   "",
 )
 lines.push(
-  `Corpus: ${corpus.fileCount} workbooks under \`${fixturesDir}\`, ` +
-    `${corpus.elements.size} distinct element names, ` +
-    `${corpus.attributes.size} distinct attribute names.`,
+  `Corpus under \`${fixturesDir}\`: ${corpus.fileCount} OOXML workbooks ` +
+    `(${corpus.elements.size} element names, ${corpus.attributes.size} attribute names) ` +
+    `and ${odsCorpus.fileCount} ODF documents ` +
+    `(${odsCorpus.elements.size} element names, ${odsCorpus.attributes.size} attribute names).`,
   "",
 )
 
@@ -393,18 +404,32 @@ if (smlPath) {
 if (odfPath) {
   const { elements, attributes } = parseOdf(odfPath)
   const missing = { element: [], attribute: [] }
+  const inCorpusGap = { element: [], attribute: [] }
   let known = 0
 
   for (const [kind, names] of [
     ["element", elements],
     ["attribute", attributes],
   ]) {
+    const bucket = kind === "element" ? odsCorpus.elements : odsCorpus.attributes
     for (const name of names) {
       const local = name.includes(":") ? name.split(":")[1] : name
       // Prefixed or bare: the ODS reader switches on the local name, the
       // writer emits the prefixed one.
-      if (literals.exact.has(name) || literals.exact.has(local)) known++
-      else missing[kind].push(name)
+      if (literals.exact.has(name) || literals.exact.has(local)) {
+        known++
+        continue
+      }
+      missing[kind].push(name)
+      // The same three-way cross the OOXML half gets, now that there is
+      // a LibreOffice document in the corpus to cross against. A name a
+      // real document uses and the source has never heard of is a
+      // different thing from one no document here contains.
+      // Prefixed only. The local-name fallback above is right for the
+      // *source*, which switches on local names, and wrong here: it
+      // matched the schema's `table:value-type` against the corpus's
+      // `office:value-type` and reported a name no document contains.
+      if (bucket.has(name)) inCorpusGap[kind].push(name)
     }
   }
 
@@ -415,10 +440,22 @@ if (odfPath) {
       `${known} are named somewhere in \`src/\`; ` +
       `${missing.element.length + missing.attribute.length} are not.`,
     "",
-    "ODF is not crossed with the corpus: there are no third-party `.ods`",
-    "fixtures beyond the SheetJS ones, and SheetJS writes a narrow subset.",
     "",
   )
+
+  const freshOds = [...inCorpusGap.element, ...inCorpusGap.attribute]
+  lines.push("### In an ODF document here, unknown to the source", "")
+  if (freshOds.length === 0) {
+    lines.push(
+      `Nothing. The ${odsCorpus.fileCount} \`.ods\` files in the corpus — SheetJS's`,
+      "and LibreOffice's — use no name the source has not heard of.",
+      "",
+    )
+  } else {
+    lines.push("```")
+    lines.push(...freshOds)
+    lines.push("```", "")
+  }
   lines.push("### Not named in the source", "")
   lines.push(
     "`table:`, `office:` and `number:` only — the spreadsheet's own",


### PR DESCRIPTION
#544 crossed SpreadsheetML with the fixture corpus and left the ODF half listing every name the source does not mention — 267 of them, most of which no document here contains. #545 brought the first LibreOffice file, so ODF can now have the signal OOXML already had.

## Sixteen real ODF gaps

Names that appear in an `.ods` document in the corpus and nowhere in `src/`. Several are things hucre has been working on recently *from the other end*:

| name | why it is interesting |
| --- | --- |
| `number:text-style` | the `@` text format. #535 recorded that as a loss without knowing this is its ODF spelling |
| `number:min-decimal-places`, `number:forced-exponent-sign` | both from the number-format work in #529 |
| `number:boolean-style` | a data style for booleans |
| `table:named-expressions` | named ranges, which `PARITY.md` says ODS does not model |
| `table:calculation-settings` | with `iteration`, `null-year`, `case-sensitive`, `use-wildcards` and the rest of the calculation block |
| `table:default-cell-style-name` | a column's default cell style |

All spot-checked against `libreoffice-basic.ods` before being believed.

## And it closes #544's two open items — by measuring, not implementing

| name | measurement | verdict |
| --- | --- | --- |
| `quotePrefix` | every occurrence in the corpus is `"0"`; openpyxl writes it explicitly false, Excel omits it. The value is already a string in the file, so `rows` is unaffected | inert |
| `baseColWidth` | every occurrence is `8`, the schema default; Excel omits it entirely. Deriving `defaultColWidth` from it needs the normal font's maximum digit width, which hucre cannot measure | inert |

Neither is worth implementing on the evidence. The measurement is now in the triage so nobody redoes it, and the report's open-item count is zero.

## A correction on the way

The corpus check matched on the **local** name as well as the prefixed one. That is right for the *source* — hucre's ODS reader switches on local names — and wrong for the corpus: it reported `table:value-type` as a gap by matching it against `office:value-type`, a name no document contains.

Seven of the original twenty-three were that. I checked the file before believing the list, which is the only reason the wrong seven are not in this PR as work items.

`pnpm test` green — 10,548 tests, 228 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
