### PR TITLE
fix(ods): write valid ODF, checked against the OASIS grammar

### DIFF
--- a/scripts/validate-odf.mjs
+++ b/scripts/validate-odf.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// ── Does hucre write valid ODF? ──────────────────────────────────────
+//
+// Every ODS test in this repository reads the file back with hucre, so
+// they answer "does hucre agree with itself". They cannot answer "is this
+// a valid OpenDocument", and LibreOffice — lenient by design — cannot
+// either: it opened both of the defects this script found on its first
+// run.
+//
+//   * `<style:style style:family="table-cell">` has an *ordered* content
+//     model. hucre wrote `style:text-properties` before
+//     `style:table-cell-properties`, so every cell with both a font and a
+//     fill produced a document the schema rejects.
+//   * `<office:settings/>` was written empty. The element is optional and,
+//     when present, requires one or more `config:config-item-set`.
+//
+// And one the schema caught the day after it was introduced:
+// `number:min-decimal-places` is an ODF 1.3 attribute, and hucre declared
+// `office:version="1.2"`.
+//
+// What this is: the published RELAX NG grammar, run over documents hucre
+// wrote, by `jing` — the reference validator. Neither the schemas nor the
+// validator are vendored; they are large and none of them is hucre's to
+// redistribute.
+//
+//   curl -sSLO https://docs.oasis-open.org/office/OpenDocument/v1.3/os/schemas/OpenDocument-v1.3-schema.rng
+//   curl -sSLO https://docs.oasis-open.org/office/OpenDocument/v1.3/os/schemas/OpenDocument-v1.3-manifest-schema.rng
+//   curl -sSLO https://repo1.maven.org/maven2/org/relaxng/jing/20220510/jing-20220510.jar
+//
+//   node scripts/validate-odf.mjs \
+//     --schema OpenDocument-v1.3-schema.rng \
+//     --manifest-schema OpenDocument-v1.3-manifest-schema.rng \
+//     --jing jing-20220510.jar
+//
+// `-i` is passed to jing throughout: the OASIS grammar does not compile
+// under its ID/IDREF checking, which is a property of the schema rather
+// than of any document.
+
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+
+const args = new Map()
+for (let i = 2; i < process.argv.length; i += 2) {
+  args.set(process.argv[i].replace(/^--/, ""), process.argv[i + 1])
+}
+const schema = args.get("schema")
+const manifestSchema = args.get("manifest-schema")
+const jing = args.get("jing")
+const dist = args.get("dist") ?? new URL("../dist/index.mjs", import.meta.url).href
+
+if (!schema || !jing) {
+  console.error("usage: node scripts/validate-odf.mjs --schema <odf.rng> --jing <jing.jar>")
+  console.error("       [--manifest-schema <manifest.rng>]  (see the header for where to get them)")
+  process.exit(1)
+}
+
+const hucre = await import(dist)
+
+// ── The documents to check ───────────────────────────────────────────
+//
+// Chosen to reach the parts of the writer that produce structure rather
+// than values: a style with several facets at once (which is what found
+// the child-order bug), every kind of number format, and each of the
+// three writers, because they build the document differently.
+
+const STYLE = {
+  font: { bold: true, italic: true, size: 14, color: { rgb: "FF0000" } },
+  fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } },
+  alignment: { horizontal: "center" },
+}
+
+const NUMBER_FORMATS = [
+  "0.00",
+  "#.##",
+  "#,##0.00",
+  "0%",
+  "0.0#%",
+  '"$"#,##0.00',
+  "yyyy-mm-dd",
+  "hh:mm:ss",
+  "0.00E+00",
+  "##0.0E+0",
+  "@",
+]
+
+async function drain(stream) {
+  const chunks = []
+  const reader = stream.getReader()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  const out = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0))
+  let at = 0
+  for (const c of chunks) {
+    out.set(c, at)
+    at += c.length
+  }
+  return out
+}
+
+async function documents() {
+  const out = []
+
+  const cells = new Map([["0,0", { value: "Name", style: STYLE }]])
+  NUMBER_FORMATS.forEach((numFmt, i) => {
+    cells.set(`${i + 1},0`, { value: 1234.5, style: { numFmt } })
+  })
+  cells.set(`${NUMBER_FORMATS.length + 1},0`, { value: 1, formula: "A2+1" })
+  cells.set(`${NUMBER_FORMATS.length + 2},0`, {
+    value: "link",
+    hyperlink: { target: "https://example.test", tooltip: "t" },
+  })
+
+  const rows = [
+    ["Name", "Qty"],
+    ...NUMBER_FORMATS.map(() => [1234.5, null]),
+    [1, null],
+    ["link", null],
+  ]
+
+  out.push([
+    "writeOds (styles, formats, formula, hyperlink, merge)",
+    await hucre.writeOds({
+      sheets: [
+        {
+          name: "Data",
+          rows,
+          cells,
+          columns: [{ width: 20 }, { width: 10 }],
+          merges: ["A1:B1"],
+        },
+        { name: "Second", rows: [["a", "b"]] },
+      ],
+      properties: { title: "T", creator: "C", description: "D" },
+    }),
+  ])
+
+  out.push([
+    "writeOdsStream (values only)",
+    await drain(hucre.writeOdsStream(rows, { name: "Stream", columns: [{ width: 12 }] })),
+  ])
+
+  const incremental = new hucre.OdsStreamWriter({
+    name: "Incremental",
+    columns: [{ header: "A", width: 15 }, { header: "B" }],
+  })
+  incremental.addRow(["x", { value: 1, style: STYLE }])
+  incremental.addRow([{ value: 2, style: { numFmt: "#,##0.00" } }, null])
+  out.push(["OdsStreamWriter (buffered, styled)", await incremental.finish()])
+
+  return out
+}
+
+// ── Validation ───────────────────────────────────────────────────────
+
+const PARTS = ["content.xml", "styles.xml", "meta.xml", "settings.xml"]
+
+/** Pull one entry out of an ODS with hucre's own ZIP reader. */
+async function extract(bytes, path) {
+  const { ZipReader } = await import(new URL("../dist/zip/reader.mjs", import.meta.url).href).catch(
+    () => ({}),
+  )
+  if (ZipReader) return new TextDecoder().decode(await new ZipReader(bytes).extract(path))
+  // The bundle does not export it; read the workbook back through the
+  // public API is not enough, so fall back to `unzip -p`.
+  const dir = mkdtempSync(join(tmpdir(), "hucre-odf-"))
+  const file = join(dir, "doc.ods")
+  writeFileSync(file, bytes)
+  return execFileSync("unzip", ["-p", file, path], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  })
+}
+
+function validate(file, rng) {
+  try {
+    execFileSync("java", ["-jar", jing, "-i", rng, file], { encoding: "utf8", stdio: "pipe" })
+    return null
+  } catch (error) {
+    return `${error.stdout ?? ""}${error.stderr ?? ""}`.trim() || String(error)
+  }
+}
+
+const work = mkdtempSync(join(tmpdir(), "hucre-odf-val-"))
+let failures = 0
+
+for (const [label, bytes] of await documents()) {
+  console.log(`\n${label}  (${bytes.length} bytes)`)
+
+  const checks = [...PARTS.map((p) => [p, schema])]
+  if (manifestSchema) checks.push(["META-INF/manifest.xml", manifestSchema])
+
+  for (const [part, rng] of checks) {
+    let xml
+    try {
+      xml = await extract(bytes, part)
+    } catch {
+      console.log(`  ${part.padEnd(24)} (absent)`)
+      continue
+    }
+
+    const file = join(work, part.replace(/\//g, "_"))
+    mkdirSync(dirname(file), { recursive: true })
+    writeFileSync(file, xml)
+
+    const errors = validate(file, rng)
+    if (errors) {
+      failures++
+      console.log(`  ${part.padEnd(24)} INVALID`)
+      for (const line of errors.split("\n").slice(0, 4)) console.log(`    ${line}`)
+    } else {
+      console.log(`  ${part.padEnd(24)} valid`)
+    }
+  }
+}
+
+console.log(failures === 0 ? "\nAll parts valid." : `\n${failures} invalid part(s).`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/ods/incremental-writer.ts
+++ b/src/ods/incremental-writer.ts
@@ -257,7 +257,7 @@ function xmlDocumentContent(children: string[]): string {
     ' xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"' +
     ' xmlns:xlink="http://www.w3.org/1999/xlink"' +
     ' xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2"' +
-    ' office:version="1.2">' +
+    ' office:version="1.3">' +
     children.join("") +
     "</office:document-content>"
   )

--- a/src/ods/stream-writer.ts
+++ b/src/ods/stream-writer.ts
@@ -107,7 +107,7 @@ const CONTENT_HEAD =
   ' xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"' +
   ' xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"' +
   ' xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2"' +
-  ' office:version="1.2">'
+  ' office:version="1.3">'
 
 /** Serialize content.xml into ~64 KB encoded chunks, pulling lazily. */
 async function* contentChunks(

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -649,12 +649,19 @@ function generateStyleElement(name: string, style: CellStyle, dataStyleName?: st
     cellProps["fo:background-color"] = `#${style.fill.fgColor.rgb}`
   }
 
+  // The order is the grammar's, not a preference. `<style:style>` with
+  // `style:family="table-cell"` is a sequence — table-cell-properties,
+  // then paragraph-properties, then text-properties — and writing the
+  // text first produced a document the OASIS schema rejects for every
+  // cell that had both a font and a fill. Nothing here noticed, because
+  // every test reads the file back with hucre and LibreOffice opens it
+  // regardless; `jing` against the published RELAX NG is what found it.
   const children: string[] = []
-  if (Object.keys(textProps).length > 0) {
-    children.push(xmlSelfClose("style:text-properties", textProps))
-  }
   if (Object.keys(cellProps).length > 0) {
     children.push(xmlSelfClose("style:table-cell-properties", cellProps))
+  }
+  if (Object.keys(textProps).length > 0) {
+    children.push(xmlSelfClose("style:text-properties", textProps))
   }
 
   const attrs: Record<string, string> = { "style:name": name, "style:family": "table-cell" }
@@ -1304,7 +1311,7 @@ function writeContentXml(options: WriteOptions): string {
       "xmlns:svg": NS_SVG,
       "xmlns:xlink": NS_XLINK,
       "xmlns:of": NS_OF,
-      "office:version": "1.2",
+      "office:version": "1.3",
     },
     contentParts,
   )
@@ -1347,7 +1354,7 @@ export function writeMetaXml(props?: WorkbookProperties): string {
       "xmlns:office": NS_OFFICE,
       "xmlns:meta": NS_META,
       "xmlns:dc": NS_DC,
-      "office:version": "1.2",
+      "office:version": "1.3",
     },
     metaContent,
   )
@@ -1374,7 +1381,7 @@ export function writeStylesXml(): string {
       "xmlns:fo": NS_FO,
       "xmlns:number": NS_NUMBER,
       "xmlns:svg": NS_SVG,
-      "office:version": "1.2",
+      "office:version": "1.3",
     },
     children,
   )
@@ -1390,9 +1397,14 @@ export function writeSettingsXml(): string {
     {
       "xmlns:office": NS_OFFICE,
       "xmlns:config": NS_CONFIG,
-      "office:version": "1.2",
+      "office:version": "1.3",
     },
-    xmlElement("office:settings", undefined, ""),
+    // No `<office:settings/>`. The element is optional, but the grammar
+    // requires *one or more* `config:config-item-set` inside it, so an
+    // empty one is invalid — and hucre has no view state, cursor
+    // position or window geometry to record. The part itself stays,
+    // because the manifest lists it and a reader may look for it.
+    "",
   )
 }
 
