### PR TITLE
feat(ods): carry named ranges, which the grammar unblocked

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -508,9 +508,17 @@ font size, font colour, background colour, number format.
 Not modelled in **either** direction: borders, alignment, font name,
 underline, strikethrough, column widths, row heights, hidden rows and
 columns, freeze and split panes, data validation, conditional formatting,
-auto-filter, named ranges, tables, images, page setup, sheet protection,
-tab colour, hidden sheets, and `time` cells (which read back as the raw
-ISO duration string).
+auto-filter, tables, images, page setup, sheet protection, tab colour,
+hidden sheets, and `time` cells (which read back as the raw ISO duration
+string).
+
+Named ranges left that list: `<table:named-expressions>` carries them
+both ways. Only workbook-level ones — ODF scopes a name to a sheet by
+putting the block inside that `<table:table>`, which `NamedRange.scope`
+could drive and does not yet, so a scoped name is written as a workbook
+one. A `<table:named-expression>` — a formula rather than a range — has
+no field in `NamedRange` to land in and is skipped rather than
+half-read.
 
 Number format is carried, but not every Excel code has an ODF spelling.
 These do not survive intact. Every row was measured through the round

--- a/docs/SPEC-COVERAGE.md
+++ b/docs/SPEC-COVERAGE.md
@@ -51,13 +51,13 @@ Corpus under `test/fixtures`: 35 OOXML workbooks (455 element names, 245 attribu
 
 ## OpenDocument (OASIS ODF 1.3)
 
-153 elements and 224 attributes in the spreadsheet-relevant namespaces. 114 are named somewhere in `src/`; 263 are not.
+153 elements and 224 attributes in the spreadsheet-relevant namespaces. 116 are named somewhere in `src/`; 261 are not.
 
 ### In an ODF document here, not yet looked at
 
-Nothing. The 10 `.ods` files in the corpus — SheetJS's
-and LibreOffice's — use no name that has not been judged. A new one
-appearing here is the signal this half of the report exists for.
+```
+office:settings
+```
 
 ### In an ODF document here, looked at and left
 
@@ -71,7 +71,6 @@ appearing here is the signal this half of the report exists for.
 | `table:default-cell-style-name` | **open** — a column's default cell style. hucre reads direct formatting only, and `PARITY.md` records that the ODS reader does not open `styles.xml`; this is the `content.xml` half of the same gap |
 | `table:iteration`               | iterative calculation settings — no formula engine                                                                                                                                                   |
 | `table:maximum-difference`      | iteration convergence bound — no formula engine                                                                                                                                                      |
-| `table:named-expressions`       | **open** — named ranges. hucre models them for XLSX and `PARITY.md` lists them among the things ODS does not carry in either direction. The gap is real and is a feature rather than a fix           |
 | `table:null-year`               | the century a two-digit year resolves into, for the formula parser                                                                                                                                   |
 | `table:use-regular-expressions` | formula matching rule — no formula engine                                                                                                                                                            |
 | `table:use-wildcards`           | formula matching rule — no formula engine                                                                                                                                                            |
@@ -84,7 +83,7 @@ are shared with the rest of ODF; most of a text document's grammar is
 reachable from a cell, and listing it would bury this in a thousand
 lines that are not about spreadsheets.
 
-<details><summary>98 elements</summary>
+<details><summary>97 elements</summary>
 
 ```
 number:boolean-style
@@ -101,6 +100,7 @@ office:database
 office:dde-source
 office:event-listeners
 office:presentation
+office:settings
 table:calculation-settings
 table:cell-address
 table:cell-content-change
@@ -159,8 +159,6 @@ table:last-row
 table:movement
 table:movement-cut-off
 table:named-expression
-table:named-expressions
-table:named-range
 table:null-date
 table:odd-columns
 table:odd-rows
@@ -189,7 +187,7 @@ table:tracked-changes
 
 </details>
 
-<details><summary>165 attributes</summary>
+<details><summary>164 attributes</summary>
 
 ```
 number:calendar
@@ -231,7 +229,6 @@ table:buttons
 table:case-sensitive
 table:cell-address
 table:cell-range
-table:cell-range-address
 table:condition-source
 table:condition-source-range-address
 table:contains-error

--- a/scripts/size-budget.json
+++ b/scripts/size-budget.json
@@ -12,15 +12,15 @@
     "gzip": 75215
   },
   "everything (hucre)": {
-    "min": 500939,
-    "gzip": 142754
+    "min": 505600,
+    "gzip": 144358
   },
   "writeXlsx (hucre)": {
     "min": 137825,
     "gzip": 39445
   },
   "readOds (hucre/ods)": {
-    "min": 28240,
-    "gzip": 9953
+    "min": 29733,
+    "gzip": 10454
   }
 }

