### PR TITLE
feat(ods): an optional digit stays optional, and #,### keeps its separator

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -520,13 +520,21 @@ trip rather than reasoned about:
 | ----------------- | ------------- | ------------------------------------------------------------------------------------------------ |
 | `0.00_);(0.00)`   | `0.00;(0.00)` | `_)` reserves the width of a character. ODF has no equivalent, so the padding is dropped         |
 | `##0.0E+0`        | `0.0E+0`      | engineering notation steps the integer part in threes, which ODF spells with `exponent-interval` |
-| `#`, `#.##`       | `0`, `0.00`   | `#` is an optional digit and `0` a mandatory one. ODF counts digits, so the distinction goes     |
 | `[mm]:ss`, `[ss]` | `mm:ss`, `ss` | the elapsed marker survives on hours (`[hh]:mm`) but not on minutes or seconds alone             |
 | `0.00;[Red]-0.00` | `0.00;-0.00`  | colour tags are dropped on purpose — it is what stops `[White]0.00` being read as a time format  |
 | `0.00;;`          | `0.00`        | empty trailing sections have nothing to write                                                    |
 
 `General` returning no `numFmt` is not in that list: General _is_ the
 absence of a data style, so there is nothing lost.
+
+Two rows have left that list since it was written, both for the same
+reason and both found the same way. `#` versus `0` — an optional digit
+against a mandatory one — was described here as a distinction ODF could
+not express; it expresses it with `number:min-decimal-places` and
+`number:min-integer-digits`, which LibreOffice writes on every number
+style. `#,###` was worse than documented: it lost its thousands separator
+as well, because the writer's grouping test only recognised `#,##0` and
+`0,000` literally.
 
 `@` — the text format — used to be on that list, described here as having
 "no data style to write". That was wrong. ODF spells it

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -208,6 +208,21 @@ function parseDataStyles(autoStyles: XmlElement): Map<string, string> {
   return out
 }
 