@@ -1405,7 +1417,7 @@ export function writeManifestXml(): string {
   entries.push(
     xmlSelfClose("manifest:file-entry", {
       "manifest:full-path": "/",
-      "manifest:version": "1.2",
+      "manifest:version": "1.3",
       "manifest:media-type": MIMETYPE,
     }),
   )
@@ -1438,7 +1450,7 @@ export function writeManifestXml(): string {
     "manifest:manifest",
     {
       "xmlns:manifest": NS_MANIFEST,
-      "manifest:version": "1.2",
+      "manifest:version": "1.3",
     },
     entries,
   )

--- a/test/ods-schema-validity.test.ts
+++ b/test/ods-schema-validity.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+import type { CellStyle } from "../src/_types"
+
+// ═══════════════════════════════════════════════════════════════════════
+// Two ways hucre wrote ODF that the OASIS grammar rejects. Both were
+// invisible to every test in this repository, because every one of them
+// reads the file back with hucre — and LibreOffice is lenient enough to
+// open both without complaint. They were found by validating the output
+// against the published RELAX NG schema with `jing`.
+//
+// 1. `<style:style style:family="table-cell">` has an ordered content
+//    model: table-cell-properties, then paragraph-properties, then
+//    text-properties. hucre wrote text first, so any cell that had both
+//    a font and a fill produced a document no strict ODF consumer
+//    accepts.
+//
+// 2. `number:min-decimal-places` does not exist in ODF 1.2 — it was
+//    added in 1.3 — and hucre declares `office:version="1.2"`. #549
+//    started writing it, which made every document with a number format
+//    invalid against the version it claimed to be.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function contentXml(bytes: Uint8Array): Promise<string> {
+  return dec.decode(await new ZipReader(bytes).extract("content.xml"))
+}
+
+const STYLE: CellStyle = {
+  font: { bold: true },
+  fill: { type: "pattern", pattern: "solid", fgColor: { rgb: "FFFF00" } },
+}
+
+describe("a cell style writes its children in the order ODF requires", () => {
+  it("table-cell-properties before text-properties", async () => {
+    const bytes = await writeOds({
+      sheets: [
+        {
+          name: "S",
+          rows: [["x"]],
+          cells: new Map([["0,0", { value: "x", style: STYLE }]]),
+        },
+      ],
+    })
+    const xml = await contentXml(bytes)
+
+    const cell = xml.indexOf("style:table-cell-properties")
+    const text = xml.indexOf("style:text-properties")
+
+    expect(cell, "both properties should be present").toBeGreaterThan(-1)
+    expect(text, "both properties should be present").toBeGreaterThan(-1)
+    expect(cell, "table-cell-properties must come first").toBeLessThan(text)
+  })
+
+  it("and the style still reads back whole", async () => {
+    const bytes = await writeOds({
+      sheets: [
+        { name: "S", rows: [["x"]], cells: new Map([["0,0", { value: "x", style: STYLE }]]) },
+      ],
+    })
+    const cell = (await readOds(bytes, { readStyles: true })).sheets[0]!.cells?.get("0,0")
+
+    expect(cell?.style?.font?.bold).toBe(true)
+    expect(cell?.style?.fill?.type).toBe("pattern")
+    if (cell?.style?.fill?.type === "pattern") {
+      expect(cell.style.fill.fgColor?.rgb).toBe("FFFF00")
+    }
+  })
+})
+
+describe("the document declares the version it actually uses", () => {
+  it("declares ODF 1.3, because it writes 1.3 attributes", async () => {
+    // `number:min-decimal-places` arrived in ODF 1.3. Writing it under a
+    // 1.2 declaration is what made the document invalid; the attribute is
+    // worth keeping, so the declaration is what moves.
+    const bytes = await writeOds({
+      sheets: [
+        {
+          name: "S",
+          rows: [[1]],
+          cells: new Map([["0,0", { value: 1, style: { numFmt: "#.##" } }]]),
+        },
+      ],
+    })
+    const xml = await contentXml(bytes)
+
+    expect(xml).toContain('office:version="1.3"')
+    expect(xml).toContain("number:min-decimal-places")
+  })
+
+  it("in every part, not just content.xml", async () => {
+    const bytes = await writeOds({ sheets: [{ name: "S", rows: [["x"]] }] })
+    const zip = new ZipReader(bytes)
+
+    for (const part of ["content.xml", "styles.xml", "meta.xml"]) {
+      const xml = dec.decode(await zip.extract(part))
+      expect(xml, part).toContain('office:version="1.3"')
+    }
+  })
+})

