### PR TITLE
fix(xls,xlsb): a FORMAT record redefining a built-in id wins

### DIFF
--- a/src/xls/reader.ts
+++ b/src/xls/reader.ts
@@ -143,10 +143,18 @@ function parseWorkbookRecords(stream: Uint8Array, options?: ReadOptions): Workbo
     }
   }
 
+  // The workbook's own FORMAT records win over the built-in id table: a
+  // file may redefine a built-in id (ECMA-376 §18.8.30), and 1C allocates
+  // its custom formats from id 50 rather than 164 — landing on the
+  // Thai/Chinese/Korean date block. Asking the built-in table first meant
+  // the FORMAT record was never consulted, so `'000000000000'`, the mask
+  // for a leading-zero barcode, read back as `Invalid Date` and the number
+  // was gone. `isDateStyle` in xlsx/styles.ts has always had this order;
+  // the two BIFF readers disagreed with it. See #568.
   const dateXf = xfFmtIds.map((id) => {
-    if (isBuiltinDateFormatId(id)) return true
     const code = fmtCodes.get(id)
-    return code ? isDateFormat(code) : false
+    if (code !== undefined) return isDateFormat(code)
+    return isBuiltinDateFormatId(id)
   })
 
   const isDate = (ixfe: number): boolean => dateXf[ixfe] === true

--- a/src/xlsx/xlsb/reader.ts
+++ b/src/xlsx/xlsb/reader.ts
@@ -251,10 +251,15 @@ function parseStylesBin(bin: Uint8Array): boolean[] {
       cellXfFmtIds.push(c.u16()) // iFmt
     }
   }
+  // A BrtFmt record wins over the built-in id table — same precedence as
+  // `isDateStyle` in xlsx/styles.ts, and for the same reason: a file may
+  // redefine a built-in id, and a numeric mask parked on a built-in *date*
+  // id then read back as `Invalid Date`. See #568 and the note in
+  // xls/reader.ts.
   return cellXfFmtIds.map((id) => {
-    if (isBuiltinDateFormatId(id)) return true
     const code = numFmtCodes.get(id)
-    return code ? isDateFormat(code) : false
+    if (code !== undefined) return isDateFormat(code)
+    return isBuiltinDateFormatId(id)
   })
 }
 