+/**
+ * The integer half of a number format, from the digit counts ODF gives.
+ *
+ * `min-integer-digits="0"` means no digit is mandatory — `#` — and one
+ * or more means that many `0`s. Grouping needs three positions before
+ * the separator, so a single mandatory digit is `#,##0` and two is
+ * `#,#00`.
+ */
+function integerPattern(minInteger: number, grouping: boolean): string {
+  if (!grouping) return minInteger <= 0 ? "#" : "0".repeat(minInteger)
+  if (minInteger <= 0) return "#,###"
+  const mandatory = "0".repeat(minInteger)
+  return minInteger >= 3 ? `#,${mandatory}` : `#,${"#".repeat(3 - minInteger)}${mandatory}`
+}
+
 function serializeDataStyleChildren(
   el: XmlElement,
   kind: "number" | "percentage" | "currency" | "date" | "time" | "text",
@@ -219,13 +234,30 @@ function serializeDataStyleChildren(
     const local = child.local || child.tag
     if (local === "number") {
       // Reached while parsing styles.xml, before any cell data.
-      const decimals = Math.min(
-        parseInt(child.attrs["number:decimal-places"] ?? "0", 10) || 0,
-        MAX_REPEAT_COUNT,
+      const clamp = (raw: string | undefined, fallback: number): number => {
+        if (raw === undefined) return fallback
+        const n = parseInt(raw, 10)
+        return Number.isFinite(n) ? Math.min(Math.max(n, 0), MAX_REPEAT_COUNT) : fallback
+      }
+
+      const maxDecimals = clamp(child.attrs["number:decimal-places"], 0)
+      // Absent means every decimal is shown, which is what this reader
+      // assumed before it read the attribute at all — so a file written
+      // by a tool that omits it reads exactly as it used to.
+      const minDecimals = Math.min(
+        clamp(child.attrs["number:min-decimal-places"], maxDecimals),
+        maxDecimals,
       )
+      const minInteger = clamp(child.attrs["number:min-integer-digits"], 1)
       const grouping = child.attrs["number:grouping"] === "true"
-      const integerPart = grouping ? "#,##0" : "0"
-      out += decimals > 0 ? `${integerPart}.${"0".repeat(decimals)}` : integerPart
+
+      // `0` is a digit always shown and `#` one shown only when there is
+      // something to show, so the two counts are the difference between
+      // `0.00` and `#.##`. See #535, which recorded this as a loss.
+      out += integerPattern(minInteger, grouping)
+      if (maxDecimals > 0) {
+        out += `.${"0".repeat(minDecimals)}${"#".repeat(maxDecimals - minDecimals)}`
+      }
     } else if (local === "scientific-number") {
       // `<number:scientific-number number:decimal-places="2"
       //  number:min-integer-digits="1" number:min-exponent-digits="2"/>`

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -162,8 +162,47 @@ function decimalsFromCode(code: string): number {
   return m ? m[1].length : 0
 }
 
+/**
+ * How many digits a number format always shows, and how many at most.
+ *
+ * `0` is a digit that is always shown, `#` one shown only if there is
+ * something to show — so `#.##` displays 1234.5 as "1234.5" and `0.00`
+ * as "1234.50". ODF carries both counts: `number:decimal-places` is the
+ * maximum and `number:min-decimal-places` the minimum, with
+ * `number:min-integer-digits` doing the same job left of the point.
+ *
+ * #535 recorded the distinction as one ODS could not carry. It can; the
+ * writer was simply emitting one count and a hardcoded `1`.
+ */
+function digitCounts(code: string): {
+  minInteger: number
+  minDecimals: number
+  maxDecimals: number
+} {
+  // Only the first section — Excel's `positive;negative;zero` are
+  // separate styles, and the caller has already split them.
+  const section = code.split(";")[0] ?? ""
+  const digits = section.match(/[0#?]+(?:,[0#?]+)*(?:\.[0#?]+)?/)?.[0] ?? ""
+  const [integerPart = "", decimalPart = ""] = digits.split(".")
+
+  return {
+    // `?` is a digit-or-space placeholder; it holds a position, so it
+    // counts as shown for this purpose.
+    minInteger: (integerPart.match(/[0?]/g) ?? []).length,
+    minDecimals: (decimalPart.match(/[0?]/g) ?? []).length,
+    maxDecimals: decimalPart.length,
+  }
+}
+
 function hasGrouping(code: string): boolean {
-  return /#,##0|0,000/.test(code)
+  // A comma between digit placeholders with three after it is the
+  // thousands separator. Matching only `#,##0` and `0,000` missed
+  // `#,###` — a wholly optional grouped integer — which then lost its
+  // separator entirely and came back as `0`.
+  //
+  // The three placeholders matter: a trailing `0,,` is Excel's
+  // scale-by-millions, not grouping, and has nothing after the commas.
+  return /[0#?],[0#?]{3}/.test(code)
 }
 
 /**
@@ -199,10 +238,12 @@ function parseScientificFormat(
 }
 
 /** Build a `<number:number>` child for numeric / percentage / currency styles */
-function buildNumberChild(decimals: number, grouping: boolean): string {
+function buildNumberChild(code: string, grouping: boolean): string {
+  const { minInteger, minDecimals, maxDecimals } = digitCounts(code)
   const attrs: Record<string, string> = {
-    "number:decimal-places": String(decimals),
-    "number:min-integer-digits": "1",
+    "number:decimal-places": String(maxDecimals),
+    "number:min-decimal-places": String(minDecimals),
+    "number:min-integer-digits": String(minInteger),
   }
   if (grouping) attrs["number:grouping"] = "true"
   return xmlSelfClose("number:number", attrs)
@@ -486,7 +527,7 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
     const decimals = decimalsFromCode(section)
     const grouping = hasGrouping(section)
     const children = [
-      buildNumberChild(decimals, grouping),
+      buildNumberChild(section, grouping),
       xmlElement("number:text", undefined, "%"),
     ]
     return { kind: "percentage", children }
@@ -497,7 +538,7 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
     const decimals = decimalsFromCode(section)
     const grouping = hasGrouping(section)
     const symbol = xmlElement("number:currency-symbol", undefined, odsEscape(currency))
-    const number = buildNumberChild(decimals, grouping)
+    const number = buildNumberChild(section, grouping)
     // Detect symbol position: leading vs trailing
     const beforeNum = /^[^0#]*(\$|\[\$|"[$€£¥₺₽₹])/.test(section)
     const children = beforeNum ? [symbol, number] : [number, symbol]
@@ -541,7 +582,7 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   // A section with no `#`/`0` at all is pure literal text — Excel's third
   // section is often `"-"` for zero — and gets no <number:number> child.
   if (/[#0?]/.test(section)) {
-    children.push(buildNumberChild(decimalsFromCode(section), hasGrouping(section)))
+    children.push(buildNumberChild(section, hasGrouping(section)))
   } else if (children.length === 0) {
     return undefined
   }

--- a/test/ods-optional-digits.test.ts
+++ b/test/ods-optional-digits.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// In an Excel number format `0` is a digit that is always shown and `#`
+// is one shown only if there is something to show. `#.##` displays 1234.5
+// as "1234.5"; `0.00` displays it as "1234.50".
+//
+// #535 recorded that distinction as a loss ODS could not carry — "ODF
+// counts digits, so the distinction goes". It does not. ODF carries both
+// counts: `number:decimal-places` is the maximum and
+// `number:min-decimal-places` the minimum, and `number:min-integer-digits`
+// does the same job on the other side of the point. LibreOffice writes
+// all three.
+//
+// Found the same way as the text format in #548 — by crossing the ODF
+// grammar with a LibreOffice document rather than by re-reading the page
+// that said it was impossible.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function bytesFor(numFmt: string): Promise<Uint8Array> {
+  return writeOds({
+    sheets: [
+      {
+        name: "S",
+        rows: [[1234.5]],
+        cells: new Map([["0,0", { value: 1234.5, style: { numFmt } as CellStyle }]]),
+      },
+    ],
+  })
+}
+
+async function roundTrip(numFmt: string): Promise<string | undefined> {
+  const wb = await readOds(await bytesFor(numFmt), { readStyles: true })
+  return wb.sheets[0]!.cells?.get("0,0")?.style?.numFmt
+}
+
+describe("an optional decimal stays optional", () => {
+  it("round-trips the forms that differ only in # versus 0", async () => {
+    for (const numFmt of ["0.00", "#.##", "0.0#", "#,##0.00", "#,##0.##"]) {
+      expect(await roundTrip(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+
+  it("writes both counts, which is how ODF says it", async () => {
+    const xml = dec.decode(await new ZipReader(await bytesFor("0.0#")).extract("content.xml"))
+
+    // Two decimals at most, one always shown.
+    expect(xml).toContain('number:decimal-places="2"')
+    expect(xml).toContain('number:min-decimal-places="1"')
+  })
+
+  it("a fully mandatory format says so", async () => {
+    const xml = dec.decode(await new ZipReader(await bytesFor("0.00")).extract("content.xml"))
+
+    expect(xml).toContain('number:decimal-places="2"')
+    expect(xml).toContain('number:min-decimal-places="2"')
+  })
+})
+
+describe("an optional integer digit too", () => {
+  it("keeps # distinct from 0", async () => {
+    expect(await roundTrip("#")).toBe("#")
+    expect(await roundTrip("0")).toBe("0")
+  })
+
+  it("and keeps grouping when there is no mandatory digit", async () => {
+    // `#,###` lost its separator entirely, coming back as `0`.
+    expect(await roundTrip("#,###")).toBe("#,###")
+  })
+
+  it("writes min-integer-digits 0 for a wholly optional integer part", async () => {
+    const xml = dec.decode(await new ZipReader(await bytesFor("#.##")).extract("content.xml"))
+
+    expect(xml).toContain('number:min-integer-digits="0"')
+  })
+})
+
+describe("the formats around them are unchanged", () => {
+  it("still round-trip", async () => {
+    for (const numFmt of [
+      "#,##0",
+      "0%",
+      "0.00%",
+      "yyyy-mm-dd",
+      "hh:mm:ss",
+      '"$"#,##0.00',
+      "0.00E+00",
+      "@",
+    ]) {
+      expect(await roundTrip(numFmt), numFmt).toBe(numFmt)
+    }
+  })
+})

--- a/test/ods-scientific-format.test.ts
+++ b/test/ods-scientific-format.test.ts
@@ -136,12 +136,15 @@ describe("the number-format codes ODS still cannot carry", () => {
     expect((await styleOf("@"))?.numFmt).toBe("@")
   })
 
-  it("makes an optional digit a mandatory one", async () => {
-    // `#` means "a digit if there is one" and `0` means "always a digit".
-    // ODF counts digits, so `#.##` displays 1234.50 where Excel showed
-    // 1234.5.
-    expect((await styleOf("#"))?.numFmt).toBe("0")
-    expect((await styleOf("#.##"))?.numFmt).toBe("0.00")
+  it("keeps an optional digit optional after all", async () => {
+    // This test used to assert the opposite, on the same mistaken reading
+    // as the `@` case above: ODF carries *both* counts —
+    // `number:decimal-places` is the maximum and `min-decimal-places` the
+    // minimum, with `min-integer-digits` doing the job on the other side
+    // of the point. Kept here pointing the right way; the real coverage
+    // is in test/ods-optional-digits.test.ts.
+    expect((await styleOf("#"))?.numFmt).toBe("#")
+    expect((await styleOf("#.##"))?.numFmt).toBe("#.##")
   })
 
   it("keeps the elapsed marker on hours but not on minutes or seconds", async () => {


### PR DESCRIPTION
In an Excel number format `0` is a digit **always** shown and `#` one shown **only if there is something to show**. `#.##` displays 1234.5 as `1234.5`; `0.00` displays it as `1234.50`.

#535 recorded that as a loss ODS could not carry:

> | `#`, `#.##` | `0`, `0.00` | `#` is an optional digit and `0` a mandatory one. ODF counts digits, so the distinction goes |

It does not. **ODF carries both counts** — `number:decimal-places` is the maximum, `number:min-decimal-places` the minimum, and `number:min-integer-digits` does the same job left of the point. LibreOffice writes all three on every number style it produces:

```xml
<number:number number:decimal-places="2" number:min-decimal-places="2" number:min-integer-digits="1"/>
```

The writer was emitting one count and a hardcoded `min-integer-digits="1"`, so every `#` became a `0` on the way out.

## A second loss underneath, which was not documented at all

`#,###` came back as `0` — not merely mandatory but **ungrouped**. The thousands separator vanished.

The grouping test was `/#,##0|0,000/`: it recognises those two spellings and no others, so a wholly optional grouped integer matched nothing. It is now a comma between digit placeholders with three after it — which is what a thousands separator *is* — and still refuses Excel's scale-by-millions `0,,`, where the commas have nothing after them.

## Compatibility

Absent `min-decimal-places` is read as equal to `decimal-places`, so a file written by a tool that omits the attribute reads **exactly as it did before**. The change only adds information; it does not reinterpret files that never carried it.

| | before | after |
| --- | --- | --- |
| `0.00` | `0.00` | `0.00` |
| `#.##` | `0.00` | `#.##` |
| `0.0#` | `0.00` | `0.0#` |
| `#,##0.##` | `#,##0.00` | `#,##0.##` |
| `#` | `0` | `#` |
| `#,###` | `0` | `#,###` |

## How it was found

By crossing the ODF grammar with a LibreOffice document — `number:min-decimal-places` was in the schema, in `libreoffice-basic.ods`, and nowhere in `src/`. Not by re-reading the page that said it was impossible.

That is **three** documented "losses" the spec-coverage report has now overturned: the indexed palette (#546), the text format (#548), and this. All three had been written down as permanent, which is what stopped anyone checking.

The test that pinned the old behaviour is flipped rather than deleted, with a note saying which way it used to point.

`pnpm test` green — 10,560 tests, 230 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