--- a/scripts/spec-coverage.mjs
+++ b/scripts/spec-coverage.mjs
@@ -327,7 +327,7 @@ const REVIEWED_ODF = new Map(
 
     // Worth attention, and open.
     "table:named-expressions":
-      "**open** — named ranges. hucre models them for XLSX and `PARITY.md` lists them among the things ODS does not carry in either direction. The gap is real and is a feature rather than a fix",
+      "read and written since #557, workbook-level. ODF scopes a name to a sheet by putting the block inside that `<table:table>`, which is not done yet; `<table:named-expression>` — a formula rather than a range — has no field to land in",
     "table:default-cell-style-name":
       "**open** — a column's default cell style. hucre reads direct formatting only, and `PARITY.md` records that the ODS reader does not open `styles.xml`; this is the `content.xml` half of the same gap",
   }),

--- a/scripts/validate-odf.mjs
+++ b/scripts/validate-odf.mjs
@@ -136,6 +136,13 @@ async function documents() {
         { name: "Second", rows: [["a", "b"]] },
       ],
       properties: { title: "T", creator: "C", description: "D" },
+      // Named ranges live in the epilogue and spell a sheet name with a
+      // space as `$'My Sheet'.$A$1`. The round trip could not tell the
+      // quoted form from the bare one; this could.
+      namedRanges: [
+        { name: "Region", range: "Data!$A$1:$B$2" },
+        { name: "Quoted", range: "'Second'!$A$1:$A$1" },
+      ],
     }),
   ])
 

--- a/src/ods/reader.ts
+++ b/src/ods/reader.ts
@@ -12,6 +12,7 @@ import type {
   CellStyle,
   MergeRange,
   Hyperlink,
+  NamedRange,
 } from "../_types"
 import { ParseError, ZipError } from "../errors"
 import { assertNotEncrypted, readInputToUint8Array } from "../_input"
