### PR TITLE
test(xlsx): validate the charts and drawings too, against their own schemas

### DIFF
--- a/scripts/validate-ooxml.mjs
+++ b/scripts/validate-ooxml.mjs
@@ -11,9 +11,14 @@
 // `writeXlsxStream`, `XlsxStreamWriter` — produce parts that validate
 // against the ECMA-376 Transitional schema, including with tables,
 // sparklines, comments, data validations, conditional formatting,
-// auto-filters, freeze panes, page setup and named ranges. Worth
-// recording as a checked fact rather than an assumption, and worth
+// auto-filters, freeze panes, page setup and named ranges. So do the
+// charts and their drawings, in all seven types the writer supports.
+// Worth recording as a checked fact rather than an assumption, and worth
 // having the tool for the next feature.
+//
+// A chart is DrawingML, not SpreadsheetML — `sml.xsd` has never heard of
+// `c:chartSpace` — so each part is checked against the schema that
+// describes it rather than all of them against one.
 //
 // Two things to know before reading its output.
 //
@@ -188,24 +193,72 @@ async function documents() {
     }),
   ])
 
+  // Charts are DrawingML rather than SpreadsheetML and are the most
+  // structured thing hucre writes, so each supported type gets a
+  // document. `radar`, `bubble` and `stock` are refused by the writer
+  // with a typed error, which is its own correct answer.
+  for (const type of ["bar", "column", "line", "pie", "doughnut", "area", "scatter"]) {
+    out.push([
+      `writeXlsx (${type} chart, axes, legend, data labels)`,
+      await hucre.writeXlsx({
+        sheets: [
+          {
+            name: "Data",
+            rows: [
+              ["M", "S"],
+              ["a", 1],
+              ["b", 2],
+              ["c", 3],
+            ],
+            charts: [
+              {
+                type,
+                title: type,
+                anchor: { type: "twoCell", from: { row: 0, col: 4 }, to: { row: 12, col: 10 } },
+                series: [{ name: "S", categories: "Data!$A$2:$A$4", values: "Data!$B$2:$B$4" }],
+                legend: { position: "right" },
+                dataLabels: { showValue: true },
+                axes: { x: { title: "X", gridlines: true }, y: { title: "Y", min: 0, max: 10 } },
+              },
+            ],
+          },
+        ],
+      }),
+    ])
+  }
+
   return out
 }
 
 // ── Validation ───────────────────────────────────────────────────────
 
-/** Every SpreadsheetML part in the package, by path. */
-function smlParts(dir) {
-  const out = execFileSync("unzip", ["-Z1", dir], { encoding: "utf8" })
+/**
+ * Each part in the package, paired with the schema that describes it.
+ *
+ * A chart is not SpreadsheetML: `xl/charts/chart1.xml` is DrawingML and
+ * `sml.xsd` has never heard of it. Validating everything against one
+ * schema would report the most complex thing hucre writes as an unknown
+ * element and call it a day.
+ */
+function partsToCheck(pkg, schemaDir) {
+  const all = execFileSync("unzip", ["-Z1", pkg], { encoding: "utf8" })
     .split("\n")
     .map((s) => s.trim())
     .filter(Boolean)
-  // The parts sml.xsd describes. Drawings, charts and the relationship
-  // files have their own schemas and are not this script's business.
-  return out.filter(
-    (p) =>
-      /^xl\/(workbook|styles|sharedStrings)\.xml$/.test(p) ||
-      /^xl\/(worksheets|tables)\/[^/]+\.xml$/.test(p),
-  )
+
+  const out = []
+  for (const part of all) {
+    if (/^xl\/(workbook|styles|sharedStrings)\.xml$/.test(part)) out.push([part, schema])
+    else if (/^xl\/(worksheets|tables)\/[^/]+\.xml$/.test(part)) out.push([part, schema])
+    else if (/^xl\/charts\/chart\d+\.xml$/.test(part)) {
+      out.push([part, join(schemaDir, "dml-chart.xsd")])
+    } else if (/^xl\/drawings\/drawing\d+\.xml$/.test(part)) {
+      out.push([part, join(schemaDir, "dml-spreadsheetDrawing.xsd")])
+    }
+    // Relationship parts, content types, docProps and VML have their own
+    // schemas elsewhere in the package and are not this script's business.
+  }
+  return out
 }
 
 let failures = 0
@@ -219,11 +272,11 @@ for (const [label, bytes] of await documents()) {
   mkdirSync(extracted, { recursive: true })
   execFileSync("unzip", ["-o", "-q", pkg, "-d", extracted])
 
-  for (const part of smlParts(pkg)) {
+  for (const [part, partSchema] of partsToCheck(pkg, dirname(schema))) {
     const file = join(extracted, part)
     let output
     try {
-      output = execFileSync("java", ["-cp", work, "XsdValidate", schema, file], {
+      output = execFileSync("java", ["-cp", work, "XsdValidate", partSchema, file], {
         encoding: "utf8",
         stdio: "pipe",
       })


### PR DESCRIPTION
#553 checked the SpreadsheetML parts and stopped there — which left **the most structured thing hucre writes** unchecked.

A chart is DrawingML. `sml.xsd` has never heard of `c:chartSpace`, so validating it against the workbook's schema would report the whole thing as an unknown element and call it a day.

Each part is now paired with the schema that describes it:

| part | schema |
| --- | --- |
| `xl/charts/chartN.xml` | `dml-chart.xsd` |
| `xl/drawings/drawingN.xml` | `dml-spreadsheetDrawing.xsd` |
| workbook, styles, sharedStrings, worksheets, tables | `sml.xsd` |

## Result

All seven chart types the writer supports — bar, column, line, pie, doughnut, area, scatter — produce valid chart **and** drawing parts, with titles, axes, gridlines, bounds, legends and data labels.

`radar`, `bubble` and `stock` are refused by the writer with a typed error. That is its own correct answer, and not something to validate.

**58 parts across eleven documents, all valid.**

## The teeth check, which took three tries

Worth recording, because the first two proved nothing:

1. Mutating `<c:legendPos>` changed the source but **not the output** — that path is not reached by these documents. The report stayed green and would have looked like a passing teeth check.
2. `c:barDir` is not written where I first went looking for it (`chart-writer.ts`); the mutation applied to nothing.
3. Renaming it where it actually lives — `chart/plotArea.ts:1224` — puts `c:bogusDir` in the chart XML (verified by grepping the generated part) and turns the report red on two documents.

A teeth check that is not itself verified proves nothing — the same mistake as a test that cannot fail, one level up.

`pnpm test` green — 10,571 tests, 232 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
