### PR TITLE
feat(ods): carry the text format, which PARITY said could not be carried

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -519,7 +519,6 @@ trip rather than reasoned about:
 | code              | comes back as | why                                                                                              |
 | ----------------- | ------------- | ------------------------------------------------------------------------------------------------ |
 | `0.00_);(0.00)`   | `0.00;(0.00)` | `_)` reserves the width of a character. ODF has no equivalent, so the padding is dropped         |
-| `@`               | _(General)_   | the text format has no data style to write; a cell already carrying a string is unaffected       |
 | `##0.0E+0`        | `0.0E+0`      | engineering notation steps the integer part in threes, which ODF spells with `exponent-interval` |
 | `#`, `#.##`       | `0`, `0.00`   | `#` is an optional digit and `0` a mandatory one. ODF counts digits, so the distinction goes     |
 | `[mm]:ss`, `[ss]` | `mm:ss`, `ss` | the elapsed marker survives on hours (`[hh]:mm`) but not on minutes or seconds alone             |
@@ -528,6 +527,15 @@ trip rather than reasoned about:
 
 `General` returning no `numFmt` is not in that list: General _is_ the
 absence of a data style, so there is nothing lost.
+
+`@` — the text format — used to be on that list, described here as having
+"no data style to write". That was wrong. ODF spells it
+`<number:text-style>` and LibreOffice writes one into every document it
+saves; hucre carries it now. The error survived because it was written
+down: a documented loss is one nobody looks at again. It was found by
+crossing the ODF grammar with a LibreOffice file
+([`SPEC-COVERAGE.md`](SPEC-COVERAGE.md)), not by anyone re-reading this
+page.
 
 Ordinary scientific formats — `0.00E+00` and its widths — do round-trip,
 through `<number:scientific-number>`. They did not until it was written:

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -162,6 +162,8 @@ function parseDataStyles(autoStyles: XmlElement): Map<string, string> {
       code = serializeDataStyleChildren(child, "currency")
     } else if (local === "date-style") {
       code = serializeDataStyleChildren(child, "date")
+    } else if (local === "text-style") {
+      code = serializeDataStyleChildren(child, "text")
     } else if (local === "time-style") {
       const truncate = child.attrs["number:truncate-on-overflow"]
       code = serializeDataStyleChildren(child, "time", truncate === "false")
@@ -208,7 +210,7 @@ function parseDataStyles(autoStyles: XmlElement): Map<string, string> {
 
 function serializeDataStyleChildren(
   el: XmlElement,
-  kind: "number" | "percentage" | "currency" | "date" | "time",
+  kind: "number" | "percentage" | "currency" | "date" | "time" | "text",
   bracketDuration = false,
 ): string {
   let out = ""
@@ -246,6 +248,9 @@ function serializeDataStyleChildren(
         "0".repeat(integerDigits) +
         (decimals > 0 ? `.${"0".repeat(decimals)}` : "") +
         `E+${"0".repeat(exponentDigits)}`
+    } else if (local === "text-content") {
+      // The placeholder for the cell's own text — Excel's `@`.
+      out += "@"
     } else if (local === "currency-symbol") {
       const text = child.children.filter((c: unknown) => typeof c === "string").join("")
       out += `"${text}"`

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -95,7 +95,7 @@ export function formatOdsDateValue(date: Date): string {
 // references a data style by name through `style:data-style-name` on
 // its `<style:style>` element.
 
-type OdsNumFmtKind = "number" | "percentage" | "currency" | "date" | "time"
+type OdsNumFmtKind = "number" | "percentage" | "currency" | "date" | "time" | "text"
 
 interface OdsNumFmtDef {
   /** Element local name (no namespace prefix) */
@@ -437,8 +437,18 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   if (!code) return undefined
 
   const trimmed = code.trim()
-  // "General" or "@" (text) — no data style needed
-  if (trimmed === "General" || trimmed === "@" || trimmed === "") return undefined
+  // `General` is the *absence* of a format, and so is the empty string.
+  if (trimmed === "General" || trimmed === "") return undefined
+
+  // `@` is not. It says "show this as text", and ODF spells that
+  // `<number:text-style>` with a `<number:text-content/>` placeholder —
+  // LibreOffice writes one into every document it saves. #535 recorded
+  // this as a loss ODS could not carry, which was wrong; the report in
+  // #547 found the spelling by crossing the grammar with a LibreOffice
+  // file.
+  if (trimmed === "@") {
+    return { kind: "text", children: [xmlSelfClose("number:text-content")] }
+  }
 
   // Excel's built-in date and time codes carry a locale prefix —
   // `[$-409]mmm-yy`, `[$-F800]dddd, mmmm dd, yyyy`. It is a hint about

--- a/test/coverage-ods-branches.test.ts
+++ b/test/coverage-ods-branches.test.ts
@@ -1166,10 +1166,14 @@ describe("ODS writer — date format code round-trips", () => {
   })
 
   it("drops formats it cannot translate rather than emitting an empty style", async () => {
-    // "General" and "@" have no ODF data-style equivalent; the cell style
-    // would carry nothing else, so no <style:style> is emitted at all.
+    // "General" is the absence of a format, so the cell style carries
+    // nothing else and no <style:style> is emitted at all.
+    //
+    // `@` used to be asserted here too, on the belief that ODF had no
+    // equivalent. It has one — `<number:text-style>` — and now round
+    // trips; see test/ods-text-format.test.ts.
     expect(await roundTrip("General")).toBeUndefined()
-    expect(await roundTrip("@")).toBeUndefined()
+    expect(await roundTrip("@")).toBe("@")
   })
 
   it("shares one data style between two different cell styles", async () => {

--- a/test/ods-numfmt.test.ts
+++ b/test/ods-numfmt.test.ts
@@ -191,15 +191,19 @@ describe("ODS writer — numFmt data styles", () => {
     expect(findChildren(autoStyles, "style")).toHaveLength(2)
   })
 
-  it("ignores numFmt = 'General' / '@'", async () => {
+  it("ignores numFmt = 'General'", async () => {
+    // `General` is the absence of a format, so there is nothing to write.
+    // `@` used to be bundled in here on the belief that ODF had no
+    // spelling for it; it does — `<number:text-style>` — and it is
+    // covered in test/ods-text-format.test.ts.
     const cells = new Map<string, Partial<Cell>>()
     cells.set("0,0", { value: 1, style: { numFmt: "General" } })
-    cells.set("0,1", { value: 2, style: { numFmt: "@" } })
     const data = await writeOds({
-      sheets: [{ name: "Sheet1", rows: [[1, 2]], cells }],
+      sheets: [{ name: "Sheet1", rows: [[1]], cells }],
     })
     const autoStyles = await getAutomaticStyles(data)
     expect(findChildren(autoStyles, "number-style")).toHaveLength(0)
+    expect(findChildren(autoStyles, "text-style")).toHaveLength(0)
     expect(findChildren(autoStyles, "percentage-style")).toHaveLength(0)
     expect(findChildren(autoStyles, "date-style")).toHaveLength(0)
     expect(findChildren(autoStyles, "time-style")).toHaveLength(0)

--- a/test/ods-scientific-format.test.ts
+++ b/test/ods-scientific-format.test.ts
@@ -126,10 +126,14 @@ describe("the number-format codes ODS still cannot carry", () => {
     expect((await styleOf("0.00_);(0.00)"))?.numFmt).toBe("0.00;(0.00)")
   })
 
-  it("has no data style for the text format", async () => {
-    // A cell already holding a string is unaffected — this only matters
-    // for a number one asked to display as text.
-    expect((await styleOf("@"))?.numFmt).toBeUndefined()
+  it("carries the text format after all", async () => {
+    // This test used to assert the opposite, and the comment above it in
+    // PARITY.md said `@` had no data style to write. Both were wrong:
+    // ODF spells it `<number:text-style>`, which is what LibreOffice
+    // writes. Kept here pointing the right way so the mistake is not
+    // re-made from this file; the real coverage is in
+    // test/ods-text-format.test.ts.
+    expect((await styleOf("@"))?.numFmt).toBe("@")
   })
 
   it("makes an optional digit a mandatory one", async () => {

--- a/test/ods-text-format.test.ts
+++ b/test/ods-text-format.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// `@` is Excel's text format: display this cell as text, whatever it
+// holds. #535 recorded it as a loss ODS could not carry —
+//
+//   | `@` | _(General)_ | the text format has no data style to write |
+//
+// — which was wrong, and wrong in the way that is hardest to notice: it
+// was written down, so nobody looked again. ODF has
+// `<number:text-style>`, and LibreOffice writes one into every document
+// it saves.
+//
+// Found by `scripts/spec-coverage.mjs` after #547 crossed the ODF half
+// with the corpus: `number:text-style` is in the grammar, in
+// `libreoffice-basic.ods`, and was nowhere in `src/`.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function bytesFor(numFmt: string): Promise<Uint8Array> {
+  return writeOds({
+    sheets: [
+      {
+        name: "S",
+        rows: [["hello"]],
+        cells: new Map([["0,0", { value: "hello", style: { numFmt } as CellStyle }]]),
+      },
+    ],
+  })
+}
+
+async function roundTrip(numFmt: string): Promise<string | undefined> {
+  const wb = await readOds(await bytesFor(numFmt), { readStyles: true })
+  return wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt
+}
+
+describe("the text format survives ODS", () => {
+  it("round-trips as @", async () => {
+    expect(await roundTrip("@")).toBe("@")
+  })
+
+  it("as ODF's own element, so LibreOffice shows it too", async () => {
+    const xml = dec.decode(await new ZipReader(await bytesFor("@")).extract("content.xml"))
+
+    expect(xml).toContain("<number:text-style")
+    expect(xml).toContain("<number:text-content/>")
+  })
+
+  it("and the cell keeps its value", async () => {
+    const wb = await readOds(await bytesFor("@"))
+
+    expect(wb.sheets[0]!.rows[0]![0]).toBe("hello")
+  })
+})
+
+describe("what General does is unchanged", () => {
+  it("General still writes no data style", async () => {
+    // `General` is the *absence* of a format. It must not become a text
+    // style just because `@` now does.
+    const xml = dec.decode(await new ZipReader(await bytesFor("General")).extract("content.xml"))
+
+    expect(xml).not.toContain("<number:text-style")
+    expect(await roundTrip("General")).toBeUndefined()
+  })
+
+  it("and the ordinary formats are untouched", async () => {
+    for (const numFmt of ["0.00", "#,##0", "0%", "yyyy-mm-dd", "hh:mm:ss", '"$"#,##0.00']) {
+      expect(await roundTrip(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+})


### PR DESCRIPTION
`@` is Excel's text format — *display this cell as text, whatever it holds*.

#535 recorded it as a loss ODS could not carry:

> | `@` | *(General)* | the text format has no data style to write |

That was **wrong**. ODF spells it `<number:text-style>` with a `<number:text-content/>` placeholder, and LibreOffice writes one into every document it saves:

```xml
<number:text-style style:name="N133"><number:text-content/>…</number:text-style>
```

## Why it survived

Because it was written down. A documented loss is one nobody looks at again — and this one had:

- a row in `PARITY.md` explaining why it was impossible,
- a test pinning it (`has no data style for the text format`),
- two more tests asserting it alongside `General`.

Four places agreeing with each other, and none of them with the format. That is a worse failure mode than an undocumented bug, because every one of those artefacts made the next person less likely to check.

It was found by **crossing the ODF grammar with a LibreOffice document** (#547) — not by anyone re-reading the page. That is the argument for deriving the gap list instead of remembering it, and this is the second thing the report has caught after the indexed palette in #546.

## What changed

| | before | after |
| --- | --- | --- |
| `@` | dropped | `<number:text-style><number:text-content/></number:text-style>`, round-trips as `@` |
| `General` | dropped | **unchanged** — still no data style |

`General` is the *absence* of a format; `@` is not. Treating them as the same case is exactly what the old code did, and the split is the fix.

The test asserts on the emitted element, not only the round trip: a reader-side reconstruction would have made hucre agree with itself and left the file showing a number in LibreOffice.

## The tests that were wrong

Updated rather than deleted, each with a note saying which way it used to point, so the mistake cannot be re-made from the file that used to enforce it. `PARITY.md` now says the same, including *why* the error lasted.

`pnpm test` green — 10,553 tests, 229 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