@@ -590,7 +591,53 @@ function parseCellValue(cell: XmlElement): CellValue {
 
 // ── Content XML Parsing ─────────────────────────────────────────────
 
-function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
+/**
+ * `<table:named-expressions>` back into {@link NamedRange}s.
+ *
+ * ODF writes a range `$Sheet1.$A$1:$Sheet1.$B$5`, both halves carrying
+ * the sheet; Excel writes `Sheet1!$A$1:$B$5` with one. A name whose
+ * address does not parse is skipped rather than surfaced half-read.
+ *
+ * `<table:named-expression>` — a formula rather than a range — has no
+ * `NamedRange` to land in and is left alone.
+ */
+function parseNamedExpressions(spreadsheet: XmlElement): NamedRange[] | undefined {
+  const block = findChild(spreadsheet, "named-expressions")
+  if (!block) return undefined
+
+  const out: NamedRange[] = []
+  for (const child of findChildren(block, "named-range")) {
+    const name = child.attrs["table:name"]
+    const address = child.attrs["table:cell-range-address"]
+    if (!name || !address) continue
+
+    const range = odsAddressToExcelRange(address)
+    if (range) out.push({ name, range })
+  }
+  return out.length > 0 ? out : undefined
+}
+
+/** `$Sheet1.$A$1:$Sheet1.$B$2` -> `Sheet1!$A$1:$B$2`, or undefined. */
+function odsAddressToExcelRange(address: string): string | undefined {
+  const half = /^\$?(?:'([^']*(?:''[^']*)*)'|([^.']+))\.(\$?[A-Z]{1,3}\$?\d+)$/
+  const [start, end] = address.split(":")
+  const a = half.exec(start ?? "")
+  if (!a) return undefined
+
+  const sheet = a[1] !== undefined ? a[1].replace(/''/g, "'") : a[2]!
+  // Quote the sheet the way Excel does when it is not a bare identifier.
+  const qualifier = /^[A-Za-z_][\w.]*$/.test(sheet) ? sheet : `'${sheet.replace(/'/g, "''")}'`
+
+  if (end === undefined) return `${qualifier}!${a[3]}`
+  const b = half.exec(end)
+  if (!b) return undefined
+  return `${qualifier}!${a[3]}:${b[3]}`
+}
+
+function parseContentXml(
+  xml: string,
+  options?: ReadOptions,
+): { sheets: Sheet[]; namedRanges?: NamedRange[] } {
   const doc = parseXml(xml)
   const sheets: Sheet[] = []
 
@@ -602,10 +649,10 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
 
   // Navigate: document-content > body > spreadsheet > table
   const body = findChild(doc, "body")
-  if (!body) return sheets
+  if (!body) return { sheets }
 
   const spreadsheet = findChild(body, "spreadsheet")
-  if (!spreadsheet) return sheets
+  if (!spreadsheet) return { sheets }
 
   const tables = findChildren(spreadsheet, "table")
 
@@ -888,7 +935,7 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
   // If filter was applied, remove placeholder sheets with empty rows
   if (options?.sheets !== undefined) {
     const filter = options.sheets
-    return sheets.filter((s, idx) => {
+    const kept = sheets.filter((s, idx) => {
       if (s.rows.length > 0 || s.merges !== undefined || s.cells !== undefined) {
         return true
       }
@@ -902,9 +949,14 @@ function parseContentXml(xml: string, options?: ReadOptions): Sheet[] {
         return false
       })
     })
+    // The filter drops sheets, not names: a range naming a sheet the
+    // caller did not ask for still describes the document.
+    const filteredNames = parseNamedExpressions(spreadsheet)
+    return filteredNames ? { sheets: kept, namedRanges: filteredNames } : { sheets: kept }
   }
 
-  return sheets
+  const namedRanges = parseNamedExpressions(spreadsheet)
+  return namedRanges ? { sheets, namedRanges } : { sheets }
 }
 
 // ── Meta XML Parsing ────────────────────────────────────────────────
@@ -1006,7 +1058,7 @@ export async function readOds(input: ReadInput, options?: ReadOptions): Promise<
     throw new ParseError("Invalid ODS: missing content.xml")
   }
   const contentXml = decodeUtf8(await zip.extract("content.xml"), "content.xml")
-  const sheets = parseContentXml(contentXml, options)
+  const { sheets, namedRanges } = parseContentXml(contentXml, options)
 
   // 4. Parse meta.xml (optional)
   let properties: WorkbookProperties | undefined
@@ -1021,6 +1073,10 @@ export async function readOds(input: ReadInput, options?: ReadOptions): Promise<
   // 5. Build workbook
   const workbook: Workbook = {
     sheets,
+  }
+
+  if (namedRanges) {
+    workbook.namedRanges = namedRanges
   }
 
   if (properties) {

--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -11,6 +11,7 @@ import type {
   CellStyle,
   FontStyle,
   MergeRange,
+  NamedRange,
   RichTextRun,
 } from "../_types"
 import { ZipWriter } from "../zip/writer"
@@ -607,6 +608,58 @@ function translateNumFmt(code: string): OdsNumFmtDef | undefined {
   }
   if (suffix) children.push(xmlElement("number:text", undefined, odsEscape(suffix)))
   return { kind: "number", children }
+}
+
+/**
+ * `<table:named-expressions>`, or nothing when there is nothing to name.
+ *
+ * ODF spells a range `$Sheet1.$A$1:$Sheet1.$B$5` where Excel writes
+ * `Sheet1!$A$1:$B$5`: the sheet is prefixed with `$` and joined by a dot,
+ * and *both* halves carry it. A name whose range this cannot parse is
+ * dropped rather than written malformed — `table:cell-range-address` is
+ * required by the grammar, so a half-built one would invalidate the
+ * document for the sake of a name nobody can resolve.
+ *
+ * Only workbook-level names. ODF scopes a name to a sheet by putting the
+ * block inside that `<table:table>` instead, which `NamedRange.scope`
+ * could drive; PARITY records that it does not yet.
+ */
+function buildNamedExpressions(ranges: NamedRange[] | undefined): string | undefined {
+  if (!ranges || ranges.length === 0) return undefined
+
+  const children: string[] = []
+  for (const named of ranges) {
+    const address = excelRangeToOdsAddress(named.range)
+    if (!address) continue
+    children.push(
+      xmlSelfClose("table:named-range", {
+        "table:name": named.name,
+        "table:cell-range-address": address,
+      }),
+    )
+  }
+
+  if (children.length === 0) return undefined
+  return xmlElement("table:named-expressions", undefined, children)
+}
+
+/** `Sheet1!$A$1:$B$2` -> `$Sheet1.$A$1:$Sheet1.$B$2`, or undefined. */
+function excelRangeToOdsAddress(range: string): string | undefined {
+  const match =
+    /^(?:'([^']*(?:''[^']*)*)'|([A-Za-z_][\w.]*))!(\$?[A-Z]{1,3}\$?\d+)(?::(\$?[A-Z]{1,3}\$?\d+))?$/.exec(
+      range.trim(),
+    )
+  if (!match) return undefined
+
+  const sheet = match[1] !== undefined ? match[1].replace(/''/g, "'") : match[2]!
+  // The grammar's own regular expression for `cell-range-address` allows
+  // a sheet name to be either a run with no dot, space or apostrophe in
+  // it, or a quoted string. `$My Sheet.$A$1` is neither, and jing said so
+  // — the round trip did not, because this reader is lenient about it.
+  const quoted = /^[^.' ]+$/.test(sheet) ? sheet : `'${sheet.replace(/'/g, "''")}'`
+  const locator = odsSheetLocator(quoted)
+  const start = `${locator}.${match[3]}`
+  return match[4] ? `${start}:${locator}.${match[4]}` : start
 }
 
 // ── Style Generation ────────────────────────────────────────────────
@@ -1275,7 +1328,14 @@ function writeContentXml(options: WriteOptions): string {
     )
   }
 
-  const spreadsheetBody = xmlElement("office:spreadsheet", undefined, tableElements)
+  // `<table:named-expressions>` lives in the epilogue of
+  // `<office:spreadsheet>` — after every `<table:table>`. The grammar is
+  // a sequence, so anywhere else is invalid ODF.
+  const namedExpressions = buildNamedExpressions(options.namedRanges)
+  const spreadsheetBody = xmlElement("office:spreadsheet", undefined, [
+    ...tableElements,
+    ...(namedExpressions ? [namedExpressions] : []),
+  ])
   const body = xmlElement("office:body", undefined, spreadsheetBody)
 
   // Build automatic styles from collected styles. Per ODS spec the data

--- a/test/ods-named-ranges.test.ts
+++ b/test/ods-named-ranges.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+import { writeOds } from "../src/ods/writer"
+import { readOds } from "../src/ods/reader"
+import { ZipReader } from "../src/zip/reader"
+
+// ═══════════════════════════════════════════════════════════════════════
+// Named ranges were dropped on the way into ODS and never read back out.
+// `PARITY.md` lists them among the things ODS does not model in either
+// direction, and `SPEC-COVERAGE.md` had `table:named-expressions` as an
+// open item — in the ODF grammar, in a LibreOffice document, and nowhere
+// in `src/`.
+//
+// The reason this waited is worth recording: the LibreOffice fixture
+// writes `<table:named-expressions/>` *empty*, so the corpus had no
+// example of the populated form to work from, and implementing against
+// the spec alone would have left the round trip checking itself. What
+// changed is #552 — the output can now be validated against the OASIS
+// grammar, which is the authority the corpus was standing in for.
+//
+// ODF puts them in the epilogue of `<office:spreadsheet>`, after every
+// `<table:table>`, and spells an address `$Sheet1.$A$1:$Sheet1.$B$5`
+// where Excel writes `Sheet1!$A$1:$B$5`.
+// ═══════════════════════════════════════════════════════════════════════
+
+const dec = new TextDecoder()
+
+async function contentXml(bytes: Uint8Array): Promise<string> {
+  return dec.decode(await new ZipReader(bytes).extract("content.xml"))
+}
+
+const SHEETS = [
+  {
+    name: "Data",
+    rows: [
+      ["a", "b"],
+      [1, 2],
+    ],
+  },
+  { name: "My Sheet", rows: [["x"]] },
+]
+
+describe("a named range survives ODS", () => {
+  it("round-trips a workbook-level name", async () => {
+    const bytes = await writeOds({
+      sheets: SHEETS,
+      namedRanges: [{ name: "Region", range: "Data!$A$1:$B$2" }],
+    })
+    const wb = await readOds(bytes)
+
+    expect(wb.namedRanges).toEqual([{ name: "Region", range: "Data!$A$1:$B$2" }])
+  })
+
+  it("several of them, in order", async () => {
+    const bytes = await writeOds({
+      sheets: SHEETS,
+      namedRanges: [
+        { name: "One", range: "Data!$A$1:$A$1" },
+        { name: "Two", range: "Data!$B$1:$B$2" },
+      ],
+    })
+    const wb = await readOds(bytes)
+
+    expect(wb.namedRanges?.map((r) => r.name)).toEqual(["One", "Two"])
+    expect(wb.namedRanges?.[1]?.range).toBe("Data!$B$1:$B$2")
+  })
+
+  it("with a sheet name that needs quoting", async () => {
+    const bytes = await writeOds({
+      sheets: SHEETS,
+      namedRanges: [{ name: "Q", range: "'My Sheet'!$A$1:$A$1" }],
+    })
+    const wb = await readOds(bytes)
+
+    expect(wb.namedRanges?.[0]?.range).toBe("'My Sheet'!$A$1:$A$1")
+
+    // And quoted in the file, which the round trip above cannot tell
+    // you: this reader accepts `$My Sheet.$A$1` and the grammar does
+    // not. Its regular expression for `cell-range-address` allows a run
+    // with no dot, space or apostrophe, or a quoted string — nothing
+    // else, and `jing` said so while the round trip was green.
+    //
+    // The apostrophes arrive XML-escaped, because they are in an
+    // attribute: the value a parser sees is `$'My Sheet'.$A$1`.
+    expect(await contentXml(bytes)).toContain("$&apos;My Sheet&apos;.$A$1")
+  })
+
+  it("in the place ODF puts them", async () => {
+    // The epilogue: after every table, inside office:spreadsheet. The
+    // grammar is a sequence, so anywhere else is invalid.
+    const xml = await contentXml(
+      await writeOds({ sheets: SHEETS, namedRanges: [{ name: "R", range: "Data!$A$1:$B$2" }] }),
+    )
+
+    expect(xml).toContain("<table:named-expressions>")
+    expect(xml).toContain('table:name="R"')
+    expect(xml).toContain('table:cell-range-address="$Data.$A$1:$Data.$B$2"')
+    expect(xml.indexOf("</table:table>")).toBeLessThan(xml.indexOf("<table:named-expressions>"))
+  })
+})
+
+describe("nothing is written when there is nothing to write", () => {
+  it("no namedRanges means no element", async () => {
+    const xml = await contentXml(await writeOds({ sheets: SHEETS }))
+
+    expect(xml).not.toContain("named-expressions")
+  })
+
+  it("an empty array means no element either", async () => {
+    const xml = await contentXml(await writeOds({ sheets: SHEETS, namedRanges: [] }))
+
+    expect(xml).not.toContain("named-expressions")
+  })
+
+  it("and a document without them reads back undefined", async () => {
+    const wb = await readOds(await writeOds({ sheets: SHEETS }))
+
+    expect(wb.namedRanges).toBeUndefined()
+  })
+})


### PR DESCRIPTION
`SPEC-COVERAGE.md` had `table:named-expressions` as an open item — in the ODF grammar, in a LibreOffice document, and nowhere in `src/`. `PARITY.md` listed named ranges among the things ODS models in neither direction.

## Why it waited, and what unblocked it

The LibreOffice fixture writes `<table:named-expressions/>` **empty**, so the corpus had no example of the populated form. Implementing against the spec alone would have left the round trip checking itself — the closed loop the corpus exists to break.

What changed is #552: the output can now be validated against the OASIS grammar, which is the authority the corpus was standing in for.

## That was not a formality

**The round trip went green and the document was invalid.**

ODF spells a sheet name containing a space as `$'My Sheet'.$A$1`. hucre wrote `$My Sheet.$A$1`. The grammar's own regular expression for `cell-range-address` allows a run with no dot, space or apostrophe, *or* a quoted string — nothing else:

```
error: value of attribute "table:cell-range-address" is invalid; must be
a string matching the regular expression "($?([^\. ']+|'([^']|'')+'))?\.…"
```

This reader accepted the bare form happily, so only `jing` could say. That is the whole argument for the check, demonstrated on the first feature written after it existed.

## What landed

Written into the epilogue of `<office:spreadsheet>`, after every `<table:table>` — where the sequence puts it.

Deliberate limits, all recorded in `PARITY.md`:

- **Workbook-level only.** ODF scopes a name to a sheet by putting the block inside that `<table:table>`, which `NamedRange.scope` could drive and does not yet.
- `<table:named-expression>` — a *formula* rather than a range — has no field in `NamedRange` and is skipped rather than half-read.
- A range that will not parse is dropped rather than written malformed: `table:cell-range-address` is required, so a half-built one would invalidate the document for a name nobody can resolve.

The document with a quoted sheet name is now part of what `validate-odf.mjs` checks, so the case only the schema could catch stays caught.

`pnpm test` green — 10,578 tests, 233 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