--- a/test/xls.test.ts
+++ b/test/xls.test.ts
@@ -40,6 +40,7 @@ const SID = {
   FORMULA: 0x0006,
   EOF: 0x000a,
   DATEMODE: 0x0022,
+  FORMAT: 0x041e,
   NUMBER: 0x0203,
   LABEL: 0x0204,
   BOOLERR: 0x0205,
@@ -63,7 +64,9 @@ function sstRecord(strings: string[]): number[] {
   return record(SID.SST, body)
 }
 
-function buildXls(opts: { dateFmtId?: number } = {}): Uint8Array {
+function buildXls(
+  opts: { dateFmtId?: number; fmtCodes?: Array<[number, string]>; value?: number } = {},
+): Uint8Array {
   const strings = ["Name", "Score", "Ada"]
 
   const sheet = concat([
@@ -73,7 +76,7 @@ function buildXls(opts: { dateFmtId?: number } = {}): Uint8Array {
     record(SID.LABELSST, [...u16(1), ...u16(0), ...u16(0), ...u32(2)]),
     record(SID.RK, [...u16(1), ...u16(1), ...u16(0), ...rkInt(95)]),
     record(SID.NUMBER, [...u16(1), ...u16(2), ...u16(0), ...f64(3.14)]),
-    record(SID.NUMBER, [...u16(1), ...u16(3), ...u16(1), ...f64(45000)]), // date xf
+    record(SID.NUMBER, [...u16(1), ...u16(3), ...u16(1), ...f64(opts.value ?? 45000)]), // date xf
     record(SID.LABEL, [...u16(2), ...u16(0), ...u16(0), ...xlStr("Hi")]),
     record(SID.BOOLERR, [...u16(2), ...u16(1), ...u16(0), 1, 0]), // true
     record(SID.BOOLERR, [...u16(2), ...u16(2), ...u16(0), 0x07, 1]), // #DIV/0!
@@ -95,6 +98,11 @@ function buildXls(opts: { dateFmtId?: number } = {}): Uint8Array {
     concat([
       bof(0x0005),
       record(SID.DATEMODE, u16(0)),
+      // FORMAT records — the workbook's own number-format definitions,
+      // which may redefine a built-in id. See #568.
+      ...(opts.fmtCodes ?? []).map(([id, code]) =>
+        record(SID.FORMAT, [...u16(id), ...xlStr(code)]),
+      ),
       record(SID.XF, [...u16(0), ...u16(0), ...Array.from({ length: 16 }, () => 0)]), // general
       // The date xf's built-in format id is a parameter: the built-in date
       // set is wider than the familiar 14-22 block. See the CJK case below.
@@ -159,6 +167,46 @@ describe("XLS (BIFF8) reader", () => {
       const wb = await readXls(buildXls({ dateFmtId: 3 }))
 
       expect(wb.sheets[0].rows[1][3]).toBe(45000)
+    })
+  })
+
+  // ── #568: a FORMAT record redefining a built-in id ──────────────────
+  // The built-in table was consulted first, so a workbook's own FORMAT
+  // record for that id was never read. readXlsx has always resolved it
+  // the other way round; these are the cases where the three disagreed.
+  describe("a FORMAT record redefines a built-in id", () => {
+    it("reads a number when the file redefines a built-in date id numerically", async () => {
+      // 1C allocates its custom formats from id 50 — inside the
+      // Thai/Chinese/Korean date block — and '000000000000' is its mask
+      // for a leading-zero barcode. Read as a date serial this value is
+      // out of range, so the cell came back Invalid Date and the barcode
+      // was unrecoverable through the API.
+      const wb = await readXls(
+        buildXls({ dateFmtId: 50, fmtCodes: [[50, "000000000000"]], value: 81227827687 }),
+      )
+
+      expect(wb.sheets[0].rows[1][3]).toBe(81227827687)
+    })
+
+    it("reads a number when the file redefines id 14 as '#,##0'", async () => {
+      // The xlsx reader's own note names this case: redefining 14 made it
+      // resolve to a numeric format *and* report as a date, so the serial
+      // was converted and then formatted numerically.
+      const wb = await readXls(buildXls({ dateFmtId: 14, fmtCodes: [[14, "#,##0"]] }))
+
+      expect(wb.sheets[0].rows[1][3]).toBe(45000)
+    })
+
+    it("reads a Date when the file redefines a numeric built-in id as a date", async () => {
+      const wb = await readXls(buildXls({ dateFmtId: 3, fmtCodes: [[3, "yyyy-mm-dd"]] }))
+
+      expect(wb.sheets[0].rows[1][3]).toBeInstanceOf(Date)
+    })
+
+    it("keeps the built-in meaning when the file redefines some other id", async () => {
+      const wb = await readXls(buildXls({ dateFmtId: 50, fmtCodes: [[164, "000000000000"]] }))
+
+      expect(wb.sheets[0].rows[1][3]).toBeInstanceOf(Date)
     })
   })
 

--- a/test/xlsb.test.ts
+++ b/test/xlsb.test.ts
@@ -71,6 +71,7 @@ const BrtRowHdr = 0,
   BrtCellSt = 6,
   BrtCellIsst = 7,
   BrtSSTItem = 19,
+  BrtFmt = 44,
   BrtXF = 47,
   BrtWbProp = 153,
   BrtBundleSh = 156,
@@ -89,7 +90,12 @@ const wbProp = (date1904: boolean): Uint8Array =>
   rec(BrtWbProp, concat([u32(date1904 ? 1 : 0), u32(0), nwstr(null)]))
 
 async function buildXlsb(
-  opts: { date1904?: boolean; dateFmtId?: number } = {},
+  opts: {
+    date1904?: boolean
+    dateFmtId?: number
+    fmtCodes?: Array<[number, string]>
+    value?: number
+  } = {},
 ): Promise<Uint8Array> {
   // Shared strings: 0:"Name" 1:"Score" 2:"Ada"
   const sst = concat([
@@ -102,6 +108,9 @@ async function buildXlsb(
   // familiar 14-22 block — see the CJK case below.
   const dateFmtId = opts.dateFmtId ?? 14
   const styles = concat([
+    // BrtFmt — the workbook's own number-format definitions, which may
+    // redefine a built-in id. See #568.
+    ...(opts.fmtCodes ?? []).map(([id, code]) => rec(BrtFmt, concat([u16(id), wstr(code)]))),
     rec(BrtBeginCellXFs, u32(2)),
     rec(BrtXF, concat([u16(0), u16(0), u16(0), u16(0), u16(0), [0, 0]])),
     rec(BrtXF, concat([u16(0), u16(dateFmtId), u16(0), u16(0), u16(0), [0, 0]])),
@@ -116,7 +125,7 @@ async function buildXlsb(
     rec(BrtCellIsst, concat([cellPrefix(0, 0), u32(2)])),
     rec(BrtCellRk, concat([cellPrefix(1, 0), rkInt(95)])),
     rec(BrtCellReal, concat([cellPrefix(2, 0), f64(3.14)])),
-    rec(BrtCellReal, concat([cellPrefix(3, 1), f64(45000)])), // date serial via date xf
+    rec(BrtCellReal, concat([cellPrefix(3, 1), f64(opts.value ?? 45000)])), // date serial via date xf
     rec(BrtRowHdr, u32(2)),
     rec(BrtCellSt, concat([cellPrefix(0, 0), wstr("Hi")])),
     rec(BrtCellBool, concat([cellPrefix(1, 0), [1]])),
@@ -280,6 +289,40 @@ describe("XLSB reader", () => {
       const wb = await readXlsb(await buildXlsb({ dateFmtId: 3 }))
 
       expect(wb.sheets[0].rows[1][3]).toBe(45000)
+    })
+  })
+
+  // ── #568: a BrtFmt record redefining a built-in id ──────────────────
+  // The built-in table was consulted first, so the file's own BrtFmt for
+  // that id was never read — the same disagreement with readXlsx that
+  // xls/reader.ts had.
+  describe("a BrtFmt record redefines a built-in id", () => {
+    it("reads a number when the file redefines a built-in date id numerically", async () => {
+      const wb = await readXlsb(
+        await buildXlsb({ dateFmtId: 50, fmtCodes: [[50, "000000000000"]], value: 81227827687 }),
+      )
+
+      expect(wb.sheets[0].rows[1][3]).toBe(81227827687)
+    })
+
+    it("reads a number when the file redefines id 14 as '#,##0'", async () => {
+      const wb = await readXlsb(await buildXlsb({ dateFmtId: 14, fmtCodes: [[14, "#,##0"]] }))
+
+      expect(wb.sheets[0].rows[1][3]).toBe(45000)
+    })
+
+    it("reads a Date when the file redefines a numeric built-in id as a date", async () => {
+      const wb = await readXlsb(await buildXlsb({ dateFmtId: 3, fmtCodes: [[3, "yyyy-mm-dd"]] }))
+
+      expect(wb.sheets[0].rows[1][3]).toBeInstanceOf(Date)
+    })
+
+    it("keeps the built-in meaning when the file redefines some other id", async () => {
+      const wb = await readXlsb(
+        await buildXlsb({ dateFmtId: 50, fmtCodes: [[164, "000000000000"]] }),
+      )
+
+      expect(wb.sheets[0].rows[1][3]).toBeInstanceOf(Date)
     })
   })
 


### PR DESCRIPTION
Closes #568.

## What was wrong

`readXls` and `readXlsb` tested the built-in date-format id table **before** the workbook's own `FORMAT` / `BrtFmt` records, so a file that redefines a built-in id never had its own definition read. `readXlsx` has always resolved it the other way round — the three readers disagreed.

The file that found it is a 1C-authored `.xls`. 1C allocates its custom formats from id 50 rather than 164 — inside the Thai/Chinese/Korean date block — and `'000000000000'` is its mask for a leading-zero UPC-A. Those cells went through `serialToDate`, and a barcode is far too large to be a date:

```js
// numFmtId 50, redefined by the file as '000000000000'
const wb = await readXls(bytes)
wb.sheets[0].rows[1][0]
// before: Invalid Date   — and the original number is gone, there is no
//                          API that hands it back
// after:  81227827687
```

It cuts the other way too, and that direction is named in `isDateStyle`'s own comment: id 14 redefined as `'#,##0'` resolved to a numeric format *and* reported as a date, so the serial was converted and then formatted numerically.

## Why the tests did not catch it

`test/xls.test.ts` and `test/xlsb.test.ts` cover the built-in id table thoroughly — the whole #439 CJK and Thai/Chinese/Korean block, id by id. But every one of those cases styles a cell with a built-in id and emits **no** `FORMAT` record, because neither test builder could emit one. The built-in leg was therefore the only leg the BIFF tests ever exercised, and the disagreement with `readXlsx` was invisible from inside the suite.

## What landed

Both readers now ask the file first and fall back to the built-in table, matching `isDateStyle` in `src/xlsx/styles.ts`:

```ts
const dateXf = xfFmtIds.map((id) => {
  const code = fmtCodes.get(id)
  if (code !== undefined) return isDateFormat(code)
  return isBuiltinDateFormatId(id)
})
```

The reason is written into both call sites with the issue number, and `xlsx/styles.ts` is named from them so the three stay findable as one rule.

Both test builders gained a `fmtCodes` option (and a `value`, so the assertion can be the real barcode). Eight new tests, four of which **fail against `main`** — two per reader, one for each direction:

| test | before |
| --- | --- |
| id 50 redefined as `'000000000000'` | `Invalid Date` ❌ |
| id 14 redefined as `'#,##0'` | `2023-03-15T00:00:00.000Z` ❌ |
| id 3 redefined as `'yyyy-mm-dd'` | passes — guards the new order |
| a redefinition of some *other* id (164) | passes — guards the fallback |

The last two matter because the fallback has to survive: the #439 built-ins carry no format code in the file, so if the fallback were lost the CJK block would silently stop reading as dates. Those 38 tests still pass.

`pnpm test` is green — 236 files, 10,640 tests.

## One deliberate edge

The condition is `code !== undefined`, not a truthiness check. A `FORMAT` record whose string is empty now means "the file redefined this id to nothing" and reads as not-a-date, where before an empty string fell through to the built-in table. Such a record is malformed either way; this is the reading consistent with the precedence rule.

`docs/PARITY.md` is unchanged on purpose — this corrects date detection, it does not add or remove a read/write loss, and the XLS/XLSB table's "Dates, honouring the file's 1900/1904 flag: yes" says the same thing after as before.

## What I did not verify

- **I did not open anything in Excel.** Nothing here writes a file, so there is no output to check, but the claim about what 1C emits comes from reading its files, not from re-saving them in Excel.
- **No real `.xlsb` was tested.** 1C does not write XLSB; the reader had the identical shape and the identical bug, so it is fixed by parity and covered only by the synthetic records the test builder emits. If you would rather that change waited for a file that actually exhibits it, say so and I will split it out.
- **The corpus behind the "0.7% of rows" figure is partner invoices I cannot attach.** The repro in #568 builds an equivalent file with `xlwt` in five lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and number format detection when opening XLS and XLSB files.
  * Custom, file-defined formatting now correctly takes precedence over built-in format definitions.
  * Prevented numeric values with custom masks from being incorrectly interpreted as invalid dates.
* **Tests**
  * Added coverage for custom formats, overridden built-in formats, and unrelated format identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->