--- a/test/ods-spec-fixes.test.ts
+++ b/test/ods-spec-fixes.test.ts
@@ -60,12 +60,15 @@ describe("ODS spec — #111: settings.xml", () => {
     // Root element should be office:document-settings
     expect(settingsDoc.tag).toContain("document-settings")
 
-    // Should have office:version="1.2"
-    expect(settingsDoc.attrs["office:version"]).toBe("1.2")
+    // 1.3 since #552: hucre writes `number:min-decimal-places`, which
+    // ODF added in 1.3, so declaring 1.2 made the document invalid.
+    expect(settingsDoc.attrs["office:version"]).toBe("1.3")
 
-    // Should contain office:settings child element
-    const settings = findChild(settingsDoc, "settings")
-    expect(settings).toBeDefined()
+    // No `<office:settings>` child. The element is optional and, when
+    // present, the grammar requires one or more `config:config-item-set`
+    // inside it — so the empty one hucre used to write was invalid ODF,
+    // which `jing` against the published schema found. See #552.
+    expect(findChild(settingsDoc, "settings")).toBeUndefined()
   })
 
   it("settings.xml has required namespace declarations", async () => {
@@ -107,7 +110,7 @@ describe("ODS spec — #111: settings.xml", () => {
 // ── #112: manifest.xml version attribute ────────────────────────────
 
 describe("ODS spec — #112: manifest.xml version", () => {
-  it('root entry "/" has manifest:version="1.2"', async () => {
+  it('root entry "/" has manifest:version="1.3"', async () => {
     const data = await writeOds({
       sheets: [{ name: "Sheet1", rows: [["test"]] }],
     })
@@ -117,7 +120,7 @@ describe("ODS spec — #112: manifest.xml version", () => {
     const rootEntry = entries.find((e: any) => e.attrs["manifest:full-path"] === "/")
 
     expect(rootEntry).toBeDefined()
-    expect(rootEntry.attrs["manifest:version"]).toBe("1.2")
+    expect(rootEntry.attrs["manifest:version"]).toBe("1.3")
   })
 
   it("manifest root element has manifest:version attribute", async () => {
@@ -126,7 +129,7 @@ describe("ODS spec — #112: manifest.xml version", () => {
     })
 
     const manifest = await parseXmlFromZip(data, "META-INF/manifest.xml")
-    expect(manifest.attrs["manifest:version"]).toBe("1.2")
+    expect(manifest.attrs["manifest:version"]).toBe("1.3")
   })
 
   it("manifest contains all required file entries including settings.xml", async () => {

--- a/test/ods.test.ts
+++ b/test/ods.test.ts
@@ -132,7 +132,7 @@ describe("ODS Writer", () => {
     const manifest = await parseXmlFromZip(data, "META-INF/manifest.xml")
     const entries = findChildren(manifest, "file-entry")
     const rootEntry = entries.find((e: any) => e.attrs["manifest:full-path"] === "/")
-    expect(rootEntry.attrs["manifest:version"]).toBe("1.2")
+    expect(rootEntry.attrs["manifest:version"]).toBe("1.3")
   })
 
   it("writes string cells correctly", async () => {
@@ -339,7 +339,7 @@ describe("ODS Writer", () => {
     })
 
     const contentDoc = await parseXmlFromZip(data, "content.xml")
-    expect(contentDoc.attrs["office:version"]).toBe("1.2")
+    expect(contentDoc.attrs["office:version"]).toBe("1.3")
   })
 
   it("content.xml has required namespace declarations", async () => {
@@ -470,7 +470,7 @@ describe("ODS Writer", () => {
     })
 
     const stylesDoc = await parseXmlFromZip(data, "styles.xml")
-    expect(stylesDoc.attrs["office:version"]).toBe("1.2")
+    expect(stylesDoc.attrs["office:version"]).toBe("1.3")
   })
 
   it("styles.xml has required namespace declarations", async () => {


### PR DESCRIPTION
Every ODS test in this repository reads the file back **with hucre**, so they answer *"does hucre agree with itself"*. They cannot answer *"is this a valid OpenDocument"* — and LibreOffice cannot either. It is lenient by design and opened all three of these without complaint.

Running the published OASIS RELAX NG schema over hucre's output with `jing`, the reference validator, found them in one pass.

## Three defects

**Child order.** `<style:style style:family="table-cell">` has an *ordered* content model — table-cell-properties, then paragraph-properties, then text-properties. hucre wrote the text first, so **every cell carrying both a font and a fill** produced a document no strict ODF consumer accepts. True for as long as the ODS writer has emitted both.

**An empty settings element.** `<office:settings/>` is optional; when present the grammar requires one or more `config:config-item-set`. hucre wrote it empty on every document. It is now omitted — hucre has no view state to record — and the part itself stays, because the manifest lists it.

**A version claim that outran the content.** `number:min-decimal-places` is an ODF **1.3** attribute. #549 started writing it *yesterday* while every part still declared `office:version="1.2"`, making every document with a number format invalid against the version it claimed to be.

The attribute is worth keeping, so the declaration moves: 1.3 across content, styles, meta, settings and the manifest. That is what LibreOffice does too — it declares 1.4 and writes 1.4.

## The result

All five parts of all three writers — `writeOds`, `writeOdsStream`, `OdsStreamWriter` — now validate:

```
writeOds (styles, formats, formula, hyperlink, merge)
  content.xml   valid    styles.xml   valid    meta.xml   valid
  settings.xml  valid    META-INF/manifest.xml  valid
…
All parts valid.
```

## `scripts/validate-odf.mjs`

Makes it repeatable. **Not** wired into `pnpm test`: it needs a JVM, a 750 KB validator and two schemas, none of which is hucre's to vendor — the header gives the three `curl` commands.

Checked for teeth rather than assumed: reverting the child-order fix turns it red on two documents.

One detail worth recording — the OASIS grammar does not compile under jing's ID/IDREF checking, so `-i` is passed throughout. That is a property of the schema, not of any document; LibreOffice's own file provokes the same complaint.

`pnpm test` green — 10,571 tests, 232 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
