### PR TITLE
fix(xml): accept the element names XML actually allows

### DIFF
--- a/src/xml/data-writer.ts
+++ b/src/xml/data-writer.ts
@@ -24,7 +24,31 @@ export interface XmlWriteOptions {
   indent?: string
 }
 
-const VALID_NAME_RE = /^[A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?$/
+// ── What may be an element or attribute name ────────────────────────
+//
+// XML 1.0 §2.3, the `NameStartChar` and `NameChar` productions, minus
+// the colon — which is spelled separately below so a name may carry one
+// prefix and not a colon anywhere it likes. That is `QName` from
+// Namespaces in XML §4, and it is what an XML consumer will accept.
+//
+// This used to be `/^[A-Za-z_][\w.-]*…/` — ASCII only. `NameStartChar`
+// runs from #xC0, so **every** accented or non-Latin heading was
+// refused: `Şehir`, `Größe`, `café`, `名前`. A spreadsheet whose column
+// names are not English could not be written to XML at all; it threw.
+// The rejected names were valid XML, and the ones the production really
+// does forbid — a leading digit, a space, `<` — are still rejected.
+//
+// The `u` flag is required: #x10000–#xEFFFF is above the BMP, and
+// without it the surrogate halves are matched separately and a name made
+// of astral characters slips through as two non-matching units.
+const NAME_START = "A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF"
+const NAME_START_2 = "\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF"
+const NAME_START_3 = "\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\u{10000}-\\u{EFFFF}"
+const START = `[${NAME_START}${NAME_START_2}${NAME_START_3}]`
+const REST = `[${NAME_START}${NAME_START_2}${NAME_START_3}\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]`
+
+/** One `NCName`, optionally prefixed by another — i.e. a `QName`. */
+const VALID_NAME_RE = new RegExp(`^${START}${REST}*(?::${START}${REST}*)?$`, "u")
 
 function escapeText(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")

--- a/test/xml-names.test.ts
+++ b/test/xml-names.test.ts
@@ -1,0 +1,100 @@
+// `writeXml` turns a column heading into an element name, and used to
+// accept only ASCII ones. XML 1.0 §2.3's `NameStartChar` begins at #xC0,
+// so every accented or non-Latin heading was refused — a spreadsheet
+// whose columns are not named in English could not be written to XML at
+// all. It threw rather than mangling, so nothing silently escaped; the
+// format was simply unavailable.
+
+import { describe, expect, it } from "vitest"
+import { writeXml, writeXmlStream } from "../src/xml/data-writer"
+import { readXml } from "../src/xml/data-reader"
+import { ParseError } from "../src/errors"
+
+const drain = async (stream: ReadableStream<Uint8Array>): Promise<string> => {
+  let out = ""
+  const decoder = new TextDecoder()
+  for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
+    out += decoder.decode(chunk, { stream: true })
+  }
+  return out + decoder.decode()
+}
+
+describe("element names XML allows", () => {
+  const accepted = [
+    ["Şehir", "Turkish"],
+    ["Ünvan", "Turkish, U+00DC"],
+    ["Größe", "German"],
+    ["café", "French"],
+    ["naïve", "French, combining-range neighbour"],
+    ["名前", "Japanese"],
+    ["日付", "Japanese"],
+    ["Ελλάδα", "Greek"],
+    ["Кириллица", "Cyrillic"],
+    ["ns:Şehir", "prefixed"],
+    ["a·b", "U+00B7, a NameChar but not a NameStartChar"],
+    ["_x", "underscore start"],
+    ["a-b", "hyphen"],
+  ] as const
+
+  for (const [name, why] of accepted) {
+    it(`accepts ${name} (${why})`, () => {
+      const xml = writeXml([{ [name]: 1 }], { rootTag: "rows", rowTag: "row" })
+      expect(xml).toContain(`<${name}>`)
+    })
+  }
+
+  it("round-trips a non-ASCII name through the reader", () => {
+    const xml = writeXml([{ Şehir: "İzmir", Ürün: 3 }])
+    const { data, headers } = readXml(xml)
+    // Values come back as text — `readXml` does no type inference by
+    // default. The name is what this is about.
+    expect(data[0]).toEqual({ Şehir: "İzmir", Ürün: "3" })
+    expect(headers).toEqual(["Şehir", "Ürün"])
+  })
+
+  it("leaves the dot doing its own job", () => {
+    // A dot in a key is this writer's nesting separator, not part of the
+    // name — unchanged by any of this.
+    expect(writeXml([{ "a.b": 1 }])).toContain("<a><b>1</b></a>")
+  })
+
+  it("takes one as rootTag and rowTag", () => {
+    const xml = writeXml([{ a: 1 }], { rootTag: "şehirler", rowTag: "şehir" })
+    expect(xml).toContain("<şehirler>")
+    expect(xml).toContain("<şehir>")
+  })
+})
+
+describe("element names XML forbids", () => {
+  const rejected = [
+    ["1st", "leading digit"],
+    ["-x", "leading hyphen"],
+    [".x", "leading dot"],
+    ["·x", "U+00B7 leading — a NameChar, not a NameStartChar"],
+    ["a b", "space"],
+    ["a<b", "angle bracket"],
+    ["a:b:c", "two colons"],
+    ["", "empty"],
+    ["́x", "leading combining acute — NameChar only"],
+  ] as const
+
+  for (const [name, why] of rejected) {
+    it(`rejects ${JSON.stringify(name)} (${why})`, () => {
+      expect(() => writeXml([{ [name]: 1 }])).toThrow(ParseError)
+    })
+  }
+})
+
+describe("the streaming writer agrees", () => {
+  it("accepts the same names", async () => {
+    const out = await drain(writeXmlStream([{ Şehir: "İzmir" }], { rootTag: "kayıtlar" }))
+    expect(out).toContain("<Şehir>")
+    expect(out).toContain("<kayıtlar>")
+  })
+
+  it("rejects the same names", async () => {
+    // The generator is lazy, so the name is checked on the first pull
+    // rather than at the call — draining is what asks the question.
+    await expect(drain(writeXmlStream([{ a: 1 }], { rootTag: "1st" }))).rejects.toThrow(ParseError)
+  })
+})


### PR DESCRIPTION
fix(xml): accept the element names XML actually allows

`writeXml` turns a column heading into an element name and validated it
with

    /^[A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?$/

which is ASCII. XML 1.0 §2.3's `NameStartChar` runs from #xC0, so every
accented or non-Latin heading was refused:

    writeXml([{ Şehir: "İzmir" }])
    ParseError: Invalid XML name for element "Şehir": "Şehir"

`Şehir`, `Ünvan`, `Größe`, `café`, `naïve`, `名前`, `Ελλάδα`,
`Кириллица` — all valid XML, all rejected. A spreadsheet whose columns
are not named in English could not be written to XML **at all**. Not
mangled, not escaped: the format was unavailable, and the error said the
name was invalid when it was the check that was.

Found while testing #563, where a Turkish sheet could go to CSV, TSV,
JSON, NDJSON, HTML and Markdown but not XML.

## The productions, minus the colon

`NameStartChar` and `NameChar` verbatim, with `:` pulled out so a name
may carry one prefix rather than a colon wherever it likes — that is
`QName` from Namespaces in XML §4, and it is what the old regex was
reaching for too.

The `u` flag is not optional here: #x10000–#xEFFFF is above the BMP, and
without it the surrogate halves match separately.

Nothing new is accepted that XML forbids. A leading digit, a leading
hyphen or dot, a space, `<`, two colons, the empty string, and a leading
combining mark — `NameChar` but not `NameStartChar` — are still refused,
each with a test.

## Checked

27 tests, **14 of which fail against the old regex** and none of which is
a rejection case: the tests that say what stays refused pass either way,
which is the point of having them.

The reader was never the problem — `parseXml` reads any well-formed name
— and a non-ASCII name now round-trips through both.

`pnpm test` green — 10,622 tests, 236 files.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>


🤖 Generated with [Claude Code](https://claude.com/claude-code)
