### PR TITLE
fix(ods): the generator is hucre, not the name the project used to have

### DIFF
--- a/src/ods/writer.ts
+++ b/src/ods/writer.ts
@@ -1396,7 +1396,10 @@ export function writeMetaXml(props?: WorkbookProperties): string {
   const modified = props?.modified ?? new Date()
   children.push(xmlElement("dc:date", undefined, formatOdsDate(modified)))
 
-  children.push(xmlElement("meta:generator", undefined, "defter"))
+  // The producing application, per ODF §4.3.2.1. The same name the XLSX
+  // writer puts in `<Application>` — this said `defter`, the project's
+  // former name, for as long as the ODS writer has existed.
+  children.push(xmlElement("meta:generator", undefined, "hucre"))
 
   const metaContent = xmlElement("office:meta", undefined, children)
 

--- a/test/ods.test.ts
+++ b/test/ods.test.ts
@@ -272,7 +272,7 @@ describe("ODS Writer", () => {
     expect(cells[1].attrs["office:value-type"]).toBeUndefined()
   })
 
-  it("writes Application: defter in meta.xml", async () => {
+  it("names itself as the generator in meta.xml", async () => {
     const data = await writeOds({
       sheets: [{ name: "Sheet1", rows: [["test"]] }],
     })
@@ -280,7 +280,7 @@ describe("ODS Writer", () => {
     const metaDoc = await parseXmlFromZip(data, "meta.xml")
     const metaEl = findChild(metaDoc, "meta")
     const generator = findChild(metaEl, "generator")
-    expect(getElementText(generator)).toBe("defter")
+    expect(getElementText(generator)).toBe("hucre")
   })
 
   it("writes document properties in meta.xml", async () => {


### PR DESCRIPTION
Every ODS hucre has ever written says this in `meta.xml`:

```xml
<meta:generator>defter</meta:generator>
```

`defter` is what the project was called before it was renamed. The XLSX
writer has said `hucre` in `docProps/app.xml`'s `<Application>` the whole
time, so the two writers disagreed about what produced the file, and one
of them was naming software that does not exist.

ODF §4.3.2.1 has `meta:generator` name the producing application —
LibreOffice records it on open, and it is the first thing asked for when a
document is reported as malformed. Anyone tracing a bad ODS back to its
producer had a name with no project behind it.

## Why it lasted this long

The test that pinned it pinned it by name:

```ts
it("writes Application: defter in meta.xml", …)
  expect(getElementText(generator)).toBe("defter")
```

A rename sweep over the source finds `defter` in a string literal and
stops, because a test asserts it — the test looks like the requirement
rather than a copy of it. Renaming the test as well is the point: it now
says *"names itself as the generator"*, which stays true through the next
rename.

The surviving `Defter`s in `src/errors.ts` are the deliberate deprecated
`DefterError` alias and stay.

`pnpm test` green — 10,583 tests, 234 files. The ODS output still
validates against the OASIS grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
